### PR TITLE
Fixed @FP_POINTS key in Fantasy Grounds output template

### DIFF
--- a/Library/Output Templates/Fantasy Grounds PC - No Mods.xml
+++ b/Library/Output Templates/Fantasy Grounds PC - No Mods.xml
@@ -69,7 +69,7 @@
       <perception type="number">@PERCEPTION</perception>
       <perception_points type="number">@PERCEPTION_POINTS</perception_points>
       <fatiguepoints type="number">@BASIC_FP</fatiguepoints>
-      <fatiguepoints_points type="number">FP_POINTS</fatiguepoints_points>
+      <fatiguepoints_points type="number">@FP_POINTS</fatiguepoints_points>
       <fps type="number">@FP</fps>
       <basiclift type="string">@BASIC_LIFT</basiclift>
       <thrust type="string">@THRUST</thrust>

--- a/Library/Output Templates/Fantasy Grounds PC.xml
+++ b/Library/Output Templates/Fantasy Grounds PC.xml
@@ -69,7 +69,7 @@
       <perception type="number">@PERCEPTION</perception>
       <perception_points type="number">@PERCEPTION_POINTS</perception_points>
       <fatiguepoints type="number">@BASIC_FP</fatiguepoints>
-      <fatiguepoints_points type="number">FP_POINTS</fatiguepoints_points>
+      <fatiguepoints_points type="number">@FP_POINTS</fatiguepoints_points>
       <fps type="number">@FP</fps>
       <basiclift type="string">@BASIC_LIFT</basiclift>
       <thrust type="string">@THRUST</thrust>


### PR DESCRIPTION
I noticed this error when I started working on a character import for Foundry VTT.   I am going to use the Fantasy Grounds format (since this can also be generated by GCA) as a start, and may create new output templates as time goes on.