### PR TITLE
Minor fix to allow dagger and double dagger weapon strength values

### DIFF
--- a/Library/Output Templates/Foundry VTT.xml
+++ b/Library/Output Templates/Foundry VTT.xml
@@ -88,7 +88,7 @@
       <meleecombatlist>@HIERARCHICAL_MELEE_LOOP_START
         <id-@ID>
           <name type="string">@DESCRIPTION_PRIMARY</name>
-          <st type="string">@WEAPON_STRENGTH</st>
+          <st type="string">@STRENGTH</st>
           <weight type="string">@WEIGHT</weight>
           <tl type="string">@TL</tl>
           <cost type="string">@COST</cost>
@@ -109,7 +109,7 @@
       <rangedcombatlist>@HIERARCHICAL_RANGED_LOOP_START
         <id-@ID>
           <name type="string">@DESCRIPTION_PRIMARY</name>
-          <st type="string">@WEAPON_STRENGTH</st>
+          <st type="string">@STRENGTH</st>
           <bulk type="number">@BULK</bulk>
           <lc type="string">@LEGALITY_CLASS</lc>
           <ammo type="number">@AMMO</ammo>


### PR DESCRIPTION
Fantasy Grounds could not display the html character that got generated, and instead printed out all of the text.    So I had created a special output key to just print out the weapon's strength number, instead of the whole string. 
But Foundry can display it.

WEAPON_STRENGTH = 10
STRENGTH = 10&#8224;