### PR TITLE
Updated backsword  in Low Tech Equipment.eqp

### DIFF
--- a/Library/Low Tech/Low Tech Equipment.eqp
+++ b/Library/Low Tech/Low Tech Equipment.eqp
@@ -426,7 +426,7 @@
 				<modifier>0</modifier>
 			</default>
 		</melee_weapon>
-		<notes>The Hilt Punch attack receives damage bonuses for whichever of Boxing (p. B182), Brawling (p. B182), or Karate (p. B203) is used to deliver it</notes>
+		<notes>The Hilt Punch attack receives damage bonuses for Brawling (p. B182)</notes>
 		<categories>
 			<category>Melee Weapon</category>
 		</categories>

--- a/Library/Low Tech/Low Tech Equipment.eqp
+++ b/Library/Low Tech/Low Tech Equipment.eqp
@@ -339,6 +339,45 @@
 			<reach>1</reach>
 			<parry>0</parry>
 			<block>No</block>
+			<default>
+				<type>DX</type>
+				<modifier>-5</modifier>
+			</default>
+			<default>
+				<type>Skill</type>
+				<name>Broadsword</name>
+				<modifier>0</modifier>
+			</default>
+			<default>
+				<type>Skill</type>
+				<name>Force Sword</name>
+				<modifier>-4</modifier>
+			</default>
+			<default>
+				<type>Skill</type>
+				<name>Rapier</name>
+				<modifier>-4</modifier>
+			</default>
+			<default>
+				<type>Skill</type>
+				<name>Saber</name>
+				<modifier>-4</modifier>
+			</default>
+			<default>
+				<type>Skill</type>
+				<name>Shortsword</name>
+				<modifier>-2</modifier>
+			</default>
+			<default>
+				<type>Skill</type>
+				<name>Two-Handed Sword</name>
+				<modifier>-4</modifier>
+			</default>
+			<default>
+				<type>Skill</type>
+				<name>Sword!</name>
+				<modifier>0</modifier>
+			</default>
 		</melee_weapon>
 		<melee_weapon>
 			<damage type="imp" st="thr" base="+1"/>
@@ -347,8 +386,47 @@
 			<reach>1</reach>
 			<parry>0</parry>
 			<block>No</block>
+			<default>
+				<type>DX</type>
+				<modifier>-5</modifier>
+			</default>
+			<default>
+				<type>Skill</type>
+				<name>Broadsword</name>
+				<modifier>0</modifier>
+			</default>
+			<default>
+				<type>Skill</type>
+				<name>Force Sword</name>
+				<modifier>-4</modifier>
+			</default>
+			<default>
+				<type>Skill</type>
+				<name>Rapier</name>
+				<modifier>-4</modifier>
+			</default>
+			<default>
+				<type>Skill</type>
+				<name>Saber</name>
+				<modifier>-4</modifier>
+			</default>
+			<default>
+				<type>Skill</type>
+				<name>Shortsword</name>
+				<modifier>-2</modifier>
+			</default>
+			<default>
+				<type>Skill</type>
+				<name>Two-Handed Sword</name>
+				<modifier>-4</modifier>
+			</default>
+			<default>
+				<type>Skill</type>
+				<name>Sword!</name>
+				<modifier>0</modifier>
+			</default>
 		</melee_weapon>
-		<notes>Attack receives damage bonuses for whichever of Boxing (p. B182), Brawling (p. B182), or Karate (p. B203) is used to deliver it</notes>
+		<notes>The Hilt Punch attack receives damage bonuses for whichever of Boxing (p. B182), Brawling (p. B182), or Karate (p. B203) is used to deliver it</notes>
 		<categories>
 			<category>Melee Weapon</category>
 		</categories>


### PR DESCRIPTION
Added skill defaults for Swing and Thrust usages and elaborated upon the damage bonus note so that it only references the Hilt Punch attack.