### PR TITLE
Alternative way to organize Low-Tech Armor

### DIFF
--- a/Library/Low Tech/Low Tech Armor.eqp
+++ b/Library/Low Tech/Low Tech Armor.eqp
@@ -1,0 +1,17116 @@
+{
+	"type": "equipment_list",
+	"version": 1,
+	"rows": [
+		{
+			"type": "equipment",
+			"version": 1,
+			"quantity": 1,
+			"description": "Cane",
+			"tech_level": "0",
+			"modifiers": [
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Head",
+					"cost_type": "to_original_cost",
+					"cost": "+10.5",
+					"weight_type": "to_original_weight",
+					"weight": "+3.6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 1,
+							"location": "skull"
+						},
+						{
+							"type": "dr_bonus",
+							"amount": 1,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Skull",
+					"cost_type": "to_original_cost",
+					"cost": "+7",
+					"weight_type": "to_original_weight",
+					"weight": "+2.4 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 1,
+							"location": "skull"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Face",
+					"cost_type": "to_original_cost",
+					"cost": "+3.5",
+					"weight_type": "to_original_weight",
+					"weight": "+1.2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 1,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Neck",
+					"cost_type": "to_original_cost",
+					"cost": "+1.75",
+					"weight_type": "to_original_weight",
+					"weight": "+0.6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 1,
+							"location": "neck"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Torso",
+					"cost_type": "to_original_cost",
+					"cost": "+35",
+					"weight_type": "to_original_weight",
+					"weight": "+12 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 1,
+							"location": "torso"
+						}
+					],
+					"notes": "Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Chest",
+					"cost_type": "to_original_cost",
+					"cost": "+26.25",
+					"weight_type": "to_original_weight",
+					"weight": "+9 lb",
+					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Abdomen",
+					"cost_type": "to_original_cost",
+					"cost": "+26.25",
+					"weight_type": "to_original_weight",
+					"weight": "+9 lb",
+					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Groin",
+					"cost_type": "to_original_cost",
+					"cost": "+1.75",
+					"weight_type": "to_original_weight",
+					"weight": "+0.6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 1,
+							"location": "groin"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+17.5",
+					"weight_type": "to_original_weight",
+					"weight": "+6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 1,
+							"location": "arms"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shoulders",
+					"cost_type": "to_original_cost",
+					"cost": "+3.5",
+					"weight_type": "to_original_weight",
+					"weight": "+1.2 lb",
+					"notes": "Roll 1d; on 6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Upper Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+3.5",
+					"weight_type": "to_original_weight",
+					"weight": "+1.2 lb",
+					"notes": "Roll 1d; on 5, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Elbows",
+					"cost_type": "to_original_cost",
+					"cost": "+1.75",
+					"weight_type": "to_original_weight",
+					"weight": "+0.6 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Forearms",
+					"cost_type": "to_original_cost",
+					"cost": "+8.75",
+					"weight_type": "to_original_weight",
+					"weight": "+3 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Hands",
+					"cost_type": "to_original_cost",
+					"cost": "+3.5",
+					"weight_type": "to_original_weight",
+					"weight": "+1.2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 1,
+							"location": "hands"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Legs",
+					"cost_type": "to_original_cost",
+					"cost": "+35",
+					"weight_type": "to_original_weight",
+					"weight": "+12 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 1,
+							"location": "legs"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Thighs",
+					"cost_type": "to_original_cost",
+					"cost": "+15.75",
+					"weight_type": "to_original_weight",
+					"weight": "+5.4 lb",
+					"notes": "Roll 1d; on 5-6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Knees",
+					"cost_type": "to_original_cost",
+					"cost": "+1.75",
+					"weight_type": "to_original_weight",
+					"weight": "+0.6 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shins",
+					"cost_type": "to_original_cost",
+					"cost": "+17.5",
+					"weight_type": "to_original_weight",
+					"weight": "+6 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Feet",
+					"cost_type": "to_original_cost",
+					"cost": "+3.5",
+					"weight_type": "to_original_weight",
+					"weight": "+1.2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 1,
+							"location": "feet"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "@Covers only half (front only, one arm, etc)@",
+					"cost_type": "to_base_cost",
+					"cost": "x0.5",
+					"weight_type": "to_base_weight",
+					"weight": "x0.5"
+				}
+			],
+			"notes": "Combustible. If DR is penetrated by burning damage, it can catch fire. See Making Things Burn (p. B433); treat the armor material as resistant; Holdout: -1."
+		},
+		{
+			"type": "equipment",
+			"version": 1,
+			"quantity": 1,
+			"description": "Cloth, Padded",
+			"tech_level": "0",
+			"modifiers": [
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Head",
+					"cost_type": "to_original_cost",
+					"cost": "+15",
+					"weight_type": "to_original_weight",
+					"weight": "+1.8 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 1,
+							"location": "skull"
+						},
+						{
+							"type": "dr_bonus",
+							"amount": 1,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Skull",
+					"cost_type": "to_original_cost",
+					"cost": "+10",
+					"weight_type": "to_original_weight",
+					"weight": "+1.2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 1,
+							"location": "skull"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Face",
+					"cost_type": "to_original_cost",
+					"cost": "+5",
+					"weight_type": "to_original_weight",
+					"weight": "+0.6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 1,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Neck",
+					"cost_type": "to_original_cost",
+					"cost": "+2.5",
+					"weight_type": "to_original_weight",
+					"weight": "+0.3 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 1,
+							"location": "neck"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Torso",
+					"cost_type": "to_original_cost",
+					"cost": "+50",
+					"weight_type": "to_original_weight",
+					"weight": "+6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 1,
+							"location": "torso"
+						}
+					],
+					"notes": "Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Chest",
+					"cost_type": "to_original_cost",
+					"cost": "+37.5",
+					"weight_type": "to_original_weight",
+					"weight": "+4.5 lb",
+					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Abdomen",
+					"cost_type": "to_original_cost",
+					"cost": "+37.5",
+					"weight_type": "to_original_weight",
+					"weight": "+4.5 lb",
+					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Groin",
+					"cost_type": "to_original_cost",
+					"cost": "+2.5",
+					"weight_type": "to_original_weight",
+					"weight": "+0.3 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 1,
+							"location": "groin"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+25",
+					"weight_type": "to_original_weight",
+					"weight": "+3 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 1,
+							"location": "arms"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shoulders",
+					"cost_type": "to_original_cost",
+					"cost": "+5",
+					"weight_type": "to_original_weight",
+					"weight": "+0.6 lb",
+					"notes": "Roll 1d; on 6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Upper Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+5",
+					"weight_type": "to_original_weight",
+					"weight": "+0.6 lb",
+					"notes": "Roll 1d; on 5, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Elbows",
+					"cost_type": "to_original_cost",
+					"cost": "+2.5",
+					"weight_type": "to_original_weight",
+					"weight": "+0.3 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Forearms",
+					"cost_type": "to_original_cost",
+					"cost": "+12.5",
+					"weight_type": "to_original_weight",
+					"weight": "+1.5 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Hands",
+					"cost_type": "to_original_cost",
+					"cost": "+5",
+					"weight_type": "to_original_weight",
+					"weight": "+0.6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 1,
+							"location": "hands"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Legs",
+					"cost_type": "to_original_cost",
+					"cost": "+50",
+					"weight_type": "to_original_weight",
+					"weight": "+6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 1,
+							"location": "legs"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Thighs",
+					"cost_type": "to_original_cost",
+					"cost": "+22.5",
+					"weight_type": "to_original_weight",
+					"weight": "+2.7 lb",
+					"notes": "Roll 1d; on 5-6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Knees",
+					"cost_type": "to_original_cost",
+					"cost": "+2.5",
+					"weight_type": "to_original_weight",
+					"weight": "+0.3 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shins",
+					"cost_type": "to_original_cost",
+					"cost": "+25",
+					"weight_type": "to_original_weight",
+					"weight": "+3 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Feet",
+					"cost_type": "to_original_cost",
+					"cost": "+5",
+					"weight_type": "to_original_weight",
+					"weight": "+0.6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 1,
+							"location": "feet"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "@Covers only half (front only, one arm, etc)@",
+					"cost_type": "to_base_cost",
+					"cost": "x0.5",
+					"weight_type": "to_base_weight",
+					"weight": "x0.5"
+				}
+			],
+			"notes": "Flexible, susceptible to blunt trauma; Holdout: -1."
+		},
+		{
+			"type": "equipment",
+			"version": 1,
+			"quantity": 1,
+			"description": "Horn",
+			"tech_level": "0",
+			"modifiers": [
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Head",
+					"cost_type": "to_original_cost",
+					"cost": "+75",
+					"weight_type": "to_original_weight",
+					"weight": "+7.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "skull"
+						},
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Skull",
+					"cost_type": "to_original_cost",
+					"cost": "+50",
+					"weight_type": "to_original_weight",
+					"weight": "+5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "skull"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Face",
+					"cost_type": "to_original_cost",
+					"cost": "+25",
+					"weight_type": "to_original_weight",
+					"weight": "+2.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Neck",
+					"cost_type": "to_original_cost",
+					"cost": "+12.5",
+					"weight_type": "to_original_weight",
+					"weight": "+1.25 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "neck"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Torso",
+					"cost_type": "to_original_cost",
+					"cost": "+250",
+					"weight_type": "to_original_weight",
+					"weight": "+25 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "torso"
+						}
+					],
+					"notes": "Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Chest",
+					"cost_type": "to_original_cost",
+					"cost": "+187.5",
+					"weight_type": "to_original_weight",
+					"weight": "+18.75 lb",
+					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Abdomen",
+					"cost_type": "to_original_cost",
+					"cost": "+187.5",
+					"weight_type": "to_original_weight",
+					"weight": "+18.75 lb",
+					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Groin",
+					"cost_type": "to_original_cost",
+					"cost": "+12.5",
+					"weight_type": "to_original_weight",
+					"weight": "+1.25 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "groin"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+125",
+					"weight_type": "to_original_weight",
+					"weight": "+12.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "arms"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shoulders",
+					"cost_type": "to_original_cost",
+					"cost": "+25",
+					"weight_type": "to_original_weight",
+					"weight": "+2.5 lb",
+					"notes": "Roll 1d; on 6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Upper Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+25",
+					"weight_type": "to_original_weight",
+					"weight": "+2.5 lb",
+					"notes": "Roll 1d; on 5, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Elbows",
+					"cost_type": "to_original_cost",
+					"cost": "+12.5",
+					"weight_type": "to_original_weight",
+					"weight": "+1.25 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Forearms",
+					"cost_type": "to_original_cost",
+					"cost": "+62.5",
+					"weight_type": "to_original_weight",
+					"weight": "+6.25 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Hands",
+					"cost_type": "to_original_cost",
+					"cost": "+25",
+					"weight_type": "to_original_weight",
+					"weight": "+2.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "hands"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Legs",
+					"cost_type": "to_original_cost",
+					"cost": "+250",
+					"weight_type": "to_original_weight",
+					"weight": "+25 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "legs"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Thighs",
+					"cost_type": "to_original_cost",
+					"cost": "+112.5",
+					"weight_type": "to_original_weight",
+					"weight": "+11.25 lb",
+					"notes": "Roll 1d; on 5-6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Knees",
+					"cost_type": "to_original_cost",
+					"cost": "+12.5",
+					"weight_type": "to_original_weight",
+					"weight": "+1.25 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shins",
+					"cost_type": "to_original_cost",
+					"cost": "+125",
+					"weight_type": "to_original_weight",
+					"weight": "+12.5 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Feet",
+					"cost_type": "to_original_cost",
+					"cost": "+25",
+					"weight_type": "to_original_weight",
+					"weight": "+2.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "feet"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "@Covers only half (front only, one arm, etc)@",
+					"cost_type": "to_base_cost",
+					"cost": "x0.5",
+					"weight_type": "to_base_weight",
+					"weight": "x0.5"
+				}
+			],
+			"notes": "Holdout: -3."
+		},
+		{
+			"type": "equipment",
+			"version": 1,
+			"quantity": 1,
+			"description": "Layered Cloth, Light",
+			"tech_level": "0",
+			"modifiers": [
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Head",
+					"cost_type": "to_original_cost",
+					"cost": "+45",
+					"weight_type": "to_original_weight",
+					"weight": "+3.6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "skull"
+						},
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Skull",
+					"cost_type": "to_original_cost",
+					"cost": "+30",
+					"weight_type": "to_original_weight",
+					"weight": "+2.4 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "skull"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Face",
+					"cost_type": "to_original_cost",
+					"cost": "+15",
+					"weight_type": "to_original_weight",
+					"weight": "+1.2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Neck",
+					"cost_type": "to_original_cost",
+					"cost": "+7.5",
+					"weight_type": "to_original_weight",
+					"weight": "+0.6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "neck"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Torso",
+					"cost_type": "to_original_cost",
+					"cost": "+150",
+					"weight_type": "to_original_weight",
+					"weight": "+12 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "torso"
+						}
+					],
+					"notes": "Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Chest",
+					"cost_type": "to_original_cost",
+					"cost": "+112.5",
+					"weight_type": "to_original_weight",
+					"weight": "+9 lb",
+					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Abdomen",
+					"cost_type": "to_original_cost",
+					"cost": "+112.5",
+					"weight_type": "to_original_weight",
+					"weight": "+9 lb",
+					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Groin",
+					"cost_type": "to_original_cost",
+					"cost": "+7.5",
+					"weight_type": "to_original_weight",
+					"weight": "+0.6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "groin"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+75",
+					"weight_type": "to_original_weight",
+					"weight": "+6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "arms"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shoulders",
+					"cost_type": "to_original_cost",
+					"cost": "+15",
+					"weight_type": "to_original_weight",
+					"weight": "+1.2 lb",
+					"notes": "Roll 1d; on 6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Upper Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+15",
+					"weight_type": "to_original_weight",
+					"weight": "+1.2 lb",
+					"notes": "Roll 1d; on 5, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Elbows",
+					"cost_type": "to_original_cost",
+					"cost": "+7.5",
+					"weight_type": "to_original_weight",
+					"weight": "+0.6 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Forearms",
+					"cost_type": "to_original_cost",
+					"cost": "+37.5",
+					"weight_type": "to_original_weight",
+					"weight": "+3 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Hands",
+					"cost_type": "to_original_cost",
+					"cost": "+15",
+					"weight_type": "to_original_weight",
+					"weight": "+1.2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "hands"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Legs",
+					"cost_type": "to_original_cost",
+					"cost": "+150",
+					"weight_type": "to_original_weight",
+					"weight": "+12 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "legs"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Thighs",
+					"cost_type": "to_original_cost",
+					"cost": "+67.5",
+					"weight_type": "to_original_weight",
+					"weight": "+5.4 lb",
+					"notes": "Roll 1d; on 5-6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Knees",
+					"cost_type": "to_original_cost",
+					"cost": "+7.5",
+					"weight_type": "to_original_weight",
+					"weight": "+0.6 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shins",
+					"cost_type": "to_original_cost",
+					"cost": "+75",
+					"weight_type": "to_original_weight",
+					"weight": "+6 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Feet",
+					"cost_type": "to_original_cost",
+					"cost": "+15",
+					"weight_type": "to_original_weight",
+					"weight": "+1.2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "feet"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "@Covers only half (front only, one arm, etc)@",
+					"cost_type": "to_base_cost",
+					"cost": "x0.5",
+					"weight_type": "to_base_weight",
+					"weight": "x0.5"
+				}
+			],
+			"notes": "Flexible, susceptible to blunt trauma; Holdout: -1."
+		},
+		{
+			"type": "equipment",
+			"version": 1,
+			"quantity": 1,
+			"description": "Layered Cloth, Medium",
+			"tech_level": "0",
+			"modifiers": [
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Head",
+					"cost_type": "to_original_cost",
+					"cost": "+105",
+					"weight_type": "to_original_weight",
+					"weight": "+6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "skull"
+						},
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Skull",
+					"cost_type": "to_original_cost",
+					"cost": "+70",
+					"weight_type": "to_original_weight",
+					"weight": "+4 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "skull"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Face",
+					"cost_type": "to_original_cost",
+					"cost": "+35",
+					"weight_type": "to_original_weight",
+					"weight": "+2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Neck",
+					"cost_type": "to_original_cost",
+					"cost": "+17.5",
+					"weight_type": "to_original_weight",
+					"weight": "+1 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "neck"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Torso",
+					"cost_type": "to_original_cost",
+					"cost": "+350",
+					"weight_type": "to_original_weight",
+					"weight": "+20 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "torso"
+						}
+					],
+					"notes": "Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Chest",
+					"cost_type": "to_original_cost",
+					"cost": "+262.5",
+					"weight_type": "to_original_weight",
+					"weight": "+15 lb",
+					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Abdomen",
+					"cost_type": "to_original_cost",
+					"cost": "+262.5",
+					"weight_type": "to_original_weight",
+					"weight": "+15 lb",
+					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Groin",
+					"cost_type": "to_original_cost",
+					"cost": "+17.5",
+					"weight_type": "to_original_weight",
+					"weight": "+1 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "groin"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+175",
+					"weight_type": "to_original_weight",
+					"weight": "+10 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "arms"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shoulders",
+					"cost_type": "to_original_cost",
+					"cost": "+35",
+					"weight_type": "to_original_weight",
+					"weight": "+2 lb",
+					"notes": "Roll 1d; on 6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Upper Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+35",
+					"weight_type": "to_original_weight",
+					"weight": "+2 lb",
+					"notes": "Roll 1d; on 5, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Elbows",
+					"cost_type": "to_original_cost",
+					"cost": "+17.5",
+					"weight_type": "to_original_weight",
+					"weight": "+1 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Forearms",
+					"cost_type": "to_original_cost",
+					"cost": "+87.5",
+					"weight_type": "to_original_weight",
+					"weight": "+5 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Hands",
+					"cost_type": "to_original_cost",
+					"cost": "+35",
+					"weight_type": "to_original_weight",
+					"weight": "+2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "hands"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Legs",
+					"cost_type": "to_original_cost",
+					"cost": "+350",
+					"weight_type": "to_original_weight",
+					"weight": "+20 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "legs"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Thighs",
+					"cost_type": "to_original_cost",
+					"cost": "+157.5",
+					"weight_type": "to_original_weight",
+					"weight": "+9 lb",
+					"notes": "Roll 1d; on 5-6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Knees",
+					"cost_type": "to_original_cost",
+					"cost": "+17.5",
+					"weight_type": "to_original_weight",
+					"weight": "+1 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shins",
+					"cost_type": "to_original_cost",
+					"cost": "+175",
+					"weight_type": "to_original_weight",
+					"weight": "+10 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Feet",
+					"cost_type": "to_original_cost",
+					"cost": "+35",
+					"weight_type": "to_original_weight",
+					"weight": "+2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "feet"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "@Covers only half (front only, one arm, etc)@",
+					"cost_type": "to_base_cost",
+					"cost": "x0.5",
+					"weight_type": "to_base_weight",
+					"weight": "x0.5"
+				}
+			],
+			"notes": "Holdout: -3."
+		},
+		{
+			"type": "equipment",
+			"version": 1,
+			"quantity": 1,
+			"description": "Layered Cloth, Heavy",
+			"tech_level": "0",
+			"modifiers": [
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Head",
+					"cost_type": "to_original_cost",
+					"cost": "+180",
+					"weight_type": "to_original_weight",
+					"weight": "+8.4 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "skull"
+						},
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Skull",
+					"cost_type": "to_original_cost",
+					"cost": "+120",
+					"weight_type": "to_original_weight",
+					"weight": "+5.6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "skull"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Face",
+					"cost_type": "to_original_cost",
+					"cost": "+60",
+					"weight_type": "to_original_weight",
+					"weight": "+2.8 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Neck",
+					"cost_type": "to_original_cost",
+					"cost": "+30",
+					"weight_type": "to_original_weight",
+					"weight": "+1.4 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "neck"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Torso",
+					"cost_type": "to_original_cost",
+					"cost": "+600",
+					"weight_type": "to_original_weight",
+					"weight": "+28 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "torso"
+						}
+					],
+					"notes": "Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Chest",
+					"cost_type": "to_original_cost",
+					"cost": "+450",
+					"weight_type": "to_original_weight",
+					"weight": "+21 lb",
+					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Abdomen",
+					"cost_type": "to_original_cost",
+					"cost": "+450",
+					"weight_type": "to_original_weight",
+					"weight": "+21 lb",
+					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Groin",
+					"cost_type": "to_original_cost",
+					"cost": "+30",
+					"weight_type": "to_original_weight",
+					"weight": "+1.4 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "groin"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+300",
+					"weight_type": "to_original_weight",
+					"weight": "+14 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "arms"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shoulders",
+					"cost_type": "to_original_cost",
+					"cost": "+60",
+					"weight_type": "to_original_weight",
+					"weight": "+2.8 lb",
+					"notes": "Roll 1d; on 6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Upper Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+60",
+					"weight_type": "to_original_weight",
+					"weight": "+2.8 lb",
+					"notes": "Roll 1d; on 5, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Elbows",
+					"cost_type": "to_original_cost",
+					"cost": "+30",
+					"weight_type": "to_original_weight",
+					"weight": "+1.4 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Forearms",
+					"cost_type": "to_original_cost",
+					"cost": "+150",
+					"weight_type": "to_original_weight",
+					"weight": "+7 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Hands",
+					"cost_type": "to_original_cost",
+					"cost": "+60",
+					"weight_type": "to_original_weight",
+					"weight": "+2.8 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "hands"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Legs",
+					"cost_type": "to_original_cost",
+					"cost": "+600",
+					"weight_type": "to_original_weight",
+					"weight": "+28 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "legs"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Thighs",
+					"cost_type": "to_original_cost",
+					"cost": "+270",
+					"weight_type": "to_original_weight",
+					"weight": "+12.6 lb",
+					"notes": "Roll 1d; on 5-6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Knees",
+					"cost_type": "to_original_cost",
+					"cost": "+30",
+					"weight_type": "to_original_weight",
+					"weight": "+1.4 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shins",
+					"cost_type": "to_original_cost",
+					"cost": "+300",
+					"weight_type": "to_original_weight",
+					"weight": "+14 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Feet",
+					"cost_type": "to_original_cost",
+					"cost": "+60",
+					"weight_type": "to_original_weight",
+					"weight": "+2.8 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "feet"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "@Covers only half (front only, one arm, etc)@",
+					"cost_type": "to_base_cost",
+					"cost": "x0.5",
+					"weight_type": "to_base_weight",
+					"weight": "x0.5"
+				}
+			],
+			"notes": "Holdout: -4."
+		},
+		{
+			"type": "equipment",
+			"version": 1,
+			"quantity": 1,
+			"description": "Leather, Medium",
+			"tech_level": "0",
+			"modifiers": [
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Head",
+					"cost_type": "to_original_cost",
+					"cost": "+30",
+					"weight_type": "to_original_weight",
+					"weight": "+3.6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "skull"
+						},
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Skull",
+					"cost_type": "to_original_cost",
+					"cost": "+20",
+					"weight_type": "to_original_weight",
+					"weight": "+2.4 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "skull"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Face",
+					"cost_type": "to_original_cost",
+					"cost": "+10",
+					"weight_type": "to_original_weight",
+					"weight": "+1.2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Neck",
+					"cost_type": "to_original_cost",
+					"cost": "+5",
+					"weight_type": "to_original_weight",
+					"weight": "+0.6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "neck"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Torso",
+					"cost_type": "to_original_cost",
+					"cost": "+100",
+					"weight_type": "to_original_weight",
+					"weight": "+12 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "torso"
+						}
+					],
+					"notes": "Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Chest",
+					"cost_type": "to_original_cost",
+					"cost": "+75",
+					"weight_type": "to_original_weight",
+					"weight": "+9 lb",
+					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Abdomen",
+					"cost_type": "to_original_cost",
+					"cost": "+75",
+					"weight_type": "to_original_weight",
+					"weight": "+9 lb",
+					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Groin",
+					"cost_type": "to_original_cost",
+					"cost": "+5",
+					"weight_type": "to_original_weight",
+					"weight": "+0.6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "groin"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+50",
+					"weight_type": "to_original_weight",
+					"weight": "+6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "arms"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shoulders",
+					"cost_type": "to_original_cost",
+					"cost": "+10",
+					"weight_type": "to_original_weight",
+					"weight": "+1.2 lb",
+					"notes": "Roll 1d; on 6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Upper Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+10",
+					"weight_type": "to_original_weight",
+					"weight": "+1.2 lb",
+					"notes": "Roll 1d; on 5, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Elbows",
+					"cost_type": "to_original_cost",
+					"cost": "+5",
+					"weight_type": "to_original_weight",
+					"weight": "+0.6 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Forearms",
+					"cost_type": "to_original_cost",
+					"cost": "+25",
+					"weight_type": "to_original_weight",
+					"weight": "+3 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Hands",
+					"cost_type": "to_original_cost",
+					"cost": "+10",
+					"weight_type": "to_original_weight",
+					"weight": "+1.2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "hands"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Legs",
+					"cost_type": "to_original_cost",
+					"cost": "+100",
+					"weight_type": "to_original_weight",
+					"weight": "+12 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "legs"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Thighs",
+					"cost_type": "to_original_cost",
+					"cost": "+45",
+					"weight_type": "to_original_weight",
+					"weight": "+5.4 lb",
+					"notes": "Roll 1d; on 5-6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Knees",
+					"cost_type": "to_original_cost",
+					"cost": "+5",
+					"weight_type": "to_original_weight",
+					"weight": "+0.6 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shins",
+					"cost_type": "to_original_cost",
+					"cost": "+50",
+					"weight_type": "to_original_weight",
+					"weight": "+6 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Feet",
+					"cost_type": "to_original_cost",
+					"cost": "+10",
+					"weight_type": "to_original_weight",
+					"weight": "+1.2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "feet"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "@Covers only half (front only, one arm, etc)@",
+					"cost_type": "to_base_cost",
+					"cost": "x0.5",
+					"weight_type": "to_base_weight",
+					"weight": "x0.5"
+				}
+			],
+			"notes": "Flexible, susceptible to blunt trauma; -1 DR vs. impaling; Holdout: -1."
+		},
+		{
+			"type": "equipment",
+			"version": 1,
+			"quantity": 1,
+			"description": "Leather, Heavy",
+			"tech_level": "0",
+			"modifiers": [
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Head",
+					"cost_type": "to_original_cost",
+					"cost": "+60",
+					"weight_type": "to_original_weight",
+					"weight": "+6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "skull"
+						},
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Skull",
+					"cost_type": "to_original_cost",
+					"cost": "+40",
+					"weight_type": "to_original_weight",
+					"weight": "+4 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "skull"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Face",
+					"cost_type": "to_original_cost",
+					"cost": "+20",
+					"weight_type": "to_original_weight",
+					"weight": "+2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Neck",
+					"cost_type": "to_original_cost",
+					"cost": "+10",
+					"weight_type": "to_original_weight",
+					"weight": "+1 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "neck"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Torso",
+					"cost_type": "to_original_cost",
+					"cost": "+200",
+					"weight_type": "to_original_weight",
+					"weight": "+20 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "torso"
+						}
+					],
+					"notes": "Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Chest",
+					"cost_type": "to_original_cost",
+					"cost": "+150",
+					"weight_type": "to_original_weight",
+					"weight": "+15 lb",
+					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Abdomen",
+					"cost_type": "to_original_cost",
+					"cost": "+150",
+					"weight_type": "to_original_weight",
+					"weight": "+15 lb",
+					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Groin",
+					"cost_type": "to_original_cost",
+					"cost": "+10",
+					"weight_type": "to_original_weight",
+					"weight": "+1 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "groin"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+100",
+					"weight_type": "to_original_weight",
+					"weight": "+10 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "arms"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shoulders",
+					"cost_type": "to_original_cost",
+					"cost": "+20",
+					"weight_type": "to_original_weight",
+					"weight": "+2 lb",
+					"notes": "Roll 1d; on 6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Upper Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+20",
+					"weight_type": "to_original_weight",
+					"weight": "+2 lb",
+					"notes": "Roll 1d; on 5, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Elbows",
+					"cost_type": "to_original_cost",
+					"cost": "+10",
+					"weight_type": "to_original_weight",
+					"weight": "+1 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Forearms",
+					"cost_type": "to_original_cost",
+					"cost": "+50",
+					"weight_type": "to_original_weight",
+					"weight": "+5 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Hands",
+					"cost_type": "to_original_cost",
+					"cost": "+20",
+					"weight_type": "to_original_weight",
+					"weight": "+2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "hands"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Legs",
+					"cost_type": "to_original_cost",
+					"cost": "+200",
+					"weight_type": "to_original_weight",
+					"weight": "+20 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "legs"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Thighs",
+					"cost_type": "to_original_cost",
+					"cost": "+90",
+					"weight_type": "to_original_weight",
+					"weight": "+9 lb",
+					"notes": "Roll 1d; on 5-6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Knees",
+					"cost_type": "to_original_cost",
+					"cost": "+10",
+					"weight_type": "to_original_weight",
+					"weight": "+1 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shins",
+					"cost_type": "to_original_cost",
+					"cost": "+100",
+					"weight_type": "to_original_weight",
+					"weight": "+10 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Feet",
+					"cost_type": "to_original_cost",
+					"cost": "+20",
+					"weight_type": "to_original_weight",
+					"weight": "+2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "feet"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "@Covers only half (front only, one arm, etc)@",
+					"cost_type": "to_base_cost",
+					"cost": "x0.5",
+					"weight_type": "to_base_weight",
+					"weight": "x0.5"
+				}
+			],
+			"notes": "-1 DR vs. impaling; Holdout: -3."
+		},
+		{
+			"type": "equipment",
+			"version": 1,
+			"quantity": 1,
+			"description": "Straw",
+			"tech_level": "0",
+			"modifiers": [
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Head",
+					"cost_type": "to_original_cost",
+					"cost": "+15",
+					"weight_type": "to_original_weight",
+					"weight": "+6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "skull"
+						},
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Skull",
+					"cost_type": "to_original_cost",
+					"cost": "+10",
+					"weight_type": "to_original_weight",
+					"weight": "+4 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "skull"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Face",
+					"cost_type": "to_original_cost",
+					"cost": "+5",
+					"weight_type": "to_original_weight",
+					"weight": "+2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Neck",
+					"cost_type": "to_original_cost",
+					"cost": "+2.5",
+					"weight_type": "to_original_weight",
+					"weight": "+1 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "neck"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Torso",
+					"cost_type": "to_original_cost",
+					"cost": "+50",
+					"weight_type": "to_original_weight",
+					"weight": "+20 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "torso"
+						}
+					],
+					"notes": "Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Chest",
+					"cost_type": "to_original_cost",
+					"cost": "+37.5",
+					"weight_type": "to_original_weight",
+					"weight": "+15 lb",
+					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Abdomen",
+					"cost_type": "to_original_cost",
+					"cost": "+37.5",
+					"weight_type": "to_original_weight",
+					"weight": "+15 lb",
+					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Groin",
+					"cost_type": "to_original_cost",
+					"cost": "+2.5",
+					"weight_type": "to_original_weight",
+					"weight": "+1 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "groin"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+25",
+					"weight_type": "to_original_weight",
+					"weight": "+10 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "arms"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shoulders",
+					"cost_type": "to_original_cost",
+					"cost": "+5",
+					"weight_type": "to_original_weight",
+					"weight": "+2 lb",
+					"notes": "Roll 1d; on 6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Upper Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+5",
+					"weight_type": "to_original_weight",
+					"weight": "+2 lb",
+					"notes": "Roll 1d; on 5, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Elbows",
+					"cost_type": "to_original_cost",
+					"cost": "+2.5",
+					"weight_type": "to_original_weight",
+					"weight": "+1 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Forearms",
+					"cost_type": "to_original_cost",
+					"cost": "+12.5",
+					"weight_type": "to_original_weight",
+					"weight": "+5 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Hands",
+					"cost_type": "to_original_cost",
+					"cost": "+5",
+					"weight_type": "to_original_weight",
+					"weight": "+2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "hands"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Legs",
+					"cost_type": "to_original_cost",
+					"cost": "+50",
+					"weight_type": "to_original_weight",
+					"weight": "+20 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "legs"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Thighs",
+					"cost_type": "to_original_cost",
+					"cost": "+22.5",
+					"weight_type": "to_original_weight",
+					"weight": "+9 lb",
+					"notes": "Roll 1d; on 5-6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Knees",
+					"cost_type": "to_original_cost",
+					"cost": "+2.5",
+					"weight_type": "to_original_weight",
+					"weight": "+1 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shins",
+					"cost_type": "to_original_cost",
+					"cost": "+25",
+					"weight_type": "to_original_weight",
+					"weight": "+10 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Feet",
+					"cost_type": "to_original_cost",
+					"cost": "+5",
+					"weight_type": "to_original_weight",
+					"weight": "+2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "feet"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "@Covers only half (front only, one arm, etc)@",
+					"cost_type": "to_base_cost",
+					"cost": "x0.5",
+					"weight_type": "to_base_weight",
+					"weight": "x0.5"
+				}
+			],
+			"notes": "Combustible. If DR is penetrated by burning damage, it can catch fire. See Making Things Burn (p. B433); treat the armor material as resistant; Holdout: -2."
+		},
+		{
+			"type": "equipment",
+			"version": 1,
+			"quantity": 1,
+			"description": "Wood",
+			"tech_level": "0",
+			"modifiers": [
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Head",
+					"cost_type": "to_original_cost",
+					"cost": "+30",
+					"weight_type": "to_original_weight",
+					"weight": "+9 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "skull"
+						},
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Skull",
+					"cost_type": "to_original_cost",
+					"cost": "+20",
+					"weight_type": "to_original_weight",
+					"weight": "+6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "skull"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Face",
+					"cost_type": "to_original_cost",
+					"cost": "+10",
+					"weight_type": "to_original_weight",
+					"weight": "+3 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Neck",
+					"cost_type": "to_original_cost",
+					"cost": "+5",
+					"weight_type": "to_original_weight",
+					"weight": "+1.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "neck"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Torso",
+					"cost_type": "to_original_cost",
+					"cost": "+100",
+					"weight_type": "to_original_weight",
+					"weight": "+30 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "torso"
+						}
+					],
+					"notes": "Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Chest",
+					"cost_type": "to_original_cost",
+					"cost": "+75",
+					"weight_type": "to_original_weight",
+					"weight": "+22.5 lb",
+					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Abdomen",
+					"cost_type": "to_original_cost",
+					"cost": "+75",
+					"weight_type": "to_original_weight",
+					"weight": "+22.5 lb",
+					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Groin",
+					"cost_type": "to_original_cost",
+					"cost": "+5",
+					"weight_type": "to_original_weight",
+					"weight": "+1.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "groin"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+50",
+					"weight_type": "to_original_weight",
+					"weight": "+15 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "arms"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shoulders",
+					"cost_type": "to_original_cost",
+					"cost": "+10",
+					"weight_type": "to_original_weight",
+					"weight": "+3 lb",
+					"notes": "Roll 1d; on 6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Upper Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+10",
+					"weight_type": "to_original_weight",
+					"weight": "+3 lb",
+					"notes": "Roll 1d; on 5, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Elbows",
+					"cost_type": "to_original_cost",
+					"cost": "+5",
+					"weight_type": "to_original_weight",
+					"weight": "+1.5 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Forearms",
+					"cost_type": "to_original_cost",
+					"cost": "+25",
+					"weight_type": "to_original_weight",
+					"weight": "+7.5 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Hands",
+					"cost_type": "to_original_cost",
+					"cost": "+10",
+					"weight_type": "to_original_weight",
+					"weight": "+3 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "hands"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Legs",
+					"cost_type": "to_original_cost",
+					"cost": "+100",
+					"weight_type": "to_original_weight",
+					"weight": "+30 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "legs"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Thighs",
+					"cost_type": "to_original_cost",
+					"cost": "+45",
+					"weight_type": "to_original_weight",
+					"weight": "+13.5 lb",
+					"notes": "Roll 1d; on 5-6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Knees",
+					"cost_type": "to_original_cost",
+					"cost": "+5",
+					"weight_type": "to_original_weight",
+					"weight": "+1.5 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shins",
+					"cost_type": "to_original_cost",
+					"cost": "+50",
+					"weight_type": "to_original_weight",
+					"weight": "+15 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Feet",
+					"cost_type": "to_original_cost",
+					"cost": "+10",
+					"weight_type": "to_original_weight",
+					"weight": "+3 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "feet"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "@Covers only half (front only, one arm, etc)@",
+					"cost_type": "to_base_cost",
+					"cost": "x0.5",
+					"weight_type": "to_base_weight",
+					"weight": "x0.5"
+				}
+			],
+			"notes": "Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47); Holdout: -3."
+		},
+		{
+			"type": "equipment",
+			"version": 1,
+			"quantity": 1,
+			"description": "Layered Leather, Light",
+			"tech_level": "1",
+			"modifiers": [
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Head",
+					"cost_type": "to_original_cost",
+					"cost": "+36",
+					"weight_type": "to_original_weight",
+					"weight": "+4.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "skull"
+						},
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Skull",
+					"cost_type": "to_original_cost",
+					"cost": "+24",
+					"weight_type": "to_original_weight",
+					"weight": "+3 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "skull"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Face",
+					"cost_type": "to_original_cost",
+					"cost": "+12",
+					"weight_type": "to_original_weight",
+					"weight": "+1.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Neck",
+					"cost_type": "to_original_cost",
+					"cost": "+6",
+					"weight_type": "to_original_weight",
+					"weight": "+0.75 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "neck"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Torso",
+					"cost_type": "to_original_cost",
+					"cost": "+120",
+					"weight_type": "to_original_weight",
+					"weight": "+15 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "torso"
+						}
+					],
+					"notes": "Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Chest",
+					"cost_type": "to_original_cost",
+					"cost": "+90",
+					"weight_type": "to_original_weight",
+					"weight": "+11.25 lb",
+					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Abdomen",
+					"cost_type": "to_original_cost",
+					"cost": "+90",
+					"weight_type": "to_original_weight",
+					"weight": "+11.25 lb",
+					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Groin",
+					"cost_type": "to_original_cost",
+					"cost": "+6",
+					"weight_type": "to_original_weight",
+					"weight": "+0.75 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "groin"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+60",
+					"weight_type": "to_original_weight",
+					"weight": "+7.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "arms"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shoulders",
+					"cost_type": "to_original_cost",
+					"cost": "+12",
+					"weight_type": "to_original_weight",
+					"weight": "+1.5 lb",
+					"notes": "Roll 1d; on 6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Upper Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+12",
+					"weight_type": "to_original_weight",
+					"weight": "+1.5 lb",
+					"notes": "Roll 1d; on 5, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Elbows",
+					"cost_type": "to_original_cost",
+					"cost": "+6",
+					"weight_type": "to_original_weight",
+					"weight": "+0.75 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Forearms",
+					"cost_type": "to_original_cost",
+					"cost": "+30",
+					"weight_type": "to_original_weight",
+					"weight": "+3.75 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Hands",
+					"cost_type": "to_original_cost",
+					"cost": "+12",
+					"weight_type": "to_original_weight",
+					"weight": "+1.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "hands"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Legs",
+					"cost_type": "to_original_cost",
+					"cost": "+120",
+					"weight_type": "to_original_weight",
+					"weight": "+15 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "legs"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Thighs",
+					"cost_type": "to_original_cost",
+					"cost": "+54",
+					"weight_type": "to_original_weight",
+					"weight": "+6.75 lb",
+					"notes": "Roll 1d; on 5-6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Knees",
+					"cost_type": "to_original_cost",
+					"cost": "+6",
+					"weight_type": "to_original_weight",
+					"weight": "+0.75 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shins",
+					"cost_type": "to_original_cost",
+					"cost": "+60",
+					"weight_type": "to_original_weight",
+					"weight": "+7.5 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Feet",
+					"cost_type": "to_original_cost",
+					"cost": "+12",
+					"weight_type": "to_original_weight",
+					"weight": "+1.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "feet"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "@Covers only half (front only, one arm, etc)@",
+					"cost_type": "to_base_cost",
+					"cost": "x0.5",
+					"weight_type": "to_base_weight",
+					"weight": "x0.5"
+				}
+			],
+			"notes": "Flexible, susceptible to blunt trauma; Holdout: -1."
+		},
+		{
+			"type": "equipment",
+			"version": 1,
+			"quantity": 1,
+			"description": "Layered Leather, Medium",
+			"tech_level": "1",
+			"modifiers": [
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Head",
+					"cost_type": "to_original_cost",
+					"cost": "+66",
+					"weight_type": "to_original_weight",
+					"weight": "+7.8 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "skull"
+						},
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Skull",
+					"cost_type": "to_original_cost",
+					"cost": "+44",
+					"weight_type": "to_original_weight",
+					"weight": "+5.2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "skull"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Face",
+					"cost_type": "to_original_cost",
+					"cost": "+22",
+					"weight_type": "to_original_weight",
+					"weight": "+2.6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Neck",
+					"cost_type": "to_original_cost",
+					"cost": "+11",
+					"weight_type": "to_original_weight",
+					"weight": "+1.3 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "neck"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Torso",
+					"cost_type": "to_original_cost",
+					"cost": "+220",
+					"weight_type": "to_original_weight",
+					"weight": "+26 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "torso"
+						}
+					],
+					"notes": "Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Chest",
+					"cost_type": "to_original_cost",
+					"cost": "+165",
+					"weight_type": "to_original_weight",
+					"weight": "+19.5 lb",
+					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Abdomen",
+					"cost_type": "to_original_cost",
+					"cost": "+165",
+					"weight_type": "to_original_weight",
+					"weight": "+19.5 lb",
+					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Groin",
+					"cost_type": "to_original_cost",
+					"cost": "+11",
+					"weight_type": "to_original_weight",
+					"weight": "+1.3 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "groin"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+110",
+					"weight_type": "to_original_weight",
+					"weight": "+13 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "arms"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shoulders",
+					"cost_type": "to_original_cost",
+					"cost": "+22",
+					"weight_type": "to_original_weight",
+					"weight": "+2.6 lb",
+					"notes": "Roll 1d; on 6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Upper Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+22",
+					"weight_type": "to_original_weight",
+					"weight": "+2.6 lb",
+					"notes": "Roll 1d; on 5, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Elbows",
+					"cost_type": "to_original_cost",
+					"cost": "+11",
+					"weight_type": "to_original_weight",
+					"weight": "+1.3 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Forearms",
+					"cost_type": "to_original_cost",
+					"cost": "+55",
+					"weight_type": "to_original_weight",
+					"weight": "+6.5 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Hands",
+					"cost_type": "to_original_cost",
+					"cost": "+22",
+					"weight_type": "to_original_weight",
+					"weight": "+2.6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "hands"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Legs",
+					"cost_type": "to_original_cost",
+					"cost": "+220",
+					"weight_type": "to_original_weight",
+					"weight": "+26 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "legs"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Thighs",
+					"cost_type": "to_original_cost",
+					"cost": "+99",
+					"weight_type": "to_original_weight",
+					"weight": "+11.7 lb",
+					"notes": "Roll 1d; on 5-6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Knees",
+					"cost_type": "to_original_cost",
+					"cost": "+11",
+					"weight_type": "to_original_weight",
+					"weight": "+1.3 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shins",
+					"cost_type": "to_original_cost",
+					"cost": "+110",
+					"weight_type": "to_original_weight",
+					"weight": "+13 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Feet",
+					"cost_type": "to_original_cost",
+					"cost": "+22",
+					"weight_type": "to_original_weight",
+					"weight": "+2.6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "feet"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "@Covers only half (front only, one arm, etc)@",
+					"cost_type": "to_base_cost",
+					"cost": "x0.5",
+					"weight_type": "to_base_weight",
+					"weight": "x0.5"
+				}
+			],
+			"notes": "Holdout: -3."
+		},
+		{
+			"type": "equipment",
+			"version": 1,
+			"quantity": 1,
+			"description": "Layered Leather, Heavy",
+			"tech_level": "1",
+			"modifiers": [
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Head",
+					"cost_type": "to_original_cost",
+					"cost": "+157.5",
+					"weight_type": "to_original_weight",
+					"weight": "+10.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "skull"
+						},
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Skull",
+					"cost_type": "to_original_cost",
+					"cost": "+105",
+					"weight_type": "to_original_weight",
+					"weight": "+7 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "skull"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Face",
+					"cost_type": "to_original_cost",
+					"cost": "+52.5",
+					"weight_type": "to_original_weight",
+					"weight": "+3.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Neck",
+					"cost_type": "to_original_cost",
+					"cost": "+26.25",
+					"weight_type": "to_original_weight",
+					"weight": "+1.75 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "neck"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Torso",
+					"cost_type": "to_original_cost",
+					"cost": "+525",
+					"weight_type": "to_original_weight",
+					"weight": "+35 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "torso"
+						}
+					],
+					"notes": "Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Chest",
+					"cost_type": "to_original_cost",
+					"cost": "+393.75",
+					"weight_type": "to_original_weight",
+					"weight": "+26.25 lb",
+					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Abdomen",
+					"cost_type": "to_original_cost",
+					"cost": "+393.75",
+					"weight_type": "to_original_weight",
+					"weight": "+26.25 lb",
+					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Groin",
+					"cost_type": "to_original_cost",
+					"cost": "+26.25",
+					"weight_type": "to_original_weight",
+					"weight": "+1.75 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "groin"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+262.5",
+					"weight_type": "to_original_weight",
+					"weight": "+17.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "arms"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shoulders",
+					"cost_type": "to_original_cost",
+					"cost": "+52.5",
+					"weight_type": "to_original_weight",
+					"weight": "+3.5 lb",
+					"notes": "Roll 1d; on 6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Upper Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+52.5",
+					"weight_type": "to_original_weight",
+					"weight": "+3.5 lb",
+					"notes": "Roll 1d; on 5, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Elbows",
+					"cost_type": "to_original_cost",
+					"cost": "+26.25",
+					"weight_type": "to_original_weight",
+					"weight": "+1.75 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Forearms",
+					"cost_type": "to_original_cost",
+					"cost": "+131.25",
+					"weight_type": "to_original_weight",
+					"weight": "+8.75 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Hands",
+					"cost_type": "to_original_cost",
+					"cost": "+52.5",
+					"weight_type": "to_original_weight",
+					"weight": "+3.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "hands"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Legs",
+					"cost_type": "to_original_cost",
+					"cost": "+525",
+					"weight_type": "to_original_weight",
+					"weight": "+35 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "legs"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Thighs",
+					"cost_type": "to_original_cost",
+					"cost": "+236.25",
+					"weight_type": "to_original_weight",
+					"weight": "+15.75 lb",
+					"notes": "Roll 1d; on 5-6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Knees",
+					"cost_type": "to_original_cost",
+					"cost": "+26.25",
+					"weight_type": "to_original_weight",
+					"weight": "+1.75 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shins",
+					"cost_type": "to_original_cost",
+					"cost": "+262.5",
+					"weight_type": "to_original_weight",
+					"weight": "+17.5 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Feet",
+					"cost_type": "to_original_cost",
+					"cost": "+52.5",
+					"weight_type": "to_original_weight",
+					"weight": "+3.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "feet"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "@Covers only half (front only, one arm, etc)@",
+					"cost_type": "to_base_cost",
+					"cost": "x0.5",
+					"weight_type": "to_base_weight",
+					"weight": "x0.5"
+				}
+			],
+			"notes": "Holdout: -4."
+		},
+		{
+			"type": "equipment",
+			"version": 1,
+			"quantity": 1,
+			"description": "Scale, Light",
+			"tech_level": "1",
+			"modifiers": [
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Head",
+					"cost_type": "to_original_cost",
+					"cost": "+96",
+					"weight_type": "to_original_weight",
+					"weight": "+4.8 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "skull"
+						},
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Skull",
+					"cost_type": "to_original_cost",
+					"cost": "+64",
+					"weight_type": "to_original_weight",
+					"weight": "+3.2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "skull"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Face",
+					"cost_type": "to_original_cost",
+					"cost": "+32",
+					"weight_type": "to_original_weight",
+					"weight": "+1.6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Neck",
+					"cost_type": "to_original_cost",
+					"cost": "+16",
+					"weight_type": "to_original_weight",
+					"weight": "+0.8 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "neck"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Torso",
+					"cost_type": "to_original_cost",
+					"cost": "+320",
+					"weight_type": "to_original_weight",
+					"weight": "+16 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "torso"
+						}
+					],
+					"notes": "Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Chest",
+					"cost_type": "to_original_cost",
+					"cost": "+240",
+					"weight_type": "to_original_weight",
+					"weight": "+12 lb",
+					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Abdomen",
+					"cost_type": "to_original_cost",
+					"cost": "+240",
+					"weight_type": "to_original_weight",
+					"weight": "+12 lb",
+					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Groin",
+					"cost_type": "to_original_cost",
+					"cost": "+16",
+					"weight_type": "to_original_weight",
+					"weight": "+0.8 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "groin"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+160",
+					"weight_type": "to_original_weight",
+					"weight": "+8 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "arms"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shoulders",
+					"cost_type": "to_original_cost",
+					"cost": "+32",
+					"weight_type": "to_original_weight",
+					"weight": "+1.6 lb",
+					"notes": "Roll 1d; on 6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Upper Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+32",
+					"weight_type": "to_original_weight",
+					"weight": "+1.6 lb",
+					"notes": "Roll 1d; on 5, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Elbows",
+					"cost_type": "to_original_cost",
+					"cost": "+16",
+					"weight_type": "to_original_weight",
+					"weight": "+0.8 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Forearms",
+					"cost_type": "to_original_cost",
+					"cost": "+80",
+					"weight_type": "to_original_weight",
+					"weight": "+4 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Hands",
+					"cost_type": "to_original_cost",
+					"cost": "+32",
+					"weight_type": "to_original_weight",
+					"weight": "+1.6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "hands"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Legs",
+					"cost_type": "to_original_cost",
+					"cost": "+320",
+					"weight_type": "to_original_weight",
+					"weight": "+16 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "legs"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Thighs",
+					"cost_type": "to_original_cost",
+					"cost": "+144",
+					"weight_type": "to_original_weight",
+					"weight": "+7.2 lb",
+					"notes": "Roll 1d; on 5-6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Knees",
+					"cost_type": "to_original_cost",
+					"cost": "+16",
+					"weight_type": "to_original_weight",
+					"weight": "+0.8 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shins",
+					"cost_type": "to_original_cost",
+					"cost": "+160",
+					"weight_type": "to_original_weight",
+					"weight": "+8 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Feet",
+					"cost_type": "to_original_cost",
+					"cost": "+32",
+					"weight_type": "to_original_weight",
+					"weight": "+1.6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "feet"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "@Covers only half (front only, one arm, etc)@",
+					"cost_type": "to_base_cost",
+					"cost": "x0.5",
+					"weight_type": "to_base_weight",
+					"weight": "x0.5"
+				}
+			],
+			"notes": "-1 DR vs. crushing; Holdout: -3."
+		},
+		{
+			"type": "equipment",
+			"version": 1,
+			"quantity": 1,
+			"description": "Scale, Medium",
+			"tech_level": "1",
+			"modifiers": [
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Head",
+					"cost_type": "to_original_cost",
+					"cost": "+165",
+					"weight_type": "to_original_weight",
+					"weight": "+8.4 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "skull"
+						},
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Skull",
+					"cost_type": "to_original_cost",
+					"cost": "+110",
+					"weight_type": "to_original_weight",
+					"weight": "+5.6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "skull"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Face",
+					"cost_type": "to_original_cost",
+					"cost": "+55",
+					"weight_type": "to_original_weight",
+					"weight": "+2.8 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Neck",
+					"cost_type": "to_original_cost",
+					"cost": "+27.5",
+					"weight_type": "to_original_weight",
+					"weight": "+1.4 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "neck"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Torso",
+					"cost_type": "to_original_cost",
+					"cost": "+550",
+					"weight_type": "to_original_weight",
+					"weight": "+28 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "torso"
+						}
+					],
+					"notes": "Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Chest",
+					"cost_type": "to_original_cost",
+					"cost": "+412.5",
+					"weight_type": "to_original_weight",
+					"weight": "+21 lb",
+					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Abdomen",
+					"cost_type": "to_original_cost",
+					"cost": "+412.5",
+					"weight_type": "to_original_weight",
+					"weight": "+21 lb",
+					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Groin",
+					"cost_type": "to_original_cost",
+					"cost": "+27.5",
+					"weight_type": "to_original_weight",
+					"weight": "+1.4 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "groin"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+275",
+					"weight_type": "to_original_weight",
+					"weight": "+14 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "arms"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shoulders",
+					"cost_type": "to_original_cost",
+					"cost": "+55",
+					"weight_type": "to_original_weight",
+					"weight": "+2.8 lb",
+					"notes": "Roll 1d; on 6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Upper Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+55",
+					"weight_type": "to_original_weight",
+					"weight": "+2.8 lb",
+					"notes": "Roll 1d; on 5, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Elbows",
+					"cost_type": "to_original_cost",
+					"cost": "+27.5",
+					"weight_type": "to_original_weight",
+					"weight": "+1.4 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Forearms",
+					"cost_type": "to_original_cost",
+					"cost": "+137.5",
+					"weight_type": "to_original_weight",
+					"weight": "+7 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Hands",
+					"cost_type": "to_original_cost",
+					"cost": "+55",
+					"weight_type": "to_original_weight",
+					"weight": "+2.8 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "hands"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Legs",
+					"cost_type": "to_original_cost",
+					"cost": "+550",
+					"weight_type": "to_original_weight",
+					"weight": "+28 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "legs"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Thighs",
+					"cost_type": "to_original_cost",
+					"cost": "+247.5",
+					"weight_type": "to_original_weight",
+					"weight": "+12.6 lb",
+					"notes": "Roll 1d; on 5-6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Knees",
+					"cost_type": "to_original_cost",
+					"cost": "+27.5",
+					"weight_type": "to_original_weight",
+					"weight": "+1.4 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shins",
+					"cost_type": "to_original_cost",
+					"cost": "+275",
+					"weight_type": "to_original_weight",
+					"weight": "+14 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Feet",
+					"cost_type": "to_original_cost",
+					"cost": "+55",
+					"weight_type": "to_original_weight",
+					"weight": "+2.8 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "feet"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "@Covers only half (front only, one arm, etc)@",
+					"cost_type": "to_base_cost",
+					"cost": "x0.5",
+					"weight_type": "to_base_weight",
+					"weight": "x0.5"
+				}
+			],
+			"notes": "-1 DR vs. crushing; Holdout: -4."
+		},
+		{
+			"type": "equipment",
+			"version": 1,
+			"quantity": 1,
+			"description": "Scale, Heavy",
+			"tech_level": "1",
+			"modifiers": [
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Head",
+					"cost_type": "to_original_cost",
+					"cost": "+330",
+					"weight_type": "to_original_weight",
+					"weight": "+12 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "skull"
+						},
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Skull",
+					"cost_type": "to_original_cost",
+					"cost": "+220",
+					"weight_type": "to_original_weight",
+					"weight": "+8 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "skull"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Face",
+					"cost_type": "to_original_cost",
+					"cost": "+110",
+					"weight_type": "to_original_weight",
+					"weight": "+4 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Neck",
+					"cost_type": "to_original_cost",
+					"cost": "+55",
+					"weight_type": "to_original_weight",
+					"weight": "+2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "neck"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Torso",
+					"cost_type": "to_original_cost",
+					"cost": "+1100",
+					"weight_type": "to_original_weight",
+					"weight": "+40 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "torso"
+						}
+					],
+					"notes": "Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Chest",
+					"cost_type": "to_original_cost",
+					"cost": "+825",
+					"weight_type": "to_original_weight",
+					"weight": "+30 lb",
+					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Abdomen",
+					"cost_type": "to_original_cost",
+					"cost": "+825",
+					"weight_type": "to_original_weight",
+					"weight": "+30 lb",
+					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Groin",
+					"cost_type": "to_original_cost",
+					"cost": "+55",
+					"weight_type": "to_original_weight",
+					"weight": "+2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "groin"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+550",
+					"weight_type": "to_original_weight",
+					"weight": "+20 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "arms"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shoulders",
+					"cost_type": "to_original_cost",
+					"cost": "+110",
+					"weight_type": "to_original_weight",
+					"weight": "+4 lb",
+					"notes": "Roll 1d; on 6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Upper Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+110",
+					"weight_type": "to_original_weight",
+					"weight": "+4 lb",
+					"notes": "Roll 1d; on 5, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Elbows",
+					"cost_type": "to_original_cost",
+					"cost": "+55",
+					"weight_type": "to_original_weight",
+					"weight": "+2 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Forearms",
+					"cost_type": "to_original_cost",
+					"cost": "+275",
+					"weight_type": "to_original_weight",
+					"weight": "+10 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Hands",
+					"cost_type": "to_original_cost",
+					"cost": "+110",
+					"weight_type": "to_original_weight",
+					"weight": "+4 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "hands"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Legs",
+					"cost_type": "to_original_cost",
+					"cost": "+1100",
+					"weight_type": "to_original_weight",
+					"weight": "+40 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "legs"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Thighs",
+					"cost_type": "to_original_cost",
+					"cost": "+495",
+					"weight_type": "to_original_weight",
+					"weight": "+18 lb",
+					"notes": "Roll 1d; on 5-6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Knees",
+					"cost_type": "to_original_cost",
+					"cost": "+55",
+					"weight_type": "to_original_weight",
+					"weight": "+2 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shins",
+					"cost_type": "to_original_cost",
+					"cost": "+550",
+					"weight_type": "to_original_weight",
+					"weight": "+20 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Feet",
+					"cost_type": "to_original_cost",
+					"cost": "+110",
+					"weight_type": "to_original_weight",
+					"weight": "+4 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "feet"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "@Covers only half (front only, one arm, etc)@",
+					"cost_type": "to_base_cost",
+					"cost": "x0.5",
+					"weight_type": "to_base_weight",
+					"weight": "x0.5"
+				}
+			],
+			"notes": "Holdout: -5."
+		},
+		{
+			"type": "equipment",
+			"version": 1,
+			"quantity": 1,
+			"description": "Hardened Leather, Medium",
+			"tech_level": "2",
+			"modifiers": [
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Head",
+					"cost_type": "to_original_cost",
+					"cost": "+37.5",
+					"weight_type": "to_original_weight",
+					"weight": "+4.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "skull"
+						},
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Skull",
+					"cost_type": "to_original_cost",
+					"cost": "+25",
+					"weight_type": "to_original_weight",
+					"weight": "+3 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "skull"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Face",
+					"cost_type": "to_original_cost",
+					"cost": "+12.5",
+					"weight_type": "to_original_weight",
+					"weight": "+1.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Neck",
+					"cost_type": "to_original_cost",
+					"cost": "+6.25",
+					"weight_type": "to_original_weight",
+					"weight": "+0.75 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "neck"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Torso",
+					"cost_type": "to_original_cost",
+					"cost": "+125",
+					"weight_type": "to_original_weight",
+					"weight": "+15 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "torso"
+						}
+					],
+					"notes": "Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Chest",
+					"cost_type": "to_original_cost",
+					"cost": "+93.75",
+					"weight_type": "to_original_weight",
+					"weight": "+11.25 lb",
+					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Abdomen",
+					"cost_type": "to_original_cost",
+					"cost": "+93.75",
+					"weight_type": "to_original_weight",
+					"weight": "+11.25 lb",
+					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Groin",
+					"cost_type": "to_original_cost",
+					"cost": "+6.25",
+					"weight_type": "to_original_weight",
+					"weight": "+0.75 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "groin"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+62.5",
+					"weight_type": "to_original_weight",
+					"weight": "+7.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "arms"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shoulders",
+					"cost_type": "to_original_cost",
+					"cost": "+12.5",
+					"weight_type": "to_original_weight",
+					"weight": "+1.5 lb",
+					"notes": "Roll 1d; on 6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Upper Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+12.5",
+					"weight_type": "to_original_weight",
+					"weight": "+1.5 lb",
+					"notes": "Roll 1d; on 5, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Elbows",
+					"cost_type": "to_original_cost",
+					"cost": "+6.25",
+					"weight_type": "to_original_weight",
+					"weight": "+0.75 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Forearms",
+					"cost_type": "to_original_cost",
+					"cost": "+31.25",
+					"weight_type": "to_original_weight",
+					"weight": "+3.75 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Hands",
+					"cost_type": "to_original_cost",
+					"cost": "+12.5",
+					"weight_type": "to_original_weight",
+					"weight": "+1.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "hands"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Legs",
+					"cost_type": "to_original_cost",
+					"cost": "+125",
+					"weight_type": "to_original_weight",
+					"weight": "+15 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "legs"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Thighs",
+					"cost_type": "to_original_cost",
+					"cost": "+56.25",
+					"weight_type": "to_original_weight",
+					"weight": "+6.75 lb",
+					"notes": "Roll 1d; on 5-6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Knees",
+					"cost_type": "to_original_cost",
+					"cost": "+6.25",
+					"weight_type": "to_original_weight",
+					"weight": "+0.75 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shins",
+					"cost_type": "to_original_cost",
+					"cost": "+62.5",
+					"weight_type": "to_original_weight",
+					"weight": "+7.5 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Feet",
+					"cost_type": "to_original_cost",
+					"cost": "+12.5",
+					"weight_type": "to_original_weight",
+					"weight": "+1.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 2,
+							"location": "feet"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "@Covers only half (front only, one arm, etc)@",
+					"cost_type": "to_base_cost",
+					"cost": "x0.5",
+					"weight_type": "to_base_weight",
+					"weight": "x0.5"
+				}
+			],
+			"notes": "Holdout: -2."
+		},
+		{
+			"type": "equipment",
+			"version": 1,
+			"quantity": 1,
+			"description": "Hardened Leather, Heavy",
+			"tech_level": "2",
+			"modifiers": [
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Head",
+					"cost_type": "to_original_cost",
+					"cost": "+75",
+					"weight_type": "to_original_weight",
+					"weight": "+7.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "skull"
+						},
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Skull",
+					"cost_type": "to_original_cost",
+					"cost": "+50",
+					"weight_type": "to_original_weight",
+					"weight": "+5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "skull"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Face",
+					"cost_type": "to_original_cost",
+					"cost": "+25",
+					"weight_type": "to_original_weight",
+					"weight": "+2.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Neck",
+					"cost_type": "to_original_cost",
+					"cost": "+12.5",
+					"weight_type": "to_original_weight",
+					"weight": "+1.25 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "neck"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Torso",
+					"cost_type": "to_original_cost",
+					"cost": "+250",
+					"weight_type": "to_original_weight",
+					"weight": "+25 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "torso"
+						}
+					],
+					"notes": "Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Chest",
+					"cost_type": "to_original_cost",
+					"cost": "+187.5",
+					"weight_type": "to_original_weight",
+					"weight": "+18.75 lb",
+					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Abdomen",
+					"cost_type": "to_original_cost",
+					"cost": "+187.5",
+					"weight_type": "to_original_weight",
+					"weight": "+18.75 lb",
+					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Groin",
+					"cost_type": "to_original_cost",
+					"cost": "+12.5",
+					"weight_type": "to_original_weight",
+					"weight": "+1.25 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "groin"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+125",
+					"weight_type": "to_original_weight",
+					"weight": "+12.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "arms"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shoulders",
+					"cost_type": "to_original_cost",
+					"cost": "+25",
+					"weight_type": "to_original_weight",
+					"weight": "+2.5 lb",
+					"notes": "Roll 1d; on 6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Upper Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+25",
+					"weight_type": "to_original_weight",
+					"weight": "+2.5 lb",
+					"notes": "Roll 1d; on 5, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Elbows",
+					"cost_type": "to_original_cost",
+					"cost": "+12.5",
+					"weight_type": "to_original_weight",
+					"weight": "+1.25 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Forearms",
+					"cost_type": "to_original_cost",
+					"cost": "+62.5",
+					"weight_type": "to_original_weight",
+					"weight": "+6.25 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Hands",
+					"cost_type": "to_original_cost",
+					"cost": "+25",
+					"weight_type": "to_original_weight",
+					"weight": "+2.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "hands"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Legs",
+					"cost_type": "to_original_cost",
+					"cost": "+250",
+					"weight_type": "to_original_weight",
+					"weight": "+25 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "legs"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Thighs",
+					"cost_type": "to_original_cost",
+					"cost": "+112.5",
+					"weight_type": "to_original_weight",
+					"weight": "+11.25 lb",
+					"notes": "Roll 1d; on 5-6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Knees",
+					"cost_type": "to_original_cost",
+					"cost": "+12.5",
+					"weight_type": "to_original_weight",
+					"weight": "+1.25 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shins",
+					"cost_type": "to_original_cost",
+					"cost": "+125",
+					"weight_type": "to_original_weight",
+					"weight": "+12.5 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Feet",
+					"cost_type": "to_original_cost",
+					"cost": "+25",
+					"weight_type": "to_original_weight",
+					"weight": "+2.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "feet"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "@Covers only half (front only, one arm, etc)@",
+					"cost_type": "to_base_cost",
+					"cost": "x0.5",
+					"weight_type": "to_base_weight",
+					"weight": "x0.5"
+				}
+			],
+			"notes": "Holdout: -3."
+		},
+		{
+			"type": "equipment",
+			"version": 1,
+			"quantity": 1,
+			"description": "Jack of Plates",
+			"tech_level": "2",
+			"modifiers": [
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Head",
+					"cost_type": "to_original_cost",
+					"cost": "+90",
+					"weight_type": "to_original_weight",
+					"weight": "+5.4 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "skull"
+						},
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Skull",
+					"cost_type": "to_original_cost",
+					"cost": "+60",
+					"weight_type": "to_original_weight",
+					"weight": "+3.6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "skull"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Face",
+					"cost_type": "to_original_cost",
+					"cost": "+30",
+					"weight_type": "to_original_weight",
+					"weight": "+1.8 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Neck",
+					"cost_type": "to_original_cost",
+					"cost": "+15",
+					"weight_type": "to_original_weight",
+					"weight": "+0.9 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "neck"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Torso",
+					"cost_type": "to_original_cost",
+					"cost": "+300",
+					"weight_type": "to_original_weight",
+					"weight": "+18 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "torso"
+						}
+					],
+					"notes": "Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Chest",
+					"cost_type": "to_original_cost",
+					"cost": "+225",
+					"weight_type": "to_original_weight",
+					"weight": "+13.5 lb",
+					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Abdomen",
+					"cost_type": "to_original_cost",
+					"cost": "+225",
+					"weight_type": "to_original_weight",
+					"weight": "+13.5 lb",
+					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Groin",
+					"cost_type": "to_original_cost",
+					"cost": "+15",
+					"weight_type": "to_original_weight",
+					"weight": "+0.9 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "groin"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+150",
+					"weight_type": "to_original_weight",
+					"weight": "+9 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "arms"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shoulders",
+					"cost_type": "to_original_cost",
+					"cost": "+30",
+					"weight_type": "to_original_weight",
+					"weight": "+1.8 lb",
+					"notes": "Roll 1d; on 6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Upper Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+30",
+					"weight_type": "to_original_weight",
+					"weight": "+1.8 lb",
+					"notes": "Roll 1d; on 5, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Elbows",
+					"cost_type": "to_original_cost",
+					"cost": "+15",
+					"weight_type": "to_original_weight",
+					"weight": "+0.9 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Forearms",
+					"cost_type": "to_original_cost",
+					"cost": "+75",
+					"weight_type": "to_original_weight",
+					"weight": "+4.5 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Hands",
+					"cost_type": "to_original_cost",
+					"cost": "+30",
+					"weight_type": "to_original_weight",
+					"weight": "+1.8 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "hands"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Legs",
+					"cost_type": "to_original_cost",
+					"cost": "+300",
+					"weight_type": "to_original_weight",
+					"weight": "+18 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "legs"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Thighs",
+					"cost_type": "to_original_cost",
+					"cost": "+135",
+					"weight_type": "to_original_weight",
+					"weight": "+8.1 lb",
+					"notes": "Roll 1d; on 5-6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Knees",
+					"cost_type": "to_original_cost",
+					"cost": "+15",
+					"weight_type": "to_original_weight",
+					"weight": "+0.9 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shins",
+					"cost_type": "to_original_cost",
+					"cost": "+150",
+					"weight_type": "to_original_weight",
+					"weight": "+9 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Feet",
+					"cost_type": "to_original_cost",
+					"cost": "+30",
+					"weight_type": "to_original_weight",
+					"weight": "+1.8 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "feet"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "@Covers only half (front only, one arm, etc)@",
+					"cost_type": "to_base_cost",
+					"cost": "x0.5",
+					"weight_type": "to_base_weight",
+					"weight": "x0.5"
+				}
+			],
+			"notes": "-1 DR vs. crushing; Holdout: -3."
+		},
+		{
+			"type": "equipment",
+			"version": 1,
+			"quantity": 1,
+			"description": "Mail, Light",
+			"tech_level": "2",
+			"modifiers": [
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Head",
+					"cost_type": "to_original_cost",
+					"cost": "+150",
+					"weight_type": "to_original_weight",
+					"weight": "+3.6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "skull"
+						},
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Skull",
+					"cost_type": "to_original_cost",
+					"cost": "+100",
+					"weight_type": "to_original_weight",
+					"weight": "+2.4 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "skull"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Face",
+					"cost_type": "to_original_cost",
+					"cost": "+50",
+					"weight_type": "to_original_weight",
+					"weight": "+1.2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Neck",
+					"cost_type": "to_original_cost",
+					"cost": "+25",
+					"weight_type": "to_original_weight",
+					"weight": "+0.6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "neck"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Torso",
+					"cost_type": "to_original_cost",
+					"cost": "+500",
+					"weight_type": "to_original_weight",
+					"weight": "+12 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "torso"
+						}
+					],
+					"notes": "Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Chest",
+					"cost_type": "to_original_cost",
+					"cost": "+375",
+					"weight_type": "to_original_weight",
+					"weight": "+9 lb",
+					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Abdomen",
+					"cost_type": "to_original_cost",
+					"cost": "+375",
+					"weight_type": "to_original_weight",
+					"weight": "+9 lb",
+					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Groin",
+					"cost_type": "to_original_cost",
+					"cost": "+25",
+					"weight_type": "to_original_weight",
+					"weight": "+0.6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "groin"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+250",
+					"weight_type": "to_original_weight",
+					"weight": "+6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "arms"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shoulders",
+					"cost_type": "to_original_cost",
+					"cost": "+50",
+					"weight_type": "to_original_weight",
+					"weight": "+1.2 lb",
+					"notes": "Roll 1d; on 6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Upper Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+50",
+					"weight_type": "to_original_weight",
+					"weight": "+1.2 lb",
+					"notes": "Roll 1d; on 5, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Elbows",
+					"cost_type": "to_original_cost",
+					"cost": "+25",
+					"weight_type": "to_original_weight",
+					"weight": "+0.6 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Forearms",
+					"cost_type": "to_original_cost",
+					"cost": "+125",
+					"weight_type": "to_original_weight",
+					"weight": "+3 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Hands",
+					"cost_type": "to_original_cost",
+					"cost": "+50",
+					"weight_type": "to_original_weight",
+					"weight": "+1.2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "hands"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Legs",
+					"cost_type": "to_original_cost",
+					"cost": "+500",
+					"weight_type": "to_original_weight",
+					"weight": "+12 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "legs"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Thighs",
+					"cost_type": "to_original_cost",
+					"cost": "+225",
+					"weight_type": "to_original_weight",
+					"weight": "+5.4 lb",
+					"notes": "Roll 1d; on 5-6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Knees",
+					"cost_type": "to_original_cost",
+					"cost": "+25",
+					"weight_type": "to_original_weight",
+					"weight": "+0.6 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shins",
+					"cost_type": "to_original_cost",
+					"cost": "+250",
+					"weight_type": "to_original_weight",
+					"weight": "+6 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Feet",
+					"cost_type": "to_original_cost",
+					"cost": "+50",
+					"weight_type": "to_original_weight",
+					"weight": "+1.2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "feet"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "@Covers only half (front only, one arm, etc)@",
+					"cost_type": "to_base_cost",
+					"cost": "x0.5",
+					"weight_type": "to_base_weight",
+					"weight": "x0.5"
+				}
+			],
+			"notes": "Flexible, susceptible to blunt trauma; -2 DR vs. crushing; Holdout: -1."
+		},
+		{
+			"type": "equipment",
+			"version": 1,
+			"quantity": 1,
+			"description": "Mail, Fine",
+			"tech_level": "2",
+			"modifiers": [
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Head",
+					"cost_type": "to_original_cost",
+					"cost": "+270",
+					"weight_type": "to_original_weight",
+					"weight": "+4.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "skull"
+						},
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Skull",
+					"cost_type": "to_original_cost",
+					"cost": "+180",
+					"weight_type": "to_original_weight",
+					"weight": "+3 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "skull"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Face",
+					"cost_type": "to_original_cost",
+					"cost": "+90",
+					"weight_type": "to_original_weight",
+					"weight": "+1.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Neck",
+					"cost_type": "to_original_cost",
+					"cost": "+45",
+					"weight_type": "to_original_weight",
+					"weight": "+0.75 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "neck"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Torso",
+					"cost_type": "to_original_cost",
+					"cost": "+900",
+					"weight_type": "to_original_weight",
+					"weight": "+15 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "torso"
+						}
+					],
+					"notes": "Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Chest",
+					"cost_type": "to_original_cost",
+					"cost": "+675",
+					"weight_type": "to_original_weight",
+					"weight": "+11.25 lb",
+					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Abdomen",
+					"cost_type": "to_original_cost",
+					"cost": "+675",
+					"weight_type": "to_original_weight",
+					"weight": "+11.25 lb",
+					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Groin",
+					"cost_type": "to_original_cost",
+					"cost": "+45",
+					"weight_type": "to_original_weight",
+					"weight": "+0.75 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "groin"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+450",
+					"weight_type": "to_original_weight",
+					"weight": "+7.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "arms"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shoulders",
+					"cost_type": "to_original_cost",
+					"cost": "+90",
+					"weight_type": "to_original_weight",
+					"weight": "+1.5 lb",
+					"notes": "Roll 1d; on 6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Upper Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+90",
+					"weight_type": "to_original_weight",
+					"weight": "+1.5 lb",
+					"notes": "Roll 1d; on 5, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Elbows",
+					"cost_type": "to_original_cost",
+					"cost": "+45",
+					"weight_type": "to_original_weight",
+					"weight": "+0.75 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Forearms",
+					"cost_type": "to_original_cost",
+					"cost": "+225",
+					"weight_type": "to_original_weight",
+					"weight": "+3.75 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Hands",
+					"cost_type": "to_original_cost",
+					"cost": "+90",
+					"weight_type": "to_original_weight",
+					"weight": "+1.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "hands"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Legs",
+					"cost_type": "to_original_cost",
+					"cost": "+900",
+					"weight_type": "to_original_weight",
+					"weight": "+15 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "legs"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Thighs",
+					"cost_type": "to_original_cost",
+					"cost": "+405",
+					"weight_type": "to_original_weight",
+					"weight": "+6.75 lb",
+					"notes": "Roll 1d; on 5-6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Knees",
+					"cost_type": "to_original_cost",
+					"cost": "+45",
+					"weight_type": "to_original_weight",
+					"weight": "+0.75 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shins",
+					"cost_type": "to_original_cost",
+					"cost": "+450",
+					"weight_type": "to_original_weight",
+					"weight": "+7.5 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Feet",
+					"cost_type": "to_original_cost",
+					"cost": "+90",
+					"weight_type": "to_original_weight",
+					"weight": "+1.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "feet"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "@Covers only half (front only, one arm, etc)@",
+					"cost_type": "to_base_cost",
+					"cost": "x0.5",
+					"weight_type": "to_base_weight",
+					"weight": "x0.5"
+				}
+			],
+			"notes": "Flexible, susceptible to blunt trauma; -2 DR vs. crushing; Holdout: -2."
+		},
+		{
+			"type": "equipment",
+			"version": 1,
+			"quantity": 1,
+			"description": "Mail, Heavy",
+			"tech_level": "2",
+			"modifiers": [
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Head",
+					"cost_type": "to_original_cost",
+					"cost": "+360",
+					"weight_type": "to_original_weight",
+					"weight": "+5.4 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "skull"
+						},
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Skull",
+					"cost_type": "to_original_cost",
+					"cost": "+240",
+					"weight_type": "to_original_weight",
+					"weight": "+3.6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "skull"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Face",
+					"cost_type": "to_original_cost",
+					"cost": "+120",
+					"weight_type": "to_original_weight",
+					"weight": "+1.8 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Neck",
+					"cost_type": "to_original_cost",
+					"cost": "+60",
+					"weight_type": "to_original_weight",
+					"weight": "+0.9 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "neck"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Torso",
+					"cost_type": "to_original_cost",
+					"cost": "+1200",
+					"weight_type": "to_original_weight",
+					"weight": "+18 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "torso"
+						}
+					],
+					"notes": "Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Chest",
+					"cost_type": "to_original_cost",
+					"cost": "+900",
+					"weight_type": "to_original_weight",
+					"weight": "+13.5 lb",
+					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Abdomen",
+					"cost_type": "to_original_cost",
+					"cost": "+900",
+					"weight_type": "to_original_weight",
+					"weight": "+13.5 lb",
+					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Groin",
+					"cost_type": "to_original_cost",
+					"cost": "+60",
+					"weight_type": "to_original_weight",
+					"weight": "+0.9 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "groin"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+600",
+					"weight_type": "to_original_weight",
+					"weight": "+9 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "arms"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shoulders",
+					"cost_type": "to_original_cost",
+					"cost": "+120",
+					"weight_type": "to_original_weight",
+					"weight": "+1.8 lb",
+					"notes": "Roll 1d; on 6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Upper Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+120",
+					"weight_type": "to_original_weight",
+					"weight": "+1.8 lb",
+					"notes": "Roll 1d; on 5, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Elbows",
+					"cost_type": "to_original_cost",
+					"cost": "+60",
+					"weight_type": "to_original_weight",
+					"weight": "+0.9 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Forearms",
+					"cost_type": "to_original_cost",
+					"cost": "+300",
+					"weight_type": "to_original_weight",
+					"weight": "+4.5 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Hands",
+					"cost_type": "to_original_cost",
+					"cost": "+120",
+					"weight_type": "to_original_weight",
+					"weight": "+1.8 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "hands"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Legs",
+					"cost_type": "to_original_cost",
+					"cost": "+1200",
+					"weight_type": "to_original_weight",
+					"weight": "+18 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "legs"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Thighs",
+					"cost_type": "to_original_cost",
+					"cost": "+540",
+					"weight_type": "to_original_weight",
+					"weight": "+8.1 lb",
+					"notes": "Roll 1d; on 5-6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Knees",
+					"cost_type": "to_original_cost",
+					"cost": "+60",
+					"weight_type": "to_original_weight",
+					"weight": "+0.9 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shins",
+					"cost_type": "to_original_cost",
+					"cost": "+600",
+					"weight_type": "to_original_weight",
+					"weight": "+9 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Feet",
+					"cost_type": "to_original_cost",
+					"cost": "+120",
+					"weight_type": "to_original_weight",
+					"weight": "+1.8 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "feet"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "@Covers only half (front only, one arm, etc)@",
+					"cost_type": "to_base_cost",
+					"cost": "x0.5",
+					"weight_type": "to_base_weight",
+					"weight": "x0.5"
+				}
+			],
+			"notes": "Flexible, susceptible to blunt trauma; -2 DR vs. crushing; Holdout: -2."
+		},
+		{
+			"type": "equipment",
+			"version": 1,
+			"quantity": 1,
+			"description": "Segmented Plate, Light",
+			"tech_level": "2",
+			"modifiers": [
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Head",
+					"cost_type": "to_original_cost",
+					"cost": "+180",
+					"weight_type": "to_original_weight",
+					"weight": "+4.8 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "skull"
+						},
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Skull",
+					"cost_type": "to_original_cost",
+					"cost": "+120",
+					"weight_type": "to_original_weight",
+					"weight": "+3.2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "skull"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Face",
+					"cost_type": "to_original_cost",
+					"cost": "+60",
+					"weight_type": "to_original_weight",
+					"weight": "+1.6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Neck",
+					"cost_type": "to_original_cost",
+					"cost": "+30",
+					"weight_type": "to_original_weight",
+					"weight": "+0.8 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "neck"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Torso",
+					"cost_type": "to_original_cost",
+					"cost": "+600",
+					"weight_type": "to_original_weight",
+					"weight": "+16 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "torso"
+						}
+					],
+					"notes": "Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Chest",
+					"cost_type": "to_original_cost",
+					"cost": "+450",
+					"weight_type": "to_original_weight",
+					"weight": "+12 lb",
+					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Abdomen",
+					"cost_type": "to_original_cost",
+					"cost": "+450",
+					"weight_type": "to_original_weight",
+					"weight": "+12 lb",
+					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Groin",
+					"cost_type": "to_original_cost",
+					"cost": "+30",
+					"weight_type": "to_original_weight",
+					"weight": "+0.8 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "groin"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+300",
+					"weight_type": "to_original_weight",
+					"weight": "+8 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "arms"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shoulders",
+					"cost_type": "to_original_cost",
+					"cost": "+60",
+					"weight_type": "to_original_weight",
+					"weight": "+1.6 lb",
+					"notes": "Roll 1d; on 6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Upper Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+60",
+					"weight_type": "to_original_weight",
+					"weight": "+1.6 lb",
+					"notes": "Roll 1d; on 5, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Elbows",
+					"cost_type": "to_original_cost",
+					"cost": "+30",
+					"weight_type": "to_original_weight",
+					"weight": "+0.8 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Forearms",
+					"cost_type": "to_original_cost",
+					"cost": "+150",
+					"weight_type": "to_original_weight",
+					"weight": "+4 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Hands",
+					"cost_type": "to_original_cost",
+					"cost": "+60",
+					"weight_type": "to_original_weight",
+					"weight": "+1.6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "hands"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Legs",
+					"cost_type": "to_original_cost",
+					"cost": "+600",
+					"weight_type": "to_original_weight",
+					"weight": "+16 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "legs"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Thighs",
+					"cost_type": "to_original_cost",
+					"cost": "+270",
+					"weight_type": "to_original_weight",
+					"weight": "+7.2 lb",
+					"notes": "Roll 1d; on 5-6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Knees",
+					"cost_type": "to_original_cost",
+					"cost": "+30",
+					"weight_type": "to_original_weight",
+					"weight": "+0.8 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shins",
+					"cost_type": "to_original_cost",
+					"cost": "+300",
+					"weight_type": "to_original_weight",
+					"weight": "+8 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Feet",
+					"cost_type": "to_original_cost",
+					"cost": "+60",
+					"weight_type": "to_original_weight",
+					"weight": "+1.6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "feet"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "@Covers only half (front only, one arm, etc)@",
+					"cost_type": "to_base_cost",
+					"cost": "x0.5",
+					"weight_type": "to_base_weight",
+					"weight": "x0.5"
+				}
+			],
+			"notes": "Holdout: -3."
+		},
+		{
+			"type": "equipment",
+			"version": 1,
+			"quantity": 1,
+			"description": "Segmented Plate, Medium",
+			"tech_level": "2",
+			"modifiers": [
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Head",
+					"cost_type": "to_original_cost",
+					"cost": "+270",
+					"weight_type": "to_original_weight",
+					"weight": "+7.2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "skull"
+						},
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Skull",
+					"cost_type": "to_original_cost",
+					"cost": "+180",
+					"weight_type": "to_original_weight",
+					"weight": "+4.8 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "skull"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Face",
+					"cost_type": "to_original_cost",
+					"cost": "+90",
+					"weight_type": "to_original_weight",
+					"weight": "+2.4 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Neck",
+					"cost_type": "to_original_cost",
+					"cost": "+45",
+					"weight_type": "to_original_weight",
+					"weight": "+1.2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "neck"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Torso",
+					"cost_type": "to_original_cost",
+					"cost": "+900",
+					"weight_type": "to_original_weight",
+					"weight": "+24 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "torso"
+						}
+					],
+					"notes": "Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Chest",
+					"cost_type": "to_original_cost",
+					"cost": "+675",
+					"weight_type": "to_original_weight",
+					"weight": "+18 lb",
+					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Abdomen",
+					"cost_type": "to_original_cost",
+					"cost": "+675",
+					"weight_type": "to_original_weight",
+					"weight": "+18 lb",
+					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Groin",
+					"cost_type": "to_original_cost",
+					"cost": "+45",
+					"weight_type": "to_original_weight",
+					"weight": "+1.2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "groin"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+450",
+					"weight_type": "to_original_weight",
+					"weight": "+12 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "arms"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shoulders",
+					"cost_type": "to_original_cost",
+					"cost": "+90",
+					"weight_type": "to_original_weight",
+					"weight": "+2.4 lb",
+					"notes": "Roll 1d; on 6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Upper Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+90",
+					"weight_type": "to_original_weight",
+					"weight": "+2.4 lb",
+					"notes": "Roll 1d; on 5, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Elbows",
+					"cost_type": "to_original_cost",
+					"cost": "+45",
+					"weight_type": "to_original_weight",
+					"weight": "+1.2 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Forearms",
+					"cost_type": "to_original_cost",
+					"cost": "+225",
+					"weight_type": "to_original_weight",
+					"weight": "+6 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Hands",
+					"cost_type": "to_original_cost",
+					"cost": "+90",
+					"weight_type": "to_original_weight",
+					"weight": "+2.4 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "hands"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Legs",
+					"cost_type": "to_original_cost",
+					"cost": "+900",
+					"weight_type": "to_original_weight",
+					"weight": "+24 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "legs"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Thighs",
+					"cost_type": "to_original_cost",
+					"cost": "+405",
+					"weight_type": "to_original_weight",
+					"weight": "+10.8 lb",
+					"notes": "Roll 1d; on 5-6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Knees",
+					"cost_type": "to_original_cost",
+					"cost": "+45",
+					"weight_type": "to_original_weight",
+					"weight": "+1.2 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shins",
+					"cost_type": "to_original_cost",
+					"cost": "+450",
+					"weight_type": "to_original_weight",
+					"weight": "+12 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Feet",
+					"cost_type": "to_original_cost",
+					"cost": "+90",
+					"weight_type": "to_original_weight",
+					"weight": "+2.4 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 4,
+							"location": "feet"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "@Covers only half (front only, one arm, etc)@",
+					"cost_type": "to_base_cost",
+					"cost": "x0.5",
+					"weight_type": "to_base_weight",
+					"weight": "x0.5"
+				}
+			],
+			"notes": "Holdout: -4."
+		},
+		{
+			"type": "equipment",
+			"version": 1,
+			"quantity": 1,
+			"description": "Segmented Plate, Heavy",
+			"tech_level": "2",
+			"modifiers": [
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Head",
+					"cost_type": "to_original_cost",
+					"cost": "+360",
+					"weight_type": "to_original_weight",
+					"weight": "+9.6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "skull"
+						},
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Skull",
+					"cost_type": "to_original_cost",
+					"cost": "+240",
+					"weight_type": "to_original_weight",
+					"weight": "+6.4 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "skull"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Face",
+					"cost_type": "to_original_cost",
+					"cost": "+120",
+					"weight_type": "to_original_weight",
+					"weight": "+3.2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Neck",
+					"cost_type": "to_original_cost",
+					"cost": "+60",
+					"weight_type": "to_original_weight",
+					"weight": "+1.6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "neck"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Torso",
+					"cost_type": "to_original_cost",
+					"cost": "+1200",
+					"weight_type": "to_original_weight",
+					"weight": "+32 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "torso"
+						}
+					],
+					"notes": "Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Chest",
+					"cost_type": "to_original_cost",
+					"cost": "+900",
+					"weight_type": "to_original_weight",
+					"weight": "+24 lb",
+					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Abdomen",
+					"cost_type": "to_original_cost",
+					"cost": "+900",
+					"weight_type": "to_original_weight",
+					"weight": "+24 lb",
+					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Groin",
+					"cost_type": "to_original_cost",
+					"cost": "+60",
+					"weight_type": "to_original_weight",
+					"weight": "+1.6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "groin"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+600",
+					"weight_type": "to_original_weight",
+					"weight": "+16 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "arms"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shoulders",
+					"cost_type": "to_original_cost",
+					"cost": "+120",
+					"weight_type": "to_original_weight",
+					"weight": "+3.2 lb",
+					"notes": "Roll 1d; on 6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Upper Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+120",
+					"weight_type": "to_original_weight",
+					"weight": "+3.2 lb",
+					"notes": "Roll 1d; on 5, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Elbows",
+					"cost_type": "to_original_cost",
+					"cost": "+60",
+					"weight_type": "to_original_weight",
+					"weight": "+1.6 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Forearms",
+					"cost_type": "to_original_cost",
+					"cost": "+300",
+					"weight_type": "to_original_weight",
+					"weight": "+8 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Hands",
+					"cost_type": "to_original_cost",
+					"cost": "+120",
+					"weight_type": "to_original_weight",
+					"weight": "+3.2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "hands"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Legs",
+					"cost_type": "to_original_cost",
+					"cost": "+1200",
+					"weight_type": "to_original_weight",
+					"weight": "+32 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "legs"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Thighs",
+					"cost_type": "to_original_cost",
+					"cost": "+540",
+					"weight_type": "to_original_weight",
+					"weight": "+14.4 lb",
+					"notes": "Roll 1d; on 5-6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Knees",
+					"cost_type": "to_original_cost",
+					"cost": "+60",
+					"weight_type": "to_original_weight",
+					"weight": "+1.6 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shins",
+					"cost_type": "to_original_cost",
+					"cost": "+600",
+					"weight_type": "to_original_weight",
+					"weight": "+16 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Feet",
+					"cost_type": "to_original_cost",
+					"cost": "+120",
+					"weight_type": "to_original_weight",
+					"weight": "+3.2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "feet"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "@Covers only half (front only, one arm, etc)@",
+					"cost_type": "to_base_cost",
+					"cost": "x0.5",
+					"weight_type": "to_base_weight",
+					"weight": "x0.5"
+				}
+			],
+			"notes": "Holdout: -5."
+		},
+		{
+			"type": "equipment",
+			"version": 1,
+			"quantity": 1,
+			"description": "Mail and Plates",
+			"tech_level": "3",
+			"modifiers": [
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Head",
+					"cost_type": "to_original_cost",
+					"cost": "+300",
+					"weight_type": "to_original_weight",
+					"weight": "+6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "skull"
+						},
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Skull",
+					"cost_type": "to_original_cost",
+					"cost": "+200",
+					"weight_type": "to_original_weight",
+					"weight": "+4 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "skull"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Face",
+					"cost_type": "to_original_cost",
+					"cost": "+100",
+					"weight_type": "to_original_weight",
+					"weight": "+2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Neck",
+					"cost_type": "to_original_cost",
+					"cost": "+50",
+					"weight_type": "to_original_weight",
+					"weight": "+1 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "neck"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Torso",
+					"cost_type": "to_original_cost",
+					"cost": "+1000",
+					"weight_type": "to_original_weight",
+					"weight": "+20 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "torso"
+						}
+					],
+					"notes": "Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Chest",
+					"cost_type": "to_original_cost",
+					"cost": "+750",
+					"weight_type": "to_original_weight",
+					"weight": "+15 lb",
+					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Abdomen",
+					"cost_type": "to_original_cost",
+					"cost": "+750",
+					"weight_type": "to_original_weight",
+					"weight": "+15 lb",
+					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Groin",
+					"cost_type": "to_original_cost",
+					"cost": "+50",
+					"weight_type": "to_original_weight",
+					"weight": "+1 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "groin"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+500",
+					"weight_type": "to_original_weight",
+					"weight": "+10 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "arms"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shoulders",
+					"cost_type": "to_original_cost",
+					"cost": "+100",
+					"weight_type": "to_original_weight",
+					"weight": "+2 lb",
+					"notes": "Roll 1d; on 6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Upper Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+100",
+					"weight_type": "to_original_weight",
+					"weight": "+2 lb",
+					"notes": "Roll 1d; on 5, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Elbows",
+					"cost_type": "to_original_cost",
+					"cost": "+50",
+					"weight_type": "to_original_weight",
+					"weight": "+1 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Forearms",
+					"cost_type": "to_original_cost",
+					"cost": "+250",
+					"weight_type": "to_original_weight",
+					"weight": "+5 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Hands",
+					"cost_type": "to_original_cost",
+					"cost": "+100",
+					"weight_type": "to_original_weight",
+					"weight": "+2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "hands"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Legs",
+					"cost_type": "to_original_cost",
+					"cost": "+1000",
+					"weight_type": "to_original_weight",
+					"weight": "+20 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "legs"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Thighs",
+					"cost_type": "to_original_cost",
+					"cost": "+450",
+					"weight_type": "to_original_weight",
+					"weight": "+9 lb",
+					"notes": "Roll 1d; on 5-6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Knees",
+					"cost_type": "to_original_cost",
+					"cost": "+50",
+					"weight_type": "to_original_weight",
+					"weight": "+1 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shins",
+					"cost_type": "to_original_cost",
+					"cost": "+500",
+					"weight_type": "to_original_weight",
+					"weight": "+10 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Feet",
+					"cost_type": "to_original_cost",
+					"cost": "+100",
+					"weight_type": "to_original_weight",
+					"weight": "+2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "feet"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "@Covers only half (front only, one arm, etc)@",
+					"cost_type": "to_base_cost",
+					"cost": "x0.5",
+					"weight_type": "to_base_weight",
+					"weight": "x0.5"
+				}
+			],
+			"notes": "-1 DR vs. crushing; Holdout: -5."
+		},
+		{
+			"type": "equipment",
+			"version": 1,
+			"quantity": 1,
+			"description": "Mail, Jousting",
+			"tech_level": "3",
+			"modifiers": [
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Head",
+					"cost_type": "to_original_cost",
+					"cost": "+450",
+					"weight_type": "to_original_weight",
+					"weight": "+9 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 6,
+							"location": "skull"
+						},
+						{
+							"type": "dr_bonus",
+							"amount": 6,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Skull",
+					"cost_type": "to_original_cost",
+					"cost": "+300",
+					"weight_type": "to_original_weight",
+					"weight": "+6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 6,
+							"location": "skull"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Face",
+					"cost_type": "to_original_cost",
+					"cost": "+150",
+					"weight_type": "to_original_weight",
+					"weight": "+3 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 6,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Neck",
+					"cost_type": "to_original_cost",
+					"cost": "+75",
+					"weight_type": "to_original_weight",
+					"weight": "+1.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 6,
+							"location": "neck"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Torso",
+					"cost_type": "to_original_cost",
+					"cost": "+1500",
+					"weight_type": "to_original_weight",
+					"weight": "+30 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 6,
+							"location": "torso"
+						}
+					],
+					"notes": "Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Chest",
+					"cost_type": "to_original_cost",
+					"cost": "+1125",
+					"weight_type": "to_original_weight",
+					"weight": "+22.5 lb",
+					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Abdomen",
+					"cost_type": "to_original_cost",
+					"cost": "+1125",
+					"weight_type": "to_original_weight",
+					"weight": "+22.5 lb",
+					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Groin",
+					"cost_type": "to_original_cost",
+					"cost": "+75",
+					"weight_type": "to_original_weight",
+					"weight": "+1.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 6,
+							"location": "groin"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+750",
+					"weight_type": "to_original_weight",
+					"weight": "+15 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 6,
+							"location": "arms"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shoulders",
+					"cost_type": "to_original_cost",
+					"cost": "+150",
+					"weight_type": "to_original_weight",
+					"weight": "+3 lb",
+					"notes": "Roll 1d; on 6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Upper Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+150",
+					"weight_type": "to_original_weight",
+					"weight": "+3 lb",
+					"notes": "Roll 1d; on 5, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Elbows",
+					"cost_type": "to_original_cost",
+					"cost": "+75",
+					"weight_type": "to_original_weight",
+					"weight": "+1.5 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Forearms",
+					"cost_type": "to_original_cost",
+					"cost": "+375",
+					"weight_type": "to_original_weight",
+					"weight": "+7.5 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Hands",
+					"cost_type": "to_original_cost",
+					"cost": "+150",
+					"weight_type": "to_original_weight",
+					"weight": "+3 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 6,
+							"location": "hands"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Legs",
+					"cost_type": "to_original_cost",
+					"cost": "+1500",
+					"weight_type": "to_original_weight",
+					"weight": "+30 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 6,
+							"location": "legs"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Thighs",
+					"cost_type": "to_original_cost",
+					"cost": "+675",
+					"weight_type": "to_original_weight",
+					"weight": "+13.5 lb",
+					"notes": "Roll 1d; on 5-6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Knees",
+					"cost_type": "to_original_cost",
+					"cost": "+75",
+					"weight_type": "to_original_weight",
+					"weight": "+1.5 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shins",
+					"cost_type": "to_original_cost",
+					"cost": "+750",
+					"weight_type": "to_original_weight",
+					"weight": "+15 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Feet",
+					"cost_type": "to_original_cost",
+					"cost": "+150",
+					"weight_type": "to_original_weight",
+					"weight": "+3 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 6,
+							"location": "feet"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "@Covers only half (front only, one arm, etc)@",
+					"cost_type": "to_base_cost",
+					"cost": "x0.5",
+					"weight_type": "to_base_weight",
+					"weight": "x0.5"
+				}
+			],
+			"notes": "-1 DX, except for Lance skill; Holdout: -6."
+		},
+		{
+			"type": "equipment",
+			"version": 1,
+			"quantity": 1,
+			"description": "Brigandine, Light",
+			"tech_level": "4",
+			"modifiers": [
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Head",
+					"cost_type": "to_original_cost",
+					"cost": "+270",
+					"weight_type": "to_original_weight",
+					"weight": "+3 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "skull"
+						},
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Skull",
+					"cost_type": "to_original_cost",
+					"cost": "+180",
+					"weight_type": "to_original_weight",
+					"weight": "+2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "skull"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Face",
+					"cost_type": "to_original_cost",
+					"cost": "+90",
+					"weight_type": "to_original_weight",
+					"weight": "+1 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Neck",
+					"cost_type": "to_original_cost",
+					"cost": "+45",
+					"weight_type": "to_original_weight",
+					"weight": "+0.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "neck"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Torso",
+					"cost_type": "to_original_cost",
+					"cost": "+900",
+					"weight_type": "to_original_weight",
+					"weight": "+10 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "torso"
+						}
+					],
+					"notes": "Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Chest",
+					"cost_type": "to_original_cost",
+					"cost": "+675",
+					"weight_type": "to_original_weight",
+					"weight": "+7.5 lb",
+					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Abdomen",
+					"cost_type": "to_original_cost",
+					"cost": "+675",
+					"weight_type": "to_original_weight",
+					"weight": "+7.5 lb",
+					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Groin",
+					"cost_type": "to_original_cost",
+					"cost": "+45",
+					"weight_type": "to_original_weight",
+					"weight": "+0.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "groin"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+450",
+					"weight_type": "to_original_weight",
+					"weight": "+5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "arms"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shoulders",
+					"cost_type": "to_original_cost",
+					"cost": "+90",
+					"weight_type": "to_original_weight",
+					"weight": "+1 lb",
+					"notes": "Roll 1d; on 6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Upper Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+90",
+					"weight_type": "to_original_weight",
+					"weight": "+1 lb",
+					"notes": "Roll 1d; on 5, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Elbows",
+					"cost_type": "to_original_cost",
+					"cost": "+45",
+					"weight_type": "to_original_weight",
+					"weight": "+0.5 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Forearms",
+					"cost_type": "to_original_cost",
+					"cost": "+225",
+					"weight_type": "to_original_weight",
+					"weight": "+2.5 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Hands",
+					"cost_type": "to_original_cost",
+					"cost": "+90",
+					"weight_type": "to_original_weight",
+					"weight": "+1 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "hands"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Legs",
+					"cost_type": "to_original_cost",
+					"cost": "+900",
+					"weight_type": "to_original_weight",
+					"weight": "+10 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "legs"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Thighs",
+					"cost_type": "to_original_cost",
+					"cost": "+405",
+					"weight_type": "to_original_weight",
+					"weight": "+4.5 lb",
+					"notes": "Roll 1d; on 5-6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Knees",
+					"cost_type": "to_original_cost",
+					"cost": "+45",
+					"weight_type": "to_original_weight",
+					"weight": "+0.5 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shins",
+					"cost_type": "to_original_cost",
+					"cost": "+450",
+					"weight_type": "to_original_weight",
+					"weight": "+5 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Feet",
+					"cost_type": "to_original_cost",
+					"cost": "+90",
+					"weight_type": "to_original_weight",
+					"weight": "+1 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "feet"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "@Covers only half (front only, one arm, etc)@",
+					"cost_type": "to_base_cost",
+					"cost": "x0.5",
+					"weight_type": "to_base_weight",
+					"weight": "x0.5"
+				}
+			],
+			"notes": "Holdout: -3."
+		},
+		{
+			"type": "equipment",
+			"version": 1,
+			"quantity": 1,
+			"description": "Brigandine, Medium",
+			"tech_level": "4",
+			"modifiers": [
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Head",
+					"cost_type": "to_original_cost",
+					"cost": "+540",
+					"weight_type": "to_original_weight",
+					"weight": "+6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "skull"
+						},
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Skull",
+					"cost_type": "to_original_cost",
+					"cost": "+360",
+					"weight_type": "to_original_weight",
+					"weight": "+4 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "skull"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Face",
+					"cost_type": "to_original_cost",
+					"cost": "+180",
+					"weight_type": "to_original_weight",
+					"weight": "+2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Neck",
+					"cost_type": "to_original_cost",
+					"cost": "+90",
+					"weight_type": "to_original_weight",
+					"weight": "+1 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "neck"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Torso",
+					"cost_type": "to_original_cost",
+					"cost": "+1800",
+					"weight_type": "to_original_weight",
+					"weight": "+20 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "torso"
+						}
+					],
+					"notes": "Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Chest",
+					"cost_type": "to_original_cost",
+					"cost": "+1350",
+					"weight_type": "to_original_weight",
+					"weight": "+15 lb",
+					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Abdomen",
+					"cost_type": "to_original_cost",
+					"cost": "+1350",
+					"weight_type": "to_original_weight",
+					"weight": "+15 lb",
+					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Groin",
+					"cost_type": "to_original_cost",
+					"cost": "+90",
+					"weight_type": "to_original_weight",
+					"weight": "+1 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "groin"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+900",
+					"weight_type": "to_original_weight",
+					"weight": "+10 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "arms"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shoulders",
+					"cost_type": "to_original_cost",
+					"cost": "+180",
+					"weight_type": "to_original_weight",
+					"weight": "+2 lb",
+					"notes": "Roll 1d; on 6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Upper Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+180",
+					"weight_type": "to_original_weight",
+					"weight": "+2 lb",
+					"notes": "Roll 1d; on 5, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Elbows",
+					"cost_type": "to_original_cost",
+					"cost": "+90",
+					"weight_type": "to_original_weight",
+					"weight": "+1 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Forearms",
+					"cost_type": "to_original_cost",
+					"cost": "+450",
+					"weight_type": "to_original_weight",
+					"weight": "+5 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Hands",
+					"cost_type": "to_original_cost",
+					"cost": "+180",
+					"weight_type": "to_original_weight",
+					"weight": "+2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "hands"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Legs",
+					"cost_type": "to_original_cost",
+					"cost": "+1800",
+					"weight_type": "to_original_weight",
+					"weight": "+20 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "legs"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Thighs",
+					"cost_type": "to_original_cost",
+					"cost": "+810",
+					"weight_type": "to_original_weight",
+					"weight": "+9 lb",
+					"notes": "Roll 1d; on 5-6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Knees",
+					"cost_type": "to_original_cost",
+					"cost": "+90",
+					"weight_type": "to_original_weight",
+					"weight": "+1 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shins",
+					"cost_type": "to_original_cost",
+					"cost": "+900",
+					"weight_type": "to_original_weight",
+					"weight": "+10 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Feet",
+					"cost_type": "to_original_cost",
+					"cost": "+180",
+					"weight_type": "to_original_weight",
+					"weight": "+2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 5,
+							"location": "feet"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "@Covers only half (front only, one arm, etc)@",
+					"cost_type": "to_base_cost",
+					"cost": "x0.5",
+					"weight_type": "to_base_weight",
+					"weight": "x0.5"
+				}
+			],
+			"notes": "Holdout: -5."
+		},
+		{
+			"type": "equipment",
+			"version": 1,
+			"quantity": 1,
+			"description": "Paper, Proofed",
+			"tech_level": "4",
+			"modifiers": [
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Head",
+					"cost_type": "to_original_cost",
+					"cost": "+600",
+					"weight_type": "to_original_weight",
+					"weight": "+13.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 6,
+							"location": "skull"
+						},
+						{
+							"type": "dr_bonus",
+							"amount": 6,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Skull",
+					"cost_type": "to_original_cost",
+					"cost": "+400",
+					"weight_type": "to_original_weight",
+					"weight": "+9 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 6,
+							"location": "skull"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Face",
+					"cost_type": "to_original_cost",
+					"cost": "+200",
+					"weight_type": "to_original_weight",
+					"weight": "+4.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 6,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Neck",
+					"cost_type": "to_original_cost",
+					"cost": "+100",
+					"weight_type": "to_original_weight",
+					"weight": "+2.25 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 6,
+							"location": "neck"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Torso",
+					"cost_type": "to_original_cost",
+					"cost": "+2000",
+					"weight_type": "to_original_weight",
+					"weight": "+45 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 6,
+							"location": "torso"
+						}
+					],
+					"notes": "Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Chest",
+					"cost_type": "to_original_cost",
+					"cost": "+1500",
+					"weight_type": "to_original_weight",
+					"weight": "+33.75 lb",
+					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Abdomen",
+					"cost_type": "to_original_cost",
+					"cost": "+1500",
+					"weight_type": "to_original_weight",
+					"weight": "+33.75 lb",
+					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Groin",
+					"cost_type": "to_original_cost",
+					"cost": "+100",
+					"weight_type": "to_original_weight",
+					"weight": "+2.25 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 6,
+							"location": "groin"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+1000",
+					"weight_type": "to_original_weight",
+					"weight": "+22.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 6,
+							"location": "arms"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shoulders",
+					"cost_type": "to_original_cost",
+					"cost": "+200",
+					"weight_type": "to_original_weight",
+					"weight": "+4.5 lb",
+					"notes": "Roll 1d; on 6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Upper Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+200",
+					"weight_type": "to_original_weight",
+					"weight": "+4.5 lb",
+					"notes": "Roll 1d; on 5, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Elbows",
+					"cost_type": "to_original_cost",
+					"cost": "+100",
+					"weight_type": "to_original_weight",
+					"weight": "+2.25 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Forearms",
+					"cost_type": "to_original_cost",
+					"cost": "+500",
+					"weight_type": "to_original_weight",
+					"weight": "+11.25 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Hands",
+					"cost_type": "to_original_cost",
+					"cost": "+200",
+					"weight_type": "to_original_weight",
+					"weight": "+4.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 6,
+							"location": "hands"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Legs",
+					"cost_type": "to_original_cost",
+					"cost": "+2000",
+					"weight_type": "to_original_weight",
+					"weight": "+45 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 6,
+							"location": "legs"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Thighs",
+					"cost_type": "to_original_cost",
+					"cost": "+900",
+					"weight_type": "to_original_weight",
+					"weight": "+20.25 lb",
+					"notes": "Roll 1d; on 5-6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Knees",
+					"cost_type": "to_original_cost",
+					"cost": "+100",
+					"weight_type": "to_original_weight",
+					"weight": "+2.25 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shins",
+					"cost_type": "to_original_cost",
+					"cost": "+1000",
+					"weight_type": "to_original_weight",
+					"weight": "+22.5 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Feet",
+					"cost_type": "to_original_cost",
+					"cost": "+200",
+					"weight_type": "to_original_weight",
+					"weight": "+4.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 6,
+							"location": "feet"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "@Covers only half (front only, one arm, etc)@",
+					"cost_type": "to_base_cost",
+					"cost": "x0.5",
+					"weight_type": "to_base_weight",
+					"weight": "x0.5"
+				}
+			],
+			"notes": "Combustible. If DR is penetrated by burning damage, it can catch fire. See Making Things Burn (p. B433); treat the armor material as resistant; Holdout: -6."
+		},
+		{
+			"type": "equipment",
+			"version": 1,
+			"quantity": 1,
+			"description": "Plate, Light",
+			"tech_level": "4",
+			"modifiers": [
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Head",
+					"cost_type": "to_original_cost",
+					"cost": "+300",
+					"weight_type": "to_original_weight",
+					"weight": "+2.4 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "skull"
+						},
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Skull",
+					"cost_type": "to_original_cost",
+					"cost": "+200",
+					"weight_type": "to_original_weight",
+					"weight": "+1.6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "skull"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Face",
+					"cost_type": "to_original_cost",
+					"cost": "+100",
+					"weight_type": "to_original_weight",
+					"weight": "+0.8 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Neck",
+					"cost_type": "to_original_cost",
+					"cost": "+50",
+					"weight_type": "to_original_weight",
+					"weight": "+0.4 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "neck"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Torso",
+					"cost_type": "to_original_cost",
+					"cost": "+1000",
+					"weight_type": "to_original_weight",
+					"weight": "+8 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "torso"
+						}
+					],
+					"notes": "Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Chest",
+					"cost_type": "to_original_cost",
+					"cost": "+750",
+					"weight_type": "to_original_weight",
+					"weight": "+6 lb",
+					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Abdomen",
+					"cost_type": "to_original_cost",
+					"cost": "+750",
+					"weight_type": "to_original_weight",
+					"weight": "+6 lb",
+					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Groin",
+					"cost_type": "to_original_cost",
+					"cost": "+50",
+					"weight_type": "to_original_weight",
+					"weight": "+0.4 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "groin"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+500",
+					"weight_type": "to_original_weight",
+					"weight": "+4 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "arms"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shoulders",
+					"cost_type": "to_original_cost",
+					"cost": "+100",
+					"weight_type": "to_original_weight",
+					"weight": "+0.8 lb",
+					"notes": "Roll 1d; on 6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Upper Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+100",
+					"weight_type": "to_original_weight",
+					"weight": "+0.8 lb",
+					"notes": "Roll 1d; on 5, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Elbows",
+					"cost_type": "to_original_cost",
+					"cost": "+50",
+					"weight_type": "to_original_weight",
+					"weight": "+0.4 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Forearms",
+					"cost_type": "to_original_cost",
+					"cost": "+250",
+					"weight_type": "to_original_weight",
+					"weight": "+2 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Hands",
+					"cost_type": "to_original_cost",
+					"cost": "+100",
+					"weight_type": "to_original_weight",
+					"weight": "+0.8 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "hands"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Legs",
+					"cost_type": "to_original_cost",
+					"cost": "+1000",
+					"weight_type": "to_original_weight",
+					"weight": "+8 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "legs"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Thighs",
+					"cost_type": "to_original_cost",
+					"cost": "+450",
+					"weight_type": "to_original_weight",
+					"weight": "+3.6 lb",
+					"notes": "Roll 1d; on 5-6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Knees",
+					"cost_type": "to_original_cost",
+					"cost": "+50",
+					"weight_type": "to_original_weight",
+					"weight": "+0.4 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shins",
+					"cost_type": "to_original_cost",
+					"cost": "+500",
+					"weight_type": "to_original_weight",
+					"weight": "+4 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Feet",
+					"cost_type": "to_original_cost",
+					"cost": "+100",
+					"weight_type": "to_original_weight",
+					"weight": "+0.8 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 3,
+							"location": "feet"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "@Covers only half (front only, one arm, etc)@",
+					"cost_type": "to_base_cost",
+					"cost": "x0.5",
+					"weight_type": "to_base_weight",
+					"weight": "x0.5"
+				}
+			],
+			"notes": "Holdout: -3."
+		},
+		{
+			"type": "equipment",
+			"version": 1,
+			"quantity": 1,
+			"description": "Plate, Medium",
+			"tech_level": "4",
+			"modifiers": [
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Head",
+					"cost_type": "to_original_cost",
+					"cost": "+750",
+					"weight_type": "to_original_weight",
+					"weight": "+6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 6,
+							"location": "skull"
+						},
+						{
+							"type": "dr_bonus",
+							"amount": 6,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Skull",
+					"cost_type": "to_original_cost",
+					"cost": "+500",
+					"weight_type": "to_original_weight",
+					"weight": "+4 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 6,
+							"location": "skull"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Face",
+					"cost_type": "to_original_cost",
+					"cost": "+250",
+					"weight_type": "to_original_weight",
+					"weight": "+2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 6,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Neck",
+					"cost_type": "to_original_cost",
+					"cost": "+125",
+					"weight_type": "to_original_weight",
+					"weight": "+1 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 6,
+							"location": "neck"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Torso",
+					"cost_type": "to_original_cost",
+					"cost": "+2500",
+					"weight_type": "to_original_weight",
+					"weight": "+20 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 6,
+							"location": "torso"
+						}
+					],
+					"notes": "Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Chest",
+					"cost_type": "to_original_cost",
+					"cost": "+1875",
+					"weight_type": "to_original_weight",
+					"weight": "+15 lb",
+					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Abdomen",
+					"cost_type": "to_original_cost",
+					"cost": "+1875",
+					"weight_type": "to_original_weight",
+					"weight": "+15 lb",
+					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Groin",
+					"cost_type": "to_original_cost",
+					"cost": "+125",
+					"weight_type": "to_original_weight",
+					"weight": "+1 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 6,
+							"location": "groin"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+1250",
+					"weight_type": "to_original_weight",
+					"weight": "+10 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 6,
+							"location": "arms"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shoulders",
+					"cost_type": "to_original_cost",
+					"cost": "+250",
+					"weight_type": "to_original_weight",
+					"weight": "+2 lb",
+					"notes": "Roll 1d; on 6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Upper Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+250",
+					"weight_type": "to_original_weight",
+					"weight": "+2 lb",
+					"notes": "Roll 1d; on 5, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Elbows",
+					"cost_type": "to_original_cost",
+					"cost": "+125",
+					"weight_type": "to_original_weight",
+					"weight": "+1 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Forearms",
+					"cost_type": "to_original_cost",
+					"cost": "+625",
+					"weight_type": "to_original_weight",
+					"weight": "+5 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Hands",
+					"cost_type": "to_original_cost",
+					"cost": "+250",
+					"weight_type": "to_original_weight",
+					"weight": "+2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 6,
+							"location": "hands"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Legs",
+					"cost_type": "to_original_cost",
+					"cost": "+2500",
+					"weight_type": "to_original_weight",
+					"weight": "+20 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 6,
+							"location": "legs"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Thighs",
+					"cost_type": "to_original_cost",
+					"cost": "+1125",
+					"weight_type": "to_original_weight",
+					"weight": "+9 lb",
+					"notes": "Roll 1d; on 5-6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Knees",
+					"cost_type": "to_original_cost",
+					"cost": "+125",
+					"weight_type": "to_original_weight",
+					"weight": "+1 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shins",
+					"cost_type": "to_original_cost",
+					"cost": "+1250",
+					"weight_type": "to_original_weight",
+					"weight": "+10 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Feet",
+					"cost_type": "to_original_cost",
+					"cost": "+250",
+					"weight_type": "to_original_weight",
+					"weight": "+2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 6,
+							"location": "feet"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "@Covers only half (front only, one arm, etc)@",
+					"cost_type": "to_base_cost",
+					"cost": "x0.5",
+					"weight_type": "to_base_weight",
+					"weight": "x0.5"
+				}
+			],
+			"notes": "Holdout: -6."
+		},
+		{
+			"type": "equipment",
+			"version": 1,
+			"quantity": 1,
+			"description": "Plate, Heavy",
+			"tech_level": "4",
+			"modifiers": [
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Head",
+					"cost_type": "to_original_cost",
+					"cost": "+1200",
+					"weight_type": "to_original_weight",
+					"weight": "+9.6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 9,
+							"location": "skull"
+						},
+						{
+							"type": "dr_bonus",
+							"amount": 9,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Skull",
+					"cost_type": "to_original_cost",
+					"cost": "+800",
+					"weight_type": "to_original_weight",
+					"weight": "+6.4 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 9,
+							"location": "skull"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Face",
+					"cost_type": "to_original_cost",
+					"cost": "+400",
+					"weight_type": "to_original_weight",
+					"weight": "+3.2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 9,
+							"location": "face"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Neck",
+					"cost_type": "to_original_cost",
+					"cost": "+200",
+					"weight_type": "to_original_weight",
+					"weight": "+1.6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 9,
+							"location": "neck"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Torso",
+					"cost_type": "to_original_cost",
+					"cost": "+4000",
+					"weight_type": "to_original_weight",
+					"weight": "+32 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 9,
+							"location": "torso"
+						}
+					],
+					"notes": "Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Chest",
+					"cost_type": "to_original_cost",
+					"cost": "+3000",
+					"weight_type": "to_original_weight",
+					"weight": "+24 lb",
+					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Abdomen",
+					"cost_type": "to_original_cost",
+					"cost": "+3000",
+					"weight_type": "to_original_weight",
+					"weight": "+24 lb",
+					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Groin",
+					"cost_type": "to_original_cost",
+					"cost": "+200",
+					"weight_type": "to_original_weight",
+					"weight": "+1.6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 9,
+							"location": "groin"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+2000",
+					"weight_type": "to_original_weight",
+					"weight": "+16 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 9,
+							"location": "arms"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shoulders",
+					"cost_type": "to_original_cost",
+					"cost": "+400",
+					"weight_type": "to_original_weight",
+					"weight": "+3.2 lb",
+					"notes": "Roll 1d; on 6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Upper Arms",
+					"cost_type": "to_original_cost",
+					"cost": "+400",
+					"weight_type": "to_original_weight",
+					"weight": "+3.2 lb",
+					"notes": "Roll 1d; on 5, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Elbows",
+					"cost_type": "to_original_cost",
+					"cost": "+200",
+					"weight_type": "to_original_weight",
+					"weight": "+1.6 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Forearms",
+					"cost_type": "to_original_cost",
+					"cost": "+1000",
+					"weight_type": "to_original_weight",
+					"weight": "+8 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Hands",
+					"cost_type": "to_original_cost",
+					"cost": "+400",
+					"weight_type": "to_original_weight",
+					"weight": "+3.2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 9,
+							"location": "hands"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Legs",
+					"cost_type": "to_original_cost",
+					"cost": "+4000",
+					"weight_type": "to_original_weight",
+					"weight": "+32 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 9,
+							"location": "legs"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Thighs",
+					"cost_type": "to_original_cost",
+					"cost": "+1800",
+					"weight_type": "to_original_weight",
+					"weight": "+14.4 lb",
+					"notes": "Roll 1d; on 5-6, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Knees",
+					"cost_type": "to_original_cost",
+					"cost": "+200",
+					"weight_type": "to_original_weight",
+					"weight": "+1.6 lb",
+					"notes": "Roll 1d; on 4, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Shins",
+					"cost_type": "to_original_cost",
+					"cost": "+2000",
+					"weight_type": "to_original_weight",
+					"weight": "+16 lb",
+					"notes": "Roll 1d; on 1-3, the armor is hit."
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "Feet",
+					"cost_type": "to_original_cost",
+					"cost": "+400",
+					"weight_type": "to_original_weight",
+					"weight": "+3.2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"amount": 9,
+							"location": "feet"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier",
+					"version": 1,
+					"disabled": true,
+					"name": "@Covers only half (front only, one arm, etc)@",
+					"cost_type": "to_base_cost",
+					"cost": "x0.5",
+					"weight_type": "to_base_weight",
+					"weight": "x0.5"
+				}
+			],
+			"notes": "Holdout: -9."
+		},
+		{
+			"type": "equipment_container",
+			"version": 1,
+			"description": "Face Protection",
+			"open": true,
+			"children": [
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Cane",
+					"tech_level": "0",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Nasal",
+							"cost_type": "to_original_cost",
+							"cost": "+1.75",
+							"weight_type": "to_original_weight",
+							"weight": "+0.6 lb",
+							"notes": "+1/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Brim",
+							"cost_type": "to_original_cost",
+							"cost": "+5.25",
+							"weight_type": "to_original_weight",
+							"weight": "+1.8 lb",
+							"notes": "+1/6; +5/6 from above"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+5.25",
+							"weight_type": "to_original_weight",
+							"weight": "+1.8 lb",
+							"notes": "+2/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Full Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+5.25",
+							"weight_type": "to_original_weight",
+							"weight": "+1.8 lb",
+							"notes": "+3/6; gives Hard of Hearing"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Spectacles",
+							"cost_type": "to_original_cost",
+							"cost": "+1.75",
+							"weight_type": "to_original_weight",
+							"weight": "+0.6 lb",
+							"notes": "+1/6; gives No Peripheral Vision"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Visor",
+							"cost_type": "to_original_cost",
+							"cost": "+8.75",
+							"weight_type": "to_original_weight",
+							"weight": "+3 lb",
+							"notes": "+5/6; gives Hard of Hearing and No Peripheral Vision"
+						}
+					],
+					"notes": "Roll 1d. If result is equal to or less than total protection, the armor is hit.",
+					"reference": "LT112"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Cloth, Padded",
+					"tech_level": "0",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Nasal",
+							"cost_type": "to_original_cost",
+							"cost": "+2.5",
+							"weight_type": "to_original_weight",
+							"weight": "+0.3 lb",
+							"notes": "+1/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Brim",
+							"cost_type": "to_original_cost",
+							"cost": "+7.5",
+							"weight_type": "to_original_weight",
+							"weight": "+0.9 lb",
+							"notes": "+1/6; +5/6 from above"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+7.5",
+							"weight_type": "to_original_weight",
+							"weight": "+0.9 lb",
+							"notes": "+2/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Full Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+7.5",
+							"weight_type": "to_original_weight",
+							"weight": "+0.9 lb",
+							"notes": "+3/6; gives Hard of Hearing"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Spectacles",
+							"cost_type": "to_original_cost",
+							"cost": "+2.5",
+							"weight_type": "to_original_weight",
+							"weight": "+0.3 lb",
+							"notes": "+1/6; gives No Peripheral Vision"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Visor",
+							"cost_type": "to_original_cost",
+							"cost": "+12.5",
+							"weight_type": "to_original_weight",
+							"weight": "+1.5 lb",
+							"notes": "+5/6; gives Hard of Hearing and No Peripheral Vision"
+						}
+					],
+					"notes": "Roll 1d. If result is equal to or less than total protection, the armor is hit.",
+					"reference": "LT112"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Horn",
+					"tech_level": "0",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Nasal",
+							"cost_type": "to_original_cost",
+							"cost": "+12.5",
+							"weight_type": "to_original_weight",
+							"weight": "+1.25 lb",
+							"notes": "+1/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Brim",
+							"cost_type": "to_original_cost",
+							"cost": "+37.5",
+							"weight_type": "to_original_weight",
+							"weight": "+3.75 lb",
+							"notes": "+1/6; +5/6 from above"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+37.5",
+							"weight_type": "to_original_weight",
+							"weight": "+3.75 lb",
+							"notes": "+2/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Full Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+37.5",
+							"weight_type": "to_original_weight",
+							"weight": "+3.75 lb",
+							"notes": "+3/6; gives Hard of Hearing"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Spectacles",
+							"cost_type": "to_original_cost",
+							"cost": "+12.5",
+							"weight_type": "to_original_weight",
+							"weight": "+1.25 lb",
+							"notes": "+1/6; gives No Peripheral Vision"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Visor",
+							"cost_type": "to_original_cost",
+							"cost": "+62.5",
+							"weight_type": "to_original_weight",
+							"weight": "+6.25 lb",
+							"notes": "+5/6; gives Hard of Hearing and No Peripheral Vision"
+						}
+					],
+					"notes": "Roll 1d. If result is equal to or less than total protection, the armor is hit.",
+					"reference": "LT112"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Layered Cloth, Light",
+					"tech_level": "0",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Nasal",
+							"cost_type": "to_original_cost",
+							"cost": "+7.5",
+							"weight_type": "to_original_weight",
+							"weight": "+0.6 lb",
+							"notes": "+1/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Brim",
+							"cost_type": "to_original_cost",
+							"cost": "+22.5",
+							"weight_type": "to_original_weight",
+							"weight": "+1.8 lb",
+							"notes": "+1/6; +5/6 from above"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+22.5",
+							"weight_type": "to_original_weight",
+							"weight": "+1.8 lb",
+							"notes": "+2/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Full Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+22.5",
+							"weight_type": "to_original_weight",
+							"weight": "+1.8 lb",
+							"notes": "+3/6; gives Hard of Hearing"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Spectacles",
+							"cost_type": "to_original_cost",
+							"cost": "+7.5",
+							"weight_type": "to_original_weight",
+							"weight": "+0.6 lb",
+							"notes": "+1/6; gives No Peripheral Vision"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Visor",
+							"cost_type": "to_original_cost",
+							"cost": "+37.5",
+							"weight_type": "to_original_weight",
+							"weight": "+3 lb",
+							"notes": "+5/6; gives Hard of Hearing and No Peripheral Vision"
+						}
+					],
+					"notes": "Roll 1d. If result is equal to or less than total protection, the armor is hit.",
+					"reference": "LT112"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Layered Cloth, Medium",
+					"tech_level": "0",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Nasal",
+							"cost_type": "to_original_cost",
+							"cost": "+17.5",
+							"weight_type": "to_original_weight",
+							"weight": "+1 lb",
+							"notes": "+1/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Brim",
+							"cost_type": "to_original_cost",
+							"cost": "+52.5",
+							"weight_type": "to_original_weight",
+							"weight": "+3 lb",
+							"notes": "+1/6; +5/6 from above"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+52.5",
+							"weight_type": "to_original_weight",
+							"weight": "+3 lb",
+							"notes": "+2/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Full Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+52.5",
+							"weight_type": "to_original_weight",
+							"weight": "+3 lb",
+							"notes": "+3/6; gives Hard of Hearing"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Spectacles",
+							"cost_type": "to_original_cost",
+							"cost": "+17.5",
+							"weight_type": "to_original_weight",
+							"weight": "+1 lb",
+							"notes": "+1/6; gives No Peripheral Vision"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Visor",
+							"cost_type": "to_original_cost",
+							"cost": "+87.5",
+							"weight_type": "to_original_weight",
+							"weight": "+5 lb",
+							"notes": "+5/6; gives Hard of Hearing and No Peripheral Vision"
+						}
+					],
+					"notes": "Roll 1d. If result is equal to or less than total protection, the armor is hit.",
+					"reference": "LT112"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Layered Cloth, Heavy",
+					"tech_level": "0",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Nasal",
+							"cost_type": "to_original_cost",
+							"cost": "+30",
+							"weight_type": "to_original_weight",
+							"weight": "+1.4 lb",
+							"notes": "+1/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Brim",
+							"cost_type": "to_original_cost",
+							"cost": "+90",
+							"weight_type": "to_original_weight",
+							"weight": "+4.2 lb",
+							"notes": "+1/6; +5/6 from above"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+90",
+							"weight_type": "to_original_weight",
+							"weight": "+4.2 lb",
+							"notes": "+2/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Full Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+90",
+							"weight_type": "to_original_weight",
+							"weight": "+4.2 lb",
+							"notes": "+3/6; gives Hard of Hearing"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Spectacles",
+							"cost_type": "to_original_cost",
+							"cost": "+30",
+							"weight_type": "to_original_weight",
+							"weight": "+1.4 lb",
+							"notes": "+1/6; gives No Peripheral Vision"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Visor",
+							"cost_type": "to_original_cost",
+							"cost": "+150",
+							"weight_type": "to_original_weight",
+							"weight": "+7 lb",
+							"notes": "+5/6; gives Hard of Hearing and No Peripheral Vision"
+						}
+					],
+					"notes": "Roll 1d. If result is equal to or less than total protection, the armor is hit.",
+					"reference": "LT112"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Leather, Medium",
+					"tech_level": "0",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Nasal",
+							"cost_type": "to_original_cost",
+							"cost": "+5",
+							"weight_type": "to_original_weight",
+							"weight": "+0.6 lb",
+							"notes": "+1/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Brim",
+							"cost_type": "to_original_cost",
+							"cost": "+15",
+							"weight_type": "to_original_weight",
+							"weight": "+1.8 lb",
+							"notes": "+1/6; +5/6 from above"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+15",
+							"weight_type": "to_original_weight",
+							"weight": "+1.8 lb",
+							"notes": "+2/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Full Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+15",
+							"weight_type": "to_original_weight",
+							"weight": "+1.8 lb",
+							"notes": "+3/6; gives Hard of Hearing"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Spectacles",
+							"cost_type": "to_original_cost",
+							"cost": "+5",
+							"weight_type": "to_original_weight",
+							"weight": "+0.6 lb",
+							"notes": "+1/6; gives No Peripheral Vision"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Visor",
+							"cost_type": "to_original_cost",
+							"cost": "+25",
+							"weight_type": "to_original_weight",
+							"weight": "+3 lb",
+							"notes": "+5/6; gives Hard of Hearing and No Peripheral Vision"
+						}
+					],
+					"notes": "Roll 1d. If result is equal to or less than total protection, the armor is hit.",
+					"reference": "LT112"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Leather, Heavy",
+					"tech_level": "0",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Nasal",
+							"cost_type": "to_original_cost",
+							"cost": "+10",
+							"weight_type": "to_original_weight",
+							"weight": "+1 lb",
+							"notes": "+1/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Brim",
+							"cost_type": "to_original_cost",
+							"cost": "+30",
+							"weight_type": "to_original_weight",
+							"weight": "+3 lb",
+							"notes": "+1/6; +5/6 from above"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+30",
+							"weight_type": "to_original_weight",
+							"weight": "+3 lb",
+							"notes": "+2/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Full Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+30",
+							"weight_type": "to_original_weight",
+							"weight": "+3 lb",
+							"notes": "+3/6; gives Hard of Hearing"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Spectacles",
+							"cost_type": "to_original_cost",
+							"cost": "+10",
+							"weight_type": "to_original_weight",
+							"weight": "+1 lb",
+							"notes": "+1/6; gives No Peripheral Vision"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Visor",
+							"cost_type": "to_original_cost",
+							"cost": "+50",
+							"weight_type": "to_original_weight",
+							"weight": "+5 lb",
+							"notes": "+5/6; gives Hard of Hearing and No Peripheral Vision"
+						}
+					],
+					"notes": "Roll 1d. If result is equal to or less than total protection, the armor is hit.",
+					"reference": "LT112"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Straw",
+					"tech_level": "0",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Nasal",
+							"cost_type": "to_original_cost",
+							"cost": "+2.5",
+							"weight_type": "to_original_weight",
+							"weight": "+1 lb",
+							"notes": "+1/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Brim",
+							"cost_type": "to_original_cost",
+							"cost": "+7.5",
+							"weight_type": "to_original_weight",
+							"weight": "+3 lb",
+							"notes": "+1/6; +5/6 from above"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+7.5",
+							"weight_type": "to_original_weight",
+							"weight": "+3 lb",
+							"notes": "+2/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Full Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+7.5",
+							"weight_type": "to_original_weight",
+							"weight": "+3 lb",
+							"notes": "+3/6; gives Hard of Hearing"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Spectacles",
+							"cost_type": "to_original_cost",
+							"cost": "+2.5",
+							"weight_type": "to_original_weight",
+							"weight": "+1 lb",
+							"notes": "+1/6; gives No Peripheral Vision"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Visor",
+							"cost_type": "to_original_cost",
+							"cost": "+12.5",
+							"weight_type": "to_original_weight",
+							"weight": "+5 lb",
+							"notes": "+5/6; gives Hard of Hearing and No Peripheral Vision"
+						}
+					],
+					"notes": "Roll 1d. If result is equal to or less than total protection, the armor is hit.",
+					"reference": "LT112"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Wood",
+					"tech_level": "0",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Nasal",
+							"cost_type": "to_original_cost",
+							"cost": "+5",
+							"weight_type": "to_original_weight",
+							"weight": "+1.5 lb",
+							"notes": "+1/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Brim",
+							"cost_type": "to_original_cost",
+							"cost": "+15",
+							"weight_type": "to_original_weight",
+							"weight": "+4.5 lb",
+							"notes": "+1/6; +5/6 from above"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+15",
+							"weight_type": "to_original_weight",
+							"weight": "+4.5 lb",
+							"notes": "+2/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Full Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+15",
+							"weight_type": "to_original_weight",
+							"weight": "+4.5 lb",
+							"notes": "+3/6; gives Hard of Hearing"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Spectacles",
+							"cost_type": "to_original_cost",
+							"cost": "+5",
+							"weight_type": "to_original_weight",
+							"weight": "+1.5 lb",
+							"notes": "+1/6; gives No Peripheral Vision"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Visor",
+							"cost_type": "to_original_cost",
+							"cost": "+25",
+							"weight_type": "to_original_weight",
+							"weight": "+7.5 lb",
+							"notes": "+5/6; gives Hard of Hearing and No Peripheral Vision"
+						}
+					],
+					"notes": "Roll 1d. If result is equal to or less than total protection, the armor is hit.",
+					"reference": "LT112"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Layered Leather, Light",
+					"tech_level": "1",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Nasal",
+							"cost_type": "to_original_cost",
+							"cost": "+6",
+							"weight_type": "to_original_weight",
+							"weight": "+0.75 lb",
+							"notes": "+1/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Brim",
+							"cost_type": "to_original_cost",
+							"cost": "+18",
+							"weight_type": "to_original_weight",
+							"weight": "+2.25 lb",
+							"notes": "+1/6; +5/6 from above"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+18",
+							"weight_type": "to_original_weight",
+							"weight": "+2.25 lb",
+							"notes": "+2/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Full Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+18",
+							"weight_type": "to_original_weight",
+							"weight": "+2.25 lb",
+							"notes": "+3/6; gives Hard of Hearing"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Spectacles",
+							"cost_type": "to_original_cost",
+							"cost": "+6",
+							"weight_type": "to_original_weight",
+							"weight": "+0.75 lb",
+							"notes": "+1/6; gives No Peripheral Vision"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Visor",
+							"cost_type": "to_original_cost",
+							"cost": "+30",
+							"weight_type": "to_original_weight",
+							"weight": "+3.75 lb",
+							"notes": "+5/6; gives Hard of Hearing and No Peripheral Vision"
+						}
+					],
+					"notes": "Roll 1d. If result is equal to or less than total protection, the armor is hit.",
+					"reference": "LT112"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Layered Leather, Medium",
+					"tech_level": "1",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Nasal",
+							"cost_type": "to_original_cost",
+							"cost": "+11",
+							"weight_type": "to_original_weight",
+							"weight": "+1.3 lb",
+							"notes": "+1/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Brim",
+							"cost_type": "to_original_cost",
+							"cost": "+33",
+							"weight_type": "to_original_weight",
+							"weight": "+3.9 lb",
+							"notes": "+1/6; +5/6 from above"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+33",
+							"weight_type": "to_original_weight",
+							"weight": "+3.9 lb",
+							"notes": "+2/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Full Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+33",
+							"weight_type": "to_original_weight",
+							"weight": "+3.9 lb",
+							"notes": "+3/6; gives Hard of Hearing"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Spectacles",
+							"cost_type": "to_original_cost",
+							"cost": "+11",
+							"weight_type": "to_original_weight",
+							"weight": "+1.3 lb",
+							"notes": "+1/6; gives No Peripheral Vision"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Visor",
+							"cost_type": "to_original_cost",
+							"cost": "+55",
+							"weight_type": "to_original_weight",
+							"weight": "+6.5 lb",
+							"notes": "+5/6; gives Hard of Hearing and No Peripheral Vision"
+						}
+					],
+					"notes": "Roll 1d. If result is equal to or less than total protection, the armor is hit.",
+					"reference": "LT112"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Layered Leather, Heavy",
+					"tech_level": "1",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Nasal",
+							"cost_type": "to_original_cost",
+							"cost": "+26.25",
+							"weight_type": "to_original_weight",
+							"weight": "+1.75 lb",
+							"notes": "+1/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Brim",
+							"cost_type": "to_original_cost",
+							"cost": "+78.75",
+							"weight_type": "to_original_weight",
+							"weight": "+5.25 lb",
+							"notes": "+1/6; +5/6 from above"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+78.75",
+							"weight_type": "to_original_weight",
+							"weight": "+5.25 lb",
+							"notes": "+2/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Full Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+78.75",
+							"weight_type": "to_original_weight",
+							"weight": "+5.25 lb",
+							"notes": "+3/6; gives Hard of Hearing"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Spectacles",
+							"cost_type": "to_original_cost",
+							"cost": "+26.25",
+							"weight_type": "to_original_weight",
+							"weight": "+1.75 lb",
+							"notes": "+1/6; gives No Peripheral Vision"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Visor",
+							"cost_type": "to_original_cost",
+							"cost": "+131.25",
+							"weight_type": "to_original_weight",
+							"weight": "+8.75 lb",
+							"notes": "+5/6; gives Hard of Hearing and No Peripheral Vision"
+						}
+					],
+					"notes": "Roll 1d. If result is equal to or less than total protection, the armor is hit.",
+					"reference": "LT112"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Scale, Light",
+					"tech_level": "1",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Nasal",
+							"cost_type": "to_original_cost",
+							"cost": "+16",
+							"weight_type": "to_original_weight",
+							"weight": "+0.8 lb",
+							"notes": "+1/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Brim",
+							"cost_type": "to_original_cost",
+							"cost": "+48",
+							"weight_type": "to_original_weight",
+							"weight": "+2.4 lb",
+							"notes": "+1/6; +5/6 from above"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+48",
+							"weight_type": "to_original_weight",
+							"weight": "+2.4 lb",
+							"notes": "+2/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Full Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+48",
+							"weight_type": "to_original_weight",
+							"weight": "+2.4 lb",
+							"notes": "+3/6; gives Hard of Hearing"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Spectacles",
+							"cost_type": "to_original_cost",
+							"cost": "+16",
+							"weight_type": "to_original_weight",
+							"weight": "+0.8 lb",
+							"notes": "+1/6; gives No Peripheral Vision"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Visor",
+							"cost_type": "to_original_cost",
+							"cost": "+80",
+							"weight_type": "to_original_weight",
+							"weight": "+4 lb",
+							"notes": "+5/6; gives Hard of Hearing and No Peripheral Vision"
+						}
+					],
+					"notes": "Roll 1d. If result is equal to or less than total protection, the armor is hit.",
+					"reference": "LT112"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Scale, Medium",
+					"tech_level": "1",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Nasal",
+							"cost_type": "to_original_cost",
+							"cost": "+27.5",
+							"weight_type": "to_original_weight",
+							"weight": "+1.4 lb",
+							"notes": "+1/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Brim",
+							"cost_type": "to_original_cost",
+							"cost": "+82.5",
+							"weight_type": "to_original_weight",
+							"weight": "+4.2 lb",
+							"notes": "+1/6; +5/6 from above"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+82.5",
+							"weight_type": "to_original_weight",
+							"weight": "+4.2 lb",
+							"notes": "+2/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Full Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+82.5",
+							"weight_type": "to_original_weight",
+							"weight": "+4.2 lb",
+							"notes": "+3/6; gives Hard of Hearing"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Spectacles",
+							"cost_type": "to_original_cost",
+							"cost": "+27.5",
+							"weight_type": "to_original_weight",
+							"weight": "+1.4 lb",
+							"notes": "+1/6; gives No Peripheral Vision"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Visor",
+							"cost_type": "to_original_cost",
+							"cost": "+137.5",
+							"weight_type": "to_original_weight",
+							"weight": "+7 lb",
+							"notes": "+5/6; gives Hard of Hearing and No Peripheral Vision"
+						}
+					],
+					"notes": "Roll 1d. If result is equal to or less than total protection, the armor is hit.",
+					"reference": "LT112"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Scale, Heavy",
+					"tech_level": "1",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Nasal",
+							"cost_type": "to_original_cost",
+							"cost": "+55",
+							"weight_type": "to_original_weight",
+							"weight": "+2 lb",
+							"notes": "+1/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Brim",
+							"cost_type": "to_original_cost",
+							"cost": "+165",
+							"weight_type": "to_original_weight",
+							"weight": "+6 lb",
+							"notes": "+1/6; +5/6 from above"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+165",
+							"weight_type": "to_original_weight",
+							"weight": "+6 lb",
+							"notes": "+2/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Full Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+165",
+							"weight_type": "to_original_weight",
+							"weight": "+6 lb",
+							"notes": "+3/6; gives Hard of Hearing"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Spectacles",
+							"cost_type": "to_original_cost",
+							"cost": "+55",
+							"weight_type": "to_original_weight",
+							"weight": "+2 lb",
+							"notes": "+1/6; gives No Peripheral Vision"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Visor",
+							"cost_type": "to_original_cost",
+							"cost": "+275",
+							"weight_type": "to_original_weight",
+							"weight": "+10 lb",
+							"notes": "+5/6; gives Hard of Hearing and No Peripheral Vision"
+						}
+					],
+					"notes": "Roll 1d. If result is equal to or less than total protection, the armor is hit.",
+					"reference": "LT112"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Hardened Leather, Medium",
+					"tech_level": "2",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Nasal",
+							"cost_type": "to_original_cost",
+							"cost": "+6.25",
+							"weight_type": "to_original_weight",
+							"weight": "+0.75 lb",
+							"notes": "+1/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Brim",
+							"cost_type": "to_original_cost",
+							"cost": "+18.75",
+							"weight_type": "to_original_weight",
+							"weight": "+2.25 lb",
+							"notes": "+1/6; +5/6 from above"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+18.75",
+							"weight_type": "to_original_weight",
+							"weight": "+2.25 lb",
+							"notes": "+2/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Full Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+18.75",
+							"weight_type": "to_original_weight",
+							"weight": "+2.25 lb",
+							"notes": "+3/6; gives Hard of Hearing"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Spectacles",
+							"cost_type": "to_original_cost",
+							"cost": "+6.25",
+							"weight_type": "to_original_weight",
+							"weight": "+0.75 lb",
+							"notes": "+1/6; gives No Peripheral Vision"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Visor",
+							"cost_type": "to_original_cost",
+							"cost": "+31.25",
+							"weight_type": "to_original_weight",
+							"weight": "+3.75 lb",
+							"notes": "+5/6; gives Hard of Hearing and No Peripheral Vision"
+						}
+					],
+					"notes": "Roll 1d. If result is equal to or less than total protection, the armor is hit.",
+					"reference": "LT112"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Hardened Leather, Heavy",
+					"tech_level": "2",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Nasal",
+							"cost_type": "to_original_cost",
+							"cost": "+12.5",
+							"weight_type": "to_original_weight",
+							"weight": "+1.25 lb",
+							"notes": "+1/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Brim",
+							"cost_type": "to_original_cost",
+							"cost": "+37.5",
+							"weight_type": "to_original_weight",
+							"weight": "+3.75 lb",
+							"notes": "+1/6; +5/6 from above"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+37.5",
+							"weight_type": "to_original_weight",
+							"weight": "+3.75 lb",
+							"notes": "+2/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Full Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+37.5",
+							"weight_type": "to_original_weight",
+							"weight": "+3.75 lb",
+							"notes": "+3/6; gives Hard of Hearing"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Spectacles",
+							"cost_type": "to_original_cost",
+							"cost": "+12.5",
+							"weight_type": "to_original_weight",
+							"weight": "+1.25 lb",
+							"notes": "+1/6; gives No Peripheral Vision"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Visor",
+							"cost_type": "to_original_cost",
+							"cost": "+62.5",
+							"weight_type": "to_original_weight",
+							"weight": "+6.25 lb",
+							"notes": "+5/6; gives Hard of Hearing and No Peripheral Vision"
+						}
+					],
+					"notes": "Roll 1d. If result is equal to or less than total protection, the armor is hit.",
+					"reference": "LT112"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Jack of Plates",
+					"tech_level": "2",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Nasal",
+							"cost_type": "to_original_cost",
+							"cost": "+15",
+							"weight_type": "to_original_weight",
+							"weight": "+0.9 lb",
+							"notes": "+1/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Brim",
+							"cost_type": "to_original_cost",
+							"cost": "+45",
+							"weight_type": "to_original_weight",
+							"weight": "+2.7 lb",
+							"notes": "+1/6; +5/6 from above"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+45",
+							"weight_type": "to_original_weight",
+							"weight": "+2.7 lb",
+							"notes": "+2/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Full Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+45",
+							"weight_type": "to_original_weight",
+							"weight": "+2.7 lb",
+							"notes": "+3/6; gives Hard of Hearing"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Spectacles",
+							"cost_type": "to_original_cost",
+							"cost": "+15",
+							"weight_type": "to_original_weight",
+							"weight": "+0.9 lb",
+							"notes": "+1/6; gives No Peripheral Vision"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Visor",
+							"cost_type": "to_original_cost",
+							"cost": "+75",
+							"weight_type": "to_original_weight",
+							"weight": "+4.5 lb",
+							"notes": "+5/6; gives Hard of Hearing and No Peripheral Vision"
+						}
+					],
+					"notes": "Roll 1d. If result is equal to or less than total protection, the armor is hit.",
+					"reference": "LT112"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Mail, Light",
+					"tech_level": "2",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Nasal",
+							"cost_type": "to_original_cost",
+							"cost": "+25",
+							"weight_type": "to_original_weight",
+							"weight": "+0.6 lb",
+							"notes": "+1/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Brim",
+							"cost_type": "to_original_cost",
+							"cost": "+75",
+							"weight_type": "to_original_weight",
+							"weight": "+1.8 lb",
+							"notes": "+1/6; +5/6 from above"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+75",
+							"weight_type": "to_original_weight",
+							"weight": "+1.8 lb",
+							"notes": "+2/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Full Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+75",
+							"weight_type": "to_original_weight",
+							"weight": "+1.8 lb",
+							"notes": "+3/6; gives Hard of Hearing"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Spectacles",
+							"cost_type": "to_original_cost",
+							"cost": "+25",
+							"weight_type": "to_original_weight",
+							"weight": "+0.6 lb",
+							"notes": "+1/6; gives No Peripheral Vision"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Visor",
+							"cost_type": "to_original_cost",
+							"cost": "+125",
+							"weight_type": "to_original_weight",
+							"weight": "+3 lb",
+							"notes": "+5/6; gives Hard of Hearing and No Peripheral Vision"
+						}
+					],
+					"notes": "Roll 1d. If result is equal to or less than total protection, the armor is hit.",
+					"reference": "LT112"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Mail, Fine",
+					"tech_level": "2",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Nasal",
+							"cost_type": "to_original_cost",
+							"cost": "+45",
+							"weight_type": "to_original_weight",
+							"weight": "+0.75 lb",
+							"notes": "+1/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Brim",
+							"cost_type": "to_original_cost",
+							"cost": "+135",
+							"weight_type": "to_original_weight",
+							"weight": "+2.25 lb",
+							"notes": "+1/6; +5/6 from above"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+135",
+							"weight_type": "to_original_weight",
+							"weight": "+2.25 lb",
+							"notes": "+2/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Full Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+135",
+							"weight_type": "to_original_weight",
+							"weight": "+2.25 lb",
+							"notes": "+3/6; gives Hard of Hearing"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Spectacles",
+							"cost_type": "to_original_cost",
+							"cost": "+45",
+							"weight_type": "to_original_weight",
+							"weight": "+0.75 lb",
+							"notes": "+1/6; gives No Peripheral Vision"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Visor",
+							"cost_type": "to_original_cost",
+							"cost": "+225",
+							"weight_type": "to_original_weight",
+							"weight": "+3.75 lb",
+							"notes": "+5/6; gives Hard of Hearing and No Peripheral Vision"
+						}
+					],
+					"notes": "Roll 1d. If result is equal to or less than total protection, the armor is hit.",
+					"reference": "LT112"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Mail, Heavy",
+					"tech_level": "2",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Nasal",
+							"cost_type": "to_original_cost",
+							"cost": "+60",
+							"weight_type": "to_original_weight",
+							"weight": "+0.9 lb",
+							"notes": "+1/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Brim",
+							"cost_type": "to_original_cost",
+							"cost": "+180",
+							"weight_type": "to_original_weight",
+							"weight": "+2.7 lb",
+							"notes": "+1/6; +5/6 from above"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+180",
+							"weight_type": "to_original_weight",
+							"weight": "+2.7 lb",
+							"notes": "+2/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Full Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+180",
+							"weight_type": "to_original_weight",
+							"weight": "+2.7 lb",
+							"notes": "+3/6; gives Hard of Hearing"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Spectacles",
+							"cost_type": "to_original_cost",
+							"cost": "+60",
+							"weight_type": "to_original_weight",
+							"weight": "+0.9 lb",
+							"notes": "+1/6; gives No Peripheral Vision"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Visor",
+							"cost_type": "to_original_cost",
+							"cost": "+300",
+							"weight_type": "to_original_weight",
+							"weight": "+4.5 lb",
+							"notes": "+5/6; gives Hard of Hearing and No Peripheral Vision"
+						}
+					],
+					"notes": "Roll 1d. If result is equal to or less than total protection, the armor is hit.",
+					"reference": "LT112"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Segmented Plate, Light",
+					"tech_level": "2",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Nasal",
+							"cost_type": "to_original_cost",
+							"cost": "+30",
+							"weight_type": "to_original_weight",
+							"weight": "+0.8 lb",
+							"notes": "+1/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Brim",
+							"cost_type": "to_original_cost",
+							"cost": "+90",
+							"weight_type": "to_original_weight",
+							"weight": "+2.4 lb",
+							"notes": "+1/6; +5/6 from above"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+90",
+							"weight_type": "to_original_weight",
+							"weight": "+2.4 lb",
+							"notes": "+2/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Full Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+90",
+							"weight_type": "to_original_weight",
+							"weight": "+2.4 lb",
+							"notes": "+3/6; gives Hard of Hearing"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Spectacles",
+							"cost_type": "to_original_cost",
+							"cost": "+30",
+							"weight_type": "to_original_weight",
+							"weight": "+0.8 lb",
+							"notes": "+1/6; gives No Peripheral Vision"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Visor",
+							"cost_type": "to_original_cost",
+							"cost": "+150",
+							"weight_type": "to_original_weight",
+							"weight": "+4 lb",
+							"notes": "+5/6; gives Hard of Hearing and No Peripheral Vision"
+						}
+					],
+					"notes": "Roll 1d. If result is equal to or less than total protection, the armor is hit.",
+					"reference": "LT112"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Segmented Plate, Medium",
+					"tech_level": "2",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Nasal",
+							"cost_type": "to_original_cost",
+							"cost": "+45",
+							"weight_type": "to_original_weight",
+							"weight": "+1.2 lb",
+							"notes": "+1/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Brim",
+							"cost_type": "to_original_cost",
+							"cost": "+135",
+							"weight_type": "to_original_weight",
+							"weight": "+3.6 lb",
+							"notes": "+1/6; +5/6 from above"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+135",
+							"weight_type": "to_original_weight",
+							"weight": "+3.6 lb",
+							"notes": "+2/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Full Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+135",
+							"weight_type": "to_original_weight",
+							"weight": "+3.6 lb",
+							"notes": "+3/6; gives Hard of Hearing"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Spectacles",
+							"cost_type": "to_original_cost",
+							"cost": "+45",
+							"weight_type": "to_original_weight",
+							"weight": "+1.2 lb",
+							"notes": "+1/6; gives No Peripheral Vision"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Visor",
+							"cost_type": "to_original_cost",
+							"cost": "+225",
+							"weight_type": "to_original_weight",
+							"weight": "+6 lb",
+							"notes": "+5/6; gives Hard of Hearing and No Peripheral Vision"
+						}
+					],
+					"notes": "Roll 1d. If result is equal to or less than total protection, the armor is hit.",
+					"reference": "LT112"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Segmented Plate, Heavy",
+					"tech_level": "2",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Nasal",
+							"cost_type": "to_original_cost",
+							"cost": "+60",
+							"weight_type": "to_original_weight",
+							"weight": "+1.6 lb",
+							"notes": "+1/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Brim",
+							"cost_type": "to_original_cost",
+							"cost": "+180",
+							"weight_type": "to_original_weight",
+							"weight": "+4.8 lb",
+							"notes": "+1/6; +5/6 from above"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+180",
+							"weight_type": "to_original_weight",
+							"weight": "+4.8 lb",
+							"notes": "+2/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Full Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+180",
+							"weight_type": "to_original_weight",
+							"weight": "+4.8 lb",
+							"notes": "+3/6; gives Hard of Hearing"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Spectacles",
+							"cost_type": "to_original_cost",
+							"cost": "+60",
+							"weight_type": "to_original_weight",
+							"weight": "+1.6 lb",
+							"notes": "+1/6; gives No Peripheral Vision"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Visor",
+							"cost_type": "to_original_cost",
+							"cost": "+300",
+							"weight_type": "to_original_weight",
+							"weight": "+8 lb",
+							"notes": "+5/6; gives Hard of Hearing and No Peripheral Vision"
+						}
+					],
+					"notes": "Roll 1d. If result is equal to or less than total protection, the armor is hit.",
+					"reference": "LT112"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Mail and Plates",
+					"tech_level": "3",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Nasal",
+							"cost_type": "to_original_cost",
+							"cost": "+50",
+							"weight_type": "to_original_weight",
+							"weight": "+1 lb",
+							"notes": "+1/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Brim",
+							"cost_type": "to_original_cost",
+							"cost": "+150",
+							"weight_type": "to_original_weight",
+							"weight": "+3 lb",
+							"notes": "+1/6; +5/6 from above"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+150",
+							"weight_type": "to_original_weight",
+							"weight": "+3 lb",
+							"notes": "+2/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Full Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+150",
+							"weight_type": "to_original_weight",
+							"weight": "+3 lb",
+							"notes": "+3/6; gives Hard of Hearing"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Spectacles",
+							"cost_type": "to_original_cost",
+							"cost": "+50",
+							"weight_type": "to_original_weight",
+							"weight": "+1 lb",
+							"notes": "+1/6; gives No Peripheral Vision"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Visor",
+							"cost_type": "to_original_cost",
+							"cost": "+250",
+							"weight_type": "to_original_weight",
+							"weight": "+5 lb",
+							"notes": "+5/6; gives Hard of Hearing and No Peripheral Vision"
+						}
+					],
+					"notes": "Roll 1d. If result is equal to or less than total protection, the armor is hit.",
+					"reference": "LT112"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Mail, Jousting",
+					"tech_level": "3",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Nasal",
+							"cost_type": "to_original_cost",
+							"cost": "+75",
+							"weight_type": "to_original_weight",
+							"weight": "+1.5 lb",
+							"notes": "+1/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Brim",
+							"cost_type": "to_original_cost",
+							"cost": "+225",
+							"weight_type": "to_original_weight",
+							"weight": "+4.5 lb",
+							"notes": "+1/6; +5/6 from above"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+225",
+							"weight_type": "to_original_weight",
+							"weight": "+4.5 lb",
+							"notes": "+2/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Full Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+225",
+							"weight_type": "to_original_weight",
+							"weight": "+4.5 lb",
+							"notes": "+3/6; gives Hard of Hearing"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Spectacles",
+							"cost_type": "to_original_cost",
+							"cost": "+75",
+							"weight_type": "to_original_weight",
+							"weight": "+1.5 lb",
+							"notes": "+1/6; gives No Peripheral Vision"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Visor",
+							"cost_type": "to_original_cost",
+							"cost": "+375",
+							"weight_type": "to_original_weight",
+							"weight": "+7.5 lb",
+							"notes": "+5/6; gives Hard of Hearing and No Peripheral Vision"
+						}
+					],
+					"notes": "Roll 1d. If result is equal to or less than total protection, the armor is hit.",
+					"reference": "LT112"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Brigandine, Light",
+					"tech_level": "4",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Nasal",
+							"cost_type": "to_original_cost",
+							"cost": "+45",
+							"weight_type": "to_original_weight",
+							"weight": "+0.5 lb",
+							"notes": "+1/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Brim",
+							"cost_type": "to_original_cost",
+							"cost": "+135",
+							"weight_type": "to_original_weight",
+							"weight": "+1.5 lb",
+							"notes": "+1/6; +5/6 from above"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+135",
+							"weight_type": "to_original_weight",
+							"weight": "+1.5 lb",
+							"notes": "+2/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Full Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+135",
+							"weight_type": "to_original_weight",
+							"weight": "+1.5 lb",
+							"notes": "+3/6; gives Hard of Hearing"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Spectacles",
+							"cost_type": "to_original_cost",
+							"cost": "+45",
+							"weight_type": "to_original_weight",
+							"weight": "+0.5 lb",
+							"notes": "+1/6; gives No Peripheral Vision"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Visor",
+							"cost_type": "to_original_cost",
+							"cost": "+225",
+							"weight_type": "to_original_weight",
+							"weight": "+2.5 lb",
+							"notes": "+5/6; gives Hard of Hearing and No Peripheral Vision"
+						}
+					],
+					"notes": "Roll 1d. If result is equal to or less than total protection, the armor is hit.",
+					"reference": "LT112"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Brigandine, Medium",
+					"tech_level": "4",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Nasal",
+							"cost_type": "to_original_cost",
+							"cost": "+90",
+							"weight_type": "to_original_weight",
+							"weight": "+1 lb",
+							"notes": "+1/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Brim",
+							"cost_type": "to_original_cost",
+							"cost": "+270",
+							"weight_type": "to_original_weight",
+							"weight": "+3 lb",
+							"notes": "+1/6; +5/6 from above"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+270",
+							"weight_type": "to_original_weight",
+							"weight": "+3 lb",
+							"notes": "+2/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Full Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+270",
+							"weight_type": "to_original_weight",
+							"weight": "+3 lb",
+							"notes": "+3/6; gives Hard of Hearing"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Spectacles",
+							"cost_type": "to_original_cost",
+							"cost": "+90",
+							"weight_type": "to_original_weight",
+							"weight": "+1 lb",
+							"notes": "+1/6; gives No Peripheral Vision"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Visor",
+							"cost_type": "to_original_cost",
+							"cost": "+450",
+							"weight_type": "to_original_weight",
+							"weight": "+5 lb",
+							"notes": "+5/6; gives Hard of Hearing and No Peripheral Vision"
+						}
+					],
+					"notes": "Roll 1d. If result is equal to or less than total protection, the armor is hit.",
+					"reference": "LT112"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Paper, Proofed",
+					"tech_level": "4",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Nasal",
+							"cost_type": "to_original_cost",
+							"cost": "+100",
+							"weight_type": "to_original_weight",
+							"weight": "+2.25 lb",
+							"notes": "+1/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Brim",
+							"cost_type": "to_original_cost",
+							"cost": "+300",
+							"weight_type": "to_original_weight",
+							"weight": "+6.75 lb",
+							"notes": "+1/6; +5/6 from above"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+300",
+							"weight_type": "to_original_weight",
+							"weight": "+6.75 lb",
+							"notes": "+2/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Full Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+300",
+							"weight_type": "to_original_weight",
+							"weight": "+6.75 lb",
+							"notes": "+3/6; gives Hard of Hearing"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Spectacles",
+							"cost_type": "to_original_cost",
+							"cost": "+100",
+							"weight_type": "to_original_weight",
+							"weight": "+2.25 lb",
+							"notes": "+1/6; gives No Peripheral Vision"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Visor",
+							"cost_type": "to_original_cost",
+							"cost": "+500",
+							"weight_type": "to_original_weight",
+							"weight": "+11.25 lb",
+							"notes": "+5/6; gives Hard of Hearing and No Peripheral Vision"
+						}
+					],
+					"notes": "Roll 1d. If result is equal to or less than total protection, the armor is hit.",
+					"reference": "LT112"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Plate, Light",
+					"tech_level": "4",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Nasal",
+							"cost_type": "to_original_cost",
+							"cost": "+50",
+							"weight_type": "to_original_weight",
+							"weight": "+0.4 lb",
+							"notes": "+1/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Brim",
+							"cost_type": "to_original_cost",
+							"cost": "+150",
+							"weight_type": "to_original_weight",
+							"weight": "+1.2 lb",
+							"notes": "+1/6; +5/6 from above"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+150",
+							"weight_type": "to_original_weight",
+							"weight": "+1.2 lb",
+							"notes": "+2/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Full Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+150",
+							"weight_type": "to_original_weight",
+							"weight": "+1.2 lb",
+							"notes": "+3/6; gives Hard of Hearing"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Spectacles",
+							"cost_type": "to_original_cost",
+							"cost": "+50",
+							"weight_type": "to_original_weight",
+							"weight": "+0.4 lb",
+							"notes": "+1/6; gives No Peripheral Vision"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Visor",
+							"cost_type": "to_original_cost",
+							"cost": "+250",
+							"weight_type": "to_original_weight",
+							"weight": "+2 lb",
+							"notes": "+5/6; gives Hard of Hearing and No Peripheral Vision"
+						}
+					],
+					"notes": "Roll 1d. If result is equal to or less than total protection, the armor is hit.",
+					"reference": "LT112"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Plate, Medium",
+					"tech_level": "4",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Nasal",
+							"cost_type": "to_original_cost",
+							"cost": "+125",
+							"weight_type": "to_original_weight",
+							"weight": "+1 lb",
+							"notes": "+1/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Brim",
+							"cost_type": "to_original_cost",
+							"cost": "+375",
+							"weight_type": "to_original_weight",
+							"weight": "+3 lb",
+							"notes": "+1/6; +5/6 from above"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+375",
+							"weight_type": "to_original_weight",
+							"weight": "+3 lb",
+							"notes": "+2/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Full Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+375",
+							"weight_type": "to_original_weight",
+							"weight": "+3 lb",
+							"notes": "+3/6; gives Hard of Hearing"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Spectacles",
+							"cost_type": "to_original_cost",
+							"cost": "+125",
+							"weight_type": "to_original_weight",
+							"weight": "+1 lb",
+							"notes": "+1/6; gives No Peripheral Vision"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Visor",
+							"cost_type": "to_original_cost",
+							"cost": "+625",
+							"weight_type": "to_original_weight",
+							"weight": "+5 lb",
+							"notes": "+5/6; gives Hard of Hearing and No Peripheral Vision"
+						}
+					],
+					"notes": "Roll 1d. If result is equal to or less than total protection, the armor is hit.",
+					"reference": "LT112"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Plate, Heavy",
+					"tech_level": "4",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Nasal",
+							"cost_type": "to_original_cost",
+							"cost": "+200",
+							"weight_type": "to_original_weight",
+							"weight": "+1.6 lb",
+							"notes": "+1/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Brim",
+							"cost_type": "to_original_cost",
+							"cost": "+600",
+							"weight_type": "to_original_weight",
+							"weight": "+4.8 lb",
+							"notes": "+1/6; +5/6 from above"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+600",
+							"weight_type": "to_original_weight",
+							"weight": "+4.8 lb",
+							"notes": "+2/6"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Full Cheek Guards",
+							"cost_type": "to_original_cost",
+							"cost": "+600",
+							"weight_type": "to_original_weight",
+							"weight": "+4.8 lb",
+							"notes": "+3/6; gives Hard of Hearing"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Spectacles",
+							"cost_type": "to_original_cost",
+							"cost": "+200",
+							"weight_type": "to_original_weight",
+							"weight": "+1.6 lb",
+							"notes": "+1/6; gives No Peripheral Vision"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Visor",
+							"cost_type": "to_original_cost",
+							"cost": "+1000",
+							"weight_type": "to_original_weight",
+							"weight": "+8 lb",
+							"notes": "+5/6; gives Hard of Hearing and No Peripheral Vision"
+						}
+					],
+					"notes": "Roll 1d. If result is equal to or less than total protection, the armor is hit.",
+					"reference": "LT112"
+				}
+			]
+		},
+		{
+			"type": "equipment_container",
+			"version": 1,
+			"description": "Neck Protection",
+			"open": true,
+			"children": [
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Cane",
+					"tech_level": "0",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Turret",
+							"cost_type": "to_original_cost",
+							"cost": "+3.5",
+							"weight_type": "to_original_weight",
+							"weight": "+1.2 lb",
+							"tech_level": "1",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 1,
+									"location": "neck"
+								}
+							],
+							"notes": "+2/6 chance to protect face; can't look down"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Aventail",
+							"cost_type": "to_original_cost",
+							"cost": "+1.75",
+							"weight_type": "to_original_weight",
+							"weight": "+0.6 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 1,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Lobsterback",
+							"cost_type": "to_original_cost",
+							"cost": "+1.05",
+							"weight_type": "to_original_weight",
+							"weight": "+0.36 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from behind"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Mail Collar",
+							"cost_type": "to_original_cost",
+							"cost": "+1.75",
+							"weight_type": "to_original_weight",
+							"weight": "+0.6 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 1,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Standard",
+							"cost_type": "to_original_cost",
+							"cost": "+7",
+							"weight_type": "to_original_weight",
+							"weight": "+2.4 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 1,
+									"location": "neck"
+								}
+							],
+							"notes": "50% DR to hit location 9"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Ventail",
+							"cost_type": "to_original_cost",
+							"cost": "+1.05",
+							"weight_type": "to_original_weight",
+							"weight": "+0.36 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from front; +2/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Bevor",
+							"cost_type": "to_original_cost",
+							"cost": "+2.45",
+							"weight_type": "to_original_weight",
+							"weight": "+0.84 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 1,
+									"location": "neck"
+								}
+							],
+							"notes": "+1/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Gorget",
+							"cost_type": "to_original_cost",
+							"cost": "+1.75",
+							"weight_type": "to_original_weight",
+							"weight": "+0.6 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 1,
+									"location": "neck"
+								}
+							]
+						}
+					],
+					"notes": "",
+					"reference": "LT113"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Cloth, Padded",
+					"tech_level": "0",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Turret",
+							"cost_type": "to_original_cost",
+							"cost": "+5",
+							"weight_type": "to_original_weight",
+							"weight": "+0.6 lb",
+							"tech_level": "1",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 1,
+									"location": "neck"
+								}
+							],
+							"notes": "+2/6 chance to protect face; can't look down"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Aventail",
+							"cost_type": "to_original_cost",
+							"cost": "+2.5",
+							"weight_type": "to_original_weight",
+							"weight": "+0.3 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 1,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Lobsterback",
+							"cost_type": "to_original_cost",
+							"cost": "+1.5",
+							"weight_type": "to_original_weight",
+							"weight": "+0.18 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from behind"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Mail Collar",
+							"cost_type": "to_original_cost",
+							"cost": "+2.5",
+							"weight_type": "to_original_weight",
+							"weight": "+0.3 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 1,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Standard",
+							"cost_type": "to_original_cost",
+							"cost": "+10",
+							"weight_type": "to_original_weight",
+							"weight": "+1.2 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 1,
+									"location": "neck"
+								}
+							],
+							"notes": "50% DR to hit location 9"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Ventail",
+							"cost_type": "to_original_cost",
+							"cost": "+1.5",
+							"weight_type": "to_original_weight",
+							"weight": "+0.18 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from front; +2/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Bevor",
+							"cost_type": "to_original_cost",
+							"cost": "+3.5",
+							"weight_type": "to_original_weight",
+							"weight": "+0.42 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 1,
+									"location": "neck"
+								}
+							],
+							"notes": "+1/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Gorget",
+							"cost_type": "to_original_cost",
+							"cost": "+2.5",
+							"weight_type": "to_original_weight",
+							"weight": "+0.3 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 1,
+									"location": "neck"
+								}
+							]
+						}
+					],
+					"notes": "",
+					"reference": "LT113"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Horn",
+					"tech_level": "0",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Turret",
+							"cost_type": "to_original_cost",
+							"cost": "+25",
+							"weight_type": "to_original_weight",
+							"weight": "+2.5 lb",
+							"tech_level": "1",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							],
+							"notes": "+2/6 chance to protect face; can't look down"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Aventail",
+							"cost_type": "to_original_cost",
+							"cost": "+12.5",
+							"weight_type": "to_original_weight",
+							"weight": "+1.25 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Lobsterback",
+							"cost_type": "to_original_cost",
+							"cost": "+7.5",
+							"weight_type": "to_original_weight",
+							"weight": "+0.75 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from behind"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Mail Collar",
+							"cost_type": "to_original_cost",
+							"cost": "+12.5",
+							"weight_type": "to_original_weight",
+							"weight": "+1.25 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Standard",
+							"cost_type": "to_original_cost",
+							"cost": "+50",
+							"weight_type": "to_original_weight",
+							"weight": "+5 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							],
+							"notes": "50% DR to hit location 9"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Ventail",
+							"cost_type": "to_original_cost",
+							"cost": "+7.5",
+							"weight_type": "to_original_weight",
+							"weight": "+0.75 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from front; +2/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Bevor",
+							"cost_type": "to_original_cost",
+							"cost": "+17.5",
+							"weight_type": "to_original_weight",
+							"weight": "+1.75 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							],
+							"notes": "+1/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Gorget",
+							"cost_type": "to_original_cost",
+							"cost": "+12.5",
+							"weight_type": "to_original_weight",
+							"weight": "+1.25 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							]
+						}
+					],
+					"notes": "",
+					"reference": "LT113"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Layered Cloth, Light",
+					"tech_level": "0",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Turret",
+							"cost_type": "to_original_cost",
+							"cost": "+15",
+							"weight_type": "to_original_weight",
+							"weight": "+1.2 lb",
+							"tech_level": "1",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 2,
+									"location": "neck"
+								}
+							],
+							"notes": "+2/6 chance to protect face; can't look down"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Aventail",
+							"cost_type": "to_original_cost",
+							"cost": "+7.5",
+							"weight_type": "to_original_weight",
+							"weight": "+0.6 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 2,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Lobsterback",
+							"cost_type": "to_original_cost",
+							"cost": "+4.5",
+							"weight_type": "to_original_weight",
+							"weight": "+0.36 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from behind"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Mail Collar",
+							"cost_type": "to_original_cost",
+							"cost": "+7.5",
+							"weight_type": "to_original_weight",
+							"weight": "+0.6 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 2,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Standard",
+							"cost_type": "to_original_cost",
+							"cost": "+30",
+							"weight_type": "to_original_weight",
+							"weight": "+2.4 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 2,
+									"location": "neck"
+								}
+							],
+							"notes": "50% DR to hit location 9"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Ventail",
+							"cost_type": "to_original_cost",
+							"cost": "+4.5",
+							"weight_type": "to_original_weight",
+							"weight": "+0.36 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from front; +2/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Bevor",
+							"cost_type": "to_original_cost",
+							"cost": "+10.5",
+							"weight_type": "to_original_weight",
+							"weight": "+0.84 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 2,
+									"location": "neck"
+								}
+							],
+							"notes": "+1/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Gorget",
+							"cost_type": "to_original_cost",
+							"cost": "+7.5",
+							"weight_type": "to_original_weight",
+							"weight": "+0.6 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 2,
+									"location": "neck"
+								}
+							]
+						}
+					],
+					"notes": "",
+					"reference": "LT113"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Layered Cloth, Medium",
+					"tech_level": "0",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Turret",
+							"cost_type": "to_original_cost",
+							"cost": "+35",
+							"weight_type": "to_original_weight",
+							"weight": "+2 lb",
+							"tech_level": "1",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							],
+							"notes": "+2/6 chance to protect face; can't look down"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Aventail",
+							"cost_type": "to_original_cost",
+							"cost": "+17.5",
+							"weight_type": "to_original_weight",
+							"weight": "+1 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Lobsterback",
+							"cost_type": "to_original_cost",
+							"cost": "+10.5",
+							"weight_type": "to_original_weight",
+							"weight": "+0.6 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from behind"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Mail Collar",
+							"cost_type": "to_original_cost",
+							"cost": "+17.5",
+							"weight_type": "to_original_weight",
+							"weight": "+1 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Standard",
+							"cost_type": "to_original_cost",
+							"cost": "+70",
+							"weight_type": "to_original_weight",
+							"weight": "+4 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							],
+							"notes": "50% DR to hit location 9"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Ventail",
+							"cost_type": "to_original_cost",
+							"cost": "+10.5",
+							"weight_type": "to_original_weight",
+							"weight": "+0.6 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from front; +2/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Bevor",
+							"cost_type": "to_original_cost",
+							"cost": "+24.5",
+							"weight_type": "to_original_weight",
+							"weight": "+1.4 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							],
+							"notes": "+1/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Gorget",
+							"cost_type": "to_original_cost",
+							"cost": "+17.5",
+							"weight_type": "to_original_weight",
+							"weight": "+1 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							]
+						}
+					],
+					"notes": "",
+					"reference": "LT113"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Layered Cloth, Heavy",
+					"tech_level": "0",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Turret",
+							"cost_type": "to_original_cost",
+							"cost": "+60",
+							"weight_type": "to_original_weight",
+							"weight": "+2.8 lb",
+							"tech_level": "1",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 4,
+									"location": "neck"
+								}
+							],
+							"notes": "+2/6 chance to protect face; can't look down"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Aventail",
+							"cost_type": "to_original_cost",
+							"cost": "+30",
+							"weight_type": "to_original_weight",
+							"weight": "+1.4 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 4,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Lobsterback",
+							"cost_type": "to_original_cost",
+							"cost": "+18",
+							"weight_type": "to_original_weight",
+							"weight": "+0.84 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from behind"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Mail Collar",
+							"cost_type": "to_original_cost",
+							"cost": "+30",
+							"weight_type": "to_original_weight",
+							"weight": "+1.4 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 4,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Standard",
+							"cost_type": "to_original_cost",
+							"cost": "+120",
+							"weight_type": "to_original_weight",
+							"weight": "+5.6 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 4,
+									"location": "neck"
+								}
+							],
+							"notes": "50% DR to hit location 9"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Ventail",
+							"cost_type": "to_original_cost",
+							"cost": "+18",
+							"weight_type": "to_original_weight",
+							"weight": "+0.84 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from front; +2/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Bevor",
+							"cost_type": "to_original_cost",
+							"cost": "+42",
+							"weight_type": "to_original_weight",
+							"weight": "+1.96 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 4,
+									"location": "neck"
+								}
+							],
+							"notes": "+1/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Gorget",
+							"cost_type": "to_original_cost",
+							"cost": "+30",
+							"weight_type": "to_original_weight",
+							"weight": "+1.4 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 4,
+									"location": "neck"
+								}
+							]
+						}
+					],
+					"notes": "",
+					"reference": "LT113"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Leather, Medium",
+					"tech_level": "0",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Turret",
+							"cost_type": "to_original_cost",
+							"cost": "+10",
+							"weight_type": "to_original_weight",
+							"weight": "+1.2 lb",
+							"tech_level": "1",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 2,
+									"location": "neck"
+								}
+							],
+							"notes": "+2/6 chance to protect face; can't look down"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Aventail",
+							"cost_type": "to_original_cost",
+							"cost": "+5",
+							"weight_type": "to_original_weight",
+							"weight": "+0.6 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 2,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Lobsterback",
+							"cost_type": "to_original_cost",
+							"cost": "+3",
+							"weight_type": "to_original_weight",
+							"weight": "+0.36 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from behind"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Mail Collar",
+							"cost_type": "to_original_cost",
+							"cost": "+5",
+							"weight_type": "to_original_weight",
+							"weight": "+0.6 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 2,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Standard",
+							"cost_type": "to_original_cost",
+							"cost": "+20",
+							"weight_type": "to_original_weight",
+							"weight": "+2.4 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 2,
+									"location": "neck"
+								}
+							],
+							"notes": "50% DR to hit location 9"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Ventail",
+							"cost_type": "to_original_cost",
+							"cost": "+3",
+							"weight_type": "to_original_weight",
+							"weight": "+0.36 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from front; +2/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Bevor",
+							"cost_type": "to_original_cost",
+							"cost": "+7",
+							"weight_type": "to_original_weight",
+							"weight": "+0.84 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 2,
+									"location": "neck"
+								}
+							],
+							"notes": "+1/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Gorget",
+							"cost_type": "to_original_cost",
+							"cost": "+5",
+							"weight_type": "to_original_weight",
+							"weight": "+0.6 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 2,
+									"location": "neck"
+								}
+							]
+						}
+					],
+					"notes": "",
+					"reference": "LT113"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Leather, Heavy",
+					"tech_level": "0",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Turret",
+							"cost_type": "to_original_cost",
+							"cost": "+20",
+							"weight_type": "to_original_weight",
+							"weight": "+2 lb",
+							"tech_level": "1",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							],
+							"notes": "+2/6 chance to protect face; can't look down"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Aventail",
+							"cost_type": "to_original_cost",
+							"cost": "+10",
+							"weight_type": "to_original_weight",
+							"weight": "+1 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Lobsterback",
+							"cost_type": "to_original_cost",
+							"cost": "+6",
+							"weight_type": "to_original_weight",
+							"weight": "+0.6 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from behind"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Mail Collar",
+							"cost_type": "to_original_cost",
+							"cost": "+10",
+							"weight_type": "to_original_weight",
+							"weight": "+1 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Standard",
+							"cost_type": "to_original_cost",
+							"cost": "+40",
+							"weight_type": "to_original_weight",
+							"weight": "+4 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							],
+							"notes": "50% DR to hit location 9"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Ventail",
+							"cost_type": "to_original_cost",
+							"cost": "+6",
+							"weight_type": "to_original_weight",
+							"weight": "+0.6 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from front; +2/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Bevor",
+							"cost_type": "to_original_cost",
+							"cost": "+14",
+							"weight_type": "to_original_weight",
+							"weight": "+1.4 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							],
+							"notes": "+1/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Gorget",
+							"cost_type": "to_original_cost",
+							"cost": "+10",
+							"weight_type": "to_original_weight",
+							"weight": "+1 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							]
+						}
+					],
+					"notes": "",
+					"reference": "LT113"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Straw",
+					"tech_level": "0",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Turret",
+							"cost_type": "to_original_cost",
+							"cost": "+5",
+							"weight_type": "to_original_weight",
+							"weight": "+2 lb",
+							"tech_level": "1",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 2,
+									"location": "neck"
+								}
+							],
+							"notes": "+2/6 chance to protect face; can't look down"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Aventail",
+							"cost_type": "to_original_cost",
+							"cost": "+2.5",
+							"weight_type": "to_original_weight",
+							"weight": "+1 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 2,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Lobsterback",
+							"cost_type": "to_original_cost",
+							"cost": "+1.5",
+							"weight_type": "to_original_weight",
+							"weight": "+0.6 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from behind"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Mail Collar",
+							"cost_type": "to_original_cost",
+							"cost": "+2.5",
+							"weight_type": "to_original_weight",
+							"weight": "+1 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 2,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Standard",
+							"cost_type": "to_original_cost",
+							"cost": "+10",
+							"weight_type": "to_original_weight",
+							"weight": "+4 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 2,
+									"location": "neck"
+								}
+							],
+							"notes": "50% DR to hit location 9"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Ventail",
+							"cost_type": "to_original_cost",
+							"cost": "+1.5",
+							"weight_type": "to_original_weight",
+							"weight": "+0.6 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from front; +2/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Bevor",
+							"cost_type": "to_original_cost",
+							"cost": "+3.5",
+							"weight_type": "to_original_weight",
+							"weight": "+1.4 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 2,
+									"location": "neck"
+								}
+							],
+							"notes": "+1/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Gorget",
+							"cost_type": "to_original_cost",
+							"cost": "+2.5",
+							"weight_type": "to_original_weight",
+							"weight": "+1 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 2,
+									"location": "neck"
+								}
+							]
+						}
+					],
+					"notes": "",
+					"reference": "LT113"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Wood",
+					"tech_level": "0",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Turret",
+							"cost_type": "to_original_cost",
+							"cost": "+10",
+							"weight_type": "to_original_weight",
+							"weight": "+3 lb",
+							"tech_level": "1",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							],
+							"notes": "+2/6 chance to protect face; can't look down"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Aventail",
+							"cost_type": "to_original_cost",
+							"cost": "+5",
+							"weight_type": "to_original_weight",
+							"weight": "+1.5 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Lobsterback",
+							"cost_type": "to_original_cost",
+							"cost": "+3",
+							"weight_type": "to_original_weight",
+							"weight": "+0.9 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from behind"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Mail Collar",
+							"cost_type": "to_original_cost",
+							"cost": "+5",
+							"weight_type": "to_original_weight",
+							"weight": "+1.5 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Standard",
+							"cost_type": "to_original_cost",
+							"cost": "+20",
+							"weight_type": "to_original_weight",
+							"weight": "+6 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							],
+							"notes": "50% DR to hit location 9"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Ventail",
+							"cost_type": "to_original_cost",
+							"cost": "+3",
+							"weight_type": "to_original_weight",
+							"weight": "+0.9 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from front; +2/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Bevor",
+							"cost_type": "to_original_cost",
+							"cost": "+7",
+							"weight_type": "to_original_weight",
+							"weight": "+2.1 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							],
+							"notes": "+1/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Gorget",
+							"cost_type": "to_original_cost",
+							"cost": "+5",
+							"weight_type": "to_original_weight",
+							"weight": "+1.5 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							]
+						}
+					],
+					"notes": "",
+					"reference": "LT113"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Layered Leather, Light",
+					"tech_level": "1",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Turret",
+							"cost_type": "to_original_cost",
+							"cost": "+12",
+							"weight_type": "to_original_weight",
+							"weight": "+1.5 lb",
+							"tech_level": "1",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 2,
+									"location": "neck"
+								}
+							],
+							"notes": "+2/6 chance to protect face; can't look down"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Aventail",
+							"cost_type": "to_original_cost",
+							"cost": "+6",
+							"weight_type": "to_original_weight",
+							"weight": "+0.75 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 2,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Lobsterback",
+							"cost_type": "to_original_cost",
+							"cost": "+3.6",
+							"weight_type": "to_original_weight",
+							"weight": "+0.45 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from behind"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Mail Collar",
+							"cost_type": "to_original_cost",
+							"cost": "+6",
+							"weight_type": "to_original_weight",
+							"weight": "+0.75 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 2,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Standard",
+							"cost_type": "to_original_cost",
+							"cost": "+24",
+							"weight_type": "to_original_weight",
+							"weight": "+3 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 2,
+									"location": "neck"
+								}
+							],
+							"notes": "50% DR to hit location 9"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Ventail",
+							"cost_type": "to_original_cost",
+							"cost": "+3.6",
+							"weight_type": "to_original_weight",
+							"weight": "+0.45 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from front; +2/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Bevor",
+							"cost_type": "to_original_cost",
+							"cost": "+8.4",
+							"weight_type": "to_original_weight",
+							"weight": "+1.05 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 2,
+									"location": "neck"
+								}
+							],
+							"notes": "+1/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Gorget",
+							"cost_type": "to_original_cost",
+							"cost": "+6",
+							"weight_type": "to_original_weight",
+							"weight": "+0.75 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 2,
+									"location": "neck"
+								}
+							]
+						}
+					],
+					"notes": "",
+					"reference": "LT113"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Layered Leather, Medium",
+					"tech_level": "1",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Turret",
+							"cost_type": "to_original_cost",
+							"cost": "+22",
+							"weight_type": "to_original_weight",
+							"weight": "+2.6 lb",
+							"tech_level": "1",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							],
+							"notes": "+2/6 chance to protect face; can't look down"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Aventail",
+							"cost_type": "to_original_cost",
+							"cost": "+11",
+							"weight_type": "to_original_weight",
+							"weight": "+1.3 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Lobsterback",
+							"cost_type": "to_original_cost",
+							"cost": "+6.6",
+							"weight_type": "to_original_weight",
+							"weight": "+0.78 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from behind"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Mail Collar",
+							"cost_type": "to_original_cost",
+							"cost": "+11",
+							"weight_type": "to_original_weight",
+							"weight": "+1.3 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Standard",
+							"cost_type": "to_original_cost",
+							"cost": "+44",
+							"weight_type": "to_original_weight",
+							"weight": "+5.2 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							],
+							"notes": "50% DR to hit location 9"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Ventail",
+							"cost_type": "to_original_cost",
+							"cost": "+6.6",
+							"weight_type": "to_original_weight",
+							"weight": "+0.78 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from front; +2/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Bevor",
+							"cost_type": "to_original_cost",
+							"cost": "+15.4",
+							"weight_type": "to_original_weight",
+							"weight": "+1.82 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							],
+							"notes": "+1/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Gorget",
+							"cost_type": "to_original_cost",
+							"cost": "+11",
+							"weight_type": "to_original_weight",
+							"weight": "+1.3 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							]
+						}
+					],
+					"notes": "",
+					"reference": "LT113"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Layered Leather, Heavy",
+					"tech_level": "1",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Turret",
+							"cost_type": "to_original_cost",
+							"cost": "+52.5",
+							"weight_type": "to_original_weight",
+							"weight": "+3.5 lb",
+							"tech_level": "1",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 4,
+									"location": "neck"
+								}
+							],
+							"notes": "+2/6 chance to protect face; can't look down"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Aventail",
+							"cost_type": "to_original_cost",
+							"cost": "+26.25",
+							"weight_type": "to_original_weight",
+							"weight": "+1.75 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 4,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Lobsterback",
+							"cost_type": "to_original_cost",
+							"cost": "+15.75",
+							"weight_type": "to_original_weight",
+							"weight": "+1.05 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from behind"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Mail Collar",
+							"cost_type": "to_original_cost",
+							"cost": "+26.25",
+							"weight_type": "to_original_weight",
+							"weight": "+1.75 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 4,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Standard",
+							"cost_type": "to_original_cost",
+							"cost": "+105",
+							"weight_type": "to_original_weight",
+							"weight": "+7 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 4,
+									"location": "neck"
+								}
+							],
+							"notes": "50% DR to hit location 9"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Ventail",
+							"cost_type": "to_original_cost",
+							"cost": "+15.75",
+							"weight_type": "to_original_weight",
+							"weight": "+1.05 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from front; +2/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Bevor",
+							"cost_type": "to_original_cost",
+							"cost": "+36.75",
+							"weight_type": "to_original_weight",
+							"weight": "+2.45 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 4,
+									"location": "neck"
+								}
+							],
+							"notes": "+1/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Gorget",
+							"cost_type": "to_original_cost",
+							"cost": "+26.25",
+							"weight_type": "to_original_weight",
+							"weight": "+1.75 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 4,
+									"location": "neck"
+								}
+							]
+						}
+					],
+					"notes": "",
+					"reference": "LT113"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Scale, Light",
+					"tech_level": "1",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Turret",
+							"cost_type": "to_original_cost",
+							"cost": "+32",
+							"weight_type": "to_original_weight",
+							"weight": "+1.6 lb",
+							"tech_level": "1",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							],
+							"notes": "+2/6 chance to protect face; can't look down"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Aventail",
+							"cost_type": "to_original_cost",
+							"cost": "+16",
+							"weight_type": "to_original_weight",
+							"weight": "+0.8 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Lobsterback",
+							"cost_type": "to_original_cost",
+							"cost": "+9.6",
+							"weight_type": "to_original_weight",
+							"weight": "+0.48 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from behind"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Mail Collar",
+							"cost_type": "to_original_cost",
+							"cost": "+16",
+							"weight_type": "to_original_weight",
+							"weight": "+0.8 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Standard",
+							"cost_type": "to_original_cost",
+							"cost": "+64",
+							"weight_type": "to_original_weight",
+							"weight": "+3.2 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							],
+							"notes": "50% DR to hit location 9"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Ventail",
+							"cost_type": "to_original_cost",
+							"cost": "+9.6",
+							"weight_type": "to_original_weight",
+							"weight": "+0.48 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from front; +2/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Bevor",
+							"cost_type": "to_original_cost",
+							"cost": "+22.4",
+							"weight_type": "to_original_weight",
+							"weight": "+1.12 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							],
+							"notes": "+1/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Gorget",
+							"cost_type": "to_original_cost",
+							"cost": "+16",
+							"weight_type": "to_original_weight",
+							"weight": "+0.8 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							]
+						}
+					],
+					"notes": "",
+					"reference": "LT113"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Scale, Medium",
+					"tech_level": "1",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Turret",
+							"cost_type": "to_original_cost",
+							"cost": "+55",
+							"weight_type": "to_original_weight",
+							"weight": "+2.8 lb",
+							"tech_level": "1",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 4,
+									"location": "neck"
+								}
+							],
+							"notes": "+2/6 chance to protect face; can't look down"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Aventail",
+							"cost_type": "to_original_cost",
+							"cost": "+27.5",
+							"weight_type": "to_original_weight",
+							"weight": "+1.4 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 4,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Lobsterback",
+							"cost_type": "to_original_cost",
+							"cost": "+16.5",
+							"weight_type": "to_original_weight",
+							"weight": "+0.84 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from behind"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Mail Collar",
+							"cost_type": "to_original_cost",
+							"cost": "+27.5",
+							"weight_type": "to_original_weight",
+							"weight": "+1.4 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 4,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Standard",
+							"cost_type": "to_original_cost",
+							"cost": "+110",
+							"weight_type": "to_original_weight",
+							"weight": "+5.6 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 4,
+									"location": "neck"
+								}
+							],
+							"notes": "50% DR to hit location 9"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Ventail",
+							"cost_type": "to_original_cost",
+							"cost": "+16.5",
+							"weight_type": "to_original_weight",
+							"weight": "+0.84 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from front; +2/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Bevor",
+							"cost_type": "to_original_cost",
+							"cost": "+38.5",
+							"weight_type": "to_original_weight",
+							"weight": "+1.96 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 4,
+									"location": "neck"
+								}
+							],
+							"notes": "+1/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Gorget",
+							"cost_type": "to_original_cost",
+							"cost": "+27.5",
+							"weight_type": "to_original_weight",
+							"weight": "+1.4 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 4,
+									"location": "neck"
+								}
+							]
+						}
+					],
+					"notes": "",
+					"reference": "LT113"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Scale, Heavy",
+					"tech_level": "1",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Turret",
+							"cost_type": "to_original_cost",
+							"cost": "+110",
+							"weight_type": "to_original_weight",
+							"weight": "+4 lb",
+							"tech_level": "1",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 5,
+									"location": "neck"
+								}
+							],
+							"notes": "+2/6 chance to protect face; can't look down"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Aventail",
+							"cost_type": "to_original_cost",
+							"cost": "+55",
+							"weight_type": "to_original_weight",
+							"weight": "+2 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 5,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Lobsterback",
+							"cost_type": "to_original_cost",
+							"cost": "+33",
+							"weight_type": "to_original_weight",
+							"weight": "+1.2 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from behind"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Mail Collar",
+							"cost_type": "to_original_cost",
+							"cost": "+55",
+							"weight_type": "to_original_weight",
+							"weight": "+2 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 5,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Standard",
+							"cost_type": "to_original_cost",
+							"cost": "+220",
+							"weight_type": "to_original_weight",
+							"weight": "+8 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 5,
+									"location": "neck"
+								}
+							],
+							"notes": "50% DR to hit location 9"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Ventail",
+							"cost_type": "to_original_cost",
+							"cost": "+33",
+							"weight_type": "to_original_weight",
+							"weight": "+1.2 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from front; +2/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Bevor",
+							"cost_type": "to_original_cost",
+							"cost": "+77",
+							"weight_type": "to_original_weight",
+							"weight": "+2.8 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 5,
+									"location": "neck"
+								}
+							],
+							"notes": "+1/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Gorget",
+							"cost_type": "to_original_cost",
+							"cost": "+55",
+							"weight_type": "to_original_weight",
+							"weight": "+2 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 5,
+									"location": "neck"
+								}
+							]
+						}
+					],
+					"notes": "",
+					"reference": "LT113"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Hardened Leather, Medium",
+					"tech_level": "2",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Turret",
+							"cost_type": "to_original_cost",
+							"cost": "+12.5",
+							"weight_type": "to_original_weight",
+							"weight": "+1.5 lb",
+							"tech_level": "1",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 2,
+									"location": "neck"
+								}
+							],
+							"notes": "+2/6 chance to protect face; can't look down"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Aventail",
+							"cost_type": "to_original_cost",
+							"cost": "+6.25",
+							"weight_type": "to_original_weight",
+							"weight": "+0.75 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 2,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Lobsterback",
+							"cost_type": "to_original_cost",
+							"cost": "+3.75",
+							"weight_type": "to_original_weight",
+							"weight": "+0.45 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from behind"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Mail Collar",
+							"cost_type": "to_original_cost",
+							"cost": "+6.25",
+							"weight_type": "to_original_weight",
+							"weight": "+0.75 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 2,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Standard",
+							"cost_type": "to_original_cost",
+							"cost": "+25",
+							"weight_type": "to_original_weight",
+							"weight": "+3 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 2,
+									"location": "neck"
+								}
+							],
+							"notes": "50% DR to hit location 9"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Ventail",
+							"cost_type": "to_original_cost",
+							"cost": "+3.75",
+							"weight_type": "to_original_weight",
+							"weight": "+0.45 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from front; +2/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Bevor",
+							"cost_type": "to_original_cost",
+							"cost": "+8.75",
+							"weight_type": "to_original_weight",
+							"weight": "+1.05 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 2,
+									"location": "neck"
+								}
+							],
+							"notes": "+1/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Gorget",
+							"cost_type": "to_original_cost",
+							"cost": "+6.25",
+							"weight_type": "to_original_weight",
+							"weight": "+0.75 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 2,
+									"location": "neck"
+								}
+							]
+						}
+					],
+					"notes": "",
+					"reference": "LT113"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Hardened Leather, Heavy",
+					"tech_level": "2",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Turret",
+							"cost_type": "to_original_cost",
+							"cost": "+25",
+							"weight_type": "to_original_weight",
+							"weight": "+2.5 lb",
+							"tech_level": "1",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							],
+							"notes": "+2/6 chance to protect face; can't look down"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Aventail",
+							"cost_type": "to_original_cost",
+							"cost": "+12.5",
+							"weight_type": "to_original_weight",
+							"weight": "+1.25 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Lobsterback",
+							"cost_type": "to_original_cost",
+							"cost": "+7.5",
+							"weight_type": "to_original_weight",
+							"weight": "+0.75 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from behind"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Mail Collar",
+							"cost_type": "to_original_cost",
+							"cost": "+12.5",
+							"weight_type": "to_original_weight",
+							"weight": "+1.25 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Standard",
+							"cost_type": "to_original_cost",
+							"cost": "+50",
+							"weight_type": "to_original_weight",
+							"weight": "+5 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							],
+							"notes": "50% DR to hit location 9"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Ventail",
+							"cost_type": "to_original_cost",
+							"cost": "+7.5",
+							"weight_type": "to_original_weight",
+							"weight": "+0.75 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from front; +2/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Bevor",
+							"cost_type": "to_original_cost",
+							"cost": "+17.5",
+							"weight_type": "to_original_weight",
+							"weight": "+1.75 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							],
+							"notes": "+1/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Gorget",
+							"cost_type": "to_original_cost",
+							"cost": "+12.5",
+							"weight_type": "to_original_weight",
+							"weight": "+1.25 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							]
+						}
+					],
+					"notes": "",
+					"reference": "LT113"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Jack of Plates",
+					"tech_level": "2",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Turret",
+							"cost_type": "to_original_cost",
+							"cost": "+30",
+							"weight_type": "to_original_weight",
+							"weight": "+1.8 lb",
+							"tech_level": "1",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							],
+							"notes": "+2/6 chance to protect face; can't look down"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Aventail",
+							"cost_type": "to_original_cost",
+							"cost": "+15",
+							"weight_type": "to_original_weight",
+							"weight": "+0.9 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Lobsterback",
+							"cost_type": "to_original_cost",
+							"cost": "+9",
+							"weight_type": "to_original_weight",
+							"weight": "+0.54 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from behind"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Mail Collar",
+							"cost_type": "to_original_cost",
+							"cost": "+15",
+							"weight_type": "to_original_weight",
+							"weight": "+0.9 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Standard",
+							"cost_type": "to_original_cost",
+							"cost": "+60",
+							"weight_type": "to_original_weight",
+							"weight": "+3.6 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							],
+							"notes": "50% DR to hit location 9"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Ventail",
+							"cost_type": "to_original_cost",
+							"cost": "+9",
+							"weight_type": "to_original_weight",
+							"weight": "+0.54 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from front; +2/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Bevor",
+							"cost_type": "to_original_cost",
+							"cost": "+21",
+							"weight_type": "to_original_weight",
+							"weight": "+1.26 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							],
+							"notes": "+1/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Gorget",
+							"cost_type": "to_original_cost",
+							"cost": "+15",
+							"weight_type": "to_original_weight",
+							"weight": "+0.9 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							]
+						}
+					],
+					"notes": "",
+					"reference": "LT113"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Mail, Light",
+					"tech_level": "2",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Turret",
+							"cost_type": "to_original_cost",
+							"cost": "+50",
+							"weight_type": "to_original_weight",
+							"weight": "+1.2 lb",
+							"tech_level": "1",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							],
+							"notes": "+2/6 chance to protect face; can't look down"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Aventail",
+							"cost_type": "to_original_cost",
+							"cost": "+25",
+							"weight_type": "to_original_weight",
+							"weight": "+0.6 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Lobsterback",
+							"cost_type": "to_original_cost",
+							"cost": "+15",
+							"weight_type": "to_original_weight",
+							"weight": "+0.36 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from behind"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Mail Collar",
+							"cost_type": "to_original_cost",
+							"cost": "+25",
+							"weight_type": "to_original_weight",
+							"weight": "+0.6 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Standard",
+							"cost_type": "to_original_cost",
+							"cost": "+100",
+							"weight_type": "to_original_weight",
+							"weight": "+2.4 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							],
+							"notes": "50% DR to hit location 9"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Ventail",
+							"cost_type": "to_original_cost",
+							"cost": "+15",
+							"weight_type": "to_original_weight",
+							"weight": "+0.36 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from front; +2/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Bevor",
+							"cost_type": "to_original_cost",
+							"cost": "+35",
+							"weight_type": "to_original_weight",
+							"weight": "+0.84 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							],
+							"notes": "+1/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Gorget",
+							"cost_type": "to_original_cost",
+							"cost": "+25",
+							"weight_type": "to_original_weight",
+							"weight": "+0.6 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							]
+						}
+					],
+					"notes": "",
+					"reference": "LT113"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Mail, Fine",
+					"tech_level": "2",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Turret",
+							"cost_type": "to_original_cost",
+							"cost": "+90",
+							"weight_type": "to_original_weight",
+							"weight": "+1.5 lb",
+							"tech_level": "1",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 4,
+									"location": "neck"
+								}
+							],
+							"notes": "+2/6 chance to protect face; can't look down"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Aventail",
+							"cost_type": "to_original_cost",
+							"cost": "+45",
+							"weight_type": "to_original_weight",
+							"weight": "+0.75 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 4,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Lobsterback",
+							"cost_type": "to_original_cost",
+							"cost": "+27",
+							"weight_type": "to_original_weight",
+							"weight": "+0.45 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from behind"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Mail Collar",
+							"cost_type": "to_original_cost",
+							"cost": "+45",
+							"weight_type": "to_original_weight",
+							"weight": "+0.75 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 4,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Standard",
+							"cost_type": "to_original_cost",
+							"cost": "+180",
+							"weight_type": "to_original_weight",
+							"weight": "+3 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 4,
+									"location": "neck"
+								}
+							],
+							"notes": "50% DR to hit location 9"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Ventail",
+							"cost_type": "to_original_cost",
+							"cost": "+27",
+							"weight_type": "to_original_weight",
+							"weight": "+0.45 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from front; +2/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Bevor",
+							"cost_type": "to_original_cost",
+							"cost": "+63",
+							"weight_type": "to_original_weight",
+							"weight": "+1.05 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 4,
+									"location": "neck"
+								}
+							],
+							"notes": "+1/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Gorget",
+							"cost_type": "to_original_cost",
+							"cost": "+45",
+							"weight_type": "to_original_weight",
+							"weight": "+0.75 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 4,
+									"location": "neck"
+								}
+							]
+						}
+					],
+					"notes": "",
+					"reference": "LT113"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Mail, Heavy",
+					"tech_level": "2",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Turret",
+							"cost_type": "to_original_cost",
+							"cost": "+120",
+							"weight_type": "to_original_weight",
+							"weight": "+1.8 lb",
+							"tech_level": "1",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 5,
+									"location": "neck"
+								}
+							],
+							"notes": "+2/6 chance to protect face; can't look down"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Aventail",
+							"cost_type": "to_original_cost",
+							"cost": "+60",
+							"weight_type": "to_original_weight",
+							"weight": "+0.9 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 5,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Lobsterback",
+							"cost_type": "to_original_cost",
+							"cost": "+36",
+							"weight_type": "to_original_weight",
+							"weight": "+0.54 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from behind"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Mail Collar",
+							"cost_type": "to_original_cost",
+							"cost": "+60",
+							"weight_type": "to_original_weight",
+							"weight": "+0.9 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 5,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Standard",
+							"cost_type": "to_original_cost",
+							"cost": "+240",
+							"weight_type": "to_original_weight",
+							"weight": "+3.6 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 5,
+									"location": "neck"
+								}
+							],
+							"notes": "50% DR to hit location 9"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Ventail",
+							"cost_type": "to_original_cost",
+							"cost": "+36",
+							"weight_type": "to_original_weight",
+							"weight": "+0.54 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from front; +2/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Bevor",
+							"cost_type": "to_original_cost",
+							"cost": "+84",
+							"weight_type": "to_original_weight",
+							"weight": "+1.26 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 5,
+									"location": "neck"
+								}
+							],
+							"notes": "+1/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Gorget",
+							"cost_type": "to_original_cost",
+							"cost": "+60",
+							"weight_type": "to_original_weight",
+							"weight": "+0.9 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 5,
+									"location": "neck"
+								}
+							]
+						}
+					],
+					"notes": "",
+					"reference": "LT113"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Segmented Plate, Light",
+					"tech_level": "2",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Turret",
+							"cost_type": "to_original_cost",
+							"cost": "+60",
+							"weight_type": "to_original_weight",
+							"weight": "+1.6 lb",
+							"tech_level": "1",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							],
+							"notes": "+2/6 chance to protect face; can't look down"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Aventail",
+							"cost_type": "to_original_cost",
+							"cost": "+30",
+							"weight_type": "to_original_weight",
+							"weight": "+0.8 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Lobsterback",
+							"cost_type": "to_original_cost",
+							"cost": "+18",
+							"weight_type": "to_original_weight",
+							"weight": "+0.48 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from behind"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Mail Collar",
+							"cost_type": "to_original_cost",
+							"cost": "+30",
+							"weight_type": "to_original_weight",
+							"weight": "+0.8 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Standard",
+							"cost_type": "to_original_cost",
+							"cost": "+120",
+							"weight_type": "to_original_weight",
+							"weight": "+3.2 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							],
+							"notes": "50% DR to hit location 9"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Ventail",
+							"cost_type": "to_original_cost",
+							"cost": "+18",
+							"weight_type": "to_original_weight",
+							"weight": "+0.48 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from front; +2/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Bevor",
+							"cost_type": "to_original_cost",
+							"cost": "+42",
+							"weight_type": "to_original_weight",
+							"weight": "+1.12 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							],
+							"notes": "+1/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Gorget",
+							"cost_type": "to_original_cost",
+							"cost": "+30",
+							"weight_type": "to_original_weight",
+							"weight": "+0.8 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							]
+						}
+					],
+					"notes": "",
+					"reference": "LT113"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Segmented Plate, Medium",
+					"tech_level": "2",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Turret",
+							"cost_type": "to_original_cost",
+							"cost": "+90",
+							"weight_type": "to_original_weight",
+							"weight": "+2.4 lb",
+							"tech_level": "1",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 4,
+									"location": "neck"
+								}
+							],
+							"notes": "+2/6 chance to protect face; can't look down"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Aventail",
+							"cost_type": "to_original_cost",
+							"cost": "+45",
+							"weight_type": "to_original_weight",
+							"weight": "+1.2 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 4,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Lobsterback",
+							"cost_type": "to_original_cost",
+							"cost": "+27",
+							"weight_type": "to_original_weight",
+							"weight": "+0.72 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from behind"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Mail Collar",
+							"cost_type": "to_original_cost",
+							"cost": "+45",
+							"weight_type": "to_original_weight",
+							"weight": "+1.2 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 4,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Standard",
+							"cost_type": "to_original_cost",
+							"cost": "+180",
+							"weight_type": "to_original_weight",
+							"weight": "+4.8 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 4,
+									"location": "neck"
+								}
+							],
+							"notes": "50% DR to hit location 9"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Ventail",
+							"cost_type": "to_original_cost",
+							"cost": "+27",
+							"weight_type": "to_original_weight",
+							"weight": "+0.72 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from front; +2/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Bevor",
+							"cost_type": "to_original_cost",
+							"cost": "+63",
+							"weight_type": "to_original_weight",
+							"weight": "+1.68 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 4,
+									"location": "neck"
+								}
+							],
+							"notes": "+1/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Gorget",
+							"cost_type": "to_original_cost",
+							"cost": "+45",
+							"weight_type": "to_original_weight",
+							"weight": "+1.2 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 4,
+									"location": "neck"
+								}
+							]
+						}
+					],
+					"notes": "",
+					"reference": "LT113"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Segmented Plate, Heavy",
+					"tech_level": "2",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Turret",
+							"cost_type": "to_original_cost",
+							"cost": "+120",
+							"weight_type": "to_original_weight",
+							"weight": "+3.2 lb",
+							"tech_level": "1",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 5,
+									"location": "neck"
+								}
+							],
+							"notes": "+2/6 chance to protect face; can't look down"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Aventail",
+							"cost_type": "to_original_cost",
+							"cost": "+60",
+							"weight_type": "to_original_weight",
+							"weight": "+1.6 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 5,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Lobsterback",
+							"cost_type": "to_original_cost",
+							"cost": "+36",
+							"weight_type": "to_original_weight",
+							"weight": "+0.96 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from behind"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Mail Collar",
+							"cost_type": "to_original_cost",
+							"cost": "+60",
+							"weight_type": "to_original_weight",
+							"weight": "+1.6 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 5,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Standard",
+							"cost_type": "to_original_cost",
+							"cost": "+240",
+							"weight_type": "to_original_weight",
+							"weight": "+6.4 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 5,
+									"location": "neck"
+								}
+							],
+							"notes": "50% DR to hit location 9"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Ventail",
+							"cost_type": "to_original_cost",
+							"cost": "+36",
+							"weight_type": "to_original_weight",
+							"weight": "+0.96 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from front; +2/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Bevor",
+							"cost_type": "to_original_cost",
+							"cost": "+84",
+							"weight_type": "to_original_weight",
+							"weight": "+2.24 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 5,
+									"location": "neck"
+								}
+							],
+							"notes": "+1/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Gorget",
+							"cost_type": "to_original_cost",
+							"cost": "+60",
+							"weight_type": "to_original_weight",
+							"weight": "+1.6 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 5,
+									"location": "neck"
+								}
+							]
+						}
+					],
+					"notes": "",
+					"reference": "LT113"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Mail and Plates",
+					"tech_level": "3",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Turret",
+							"cost_type": "to_original_cost",
+							"cost": "+100",
+							"weight_type": "to_original_weight",
+							"weight": "+2 lb",
+							"tech_level": "1",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 5,
+									"location": "neck"
+								}
+							],
+							"notes": "+2/6 chance to protect face; can't look down"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Aventail",
+							"cost_type": "to_original_cost",
+							"cost": "+50",
+							"weight_type": "to_original_weight",
+							"weight": "+1 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 5,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Lobsterback",
+							"cost_type": "to_original_cost",
+							"cost": "+30",
+							"weight_type": "to_original_weight",
+							"weight": "+0.6 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from behind"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Mail Collar",
+							"cost_type": "to_original_cost",
+							"cost": "+50",
+							"weight_type": "to_original_weight",
+							"weight": "+1 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 5,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Standard",
+							"cost_type": "to_original_cost",
+							"cost": "+200",
+							"weight_type": "to_original_weight",
+							"weight": "+4 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 5,
+									"location": "neck"
+								}
+							],
+							"notes": "50% DR to hit location 9"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Ventail",
+							"cost_type": "to_original_cost",
+							"cost": "+30",
+							"weight_type": "to_original_weight",
+							"weight": "+0.6 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from front; +2/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Bevor",
+							"cost_type": "to_original_cost",
+							"cost": "+70",
+							"weight_type": "to_original_weight",
+							"weight": "+1.4 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 5,
+									"location": "neck"
+								}
+							],
+							"notes": "+1/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Gorget",
+							"cost_type": "to_original_cost",
+							"cost": "+50",
+							"weight_type": "to_original_weight",
+							"weight": "+1 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 5,
+									"location": "neck"
+								}
+							]
+						}
+					],
+					"notes": "",
+					"reference": "LT113"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Mail, Jousting",
+					"tech_level": "3",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Turret",
+							"cost_type": "to_original_cost",
+							"cost": "+150",
+							"weight_type": "to_original_weight",
+							"weight": "+3 lb",
+							"tech_level": "1",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 6,
+									"location": "neck"
+								}
+							],
+							"notes": "+2/6 chance to protect face; can't look down"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Aventail",
+							"cost_type": "to_original_cost",
+							"cost": "+75",
+							"weight_type": "to_original_weight",
+							"weight": "+1.5 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 6,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Lobsterback",
+							"cost_type": "to_original_cost",
+							"cost": "+45",
+							"weight_type": "to_original_weight",
+							"weight": "+0.9 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from behind"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Mail Collar",
+							"cost_type": "to_original_cost",
+							"cost": "+75",
+							"weight_type": "to_original_weight",
+							"weight": "+1.5 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 6,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Standard",
+							"cost_type": "to_original_cost",
+							"cost": "+300",
+							"weight_type": "to_original_weight",
+							"weight": "+6 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 6,
+									"location": "neck"
+								}
+							],
+							"notes": "50% DR to hit location 9"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Ventail",
+							"cost_type": "to_original_cost",
+							"cost": "+45",
+							"weight_type": "to_original_weight",
+							"weight": "+0.9 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from front; +2/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Bevor",
+							"cost_type": "to_original_cost",
+							"cost": "+105",
+							"weight_type": "to_original_weight",
+							"weight": "+2.1 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 6,
+									"location": "neck"
+								}
+							],
+							"notes": "+1/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Gorget",
+							"cost_type": "to_original_cost",
+							"cost": "+75",
+							"weight_type": "to_original_weight",
+							"weight": "+1.5 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 6,
+									"location": "neck"
+								}
+							]
+						}
+					],
+					"notes": "",
+					"reference": "LT113"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Brigandine, Light",
+					"tech_level": "4",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Turret",
+							"cost_type": "to_original_cost",
+							"cost": "+90",
+							"weight_type": "to_original_weight",
+							"weight": "+1 lb",
+							"tech_level": "1",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							],
+							"notes": "+2/6 chance to protect face; can't look down"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Aventail",
+							"cost_type": "to_original_cost",
+							"cost": "+45",
+							"weight_type": "to_original_weight",
+							"weight": "+0.5 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Lobsterback",
+							"cost_type": "to_original_cost",
+							"cost": "+27",
+							"weight_type": "to_original_weight",
+							"weight": "+0.3 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from behind"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Mail Collar",
+							"cost_type": "to_original_cost",
+							"cost": "+45",
+							"weight_type": "to_original_weight",
+							"weight": "+0.5 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Standard",
+							"cost_type": "to_original_cost",
+							"cost": "+180",
+							"weight_type": "to_original_weight",
+							"weight": "+2 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							],
+							"notes": "50% DR to hit location 9"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Ventail",
+							"cost_type": "to_original_cost",
+							"cost": "+27",
+							"weight_type": "to_original_weight",
+							"weight": "+0.3 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from front; +2/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Bevor",
+							"cost_type": "to_original_cost",
+							"cost": "+63",
+							"weight_type": "to_original_weight",
+							"weight": "+0.7 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							],
+							"notes": "+1/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Gorget",
+							"cost_type": "to_original_cost",
+							"cost": "+45",
+							"weight_type": "to_original_weight",
+							"weight": "+0.5 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							]
+						}
+					],
+					"notes": "",
+					"reference": "LT113"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Brigandine, Medium",
+					"tech_level": "4",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Turret",
+							"cost_type": "to_original_cost",
+							"cost": "+180",
+							"weight_type": "to_original_weight",
+							"weight": "+2 lb",
+							"tech_level": "1",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 5,
+									"location": "neck"
+								}
+							],
+							"notes": "+2/6 chance to protect face; can't look down"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Aventail",
+							"cost_type": "to_original_cost",
+							"cost": "+90",
+							"weight_type": "to_original_weight",
+							"weight": "+1 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 5,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Lobsterback",
+							"cost_type": "to_original_cost",
+							"cost": "+54",
+							"weight_type": "to_original_weight",
+							"weight": "+0.6 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from behind"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Mail Collar",
+							"cost_type": "to_original_cost",
+							"cost": "+90",
+							"weight_type": "to_original_weight",
+							"weight": "+1 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 5,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Standard",
+							"cost_type": "to_original_cost",
+							"cost": "+360",
+							"weight_type": "to_original_weight",
+							"weight": "+4 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 5,
+									"location": "neck"
+								}
+							],
+							"notes": "50% DR to hit location 9"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Ventail",
+							"cost_type": "to_original_cost",
+							"cost": "+54",
+							"weight_type": "to_original_weight",
+							"weight": "+0.6 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from front; +2/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Bevor",
+							"cost_type": "to_original_cost",
+							"cost": "+126",
+							"weight_type": "to_original_weight",
+							"weight": "+1.4 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 5,
+									"location": "neck"
+								}
+							],
+							"notes": "+1/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Gorget",
+							"cost_type": "to_original_cost",
+							"cost": "+90",
+							"weight_type": "to_original_weight",
+							"weight": "+1 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 5,
+									"location": "neck"
+								}
+							]
+						}
+					],
+					"notes": "",
+					"reference": "LT113"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Paper, Proofed",
+					"tech_level": "4",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Turret",
+							"cost_type": "to_original_cost",
+							"cost": "+200",
+							"weight_type": "to_original_weight",
+							"weight": "+4.5 lb",
+							"tech_level": "1",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 6,
+									"location": "neck"
+								}
+							],
+							"notes": "+2/6 chance to protect face; can't look down"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Aventail",
+							"cost_type": "to_original_cost",
+							"cost": "+100",
+							"weight_type": "to_original_weight",
+							"weight": "+2.25 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 6,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Lobsterback",
+							"cost_type": "to_original_cost",
+							"cost": "+60",
+							"weight_type": "to_original_weight",
+							"weight": "+1.35 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from behind"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Mail Collar",
+							"cost_type": "to_original_cost",
+							"cost": "+100",
+							"weight_type": "to_original_weight",
+							"weight": "+2.25 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 6,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Standard",
+							"cost_type": "to_original_cost",
+							"cost": "+400",
+							"weight_type": "to_original_weight",
+							"weight": "+9 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 6,
+									"location": "neck"
+								}
+							],
+							"notes": "50% DR to hit location 9"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Ventail",
+							"cost_type": "to_original_cost",
+							"cost": "+60",
+							"weight_type": "to_original_weight",
+							"weight": "+1.35 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from front; +2/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Bevor",
+							"cost_type": "to_original_cost",
+							"cost": "+140",
+							"weight_type": "to_original_weight",
+							"weight": "+3.15 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 6,
+									"location": "neck"
+								}
+							],
+							"notes": "+1/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Gorget",
+							"cost_type": "to_original_cost",
+							"cost": "+100",
+							"weight_type": "to_original_weight",
+							"weight": "+2.25 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 6,
+									"location": "neck"
+								}
+							]
+						}
+					],
+					"notes": "",
+					"reference": "LT113"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Plate, Light",
+					"tech_level": "4",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Turret",
+							"cost_type": "to_original_cost",
+							"cost": "+100",
+							"weight_type": "to_original_weight",
+							"weight": "+0.8 lb",
+							"tech_level": "1",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							],
+							"notes": "+2/6 chance to protect face; can't look down"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Aventail",
+							"cost_type": "to_original_cost",
+							"cost": "+50",
+							"weight_type": "to_original_weight",
+							"weight": "+0.4 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Lobsterback",
+							"cost_type": "to_original_cost",
+							"cost": "+30",
+							"weight_type": "to_original_weight",
+							"weight": "+0.24 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from behind"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Mail Collar",
+							"cost_type": "to_original_cost",
+							"cost": "+50",
+							"weight_type": "to_original_weight",
+							"weight": "+0.4 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Standard",
+							"cost_type": "to_original_cost",
+							"cost": "+200",
+							"weight_type": "to_original_weight",
+							"weight": "+1.6 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							],
+							"notes": "50% DR to hit location 9"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Ventail",
+							"cost_type": "to_original_cost",
+							"cost": "+30",
+							"weight_type": "to_original_weight",
+							"weight": "+0.24 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from front; +2/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Bevor",
+							"cost_type": "to_original_cost",
+							"cost": "+70",
+							"weight_type": "to_original_weight",
+							"weight": "+0.56 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							],
+							"notes": "+1/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Gorget",
+							"cost_type": "to_original_cost",
+							"cost": "+50",
+							"weight_type": "to_original_weight",
+							"weight": "+0.4 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 3,
+									"location": "neck"
+								}
+							]
+						}
+					],
+					"notes": "",
+					"reference": "LT113"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Plate, Medium",
+					"tech_level": "4",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Turret",
+							"cost_type": "to_original_cost",
+							"cost": "+250",
+							"weight_type": "to_original_weight",
+							"weight": "+2 lb",
+							"tech_level": "1",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 6,
+									"location": "neck"
+								}
+							],
+							"notes": "+2/6 chance to protect face; can't look down"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Aventail",
+							"cost_type": "to_original_cost",
+							"cost": "+125",
+							"weight_type": "to_original_weight",
+							"weight": "+1 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 6,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Lobsterback",
+							"cost_type": "to_original_cost",
+							"cost": "+75",
+							"weight_type": "to_original_weight",
+							"weight": "+0.6 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from behind"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Mail Collar",
+							"cost_type": "to_original_cost",
+							"cost": "+125",
+							"weight_type": "to_original_weight",
+							"weight": "+1 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 6,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Standard",
+							"cost_type": "to_original_cost",
+							"cost": "+500",
+							"weight_type": "to_original_weight",
+							"weight": "+4 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 6,
+									"location": "neck"
+								}
+							],
+							"notes": "50% DR to hit location 9"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Ventail",
+							"cost_type": "to_original_cost",
+							"cost": "+75",
+							"weight_type": "to_original_weight",
+							"weight": "+0.6 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from front; +2/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Bevor",
+							"cost_type": "to_original_cost",
+							"cost": "+175",
+							"weight_type": "to_original_weight",
+							"weight": "+1.4 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 6,
+									"location": "neck"
+								}
+							],
+							"notes": "+1/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Gorget",
+							"cost_type": "to_original_cost",
+							"cost": "+125",
+							"weight_type": "to_original_weight",
+							"weight": "+1 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 6,
+									"location": "neck"
+								}
+							]
+						}
+					],
+					"notes": "",
+					"reference": "LT113"
+				},
+				{
+					"type": "equipment",
+					"version": 1,
+					"quantity": 1,
+					"description": "Plate, Heavy",
+					"tech_level": "4",
+					"modifiers": [
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Turret",
+							"cost_type": "to_original_cost",
+							"cost": "+400",
+							"weight_type": "to_original_weight",
+							"weight": "+3.2 lb",
+							"tech_level": "1",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 9,
+									"location": "neck"
+								}
+							],
+							"notes": "+2/6 chance to protect face; can't look down"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Aventail",
+							"cost_type": "to_original_cost",
+							"cost": "+200",
+							"weight_type": "to_original_weight",
+							"weight": "+1.6 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 9,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Lobsterback",
+							"cost_type": "to_original_cost",
+							"cost": "+120",
+							"weight_type": "to_original_weight",
+							"weight": "+0.96 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from behind"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Mail Collar",
+							"cost_type": "to_original_cost",
+							"cost": "+200",
+							"weight_type": "to_original_weight",
+							"weight": "+1.6 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 9,
+									"location": "neck"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Standard",
+							"cost_type": "to_original_cost",
+							"cost": "+800",
+							"weight_type": "to_original_weight",
+							"weight": "+6.4 lb",
+							"tech_level": "2",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 9,
+									"location": "neck"
+								}
+							],
+							"notes": "50% DR to hit location 9"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Ventail",
+							"cost_type": "to_original_cost",
+							"cost": "+120",
+							"weight_type": "to_original_weight",
+							"weight": "+0.96 lb",
+							"tech_level": "2",
+							"notes": "Protects neck from front; +2/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Bevor",
+							"cost_type": "to_original_cost",
+							"cost": "+280",
+							"weight_type": "to_original_weight",
+							"weight": "+2.24 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 9,
+									"location": "neck"
+								}
+							],
+							"notes": "+1/6 chance to protect face"
+						},
+						{
+							"type": "eqp_modifier",
+							"version": 1,
+							"disabled": true,
+							"name": "Gorget",
+							"cost_type": "to_original_cost",
+							"cost": "+200",
+							"weight_type": "to_original_weight",
+							"weight": "+1.6 lb",
+							"tech_level": "3",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"amount": 9,
+									"location": "neck"
+								}
+							]
+						}
+					],
+					"notes": "",
+					"reference": "LT113"
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
Instead of having a long-long list like the one in Instant Armor, this library uses equipment modifiers to greatly reduce the number of visible items. The user simply picks the material, then selects the locations.