### PR TITLE
Fix for "Missing Spell Type Info from FG Export Template"

### DIFF
--- a/Library/Output Templates/Fantasy Grounds PC - No Mods.xml
+++ b/Library/Output Templates/Fantasy Grounds PC - No Mods.xml
@@ -28,7 +28,7 @@
           <points type="number">@POINTS</points>
           <resist type="string"></resist>
           <time type="string">@TIME_CAST</time>
-          <type type="string"></type>
+          <type type="string">@DIFFICULTY</type>
           <text type="formattedtext"><p>@DESCRIPTION_NOTES @DESCRIPTION_MODIFIER_NOTES_PAREN</p><p>Page Ref: @REF</p></text>
        </id-@ID>@SPELLS_LOOP_END
       </spelllist>

--- a/Library/Output Templates/Fantasy Grounds PC.xml
+++ b/Library/Output Templates/Fantasy Grounds PC.xml
@@ -28,7 +28,7 @@
           <points type="number">@POINTS</points>
           <resist type="string"></resist>
           <time type="string">@TIME_CAST</time>
-          <type type="string"></type>
+          <type type="string">@DIFFICULTY</type>
           <text type="formattedtext"><p>@DESCRIPTION_NOTES @DESCRIPTION_MODIFIER_NOTES_PAREN</p><p>Page Ref: @REF</p></text>
        </id-@ID>@SPELLS_LOOP_END
       </spelllist>


### PR DESCRIPTION
Fix for https://github.com/richardwilkes/gcs/issues/280