### PR TITLE
Fixed Heavy Spear Tip Slash Reach

### DIFF
--- a/Library/Low Tech/Low Tech Equipment.eqp
+++ b/Library/Low Tech/Low Tech Equipment.eqp
@@ -6,6 +6,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "51eea2a3-09c6-42d1-9c21-1e6a22f52ea0",
 			"quantity": 1,
 			"description": "Abacus",
 			"tech_level": "2",
@@ -19,6 +20,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "7c29bb49-33e9-497c-8d42-fa1c1ed84989",
 			"quantity": 1,
 			"description": "Air Bladder",
 			"tech_level": "2",
@@ -32,6 +34,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "d519fa7e-2147-4033-9ae1-73401d160138",
 			"quantity": 1,
 			"description": "Apron, Leather",
 			"tech_level": "1",
@@ -52,6 +55,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "8cc2299f-334b-4c66-92ef-b9470fc45945",
 			"quantity": 1,
 			"description": "Arbalest",
 			"tech_level": "3",
@@ -99,6 +103,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "5708a4c4-f897-4307-b24e-e240aa5cefa8",
 			"quantity": 1,
 			"description": "Arbalest Bolt",
 			"tech_level": "3",
@@ -112,6 +117,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "083bc3c9-8d7e-4dab-8346-5a22e33e65e8",
 			"quantity": 1,
 			"description": "Arbalest Tripod",
 			"tech_level": "3",
@@ -125,6 +131,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "c1a93876-c589-44ca-89dd-8ebf35b3f0ae",
 			"quantity": 1,
 			"description": "Arquebus",
 			"tech_level": "4",
@@ -171,6 +178,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "dc703e2f-4fc9-4bce-8651-2fa8a740532f",
 			"quantity": 1,
 			"description": "Arquebus Bullet",
 			"tech_level": "4",
@@ -184,6 +192,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "9ebe4d88-426e-42b2-838c-56affa8d3135",
 			"quantity": 1,
 			"description": "Arrow Spoon",
 			"tech_level": "2",
@@ -196,6 +205,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "8ae6fb6d-8af9-4fca-a0c7-2b9c6f0b6940",
 			"quantity": 1,
 			"description": "Atlatl",
 			"tech_level": "0",
@@ -274,6 +284,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "8c9dcf71-d9fc-4d67-853a-d659bbd76c8b",
 			"quantity": 1,
 			"description": "Atlatl Dart",
 			"tech_level": "0",
@@ -287,6 +298,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "edcb0b8b-0ffb-471d-af84-9e6995e58acc",
 			"quantity": 1,
 			"description": "Axe",
 			"tech_level": "0",
@@ -373,6 +385,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "e7967b93-ba6a-4870-af58-972d3907957c",
 			"quantity": 1,
 			"description": "Backsword",
 			"tech_level": "4",
@@ -520,6 +533,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "186e488a-1ce8-4979-b484-e0558457d77f",
 			"quantity": 1,
 			"description": "Bagpipe",
 			"tech_level": "3",
@@ -533,6 +547,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "620499aa-1b03-4023-a01f-7882c807eb17",
 			"quantity": 1,
 			"description": "Balisong",
 			"tech_level": "3",
@@ -625,6 +640,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "83825624-567b-4428-8ebf-4fb66035a61f",
 			"quantity": 1,
 			"description": "Ballista, 0.03-lb Bullet",
 			"tech_level": "2",
@@ -639,6 +655,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "4d15ed60-3c15-41dd-a6e0-2e624748f126",
 			"quantity": 1,
 			"description": "Ballista, 0.03-lb Stone",
 			"tech_level": "2",
@@ -652,6 +669,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "cdd9f5e5-6e16-424a-9d79-fbc927be27ff",
 			"quantity": 1,
 			"description": "Ballista, 0.03-lb.",
 			"tech_level": "2",
@@ -690,6 +708,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "2bfc21f4-a9a7-466b-b868-6abd5122a6cc",
 			"quantity": 1,
 			"description": "Ballista, 0.06-lb Bullet",
 			"tech_level": "2",
@@ -704,6 +723,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "5bff8096-d49a-4684-81e2-5b0ebf4efd1e",
 			"quantity": 1,
 			"description": "Ballista, 0.06-lb Stone",
 			"tech_level": "2",
@@ -717,6 +737,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "0b85d12d-9a22-4fd5-aff2-a712c6f42c36",
 			"quantity": 1,
 			"description": "Ballista, 0.06-lb.",
 			"tech_level": "2",
@@ -755,6 +776,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "1222988d-8905-46b1-8442-2e70cae0bb15",
 			"quantity": 1,
 			"description": "Ballista, 0.12-lb Bullet",
 			"tech_level": "2",
@@ -769,6 +791,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "d35f64ed-3431-4467-a68d-7af3d45c62a2",
 			"quantity": 1,
 			"description": "Ballista, 0.12-lb Stone",
 			"tech_level": "2",
@@ -782,6 +805,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "ce85b465-ccda-4bed-a8a9-db0d1686378b",
 			"quantity": 1,
 			"description": "Ballista, 0.12-lb.",
 			"tech_level": "2",
@@ -820,6 +844,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "2b88b29d-be99-453e-9292-ccec51cf5ab8",
 			"quantity": 1,
 			"description": "Ballista, 0.18-lb Bullet",
 			"tech_level": "2",
@@ -834,6 +859,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "2d47bd85-2345-4f5a-ab20-874bd6d17f2a",
 			"quantity": 1,
 			"description": "Ballista, 0.18-lb Stone",
 			"tech_level": "2",
@@ -847,6 +873,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "510e6ba6-90cc-49e8-887a-08c798ced3f4",
 			"quantity": 1,
 			"description": "Ballista, 0.18-lb.",
 			"tech_level": "2",
@@ -885,6 +912,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "c8a3d20c-fce7-4c76-895c-e6d164e35319",
 			"quantity": 1,
 			"description": "Ballista, 1-lb Stone",
 			"tech_level": "3",
@@ -898,6 +926,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "d6641954-df21-4096-966e-a05c691f0db0",
 			"quantity": 1,
 			"description": "Ballista, 1-lb.",
 			"tech_level": "2",
@@ -945,6 +974,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "94ee2d91-00ed-4208-a100-272302d9525f",
 			"quantity": 1,
 			"description": "Ballista, 1-lb. Tripod",
 			"tech_level": "2",
@@ -958,6 +988,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "05f3b44c-c8c0-40f5-8a24-7b0172f1f730",
 			"quantity": 1,
 			"description": "Ballista, 2-lb Stone",
 			"tech_level": "3",
@@ -971,6 +1002,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "d21d4f8f-3285-4d6b-880f-b7f9fba89c8f",
 			"quantity": 1,
 			"description": "Ballista, 2-lb.",
 			"tech_level": "2",
@@ -1018,6 +1050,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "f1b57103-49ba-4b57-830f-df169577b8e9",
 			"quantity": 1,
 			"description": "Ballista, 2-lb. Tripod",
 			"tech_level": "2",
@@ -1031,6 +1064,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "4cc6affd-cdc3-4634-8dc8-2a091ad9f08c",
 			"quantity": 1,
 			"description": "Ballista, 5-lb Stone",
 			"tech_level": "3",
@@ -1044,6 +1078,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "c07c3fe7-e6e0-4f1d-88c4-1311c97c7968",
 			"quantity": 1,
 			"description": "Ballista, 5-lb.",
 			"tech_level": "2",
@@ -1091,6 +1126,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "1e09ca85-6b37-4a9f-b65a-887c007b4efb",
 			"quantity": 1,
 			"description": "Ballista, 5-lb. Tripod",
 			"tech_level": "2",
@@ -1104,6 +1140,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "d598dc1b-b3bd-4041-a76a-52928a935e13",
 			"quantity": 1,
 			"description": "Ballista, 10-lb Stone",
 			"tech_level": "3",
@@ -1117,6 +1154,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "44168f60-4bef-4781-8400-1f7fe5c10865",
 			"quantity": 1,
 			"description": "Ballista, 10-lb.",
 			"tech_level": "2",
@@ -1195,6 +1233,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "330e9c38-2965-49f6-9683-d4b20a9cd3b6",
 			"quantity": 1,
 			"description": "Ballista, 10-lb. Tripod",
 			"tech_level": "2",
@@ -1208,6 +1247,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "3238cf11-d7da-4948-9c33-c2f1719596fb",
 			"quantity": 1,
 			"description": "Ballista, 15-lb Stone",
 			"tech_level": "3",
@@ -1221,6 +1261,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "65e8b379-74da-46f3-9485-45e53ad20a5f",
 			"quantity": 1,
 			"description": "Ballista, 15-lb.",
 			"tech_level": "2",
@@ -1299,6 +1340,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "b6f896a5-6c57-4b32-bb55-edcb72838b95",
 			"quantity": 1,
 			"description": "Ballista, 15-lb. Tripod",
 			"tech_level": "2",
@@ -1312,6 +1354,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "2ceb848b-f96f-44ad-bd54-152ff5a9c22f",
 			"quantity": 1,
 			"description": "Ballista, 20-lb Stone",
 			"tech_level": "3",
@@ -1325,6 +1368,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "3201bffd-77ce-4611-bcb8-d4c79369c366",
 			"quantity": 1,
 			"description": "Ballista, 20-lb.",
 			"tech_level": "2",
@@ -1403,6 +1447,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "995e6e65-ebbc-4ae4-9865-24ebb33f7e2a",
 			"quantity": 1,
 			"description": "Ballista, 20-lb. Tripod",
 			"tech_level": "2",
@@ -1416,6 +1461,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "a42819ff-d13b-4270-9794-5d2b087cd79e",
 			"quantity": 1,
 			"description": "Ballista, 30-lb Stone",
 			"tech_level": "3",
@@ -1429,6 +1475,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "42f138a3-1e6c-40ac-a885-1f64c5daf602",
 			"quantity": 1,
 			"description": "Ballista, 30-lb.",
 			"tech_level": "2",
@@ -1491,6 +1538,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "5239188e-53c0-42fb-a25f-cd58dd580c23",
 			"quantity": 1,
 			"description": "Ballista, 30-lb. Tripod",
 			"tech_level": "2",
@@ -1504,6 +1552,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "60b37498-1e7a-42aa-9cd1-0c0c3024a182",
 			"quantity": 1,
 			"description": "Ballista, 60-lb Stone",
 			"tech_level": "3",
@@ -1517,6 +1566,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "8f527062-b0ca-461a-9e8f-0b070fe79b7a",
 			"quantity": 1,
 			"description": "Ballista, 60-lb.",
 			"tech_level": "2",
@@ -1595,6 +1645,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "504ad7c4-37e0-46f5-9c0b-475793c74055",
 			"quantity": 1,
 			"description": "Ballista, 60-lb. Tripod",
 			"tech_level": "2",
@@ -1608,6 +1659,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "8a5f5b81-1b6c-48c5-a367-b5f10a5b24a2",
 			"quantity": 1,
 			"description": "Ballista, 180-lb Stone",
 			"tech_level": "3",
@@ -1621,6 +1673,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "fb524fa6-4f59-4065-aa29-591c5391003b",
 			"quantity": 1,
 			"description": "Ballista, 180-lb.",
 			"tech_level": "2",
@@ -1699,6 +1752,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "89826b8b-13ec-41b8-9787-e6f559ef6ddd",
 			"quantity": 1,
 			"description": "Ballista, 180-lb. Tripod",
 			"tech_level": "2",
@@ -1712,6 +1766,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "2248aa56-37f2-4f87-9e60-8e64c6341a58",
 			"quantity": 1,
 			"description": "Bamboo Land Mine",
 			"tech_level": "4",
@@ -1727,6 +1782,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "207f8d36-03d8-41f1-8631-1f12672cca7e",
 			"quantity": 1,
 			"description": "Bandolier",
 			"tech_level": "4",
@@ -1740,6 +1796,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "a38f5dab-cc0c-4c37-871c-99efcf508cb3",
 			"quantity": 1,
 			"description": "Barbed Arrow",
 			"tech_level": "0",
@@ -1755,6 +1812,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "0d89bf9f-d092-4352-b219-967b760bc516",
 			"quantity": 1,
 			"description": "Barber's Kit",
 			"tech_level": "1",
@@ -1779,6 +1837,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "9b7e5034-77cc-400b-8916-61e37551b6b9",
 			"quantity": 1,
 			"description": "Bastard Sword",
 			"tech_level": "3",
@@ -1956,6 +2015,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "9e307c3f-b534-4adf-a71c-8edf0178bb99",
 			"quantity": 1,
 			"description": "Bathtub, Earthenware",
 			"tech_level": "1",
@@ -1969,6 +2029,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "b244128c-c4f8-4dd6-a2cd-240d953406e3",
 			"quantity": 1,
 			"description": "Bathtub, Metal",
 			"tech_level": "1",
@@ -1982,6 +2043,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "fa962383-1c1e-43d0-b326-3f2420f93780",
 			"quantity": 1,
 			"description": "Baton",
 			"tech_level": "0",
@@ -2111,6 +2173,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "48e02615-d611-4f01-90b4-640d08583eab",
 			"quantity": 1,
 			"description": "Battle Car",
 			"tech_level": "2",
@@ -2125,6 +2188,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "9837c49b-1dc8-439b-b01e-41482f444b27",
 			"quantity": 1,
 			"description": "Beads, copper, per foot",
 			"tech_level": "0",
@@ -2138,6 +2202,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "3641bd9b-bb33-4691-be4e-4c3a3c42b810",
 			"quantity": 1,
 			"description": "Beads, gold, per foot",
 			"tech_level": "0",
@@ -2151,6 +2216,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "1eb64b48-70f7-448a-a0a7-18b2e6d464d6",
 			"quantity": 1,
 			"description": "Beads, silver, per foot",
 			"tech_level": "0",
@@ -2164,6 +2230,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "f31bd7cb-8830-4345-bdcd-bfeb01e6da71",
 			"quantity": 1,
 			"description": "Beam Sling, 15-Man",
 			"tech_level": "3",
@@ -2207,6 +2274,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "8371e2f5-8077-46ad-8b5e-d1b9a52359ef",
 			"quantity": 1,
 			"description": "Beam Sling, 15-Man Stone",
 			"tech_level": "3",
@@ -2220,6 +2288,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "951778fe-1677-4c12-86e5-79c85dfaad6e",
 			"quantity": 1,
 			"description": "Beam Sling, 30-Man",
 			"tech_level": "3",
@@ -2263,6 +2332,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "c6b95562-4ff5-4ced-b5e4-24b70b47d5fa",
 			"quantity": 1,
 			"description": "Beam Sling, 30-Man Stone",
 			"tech_level": "3",
@@ -2276,6 +2346,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "476ec180-9cbe-4a63-ad46-a2e77809047c",
 			"quantity": 1,
 			"description": "Beam Sling, 50-Man",
 			"tech_level": "3",
@@ -2319,6 +2390,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "45f60dbb-e67b-4448-86d3-3cfde9f83ed5",
 			"quantity": 1,
 			"description": "Beam Sling, 50-Man Stone",
 			"tech_level": "3",
@@ -2332,6 +2404,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "3b861edf-3ac0-418b-b66a-b95dc7497fdb",
 			"quantity": 1,
 			"description": "Beam Sling, 100-Man",
 			"tech_level": "3",
@@ -2375,6 +2448,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "4653680f-79b5-430d-b150-944e8306258c",
 			"quantity": 1,
 			"description": "Beam Sling, 100-Man Stone",
 			"tech_level": "3",
@@ -2388,6 +2462,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "a04f80a7-fbec-4187-b216-723d6187e67a",
 			"quantity": 1,
 			"description": "Beam Sling, Weighted, 30-Man",
 			"tech_level": "3",
@@ -2431,6 +2506,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "39e69f2d-e97c-4e45-a7e1-0b98514a1383",
 			"quantity": 1,
 			"description": "Beam Sling, Weighted, 50-Man",
 			"tech_level": "3",
@@ -2474,6 +2550,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "86410314-b206-40ab-8647-59b323b88e87",
 			"quantity": 1,
 			"description": "Belladonna",
 			"tech_level": "0",
@@ -2487,6 +2564,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "4e13fd02-a6ad-4073-b369-307e7434d1c9",
 			"quantity": 1,
 			"description": "Belt Hook",
 			"tech_level": "4",
@@ -2500,6 +2578,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "ae12db92-b375-40b2-ae55-677f3432c843",
 			"quantity": 1,
 			"description": "Bill",
 			"tech_level": "3",
@@ -2629,6 +2708,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "b27acf5a-7baf-48f2-99e1-810481b5851a",
 			"quantity": 1,
 			"description": "Blackjack",
 			"tech_level": "1",
@@ -2666,6 +2746,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "153328ad-f145-4e1f-9e8f-7499d12948ec",
 			"quantity": 1,
 			"description": "Bladed Hand",
 			"tech_level": "3",
@@ -2716,6 +2797,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "65ae8ce8-038a-4b4a-b331-932e591e4256",
 			"quantity": 1,
 			"description": "Bleeding Cup",
 			"tech_level": "1",
@@ -2729,6 +2811,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "d1175f91-1de8-4c8a-9ee2-f27d8089c441",
 			"quantity": 1,
 			"description": "Blowpipe",
 			"tech_level": "0",
@@ -2770,6 +2853,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "305d13d5-329d-40f6-ae07-a1a90afcb6f0",
 			"quantity": 1,
 			"description": "Blowpipe Dart",
 			"tech_level": "0",
@@ -2784,6 +2868,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "116f3b66-09b7-4733-80df-54e3f75f1b5d",
 			"quantity": 1,
 			"description": "Blunderbuss",
 			"tech_level": "4",
@@ -2830,6 +2915,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "a2ce32b5-6b9f-4944-accf-0c261b05dfb5",
 			"quantity": 1,
 			"description": "Blunderbuss Shot",
 			"tech_level": "4",
@@ -2843,6 +2929,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "15c978bb-198c-4394-9537-65e9a01099a4",
 			"quantity": 1,
 			"description": "Blunt Arrow",
 			"tech_level": "0",
@@ -2858,6 +2945,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "1d6de863-dd3d-4bc9-936f-0e4a97be9cec",
 			"quantity": 1,
 			"description": "Board Games",
 			"tech_level": "1",
@@ -2871,6 +2959,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "62f820b5-b38a-49d8-9ddb-797d49618fc2",
 			"quantity": 1,
 			"description": "Bokken",
 			"tech_level": "3",
@@ -3048,6 +3137,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "7979dbdc-8ac8-46e0-99bb-0191ae1a85b3",
 			"quantity": 1,
 			"description": "Bola Perdida",
 			"tech_level": "0",
@@ -3123,6 +3213,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "1dcda88d-798c-49a0-9dad-850b807cd6fb",
 			"quantity": 1,
 			"description": "Bolas",
 			"tech_level": "0",
@@ -3192,6 +3283,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "44adafb5-6fa2-4e07-b9e2-be42696f8f8c",
 			"quantity": 1,
 			"description": "Bombard",
 			"tech_level": "3",
@@ -3233,6 +3325,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "2d5a9d3a-3904-42a5-9a0d-2bce212d99dd",
 			"quantity": 1,
 			"description": "Bombard Metal Ball",
 			"tech_level": "3",
@@ -3246,6 +3339,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "8751d8e3-5e69-4bd7-b732-5e04b74cc0e5",
 			"quantity": 1,
 			"description": "Bombard Stone Ball",
 			"tech_level": "3",
@@ -3259,6 +3353,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "3a121f70-c547-4c76-a218-9e2eb356c524",
 			"quantity": 1,
 			"description": "Bombard, Large",
 			"tech_level": "3",
@@ -3300,6 +3395,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "87aa98dc-bbbc-4c25-bfaf-04458f7bfa8a",
 			"quantity": 1,
 			"description": "Bombard, Large Metal Ball",
 			"tech_level": "3",
@@ -3313,6 +3409,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "6b452076-09b7-4796-a865-25003dcb9c43",
 			"quantity": 1,
 			"description": "Boomerang",
 			"tech_level": "0",
@@ -3353,6 +3450,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "cdff818f-f0ea-4e9e-8b51-9976ee43944b",
 			"quantity": 1,
 			"description": "Boots, leather",
 			"tech_level": "2",
@@ -3366,6 +3464,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "0cc649c7-4181-418a-8ace-1bacb9fdee24",
 			"quantity": 1,
 			"description": "Bowel-Raker Arrow",
 			"tech_level": "0",
@@ -3381,6 +3480,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "a6731b5e-46df-4740-badb-5d4fc4c3709a",
 			"quantity": 1,
 			"description": "Bracelet, copper",
 			"tech_level": "0",
@@ -3394,6 +3494,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "5c29b84d-4a9d-4e1e-83e5-7238b18238ba",
 			"quantity": 1,
 			"description": "Bracelet, gold",
 			"tech_level": "0",
@@ -3407,6 +3508,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "4beb31d4-8328-4c08-bd74-747441c68ed8",
 			"quantity": 1,
 			"description": "Bracelet, silver",
 			"tech_level": "0",
@@ -3420,6 +3522,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "f6286ca2-0760-4a6f-b68b-7a7f945bc9c1",
 			"quantity": 1,
 			"description": "Brass Knuckles",
 			"tech_level": "1",
@@ -3464,6 +3567,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "9b891199-b6bb-4b21-b2fc-18d863903715",
 			"quantity": 1,
 			"description": "Breathing Tube",
 			"tech_level": "1",
@@ -3477,6 +3581,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "8ae33060-5e8b-4133-a8bc-69cf4bf008ed",
 			"quantity": 1,
 			"description": "Breechloading Carbine",
 			"tech_level": "4",
@@ -3523,6 +3628,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "9a4dadc1-8074-4c38-92c8-2633513a4ffb",
 			"quantity": 1,
 			"description": "Breechloading Carbine Bullet",
 			"tech_level": "4",
@@ -3536,6 +3642,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "c28d29fe-2ca1-4059-9c90-456e2e3ac3cd",
 			"quantity": 1,
 			"description": "Bridle and Bit",
 			"tech_level": "1",
@@ -3549,6 +3656,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "c6f53681-ecea-46d1-b548-3aeaf44131e1",
 			"quantity": 1,
 			"description": "Brig, 50'",
 			"tech_level": "4",
@@ -3562,6 +3670,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "dcb933c6-c944-4b31-831d-9ee588d51dc6",
 			"quantity": 1,
 			"description": "Broadsword",
 			"tech_level": "2",
@@ -3673,6 +3782,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "0e1411b3-ec51-4f35-ac9a-f1111be1a55f",
 			"quantity": 1,
 			"description": "Brush",
 			"tech_level": "1",
@@ -3685,6 +3795,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "bc1fbbb6-e87f-479e-900a-3e6d2c2a133b",
 			"quantity": 1,
 			"description": "Brush",
 			"tech_level": "1",
@@ -3698,6 +3809,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "7f9f7a4f-94dd-4bc6-8e61-bdbb18d0db5f",
 			"quantity": 1,
 			"description": "Bullet-Molding Gear",
 			"tech_level": "4",
@@ -3711,6 +3823,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "c4552353-92a1-414a-a73e-a9bce76616ab",
 			"quantity": 1,
 			"description": "Burning Glass, Glass",
 			"tech_level": "3",
@@ -3724,6 +3837,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "99831fea-2cc5-4ba9-8946-2c4fde2f195d",
 			"quantity": 1,
 			"description": "Burning Glass, Quartz",
 			"tech_level": "2",
@@ -3737,6 +3851,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "5dea3da5-ca10-4e05-ba31-636e44676ccf",
 			"quantity": 1,
 			"description": "Caliver",
 			"tech_level": "4",
@@ -3783,6 +3898,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "a1a6124e-8d9b-4791-8a7d-40b65f618c47",
 			"quantity": 1,
 			"description": "Caliver Bullet",
 			"tech_level": "4",
@@ -3796,6 +3912,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "632cf0d5-dc2d-4b3f-8747-1c0f54d05d48",
 			"quantity": 1,
 			"description": "Candle Case",
 			"tech_level": "3",
@@ -3809,6 +3926,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "d3943d31-86f1-476d-8fb7-5cf7e913cfc5",
 			"quantity": 6,
 			"description": "Candle, Graduated",
 			"tech_level": "3",
@@ -3822,6 +3940,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "a13d1dfe-e537-40d3-9247-fa9d3c77e7cf",
 			"quantity": 1,
 			"description": "Cannon",
 			"tech_level": "4",
@@ -3869,6 +3988,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "e53c62c9-9d9b-4603-a2b5-48b5a06cbc79",
 			"quantity": 1,
 			"description": "Cannon Truck Carriage Mount",
 			"tech_level": "4",
@@ -3882,6 +4002,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "ff5856cf-0149-4415-b6e3-7d061221b125",
 			"quantity": 1,
 			"description": "Cannon, 3-lb.",
 			"tech_level": "4",
@@ -3929,6 +4050,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "18f2c385-3924-4d2e-be98-e113e2d7ee1f",
 			"quantity": 1,
 			"description": "Cannon, 3-lb. Cannonball",
 			"tech_level": "4",
@@ -3942,6 +4064,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "caba81d5-59f9-4df3-9872-1c61bf388016",
 			"quantity": 1,
 			"description": "Cannon, 3-lb. Field Carriage Mount",
 			"tech_level": "4",
@@ -3955,6 +4078,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "bc32fdee-092b-456a-abac-1206406f53e6",
 			"quantity": 1,
 			"description": "Cannon, 12-lb.",
 			"tech_level": "4",
@@ -4002,6 +4126,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "7ed57df2-4edc-40e8-96c9-143dd6efe9ea",
 			"quantity": 1,
 			"description": "Cannon, 12-lb. Cannonball",
 			"tech_level": "4",
@@ -4015,6 +4140,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "14594d71-aac0-44a6-826a-9157b43f9d58",
 			"quantity": 1,
 			"description": "Cannon, 12-lb. Field Carriage Mount",
 			"tech_level": "4",
@@ -4028,6 +4154,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "8f514fe9-8b40-48f2-8f0b-91f8d344db17",
 			"quantity": 1,
 			"description": "Cannon, 24-lb.",
 			"tech_level": "4",
@@ -4075,6 +4202,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "80b97572-352a-4bc8-b735-2d196bab7e3b",
 			"quantity": 1,
 			"description": "Cannon, 24-lb. Cannonball",
 			"tech_level": "4",
@@ -4088,6 +4216,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "2463cb20-0cb1-493b-8d31-0cd1bd56e8e3",
 			"quantity": 1,
 			"description": "Cannon, 24-lb. Field Carriage Mount",
 			"tech_level": "4",
@@ -4101,6 +4230,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "c3449100-ed1d-4e16-affc-23baa6ec8b59",
 			"quantity": 1,
 			"description": "Cantharides",
 			"tech_level": "0",
@@ -4114,6 +4244,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "62d3a1c8-f430-4979-9407-8a80fdb2cc3a",
 			"quantity": 1,
 			"description": "Carbine",
 			"tech_level": "4",
@@ -4160,6 +4291,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "a7bbe7d1-6a3c-41ec-a429-e67447b76b02",
 			"quantity": 1,
 			"description": "Carbine Bullet",
 			"tech_level": "4",
@@ -4173,6 +4305,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "a6adc1a6-adf6-4966-8c3f-9a9e3ef34393",
 			"quantity": 1,
 			"description": "Cards",
 			"tech_level": "3",
@@ -4186,6 +4319,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "8fc0c0d8-6914-48e9-a8b6-e1914ccde6ca",
 			"quantity": 1,
 			"description": "Carriage",
 			"tech_level": "4",
@@ -4200,6 +4334,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "9f0a05f2-58e1-46f5-b093-d6da3960b7f2",
 			"quantity": 1,
 			"description": "Carroballista",
 			"tech_level": "2",
@@ -4247,6 +4382,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "2874151c-fd09-4701-99ba-70b6b2df09b2",
 			"quantity": 1,
 			"description": "Carroballista Bolt",
 			"tech_level": "3",
@@ -4260,6 +4396,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "456b21b8-02b4-43cd-bd81-fea535d76ccf",
 			"quantity": 1,
 			"description": "Cataract Needles",
 			"tech_level": "2",
@@ -4272,6 +4409,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "4282d7ff-651f-47d7-b378-3bbe24127ba5",
 			"quantity": 1,
 			"description": "Catheter",
 			"tech_level": "2",
@@ -4284,6 +4422,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "2561760b-8cd4-4913-9f9f-874c577b33ff",
 			"quantity": 1,
 			"description": "Cautery",
 			"tech_level": "2",
@@ -4297,6 +4436,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "11697133-fbe6-4464-9abe-50c6527b8119",
 			"quantity": 1,
 			"description": "Cavalry Saber",
 			"tech_level": "4",
@@ -4407,6 +4547,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "505da1d7-ac45-463c-b389-6ff53c518b03",
 			"quantity": 1,
 			"description": "Cestus",
 			"tech_level": "2",
@@ -4458,6 +4599,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "658503d8-ddde-4b62-9ba1-991da8a3856b",
 			"quantity": 1,
 			"description": "Chain Whip, 1 yard",
 			"tech_level": "3",
@@ -4512,6 +4654,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "ede7ac60-290e-45ab-ba67-ad2dd8558757",
 			"quantity": 1,
 			"description": "Chain Whip, 2 yards",
 			"tech_level": "3",
@@ -4566,6 +4709,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "57de38b8-d939-4d45-92ba-98f11731c884",
 			"quantity": 1,
 			"description": "Chain Whip, 3 yards",
 			"tech_level": "3",
@@ -4620,6 +4764,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "63da63a9-8b94-485a-97f8-ff4d2b8c5971",
 			"quantity": 1,
 			"description": "Chain Whip, 4 yards",
 			"tech_level": "3",
@@ -4674,6 +4819,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "b0c19751-7c40-4bcb-9b8e-8dc8c6a9eec2",
 			"quantity": 1,
 			"description": "Chain, copper, per foot",
 			"tech_level": "0",
@@ -4687,6 +4833,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "d573c028-c69c-47ef-9dbb-6bed24fa63af",
 			"quantity": 1,
 			"description": "Chain, gold, per foot",
 			"tech_level": "0",
@@ -4700,6 +4847,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "3a615185-07f2-48db-8dbf-67dd4f407f48",
 			"quantity": 1,
 			"description": "Chain, silver, per foot",
 			"tech_level": "0",
@@ -4713,6 +4861,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "78512d84-b31e-413e-985b-3bfb7a010094",
 			"quantity": 1,
 			"description": "Chakram",
 			"tech_level": "2",
@@ -4759,6 +4908,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "aef4f5c3-33b3-446b-871c-cbf47f40d5b7",
 			"quantity": 1,
 			"description": "Cheiroballistra Bolt",
 			"tech_level": "2",
@@ -4772,6 +4922,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "27f69ead-3a69-44fc-b0a7-c34eb67c0bd7",
 			"quantity": 1,
 			"description": "Cheiroballistra, 18”",
 			"tech_level": "2",
@@ -4810,6 +4961,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "cebd17ab-9e80-4f04-9f3c-4084b6b8bcea",
 			"quantity": 1,
 			"description": "Cheirosiphon",
 			"tech_level": "3",
@@ -4857,6 +5009,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "34225214-e322-4a56-9f3b-020273c3a358",
 			"quantity": 1,
 			"description": "Climbing Pole",
 			"tech_level": "1",
@@ -4870,6 +5023,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "9b4f42e7-963b-4e5d-b3e0-30f954bb2c4d",
 			"quantity": 1,
 			"description": "Climbing Spikes, set of four",
 			"tech_level": "2",
@@ -4883,6 +5037,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "17dfecd6-acfa-45fc-9f24-8f27b750aa11",
 			"quantity": 1,
 			"description": "Cloak, Expensive (Status 4)",
 			"tech_level": "0",
@@ -4932,6 +5087,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "d742b3aa-425f-4326-b4b2-69f22bf74b52",
 			"quantity": 1,
 			"description": "Cloak, Freeman (Status 0)",
 			"tech_level": "0",
@@ -4981,6 +5137,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "5ce68a4d-2f05-4218-9a43-7e0fa55bf901",
 			"quantity": 1,
 			"description": "Cloak, Leather/Wool, Expensive (Status 4)",
 			"tech_level": "0",
@@ -5030,6 +5187,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "c4183310-5cca-40cb-a035-f3b0730408ea",
 			"quantity": 1,
 			"description": "Cloak, Leather/Wool, Freeman (Status 0)",
 			"tech_level": "0",
@@ -5079,6 +5237,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "6cc868c1-db02-4f1d-ba9e-a35a63947cee",
 			"quantity": 1,
 			"description": "Cloak, Leather/Wool, Poor (Status -2)",
 			"tech_level": "0",
@@ -5128,6 +5287,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "3f5286ec-f14c-4597-87ff-f30f2605d2cf",
 			"quantity": 1,
 			"description": "Cloak, Poor (Status -2)",
 			"tech_level": "0",
@@ -5177,6 +5337,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "ce3aad49-9e43-4f37-a96c-4340c5f9bf6b",
 			"description": "Cloth Bag, 1 cup",
 			"tech_level": "0",
 			"value": "0.25",
@@ -5205,6 +5366,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "64db3fab-579e-4874-b29e-9235becb2622",
 			"description": "Cloth Bag, 1 gal.",
 			"tech_level": "0",
 			"value": "1.75",
@@ -5233,6 +5395,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "b8b0e0bf-11dd-4cc8-947a-fd4ed73821cc",
 			"description": "Cloth Bag, 1 quart",
 			"tech_level": "0",
 			"value": "0.75",
@@ -5261,6 +5424,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "4eddc5c4-e4b1-4737-9457-b09fc13082d9",
 			"description": "Cloth Bag, 1/4 cup",
 			"tech_level": "0",
 			"value": "0.1",
@@ -5289,6 +5453,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "4ec13b9f-cd1a-487e-bce3-7dead02e7752",
 			"description": "Cloth Bag, 2 gal.",
 			"tech_level": "0",
 			"value": "2.75",
@@ -5317,6 +5482,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "f9d15c1b-525e-4d68-b759-5dd9e3d5e27c",
 			"description": "Cloth Bag, 6 gal.",
 			"tech_level": "0",
 			"value": "6",
@@ -5345,6 +5511,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "26c326f2-cb87-4c13-8ec9-6b47664173b6",
 			"description": "Cloth Bag, 20 gal.",
 			"tech_level": "0",
 			"value": "13",
@@ -5373,6 +5540,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "2026fe6d-dfc1-41ba-986d-4e6da78dce8e",
 			"description": "Cloth Bag, 40 gal.",
 			"tech_level": "0",
 			"value": "20",
@@ -5401,6 +5569,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "2cdd9fd6-f0a8-4baf-8548-010192a8abfd",
 			"description": "Cloth Bag, 80 gal.",
 			"tech_level": "0",
 			"value": "32",
@@ -5429,6 +5598,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "ecc14874-1f68-4637-9786-2dba3dc15133",
 			"description": "Cloth Bag, 120 gal.",
 			"tech_level": "0",
 			"value": "42",
@@ -5457,6 +5627,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "e3e7f318-1002-466c-a8c9-71c9b7a2ac6b",
 			"quantity": 1,
 			"description": "Clothing, Ordinary, Freeman (Status 0)",
 			"tech_level": "0",
@@ -5470,6 +5641,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "e307a458-9972-48e3-abb2-4f8d00961be3",
 			"quantity": 1,
 			"description": "Clothing, Ordinary, Merchant (Status 1)",
 			"tech_level": "0",
@@ -5483,6 +5655,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "cd662eaa-19c1-44fc-aa1f-b415d47749e1",
 			"quantity": 1,
 			"description": "Clothing, Ordinary, Noble (Status 4)",
 			"tech_level": "0",
@@ -5496,6 +5669,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "a5c96243-0074-4a7e-8274-03483c68fead",
 			"quantity": 1,
 			"description": "Clothing, Ordinary, Poor (Status -2)",
 			"tech_level": "0",
@@ -5509,6 +5683,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "723c145b-0b46-4f7c-bbcb-e55cb10cf531",
 			"quantity": 1,
 			"description": "Clothing, Ordinary, Royal (Status 7)",
 			"tech_level": "0",
@@ -5522,6 +5697,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "d92f7049-c431-4f64-915b-f412e48c4059",
 			"quantity": 1,
 			"description": "Clothing, Summer, Freeman (Status 0)",
 			"tech_level": "0",
@@ -5535,6 +5711,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "c014d5af-f952-47de-a54c-b0011cc866d0",
 			"quantity": 1,
 			"description": "Clothing, Summer, Merchant (Status 1)",
 			"tech_level": "0",
@@ -5548,6 +5725,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "00fbc7aa-e34a-4a99-be4d-ac03014de116",
 			"quantity": 1,
 			"description": "Clothing, Summer, Noble (Status 4)",
 			"tech_level": "0",
@@ -5561,6 +5739,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "c1e2ba72-dd8b-4cb4-9a78-053a3a5ad436",
 			"quantity": 1,
 			"description": "Clothing, Summer, Poor (Status -2)",
 			"tech_level": "0",
@@ -5574,6 +5753,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "dec59a95-de05-4dba-8792-212e8434898c",
 			"quantity": 1,
 			"description": "Clothing, Summer, Royal (Status 7)",
 			"tech_level": "0",
@@ -5587,6 +5767,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "11f07193-fe24-424f-b52a-7c47bc5d58cf",
 			"quantity": 1,
 			"description": "Clothing, Winter, Freeman (Status 0)",
 			"tech_level": "0",
@@ -5600,6 +5781,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "d09f2da7-3df5-4243-b55f-7154a887269d",
 			"quantity": 1,
 			"description": "Clothing, Winter, Merchant (Status 1)",
 			"tech_level": "0",
@@ -5613,6 +5795,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "2f54d32a-8a76-4359-a000-12af21a2dd8f",
 			"quantity": 1,
 			"description": "Clothing, Winter, Noble (Status 4)",
 			"tech_level": "0",
@@ -5626,6 +5809,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "f292baff-96ce-460e-8c7c-b3f0abda4709",
 			"quantity": 1,
 			"description": "Clothing, Winter, Poor (Status -2)",
 			"tech_level": "0",
@@ -5639,6 +5823,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "8dbd459b-471e-4b78-9756-56c89c029b9e",
 			"quantity": 1,
 			"description": "Clothing, Winter, Royal (Status 7)",
 			"tech_level": "0",
@@ -5652,6 +5837,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "d6a9dbb1-4f1f-4d5e-9062-c34f50277702",
 			"quantity": 1,
 			"description": "Coach",
 			"tech_level": "4",
@@ -5666,6 +5852,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "9dabc331-15db-4c68-b552-1598ec78ebc2",
 			"quantity": 1,
 			"description": "Coat, Long",
 			"tech_level": "1",
@@ -5679,6 +5866,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "f6960610-8a5d-436b-87fc-0be4efe2444d",
 			"quantity": 1,
 			"description": "Coat, Long, Heavy",
 			"tech_level": "1",
@@ -5699,6 +5887,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "7110ebed-d26b-406d-af68-36dfd92b864e",
 			"quantity": 1,
 			"description": "Comb",
 			"tech_level": "0",
@@ -5712,6 +5901,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "918d2a8a-a9b8-4576-bd24-b077df793865",
 			"quantity": 1,
 			"description": "Combat Fan",
 			"tech_level": "3",
@@ -5762,6 +5952,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "f5d78a0c-431b-49ce-848e-97b35c3a5eeb",
 			"quantity": 1,
 			"description": "Compass",
 			"tech_level": "3",
@@ -5786,6 +5977,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "8c421c42-bfe4-4101-a227-2b1c61929aa4",
 			"quantity": 1,
 			"description": "Composite Crossbow",
 			"tech_level": "3",
@@ -5827,6 +6019,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "8ad7d74b-6f84-4eec-8953-0dcd6d07f395",
 			"quantity": 1,
 			"description": "Corned Black Powder",
 			"tech_level": "4",
@@ -5841,6 +6034,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "da0f9e15-7874-4030-a433-990f3a68b2a9",
 			"quantity": 1,
 			"description": "Cosmetics, Better, Cheap, per use",
 			"tech_level": "0",
@@ -5854,6 +6048,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "35e53abc-405f-4491-ac54-d9ad1f1f5092",
 			"quantity": 1,
 			"description": "Cosmetics, Better, Expensive, per use",
 			"tech_level": "0",
@@ -5867,6 +6062,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "5914d2d9-06f8-4ae5-aae6-1283ae581554",
 			"quantity": 1,
 			"description": "Cosmetics, Common, Cheap, per use",
 			"tech_level": "0",
@@ -5880,6 +6076,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "82a10225-562e-4116-8c8e-2aa2a3c02edc",
 			"quantity": 1,
 			"description": "Cosmetics, Common, Expensive, per use",
 			"tech_level": "0",
@@ -5893,6 +6090,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "5b9de033-2043-4806-835f-9fd9513b9ceb",
 			"quantity": 1,
 			"description": "Crapaudeau",
 			"tech_level": "3",
@@ -5934,6 +6132,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "8508c8de-db5b-44ca-be66-7fae2a40741c",
 			"quantity": 1,
 			"description": "Crapaudeau Stone",
 			"tech_level": "3",
@@ -5947,6 +6146,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "842bc2ac-b261-4795-baef-ab574f4c89f4",
 			"quantity": 1,
 			"description": "Crossbow",
 			"tech_level": "2",
@@ -5988,6 +6188,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "7551e399-12b7-4ccb-a07a-19d865f10029",
 			"quantity": 1,
 			"description": "Crouching Tiger Gun",
 			"tech_level": "4",
@@ -6054,6 +6255,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "588798f7-6995-4aec-badd-052068911091",
 			"quantity": 1,
 			"description": "Crouching Tiger Gun Shot",
 			"tech_level": "4",
@@ -6067,6 +6269,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "aa85bd2e-6d9f-45ea-b838-aaae62227cd8",
 			"quantity": 1,
 			"description": "Crouching Tiger Gun Stone",
 			"tech_level": "4",
@@ -6080,6 +6283,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "d6e17639-8af9-48fd-a7e6-fb722e2aaa86",
 			"quantity": 1,
 			"description": "Crown, copper",
 			"tech_level": "0",
@@ -6093,6 +6297,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "72cc3580-d8af-4205-a522-4ae13218fff6",
 			"quantity": 1,
 			"description": "Crown, gold",
 			"tech_level": "0",
@@ -6106,6 +6311,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "5db9379c-fccd-4cbf-a153-79bd0910bdab",
 			"quantity": 1,
 			"description": "Crown, silver",
 			"tech_level": "0",
@@ -6119,6 +6325,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "82c813fe-ca30-488b-b0d6-fea1ee8568d9",
 			"quantity": 1,
 			"description": "Culverin",
 			"tech_level": "4",
@@ -6166,6 +6373,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "c28ed2f2-3997-43b9-868e-637c54f42639",
 			"quantity": 1,
 			"description": "Culverin Cannonball",
 			"tech_level": "4",
@@ -6179,6 +6387,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "8498b915-a50c-4d66-b330-a8d46598f063",
 			"quantity": 1,
 			"description": "Culverin Truck Carriage Mount",
 			"tech_level": "4",
@@ -6192,6 +6401,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "3a5524b2-20c7-4c77-90b3-112334292af3",
 			"quantity": 1,
 			"description": "Curare",
 			"tech_level": "0",
@@ -6205,6 +6415,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "5085c99f-8dfc-43e6-af9d-7a6828c41828",
 			"quantity": 1,
 			"description": "Cutlass",
 			"tech_level": "4",
@@ -6352,6 +6563,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "a4088bf8-6164-4d52-a868-058b969e6f11",
 			"quantity": 1,
 			"description": "Cutting Arrow",
 			"tech_level": "0",
@@ -6367,6 +6579,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "1d036360-1d20-4c8d-8a25-62f2454150bb",
 			"quantity": 1,
 			"description": "Cylinder Seal",
 			"tech_level": "1",
@@ -6379,6 +6592,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "3e817a8d-2115-42db-a17d-c59fb2a7f332",
 			"quantity": 1,
 			"description": "Dagger",
 			"tech_level": "1",
@@ -6459,6 +6673,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "452f2f03-9b7b-4c4b-acdb-32410c28efda",
 			"quantity": 1,
 			"description": "Dao",
 			"tech_level": "3",
@@ -6569,6 +6784,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "770c34d0-3e0d-4aa5-b59a-fe46240ffc19",
 			"quantity": 1,
 			"description": "Dart Sling",
 			"tech_level": "1",
@@ -6610,6 +6826,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "729c0b32-9a63-43f2-8028-96e2255e8fa3",
 			"quantity": 1,
 			"description": "Dart Sling Dart",
 			"tech_level": "1",
@@ -6624,6 +6841,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "54ff34c8-3743-4be9-bba7-7a9bcc283bb0",
 			"quantity": 1,
 			"description": "Deathcap Mushroom",
 			"tech_level": "0",
@@ -6637,6 +6855,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "3b117c31-db22-4512-af5d-a5dafe002f7c",
 			"quantity": 1,
 			"description": "Deer Antlers",
 			"tech_level": "3",
@@ -6746,6 +6965,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "c8a73d6f-593b-4a0f-9244-c59624c370bd",
 			"quantity": 1,
 			"description": "Diagnostic Manual, Basic",
 			"tech_level": "1",
@@ -6759,6 +6979,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "8c853f1d-90fb-44f1-bc3b-f9191078fda1",
 			"quantity": 1,
 			"description": "Diagnostic Manual, Comprehensive",
 			"tech_level": "1",
@@ -6772,6 +6993,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "eacb0d9e-40d7-46b3-bc35-4d78eb2ea249",
 			"quantity": 1,
 			"description": "Dice",
 			"tech_level": "1",
@@ -6784,6 +7006,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "e8fe53a0-60c4-48e0-a294-140ff05ae37c",
 			"quantity": 1,
 			"description": "Discus",
 			"tech_level": "1",
@@ -6830,6 +7053,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "e586c20c-e6d8-4d9a-aa26-52403f0ab997",
 			"quantity": 1,
 			"description": "Distilled Liquors, per pint",
 			"tech_level": "3",
@@ -6842,6 +7066,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "0c205d5b-db29-468f-9ec5-42ec77d5d546",
 			"quantity": 1,
 			"description": "Diving Boat",
 			"tech_level": "4",
@@ -6855,6 +7080,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "6e0bfe33-42e5-4e95-9f84-a27bfda6d787",
 			"quantity": 1,
 			"description": "Diving Stone",
 			"tech_level": "0",
@@ -6868,6 +7094,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "d76e9c5b-086f-4dfe-84e4-737510856ffd",
 			"quantity": 1,
 			"description": "Dogsled",
 			"tech_level": "0",
@@ -6882,6 +7109,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "6963884a-b740-458d-8ab2-5c0a309bdabc",
 			"quantity": 1,
 			"description": "Doll, Clay",
 			"tech_level": "0",
@@ -6895,6 +7123,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "c5716d8a-1eb7-4469-9260-e5844f5c5823",
 			"quantity": 1,
 			"description": "Doll, Cloth",
 			"tech_level": "0",
@@ -6907,6 +7136,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "1a5651d2-2b4a-4ccd-82fe-1ab530ec050b",
 			"quantity": 1,
 			"description": "Dominos, 30 tiles",
 			"tech_level": "1",
@@ -6920,6 +7150,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "9c4b28af-69e9-423c-8874-0e2e6947da96",
 			"quantity": 1,
 			"description": "Double Canoe, 30’",
 			"tech_level": "1",
@@ -6933,6 +7164,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "d89ac017-9cd9-46f3-9675-8f0a44820e08",
 			"quantity": 1,
 			"description": "Dragon Pistol, Heavy Bullet",
 			"tech_level": "4",
@@ -6946,6 +7178,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "f5267a0c-c49a-4308-9b51-6a7b34d987f1",
 			"quantity": 1,
 			"description": "Dragon Pistol, Light Bullet",
 			"tech_level": "4",
@@ -6959,6 +7192,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "7296426d-b608-4678-a52a-4cb9fa4471e2",
 			"quantity": 1,
 			"description": "Dragoon Pistol, Heavy",
 			"tech_level": "4",
@@ -7005,6 +7239,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "8614d2aa-f05a-404b-9b00-3f4fcd22630f",
 			"quantity": 1,
 			"description": "Dragoon Pistol, Light",
 			"tech_level": "4",
@@ -7051,6 +7286,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "438ad5dd-3958-4ec1-b84f-3dfd350563ab",
 			"quantity": 1,
 			"description": "Dress Smallsword",
 			"tech_level": "4",
@@ -7108,6 +7344,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "68e32c99-f7a0-4c77-88d6-b1fb6486676a",
 			"quantity": 1,
 			"description": "Duck's Foot Pistol Bullet",
 			"tech_level": "4",
@@ -7121,6 +7358,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "f747572a-5a8b-4e2a-b6ae-3b72bef558f3",
 			"quantity": 1,
 			"description": "Duck’s Foot Pistol",
 			"tech_level": "4",
@@ -7167,6 +7405,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "ebb9577a-b317-4089-9afe-3fc54eea28df",
 			"quantity": 1,
 			"description": "Dueling Bill",
 			"tech_level": "3",
@@ -7296,6 +7535,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "d29a10b7-913b-45eb-b9e8-1d68632ccd75",
 			"quantity": 1,
 			"description": "Dueling Glaive",
 			"tech_level": "3",
@@ -7387,6 +7627,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "855f278b-d5d4-4ec3-a020-702bce066796",
 			"quantity": 1,
 			"description": "Dueling Halberd",
 			"tech_level": "3",
@@ -7516,6 +7757,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "ad38b15d-fcfd-4775-84b6-d02c4b8f015d",
 			"quantity": 1,
 			"description": "Dugout Canoe, 8’",
 			"tech_level": "0",
@@ -7529,6 +7771,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "2c1992d9-d94c-4e2b-9e6e-2542fcc5554d",
 			"quantity": 1,
 			"description": "Dusack",
 			"tech_level": "2",
@@ -7658,6 +7901,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "cdad4619-659c-4208-804c-f99a550229c9",
 			"quantity": 1,
 			"description": "Ear Trumpet",
 			"tech_level": "4",
@@ -7671,6 +7915,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "b12ecf98-1af9-434a-8b4f-15957952ef82",
 			"description": "Earthenware Jar, 1 cup",
 			"tech_level": "0",
 			"value": "0.25",
@@ -7699,6 +7944,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "5762198c-5c3c-436f-b7b8-f3bba8432ad5",
 			"description": "Earthenware Jar, 1 gal.",
 			"tech_level": "0",
 			"value": "3",
@@ -7727,6 +7973,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "761ac411-af15-4b89-be76-579d740b2bdb",
 			"description": "Earthenware Jar, 1 quart",
 			"tech_level": "0",
 			"value": "1",
@@ -7755,6 +8002,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "1a99f877-8c94-4b1f-9a4c-aea23c957a04",
 			"description": "Earthenware Jar, 1/4 cup",
 			"tech_level": "0",
 			"value": "0.1",
@@ -7783,6 +8031,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "8e46dbd9-f43a-4ae8-b8e8-c3dcd3e890f9",
 			"description": "Earthenware Jar, 2 gal.",
 			"tech_level": "0",
 			"value": "7.5",
@@ -7811,6 +8060,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "3547310f-7a91-475b-a5b6-292382292593",
 			"description": "Earthenware Jar, 6 gal.",
 			"tech_level": "0",
 			"value": "16",
@@ -7839,6 +8089,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "934927b2-f501-4e1f-975f-23df29e249d2",
 			"description": "Earthenware Jar, 20 gal.",
 			"tech_level": "0",
 			"value": "41",
@@ -7867,6 +8118,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "44d37187-6218-4ed6-b6ac-6892fefc3a3f",
 			"description": "Earthenware Jar, Porcelain, 1 cup",
 			"tech_level": "0",
 			"value": "0.75",
@@ -7895,6 +8147,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "3230ba29-0a6e-4ca1-91d9-43654ac76209",
 			"description": "Earthenware Jar, Porcelain, 1 gal.",
 			"tech_level": "0",
 			"value": "9",
@@ -7923,6 +8176,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "9ff34e0e-be3f-47a0-8818-149e14811c84",
 			"description": "Earthenware Jar, Porcelain, 1 quart",
 			"tech_level": "0",
 			"value": "3",
@@ -7951,6 +8205,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "87ac1b5d-d3f3-4707-b073-7a127b6b5fab",
 			"description": "Earthenware Jar, Porcelain, 1/4 cup",
 			"tech_level": "0",
 			"value": "0.3",
@@ -7979,6 +8234,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "3ea3c9fd-fccc-4cc8-bd61-8c7f1f91eadd",
 			"description": "Earthenware Jar, Porcelain, 2 gal.",
 			"tech_level": "0",
 			"value": "22.5",
@@ -8007,6 +8263,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "83b252e3-a1a0-46a1-8f1c-fd6d8eb4c03a",
 			"description": "Earthenware Jar, Porcelain, 6 gal.",
 			"tech_level": "0",
 			"value": "48",
@@ -8035,6 +8292,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "b9842e16-5333-4b28-a699-6d73b590d9fd",
 			"description": "Earthenware Jar, Porcelain, 20 gal.",
 			"tech_level": "0",
 			"value": "123",
@@ -8063,6 +8321,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "2eb09b82-a395-472e-a18a-26c82c972e75",
 			"quantity": 1,
 			"description": "Edged Rapier",
 			"tech_level": "4",
@@ -8163,6 +8422,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "e508effc-2854-4bde-b597-f61fc043bf3b",
 			"quantity": 1,
 			"description": "Enhanced Tinder",
 			"tech_level": "1",
@@ -8176,6 +8436,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "e28ce491-0142-4b43-9bff-2638ce07911a",
 			"quantity": 1,
 			"description": "Eruptor",
 			"tech_level": "3",
@@ -8223,6 +8484,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "515c0674-5897-4b20-ba05-cfddaf70f333",
 			"quantity": 1,
 			"description": "Estoc",
 			"tech_level": "3",
@@ -8335,6 +8597,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "b9ccaf22-952a-4722-9499-f2e9070de743",
 			"quantity": 1,
 			"description": "Eyeglasses",
 			"tech_level": "3",
@@ -8348,6 +8611,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "b87b0bfe-299f-4183-811f-593b0a0c610f",
 			"quantity": 1,
 			"description": "Eyelash Cautery",
 			"tech_level": "2",
@@ -8360,6 +8624,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "31b63172-bd1f-415e-8a4f-e8fa0ed054eb",
 			"quantity": 1,
 			"description": "Eyelash Forceps",
 			"tech_level": "2",
@@ -8372,6 +8637,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "7af05f56-5073-442b-8856-f57c43d7ff94",
 			"quantity": 1,
 			"description": "Faering, 20'",
 			"tech_level": "3",
@@ -8385,6 +8651,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "895f756b-8330-4da1-b4ff-585953bc815e",
 			"quantity": 1,
 			"description": "Falchion",
 			"tech_level": "2",
@@ -8516,6 +8783,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "aac01b49-2058-4418-b494-9a640fc37c9d",
 			"quantity": 1,
 			"description": "Falcon",
 			"tech_level": "4",
@@ -8562,6 +8830,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "dc9eae3f-a179-48ce-a81c-ac11c2c795b5",
 			"quantity": 1,
 			"description": "Falcon Cannonball",
 			"tech_level": "4",
@@ -8575,6 +8844,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "c183731d-cbb0-4559-92ca-4ca7fbb19f96",
 			"quantity": 1,
 			"description": "Falcon Truck Carriage Mount",
 			"tech_level": "4",
@@ -8588,6 +8858,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "442105ea-8624-42ab-8047-863d534318e2",
 			"quantity": 1,
 			"description": "Falconet",
 			"tech_level": "4",
@@ -8634,6 +8905,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "9ec8b866-337e-49b8-96d1-0ba9d67cfd2e",
 			"quantity": 1,
 			"description": "Falconet Cannonball",
 			"tech_level": "4",
@@ -8647,6 +8919,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "8cd8cbb3-169b-4665-8035-ff25894f1a28",
 			"quantity": 1,
 			"description": "Falconet Truck Carriage Mount",
 			"tech_level": "4",
@@ -8660,6 +8933,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "9c57eeba-1ac4-4ebd-ab15-90b31df58fba",
 			"quantity": 1,
 			"description": "Fermented Beverages, per gallon",
 			"tech_level": "1",
@@ -8672,6 +8946,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "561779d1-5f61-4801-9881-31f83211fc67",
 			"quantity": 1,
 			"description": "Fibula, copper",
 			"tech_level": "0",
@@ -8685,6 +8960,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "c835f189-0721-472e-86df-5dec5cf99903",
 			"quantity": 1,
 			"description": "Fibula, gold",
 			"tech_level": "0",
@@ -8698,6 +8974,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "1f87ec71-8fc1-4bad-8a44-4c4022a77ea7",
 			"quantity": 1,
 			"description": "Fibula, silver",
 			"tech_level": "0",
@@ -8711,6 +8988,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "06a58fdf-830a-4872-ae37-cd6979242911",
 			"quantity": 1,
 			"description": "Fife",
 			"tech_level": "2",
@@ -8724,6 +9002,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "ba7eaf6f-1395-4f7a-8142-30639e6db2a9",
 			"quantity": 1,
 			"description": "Fifty-Man Sledge",
 			"tech_level": "1",
@@ -8737,6 +9016,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "97c63cf0-ba88-4fbb-854c-b35495bd5b21",
 			"quantity": 1,
 			"description": "Fire Arrow",
 			"tech_level": "0",
@@ -8752,6 +9032,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "ca36e05a-b7a8-41e8-92e6-1640793c9da9",
 			"quantity": 1,
 			"description": "Fire-Cage Arrow",
 			"tech_level": "0",
@@ -8767,6 +9048,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "7ee440e8-a5a8-47ca-9409-1f9e2010f0d8",
 			"quantity": 1,
 			"description": "Fire-Lance",
 			"tech_level": "3",
@@ -8813,6 +9095,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "76770724-ec43-410a-bca5-7ec361cde1d1",
 			"quantity": 1,
 			"description": "Fire-Siphon",
 			"tech_level": "3",
@@ -8860,6 +9143,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "83554dbb-b2b8-45eb-874c-baaac12096df",
 			"quantity": 1,
 			"description": "Firebow",
 			"tech_level": "0",
@@ -8873,6 +9157,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "a2b56b2f-dbb8-4346-ad56-98e731e9ee4f",
 			"quantity": 1,
 			"description": "Fishing Boat, 27'",
 			"tech_level": "2",
@@ -8886,6 +9171,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "1afb2bde-d3f7-4447-b98c-63dcbac56b92",
 			"quantity": 1,
 			"description": "Flail",
 			"tech_level": "2",
@@ -8940,6 +9226,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "a7e82834-a611-4090-a336-e1ee2d3bf6c1",
 			"quantity": 1,
 			"description": "Flight Arrow",
 			"tech_level": "0",
@@ -8955,6 +9242,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "2b671d1c-981d-42d9-ad2c-8a4c4203a00f",
 			"quantity": 1,
 			"description": "Flint",
 			"tech_level": "0",
@@ -8968,6 +9256,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "99b4fc95-1708-445e-b11d-3bc7f8a9050f",
 			"quantity": 1,
 			"description": "Flintlock Carbine",
 			"tech_level": "4",
@@ -9014,6 +9303,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "f1217d0d-f973-423e-9831-597ad70b81b5",
 			"quantity": 1,
 			"description": "Flintlock Carbine Bullet",
 			"tech_level": "4",
@@ -9027,6 +9317,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "f67dc616-55cb-4ca8-9cc2-2eae7d205fb3",
 			"quantity": 1,
 			"description": "Foot Wrappings",
 			"tech_level": "0",
@@ -9040,6 +9331,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "176e591b-9e37-46b4-9f7c-128cc924d025",
 			"quantity": 1,
 			"description": "Foot Wrappings, Boot",
 			"tech_level": "0",
@@ -9053,6 +9345,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "ae09656f-e308-4547-8e6e-dccc394cbc13",
 			"quantity": 1,
 			"description": "Forceps",
 			"tech_level": "1",
@@ -9065,6 +9358,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "e394968b-0c96-4d31-86b6-cc51aadce4d6",
 			"quantity": 1,
 			"description": "Forceps, Dental",
 			"tech_level": "2",
@@ -9078,6 +9372,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "7a486b65-4976-4a47-9e3c-314993976168",
 			"quantity": 1,
 			"description": "Forceps, Dental Splinter",
 			"tech_level": "2",
@@ -9090,6 +9385,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "aa2cab58-a055-49ea-9255-e965e7fec58c",
 			"quantity": 1,
 			"description": "Forceps, Staphylagra",
 			"tech_level": "2",
@@ -9102,6 +9398,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "5ac0aa0b-00c2-44c8-97ee-961db6bda7c0",
 			"quantity": 1,
 			"description": "Fowling Boat, 16’",
 			"tech_level": "1",
@@ -9115,6 +9412,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "4a79a91d-b2cb-47ca-8025-5298e2b678b7",
 			"quantity": 1,
 			"description": "Fowling Crossbow",
 			"tech_level": "4",
@@ -9156,6 +9454,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "170bc173-7854-4ae0-b4b5-62af02f73b3c",
 			"quantity": 1,
 			"description": "Fowling Piece Shot",
 			"tech_level": "4",
@@ -9169,6 +9468,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "ba72d527-595e-4252-afef-e9a38d33342d",
 			"quantity": 1,
 			"description": "Fowling Piece, Double",
 			"tech_level": "4",
@@ -9216,6 +9516,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "7280a371-245b-427e-84ee-af9aa7e615f4",
 			"quantity": 1,
 			"description": "Fowling Piece, Single",
 			"tech_level": "4",
@@ -9263,6 +9564,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "196bd3f0-fafd-4217-bdbe-c8696d1349a9",
 			"quantity": 1,
 			"description": "Fusil de Chasse",
 			"tech_level": "4",
@@ -9309,6 +9611,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "f80774f7-e1fc-4497-b470-72b71b89a3f9",
 			"quantity": 1,
 			"description": "Fusil de Chasse Bullet",
 			"tech_level": "4",
@@ -9322,6 +9625,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "86ed6967-9059-4c59-abe4-5284e3290608",
 			"quantity": 1,
 			"description": "Fusil Ordinaire",
 			"tech_level": "4",
@@ -9368,6 +9672,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "bdebbe82-2eb8-43cb-8ed1-0bf634f57efe",
 			"quantity": 1,
 			"description": "Fusil Ordinaire Bullet",
 			"tech_level": "4",
@@ -9381,6 +9686,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "21c2334e-ec79-4de0-bcd4-ab6d09465eae",
 			"quantity": 1,
 			"description": "Gada",
 			"tech_level": "1",
@@ -9472,6 +9778,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "537bfc33-39df-43db-a3ed-aa6cd54822e8",
 			"quantity": 1,
 			"description": "Garrote",
 			"tech_level": "0",
@@ -9506,6 +9813,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "0f9cc2eb-f9c2-470a-8f30-1a9e1ff0187f",
 			"quantity": 1,
 			"description": "Gastraphetes",
 			"tech_level": "2",
@@ -9546,6 +9854,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "6af0e68c-ac8f-40a9-9aa9-f466e236118b",
 			"quantity": 1,
 			"description": "Gastraphetes Bolt",
 			"tech_level": "2",
@@ -9559,6 +9868,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "e41c4d5c-5302-4fd5-9a5e-37fdfabc8a83",
 			"quantity": 1,
 			"description": "Gastraphetes Bolt",
 			"tech_level": "3",
@@ -9572,6 +9882,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "7fec6e0f-4c77-43cd-a8ea-a8c7c1ae4891",
 			"quantity": 1,
 			"description": "Gastraphetes, Double",
 			"tech_level": "2",
@@ -9619,6 +9930,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "5fa5417d-6d6d-45e5-a20d-b0f425416e97",
 			"quantity": 1,
 			"description": "Gastraphetes, Double Tripod",
 			"tech_level": "2",
@@ -9632,6 +9944,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "e3bfb038-00b7-4504-8e72-b13d07e710aa",
 			"quantity": 1,
 			"description": "Gastraphetes, Mountain",
 			"tech_level": "2",
@@ -9679,6 +9992,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "7755348a-edfe-4574-9eee-98f8438a5cb7",
 			"quantity": 1,
 			"description": "Gastraphetes, Mountain Bolt",
 			"tech_level": "3",
@@ -9692,6 +10006,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "ab0d9fcc-6c32-40b9-ad46-c9e509a5ad30",
 			"quantity": 1,
 			"description": "Gastraphetes, Mountain Tripod",
 			"tech_level": "2",
@@ -9705,6 +10020,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "c554521b-372d-4ff1-824e-5b758fb328ea",
 			"quantity": 1,
 			"description": "Glaive",
 			"tech_level": "1",
@@ -9796,6 +10112,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "9dd54e2f-4b65-42c7-9f38-0085bea483e4",
 			"description": "Glass Bottle, 1 cup",
 			"tech_level": "0",
 			"value": "1.5",
@@ -9824,6 +10141,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "27ff0f04-3b98-4b78-98b3-da74db191a2b",
 			"description": "Glass Bottle, 1 gal.",
 			"tech_level": "0",
 			"value": "13.5",
@@ -9852,6 +10170,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "15b7fa5b-60ec-4b85-a33c-ec0844e88c38",
 			"description": "Glass Bottle, 1 quart",
 			"tech_level": "0",
 			"value": "3.75",
@@ -9880,6 +10199,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "ae104c15-4258-4d7d-923b-2fcd466ea89b",
 			"description": "Glass Bottle, 1/4 cup",
 			"tech_level": "0",
 			"value": "0.5",
@@ -9908,6 +10228,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "42048410-6dde-4643-ac20-27aabc3d4c9c",
 			"description": "Glass Bottle, 2 gal.",
 			"tech_level": "0",
 			"value": "21",
@@ -9936,6 +10257,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "b11701ff-7156-4357-863e-2e4b75c46dcc",
 			"quantity": 1,
 			"description": "Gonne",
 			"tech_level": "3",
@@ -10012,6 +10334,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "880f779c-95c9-4aea-bd13-a9e9e5b4c911",
 			"quantity": 1,
 			"description": "Gonne Bolt",
 			"tech_level": "3",
@@ -10025,6 +10348,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "6737cbda-57f9-4a4c-b14d-813f456da110",
 			"quantity": 1,
 			"description": "Gonne Bullet",
 			"tech_level": "3",
@@ -10038,6 +10362,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "4b9e1c16-7b32-4cab-9067-805bc01d2469",
 			"quantity": 1,
 			"description": "Grappling Hook, Padded",
 			"tech_level": "1",
@@ -10051,6 +10376,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "5e59480f-83db-46f0-8a2e-0c34fc9809ab",
 			"quantity": 1,
 			"description": "Grappling Hook, Unpadded",
 			"tech_level": "1",
@@ -10064,6 +10390,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "dc8c7bf7-0afd-458f-8e65-d328be110c0a",
 			"quantity": 1,
 			"description": "Great Axe",
 			"tech_level": "1",
@@ -10117,6 +10444,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "5b5a079d-5e3f-4061-9786-1e2db1791b99",
 			"quantity": 1,
 			"description": "Greatsword",
 			"tech_level": "3",
@@ -10198,6 +10526,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "1c9bcfb5-2be8-4101-8b45-500a41279f02",
 			"quantity": 1,
 			"description": "Greek Fire",
 			"tech_level": "3",
@@ -10212,6 +10541,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "31a6cf1b-4c34-411e-8e67-cdf8efbfcd1e",
 			"quantity": 1,
 			"description": "Gun-Cleaning Kit",
 			"tech_level": "4",
@@ -10225,6 +10555,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "0061b5bd-19a2-467a-968f-0c7b809cd84b",
 			"quantity": 1,
 			"description": "Halberd",
 			"tech_level": "3",
@@ -10355,6 +10686,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "bb693195-ccfd-4f02-a1b4-dc8b185b02aa",
 			"quantity": 1,
 			"description": "Harp",
 			"tech_level": "1",
@@ -10368,6 +10700,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "0ba14c0d-d85a-489d-94b5-1995ac24f5a3",
 			"quantity": 1,
 			"description": "Harpoon",
 			"tech_level": "2",
@@ -10416,6 +10749,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "47ca7916-1c90-4449-b85d-0adce879a91a",
 			"quantity": 1,
 			"description": "Hatchet",
 			"tech_level": "0",
@@ -10488,6 +10822,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "e33681fd-d380-4785-841d-140acaf1152c",
 			"quantity": 1,
 			"description": "Heavy Chariot",
 			"tech_level": "1",
@@ -10502,6 +10837,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "23e69753-a894-4a82-a284-8e0cd7122227",
 			"quantity": 1,
 			"description": "Heavy Horse-Cutter",
 			"tech_level": "3",
@@ -10593,6 +10929,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "024236ad-0cee-4659-93dd-5eacae1c8152",
 			"quantity": 1,
 			"description": "Heavy Sling",
 			"tech_level": "0",
@@ -10634,6 +10971,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "185e853f-8a1d-4ffc-9b84-ec5105016638",
 			"quantity": 1,
 			"description": "Heavy Sling Shaped Rock",
 			"tech_level": "0",
@@ -10647,6 +10985,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "a7ffe69f-f377-45e1-b111-6183f8bce127",
 			"quantity": 1,
 			"description": "Heavy Spear",
 			"tech_level": "1",
@@ -10728,6 +11067,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "9e788014-eea2-4dde-bbea-c287b9975f0a",
 			"quantity": 1,
 			"description": "Hemlock",
 			"tech_level": "0",
@@ -10741,6 +11081,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "6455437d-5e0c-425d-8b2d-43e191187180",
 			"quantity": 1,
 			"description": "Highland Pistol",
 			"tech_level": "4",
@@ -10787,6 +11128,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "e530dff8-66cf-4d4d-a5ca-0d8608994d90",
 			"quantity": 1,
 			"description": "Highland Pistol Bullet",
 			"tech_level": "4",
@@ -10800,6 +11142,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "1151cb82-f9ef-44f1-9526-0e2d25425170",
 			"quantity": 1,
 			"description": "Holsters",
 			"tech_level": "4",
@@ -10813,6 +11156,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "ae78dfef-6d94-47ff-bca0-454e2969d167",
 			"quantity": 1,
 			"description": "Hook Sword",
 			"tech_level": "3",
@@ -10896,6 +11240,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "c2b3a458-e174-44f0-bd87-3ce9ef23133d",
 			"quantity": 1,
 			"description": "Hook, Surgical",
 			"tech_level": "1",
@@ -10908,6 +11253,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "50068d7a-c1a2-4ead-bc8f-db44877f0cfd",
 			"quantity": 1,
 			"description": "Horse Blanket",
 			"tech_level": "1",
@@ -10921,6 +11267,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "3e2e211f-171b-4311-a353-82900d9439be",
 			"quantity": 1,
 			"description": "Horseshoes",
 			"tech_level": "3",
@@ -10934,6 +11281,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "17fc479b-6da2-4eda-99c4-0703d0526220",
 			"quantity": 1,
 			"description": "Housebreaker's Kit",
 			"tech_level": "2",
@@ -10947,6 +11295,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "f3e335ba-05a3-4f08-a6f2-ad5dc43db6bb",
 			"quantity": 1,
 			"description": "Humming Bulb Arrow",
 			"tech_level": "0",
@@ -10961,6 +11310,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "751570c4-3423-4eb5-a3c3-94e4fd7fdc98",
 			"quantity": 1,
 			"description": "Hungamunga",
 			"tech_level": "2",
@@ -11120,6 +11470,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "0603eb04-c71a-4a78-9fdb-9d2ff31e70a0",
 			"quantity": 1,
 			"description": "Hunting Crossbow",
 			"tech_level": "4",
@@ -11162,6 +11513,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "b8eb78e4-77a5-4fe1-9f23-b1956c1afbfa",
 			"quantity": 1,
 			"description": "Hunting Horn, Brass",
 			"tech_level": "3",
@@ -11175,6 +11527,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "2ad3d4c4-0cee-4210-81cd-1f0aa98b7606",
 			"quantity": 1,
 			"description": "Hunting Shirt, Dyed",
 			"tech_level": "1",
@@ -11188,6 +11541,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "8e30dca2-cf4c-4ab2-a8e6-50f42d8a3f41",
 			"quantity": 1,
 			"description": "Hunting Shirt, Plain",
 			"tech_level": "1",
@@ -11201,6 +11555,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "89959c06-c589-4b40-8cc0-9b4bb71d485e",
 			"quantity": 1,
 			"description": "Incendiaries, Early Mixtures",
 			"tech_level": "2",
@@ -11215,6 +11570,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "dea5f9ac-047b-462f-b6ab-883e34d40b2f",
 			"quantity": 1,
 			"description": "Incendiary Blowpipe",
 			"tech_level": "3",
@@ -11256,6 +11612,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "fde0aee2-aeae-4423-ae07-aacf93d56cd8",
 			"quantity": 1,
 			"description": "Incendiary Blowpipe Charge",
 			"tech_level": "2",
@@ -11269,6 +11626,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "eef2d922-63b9-4e41-a25b-8bc56f02d97f",
 			"quantity": 1,
 			"description": "Incendiary Sphere",
 			"tech_level": "3",
@@ -11284,6 +11642,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "8e88c1b4-bd25-4df8-b01a-a16e52ad06cf",
 			"quantity": 1,
 			"description": "Incense, Cheap, per ounce",
 			"tech_level": "0",
@@ -11297,6 +11656,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "325deefe-71ae-402d-ab31-4b0dcc557d24",
 			"quantity": 1,
 			"description": "Incense, Fine, per ounce",
 			"tech_level": "0",
@@ -11310,6 +11670,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "bebb126a-7b1d-448d-a811-d4fac9714553",
 			"quantity": 1,
 			"description": "Ink Stone",
 			"tech_level": "1",
@@ -11323,6 +11684,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "d8870007-70e6-4d3a-8548-2e5bd80d2b9b",
 			"quantity": 1,
 			"description": "Ink, per pint",
 			"tech_level": "1",
@@ -11336,6 +11698,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "8381e177-486c-41ec-90be-91acebdfb2d3",
 			"quantity": 1,
 			"description": "Iron Bomb",
 			"tech_level": "3",
@@ -11351,6 +11714,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "38d662e7-b210-45a1-96bb-3e88068e8719",
 			"quantity": 1,
 			"description": "Iron Fire-Lance",
 			"tech_level": "3",
@@ -11397,6 +11761,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "222e0264-08ea-462a-9b59-dfe68c6f85e0",
 			"quantity": 1,
 			"description": "Javelin",
 			"tech_level": "1",
@@ -11483,6 +11848,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "b6fa9b87-6ff0-461e-8d92-c7ebf29c9084",
 			"quantity": 1,
 			"description": "Javelin w. Thong",
 			"tech_level": "1",
@@ -11568,6 +11934,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "c4818ae2-5ed9-42aa-8ac4-e88581590dd0",
 			"quantity": 1,
 			"description": "Jian",
 			"tech_level": "3",
@@ -11678,6 +12045,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "a36e650e-7c4c-4105-ac8e-bb970277ce49",
 			"quantity": 1,
 			"description": "Jo",
 			"tech_level": "0",
@@ -11899,6 +12267,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "f7ffd49c-4fb3-482d-b880-9bcc2b7fcf20",
 			"quantity": 1,
 			"description": "Jolly Boat, 18'",
 			"tech_level": "4",
@@ -11912,6 +12281,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "25e22636-56e3-4e87-8a9d-d55b4c7496a1",
 			"quantity": 1,
 			"description": "Jutte",
 			"tech_level": "3",
@@ -12040,6 +12410,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "915c28ef-2c7a-41f3-8b5a-e8611b1512d4",
 			"quantity": 1,
 			"description": "Jäger Rifle",
 			"tech_level": "4",
@@ -12086,6 +12457,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "82030255-1c7d-4863-8569-a3efcc06016d",
 			"quantity": 1,
 			"description": "Jäger Rifle Bullet",
 			"tech_level": "4",
@@ -12099,6 +12471,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "6ca43827-5c62-414c-ae3f-989579043043",
 			"quantity": 1,
 			"description": "Jäger Rifle, Double-Barreled",
 			"tech_level": "4",
@@ -12145,6 +12518,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "55fc776a-3bf3-4237-83d3-9a00d6dc72c0",
 			"quantity": 1,
 			"description": "Kakute",
 			"tech_level": "3",
@@ -12171,6 +12545,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "be7e41cc-7a0c-4be4-aa10-1a09f345ed2b",
 			"quantity": 1,
 			"description": "Katana",
 			"tech_level": "3",
@@ -12348,6 +12723,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "4b47ac6e-a284-48d9-8dea-69924b07acf8",
 			"quantity": 1,
 			"description": "Katar",
 			"tech_level": "2",
@@ -12447,6 +12823,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "87c606db-506d-4c27-bdc0-998f7648c177",
 			"quantity": 1,
 			"description": "Kayak, 18’",
 			"tech_level": "0",
@@ -12460,6 +12837,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "79dca0a5-8393-43e8-a74d-f0bbe3543fdb",
 			"quantity": 1,
 			"description": "Kettledrums, Cavalry",
 			"tech_level": "3",
@@ -12473,6 +12851,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "c841d77f-90ba-4d00-80bb-0e4f68a8135c",
 			"quantity": 1,
 			"description": "Khopesh",
 			"tech_level": "1",
@@ -12555,6 +12934,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "cfdf0771-56b2-4732-83b0-0f32912a4898",
 			"quantity": 1,
 			"description": "Kite",
 			"tech_level": "2",
@@ -12568,6 +12948,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "1a44e13a-91b4-46dc-a388-eb388311bc4a",
 			"quantity": 1,
 			"description": "Knife-Wheel",
 			"tech_level": "3",
@@ -12762,6 +13143,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "bc9a152a-29a0-4331-a862-6b73e9d94853",
 			"quantity": 1,
 			"description": "Knobbed Club",
 			"tech_level": "0",
@@ -12810,6 +13192,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "4059227c-f714-409c-9884-1e0d77959a82",
 			"quantity": 1,
 			"description": "Kukri",
 			"tech_level": "2",
@@ -12901,6 +13284,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "bfe56241-7cc0-4a6e-84c5-f6e6ba2e7de3",
 			"quantity": 1,
 			"description": "Kusari",
 			"tech_level": "3",
@@ -12993,6 +13377,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "41913253-5f64-40cb-8b11-3a7796f54086",
 			"quantity": 1,
 			"description": "Kusarigama",
 			"tech_level": "3",
@@ -13123,6 +13508,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "5118e5c0-03d5-49d4-b2d9-7cd1cd399994",
 			"quantity": 1,
 			"description": "Kusarijutte",
 			"tech_level": "3",
@@ -13215,6 +13601,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "03045849-875c-443d-8958-23bdbecf77e2",
 			"quantity": 1,
 			"description": "Lacquer",
 			"tech_level": "1",
@@ -13228,6 +13615,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "c6c8c13f-c47a-4e22-805d-48a08b5f5c0a",
 			"quantity": 1,
 			"description": "Ladder, 6'",
 			"tech_level": "1",
@@ -13241,6 +13629,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "5c2d7ca5-b755-4a88-b1d5-24c43e28fc14",
 			"quantity": 1,
 			"description": "Ladder, Rope, 30 feet",
 			"tech_level": "1",
@@ -13254,6 +13643,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "7317735c-f7b7-4e00-ba3b-8e29ce27471a",
 			"quantity": 1,
 			"description": "Lajatang",
 			"tech_level": "3",
@@ -13345,6 +13735,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "fe8b24a6-4a06-43bd-aa48-93cd83b4d921",
 			"quantity": 1,
 			"description": "Lance",
 			"tech_level": "2",
@@ -13389,6 +13780,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "81f1d03c-d030-4263-a270-5b9a53cd583c",
 			"quantity": 1,
 			"description": "Lancet",
 			"tech_level": "2",
@@ -13401,6 +13793,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "d8014b3f-ccdc-4283-8625-56ab881cdce7",
 			"quantity": 1,
 			"description": "Lantaka",
 			"tech_level": "3",
@@ -13447,6 +13840,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "2c9c07bb-6cbe-4e3d-9224-7b604953c94d",
 			"quantity": 1,
 			"description": "Lantaka Cannonball",
 			"tech_level": "3",
@@ -13460,6 +13854,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "ff829987-e69f-43cc-9b9f-291e819e734d",
 			"quantity": 1,
 			"description": "Lantaka Pintle Mount",
 			"tech_level": "3",
@@ -13473,6 +13868,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "8256e842-bfa5-49f8-8ecd-4600cf8ba66a",
 			"quantity": 1,
 			"description": "Large Bark Canoe, 20’",
 			"tech_level": "0",
@@ -13486,6 +13882,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "b71136d2-accd-4247-94bc-6fca30e33ee7",
 			"quantity": 1,
 			"description": "Large Falchion",
 			"tech_level": "2",
@@ -13597,6 +13994,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "7d8102f0-fca4-4066-9f52-c5d0f554ca72",
 			"quantity": 1,
 			"description": "Large Hide Boat, 36’",
 			"tech_level": "1",
@@ -13610,6 +14008,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "3f55af6f-38dd-42bb-ae62-467580bfe5df",
 			"quantity": 1,
 			"description": "Large Hungamunga",
 			"tech_level": "2",
@@ -13722,6 +14121,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "ba5c5514-f0f8-410d-af47-c75e7bb0612c",
 			"quantity": 1,
 			"description": "Large Katar",
 			"tech_level": "2",
@@ -13861,6 +14261,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "fedcafeb-82a5-4120-a2fc-f97a3c60d011",
 			"quantity": 1,
 			"description": "Large Knife",
 			"tech_level": "0",
@@ -13977,6 +14378,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "bfbd39c2-1d22-4093-98b6-6b7af48eb310",
 			"quantity": 1,
 			"description": "Large Net",
 			"tech_level": "0",
@@ -14017,6 +14419,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "8fd6a4b1-efad-471e-bbe2-f4dc06a8e104",
 			"quantity": 1,
 			"description": "Large Quadrens",
 			"tech_level": "2",
@@ -14091,6 +14494,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "d24a5674-f6fd-4db3-b0e4-ebfc9265c23c",
 			"quantity": 1,
 			"description": "Large Throwing Knife",
 			"tech_level": "2",
@@ -14248,6 +14652,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "28d18250-e275-49d6-bac5-8db6e9afa0aa",
 			"quantity": 1,
 			"description": "Lariat",
 			"tech_level": "1",
@@ -14283,6 +14688,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "db58765c-54cd-4cd0-b1be-2afa99263d6d",
 			"quantity": 1,
 			"description": "Late Katana",
 			"tech_level": "4",
@@ -14460,6 +14866,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "8d7dd439-4aba-4b41-a475-991eb70f486a",
 			"description": "Leather Pouch, 1 cup",
 			"tech_level": "0",
 			"value": "0.75",
@@ -14488,6 +14895,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "a2961da5-2e91-4632-b0dc-2aeba3417d01",
 			"description": "Leather Pouch, 1 gal.",
 			"tech_level": "0",
 			"value": "4.5",
@@ -14516,6 +14924,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "ca521d5d-d8fa-4598-9446-76af37ffbe15",
 			"description": "Leather Pouch, 1 quart",
 			"tech_level": "0",
 			"value": "2",
@@ -14544,6 +14953,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "24635e25-0aa4-48c6-ab3c-38d3972afd70",
 			"description": "Leather Pouch, 1/4 cup",
 			"tech_level": "0",
 			"value": "0.25",
@@ -14572,6 +14982,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "23f7b7a5-a152-4c40-af2a-b9bcbc6ebed8",
 			"description": "Leather Pouch, 2 gal.",
 			"tech_level": "0",
 			"value": "7.35",
@@ -14600,6 +15011,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "67a11318-18cb-471a-9a27-2f44af8b24b7",
 			"description": "Leather Pouch, 6 gal.",
 			"tech_level": "0",
 			"value": "15",
@@ -14628,6 +15040,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "51f60919-98a7-4c6c-ba02-b5a6bb7be2b2",
 			"description": "Leather Pouch, 20 gal.",
 			"tech_level": "0",
 			"value": "34",
@@ -14656,6 +15069,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "6c5507e4-55b5-4062-a46f-d97c00522ca9",
 			"description": "Leather Pouch, 40 gal.",
 			"tech_level": "0",
 			"value": "53",
@@ -14684,6 +15098,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "a2d86098-0329-4831-b14e-8980e37c3301",
 			"description": "Leather Pouch, 80 gal.",
 			"tech_level": "0",
 			"value": "85",
@@ -14712,6 +15127,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "26f7cf6d-4471-4ead-a780-74eb8059594d",
 			"description": "Leather Pouch, 120 gal.",
 			"tech_level": "0",
 			"value": "111",
@@ -14740,6 +15156,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "deea0f73-d062-4c45-9c4c-33ee571d6ca9",
 			"quantity": 1,
 			"description": "Light Chariot",
 			"tech_level": "1",
@@ -14754,6 +15171,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "ab64e2e6-225a-45c6-a44f-e0ba8e85e4f0",
 			"quantity": 1,
 			"description": "Light Club",
 			"tech_level": "0",
@@ -14865,6 +15283,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "f0f934af-12a9-4e25-b419-8a6775869fd2",
 			"quantity": 1,
 			"description": "Light Edged Rapier",
 			"tech_level": "4",
@@ -14966,6 +15385,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "4f22f5d1-9781-471a-9cc5-0a8b883f6be3",
 			"quantity": 1,
 			"description": "Light Horse-Cutter",
 			"tech_level": "3",
@@ -15057,6 +15477,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "6c8903f9-2712-4cc0-8e6f-0d2c99fdcc38",
 			"quantity": 1,
 			"description": "Light Rapier",
 			"tech_level": "4",
@@ -15115,6 +15536,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "1b322d61-d05f-4b17-ac97-838ac71ec072",
 			"quantity": 1,
 			"description": "Light Whip, 1 yd",
 			"tech_level": "1",
@@ -15164,6 +15586,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "dad859d0-dd50-40e2-a407-36b6287d2a49",
 			"quantity": 1,
 			"description": "Light Whip, 2 yd",
 			"tech_level": "1",
@@ -15213,6 +15636,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "9cf5ee05-ce16-40d8-92b8-51da529bdf8f",
 			"quantity": 1,
 			"description": "Light Whip, 3 yd",
 			"tech_level": "1",
@@ -15262,6 +15686,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "c5474105-7a8e-4321-a7a9-be8168d76e9b",
 			"quantity": 1,
 			"description": "Light Whip, 4 yd",
 			"tech_level": "1",
@@ -15311,6 +15736,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "368e0313-a035-442e-9e7c-b647bf71cb4c",
 			"quantity": 1,
 			"description": "Light Whip, 5 yd",
 			"tech_level": "1",
@@ -15360,6 +15786,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "c8a831ec-3417-41b8-a10f-14e610dfd9d3",
 			"quantity": 1,
 			"description": "Light Whip, 6 yd",
 			"tech_level": "1",
@@ -15409,6 +15836,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "045f1d06-099f-4627-b1ca-20bca428472b",
 			"quantity": 1,
 			"description": "Light Whip, 7 yd",
 			"tech_level": "1",
@@ -15458,6 +15886,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "847f3ecd-b13a-4909-ab47-33e59db7a926",
 			"quantity": 1,
 			"description": "Lime Powder",
 			"tech_level": "1",
@@ -15471,6 +15900,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "3a403a3d-9d19-4b33-b726-49ea17aea55d",
 			"quantity": 1,
 			"description": "Litter",
 			"tech_level": "0",
@@ -15485,6 +15915,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "2480f518-0411-470b-a68e-edf95af5e415",
 			"quantity": 1,
 			"description": "Lockpick Set, Basic",
 			"tech_level": "1",
@@ -15498,6 +15929,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "ecefa6a8-b3c0-415a-93ec-eec2cb9ac2b5",
 			"quantity": 1,
 			"description": "Lockpick Set, Good",
 			"tech_level": "2",
@@ -15511,6 +15943,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "c9e4fafc-9d54-4488-978f-be52305d7e8f",
 			"quantity": 1,
 			"description": "Long Axe",
 			"tech_level": "2",
@@ -15564,6 +15997,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "efdb63f5-415c-4bb6-b2fa-f471ea98af1d",
 			"quantity": 1,
 			"description": "Long Dugout Canoe, 30’",
 			"tech_level": "0",
@@ -15577,6 +16011,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "570829f7-b100-49a8-b10d-d57fd0fa37d3",
 			"quantity": 1,
 			"description": "Long Knife",
 			"tech_level": "1",
@@ -15782,6 +16217,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "65896a83-c6f0-4d92-a68a-c1d33f8afa1e",
 			"quantity": 1,
 			"description": "Long Spear",
 			"tech_level": "2",
@@ -15849,6 +16285,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "3246ab36-a310-45b2-8dd9-cdf49c37e642",
 			"quantity": 1,
 			"description": "Long Staff",
 			"tech_level": "0",
@@ -15930,6 +16367,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "6fd1e348-5dc5-45f1-9d13-7853e501f1df",
 			"quantity": 1,
 			"description": "Long-Range Awe-Inspiring Gun",
 			"tech_level": "4",
@@ -16000,6 +16438,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "07345b4a-d190-405f-8b1c-61c602795ba6",
 			"quantity": 1,
 			"description": "Long-Range Awe-Inspiring Gun Lead Ball",
 			"tech_level": "4",
@@ -16013,6 +16452,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "c77a6290-6127-4daf-b9af-acfff77d5b1d",
 			"quantity": 1,
 			"description": "Long-Range Awe-Inspiring Gun Lead Shot",
 			"tech_level": "4",
@@ -16026,6 +16466,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "142ce9f0-7fb5-4d52-b43e-89d683ad6f31",
 			"quantity": 1,
 			"description": "Longboat, 30'",
 			"tech_level": "4",
@@ -16039,6 +16480,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "c27a4a02-994d-4c37-9623-07f40cbd0e4a",
 			"quantity": 1,
 			"description": "Longbow",
 			"tech_level": "0",
@@ -16080,6 +16522,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "c28b14f3-cbab-4b0b-83a0-35f8677fec45",
 			"quantity": 1,
 			"description": "Longsword",
 			"tech_level": "3",
@@ -16257,6 +16700,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "4b678b9f-81aa-4800-b595-829a63906298",
 			"quantity": 1,
 			"description": "Luxury Travel Kit",
 			"tech_level": "2",
@@ -16270,6 +16714,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "8758621d-e154-4df4-8607-4cf03aa72977",
 			"quantity": 1,
 			"description": "Mace",
 			"tech_level": "2",
@@ -16382,6 +16827,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "b4feb00c-7e3f-4061-ab55-9f3fdf544ad0",
 			"quantity": 1,
 			"description": "Macuahuilzoctli",
 			"tech_level": "0",
@@ -16513,6 +16959,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "5850b008-1497-4b60-a085-81708ece6977",
 			"quantity": 1,
 			"description": "Macuahuitl",
 			"tech_level": "0",
@@ -16625,6 +17072,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "d059379c-73a2-43e6-a9e6-2422e1aaf8e8",
 			"quantity": 1,
 			"description": "Main-Gauche",
 			"tech_level": "4",
@@ -16817,6 +17265,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "5684e1c9-fff9-4c60-b10f-9e576d2bf8ca",
 			"quantity": 1,
 			"description": "Match Cover",
 			"tech_level": "4",
@@ -16830,6 +17279,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "c0531ad8-0786-4782-ad7c-d22102f1b118",
 			"quantity": 1,
 			"description": "Maul",
 			"tech_level": "0",
@@ -16883,6 +17333,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "484a9d0f-a3bf-439a-b79c-fa9175f1ff2e",
 			"quantity": 1,
 			"description": "Melee Net",
 			"tech_level": "2",
@@ -16923,6 +17374,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "5d90873d-e2fa-4825-aa9e-d734006f5b8a",
 			"description": "Metal Box, Bronze, 1 cup",
 			"tech_level": "1",
 			"value": "72",
@@ -16951,6 +17403,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "d2c0cee0-b93f-4e81-a6c1-f999bb8b4fb1",
 			"description": "Metal Box, Bronze, 1 gal.",
 			"tech_level": "1",
 			"value": "460",
@@ -16979,6 +17432,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "df208433-62c4-4dc7-b42b-70de0d5b07cd",
 			"description": "Metal Box, Bronze, 1 quart",
 			"tech_level": "1",
 			"value": "184",
@@ -17007,6 +17461,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "7dad1644-3fa3-4c89-b31a-1f1ddf6ba6c7",
 			"description": "Metal Box, Bronze, 1/4 cup",
 			"tech_level": "1",
 			"value": "28",
@@ -17035,6 +17490,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "08175b94-c381-4112-b194-8dc464500ff6",
 			"description": "Metal Box, Bronze, 2 gal.",
 			"tech_level": "1",
 			"value": "1468",
@@ -17063,6 +17519,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "2f3557e7-de6b-4150-82e2-0ad7b48cc876",
 			"description": "Metal Box, Bronze, 6 gal.",
 			"tech_level": "1",
 			"value": "3044",
@@ -17091,6 +17548,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "d97e8b0c-5284-425b-ba20-5d09f3f86bed",
 			"description": "Metal Box, Bronze, 20 gal.",
 			"tech_level": "1",
 			"value": "6800",
@@ -17119,6 +17577,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "a42c7e03-4af3-4eb9-bd65-991c80878430",
 			"description": "Metal Box, Bronze, 40 gal.",
 			"tech_level": "1",
 			"value": "16200",
@@ -17147,6 +17606,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "9a0ea336-42bf-4586-acf6-1d5beb8c173f",
 			"description": "Metal Box, Bronze, 80 gal.",
 			"tech_level": "1",
 			"value": "25668",
@@ -17175,6 +17635,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "1aad17fb-4162-408f-841f-9a8f10d3de76",
 			"description": "Metal Box, Bronze, 120 gal.",
 			"tech_level": "1",
 			"value": "33636",
@@ -17203,6 +17664,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "96b1e2ba-a219-49e3-b2e8-72b2620b3e8e",
 			"description": "Metal Box, Iron, 1 cup",
 			"tech_level": "2",
 			"value": "18",
@@ -17231,6 +17693,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "50932eb8-bdb0-4053-b11a-cd69970e362c",
 			"description": "Metal Box, Iron, 1 gal.",
 			"tech_level": "2",
 			"value": "115",
@@ -17259,6 +17722,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "03e7f231-8db7-49ff-883c-d347f2a8acca",
 			"description": "Metal Box, Iron, 1 quart",
 			"tech_level": "2",
 			"value": "46",
@@ -17287,6 +17751,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "ae19072c-2234-4314-a4d8-c1524a8f6756",
 			"description": "Metal Box, Iron, 1/4 cup",
 			"tech_level": "2",
 			"value": "7",
@@ -17315,6 +17780,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "191d37f7-2127-4ed3-8c70-fcb3d8226658",
 			"description": "Metal Box, Iron, 2 gal.",
 			"tech_level": "2",
 			"value": "367",
@@ -17343,6 +17809,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "ac3a0c1f-9e42-4368-9073-beee428a83d1",
 			"description": "Metal Box, Iron, 6 gal.",
 			"tech_level": "2",
 			"value": "761",
@@ -17371,6 +17838,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "3ffc4452-daa1-4652-a3fa-04a13e66d8d7",
 			"description": "Metal Box, Iron, 20 gal.",
 			"tech_level": "2",
 			"value": "1700",
@@ -17399,6 +17867,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "92ce1a12-43c0-4f61-b12d-7806df72ed70",
 			"description": "Metal Box, Iron, 40 gal.",
 			"tech_level": "2",
 			"value": "4050",
@@ -17427,6 +17896,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "9defd4be-4f42-4b29-9b22-78fd22c3c2ed",
 			"description": "Metal Box, Iron, 80 gal.",
 			"tech_level": "2",
 			"value": "6417",
@@ -17455,6 +17925,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "7d909dff-4b47-4a34-8421-4b018a47599b",
 			"description": "Metal Box, Iron, 120 gal.",
 			"tech_level": "2",
 			"value": "8409",
@@ -17483,6 +17954,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "c9787d17-a072-4cb9-a442-772900142a53",
 			"quantity": 1,
 			"description": "Military Crossbow",
 			"tech_level": "4",
@@ -17524,6 +17996,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "c3959983-586e-4440-b8d6-295cdd019e29",
 			"quantity": 1,
 			"description": "Military Pistol",
 			"tech_level": "4",
@@ -17570,6 +18043,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "767b4517-7d21-4edf-a659-516c3e7e9afe",
 			"quantity": 1,
 			"description": "Military Pistol Bullet",
 			"tech_level": "4",
@@ -17583,6 +18057,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "aacb0186-226e-4e4d-963b-f92eb63c9b6a",
 			"quantity": 1,
 			"description": "Mittens",
 			"tech_level": "0",
@@ -17597,6 +18072,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "b2b8694f-7e0f-490a-b274-074d5f270b0a",
 			"quantity": 1,
 			"description": "Monankon",
 			"tech_level": "2",
@@ -17640,6 +18116,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "0a508d6f-4319-46bf-9e54-4103c0f27b6e",
 			"quantity": 1,
 			"description": "Monankon Stone",
 			"tech_level": "2",
@@ -17653,6 +18130,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "96a4c7d4-27da-4905-b400-dae496344ee1",
 			"quantity": 1,
 			"description": "Monk's Spade",
 			"tech_level": "3",
@@ -17782,6 +18260,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "a94b539b-21f2-4d57-b95a-acb7a7ff25ca",
 			"quantity": 1,
 			"description": "Monkshood",
 			"tech_level": "0",
@@ -17795,6 +18274,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "9ae07982-051d-4c4e-9603-189c57140e84",
 			"quantity": 1,
 			"description": "Morningstar",
 			"tech_level": "0",
@@ -17843,6 +18323,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "559de6f3-64a7-44af-a1d3-d35284d7eed7",
 			"quantity": 1,
 			"description": "Mr. Facing-Both-Ways Gonne",
 			"tech_level": "3",
@@ -17890,6 +18371,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "195be2bb-f26a-4bb5-b712-f68ea62442c7",
 			"quantity": 1,
 			"description": "Musket",
 			"tech_level": "4",
@@ -17936,6 +18418,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "032bd083-5272-45b2-9696-c058358f1414",
 			"quantity": 1,
 			"description": "Musket Bullet",
 			"tech_level": "4",
@@ -17949,6 +18432,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "97a26992-3051-4b06-a08d-8f7f114ec0b7",
 			"quantity": 1,
 			"description": "Musket Rest",
 			"tech_level": "4",
@@ -17962,6 +18446,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "c077ee79-bb9e-4ab7-8a12-1713680df3d0",
 			"quantity": 1,
 			"description": "Myrmex",
 			"tech_level": "1",
@@ -18013,6 +18498,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "449e202c-4347-48c2-baa1-77fdd276b997",
 			"quantity": 1,
 			"description": "Naginata",
 			"tech_level": "2",
@@ -18170,6 +18656,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "b6e26053-159e-438d-8991-c45a19cb0a1f",
 			"quantity": 1,
 			"description": "Naphtha",
 			"tech_level": "3",
@@ -18184,6 +18671,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "57251d48-a390-459d-8d71-dd8c00ddd5ca",
 			"quantity": 1,
 			"description": "Needle, Surgical",
 			"tech_level": "1",
@@ -18196,6 +18684,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "f7343536-4919-4854-86a7-44e744e6489d",
 			"quantity": 1,
 			"description": "Nunchaku",
 			"tech_level": "0",
@@ -18244,6 +18733,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "50b0a8bf-ab66-48ab-9bd4-86c38b89c1b2",
 			"quantity": 1,
 			"description": "Oar",
 			"tech_level": "0",
@@ -18297,6 +18787,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "70915cb0-59ee-4c54-9e08-25ec6b6082f4",
 			"quantity": 1,
 			"description": "Oblong Hide Boat, 5’",
 			"tech_level": "0",
@@ -18310,6 +18801,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "fc71710f-1233-43e7-b639-1cc2c1bf8592",
 			"quantity": 1,
 			"description": "Outrigger Canoe, 30’",
 			"tech_level": "0",
@@ -18323,6 +18815,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "4db1972a-4098-4061-aad2-a5f08b4c6de5",
 			"quantity": 1,
 			"description": "Oxcart",
 			"tech_level": "1",
@@ -18337,6 +18830,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "2eb41bed-65e1-4051-840d-f72279b0dca3",
 			"quantity": 1,
 			"description": "Paper Bomb",
 			"tech_level": "3",
@@ -18352,6 +18846,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "3b8659df-034e-4777-9b84-709ac4840122",
 			"quantity": 1,
 			"description": "Parchment, per sheet",
 			"tech_level": "2",
@@ -18365,6 +18860,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "e7d454a0-d40b-4cb4-a706-90af00387fb2",
 			"quantity": 1,
 			"description": "Pata",
 			"tech_level": "2",
@@ -18482,6 +18978,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "d08f2964-2e29-4cc5-bbca-73c6adb00645",
 			"quantity": 1,
 			"description": "Pencil, dozen",
 			"tech_level": "4",
@@ -18495,6 +18992,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "521f922a-5cf3-4eac-8e9b-738a680d3cfb",
 			"quantity": 1,
 			"description": "Perfume, Cheap, per application",
 			"tech_level": "0",
@@ -18508,6 +19006,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "597c19bb-b97c-402b-9924-52bcd498045a",
 			"quantity": 1,
 			"description": "Perfume, Expensive, per application",
 			"tech_level": "0",
@@ -18521,6 +19020,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "470611eb-718f-4a1b-ba32-8b3736900c41",
 			"quantity": 1,
 			"description": "Petard",
 			"tech_level": "4",
@@ -18536,6 +19036,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "20049e8d-fe84-4dcb-bfca-1e85e0d4c8b9",
 			"quantity": 1,
 			"description": "Petrobolos, 5-lb Stone",
 			"tech_level": "3",
@@ -18549,6 +19050,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "72d1e84f-03b2-4ba9-be92-8314e788d2ea",
 			"quantity": 1,
 			"description": "Petrobolos, 5-lb.",
 			"tech_level": "2",
@@ -18596,6 +19098,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "5a9cb34e-16c2-4741-b5aa-ea532e193bf5",
 			"quantity": 1,
 			"description": "Petrobolos, 5-lb. Tripod",
 			"tech_level": "2",
@@ -18609,6 +19112,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "e8a497fa-03d6-41bd-a83e-802dcec149d5",
 			"quantity": 1,
 			"description": "Petrobolos, 40-lb Stone",
 			"tech_level": "3",
@@ -18622,6 +19126,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "73c10053-94b2-4be1-a415-6fd1d49d8712",
 			"quantity": 1,
 			"description": "Petrobolos, 40-lb.",
 			"tech_level": "2",
@@ -18669,6 +19174,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "099bebac-fdfe-4ff4-8065-dda2a4226e61",
 			"quantity": 1,
 			"description": "Petrobolos, 40-lb. Tripod",
 			"tech_level": "2",
@@ -18682,6 +19188,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "f2d8928a-55d4-4112-8b44-b0d2b8ec73b8",
 			"quantity": 1,
 			"description": "Petronel",
 			"tech_level": "4",
@@ -18728,6 +19235,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "9f4db33a-54a0-4865-a0b4-2edf0792b15a",
 			"quantity": 1,
 			"description": "Petronel Bullet",
 			"tech_level": "4",
@@ -18741,6 +19249,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "bd5bb76e-2957-4e8a-ae02-e46f9a540e46",
 			"quantity": 1,
 			"description": "Pick",
 			"tech_level": "3",
@@ -18789,6 +19298,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "d7a5171e-8b0e-4999-8aa7-e36246472568",
 			"quantity": 1,
 			"description": "Piercing, copper",
 			"tech_level": "0",
@@ -18802,6 +19312,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "0586c1a7-4968-4e74-a839-3a0dbe30d1f2",
 			"quantity": 1,
 			"description": "Piercing, gold",
 			"tech_level": "0",
@@ -18815,6 +19326,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "99b59baf-4a06-4d2a-a539-a6f2d4a1a990",
 			"quantity": 1,
 			"description": "Piercing, silver",
 			"tech_level": "0",
@@ -18828,6 +19340,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "d9435865-6672-4b6f-873c-013c6bca556d",
 			"quantity": 1,
 			"description": "Pike",
 			"tech_level": "2",
@@ -18876,6 +19389,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "feeb7933-ac93-42d6-95cc-8774c69eca25",
 			"quantity": 1,
 			"description": "Pilgrim's Kit",
 			"tech_level": "2",
@@ -18889,6 +19403,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "ebd54a9d-211a-4899-a3a5-4548d631670f",
 			"quantity": 1,
 			"description": "Pipe",
 			"tech_level": "0",
@@ -18902,6 +19417,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "16362a11-ed91-419f-9971-59957d374297",
 			"quantity": 1,
 			"description": "Pistol Crossbow",
 			"tech_level": "3",
@@ -18944,6 +19460,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "dd186aae-303a-4025-b6be-05e09da546fc",
 			"quantity": 1,
 			"description": "Pistol Crossbow Dart",
 			"tech_level": "3",
@@ -18958,6 +19475,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "59de617a-9d08-4aea-88ac-dae71e606478",
 			"quantity": 1,
 			"description": "Piton",
 			"tech_level": "2",
@@ -18971,6 +19489,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "01e9154f-03e8-47e9-834e-7b22986d116a",
 			"quantity": 1,
 			"description": "Piton Hammer",
 			"tech_level": "2",
@@ -18984,6 +19503,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "dba0b9bf-4321-4246-b946-b9d8b1122c6c",
 			"quantity": 1,
 			"description": "Plug, copper",
 			"tech_level": "0",
@@ -18997,6 +19517,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "cfbb9a51-8cf6-4b77-a3fc-c2254e580430",
 			"quantity": 1,
 			"description": "Plug, gold",
 			"tech_level": "0",
@@ -19010,6 +19531,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "94480ddf-7a93-4cfb-94ce-c57a27eb049f",
 			"quantity": 1,
 			"description": "Plug, silver",
 			"tech_level": "0",
@@ -19023,6 +19545,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "9e19d8a1-859d-4053-a880-af79e9e4bfe8",
 			"quantity": 1,
 			"description": "Pocket Pistol",
 			"tech_level": "4",
@@ -19069,6 +19592,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "8d7087c3-48ab-4096-8961-90adbe50c09e",
 			"quantity": 1,
 			"description": "Pocket Pistol Bullet",
 			"tech_level": "4",
@@ -19082,6 +19606,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "6c195374-f54a-4c6b-9468-e9fab44111fd",
 			"quantity": 1,
 			"description": "Poleaxe",
 			"tech_level": "3",
@@ -19173,6 +19698,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "37adf331-0b7b-4e6e-bf1e-2c7a08c4567b",
 			"quantity": 1,
 			"description": "Pollaxe",
 			"tech_level": "3",
@@ -19302,6 +19828,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "ee2b12bf-29ae-4f4d-b726-7a17fee22efb",
 			"quantity": 1,
 			"description": "Polybolos",
 			"tech_level": "2",
@@ -19349,6 +19876,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "427728ce-3315-4fba-abac-fb08101bed55",
 			"quantity": 1,
 			"description": "Polybolos Bolt",
 			"tech_level": "3",
@@ -19362,6 +19890,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "67d7f580-7762-41ba-aa1d-62e1df1a36d6",
 			"quantity": 1,
 			"description": "Polybolos Tripod",
 			"tech_level": "2",
@@ -19375,6 +19904,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "9d1ed98d-2418-40de-9e13-4321b1b8370b",
 			"quantity": 1,
 			"description": "Portable Sundial",
 			"tech_level": "2",
@@ -19388,6 +19918,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "5576ba91-52da-416e-89a6-e0b30627d770",
 			"quantity": 1,
 			"description": "Prepared Block",
 			"tech_level": "0",
@@ -19401,6 +19932,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "c43d31ed-233b-4119-8ccd-c376039eb104",
 			"quantity": 1,
 			"description": "Probe, Surgical",
 			"tech_level": "1",
@@ -19413,6 +19945,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "8c349485-17c6-43d5-b7cf-c14f6d40816f",
 			"quantity": 1,
 			"description": "Prodd",
 			"tech_level": "3",
@@ -19454,6 +19987,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "ef116fa4-64fd-40ce-a76a-4d5298a2c3d8",
 			"quantity": 1,
 			"description": "Prodd Pellet",
 			"tech_level": "3",
@@ -19468,6 +20002,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "599eb3a4-8c4a-4482-a21e-fffd6a23468f",
 			"quantity": 1,
 			"description": "Pry-Bar",
 			"tech_level": "2",
@@ -19481,6 +20016,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "60198252-5e22-4013-b1c5-f8a770f89a0f",
 			"quantity": 1,
 			"description": "Pry-Bar, Small",
 			"tech_level": "2",
@@ -19494,6 +20030,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "9fe02001-104d-4646-af19-bfd8e4d776b9",
 			"quantity": 1,
 			"description": "Puckle Gun",
 			"tech_level": "4",
@@ -19541,6 +20078,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "bb19993a-bc3a-4450-97bd-ea352b0e4172",
 			"quantity": 1,
 			"description": "Puckle Gun Bullet",
 			"tech_level": "4",
@@ -19554,6 +20092,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "382091ef-4779-466c-be50-cbe1bd741c4e",
 			"quantity": 1,
 			"description": "Puffer Pistol",
 			"tech_level": "4",
@@ -19600,6 +20139,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "4aab6e14-ced7-42af-8549-96b95000d9ac",
 			"quantity": 1,
 			"description": "Puffer Pistol Bullet",
 			"tech_level": "4",
@@ -19613,6 +20153,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "e32b3ce0-5b9f-4b82-aba6-7bf3c31b5392",
 			"quantity": 1,
 			"description": "Pumice",
 			"tech_level": "1",
@@ -19626,6 +20167,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "aef536e5-4c28-4d98-baa1-3f97feeb429e",
 			"quantity": 1,
 			"description": "Qian Kun Ri Yue Dao",
 			"tech_level": "3",
@@ -19769,6 +20311,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "fbdd7728-ad5c-43f7-a5ce-f53f05de27b9",
 			"quantity": 1,
 			"description": "Quadrens",
 			"tech_level": "2",
@@ -19863,6 +20406,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "52791218-1749-41ff-a1d4-a611c5b0e00b",
 			"quantity": 1,
 			"description": "Quarterstaff",
 			"tech_level": "0",
@@ -20010,6 +20554,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "0931337c-b19f-498e-b515-6db56705280d",
 			"quantity": 1,
 			"description": "Queen Anne Pistol",
 			"tech_level": "4",
@@ -20056,6 +20601,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "0cfb00fa-2974-4d4f-a6ba-f2bcf69cba0f",
 			"quantity": 1,
 			"description": "Queen Anne Pistol Bullet",
 			"tech_level": "4",
@@ -20069,6 +20615,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "1188e071-9e6a-4838-a616-9d022b381dc9",
 			"quantity": 1,
 			"description": "Quick Match",
 			"tech_level": "4",
@@ -20083,6 +20630,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "8729bbf5-3551-4276-8adb-e635652a7789",
 			"quantity": 1,
 			"description": "Quill, Cheap",
 			"tech_level": "3",
@@ -20095,6 +20643,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "819916ff-c4e2-4f15-862e-4ca46bd23596",
 			"quantity": 1,
 			"description": "Quill, Fine",
 			"tech_level": "3",
@@ -20107,6 +20656,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "e2c2ec42-8c4d-4cb6-943b-93b56218a23f",
 			"quantity": 1,
 			"description": "Rabinet",
 			"tech_level": "4",
@@ -20153,6 +20703,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "ca915e0b-14c2-4f87-86fd-4bcc1551f77a",
 			"quantity": 1,
 			"description": "Rabinet Cannonball",
 			"tech_level": "4",
@@ -20166,6 +20717,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "940629c2-fdd6-43e8-8e3a-7ae9960d0bad",
 			"quantity": 1,
 			"description": "Rabinet Truck Carriage Mount",
 			"tech_level": "4",
@@ -20179,6 +20731,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "0eedabf7-2854-4954-8e12-e62bd1392fb1",
 			"quantity": 1,
 			"description": "Raft, 4\" Logs",
 			"tech_level": "0",
@@ -20192,6 +20745,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "0cb0576e-066d-4c78-aaf8-f63d5890c46d",
 			"quantity": 1,
 			"description": "Raft, 6.5\" Reeds",
 			"tech_level": "0",
@@ -20205,6 +20759,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "8893775e-a8a5-4684-95ba-aa5b1ab06fde",
 			"quantity": 1,
 			"description": "Raft, 7\" Logs",
 			"tech_level": "0",
@@ -20218,6 +20773,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "133cf25c-d137-43f2-a91e-27d6001a6e88",
 			"quantity": 1,
 			"description": "Raft, 10\" Logs",
 			"tech_level": "0",
@@ -20231,6 +20787,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "acd966f9-237e-4362-a1ba-c0af9f83d0b4",
 			"quantity": 1,
 			"description": "Raft, 12\" Logs",
 			"tech_level": "0",
@@ -20244,6 +20801,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "54921ce8-3b60-4854-9606-6730131981cb",
 			"quantity": 1,
 			"description": "Rapier",
 			"tech_level": "4",
@@ -20302,6 +20860,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "0bd848df-e875-4d99-b2af-869c087810f0",
 			"quantity": 1,
 			"description": "Razor",
 			"tech_level": "0",
@@ -20315,6 +20874,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "07082431-3e3a-46fa-9f8a-679ae1d01570",
 			"quantity": 1,
 			"description": "Reflex Bow",
 			"tech_level": "1",
@@ -20356,6 +20916,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "e5e71813-87a4-4c68-9b7b-fb9543c471ad",
 			"quantity": 1,
 			"description": "Regular Bow",
 			"tech_level": "0",
@@ -20397,6 +20958,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "4728c682-8ea8-462a-aad7-d5ed963a7eea",
 			"quantity": 1,
 			"description": "Repeating Crossbow",
 			"tech_level": "2",
@@ -20438,6 +21000,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "4b831f2d-5d56-4f71-8d04-eea8898635bc",
 			"quantity": 1,
 			"description": "Riding Crop",
 			"tech_level": "2",
@@ -20451,6 +21014,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "b3459074-1213-4c7c-a731-41e0923a863b",
 			"quantity": 1,
 			"description": "Ring, copper",
 			"tech_level": "0",
@@ -20464,6 +21028,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "03f0bfea-9cff-4939-adfe-1171ee59ee2a",
 			"quantity": 1,
 			"description": "Ring, gold",
 			"tech_level": "0",
@@ -20477,6 +21042,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "91d29863-3a90-4b7b-bcc5-d3af76d29135",
 			"quantity": 1,
 			"description": "Ring, silver",
 			"tech_level": "0",
@@ -20490,6 +21056,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "e9a69704-1b2a-4299-af26-5f57bd0d8231",
 			"quantity": 1,
 			"description": "River Barge, 40'",
 			"tech_level": "1",
@@ -20503,6 +21070,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "ef1705ed-b81e-40ab-bbec-ad58fe1569bf",
 			"quantity": 1,
 			"description": "Rondel Dagger",
 			"tech_level": "3",
@@ -20603,6 +21171,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "5fa6addc-97b9-4615-8698-5ae15d70a66a",
 			"quantity": 1,
 			"description": "Rope Dart",
 			"tech_level": "2",
@@ -20695,6 +21264,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "aa9aa633-f9a1-4974-b21a-19429063af45",
 			"quantity": 1,
 			"description": "Round Hide Boat, 5’",
 			"tech_level": "0",
@@ -20708,6 +21278,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "be8774aa-4b85-49a4-a9c9-43b1f0eb7a57",
 			"quantity": 1,
 			"description": "Round Mace",
 			"tech_level": "0",
@@ -20787,6 +21358,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "0f69d76e-7d65-4600-9c1d-25a3d3b6cbde",
 			"quantity": 1,
 			"description": "Saber",
 			"tech_level": "4",
@@ -20896,6 +21468,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "59fbb5af-1d60-49fb-b55c-973068f5aa11",
 			"quantity": 1,
 			"description": "Saddle, Cushioned",
 			"tech_level": "2",
@@ -20909,6 +21482,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "90f76171-fd94-4e5a-b067-4de32e0295b9",
 			"quantity": 1,
 			"description": "Saddle, Horned",
 			"tech_level": "2",
@@ -20922,6 +21496,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "2ddccc47-3061-4fc0-8d59-09ee4e4bf510",
 			"quantity": 1,
 			"description": "Saddle, Riding",
 			"tech_level": "2",
@@ -20935,6 +21510,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "7df78208-0e0c-4f30-96fd-bbe5257dad10",
 			"quantity": 1,
 			"description": "Saddle, War",
 			"tech_level": "3",
@@ -20948,6 +21524,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "9034d0ef-7239-4e8c-a46c-7629d850f545",
 			"description": "Saddlebags",
 			"tech_level": "2",
 			"value": "100",
@@ -20975,6 +21552,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "7056e685-8acf-4b93-b273-9f1d1e71f4e5",
 			"quantity": 1,
 			"description": "Sai",
 			"tech_level": "3",
@@ -21185,6 +21763,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "0b87aa14-90ce-4dc5-8292-6f8b49ecee8a",
 			"quantity": 1,
 			"description": "Saker",
 			"tech_level": "4",
@@ -21232,6 +21811,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "1257aaeb-8c90-4b37-9416-c25ce3e64b2e",
 			"quantity": 1,
 			"description": "Saker Cannonball",
 			"tech_level": "4",
@@ -21245,6 +21825,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "b8abab76-d759-45a0-a736-d487b46872de",
 			"quantity": 1,
 			"description": "Saker Truck Carriage Mount",
 			"tech_level": "4",
@@ -21258,6 +21839,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "7004a934-645a-4c48-9f98-0a3e7008061c",
 			"quantity": 1,
 			"description": "Saltpeter",
 			"tech_level": "3",
@@ -21271,6 +21853,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "df4b1fe2-a9a1-470f-b64c-3ef06c2faae5",
 			"quantity": 1,
 			"description": "Sampan, 15’",
 			"tech_level": "1",
@@ -21284,6 +21867,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "dd4391e8-0162-4317-a41e-14e20cccb30a",
 			"quantity": 1,
 			"description": "Sandglass",
 			"tech_level": "3",
@@ -21297,6 +21881,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "86272a2e-46ec-424c-bc6f-c3d5df75815e",
 			"quantity": 1,
 			"description": "Scalpel",
 			"tech_level": "1",
@@ -21309,6 +21894,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "972a7385-33f9-4e6e-a8d7-9b94ced2ec32",
 			"quantity": 1,
 			"description": "Scorpion, 9\" Bolt",
 			"tech_level": "2",
@@ -21322,6 +21908,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "c64e9c4c-81b3-4f97-8645-b5e69fc293b8",
 			"quantity": 1,
 			"description": "Scorpion, 9”",
 			"tech_level": "2",
@@ -21360,6 +21947,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "9774d652-3a91-49fc-b535-73aa1241f08c",
 			"quantity": 1,
 			"description": "Scorpion, 13.5\" Bolt",
 			"tech_level": "2",
@@ -21373,6 +21961,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "a18a2003-e5dc-4218-b3f3-688e303be379",
 			"quantity": 1,
 			"description": "Scorpion, 13.5”",
 			"tech_level": "2",
@@ -21411,6 +22000,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "76a16a8b-35e7-4fb2-8702-78d484969e76",
 			"quantity": 1,
 			"description": "Scorpion, 18\" Bolt",
 			"tech_level": "2",
@@ -21424,6 +22014,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "f8079e6f-cd61-4b0a-8446-64d7a4ba7d1a",
 			"quantity": 1,
 			"description": "Scorpion, 18”",
 			"tech_level": "2",
@@ -21462,6 +22053,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "75bc12ab-4a8a-41b5-a72c-77da356237c5",
 			"quantity": 1,
 			"description": "Scorpion, 27\" Bolt",
 			"tech_level": "3",
@@ -21475,6 +22067,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "ab417e1c-699c-4aa5-9027-3b026a93e160",
 			"quantity": 1,
 			"description": "Scorpion, 27”",
 			"tech_level": "2",
@@ -21522,6 +22115,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "7f5a6375-7440-4fbc-96e7-dde00b73936b",
 			"quantity": 1,
 			"description": "Scorpion, 27” Tripod",
 			"tech_level": "2",
@@ -21535,6 +22129,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "b7fb0e92-2bdf-48ef-8103-a454beee568c",
 			"quantity": 1,
 			"description": "Scorpion, 36\" Bolt",
 			"tech_level": "3",
@@ -21548,6 +22143,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "b9581b2f-64f0-4e65-9b9d-e8ece0359ee3",
 			"quantity": 1,
 			"description": "Scorpion, 36”",
 			"tech_level": "2",
@@ -21595,6 +22191,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "74e30812-c8ba-4319-ba64-dcb160069f3f",
 			"quantity": 1,
 			"description": "Scorpion, 36” Tripod",
 			"tech_level": "2",
@@ -21608,6 +22205,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "2035607b-13d5-491b-af44-8bbde07c7881",
 			"quantity": 1,
 			"description": "Scorpion, 45\" Bolt",
 			"tech_level": "3",
@@ -21621,6 +22219,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "f47bc4a2-aee4-43ec-bdb8-d1ac670da24e",
 			"quantity": 1,
 			"description": "Scorpion, 45”",
 			"tech_level": "2",
@@ -21668,6 +22267,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "3e3c61f4-a495-4228-80b5-787c1383ed90",
 			"quantity": 1,
 			"description": "Scorpion, 45” Tripod",
 			"tech_level": "2",
@@ -21681,6 +22281,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "a107e915-34ba-45c3-94e2-cc22d050c666",
 			"quantity": 1,
 			"description": "Scorpion, 54\" Bolt",
 			"tech_level": "3",
@@ -21694,6 +22295,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "480e0abf-d2ca-4eb4-91fa-e6545e75f00b",
 			"quantity": 1,
 			"description": "Scorpion, 54”",
 			"tech_level": "2",
@@ -21741,6 +22343,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "82fc61a2-f010-4317-ba7c-26345a62d326",
 			"quantity": 1,
 			"description": "Scorpion, 54” Tripod",
 			"tech_level": "2",
@@ -21754,6 +22357,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "b4db4680-6fb0-4b7e-a812-285eb0f3daaa",
 			"quantity": 1,
 			"description": "Scorpion, 72\" Bolt",
 			"tech_level": "3",
@@ -21767,6 +22371,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "efa91333-f952-406a-906f-b31feb83e492",
 			"quantity": 1,
 			"description": "Scorpion, 72”",
 			"tech_level": "2",
@@ -21814,6 +22419,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "d6b42056-968e-47a9-b9af-101fd82fadcb",
 			"quantity": 1,
 			"description": "Scorpion, 72” Tripod",
 			"tech_level": "2",
@@ -21827,6 +22433,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "deb474d2-1be7-42a7-9cc7-cb6147603941",
 			"quantity": 1,
 			"description": "Scythe",
 			"tech_level": "1",
@@ -21957,6 +22564,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "cfcf5616-d5d2-4300-a4ec-324e6337d6f2",
 			"quantity": 1,
 			"description": "Scythed Chariot",
 			"tech_level": "2",
@@ -21971,6 +22579,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "154d3e07-db83-4341-8650-895699a182e7",
 			"quantity": 1,
 			"description": "Serpentine Black Powder",
 			"tech_level": "3",
@@ -21985,6 +22594,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "735eebe4-8bca-4694-9112-443b012d3156",
 			"quantity": 1,
 			"description": "Sewn-Plank Riverboat, 30’",
 			"tech_level": "1",
@@ -21998,6 +22608,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "fcc799a5-f82e-4d34-838f-c184d62ffe83",
 			"quantity": 1,
 			"description": "Sewn-Plank Sailboat",
 			"tech_level": "3",
@@ -22011,6 +22622,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "3b6874a1-5eae-4edc-a092-c3bfffa3a18e",
 			"quantity": 1,
 			"description": "Shackles, Iron",
 			"tech_level": "2",
@@ -22024,6 +22636,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "0d5cdb60-4dce-42c7-a319-0cbbcf727b35",
 			"quantity": 1,
 			"description": "Shaped Sling Stone",
 			"tech_level": "0",
@@ -22037,6 +22650,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "816b4996-ce5f-4cc5-80f9-9ff38ae4d41e",
 			"quantity": 1,
 			"description": "Ship's  Gun, 4-lb.",
 			"tech_level": "4",
@@ -22084,6 +22698,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "94a3a710-1dbf-4136-b5ae-e179e9200d06",
 			"quantity": 1,
 			"description": "Ship's  Gun, 9-lb.",
 			"tech_level": "4",
@@ -22131,6 +22746,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "181f0fd9-40de-4d04-86bb-d9a7803b66e4",
 			"quantity": 1,
 			"description": "Ship's  Gun, 18-lb.",
 			"tech_level": "4",
@@ -22178,6 +22794,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "6d5b6f4a-1e53-4c3c-997e-4bc136f722b9",
 			"quantity": 1,
 			"description": "Ship's  Gun, 42-lb.",
 			"tech_level": "4",
@@ -22225,6 +22842,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "1ddf0deb-fd85-4327-9263-a340ed1c29a9",
 			"quantity": 1,
 			"description": "Ship's Gun,4-lb. Cannonball",
 			"tech_level": "4",
@@ -22238,6 +22856,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "b5228881-b0b5-4f2f-b21a-43c3c4c61071",
 			"quantity": 1,
 			"description": "Ship's Gun,9-lb. Cannonball",
 			"tech_level": "4",
@@ -22251,6 +22870,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "e052109b-943d-4eef-be21-0898fa684c49",
 			"quantity": 1,
 			"description": "Ship's Gun,18-lb. Cannonball",
 			"tech_level": "4",
@@ -22264,6 +22884,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "45fca248-a050-4e4a-a5fd-22383106580c",
 			"quantity": 1,
 			"description": "Ship's Gun,42-lb. Cannonball",
 			"tech_level": "4",
@@ -22277,6 +22898,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "d4f5e035-80d8-443e-8ae0-7acdf368a618",
 			"quantity": 1,
 			"description": "Ship’s  Gun, 4-lb. Truck Carriage Mount",
 			"tech_level": "4",
@@ -22290,6 +22912,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "715f58d3-9440-4d53-a7c3-125f46515a4a",
 			"quantity": 1,
 			"description": "Ship’s  Gun, 9-lb. Truck Carriage Mount",
 			"tech_level": "4",
@@ -22303,6 +22926,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "2b57c86f-a73a-4076-b17c-9f26366b6fd1",
 			"quantity": 1,
 			"description": "Ship’s Gun, 18-lb. Truck Carriage Mount",
 			"tech_level": "4",
@@ -22316,6 +22940,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "c5f0d252-b5ae-4160-b05c-3d542753058c",
 			"quantity": 1,
 			"description": "Ship’s Gun, 42-lb. Truck Carriage Mount",
 			"tech_level": "4",
@@ -22329,6 +22954,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "95c6a506-3000-49d7-a476-d0a97f90e011",
 			"quantity": 1,
 			"description": "Shoes, leather",
 			"tech_level": "1",
@@ -22342,6 +22968,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "4321ba95-b017-44b9-94f2-70ee2152202c",
 			"quantity": 1,
 			"description": "Shooting Stick",
 			"tech_level": "4",
@@ -22355,6 +22982,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "b19403e1-bab6-481f-9607-6517a5ff0704",
 			"quantity": 1,
 			"description": "Short Baton",
 			"tech_level": "0",
@@ -22498,6 +23126,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "cb5579f0-8c5b-4ffe-be85-b9e82e5f7975",
 			"quantity": 1,
 			"description": "Short Bow",
 			"tech_level": "0",
@@ -22538,6 +23167,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "9d1258ff-c602-4aa4-a4d6-2d0ad1b0a8c1",
 			"quantity": 1,
 			"description": "Short Spear",
 			"tech_level": "1",
@@ -22618,6 +23248,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "f4bfc2c3-ec8f-4004-96c4-351613bbefde",
 			"quantity": 1,
 			"description": "Short Staff",
 			"tech_level": "0",
@@ -22717,6 +23348,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "330b8445-aeee-44d8-b9d3-1672bd748902",
 			"quantity": 1,
 			"description": "Shortsword",
 			"tech_level": "1",
@@ -22847,6 +23479,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "8745fadf-2e4a-4a6a-ac77-ee70e42765d2",
 			"quantity": 1,
 			"description": "Shotel",
 			"tech_level": "2",
@@ -22959,6 +23592,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "ddef31d9-1a64-430d-88f0-909344d502b1",
 			"quantity": 1,
 			"description": "Sickle",
 			"tech_level": "1",
@@ -23071,6 +23705,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "aa4c0281-fcb2-446e-a459-f73d499c7c3e",
 			"quantity": 1,
 			"description": "Siege Crossbow",
 			"tech_level": "4",
@@ -23113,6 +23748,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "ac71a6dd-8681-413b-84b0-540474cf7fb9",
 			"quantity": 1,
 			"description": "Signet Ring",
 			"tech_level": "2",
@@ -23125,6 +23761,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "48dfe9aa-7dc6-4e20-bc54-50ce8c4df7bb",
 			"quantity": 1,
 			"description": "Slashing Wheel",
 			"tech_level": "3",
@@ -23233,6 +23870,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "c2251d77-75de-4131-a097-4030a2605e1d",
 			"quantity": 1,
 			"description": "Sleigh",
 			"tech_level": "4",
@@ -23247,6 +23885,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "0e554991-c0db-4243-9982-5094653e12a5",
 			"quantity": 1,
 			"description": "Sling",
 			"tech_level": "0",
@@ -23288,6 +23927,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "feeb9616-71dc-4f02-9376-841ee40e3b99",
 			"quantity": 1,
 			"description": "Sling Pellet",
 			"tech_level": "0",
@@ -23302,6 +23942,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "9215086d-1135-4116-91dd-67ca916fb1b0",
 			"quantity": 1,
 			"description": "Sling, Long Arm",
 			"tech_level": "4",
@@ -23315,6 +23956,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "f2c69fcd-cbb8-49b2-9fd2-239169c72af1",
 			"quantity": 1,
 			"description": "Sloop, 21'",
 			"tech_level": "4",
@@ -23328,6 +23970,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "a313a67a-2ead-43bf-92c5-2825d20911ac",
 			"quantity": 1,
 			"description": "Slow Match",
 			"tech_level": "4",
@@ -23342,6 +23985,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "931126c9-268e-4a57-884d-79dd6c6a6933",
 			"quantity": 1,
 			"description": "Slurbow",
 			"tech_level": "3",
@@ -23409,6 +24053,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "fb69e1fd-e25a-4c4a-b033-103c41ab8ef8",
 			"quantity": 1,
 			"description": "Slurbow Dart",
 			"tech_level": "0",
@@ -23423,6 +24068,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "1c4f48e3-2ae8-4386-982f-a5a249f2910a",
 			"quantity": 1,
 			"description": "Small Axe",
 			"tech_level": "0",
@@ -23471,6 +24117,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "a5afb432-074c-468b-a060-a1cfc49ec106",
 			"quantity": 1,
 			"description": "Small Falchion",
 			"tech_level": "2",
@@ -23601,6 +24248,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "14f4c3fc-bfd3-4ff2-a0df-77163d779825",
 			"quantity": 1,
 			"description": "Small Knife",
 			"tech_level": "0",
@@ -23719,6 +24367,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "101f7d5e-dcc4-4eab-b00c-4e943910fa72",
 			"quantity": 1,
 			"description": "Small Mace",
 			"tech_level": "2",
@@ -23793,6 +24442,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "424163af-dcf7-43e9-965e-fab3dd91c4c7",
 			"quantity": 1,
 			"description": "Small Round Mace",
 			"tech_level": "0",
@@ -23867,6 +24517,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "b3513627-1b2d-4552-9b62-5e420fff7de7",
 			"quantity": 1,
 			"description": "Small Throwing Axe",
 			"tech_level": "0",
@@ -23942,6 +24593,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "df95c488-a62f-466e-930f-cfd7debe235d",
 			"quantity": 1,
 			"description": "Small Throwing Knife",
 			"tech_level": "2",
@@ -24101,6 +24753,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "72b01ce5-fbb3-4d1a-ab03-41c9d0c9811f",
 			"quantity": 1,
 			"description": "Smallsword",
 			"tech_level": "4",
@@ -24159,6 +24812,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "9555575a-42ad-49fe-a440-04a5607e5b06",
 			"quantity": 1,
 			"description": "Snaphaunce Pistol",
 			"tech_level": "4",
@@ -24205,6 +24859,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "97ac0d4a-4c56-4692-a698-ec67effcafc5",
 			"quantity": 1,
 			"description": "Snaphaunce Pistol Bullet",
 			"tech_level": "4",
@@ -24218,6 +24873,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "bc8e4060-c47b-4161-861c-9c94588b9edf",
 			"quantity": 1,
 			"description": "Soap, Liquid, Pint",
 			"tech_level": "2",
@@ -24231,6 +24887,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "e2cef6d4-fe83-4057-9d85-fb84a718ce51",
 			"quantity": 1,
 			"description": "Soap, Solid, Bar",
 			"tech_level": "2",
@@ -24244,6 +24901,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "90bfef46-3a2c-4c9d-9ac9-0f425ae291bc",
 			"quantity": 1,
 			"description": "Sodegarami",
 			"tech_level": "3",
@@ -24359,6 +25017,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "3eb1e737-b98d-4957-a69a-9aa2cae2bc41",
 			"quantity": 1,
 			"description": "Spear",
 			"tech_level": "0",
@@ -24477,6 +25136,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "295f5d8c-aef0-4f34-8ce3-e5619a0efd42",
 			"quantity": 1,
 			"description": "Spear w. Thong",
 			"tech_level": "0",
@@ -24595,6 +25255,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "e55c2325-f000-48ea-ae43-0413f513520c",
 			"quantity": 1,
 			"description": "Speculum",
 			"tech_level": "2",
@@ -24608,6 +25269,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "53869271-13e5-4cd2-b95e-53641b1420a5",
 			"quantity": 1,
 			"description": "Spike Shuriken",
 			"tech_level": "3",
@@ -24676,6 +25338,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "ffba2262-ec0e-4bec-b586-f5bd482559fc",
 			"quantity": 1,
 			"description": "Splints, Arm",
 			"tech_level": "0",
@@ -24689,6 +25352,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "7ffd8fe1-c426-410c-81b6-8f1b98ce43a2",
 			"quantity": 1,
 			"description": "Splints, Leg",
 			"tech_level": "0",
@@ -24702,6 +25366,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "2631ff5e-214f-42e6-b4e7-9442859c4a44",
 			"quantity": 1,
 			"description": "Springald",
 			"tech_level": "3",
@@ -24749,6 +25414,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "d71c798c-74c5-46c1-84ac-c16edb131dd5",
 			"quantity": 1,
 			"description": "Springald Bolt",
 			"tech_level": "3",
@@ -24762,6 +25428,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "381ee21a-2bc8-4485-a6b2-c22dedc2c1d4",
 			"quantity": 1,
 			"description": "Spurs",
 			"tech_level": "2",
@@ -24774,6 +25441,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "6d539f67-4f75-4c4c-9c32-ffb0eb3fd8ad",
 			"quantity": 1,
 			"description": "Square-Rigged Sailboat",
 			"tech_level": "2",
@@ -24787,6 +25455,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "4f09f3f0-d594-48ae-954d-cb5b88a9a9ab",
 			"quantity": 1,
 			"description": "Staff Sling",
 			"tech_level": "1",
@@ -24829,6 +25498,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "0d44fec7-501b-4ccf-b879-dad8a2a1ecfa",
 			"quantity": 1,
 			"description": "Star Shuriken",
 			"tech_level": "3",
@@ -24897,6 +25567,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "6d8fac6e-a7c0-4ca2-a0f1-5f5713fc4d27",
 			"quantity": 1,
 			"description": "Stiletto",
 			"tech_level": "3",
@@ -24999,6 +25670,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "4e39a277-4040-499d-9349-2e5b9d16f0ef",
 			"quantity": 1,
 			"description": "Stirrups",
 			"tech_level": "3",
@@ -25012,6 +25684,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "3636589f-28b7-436d-82f2-0d2ce04ec586",
 			"quantity": 1,
 			"description": "Stone-Launching Stick",
 			"tech_level": "0",
@@ -25060,6 +25733,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "0bda6e20-b147-4c8f-b9bf-22b2f8a758e6",
 			"quantity": 1,
 			"description": "Stone-Launching Stick Shaped Stone",
 			"tech_level": "0",
@@ -25075,6 +25749,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "d23facb1-2e56-4b92-9243-b9ca539edef5",
 			"quantity": 1,
 			"description": "Straddle Car",
 			"tech_level": "1",
@@ -25089,6 +25764,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "2b00a041-e77e-4744-a8e3-86a11f611190",
 			"quantity": 1,
 			"description": "Straight Composite Bow",
 			"tech_level": "1",
@@ -25129,6 +25805,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "2aea59ce-5f8a-493f-a464-83e72a08d837",
 			"quantity": 1,
 			"description": "Strigil",
 			"tech_level": "1",
@@ -25142,6 +25819,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "70a79658-e2f4-4fe2-9416-fd71e2d3e1ff",
 			"quantity": 1,
 			"description": "Stylus",
 			"tech_level": "1",
@@ -25154,6 +25832,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "3ed3258f-b8dc-4a9a-8ac5-d3d62f5e71e5",
 			"quantity": 4,
 			"description": "Sulfur Matches",
 			"tech_level": "3",
@@ -25166,6 +25845,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "76bcb94e-a9bc-4a19-b7e6-1aa170254b48",
 			"quantity": 1,
 			"description": "Surgeon Kit, Large",
 			"tech_level": "1",
@@ -25180,6 +25860,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "fbb40efd-0911-41a3-8203-c960bdcca9fe",
 			"quantity": 1,
 			"description": "Surgeon Kit, Small",
 			"tech_level": "1",
@@ -25194,6 +25875,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "e902358a-afca-446b-bbfe-1e0694bb78cf",
 			"quantity": 1,
 			"description": "Surveyor's Kit",
 			"tech_level": "2",
@@ -25207,6 +25889,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "e2e0e10e-2660-4f8d-a56a-46d52b5853f0",
 			"quantity": 1,
 			"description": "Swivel-Gun",
 			"tech_level": "4",
@@ -25253,6 +25936,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "4fe74a57-c188-419b-9f11-3cd62abe3037",
 			"quantity": 1,
 			"description": "Swivel-Gun Cannonball",
 			"tech_level": "4",
@@ -25266,6 +25950,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "35977bca-8204-4e90-9f97-6e69398d2ef2",
 			"quantity": 1,
 			"description": "Swivel-Gun Pintle Mount",
 			"tech_level": "4",
@@ -25279,6 +25964,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "6dbb1031-c310-4f1d-8a19-32ffd9baedb0",
 			"quantity": 1,
 			"description": "Tantsutsu",
 			"tech_level": "4",
@@ -25325,6 +26011,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "0bc06493-a3ed-4ab9-b90a-046e0ed92496",
 			"quantity": 1,
 			"description": "Tantsutsu Bullet",
 			"tech_level": "4",
@@ -25338,6 +26025,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "c4bf6d4c-49f9-4011-a5b8-4f0bbca94eee",
 			"quantity": 1,
 			"description": "Ten-Eyed Gonne",
 			"tech_level": "3",
@@ -25505,6 +26193,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "37b1246d-b308-4d44-9844-cd7f944bbe21",
 			"quantity": 1,
 			"description": "Teppo",
 			"tech_level": "4",
@@ -25551,6 +26240,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "72dd7865-6fad-4b12-8f23-f8e19beec0ba",
 			"quantity": 1,
 			"description": "Teppo Bullet",
 			"tech_level": "4",
@@ -25564,6 +26254,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "9ef43f2b-ddf9-44a0-917b-b62773569061",
 			"quantity": 1,
 			"description": "Tetsubo",
 			"tech_level": "2",
@@ -25721,6 +26412,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "b8e5d411-104c-4640-9a25-069768f8a6d5",
 			"quantity": 1,
 			"description": "Thonged Club",
 			"tech_level": "0",
@@ -25769,6 +26461,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "5bc2187c-ab30-41b8-847b-93c549309529",
 			"quantity": 1,
 			"description": "Three-Part Staff",
 			"tech_level": "2",
@@ -25861,6 +26554,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "1e8e7b87-97bf-40da-a598-4ffd60c3d786",
 			"quantity": 1,
 			"description": "Throwing Axe",
 			"tech_level": "0",
@@ -25974,6 +26668,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "5156e992-82f7-4fe1-ac73-eff27beb55c8",
 			"quantity": 1,
 			"description": "Throwing Dart",
 			"tech_level": "2",
@@ -26019,6 +26714,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "1828e139-36fe-41e0-83fa-484e2731a85a",
 			"quantity": 1,
 			"description": "Throwing Stick",
 			"tech_level": "0",
@@ -26060,6 +26756,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "576c9652-22eb-4831-89d8-fdb2e8b47822",
 			"quantity": 1,
 			"description": "Thrusting Bastard Sword",
 			"tech_level": "3",
@@ -26237,6 +26934,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "5f215cb5-7b83-45fb-abb1-98ae8f36b43f",
 			"quantity": 1,
 			"description": "Thrusting Broadsword",
 			"tech_level": "2",
@@ -26348,6 +27046,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "eb2b5b8a-f004-41fe-b5ec-dc8b36e8cb1d",
 			"quantity": 1,
 			"description": "Thrusting Greatsword",
 			"tech_level": "3",
@@ -26429,6 +27128,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "7baf54c8-3b6c-4763-9248-0cae8827a18d",
 			"quantity": 1,
 			"description": "Tobacco",
 			"tech_level": "0",
@@ -26442,6 +27142,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "90986d69-eb05-4e07-940c-6600aef0cb29",
 			"quantity": 1,
 			"description": "Tonfa",
 			"tech_level": "3",
@@ -26532,6 +27233,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "8b1a46af-7d94-4b15-9cad-62deb51a1ee2",
 			"quantity": 1,
 			"description": "Torc, copper",
 			"tech_level": "0",
@@ -26545,6 +27247,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "eaae27a8-c0e5-45a6-abd5-9fb712403c06",
 			"quantity": 1,
 			"description": "Torc, gold",
 			"tech_level": "0",
@@ -26558,6 +27261,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "c203f79b-2900-45b4-abdc-c52718200d8a",
 			"quantity": 1,
 			"description": "Torc, silver",
 			"tech_level": "0",
@@ -26571,6 +27275,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "2e0769d5-f478-49e3-b642-f93390410412",
 			"quantity": 1,
 			"description": "Torture Kit",
 			"tech_level": "2",
@@ -26584,6 +27289,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "46246230-4e95-48b9-a886-6efb453bdca4",
 			"quantity": 1,
 			"description": "Tourniquet",
 			"tech_level": "0",
@@ -26596,6 +27302,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "0e5c832e-1f84-4813-96aa-528409124fe0",
 			"quantity": 1,
 			"description": "Traction Bench",
 			"tech_level": "2",
@@ -26609,6 +27316,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "9851d281-206e-4ec1-97c0-c3a9f0fbf4ae",
 			"quantity": 1,
 			"description": "Trebuchet, Hinged, Large",
 			"tech_level": "3",
@@ -26652,6 +27360,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "6063e527-247f-48df-9509-765fc8b4b288",
 			"quantity": 1,
 			"description": "Trebuchet, Hinged, Small",
 			"tech_level": "3",
@@ -26695,6 +27404,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "de2fbffb-46c9-4afe-9cf2-1816e4b46a5d",
 			"quantity": 1,
 			"description": "Trebuchet, Large",
 			"tech_level": "3",
@@ -26738,6 +27448,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "ce03267d-5953-4ecc-a657-80063509ef13",
 			"quantity": 1,
 			"description": "Trebuchet, Large Stone",
 			"tech_level": "3",
@@ -26751,6 +27462,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "62301383-abf7-47d4-b46b-1bf0e04296a1",
 			"quantity": 1,
 			"description": "Trebuchet, Small",
 			"tech_level": "3",
@@ -26794,6 +27506,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "bfade0a6-917a-4f2d-909e-2bf498257880",
 			"quantity": 1,
 			"description": "Trebuchet, Small Stone",
 			"tech_level": "3",
@@ -26807,6 +27520,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "cafca4c9-efd3-49c5-bacf-4f48b75189bf",
 			"quantity": 1,
 			"description": "Trephin",
 			"tech_level": "2",
@@ -26820,6 +27534,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "2306fa2f-bb78-41bb-95be-4ca58719776e",
 			"quantity": 1,
 			"description": "Trident",
 			"tech_level": "2",
@@ -26903,6 +27618,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "4b97e295-6779-437d-8396-c2883b791674",
 			"quantity": 1,
 			"description": "Trumpet",
 			"tech_level": "2",
@@ -26916,6 +27632,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "cb9c0335-bb11-4178-9fdd-28b74a5c75b1",
 			"quantity": 1,
 			"description": "Tubular Bow",
 			"tech_level": "4",
@@ -26956,6 +27673,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "fee0319d-f319-49c1-a2e7-c37b2534f9ce",
 			"quantity": 1,
 			"description": "Tweezers",
 			"tech_level": "1",
@@ -26968,6 +27686,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "8c918c65-d9d5-4468-b749-2b2b22a04e17",
 			"quantity": 1,
 			"description": "Two-Handed Macuahuitl",
 			"tech_level": "0",
@@ -27050,6 +27769,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "0e751947-71c7-442e-95f0-59e6c957e56a",
 			"quantity": 1,
 			"description": "Urumi",
 			"tech_level": "3",
@@ -27132,6 +27852,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "16c16da7-6b55-4c39-b1bc-6da8c944fbc7",
 			"quantity": 1,
 			"description": "Vellum, per sheet",
 			"tech_level": "2",
@@ -27145,6 +27866,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "6f652967-925a-468f-ae80-d7a953df69d3",
 			"quantity": 1,
 			"description": "Veuglaire",
 			"tech_level": "3",
@@ -27186,6 +27908,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "37e7da24-5635-4668-bece-c4ba346f6a7f",
 			"quantity": 1,
 			"description": "Veuglaire Stone",
 			"tech_level": "3",
@@ -27199,6 +27922,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "f764d6d9-b1f2-4682-b922-f89128567ace",
 			"quantity": 1,
 			"description": "Viper Venom",
 			"tech_level": "0",
@@ -27212,6 +27936,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "cf1874d7-c61e-46ed-936d-42ae3f29fa18",
 			"quantity": 1,
 			"description": "Voyageur Canoe, 35’",
 			"tech_level": "4",
@@ -27225,6 +27950,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "6d179413-0299-44f6-a406-8adbc16ec841",
 			"quantity": 1,
 			"description": "Wagon",
 			"tech_level": "3",
@@ -27239,6 +27965,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "092b7aca-f2da-44ba-8206-64fd9841908b",
 			"quantity": 1,
 			"description": "Wall Gun",
 			"tech_level": "4",
@@ -27286,6 +28013,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "d5516aad-0070-4c88-994b-ee2c5bf5d089",
 			"quantity": 1,
 			"description": "Wall Gun Bullet",
 			"tech_level": "4",
@@ -27299,6 +28027,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "060cda01-3689-4e99-bb37-67ac5ed82cea",
 			"quantity": 1,
 			"description": "War Canoe, 60’",
 			"tech_level": "0",
@@ -27312,6 +28041,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "356bab10-12fa-4ee4-93b0-9410578bbee7",
 			"quantity": 1,
 			"description": "War Wagon",
 			"tech_level": "3",
@@ -27326,6 +28056,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "338e9fcd-787e-44ec-87a2-06e08f8fcee5",
 			"quantity": 1,
 			"description": "Warhammer",
 			"tech_level": "3",
@@ -27379,6 +28110,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "8b83cee0-32cf-4772-981c-5ec2703912c7",
 			"quantity": 1,
 			"description": "Water Pipe",
 			"tech_level": "2",
@@ -27392,6 +28124,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "1e662c5e-180d-491d-8a27-08d89a7dce43",
 			"quantity": 1,
 			"description": "Wax Tablet, Large",
 			"tech_level": "2",
@@ -27405,6 +28138,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "1148e054-2dcc-4227-917b-ffb8323278b2",
 			"quantity": 1,
 			"description": "Wax Tablet, Small",
 			"tech_level": "2",
@@ -27418,6 +28152,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "41e9d91b-ad5b-4201-8d13-3e9e0dbef7e6",
 			"quantity": 1,
 			"description": "Weighted Scarf",
 			"tech_level": "0",
@@ -27485,6 +28220,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "9669c1bc-0c31-4f10-b9a8-87bfd0fc92ec",
 			"quantity": 1,
 			"description": "Whip, 1 yd",
 			"tech_level": "1",
@@ -27534,6 +28270,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "3cb4c59a-947e-4c82-b3f2-e6d01c006351",
 			"quantity": 1,
 			"description": "Whip, 2 yd",
 			"tech_level": "1",
@@ -27583,6 +28320,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "9505fa66-d55d-4ed4-9a80-15042aa03dd8",
 			"quantity": 1,
 			"description": "Whip, 3 yd",
 			"tech_level": "1",
@@ -27632,6 +28370,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "a40f19f2-efbd-4044-acf4-b99eba0bdbbc",
 			"quantity": 1,
 			"description": "Whip, 4 yd",
 			"tech_level": "1",
@@ -27681,6 +28420,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "0d7b0c05-6f84-4366-bb8c-0734397b0a99",
 			"quantity": 1,
 			"description": "Whip, 5 yd",
 			"tech_level": "1",
@@ -27730,6 +28470,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "1b209070-701e-42c2-a4be-5db368278c84",
 			"quantity": 1,
 			"description": "Whip, 6 yd",
 			"tech_level": "1",
@@ -27779,6 +28520,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "3049da54-8cf1-4d90-b06b-ca0a4bda201f",
 			"quantity": 1,
 			"description": "Whip, 7 yd",
 			"tech_level": "1",
@@ -27828,6 +28570,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "ae844c70-a1d6-446a-987f-456407cd724a",
 			"description": "Wicker Basket, 1 cup",
 			"tech_level": "0",
 			"value": "0.15",
@@ -27856,6 +28599,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "cb5f2d0c-b5e4-44ac-875f-a5b2b2cea82c",
 			"description": "Wicker Basket, 1 gal.",
 			"tech_level": "0",
 			"value": "1.75",
@@ -27884,6 +28628,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "ea377cde-19ad-4e7e-be80-4a461a08e48d",
 			"description": "Wicker Basket, 1 quart",
 			"tech_level": "0",
 			"value": "0.5",
@@ -27912,6 +28657,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "aec7732c-6730-451c-8f59-69f5f5d99911",
 			"description": "Wicker Basket, 1/4 cup",
 			"tech_level": "0",
 			"value": "0.1",
@@ -27939,6 +28685,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "d9f92d35-817e-4fbc-842b-f4ac610efb90",
 			"description": "Wicker Basket, 2 gal.",
 			"tech_level": "0",
 			"value": "3",
@@ -27967,6 +28714,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "e44646bd-b95c-441a-9605-0f949a3a5a87",
 			"description": "Wicker Basket, 6 gal.",
 			"tech_level": "0",
 			"value": "7.5",
@@ -27995,6 +28743,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "0991d81a-3d72-4c41-8932-c6597c333330",
 			"description": "Wicker Basket, 20 gal.",
 			"tech_level": "0",
 			"value": "16",
@@ -28023,6 +28772,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "8174091f-cce9-4c02-86c3-a9cd6bde524c",
 			"description": "Wicker Basket, 40 gal.",
 			"tech_level": "0",
 			"value": "39",
@@ -28051,6 +28801,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "f42d4395-7da1-4693-ad22-04de61bcaecc",
 			"description": "Wicker Basket, 80 gal.",
 			"tech_level": "0",
 			"value": "62",
@@ -28079,6 +28830,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "ac36e770-0fcc-42eb-a6c9-7d149063a9b1",
 			"description": "Wicker Basket, 120 gal.",
 			"tech_level": "0",
 			"value": "108",
@@ -28107,6 +28859,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "4ae610f1-1836-4c6f-9f92-ac23b59e837b",
 			"quantity": 1,
 			"description": "Winged Tiger Gun",
 			"tech_level": "4",
@@ -28153,6 +28906,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "41f9821e-db24-4dca-bc1d-0600fca031a7",
 			"quantity": 1,
 			"description": "Winged Tiger Gun Bullet",
 			"tech_level": "4",
@@ -28166,6 +28920,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "c75353ed-2318-4745-89ec-cafa478b1234",
 			"description": "Wooden Box or Barrel, 1 cup",
 			"tech_level": "0",
 			"value": "1",
@@ -28194,6 +28949,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "742b71b2-9d81-4a8c-bbc8-a253a284b693",
 			"description": "Wooden Box or Barrel, 1 gal.",
 			"tech_level": "0",
 			"value": "10",
@@ -28222,6 +28978,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "b9d103de-c1ed-4e11-8da1-d43df5fe208f",
 			"description": "Wooden Box or Barrel, 1 quart",
 			"tech_level": "0",
 			"value": "3",
@@ -28250,6 +29007,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "899295e7-f0f4-4870-aee4-125d044f40f4",
 			"description": "Wooden Box or Barrel, 1/4 cup",
 			"tech_level": "0",
 			"value": "0.5",
@@ -28278,6 +29036,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "afa5501c-25fc-4247-b3df-454bf0eb4ea8",
 			"description": "Wooden Box or Barrel, 2 gal.",
 			"tech_level": "0",
 			"value": "17",
@@ -28306,6 +29065,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "f933eede-249c-4212-9e4a-109926f4dd24",
 			"description": "Wooden Box or Barrel, 6 gal.",
 			"tech_level": "0",
 			"value": "31",
@@ -28334,6 +29094,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "41dfa742-3c6e-445a-9b12-4db864eb3487",
 			"description": "Wooden Box or Barrel, 20 gal.",
 			"tech_level": "0",
 			"value": "55",
@@ -28362,6 +29123,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "41b02794-4d95-4f31-9482-24f050d468c6",
 			"description": "Wooden Box or Barrel, 40 gal.",
 			"tech_level": "0",
 			"value": "113",
@@ -28390,6 +29152,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "0a282689-c4ad-461d-8e99-244f7eb22338",
 			"description": "Wooden Box or Barrel, 80 gal.",
 			"tech_level": "0",
 			"value": "178",
@@ -28418,6 +29181,7 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
+			"id": "ac69717f-a666-42bf-99ec-9945353237aa",
 			"description": "Wooden Box or Barrel, 120 gal.",
 			"tech_level": "0",
 			"value": "239",
@@ -28446,6 +29210,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "22e11241-9772-4971-ad31-6bdb45ebe04e",
 			"quantity": 1,
 			"description": "Wooden Stake",
 			"tech_level": "0",
@@ -28526,6 +29291,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "5258f199-41c9-4a1b-bc1e-f79545fb914c",
 			"quantity": 1,
 			"description": "Woomera",
 			"tech_level": "0",
@@ -28573,6 +29339,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "878bde4a-ba2c-4113-9279-22597dc5dde3",
 			"quantity": 1,
 			"description": "Parrying Buckler",
 			"tech_level": "0",
@@ -28646,6 +29413,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "f6030aab-27a2-45eb-a505-b651683269ed",
 			"quantity": 1,
 			"description": "Small Shield, Light",
 			"tech_level": "0",
@@ -28719,6 +29487,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "9565a3af-968f-46d4-955e-98efa14edc0c",
 			"quantity": 1,
 			"description": "Comanche Shield",
 			"tech_level": "0",
@@ -28793,6 +29562,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "6fa638fc-cbd0-4d3e-a58b-1045f58e57a8",
 			"quantity": 1,
 			"description": "Medium Shield, Light",
 			"tech_level": "0",
@@ -28866,6 +29636,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "f3149fd8-207f-44de-8a96-28aecfcc201b",
 			"quantity": 1,
 			"description": "Large Shield, Light",
 			"tech_level": "0",
@@ -28939,6 +29710,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "4bc746ac-3fe7-49ac-a666-8b0c68282d11",
 			"quantity": 1,
 			"description": "Mycenaean Shield",
 			"tech_level": "0",
@@ -29012,6 +29784,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "9334ff62-6e77-4c9f-a31e-640ffc9e44f1",
 			"quantity": 1,
 			"description": "Small Shield, Heavy",
 			"tech_level": "1",
@@ -29085,6 +29858,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "d15a35a8-8a54-40b7-9384-55129be13641",
 			"quantity": 1,
 			"description": "Homeric Buckler, Medium",
 			"tech_level": "1",
@@ -29158,6 +29932,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "8c708e6c-dac5-4d8b-b693-cc2dc60758ab",
 			"quantity": 1,
 			"description": "Medium Shield, Heavy",
 			"tech_level": "1",
@@ -29231,6 +30006,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "28b6919f-0138-41a6-8d76-a61f5d239396",
 			"quantity": 1,
 			"description": "Homeric Buckler, Large",
 			"tech_level": "1",
@@ -29304,6 +30080,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "acb94423-d8c6-4609-98c8-60fce8346634",
 			"quantity": 1,
 			"description": "Large Shield, Heavy",
 			"tech_level": "1",
@@ -29377,6 +30154,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "5f2d02c7-a8be-475d-998a-5a7b047e64dc",
 			"quantity": 1,
 			"description": "Argive Shield",
 			"tech_level": "2",
@@ -29451,6 +30229,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "a3d6dd07-08f4-46b0-86d1-66e02c02b7b5",
 			"quantity": 1,
 			"description": "Roman Scutum, Medium",
 			"tech_level": "2",
@@ -29525,6 +30304,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "2c4cfec3-81c3-496d-8a18-c7662e821df5",
 			"quantity": 1,
 			"description": "Roman Scutum, Large",
 			"tech_level": "2",
@@ -29599,6 +30379,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "1ca0975c-2e19-4b9b-98d7-edcc89cea045",
 			"quantity": 1,
 			"description": "Dueling Buckler",
 			"tech_level": "3",
@@ -29656,6 +30437,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "7de1a1d7-5422-46c2-8cac-b519ea9d6e33",
 			"quantity": 1,
 			"description": "Heater Shield",
 			"tech_level": "3",
@@ -29729,6 +30511,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "22c7bc9e-5453-445e-82b5-eaef61c997ad",
 			"quantity": 1,
 			"description": "Kite Shield",
 			"tech_level": "3",
@@ -29802,6 +30585,7 @@
 		{
 			"type": "equipment",
 			"version": 1,
+			"id": "d63c3c87-3430-4e06-9902-63dc705db8ae",
 			"quantity": 1,
 			"description": "Dueling Long Shield",
 			"tech_level": "4",

--- a/Library/Low Tech/Low Tech Equipment.eqp
+++ b/Library/Low Tech/Low Tech Equipment.eqp
@@ -6,7 +6,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "51eea2a3-09c6-42d1-9c21-1e6a22f52ea0",
 			"quantity": 1,
 			"description": "Abacus",
 			"tech_level": "2",
@@ -20,7 +19,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "7c29bb49-33e9-497c-8d42-fa1c1ed84989",
 			"quantity": 1,
 			"description": "Air Bladder",
 			"tech_level": "2",
@@ -34,7 +32,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "d519fa7e-2147-4033-9ae1-73401d160138",
 			"quantity": 1,
 			"description": "Apron, Leather",
 			"tech_level": "1",
@@ -55,7 +52,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "8cc2299f-334b-4c66-92ef-b9470fc45945",
 			"quantity": 1,
 			"description": "Arbalest",
 			"tech_level": "3",
@@ -103,7 +99,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "5708a4c4-f897-4307-b24e-e240aa5cefa8",
 			"quantity": 1,
 			"description": "Arbalest Bolt",
 			"tech_level": "3",
@@ -117,7 +112,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "083bc3c9-8d7e-4dab-8346-5a22e33e65e8",
 			"quantity": 1,
 			"description": "Arbalest Tripod",
 			"tech_level": "3",
@@ -131,7 +125,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "c1a93876-c589-44ca-89dd-8ebf35b3f0ae",
 			"quantity": 1,
 			"description": "Arquebus",
 			"tech_level": "4",
@@ -178,7 +171,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "dc703e2f-4fc9-4bce-8651-2fa8a740532f",
 			"quantity": 1,
 			"description": "Arquebus Bullet",
 			"tech_level": "4",
@@ -192,7 +184,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "9ebe4d88-426e-42b2-838c-56affa8d3135",
 			"quantity": 1,
 			"description": "Arrow Spoon",
 			"tech_level": "2",
@@ -205,7 +196,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "8ae6fb6d-8af9-4fca-a0c7-2b9c6f0b6940",
 			"quantity": 1,
 			"description": "Atlatl",
 			"tech_level": "0",
@@ -284,7 +274,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "8c9dcf71-d9fc-4d67-853a-d659bbd76c8b",
 			"quantity": 1,
 			"description": "Atlatl Dart",
 			"tech_level": "0",
@@ -298,7 +287,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "edcb0b8b-0ffb-471d-af84-9e6995e58acc",
 			"quantity": 1,
 			"description": "Axe",
 			"tech_level": "0",
@@ -385,7 +373,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "e7967b93-ba6a-4870-af58-972d3907957c",
 			"quantity": 1,
 			"description": "Backsword",
 			"tech_level": "4",
@@ -533,7 +520,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "186e488a-1ce8-4979-b484-e0558457d77f",
 			"quantity": 1,
 			"description": "Bagpipe",
 			"tech_level": "3",
@@ -547,7 +533,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "620499aa-1b03-4023-a01f-7882c807eb17",
 			"quantity": 1,
 			"description": "Balisong",
 			"tech_level": "3",
@@ -640,7 +625,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "83825624-567b-4428-8ebf-4fb66035a61f",
 			"quantity": 1,
 			"description": "Ballista, 0.03-lb Bullet",
 			"tech_level": "2",
@@ -655,7 +639,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "4d15ed60-3c15-41dd-a6e0-2e624748f126",
 			"quantity": 1,
 			"description": "Ballista, 0.03-lb Stone",
 			"tech_level": "2",
@@ -669,7 +652,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "cdd9f5e5-6e16-424a-9d79-fbc927be27ff",
 			"quantity": 1,
 			"description": "Ballista, 0.03-lb.",
 			"tech_level": "2",
@@ -708,7 +690,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "2bfc21f4-a9a7-466b-b868-6abd5122a6cc",
 			"quantity": 1,
 			"description": "Ballista, 0.06-lb Bullet",
 			"tech_level": "2",
@@ -723,7 +704,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "5bff8096-d49a-4684-81e2-5b0ebf4efd1e",
 			"quantity": 1,
 			"description": "Ballista, 0.06-lb Stone",
 			"tech_level": "2",
@@ -737,7 +717,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "0b85d12d-9a22-4fd5-aff2-a712c6f42c36",
 			"quantity": 1,
 			"description": "Ballista, 0.06-lb.",
 			"tech_level": "2",
@@ -776,7 +755,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "1222988d-8905-46b1-8442-2e70cae0bb15",
 			"quantity": 1,
 			"description": "Ballista, 0.12-lb Bullet",
 			"tech_level": "2",
@@ -791,7 +769,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "d35f64ed-3431-4467-a68d-7af3d45c62a2",
 			"quantity": 1,
 			"description": "Ballista, 0.12-lb Stone",
 			"tech_level": "2",
@@ -805,7 +782,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "ce85b465-ccda-4bed-a8a9-db0d1686378b",
 			"quantity": 1,
 			"description": "Ballista, 0.12-lb.",
 			"tech_level": "2",
@@ -844,7 +820,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "2b88b29d-be99-453e-9292-ccec51cf5ab8",
 			"quantity": 1,
 			"description": "Ballista, 0.18-lb Bullet",
 			"tech_level": "2",
@@ -859,7 +834,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "2d47bd85-2345-4f5a-ab20-874bd6d17f2a",
 			"quantity": 1,
 			"description": "Ballista, 0.18-lb Stone",
 			"tech_level": "2",
@@ -873,7 +847,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "510e6ba6-90cc-49e8-887a-08c798ced3f4",
 			"quantity": 1,
 			"description": "Ballista, 0.18-lb.",
 			"tech_level": "2",
@@ -912,7 +885,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "c8a3d20c-fce7-4c76-895c-e6d164e35319",
 			"quantity": 1,
 			"description": "Ballista, 1-lb Stone",
 			"tech_level": "3",
@@ -926,7 +898,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "d6641954-df21-4096-966e-a05c691f0db0",
 			"quantity": 1,
 			"description": "Ballista, 1-lb.",
 			"tech_level": "2",
@@ -974,7 +945,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "94ee2d91-00ed-4208-a100-272302d9525f",
 			"quantity": 1,
 			"description": "Ballista, 1-lb. Tripod",
 			"tech_level": "2",
@@ -988,7 +958,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "05f3b44c-c8c0-40f5-8a24-7b0172f1f730",
 			"quantity": 1,
 			"description": "Ballista, 2-lb Stone",
 			"tech_level": "3",
@@ -1002,7 +971,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "d21d4f8f-3285-4d6b-880f-b7f9fba89c8f",
 			"quantity": 1,
 			"description": "Ballista, 2-lb.",
 			"tech_level": "2",
@@ -1050,7 +1018,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "f1b57103-49ba-4b57-830f-df169577b8e9",
 			"quantity": 1,
 			"description": "Ballista, 2-lb. Tripod",
 			"tech_level": "2",
@@ -1064,7 +1031,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "4cc6affd-cdc3-4634-8dc8-2a091ad9f08c",
 			"quantity": 1,
 			"description": "Ballista, 5-lb Stone",
 			"tech_level": "3",
@@ -1078,7 +1044,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "c07c3fe7-e6e0-4f1d-88c4-1311c97c7968",
 			"quantity": 1,
 			"description": "Ballista, 5-lb.",
 			"tech_level": "2",
@@ -1126,7 +1091,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "1e09ca85-6b37-4a9f-b65a-887c007b4efb",
 			"quantity": 1,
 			"description": "Ballista, 5-lb. Tripod",
 			"tech_level": "2",
@@ -1140,7 +1104,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "d598dc1b-b3bd-4041-a76a-52928a935e13",
 			"quantity": 1,
 			"description": "Ballista, 10-lb Stone",
 			"tech_level": "3",
@@ -1154,7 +1117,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "44168f60-4bef-4781-8400-1f7fe5c10865",
 			"quantity": 1,
 			"description": "Ballista, 10-lb.",
 			"tech_level": "2",
@@ -1233,7 +1195,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "330e9c38-2965-49f6-9683-d4b20a9cd3b6",
 			"quantity": 1,
 			"description": "Ballista, 10-lb. Tripod",
 			"tech_level": "2",
@@ -1247,7 +1208,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "3238cf11-d7da-4948-9c33-c2f1719596fb",
 			"quantity": 1,
 			"description": "Ballista, 15-lb Stone",
 			"tech_level": "3",
@@ -1261,7 +1221,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "65e8b379-74da-46f3-9485-45e53ad20a5f",
 			"quantity": 1,
 			"description": "Ballista, 15-lb.",
 			"tech_level": "2",
@@ -1340,7 +1299,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "b6f896a5-6c57-4b32-bb55-edcb72838b95",
 			"quantity": 1,
 			"description": "Ballista, 15-lb. Tripod",
 			"tech_level": "2",
@@ -1354,7 +1312,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "2ceb848b-f96f-44ad-bd54-152ff5a9c22f",
 			"quantity": 1,
 			"description": "Ballista, 20-lb Stone",
 			"tech_level": "3",
@@ -1368,7 +1325,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "3201bffd-77ce-4611-bcb8-d4c79369c366",
 			"quantity": 1,
 			"description": "Ballista, 20-lb.",
 			"tech_level": "2",
@@ -1447,7 +1403,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "995e6e65-ebbc-4ae4-9865-24ebb33f7e2a",
 			"quantity": 1,
 			"description": "Ballista, 20-lb. Tripod",
 			"tech_level": "2",
@@ -1461,7 +1416,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "a42819ff-d13b-4270-9794-5d2b087cd79e",
 			"quantity": 1,
 			"description": "Ballista, 30-lb Stone",
 			"tech_level": "3",
@@ -1475,7 +1429,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "42f138a3-1e6c-40ac-a885-1f64c5daf602",
 			"quantity": 1,
 			"description": "Ballista, 30-lb.",
 			"tech_level": "2",
@@ -1538,7 +1491,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "5239188e-53c0-42fb-a25f-cd58dd580c23",
 			"quantity": 1,
 			"description": "Ballista, 30-lb. Tripod",
 			"tech_level": "2",
@@ -1552,7 +1504,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "60b37498-1e7a-42aa-9cd1-0c0c3024a182",
 			"quantity": 1,
 			"description": "Ballista, 60-lb Stone",
 			"tech_level": "3",
@@ -1566,7 +1517,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "8f527062-b0ca-461a-9e8f-0b070fe79b7a",
 			"quantity": 1,
 			"description": "Ballista, 60-lb.",
 			"tech_level": "2",
@@ -1645,7 +1595,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "504ad7c4-37e0-46f5-9c0b-475793c74055",
 			"quantity": 1,
 			"description": "Ballista, 60-lb. Tripod",
 			"tech_level": "2",
@@ -1659,7 +1608,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "8a5f5b81-1b6c-48c5-a367-b5f10a5b24a2",
 			"quantity": 1,
 			"description": "Ballista, 180-lb Stone",
 			"tech_level": "3",
@@ -1673,7 +1621,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "fb524fa6-4f59-4065-aa29-591c5391003b",
 			"quantity": 1,
 			"description": "Ballista, 180-lb.",
 			"tech_level": "2",
@@ -1752,7 +1699,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "89826b8b-13ec-41b8-9787-e6f559ef6ddd",
 			"quantity": 1,
 			"description": "Ballista, 180-lb. Tripod",
 			"tech_level": "2",
@@ -1766,7 +1712,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "2248aa56-37f2-4f87-9e60-8e64c6341a58",
 			"quantity": 1,
 			"description": "Bamboo Land Mine",
 			"tech_level": "4",
@@ -1782,7 +1727,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "207f8d36-03d8-41f1-8631-1f12672cca7e",
 			"quantity": 1,
 			"description": "Bandolier",
 			"tech_level": "4",
@@ -1796,7 +1740,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "a38f5dab-cc0c-4c37-871c-99efcf508cb3",
 			"quantity": 1,
 			"description": "Barbed Arrow",
 			"tech_level": "0",
@@ -1812,7 +1755,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "0d89bf9f-d092-4352-b219-967b760bc516",
 			"quantity": 1,
 			"description": "Barber's Kit",
 			"tech_level": "1",
@@ -1837,7 +1779,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "9b7e5034-77cc-400b-8916-61e37551b6b9",
 			"quantity": 1,
 			"description": "Bastard Sword",
 			"tech_level": "3",
@@ -2015,7 +1956,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "9e307c3f-b534-4adf-a71c-8edf0178bb99",
 			"quantity": 1,
 			"description": "Bathtub, Earthenware",
 			"tech_level": "1",
@@ -2029,7 +1969,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "b244128c-c4f8-4dd6-a2cd-240d953406e3",
 			"quantity": 1,
 			"description": "Bathtub, Metal",
 			"tech_level": "1",
@@ -2043,7 +1982,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "fa962383-1c1e-43d0-b326-3f2420f93780",
 			"quantity": 1,
 			"description": "Baton",
 			"tech_level": "0",
@@ -2173,7 +2111,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "48e02615-d611-4f01-90b4-640d08583eab",
 			"quantity": 1,
 			"description": "Battle Car",
 			"tech_level": "2",
@@ -2188,7 +2125,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "9837c49b-1dc8-439b-b01e-41482f444b27",
 			"quantity": 1,
 			"description": "Beads, copper, per foot",
 			"tech_level": "0",
@@ -2202,7 +2138,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "3641bd9b-bb33-4691-be4e-4c3a3c42b810",
 			"quantity": 1,
 			"description": "Beads, gold, per foot",
 			"tech_level": "0",
@@ -2216,7 +2151,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "1eb64b48-70f7-448a-a0a7-18b2e6d464d6",
 			"quantity": 1,
 			"description": "Beads, silver, per foot",
 			"tech_level": "0",
@@ -2230,7 +2164,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "f31bd7cb-8830-4345-bdcd-bfeb01e6da71",
 			"quantity": 1,
 			"description": "Beam Sling, 15-Man",
 			"tech_level": "3",
@@ -2274,7 +2207,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "8371e2f5-8077-46ad-8b5e-d1b9a52359ef",
 			"quantity": 1,
 			"description": "Beam Sling, 15-Man Stone",
 			"tech_level": "3",
@@ -2288,7 +2220,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "951778fe-1677-4c12-86e5-79c85dfaad6e",
 			"quantity": 1,
 			"description": "Beam Sling, 30-Man",
 			"tech_level": "3",
@@ -2332,7 +2263,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "c6b95562-4ff5-4ced-b5e4-24b70b47d5fa",
 			"quantity": 1,
 			"description": "Beam Sling, 30-Man Stone",
 			"tech_level": "3",
@@ -2346,7 +2276,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "476ec180-9cbe-4a63-ad46-a2e77809047c",
 			"quantity": 1,
 			"description": "Beam Sling, 50-Man",
 			"tech_level": "3",
@@ -2390,7 +2319,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "45f60dbb-e67b-4448-86d3-3cfde9f83ed5",
 			"quantity": 1,
 			"description": "Beam Sling, 50-Man Stone",
 			"tech_level": "3",
@@ -2404,7 +2332,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "3b861edf-3ac0-418b-b66a-b95dc7497fdb",
 			"quantity": 1,
 			"description": "Beam Sling, 100-Man",
 			"tech_level": "3",
@@ -2448,7 +2375,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "4653680f-79b5-430d-b150-944e8306258c",
 			"quantity": 1,
 			"description": "Beam Sling, 100-Man Stone",
 			"tech_level": "3",
@@ -2462,7 +2388,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "a04f80a7-fbec-4187-b216-723d6187e67a",
 			"quantity": 1,
 			"description": "Beam Sling, Weighted, 30-Man",
 			"tech_level": "3",
@@ -2506,7 +2431,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "39e69f2d-e97c-4e45-a7e1-0b98514a1383",
 			"quantity": 1,
 			"description": "Beam Sling, Weighted, 50-Man",
 			"tech_level": "3",
@@ -2550,7 +2474,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "86410314-b206-40ab-8647-59b323b88e87",
 			"quantity": 1,
 			"description": "Belladonna",
 			"tech_level": "0",
@@ -2564,7 +2487,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "4e13fd02-a6ad-4073-b369-307e7434d1c9",
 			"quantity": 1,
 			"description": "Belt Hook",
 			"tech_level": "4",
@@ -2578,7 +2500,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "ae12db92-b375-40b2-ae55-677f3432c843",
 			"quantity": 1,
 			"description": "Bill",
 			"tech_level": "3",
@@ -2708,7 +2629,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "b27acf5a-7baf-48f2-99e1-810481b5851a",
 			"quantity": 1,
 			"description": "Blackjack",
 			"tech_level": "1",
@@ -2746,7 +2666,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "153328ad-f145-4e1f-9e8f-7499d12948ec",
 			"quantity": 1,
 			"description": "Bladed Hand",
 			"tech_level": "3",
@@ -2797,7 +2716,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "65ae8ce8-038a-4b4a-b331-932e591e4256",
 			"quantity": 1,
 			"description": "Bleeding Cup",
 			"tech_level": "1",
@@ -2811,7 +2729,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "d1175f91-1de8-4c8a-9ee2-f27d8089c441",
 			"quantity": 1,
 			"description": "Blowpipe",
 			"tech_level": "0",
@@ -2853,7 +2770,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "305d13d5-329d-40f6-ae07-a1a90afcb6f0",
 			"quantity": 1,
 			"description": "Blowpipe Dart",
 			"tech_level": "0",
@@ -2868,7 +2784,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "116f3b66-09b7-4733-80df-54e3f75f1b5d",
 			"quantity": 1,
 			"description": "Blunderbuss",
 			"tech_level": "4",
@@ -2915,7 +2830,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "a2ce32b5-6b9f-4944-accf-0c261b05dfb5",
 			"quantity": 1,
 			"description": "Blunderbuss Shot",
 			"tech_level": "4",
@@ -2929,7 +2843,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "15c978bb-198c-4394-9537-65e9a01099a4",
 			"quantity": 1,
 			"description": "Blunt Arrow",
 			"tech_level": "0",
@@ -2945,7 +2858,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "1d6de863-dd3d-4bc9-936f-0e4a97be9cec",
 			"quantity": 1,
 			"description": "Board Games",
 			"tech_level": "1",
@@ -2959,7 +2871,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "62f820b5-b38a-49d8-9ddb-797d49618fc2",
 			"quantity": 1,
 			"description": "Bokken",
 			"tech_level": "3",
@@ -3137,7 +3048,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "7979dbdc-8ac8-46e0-99bb-0191ae1a85b3",
 			"quantity": 1,
 			"description": "Bola Perdida",
 			"tech_level": "0",
@@ -3213,7 +3123,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "1dcda88d-798c-49a0-9dad-850b807cd6fb",
 			"quantity": 1,
 			"description": "Bolas",
 			"tech_level": "0",
@@ -3283,7 +3192,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "44adafb5-6fa2-4e07-b9e2-be42696f8f8c",
 			"quantity": 1,
 			"description": "Bombard",
 			"tech_level": "3",
@@ -3325,7 +3233,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "2d5a9d3a-3904-42a5-9a0d-2bce212d99dd",
 			"quantity": 1,
 			"description": "Bombard Metal Ball",
 			"tech_level": "3",
@@ -3339,7 +3246,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "8751d8e3-5e69-4bd7-b732-5e04b74cc0e5",
 			"quantity": 1,
 			"description": "Bombard Stone Ball",
 			"tech_level": "3",
@@ -3353,7 +3259,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "3a121f70-c547-4c76-a218-9e2eb356c524",
 			"quantity": 1,
 			"description": "Bombard, Large",
 			"tech_level": "3",
@@ -3395,7 +3300,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "87aa98dc-bbbc-4c25-bfaf-04458f7bfa8a",
 			"quantity": 1,
 			"description": "Bombard, Large Metal Ball",
 			"tech_level": "3",
@@ -3409,7 +3313,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "6b452076-09b7-4796-a865-25003dcb9c43",
 			"quantity": 1,
 			"description": "Boomerang",
 			"tech_level": "0",
@@ -3450,7 +3353,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "cdff818f-f0ea-4e9e-8b51-9976ee43944b",
 			"quantity": 1,
 			"description": "Boots, leather",
 			"tech_level": "2",
@@ -3464,7 +3366,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "0cc649c7-4181-418a-8ace-1bacb9fdee24",
 			"quantity": 1,
 			"description": "Bowel-Raker Arrow",
 			"tech_level": "0",
@@ -3480,7 +3381,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "a6731b5e-46df-4740-badb-5d4fc4c3709a",
 			"quantity": 1,
 			"description": "Bracelet, copper",
 			"tech_level": "0",
@@ -3494,7 +3394,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "5c29b84d-4a9d-4e1e-83e5-7238b18238ba",
 			"quantity": 1,
 			"description": "Bracelet, gold",
 			"tech_level": "0",
@@ -3508,7 +3407,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "4beb31d4-8328-4c08-bd74-747441c68ed8",
 			"quantity": 1,
 			"description": "Bracelet, silver",
 			"tech_level": "0",
@@ -3522,7 +3420,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "f6286ca2-0760-4a6f-b68b-7a7f945bc9c1",
 			"quantity": 1,
 			"description": "Brass Knuckles",
 			"tech_level": "1",
@@ -3567,7 +3464,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "9b891199-b6bb-4b21-b2fc-18d863903715",
 			"quantity": 1,
 			"description": "Breathing Tube",
 			"tech_level": "1",
@@ -3581,7 +3477,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "8ae33060-5e8b-4133-a8bc-69cf4bf008ed",
 			"quantity": 1,
 			"description": "Breechloading Carbine",
 			"tech_level": "4",
@@ -3628,7 +3523,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "9a4dadc1-8074-4c38-92c8-2633513a4ffb",
 			"quantity": 1,
 			"description": "Breechloading Carbine Bullet",
 			"tech_level": "4",
@@ -3642,7 +3536,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "c28d29fe-2ca1-4059-9c90-456e2e3ac3cd",
 			"quantity": 1,
 			"description": "Bridle and Bit",
 			"tech_level": "1",
@@ -3656,7 +3549,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "c6f53681-ecea-46d1-b548-3aeaf44131e1",
 			"quantity": 1,
 			"description": "Brig, 50'",
 			"tech_level": "4",
@@ -3670,7 +3562,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "dcb933c6-c944-4b31-831d-9ee588d51dc6",
 			"quantity": 1,
 			"description": "Broadsword",
 			"tech_level": "2",
@@ -3782,7 +3673,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "0e1411b3-ec51-4f35-ac9a-f1111be1a55f",
 			"quantity": 1,
 			"description": "Brush",
 			"tech_level": "1",
@@ -3795,7 +3685,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "bc1fbbb6-e87f-479e-900a-3e6d2c2a133b",
 			"quantity": 1,
 			"description": "Brush",
 			"tech_level": "1",
@@ -3809,7 +3698,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "7f9f7a4f-94dd-4bc6-8e61-bdbb18d0db5f",
 			"quantity": 1,
 			"description": "Bullet-Molding Gear",
 			"tech_level": "4",
@@ -3823,7 +3711,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "c4552353-92a1-414a-a73e-a9bce76616ab",
 			"quantity": 1,
 			"description": "Burning Glass, Glass",
 			"tech_level": "3",
@@ -3837,7 +3724,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "99831fea-2cc5-4ba9-8946-2c4fde2f195d",
 			"quantity": 1,
 			"description": "Burning Glass, Quartz",
 			"tech_level": "2",
@@ -3851,7 +3737,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "5dea3da5-ca10-4e05-ba31-636e44676ccf",
 			"quantity": 1,
 			"description": "Caliver",
 			"tech_level": "4",
@@ -3898,7 +3783,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "a1a6124e-8d9b-4791-8a7d-40b65f618c47",
 			"quantity": 1,
 			"description": "Caliver Bullet",
 			"tech_level": "4",
@@ -3912,7 +3796,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "632cf0d5-dc2d-4b3f-8747-1c0f54d05d48",
 			"quantity": 1,
 			"description": "Candle Case",
 			"tech_level": "3",
@@ -3926,7 +3809,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "d3943d31-86f1-476d-8fb7-5cf7e913cfc5",
 			"quantity": 6,
 			"description": "Candle, Graduated",
 			"tech_level": "3",
@@ -3940,7 +3822,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "a13d1dfe-e537-40d3-9247-fa9d3c77e7cf",
 			"quantity": 1,
 			"description": "Cannon",
 			"tech_level": "4",
@@ -3988,7 +3869,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "e53c62c9-9d9b-4603-a2b5-48b5a06cbc79",
 			"quantity": 1,
 			"description": "Cannon Truck Carriage Mount",
 			"tech_level": "4",
@@ -4002,7 +3882,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "ff5856cf-0149-4415-b6e3-7d061221b125",
 			"quantity": 1,
 			"description": "Cannon, 3-lb.",
 			"tech_level": "4",
@@ -4050,7 +3929,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "18f2c385-3924-4d2e-be98-e113e2d7ee1f",
 			"quantity": 1,
 			"description": "Cannon, 3-lb. Cannonball",
 			"tech_level": "4",
@@ -4064,7 +3942,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "caba81d5-59f9-4df3-9872-1c61bf388016",
 			"quantity": 1,
 			"description": "Cannon, 3-lb. Field Carriage Mount",
 			"tech_level": "4",
@@ -4078,7 +3955,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "bc32fdee-092b-456a-abac-1206406f53e6",
 			"quantity": 1,
 			"description": "Cannon, 12-lb.",
 			"tech_level": "4",
@@ -4126,7 +4002,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "7ed57df2-4edc-40e8-96c9-143dd6efe9ea",
 			"quantity": 1,
 			"description": "Cannon, 12-lb. Cannonball",
 			"tech_level": "4",
@@ -4140,7 +4015,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "14594d71-aac0-44a6-826a-9157b43f9d58",
 			"quantity": 1,
 			"description": "Cannon, 12-lb. Field Carriage Mount",
 			"tech_level": "4",
@@ -4154,7 +4028,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "8f514fe9-8b40-48f2-8f0b-91f8d344db17",
 			"quantity": 1,
 			"description": "Cannon, 24-lb.",
 			"tech_level": "4",
@@ -4202,7 +4075,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "80b97572-352a-4bc8-b735-2d196bab7e3b",
 			"quantity": 1,
 			"description": "Cannon, 24-lb. Cannonball",
 			"tech_level": "4",
@@ -4216,7 +4088,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "2463cb20-0cb1-493b-8d31-0cd1bd56e8e3",
 			"quantity": 1,
 			"description": "Cannon, 24-lb. Field Carriage Mount",
 			"tech_level": "4",
@@ -4230,7 +4101,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "c3449100-ed1d-4e16-affc-23baa6ec8b59",
 			"quantity": 1,
 			"description": "Cantharides",
 			"tech_level": "0",
@@ -4244,7 +4114,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "62d3a1c8-f430-4979-9407-8a80fdb2cc3a",
 			"quantity": 1,
 			"description": "Carbine",
 			"tech_level": "4",
@@ -4291,7 +4160,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "a7bbe7d1-6a3c-41ec-a429-e67447b76b02",
 			"quantity": 1,
 			"description": "Carbine Bullet",
 			"tech_level": "4",
@@ -4305,7 +4173,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "a6adc1a6-adf6-4966-8c3f-9a9e3ef34393",
 			"quantity": 1,
 			"description": "Cards",
 			"tech_level": "3",
@@ -4319,7 +4186,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "8fc0c0d8-6914-48e9-a8b6-e1914ccde6ca",
 			"quantity": 1,
 			"description": "Carriage",
 			"tech_level": "4",
@@ -4334,7 +4200,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "9f0a05f2-58e1-46f5-b093-d6da3960b7f2",
 			"quantity": 1,
 			"description": "Carroballista",
 			"tech_level": "2",
@@ -4382,7 +4247,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "2874151c-fd09-4701-99ba-70b6b2df09b2",
 			"quantity": 1,
 			"description": "Carroballista Bolt",
 			"tech_level": "3",
@@ -4396,7 +4260,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "456b21b8-02b4-43cd-bd81-fea535d76ccf",
 			"quantity": 1,
 			"description": "Cataract Needles",
 			"tech_level": "2",
@@ -4409,7 +4272,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "4282d7ff-651f-47d7-b378-3bbe24127ba5",
 			"quantity": 1,
 			"description": "Catheter",
 			"tech_level": "2",
@@ -4422,7 +4284,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "2561760b-8cd4-4913-9f9f-874c577b33ff",
 			"quantity": 1,
 			"description": "Cautery",
 			"tech_level": "2",
@@ -4436,7 +4297,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "11697133-fbe6-4464-9abe-50c6527b8119",
 			"quantity": 1,
 			"description": "Cavalry Saber",
 			"tech_level": "4",
@@ -4547,7 +4407,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "505da1d7-ac45-463c-b389-6ff53c518b03",
 			"quantity": 1,
 			"description": "Cestus",
 			"tech_level": "2",
@@ -4599,7 +4458,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "658503d8-ddde-4b62-9ba1-991da8a3856b",
 			"quantity": 1,
 			"description": "Chain Whip, 1 yard",
 			"tech_level": "3",
@@ -4654,7 +4512,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "ede7ac60-290e-45ab-ba67-ad2dd8558757",
 			"quantity": 1,
 			"description": "Chain Whip, 2 yards",
 			"tech_level": "3",
@@ -4709,7 +4566,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "57de38b8-d939-4d45-92ba-98f11731c884",
 			"quantity": 1,
 			"description": "Chain Whip, 3 yards",
 			"tech_level": "3",
@@ -4764,7 +4620,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "63da63a9-8b94-485a-97f8-ff4d2b8c5971",
 			"quantity": 1,
 			"description": "Chain Whip, 4 yards",
 			"tech_level": "3",
@@ -4819,7 +4674,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "b0c19751-7c40-4bcb-9b8e-8dc8c6a9eec2",
 			"quantity": 1,
 			"description": "Chain, copper, per foot",
 			"tech_level": "0",
@@ -4833,7 +4687,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "d573c028-c69c-47ef-9dbb-6bed24fa63af",
 			"quantity": 1,
 			"description": "Chain, gold, per foot",
 			"tech_level": "0",
@@ -4847,7 +4700,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "3a615185-07f2-48db-8dbf-67dd4f407f48",
 			"quantity": 1,
 			"description": "Chain, silver, per foot",
 			"tech_level": "0",
@@ -4861,7 +4713,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "78512d84-b31e-413e-985b-3bfb7a010094",
 			"quantity": 1,
 			"description": "Chakram",
 			"tech_level": "2",
@@ -4908,7 +4759,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "aef4f5c3-33b3-446b-871c-cbf47f40d5b7",
 			"quantity": 1,
 			"description": "Cheiroballistra Bolt",
 			"tech_level": "2",
@@ -4922,7 +4772,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "27f69ead-3a69-44fc-b0a7-c34eb67c0bd7",
 			"quantity": 1,
 			"description": "Cheiroballistra, 18”",
 			"tech_level": "2",
@@ -4961,7 +4810,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "cebd17ab-9e80-4f04-9f3c-4084b6b8bcea",
 			"quantity": 1,
 			"description": "Cheirosiphon",
 			"tech_level": "3",
@@ -5009,7 +4857,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "34225214-e322-4a56-9f3b-020273c3a358",
 			"quantity": 1,
 			"description": "Climbing Pole",
 			"tech_level": "1",
@@ -5023,7 +4870,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "9b4f42e7-963b-4e5d-b3e0-30f954bb2c4d",
 			"quantity": 1,
 			"description": "Climbing Spikes, set of four",
 			"tech_level": "2",
@@ -5037,7 +4883,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "17dfecd6-acfa-45fc-9f24-8f27b750aa11",
 			"quantity": 1,
 			"description": "Cloak, Expensive (Status 4)",
 			"tech_level": "0",
@@ -5087,7 +4932,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "d742b3aa-425f-4326-b4b2-69f22bf74b52",
 			"quantity": 1,
 			"description": "Cloak, Freeman (Status 0)",
 			"tech_level": "0",
@@ -5137,7 +4981,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "5ce68a4d-2f05-4218-9a43-7e0fa55bf901",
 			"quantity": 1,
 			"description": "Cloak, Leather/Wool, Expensive (Status 4)",
 			"tech_level": "0",
@@ -5187,7 +5030,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "c4183310-5cca-40cb-a035-f3b0730408ea",
 			"quantity": 1,
 			"description": "Cloak, Leather/Wool, Freeman (Status 0)",
 			"tech_level": "0",
@@ -5237,7 +5079,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "6cc868c1-db02-4f1d-ba9e-a35a63947cee",
 			"quantity": 1,
 			"description": "Cloak, Leather/Wool, Poor (Status -2)",
 			"tech_level": "0",
@@ -5287,7 +5128,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "3f5286ec-f14c-4597-87ff-f30f2605d2cf",
 			"quantity": 1,
 			"description": "Cloak, Poor (Status -2)",
 			"tech_level": "0",
@@ -5337,7 +5177,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "ce3aad49-9e43-4f37-a96c-4340c5f9bf6b",
 			"description": "Cloth Bag, 1 cup",
 			"tech_level": "0",
 			"value": "0.25",
@@ -5366,7 +5205,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "64db3fab-579e-4874-b29e-9235becb2622",
 			"description": "Cloth Bag, 1 gal.",
 			"tech_level": "0",
 			"value": "1.75",
@@ -5395,7 +5233,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "b8b0e0bf-11dd-4cc8-947a-fd4ed73821cc",
 			"description": "Cloth Bag, 1 quart",
 			"tech_level": "0",
 			"value": "0.75",
@@ -5424,7 +5261,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "4eddc5c4-e4b1-4737-9457-b09fc13082d9",
 			"description": "Cloth Bag, 1/4 cup",
 			"tech_level": "0",
 			"value": "0.1",
@@ -5453,7 +5289,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "4ec13b9f-cd1a-487e-bce3-7dead02e7752",
 			"description": "Cloth Bag, 2 gal.",
 			"tech_level": "0",
 			"value": "2.75",
@@ -5482,7 +5317,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "f9d15c1b-525e-4d68-b759-5dd9e3d5e27c",
 			"description": "Cloth Bag, 6 gal.",
 			"tech_level": "0",
 			"value": "6",
@@ -5511,7 +5345,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "26c326f2-cb87-4c13-8ec9-6b47664173b6",
 			"description": "Cloth Bag, 20 gal.",
 			"tech_level": "0",
 			"value": "13",
@@ -5540,7 +5373,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "2026fe6d-dfc1-41ba-986d-4e6da78dce8e",
 			"description": "Cloth Bag, 40 gal.",
 			"tech_level": "0",
 			"value": "20",
@@ -5569,7 +5401,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "2cdd9fd6-f0a8-4baf-8548-010192a8abfd",
 			"description": "Cloth Bag, 80 gal.",
 			"tech_level": "0",
 			"value": "32",
@@ -5598,7 +5429,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "ecc14874-1f68-4637-9786-2dba3dc15133",
 			"description": "Cloth Bag, 120 gal.",
 			"tech_level": "0",
 			"value": "42",
@@ -5627,7 +5457,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "e3e7f318-1002-466c-a8c9-71c9b7a2ac6b",
 			"quantity": 1,
 			"description": "Clothing, Ordinary, Freeman (Status 0)",
 			"tech_level": "0",
@@ -5641,7 +5470,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "e307a458-9972-48e3-abb2-4f8d00961be3",
 			"quantity": 1,
 			"description": "Clothing, Ordinary, Merchant (Status 1)",
 			"tech_level": "0",
@@ -5655,7 +5483,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "cd662eaa-19c1-44fc-aa1f-b415d47749e1",
 			"quantity": 1,
 			"description": "Clothing, Ordinary, Noble (Status 4)",
 			"tech_level": "0",
@@ -5669,7 +5496,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "a5c96243-0074-4a7e-8274-03483c68fead",
 			"quantity": 1,
 			"description": "Clothing, Ordinary, Poor (Status -2)",
 			"tech_level": "0",
@@ -5683,7 +5509,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "723c145b-0b46-4f7c-bbcb-e55cb10cf531",
 			"quantity": 1,
 			"description": "Clothing, Ordinary, Royal (Status 7)",
 			"tech_level": "0",
@@ -5697,7 +5522,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "d92f7049-c431-4f64-915b-f412e48c4059",
 			"quantity": 1,
 			"description": "Clothing, Summer, Freeman (Status 0)",
 			"tech_level": "0",
@@ -5711,7 +5535,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "c014d5af-f952-47de-a54c-b0011cc866d0",
 			"quantity": 1,
 			"description": "Clothing, Summer, Merchant (Status 1)",
 			"tech_level": "0",
@@ -5725,7 +5548,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "00fbc7aa-e34a-4a99-be4d-ac03014de116",
 			"quantity": 1,
 			"description": "Clothing, Summer, Noble (Status 4)",
 			"tech_level": "0",
@@ -5739,7 +5561,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "c1e2ba72-dd8b-4cb4-9a78-053a3a5ad436",
 			"quantity": 1,
 			"description": "Clothing, Summer, Poor (Status -2)",
 			"tech_level": "0",
@@ -5753,7 +5574,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "dec59a95-de05-4dba-8792-212e8434898c",
 			"quantity": 1,
 			"description": "Clothing, Summer, Royal (Status 7)",
 			"tech_level": "0",
@@ -5767,7 +5587,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "11f07193-fe24-424f-b52a-7c47bc5d58cf",
 			"quantity": 1,
 			"description": "Clothing, Winter, Freeman (Status 0)",
 			"tech_level": "0",
@@ -5781,7 +5600,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "d09f2da7-3df5-4243-b55f-7154a887269d",
 			"quantity": 1,
 			"description": "Clothing, Winter, Merchant (Status 1)",
 			"tech_level": "0",
@@ -5795,7 +5613,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "2f54d32a-8a76-4359-a000-12af21a2dd8f",
 			"quantity": 1,
 			"description": "Clothing, Winter, Noble (Status 4)",
 			"tech_level": "0",
@@ -5809,7 +5626,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "f292baff-96ce-460e-8c7c-b3f0abda4709",
 			"quantity": 1,
 			"description": "Clothing, Winter, Poor (Status -2)",
 			"tech_level": "0",
@@ -5823,7 +5639,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "8dbd459b-471e-4b78-9756-56c89c029b9e",
 			"quantity": 1,
 			"description": "Clothing, Winter, Royal (Status 7)",
 			"tech_level": "0",
@@ -5837,7 +5652,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "d6a9dbb1-4f1f-4d5e-9062-c34f50277702",
 			"quantity": 1,
 			"description": "Coach",
 			"tech_level": "4",
@@ -5852,7 +5666,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "9dabc331-15db-4c68-b552-1598ec78ebc2",
 			"quantity": 1,
 			"description": "Coat, Long",
 			"tech_level": "1",
@@ -5866,7 +5679,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "f6960610-8a5d-436b-87fc-0be4efe2444d",
 			"quantity": 1,
 			"description": "Coat, Long, Heavy",
 			"tech_level": "1",
@@ -5887,7 +5699,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "7110ebed-d26b-406d-af68-36dfd92b864e",
 			"quantity": 1,
 			"description": "Comb",
 			"tech_level": "0",
@@ -5901,7 +5712,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "918d2a8a-a9b8-4576-bd24-b077df793865",
 			"quantity": 1,
 			"description": "Combat Fan",
 			"tech_level": "3",
@@ -5952,7 +5762,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "f5d78a0c-431b-49ce-848e-97b35c3a5eeb",
 			"quantity": 1,
 			"description": "Compass",
 			"tech_level": "3",
@@ -5977,7 +5786,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "8c421c42-bfe4-4101-a227-2b1c61929aa4",
 			"quantity": 1,
 			"description": "Composite Crossbow",
 			"tech_level": "3",
@@ -6019,7 +5827,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "8ad7d74b-6f84-4eec-8953-0dcd6d07f395",
 			"quantity": 1,
 			"description": "Corned Black Powder",
 			"tech_level": "4",
@@ -6034,7 +5841,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "da0f9e15-7874-4030-a433-990f3a68b2a9",
 			"quantity": 1,
 			"description": "Cosmetics, Better, Cheap, per use",
 			"tech_level": "0",
@@ -6048,7 +5854,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "35e53abc-405f-4491-ac54-d9ad1f1f5092",
 			"quantity": 1,
 			"description": "Cosmetics, Better, Expensive, per use",
 			"tech_level": "0",
@@ -6062,7 +5867,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "5914d2d9-06f8-4ae5-aae6-1283ae581554",
 			"quantity": 1,
 			"description": "Cosmetics, Common, Cheap, per use",
 			"tech_level": "0",
@@ -6076,7 +5880,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "82a10225-562e-4116-8c8e-2aa2a3c02edc",
 			"quantity": 1,
 			"description": "Cosmetics, Common, Expensive, per use",
 			"tech_level": "0",
@@ -6090,7 +5893,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "5b9de033-2043-4806-835f-9fd9513b9ceb",
 			"quantity": 1,
 			"description": "Crapaudeau",
 			"tech_level": "3",
@@ -6132,7 +5934,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "8508c8de-db5b-44ca-be66-7fae2a40741c",
 			"quantity": 1,
 			"description": "Crapaudeau Stone",
 			"tech_level": "3",
@@ -6146,7 +5947,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "842bc2ac-b261-4795-baef-ab574f4c89f4",
 			"quantity": 1,
 			"description": "Crossbow",
 			"tech_level": "2",
@@ -6188,7 +5988,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "7551e399-12b7-4ccb-a07a-19d865f10029",
 			"quantity": 1,
 			"description": "Crouching Tiger Gun",
 			"tech_level": "4",
@@ -6255,7 +6054,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "588798f7-6995-4aec-badd-052068911091",
 			"quantity": 1,
 			"description": "Crouching Tiger Gun Shot",
 			"tech_level": "4",
@@ -6269,7 +6067,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "aa85bd2e-6d9f-45ea-b838-aaae62227cd8",
 			"quantity": 1,
 			"description": "Crouching Tiger Gun Stone",
 			"tech_level": "4",
@@ -6283,7 +6080,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "d6e17639-8af9-48fd-a7e6-fb722e2aaa86",
 			"quantity": 1,
 			"description": "Crown, copper",
 			"tech_level": "0",
@@ -6297,7 +6093,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "72cc3580-d8af-4205-a522-4ae13218fff6",
 			"quantity": 1,
 			"description": "Crown, gold",
 			"tech_level": "0",
@@ -6311,7 +6106,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "5db9379c-fccd-4cbf-a153-79bd0910bdab",
 			"quantity": 1,
 			"description": "Crown, silver",
 			"tech_level": "0",
@@ -6325,7 +6119,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "82c813fe-ca30-488b-b0d6-fea1ee8568d9",
 			"quantity": 1,
 			"description": "Culverin",
 			"tech_level": "4",
@@ -6373,7 +6166,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "c28ed2f2-3997-43b9-868e-637c54f42639",
 			"quantity": 1,
 			"description": "Culverin Cannonball",
 			"tech_level": "4",
@@ -6387,7 +6179,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "8498b915-a50c-4d66-b330-a8d46598f063",
 			"quantity": 1,
 			"description": "Culverin Truck Carriage Mount",
 			"tech_level": "4",
@@ -6401,7 +6192,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "3a5524b2-20c7-4c77-90b3-112334292af3",
 			"quantity": 1,
 			"description": "Curare",
 			"tech_level": "0",
@@ -6415,7 +6205,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "5085c99f-8dfc-43e6-af9d-7a6828c41828",
 			"quantity": 1,
 			"description": "Cutlass",
 			"tech_level": "4",
@@ -6563,7 +6352,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "a4088bf8-6164-4d52-a868-058b969e6f11",
 			"quantity": 1,
 			"description": "Cutting Arrow",
 			"tech_level": "0",
@@ -6579,7 +6367,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "1d036360-1d20-4c8d-8a25-62f2454150bb",
 			"quantity": 1,
 			"description": "Cylinder Seal",
 			"tech_level": "1",
@@ -6592,7 +6379,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "3e817a8d-2115-42db-a17d-c59fb2a7f332",
 			"quantity": 1,
 			"description": "Dagger",
 			"tech_level": "1",
@@ -6673,7 +6459,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "452f2f03-9b7b-4c4b-acdb-32410c28efda",
 			"quantity": 1,
 			"description": "Dao",
 			"tech_level": "3",
@@ -6784,7 +6569,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "770c34d0-3e0d-4aa5-b59a-fe46240ffc19",
 			"quantity": 1,
 			"description": "Dart Sling",
 			"tech_level": "1",
@@ -6826,7 +6610,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "729c0b32-9a63-43f2-8028-96e2255e8fa3",
 			"quantity": 1,
 			"description": "Dart Sling Dart",
 			"tech_level": "1",
@@ -6841,7 +6624,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "54ff34c8-3743-4be9-bba7-7a9bcc283bb0",
 			"quantity": 1,
 			"description": "Deathcap Mushroom",
 			"tech_level": "0",
@@ -6855,7 +6637,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "3b117c31-db22-4512-af5d-a5dafe002f7c",
 			"quantity": 1,
 			"description": "Deer Antlers",
 			"tech_level": "3",
@@ -6965,7 +6746,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "c8a73d6f-593b-4a0f-9244-c59624c370bd",
 			"quantity": 1,
 			"description": "Diagnostic Manual, Basic",
 			"tech_level": "1",
@@ -6979,7 +6759,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "8c853f1d-90fb-44f1-bc3b-f9191078fda1",
 			"quantity": 1,
 			"description": "Diagnostic Manual, Comprehensive",
 			"tech_level": "1",
@@ -6993,7 +6772,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "eacb0d9e-40d7-46b3-bc35-4d78eb2ea249",
 			"quantity": 1,
 			"description": "Dice",
 			"tech_level": "1",
@@ -7006,7 +6784,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "e8fe53a0-60c4-48e0-a294-140ff05ae37c",
 			"quantity": 1,
 			"description": "Discus",
 			"tech_level": "1",
@@ -7053,7 +6830,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "e586c20c-e6d8-4d9a-aa26-52403f0ab997",
 			"quantity": 1,
 			"description": "Distilled Liquors, per pint",
 			"tech_level": "3",
@@ -7066,7 +6842,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "0c205d5b-db29-468f-9ec5-42ec77d5d546",
 			"quantity": 1,
 			"description": "Diving Boat",
 			"tech_level": "4",
@@ -7080,7 +6855,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "6e0bfe33-42e5-4e95-9f84-a27bfda6d787",
 			"quantity": 1,
 			"description": "Diving Stone",
 			"tech_level": "0",
@@ -7094,7 +6868,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "d76e9c5b-086f-4dfe-84e4-737510856ffd",
 			"quantity": 1,
 			"description": "Dogsled",
 			"tech_level": "0",
@@ -7109,7 +6882,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "6963884a-b740-458d-8ab2-5c0a309bdabc",
 			"quantity": 1,
 			"description": "Doll, Clay",
 			"tech_level": "0",
@@ -7123,7 +6895,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "c5716d8a-1eb7-4469-9260-e5844f5c5823",
 			"quantity": 1,
 			"description": "Doll, Cloth",
 			"tech_level": "0",
@@ -7136,7 +6907,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "1a5651d2-2b4a-4ccd-82fe-1ab530ec050b",
 			"quantity": 1,
 			"description": "Dominos, 30 tiles",
 			"tech_level": "1",
@@ -7150,7 +6920,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "9c4b28af-69e9-423c-8874-0e2e6947da96",
 			"quantity": 1,
 			"description": "Double Canoe, 30’",
 			"tech_level": "1",
@@ -7164,7 +6933,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "d89ac017-9cd9-46f3-9675-8f0a44820e08",
 			"quantity": 1,
 			"description": "Dragon Pistol, Heavy Bullet",
 			"tech_level": "4",
@@ -7178,7 +6946,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "f5267a0c-c49a-4308-9b51-6a7b34d987f1",
 			"quantity": 1,
 			"description": "Dragon Pistol, Light Bullet",
 			"tech_level": "4",
@@ -7192,7 +6959,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "7296426d-b608-4678-a52a-4cb9fa4471e2",
 			"quantity": 1,
 			"description": "Dragoon Pistol, Heavy",
 			"tech_level": "4",
@@ -7239,7 +7005,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "8614d2aa-f05a-404b-9b00-3f4fcd22630f",
 			"quantity": 1,
 			"description": "Dragoon Pistol, Light",
 			"tech_level": "4",
@@ -7286,7 +7051,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "438ad5dd-3958-4ec1-b84f-3dfd350563ab",
 			"quantity": 1,
 			"description": "Dress Smallsword",
 			"tech_level": "4",
@@ -7344,7 +7108,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "68e32c99-f7a0-4c77-88d6-b1fb6486676a",
 			"quantity": 1,
 			"description": "Duck's Foot Pistol Bullet",
 			"tech_level": "4",
@@ -7358,7 +7121,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "f747572a-5a8b-4e2a-b6ae-3b72bef558f3",
 			"quantity": 1,
 			"description": "Duck’s Foot Pistol",
 			"tech_level": "4",
@@ -7405,7 +7167,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "ebb9577a-b317-4089-9afe-3fc54eea28df",
 			"quantity": 1,
 			"description": "Dueling Bill",
 			"tech_level": "3",
@@ -7535,7 +7296,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "d29a10b7-913b-45eb-b9e8-1d68632ccd75",
 			"quantity": 1,
 			"description": "Dueling Glaive",
 			"tech_level": "3",
@@ -7627,7 +7387,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "855f278b-d5d4-4ec3-a020-702bce066796",
 			"quantity": 1,
 			"description": "Dueling Halberd",
 			"tech_level": "3",
@@ -7757,7 +7516,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "ad38b15d-fcfd-4775-84b6-d02c4b8f015d",
 			"quantity": 1,
 			"description": "Dugout Canoe, 8’",
 			"tech_level": "0",
@@ -7771,7 +7529,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "2c1992d9-d94c-4e2b-9e6e-2542fcc5554d",
 			"quantity": 1,
 			"description": "Dusack",
 			"tech_level": "2",
@@ -7901,7 +7658,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "cdad4619-659c-4208-804c-f99a550229c9",
 			"quantity": 1,
 			"description": "Ear Trumpet",
 			"tech_level": "4",
@@ -7915,7 +7671,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "b12ecf98-1af9-434a-8b4f-15957952ef82",
 			"description": "Earthenware Jar, 1 cup",
 			"tech_level": "0",
 			"value": "0.25",
@@ -7944,7 +7699,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "5762198c-5c3c-436f-b7b8-f3bba8432ad5",
 			"description": "Earthenware Jar, 1 gal.",
 			"tech_level": "0",
 			"value": "3",
@@ -7973,7 +7727,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "761ac411-af15-4b89-be76-579d740b2bdb",
 			"description": "Earthenware Jar, 1 quart",
 			"tech_level": "0",
 			"value": "1",
@@ -8002,7 +7755,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "1a99f877-8c94-4b1f-9a4c-aea23c957a04",
 			"description": "Earthenware Jar, 1/4 cup",
 			"tech_level": "0",
 			"value": "0.1",
@@ -8031,7 +7783,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "8e46dbd9-f43a-4ae8-b8e8-c3dcd3e890f9",
 			"description": "Earthenware Jar, 2 gal.",
 			"tech_level": "0",
 			"value": "7.5",
@@ -8060,7 +7811,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "3547310f-7a91-475b-a5b6-292382292593",
 			"description": "Earthenware Jar, 6 gal.",
 			"tech_level": "0",
 			"value": "16",
@@ -8089,7 +7839,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "934927b2-f501-4e1f-975f-23df29e249d2",
 			"description": "Earthenware Jar, 20 gal.",
 			"tech_level": "0",
 			"value": "41",
@@ -8118,7 +7867,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "44d37187-6218-4ed6-b6ac-6892fefc3a3f",
 			"description": "Earthenware Jar, Porcelain, 1 cup",
 			"tech_level": "0",
 			"value": "0.75",
@@ -8147,7 +7895,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "3230ba29-0a6e-4ca1-91d9-43654ac76209",
 			"description": "Earthenware Jar, Porcelain, 1 gal.",
 			"tech_level": "0",
 			"value": "9",
@@ -8176,7 +7923,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "9ff34e0e-be3f-47a0-8818-149e14811c84",
 			"description": "Earthenware Jar, Porcelain, 1 quart",
 			"tech_level": "0",
 			"value": "3",
@@ -8205,7 +7951,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "87ac1b5d-d3f3-4707-b073-7a127b6b5fab",
 			"description": "Earthenware Jar, Porcelain, 1/4 cup",
 			"tech_level": "0",
 			"value": "0.3",
@@ -8234,7 +7979,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "3ea3c9fd-fccc-4cc8-bd61-8c7f1f91eadd",
 			"description": "Earthenware Jar, Porcelain, 2 gal.",
 			"tech_level": "0",
 			"value": "22.5",
@@ -8263,7 +8007,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "83b252e3-a1a0-46a1-8f1c-fd6d8eb4c03a",
 			"description": "Earthenware Jar, Porcelain, 6 gal.",
 			"tech_level": "0",
 			"value": "48",
@@ -8292,7 +8035,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "b9842e16-5333-4b28-a699-6d73b590d9fd",
 			"description": "Earthenware Jar, Porcelain, 20 gal.",
 			"tech_level": "0",
 			"value": "123",
@@ -8321,7 +8063,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "2eb09b82-a395-472e-a18a-26c82c972e75",
 			"quantity": 1,
 			"description": "Edged Rapier",
 			"tech_level": "4",
@@ -8422,7 +8163,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "e508effc-2854-4bde-b597-f61fc043bf3b",
 			"quantity": 1,
 			"description": "Enhanced Tinder",
 			"tech_level": "1",
@@ -8436,7 +8176,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "e28ce491-0142-4b43-9bff-2638ce07911a",
 			"quantity": 1,
 			"description": "Eruptor",
 			"tech_level": "3",
@@ -8484,7 +8223,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "515c0674-5897-4b20-ba05-cfddaf70f333",
 			"quantity": 1,
 			"description": "Estoc",
 			"tech_level": "3",
@@ -8597,7 +8335,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "b9ccaf22-952a-4722-9499-f2e9070de743",
 			"quantity": 1,
 			"description": "Eyeglasses",
 			"tech_level": "3",
@@ -8611,7 +8348,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "b87b0bfe-299f-4183-811f-593b0a0c610f",
 			"quantity": 1,
 			"description": "Eyelash Cautery",
 			"tech_level": "2",
@@ -8624,7 +8360,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "31b63172-bd1f-415e-8a4f-e8fa0ed054eb",
 			"quantity": 1,
 			"description": "Eyelash Forceps",
 			"tech_level": "2",
@@ -8637,7 +8372,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "7af05f56-5073-442b-8856-f57c43d7ff94",
 			"quantity": 1,
 			"description": "Faering, 20'",
 			"tech_level": "3",
@@ -8651,7 +8385,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "895f756b-8330-4da1-b4ff-585953bc815e",
 			"quantity": 1,
 			"description": "Falchion",
 			"tech_level": "2",
@@ -8783,7 +8516,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "aac01b49-2058-4418-b494-9a640fc37c9d",
 			"quantity": 1,
 			"description": "Falcon",
 			"tech_level": "4",
@@ -8830,7 +8562,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "dc9eae3f-a179-48ce-a81c-ac11c2c795b5",
 			"quantity": 1,
 			"description": "Falcon Cannonball",
 			"tech_level": "4",
@@ -8844,7 +8575,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "c183731d-cbb0-4559-92ca-4ca7fbb19f96",
 			"quantity": 1,
 			"description": "Falcon Truck Carriage Mount",
 			"tech_level": "4",
@@ -8858,7 +8588,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "442105ea-8624-42ab-8047-863d534318e2",
 			"quantity": 1,
 			"description": "Falconet",
 			"tech_level": "4",
@@ -8905,7 +8634,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "9ec8b866-337e-49b8-96d1-0ba9d67cfd2e",
 			"quantity": 1,
 			"description": "Falconet Cannonball",
 			"tech_level": "4",
@@ -8919,7 +8647,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "8cd8cbb3-169b-4665-8035-ff25894f1a28",
 			"quantity": 1,
 			"description": "Falconet Truck Carriage Mount",
 			"tech_level": "4",
@@ -8933,7 +8660,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "9c57eeba-1ac4-4ebd-ab15-90b31df58fba",
 			"quantity": 1,
 			"description": "Fermented Beverages, per gallon",
 			"tech_level": "1",
@@ -8946,7 +8672,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "561779d1-5f61-4801-9881-31f83211fc67",
 			"quantity": 1,
 			"description": "Fibula, copper",
 			"tech_level": "0",
@@ -8960,7 +8685,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "c835f189-0721-472e-86df-5dec5cf99903",
 			"quantity": 1,
 			"description": "Fibula, gold",
 			"tech_level": "0",
@@ -8974,7 +8698,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "1f87ec71-8fc1-4bad-8a44-4c4022a77ea7",
 			"quantity": 1,
 			"description": "Fibula, silver",
 			"tech_level": "0",
@@ -8988,7 +8711,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "06a58fdf-830a-4872-ae37-cd6979242911",
 			"quantity": 1,
 			"description": "Fife",
 			"tech_level": "2",
@@ -9002,7 +8724,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "ba7eaf6f-1395-4f7a-8142-30639e6db2a9",
 			"quantity": 1,
 			"description": "Fifty-Man Sledge",
 			"tech_level": "1",
@@ -9016,7 +8737,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "97c63cf0-ba88-4fbb-854c-b35495bd5b21",
 			"quantity": 1,
 			"description": "Fire Arrow",
 			"tech_level": "0",
@@ -9032,7 +8752,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "ca36e05a-b7a8-41e8-92e6-1640793c9da9",
 			"quantity": 1,
 			"description": "Fire-Cage Arrow",
 			"tech_level": "0",
@@ -9048,7 +8767,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "7ee440e8-a5a8-47ca-9409-1f9e2010f0d8",
 			"quantity": 1,
 			"description": "Fire-Lance",
 			"tech_level": "3",
@@ -9095,7 +8813,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "76770724-ec43-410a-bca5-7ec361cde1d1",
 			"quantity": 1,
 			"description": "Fire-Siphon",
 			"tech_level": "3",
@@ -9143,7 +8860,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "83554dbb-b2b8-45eb-874c-baaac12096df",
 			"quantity": 1,
 			"description": "Firebow",
 			"tech_level": "0",
@@ -9157,7 +8873,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "a2b56b2f-dbb8-4346-ad56-98e731e9ee4f",
 			"quantity": 1,
 			"description": "Fishing Boat, 27'",
 			"tech_level": "2",
@@ -9171,7 +8886,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "1afb2bde-d3f7-4447-b98c-63dcbac56b92",
 			"quantity": 1,
 			"description": "Flail",
 			"tech_level": "2",
@@ -9226,7 +8940,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "a7e82834-a611-4090-a336-e1ee2d3bf6c1",
 			"quantity": 1,
 			"description": "Flight Arrow",
 			"tech_level": "0",
@@ -9242,7 +8955,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "2b671d1c-981d-42d9-ad2c-8a4c4203a00f",
 			"quantity": 1,
 			"description": "Flint",
 			"tech_level": "0",
@@ -9256,7 +8968,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "99b4fc95-1708-445e-b11d-3bc7f8a9050f",
 			"quantity": 1,
 			"description": "Flintlock Carbine",
 			"tech_level": "4",
@@ -9303,7 +9014,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "f1217d0d-f973-423e-9831-597ad70b81b5",
 			"quantity": 1,
 			"description": "Flintlock Carbine Bullet",
 			"tech_level": "4",
@@ -9317,7 +9027,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "f67dc616-55cb-4ca8-9cc2-2eae7d205fb3",
 			"quantity": 1,
 			"description": "Foot Wrappings",
 			"tech_level": "0",
@@ -9331,7 +9040,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "176e591b-9e37-46b4-9f7c-128cc924d025",
 			"quantity": 1,
 			"description": "Foot Wrappings, Boot",
 			"tech_level": "0",
@@ -9345,7 +9053,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "ae09656f-e308-4547-8e6e-dccc394cbc13",
 			"quantity": 1,
 			"description": "Forceps",
 			"tech_level": "1",
@@ -9358,7 +9065,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "e394968b-0c96-4d31-86b6-cc51aadce4d6",
 			"quantity": 1,
 			"description": "Forceps, Dental",
 			"tech_level": "2",
@@ -9372,7 +9078,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "7a486b65-4976-4a47-9e3c-314993976168",
 			"quantity": 1,
 			"description": "Forceps, Dental Splinter",
 			"tech_level": "2",
@@ -9385,7 +9090,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "aa2cab58-a055-49ea-9255-e965e7fec58c",
 			"quantity": 1,
 			"description": "Forceps, Staphylagra",
 			"tech_level": "2",
@@ -9398,7 +9102,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "5ac0aa0b-00c2-44c8-97ee-961db6bda7c0",
 			"quantity": 1,
 			"description": "Fowling Boat, 16’",
 			"tech_level": "1",
@@ -9412,7 +9115,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "4a79a91d-b2cb-47ca-8025-5298e2b678b7",
 			"quantity": 1,
 			"description": "Fowling Crossbow",
 			"tech_level": "4",
@@ -9454,7 +9156,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "170bc173-7854-4ae0-b4b5-62af02f73b3c",
 			"quantity": 1,
 			"description": "Fowling Piece Shot",
 			"tech_level": "4",
@@ -9468,7 +9169,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "ba72d527-595e-4252-afef-e9a38d33342d",
 			"quantity": 1,
 			"description": "Fowling Piece, Double",
 			"tech_level": "4",
@@ -9516,7 +9216,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "7280a371-245b-427e-84ee-af9aa7e615f4",
 			"quantity": 1,
 			"description": "Fowling Piece, Single",
 			"tech_level": "4",
@@ -9564,7 +9263,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "196bd3f0-fafd-4217-bdbe-c8696d1349a9",
 			"quantity": 1,
 			"description": "Fusil de Chasse",
 			"tech_level": "4",
@@ -9611,7 +9309,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "f80774f7-e1fc-4497-b470-72b71b89a3f9",
 			"quantity": 1,
 			"description": "Fusil de Chasse Bullet",
 			"tech_level": "4",
@@ -9625,7 +9322,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "86ed6967-9059-4c59-abe4-5284e3290608",
 			"quantity": 1,
 			"description": "Fusil Ordinaire",
 			"tech_level": "4",
@@ -9672,7 +9368,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "bdebbe82-2eb8-43cb-8ed1-0bf634f57efe",
 			"quantity": 1,
 			"description": "Fusil Ordinaire Bullet",
 			"tech_level": "4",
@@ -9686,7 +9381,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "21c2334e-ec79-4de0-bcd4-ab6d09465eae",
 			"quantity": 1,
 			"description": "Gada",
 			"tech_level": "1",
@@ -9778,7 +9472,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "537bfc33-39df-43db-a3ed-aa6cd54822e8",
 			"quantity": 1,
 			"description": "Garrote",
 			"tech_level": "0",
@@ -9813,7 +9506,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "0f9cc2eb-f9c2-470a-8f30-1a9e1ff0187f",
 			"quantity": 1,
 			"description": "Gastraphetes",
 			"tech_level": "2",
@@ -9854,7 +9546,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "6af0e68c-ac8f-40a9-9aa9-f466e236118b",
 			"quantity": 1,
 			"description": "Gastraphetes Bolt",
 			"tech_level": "2",
@@ -9868,7 +9559,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "e41c4d5c-5302-4fd5-9a5e-37fdfabc8a83",
 			"quantity": 1,
 			"description": "Gastraphetes Bolt",
 			"tech_level": "3",
@@ -9882,7 +9572,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "7fec6e0f-4c77-43cd-a8ea-a8c7c1ae4891",
 			"quantity": 1,
 			"description": "Gastraphetes, Double",
 			"tech_level": "2",
@@ -9930,7 +9619,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "5fa5417d-6d6d-45e5-a20d-b0f425416e97",
 			"quantity": 1,
 			"description": "Gastraphetes, Double Tripod",
 			"tech_level": "2",
@@ -9944,7 +9632,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "e3bfb038-00b7-4504-8e72-b13d07e710aa",
 			"quantity": 1,
 			"description": "Gastraphetes, Mountain",
 			"tech_level": "2",
@@ -9992,7 +9679,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "7755348a-edfe-4574-9eee-98f8438a5cb7",
 			"quantity": 1,
 			"description": "Gastraphetes, Mountain Bolt",
 			"tech_level": "3",
@@ -10006,7 +9692,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "ab0d9fcc-6c32-40b9-ad46-c9e509a5ad30",
 			"quantity": 1,
 			"description": "Gastraphetes, Mountain Tripod",
 			"tech_level": "2",
@@ -10020,7 +9705,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "c554521b-372d-4ff1-824e-5b758fb328ea",
 			"quantity": 1,
 			"description": "Glaive",
 			"tech_level": "1",
@@ -10112,7 +9796,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "9dd54e2f-4b65-42c7-9f38-0085bea483e4",
 			"description": "Glass Bottle, 1 cup",
 			"tech_level": "0",
 			"value": "1.5",
@@ -10141,7 +9824,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "27ff0f04-3b98-4b78-98b3-da74db191a2b",
 			"description": "Glass Bottle, 1 gal.",
 			"tech_level": "0",
 			"value": "13.5",
@@ -10170,7 +9852,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "15b7fa5b-60ec-4b85-a33c-ec0844e88c38",
 			"description": "Glass Bottle, 1 quart",
 			"tech_level": "0",
 			"value": "3.75",
@@ -10199,7 +9880,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "ae104c15-4258-4d7d-923b-2fcd466ea89b",
 			"description": "Glass Bottle, 1/4 cup",
 			"tech_level": "0",
 			"value": "0.5",
@@ -10228,7 +9908,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "42048410-6dde-4643-ac20-27aabc3d4c9c",
 			"description": "Glass Bottle, 2 gal.",
 			"tech_level": "0",
 			"value": "21",
@@ -10257,7 +9936,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "b11701ff-7156-4357-863e-2e4b75c46dcc",
 			"quantity": 1,
 			"description": "Gonne",
 			"tech_level": "3",
@@ -10334,7 +10012,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "880f779c-95c9-4aea-bd13-a9e9e5b4c911",
 			"quantity": 1,
 			"description": "Gonne Bolt",
 			"tech_level": "3",
@@ -10348,7 +10025,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "6737cbda-57f9-4a4c-b14d-813f456da110",
 			"quantity": 1,
 			"description": "Gonne Bullet",
 			"tech_level": "3",
@@ -10362,7 +10038,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "4b9e1c16-7b32-4cab-9067-805bc01d2469",
 			"quantity": 1,
 			"description": "Grappling Hook, Padded",
 			"tech_level": "1",
@@ -10376,7 +10051,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "5e59480f-83db-46f0-8a2e-0c34fc9809ab",
 			"quantity": 1,
 			"description": "Grappling Hook, Unpadded",
 			"tech_level": "1",
@@ -10390,7 +10064,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "dc8c7bf7-0afd-458f-8e65-d328be110c0a",
 			"quantity": 1,
 			"description": "Great Axe",
 			"tech_level": "1",
@@ -10444,7 +10117,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "5b5a079d-5e3f-4061-9786-1e2db1791b99",
 			"quantity": 1,
 			"description": "Greatsword",
 			"tech_level": "3",
@@ -10526,7 +10198,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "1c9bcfb5-2be8-4101-8b45-500a41279f02",
 			"quantity": 1,
 			"description": "Greek Fire",
 			"tech_level": "3",
@@ -10541,7 +10212,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "31a6cf1b-4c34-411e-8e67-cdf8efbfcd1e",
 			"quantity": 1,
 			"description": "Gun-Cleaning Kit",
 			"tech_level": "4",
@@ -10555,7 +10225,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "0061b5bd-19a2-467a-968f-0c7b809cd84b",
 			"quantity": 1,
 			"description": "Halberd",
 			"tech_level": "3",
@@ -10686,7 +10355,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "bb693195-ccfd-4f02-a1b4-dc8b185b02aa",
 			"quantity": 1,
 			"description": "Harp",
 			"tech_level": "1",
@@ -10700,7 +10368,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "0ba14c0d-d85a-489d-94b5-1995ac24f5a3",
 			"quantity": 1,
 			"description": "Harpoon",
 			"tech_level": "2",
@@ -10749,7 +10416,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "47ca7916-1c90-4449-b85d-0adce879a91a",
 			"quantity": 1,
 			"description": "Hatchet",
 			"tech_level": "0",
@@ -10822,7 +10488,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "e33681fd-d380-4785-841d-140acaf1152c",
 			"quantity": 1,
 			"description": "Heavy Chariot",
 			"tech_level": "1",
@@ -10837,7 +10502,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "23e69753-a894-4a82-a284-8e0cd7122227",
 			"quantity": 1,
 			"description": "Heavy Horse-Cutter",
 			"tech_level": "3",
@@ -10929,7 +10593,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "024236ad-0cee-4659-93dd-5eacae1c8152",
 			"quantity": 1,
 			"description": "Heavy Sling",
 			"tech_level": "0",
@@ -10971,7 +10634,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "185e853f-8a1d-4ffc-9b84-ec5105016638",
 			"quantity": 1,
 			"description": "Heavy Sling Shaped Rock",
 			"tech_level": "0",
@@ -10985,7 +10647,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "a7ffe69f-f377-45e1-b111-6183f8bce127",
 			"quantity": 1,
 			"description": "Heavy Spear",
 			"tech_level": "1",
@@ -11067,7 +10728,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "9e788014-eea2-4dde-bbea-c287b9975f0a",
 			"quantity": 1,
 			"description": "Hemlock",
 			"tech_level": "0",
@@ -11081,7 +10741,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "6455437d-5e0c-425d-8b2d-43e191187180",
 			"quantity": 1,
 			"description": "Highland Pistol",
 			"tech_level": "4",
@@ -11128,7 +10787,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "e530dff8-66cf-4d4d-a5ca-0d8608994d90",
 			"quantity": 1,
 			"description": "Highland Pistol Bullet",
 			"tech_level": "4",
@@ -11142,7 +10800,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "1151cb82-f9ef-44f1-9526-0e2d25425170",
 			"quantity": 1,
 			"description": "Holsters",
 			"tech_level": "4",
@@ -11156,7 +10813,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "ae78dfef-6d94-47ff-bca0-454e2969d167",
 			"quantity": 1,
 			"description": "Hook Sword",
 			"tech_level": "3",
@@ -11240,7 +10896,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "c2b3a458-e174-44f0-bd87-3ce9ef23133d",
 			"quantity": 1,
 			"description": "Hook, Surgical",
 			"tech_level": "1",
@@ -11253,7 +10908,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "50068d7a-c1a2-4ead-bc8f-db44877f0cfd",
 			"quantity": 1,
 			"description": "Horse Blanket",
 			"tech_level": "1",
@@ -11267,7 +10921,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "3e2e211f-171b-4311-a353-82900d9439be",
 			"quantity": 1,
 			"description": "Horseshoes",
 			"tech_level": "3",
@@ -11281,7 +10934,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "17fc479b-6da2-4eda-99c4-0703d0526220",
 			"quantity": 1,
 			"description": "Housebreaker's Kit",
 			"tech_level": "2",
@@ -11295,7 +10947,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "f3e335ba-05a3-4f08-a6f2-ad5dc43db6bb",
 			"quantity": 1,
 			"description": "Humming Bulb Arrow",
 			"tech_level": "0",
@@ -11310,7 +10961,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "751570c4-3423-4eb5-a3c3-94e4fd7fdc98",
 			"quantity": 1,
 			"description": "Hungamunga",
 			"tech_level": "2",
@@ -11470,7 +11120,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "0603eb04-c71a-4a78-9fdb-9d2ff31e70a0",
 			"quantity": 1,
 			"description": "Hunting Crossbow",
 			"tech_level": "4",
@@ -11513,7 +11162,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "b8eb78e4-77a5-4fe1-9f23-b1956c1afbfa",
 			"quantity": 1,
 			"description": "Hunting Horn, Brass",
 			"tech_level": "3",
@@ -11527,7 +11175,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "2ad3d4c4-0cee-4210-81cd-1f0aa98b7606",
 			"quantity": 1,
 			"description": "Hunting Shirt, Dyed",
 			"tech_level": "1",
@@ -11541,7 +11188,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "8e30dca2-cf4c-4ab2-a8e6-50f42d8a3f41",
 			"quantity": 1,
 			"description": "Hunting Shirt, Plain",
 			"tech_level": "1",
@@ -11555,7 +11201,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "89959c06-c589-4b40-8cc0-9b4bb71d485e",
 			"quantity": 1,
 			"description": "Incendiaries, Early Mixtures",
 			"tech_level": "2",
@@ -11570,7 +11215,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "dea5f9ac-047b-462f-b6ab-883e34d40b2f",
 			"quantity": 1,
 			"description": "Incendiary Blowpipe",
 			"tech_level": "3",
@@ -11612,7 +11256,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "fde0aee2-aeae-4423-ae07-aacf93d56cd8",
 			"quantity": 1,
 			"description": "Incendiary Blowpipe Charge",
 			"tech_level": "2",
@@ -11626,7 +11269,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "eef2d922-63b9-4e41-a25b-8bc56f02d97f",
 			"quantity": 1,
 			"description": "Incendiary Sphere",
 			"tech_level": "3",
@@ -11642,7 +11284,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "8e88c1b4-bd25-4df8-b01a-a16e52ad06cf",
 			"quantity": 1,
 			"description": "Incense, Cheap, per ounce",
 			"tech_level": "0",
@@ -11656,7 +11297,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "325deefe-71ae-402d-ab31-4b0dcc557d24",
 			"quantity": 1,
 			"description": "Incense, Fine, per ounce",
 			"tech_level": "0",
@@ -11670,7 +11310,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "bebb126a-7b1d-448d-a811-d4fac9714553",
 			"quantity": 1,
 			"description": "Ink Stone",
 			"tech_level": "1",
@@ -11684,7 +11323,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "d8870007-70e6-4d3a-8548-2e5bd80d2b9b",
 			"quantity": 1,
 			"description": "Ink, per pint",
 			"tech_level": "1",
@@ -11698,7 +11336,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "8381e177-486c-41ec-90be-91acebdfb2d3",
 			"quantity": 1,
 			"description": "Iron Bomb",
 			"tech_level": "3",
@@ -11714,7 +11351,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "38d662e7-b210-45a1-96bb-3e88068e8719",
 			"quantity": 1,
 			"description": "Iron Fire-Lance",
 			"tech_level": "3",
@@ -11761,7 +11397,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "222e0264-08ea-462a-9b59-dfe68c6f85e0",
 			"quantity": 1,
 			"description": "Javelin",
 			"tech_level": "1",
@@ -11848,7 +11483,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "b6fa9b87-6ff0-461e-8d92-c7ebf29c9084",
 			"quantity": 1,
 			"description": "Javelin w. Thong",
 			"tech_level": "1",
@@ -11934,7 +11568,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "c4818ae2-5ed9-42aa-8ac4-e88581590dd0",
 			"quantity": 1,
 			"description": "Jian",
 			"tech_level": "3",
@@ -12045,7 +11678,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "a36e650e-7c4c-4105-ac8e-bb970277ce49",
 			"quantity": 1,
 			"description": "Jo",
 			"tech_level": "0",
@@ -12267,7 +11899,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "f7ffd49c-4fb3-482d-b880-9bcc2b7fcf20",
 			"quantity": 1,
 			"description": "Jolly Boat, 18'",
 			"tech_level": "4",
@@ -12281,7 +11912,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "25e22636-56e3-4e87-8a9d-d55b4c7496a1",
 			"quantity": 1,
 			"description": "Jutte",
 			"tech_level": "3",
@@ -12410,7 +12040,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "915c28ef-2c7a-41f3-8b5a-e8611b1512d4",
 			"quantity": 1,
 			"description": "Jäger Rifle",
 			"tech_level": "4",
@@ -12457,7 +12086,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "82030255-1c7d-4863-8569-a3efcc06016d",
 			"quantity": 1,
 			"description": "Jäger Rifle Bullet",
 			"tech_level": "4",
@@ -12471,7 +12099,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "6ca43827-5c62-414c-ae3f-989579043043",
 			"quantity": 1,
 			"description": "Jäger Rifle, Double-Barreled",
 			"tech_level": "4",
@@ -12518,7 +12145,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "55fc776a-3bf3-4237-83d3-9a00d6dc72c0",
 			"quantity": 1,
 			"description": "Kakute",
 			"tech_level": "3",
@@ -12545,7 +12171,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "be7e41cc-7a0c-4be4-aa10-1a09f345ed2b",
 			"quantity": 1,
 			"description": "Katana",
 			"tech_level": "3",
@@ -12723,7 +12348,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "4b47ac6e-a284-48d9-8dea-69924b07acf8",
 			"quantity": 1,
 			"description": "Katar",
 			"tech_level": "2",
@@ -12823,7 +12447,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "87c606db-506d-4c27-bdc0-998f7648c177",
 			"quantity": 1,
 			"description": "Kayak, 18’",
 			"tech_level": "0",
@@ -12837,7 +12460,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "79dca0a5-8393-43e8-a74d-f0bbe3543fdb",
 			"quantity": 1,
 			"description": "Kettledrums, Cavalry",
 			"tech_level": "3",
@@ -12851,7 +12473,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "c841d77f-90ba-4d00-80bb-0e4f68a8135c",
 			"quantity": 1,
 			"description": "Khopesh",
 			"tech_level": "1",
@@ -12934,7 +12555,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "cfdf0771-56b2-4732-83b0-0f32912a4898",
 			"quantity": 1,
 			"description": "Kite",
 			"tech_level": "2",
@@ -12948,7 +12568,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "1a44e13a-91b4-46dc-a388-eb388311bc4a",
 			"quantity": 1,
 			"description": "Knife-Wheel",
 			"tech_level": "3",
@@ -13143,7 +12762,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "bc9a152a-29a0-4331-a862-6b73e9d94853",
 			"quantity": 1,
 			"description": "Knobbed Club",
 			"tech_level": "0",
@@ -13192,7 +12810,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "4059227c-f714-409c-9884-1e0d77959a82",
 			"quantity": 1,
 			"description": "Kukri",
 			"tech_level": "2",
@@ -13284,7 +12901,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "bfe56241-7cc0-4a6e-84c5-f6e6ba2e7de3",
 			"quantity": 1,
 			"description": "Kusari",
 			"tech_level": "3",
@@ -13377,7 +12993,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "41913253-5f64-40cb-8b11-3a7796f54086",
 			"quantity": 1,
 			"description": "Kusarigama",
 			"tech_level": "3",
@@ -13508,7 +13123,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "5118e5c0-03d5-49d4-b2d9-7cd1cd399994",
 			"quantity": 1,
 			"description": "Kusarijutte",
 			"tech_level": "3",
@@ -13601,7 +13215,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "03045849-875c-443d-8958-23bdbecf77e2",
 			"quantity": 1,
 			"description": "Lacquer",
 			"tech_level": "1",
@@ -13615,7 +13228,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "c6c8c13f-c47a-4e22-805d-48a08b5f5c0a",
 			"quantity": 1,
 			"description": "Ladder, 6'",
 			"tech_level": "1",
@@ -13629,7 +13241,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "5c2d7ca5-b755-4a88-b1d5-24c43e28fc14",
 			"quantity": 1,
 			"description": "Ladder, Rope, 30 feet",
 			"tech_level": "1",
@@ -13643,7 +13254,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "7317735c-f7b7-4e00-ba3b-8e29ce27471a",
 			"quantity": 1,
 			"description": "Lajatang",
 			"tech_level": "3",
@@ -13735,7 +13345,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "fe8b24a6-4a06-43bd-aa48-93cd83b4d921",
 			"quantity": 1,
 			"description": "Lance",
 			"tech_level": "2",
@@ -13780,7 +13389,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "81f1d03c-d030-4263-a270-5b9a53cd583c",
 			"quantity": 1,
 			"description": "Lancet",
 			"tech_level": "2",
@@ -13793,7 +13401,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "d8014b3f-ccdc-4283-8625-56ab881cdce7",
 			"quantity": 1,
 			"description": "Lantaka",
 			"tech_level": "3",
@@ -13840,7 +13447,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "2c9c07bb-6cbe-4e3d-9224-7b604953c94d",
 			"quantity": 1,
 			"description": "Lantaka Cannonball",
 			"tech_level": "3",
@@ -13854,7 +13460,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "ff829987-e69f-43cc-9b9f-291e819e734d",
 			"quantity": 1,
 			"description": "Lantaka Pintle Mount",
 			"tech_level": "3",
@@ -13868,7 +13473,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "8256e842-bfa5-49f8-8ecd-4600cf8ba66a",
 			"quantity": 1,
 			"description": "Large Bark Canoe, 20’",
 			"tech_level": "0",
@@ -13882,7 +13486,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "b71136d2-accd-4247-94bc-6fca30e33ee7",
 			"quantity": 1,
 			"description": "Large Falchion",
 			"tech_level": "2",
@@ -13994,7 +13597,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "7d8102f0-fca4-4066-9f52-c5d0f554ca72",
 			"quantity": 1,
 			"description": "Large Hide Boat, 36’",
 			"tech_level": "1",
@@ -14008,7 +13610,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "3f55af6f-38dd-42bb-ae62-467580bfe5df",
 			"quantity": 1,
 			"description": "Large Hungamunga",
 			"tech_level": "2",
@@ -14121,7 +13722,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "ba5c5514-f0f8-410d-af47-c75e7bb0612c",
 			"quantity": 1,
 			"description": "Large Katar",
 			"tech_level": "2",
@@ -14261,7 +13861,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "fedcafeb-82a5-4120-a2fc-f97a3c60d011",
 			"quantity": 1,
 			"description": "Large Knife",
 			"tech_level": "0",
@@ -14378,7 +13977,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "bfbd39c2-1d22-4093-98b6-6b7af48eb310",
 			"quantity": 1,
 			"description": "Large Net",
 			"tech_level": "0",
@@ -14419,7 +14017,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "8fd6a4b1-efad-471e-bbe2-f4dc06a8e104",
 			"quantity": 1,
 			"description": "Large Quadrens",
 			"tech_level": "2",
@@ -14494,7 +14091,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "d24a5674-f6fd-4db3-b0e4-ebfc9265c23c",
 			"quantity": 1,
 			"description": "Large Throwing Knife",
 			"tech_level": "2",
@@ -14652,7 +14248,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "28d18250-e275-49d6-bac5-8db6e9afa0aa",
 			"quantity": 1,
 			"description": "Lariat",
 			"tech_level": "1",
@@ -14688,7 +14283,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "db58765c-54cd-4cd0-b1be-2afa99263d6d",
 			"quantity": 1,
 			"description": "Late Katana",
 			"tech_level": "4",
@@ -14866,7 +14460,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "8d7dd439-4aba-4b41-a475-991eb70f486a",
 			"description": "Leather Pouch, 1 cup",
 			"tech_level": "0",
 			"value": "0.75",
@@ -14895,7 +14488,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "a2961da5-2e91-4632-b0dc-2aeba3417d01",
 			"description": "Leather Pouch, 1 gal.",
 			"tech_level": "0",
 			"value": "4.5",
@@ -14924,7 +14516,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "ca521d5d-d8fa-4598-9446-76af37ffbe15",
 			"description": "Leather Pouch, 1 quart",
 			"tech_level": "0",
 			"value": "2",
@@ -14953,7 +14544,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "24635e25-0aa4-48c6-ab3c-38d3972afd70",
 			"description": "Leather Pouch, 1/4 cup",
 			"tech_level": "0",
 			"value": "0.25",
@@ -14982,7 +14572,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "23f7b7a5-a152-4c40-af2a-b9bcbc6ebed8",
 			"description": "Leather Pouch, 2 gal.",
 			"tech_level": "0",
 			"value": "7.35",
@@ -15011,7 +14600,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "67a11318-18cb-471a-9a27-2f44af8b24b7",
 			"description": "Leather Pouch, 6 gal.",
 			"tech_level": "0",
 			"value": "15",
@@ -15040,7 +14628,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "51f60919-98a7-4c6c-ba02-b5a6bb7be2b2",
 			"description": "Leather Pouch, 20 gal.",
 			"tech_level": "0",
 			"value": "34",
@@ -15069,7 +14656,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "6c5507e4-55b5-4062-a46f-d97c00522ca9",
 			"description": "Leather Pouch, 40 gal.",
 			"tech_level": "0",
 			"value": "53",
@@ -15098,7 +14684,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "a2d86098-0329-4831-b14e-8980e37c3301",
 			"description": "Leather Pouch, 80 gal.",
 			"tech_level": "0",
 			"value": "85",
@@ -15127,7 +14712,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "26f7cf6d-4471-4ead-a780-74eb8059594d",
 			"description": "Leather Pouch, 120 gal.",
 			"tech_level": "0",
 			"value": "111",
@@ -15156,7 +14740,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "deea0f73-d062-4c45-9c4c-33ee571d6ca9",
 			"quantity": 1,
 			"description": "Light Chariot",
 			"tech_level": "1",
@@ -15171,7 +14754,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "ab64e2e6-225a-45c6-a44f-e0ba8e85e4f0",
 			"quantity": 1,
 			"description": "Light Club",
 			"tech_level": "0",
@@ -15283,7 +14865,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "f0f934af-12a9-4e25-b419-8a6775869fd2",
 			"quantity": 1,
 			"description": "Light Edged Rapier",
 			"tech_level": "4",
@@ -15385,7 +14966,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "4f22f5d1-9781-471a-9cc5-0a8b883f6be3",
 			"quantity": 1,
 			"description": "Light Horse-Cutter",
 			"tech_level": "3",
@@ -15477,7 +15057,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "6c8903f9-2712-4cc0-8e6f-0d2c99fdcc38",
 			"quantity": 1,
 			"description": "Light Rapier",
 			"tech_level": "4",
@@ -15536,7 +15115,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "1b322d61-d05f-4b17-ac97-838ac71ec072",
 			"quantity": 1,
 			"description": "Light Whip, 1 yd",
 			"tech_level": "1",
@@ -15586,7 +15164,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "dad859d0-dd50-40e2-a407-36b6287d2a49",
 			"quantity": 1,
 			"description": "Light Whip, 2 yd",
 			"tech_level": "1",
@@ -15636,7 +15213,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "9cf5ee05-ce16-40d8-92b8-51da529bdf8f",
 			"quantity": 1,
 			"description": "Light Whip, 3 yd",
 			"tech_level": "1",
@@ -15686,7 +15262,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "c5474105-7a8e-4321-a7a9-be8168d76e9b",
 			"quantity": 1,
 			"description": "Light Whip, 4 yd",
 			"tech_level": "1",
@@ -15736,7 +15311,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "368e0313-a035-442e-9e7c-b647bf71cb4c",
 			"quantity": 1,
 			"description": "Light Whip, 5 yd",
 			"tech_level": "1",
@@ -15786,7 +15360,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "c8a831ec-3417-41b8-a10f-14e610dfd9d3",
 			"quantity": 1,
 			"description": "Light Whip, 6 yd",
 			"tech_level": "1",
@@ -15836,7 +15409,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "045f1d06-099f-4627-b1ca-20bca428472b",
 			"quantity": 1,
 			"description": "Light Whip, 7 yd",
 			"tech_level": "1",
@@ -15886,7 +15458,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "847f3ecd-b13a-4909-ab47-33e59db7a926",
 			"quantity": 1,
 			"description": "Lime Powder",
 			"tech_level": "1",
@@ -15900,7 +15471,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "3a403a3d-9d19-4b33-b726-49ea17aea55d",
 			"quantity": 1,
 			"description": "Litter",
 			"tech_level": "0",
@@ -15915,7 +15485,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "2480f518-0411-470b-a68e-edf95af5e415",
 			"quantity": 1,
 			"description": "Lockpick Set, Basic",
 			"tech_level": "1",
@@ -15929,7 +15498,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "ecefa6a8-b3c0-415a-93ec-eec2cb9ac2b5",
 			"quantity": 1,
 			"description": "Lockpick Set, Good",
 			"tech_level": "2",
@@ -15943,7 +15511,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "c9e4fafc-9d54-4488-978f-be52305d7e8f",
 			"quantity": 1,
 			"description": "Long Axe",
 			"tech_level": "2",
@@ -15997,7 +15564,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "efdb63f5-415c-4bb6-b2fa-f471ea98af1d",
 			"quantity": 1,
 			"description": "Long Dugout Canoe, 30’",
 			"tech_level": "0",
@@ -16011,7 +15577,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "570829f7-b100-49a8-b10d-d57fd0fa37d3",
 			"quantity": 1,
 			"description": "Long Knife",
 			"tech_level": "1",
@@ -16217,7 +15782,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "65896a83-c6f0-4d92-a68a-c1d33f8afa1e",
 			"quantity": 1,
 			"description": "Long Spear",
 			"tech_level": "2",
@@ -16285,7 +15849,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "3246ab36-a310-45b2-8dd9-cdf49c37e642",
 			"quantity": 1,
 			"description": "Long Staff",
 			"tech_level": "0",
@@ -16367,7 +15930,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "6fd1e348-5dc5-45f1-9d13-7853e501f1df",
 			"quantity": 1,
 			"description": "Long-Range Awe-Inspiring Gun",
 			"tech_level": "4",
@@ -16438,7 +16000,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "07345b4a-d190-405f-8b1c-61c602795ba6",
 			"quantity": 1,
 			"description": "Long-Range Awe-Inspiring Gun Lead Ball",
 			"tech_level": "4",
@@ -16452,7 +16013,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "c77a6290-6127-4daf-b9af-acfff77d5b1d",
 			"quantity": 1,
 			"description": "Long-Range Awe-Inspiring Gun Lead Shot",
 			"tech_level": "4",
@@ -16466,7 +16026,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "142ce9f0-7fb5-4d52-b43e-89d683ad6f31",
 			"quantity": 1,
 			"description": "Longboat, 30'",
 			"tech_level": "4",
@@ -16480,7 +16039,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "c27a4a02-994d-4c37-9623-07f40cbd0e4a",
 			"quantity": 1,
 			"description": "Longbow",
 			"tech_level": "0",
@@ -16522,7 +16080,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "c28b14f3-cbab-4b0b-83a0-35f8677fec45",
 			"quantity": 1,
 			"description": "Longsword",
 			"tech_level": "3",
@@ -16700,7 +16257,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "4b678b9f-81aa-4800-b595-829a63906298",
 			"quantity": 1,
 			"description": "Luxury Travel Kit",
 			"tech_level": "2",
@@ -16714,7 +16270,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "8758621d-e154-4df4-8607-4cf03aa72977",
 			"quantity": 1,
 			"description": "Mace",
 			"tech_level": "2",
@@ -16827,7 +16382,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "b4feb00c-7e3f-4061-ab55-9f3fdf544ad0",
 			"quantity": 1,
 			"description": "Macuahuilzoctli",
 			"tech_level": "0",
@@ -16959,7 +16513,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "5850b008-1497-4b60-a085-81708ece6977",
 			"quantity": 1,
 			"description": "Macuahuitl",
 			"tech_level": "0",
@@ -17072,7 +16625,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "d059379c-73a2-43e6-a9e6-2422e1aaf8e8",
 			"quantity": 1,
 			"description": "Main-Gauche",
 			"tech_level": "4",
@@ -17265,7 +16817,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "5684e1c9-fff9-4c60-b10f-9e576d2bf8ca",
 			"quantity": 1,
 			"description": "Match Cover",
 			"tech_level": "4",
@@ -17279,7 +16830,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "c0531ad8-0786-4782-ad7c-d22102f1b118",
 			"quantity": 1,
 			"description": "Maul",
 			"tech_level": "0",
@@ -17333,7 +16883,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "484a9d0f-a3bf-439a-b79c-fa9175f1ff2e",
 			"quantity": 1,
 			"description": "Melee Net",
 			"tech_level": "2",
@@ -17374,7 +16923,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "5d90873d-e2fa-4825-aa9e-d734006f5b8a",
 			"description": "Metal Box, Bronze, 1 cup",
 			"tech_level": "1",
 			"value": "72",
@@ -17403,7 +16951,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "d2c0cee0-b93f-4e81-a6c1-f999bb8b4fb1",
 			"description": "Metal Box, Bronze, 1 gal.",
 			"tech_level": "1",
 			"value": "460",
@@ -17432,7 +16979,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "df208433-62c4-4dc7-b42b-70de0d5b07cd",
 			"description": "Metal Box, Bronze, 1 quart",
 			"tech_level": "1",
 			"value": "184",
@@ -17461,7 +17007,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "7dad1644-3fa3-4c89-b31a-1f1ddf6ba6c7",
 			"description": "Metal Box, Bronze, 1/4 cup",
 			"tech_level": "1",
 			"value": "28",
@@ -17490,7 +17035,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "08175b94-c381-4112-b194-8dc464500ff6",
 			"description": "Metal Box, Bronze, 2 gal.",
 			"tech_level": "1",
 			"value": "1468",
@@ -17519,7 +17063,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "2f3557e7-de6b-4150-82e2-0ad7b48cc876",
 			"description": "Metal Box, Bronze, 6 gal.",
 			"tech_level": "1",
 			"value": "3044",
@@ -17548,7 +17091,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "d97e8b0c-5284-425b-ba20-5d09f3f86bed",
 			"description": "Metal Box, Bronze, 20 gal.",
 			"tech_level": "1",
 			"value": "6800",
@@ -17577,7 +17119,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "a42c7e03-4af3-4eb9-bd65-991c80878430",
 			"description": "Metal Box, Bronze, 40 gal.",
 			"tech_level": "1",
 			"value": "16200",
@@ -17606,7 +17147,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "9a0ea336-42bf-4586-acf6-1d5beb8c173f",
 			"description": "Metal Box, Bronze, 80 gal.",
 			"tech_level": "1",
 			"value": "25668",
@@ -17635,7 +17175,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "1aad17fb-4162-408f-841f-9a8f10d3de76",
 			"description": "Metal Box, Bronze, 120 gal.",
 			"tech_level": "1",
 			"value": "33636",
@@ -17664,7 +17203,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "96b1e2ba-a219-49e3-b2e8-72b2620b3e8e",
 			"description": "Metal Box, Iron, 1 cup",
 			"tech_level": "2",
 			"value": "18",
@@ -17693,7 +17231,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "50932eb8-bdb0-4053-b11a-cd69970e362c",
 			"description": "Metal Box, Iron, 1 gal.",
 			"tech_level": "2",
 			"value": "115",
@@ -17722,7 +17259,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "03e7f231-8db7-49ff-883c-d347f2a8acca",
 			"description": "Metal Box, Iron, 1 quart",
 			"tech_level": "2",
 			"value": "46",
@@ -17751,7 +17287,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "ae19072c-2234-4314-a4d8-c1524a8f6756",
 			"description": "Metal Box, Iron, 1/4 cup",
 			"tech_level": "2",
 			"value": "7",
@@ -17780,7 +17315,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "191d37f7-2127-4ed3-8c70-fcb3d8226658",
 			"description": "Metal Box, Iron, 2 gal.",
 			"tech_level": "2",
 			"value": "367",
@@ -17809,7 +17343,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "ac3a0c1f-9e42-4368-9073-beee428a83d1",
 			"description": "Metal Box, Iron, 6 gal.",
 			"tech_level": "2",
 			"value": "761",
@@ -17838,7 +17371,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "3ffc4452-daa1-4652-a3fa-04a13e66d8d7",
 			"description": "Metal Box, Iron, 20 gal.",
 			"tech_level": "2",
 			"value": "1700",
@@ -17867,7 +17399,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "92ce1a12-43c0-4f61-b12d-7806df72ed70",
 			"description": "Metal Box, Iron, 40 gal.",
 			"tech_level": "2",
 			"value": "4050",
@@ -17896,7 +17427,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "9defd4be-4f42-4b29-9b22-78fd22c3c2ed",
 			"description": "Metal Box, Iron, 80 gal.",
 			"tech_level": "2",
 			"value": "6417",
@@ -17925,7 +17455,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "7d909dff-4b47-4a34-8421-4b018a47599b",
 			"description": "Metal Box, Iron, 120 gal.",
 			"tech_level": "2",
 			"value": "8409",
@@ -17954,7 +17483,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "c9787d17-a072-4cb9-a442-772900142a53",
 			"quantity": 1,
 			"description": "Military Crossbow",
 			"tech_level": "4",
@@ -17996,7 +17524,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "c3959983-586e-4440-b8d6-295cdd019e29",
 			"quantity": 1,
 			"description": "Military Pistol",
 			"tech_level": "4",
@@ -18043,7 +17570,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "767b4517-7d21-4edf-a659-516c3e7e9afe",
 			"quantity": 1,
 			"description": "Military Pistol Bullet",
 			"tech_level": "4",
@@ -18057,7 +17583,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "aacb0186-226e-4e4d-963b-f92eb63c9b6a",
 			"quantity": 1,
 			"description": "Mittens",
 			"tech_level": "0",
@@ -18072,7 +17597,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "b2b8694f-7e0f-490a-b274-074d5f270b0a",
 			"quantity": 1,
 			"description": "Monankon",
 			"tech_level": "2",
@@ -18116,7 +17640,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "0a508d6f-4319-46bf-9e54-4103c0f27b6e",
 			"quantity": 1,
 			"description": "Monankon Stone",
 			"tech_level": "2",
@@ -18130,7 +17653,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "96a4c7d4-27da-4905-b400-dae496344ee1",
 			"quantity": 1,
 			"description": "Monk's Spade",
 			"tech_level": "3",
@@ -18260,7 +17782,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "a94b539b-21f2-4d57-b95a-acb7a7ff25ca",
 			"quantity": 1,
 			"description": "Monkshood",
 			"tech_level": "0",
@@ -18274,7 +17795,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "9ae07982-051d-4c4e-9603-189c57140e84",
 			"quantity": 1,
 			"description": "Morningstar",
 			"tech_level": "0",
@@ -18323,7 +17843,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "559de6f3-64a7-44af-a1d3-d35284d7eed7",
 			"quantity": 1,
 			"description": "Mr. Facing-Both-Ways Gonne",
 			"tech_level": "3",
@@ -18371,7 +17890,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "195be2bb-f26a-4bb5-b712-f68ea62442c7",
 			"quantity": 1,
 			"description": "Musket",
 			"tech_level": "4",
@@ -18418,7 +17936,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "032bd083-5272-45b2-9696-c058358f1414",
 			"quantity": 1,
 			"description": "Musket Bullet",
 			"tech_level": "4",
@@ -18432,7 +17949,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "97a26992-3051-4b06-a08d-8f7f114ec0b7",
 			"quantity": 1,
 			"description": "Musket Rest",
 			"tech_level": "4",
@@ -18446,7 +17962,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "c077ee79-bb9e-4ab7-8a12-1713680df3d0",
 			"quantity": 1,
 			"description": "Myrmex",
 			"tech_level": "1",
@@ -18498,7 +18013,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "449e202c-4347-48c2-baa1-77fdd276b997",
 			"quantity": 1,
 			"description": "Naginata",
 			"tech_level": "2",
@@ -18656,7 +18170,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "b6e26053-159e-438d-8991-c45a19cb0a1f",
 			"quantity": 1,
 			"description": "Naphtha",
 			"tech_level": "3",
@@ -18671,7 +18184,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "57251d48-a390-459d-8d71-dd8c00ddd5ca",
 			"quantity": 1,
 			"description": "Needle, Surgical",
 			"tech_level": "1",
@@ -18684,7 +18196,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "f7343536-4919-4854-86a7-44e744e6489d",
 			"quantity": 1,
 			"description": "Nunchaku",
 			"tech_level": "0",
@@ -18733,7 +18244,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "50b0a8bf-ab66-48ab-9bd4-86c38b89c1b2",
 			"quantity": 1,
 			"description": "Oar",
 			"tech_level": "0",
@@ -18787,7 +18297,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "70915cb0-59ee-4c54-9e08-25ec6b6082f4",
 			"quantity": 1,
 			"description": "Oblong Hide Boat, 5’",
 			"tech_level": "0",
@@ -18801,7 +18310,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "fc71710f-1233-43e7-b639-1cc2c1bf8592",
 			"quantity": 1,
 			"description": "Outrigger Canoe, 30’",
 			"tech_level": "0",
@@ -18815,7 +18323,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "4db1972a-4098-4061-aad2-a5f08b4c6de5",
 			"quantity": 1,
 			"description": "Oxcart",
 			"tech_level": "1",
@@ -18830,7 +18337,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "2eb41bed-65e1-4051-840d-f72279b0dca3",
 			"quantity": 1,
 			"description": "Paper Bomb",
 			"tech_level": "3",
@@ -18846,7 +18352,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "3b8659df-034e-4777-9b84-709ac4840122",
 			"quantity": 1,
 			"description": "Parchment, per sheet",
 			"tech_level": "2",
@@ -18860,7 +18365,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "e7d454a0-d40b-4cb4-a706-90af00387fb2",
 			"quantity": 1,
 			"description": "Pata",
 			"tech_level": "2",
@@ -18978,7 +18482,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "d08f2964-2e29-4cc5-bbca-73c6adb00645",
 			"quantity": 1,
 			"description": "Pencil, dozen",
 			"tech_level": "4",
@@ -18992,7 +18495,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "521f922a-5cf3-4eac-8e9b-738a680d3cfb",
 			"quantity": 1,
 			"description": "Perfume, Cheap, per application",
 			"tech_level": "0",
@@ -19006,7 +18508,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "597c19bb-b97c-402b-9924-52bcd498045a",
 			"quantity": 1,
 			"description": "Perfume, Expensive, per application",
 			"tech_level": "0",
@@ -19020,7 +18521,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "470611eb-718f-4a1b-ba32-8b3736900c41",
 			"quantity": 1,
 			"description": "Petard",
 			"tech_level": "4",
@@ -19036,7 +18536,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "20049e8d-fe84-4dcb-bfca-1e85e0d4c8b9",
 			"quantity": 1,
 			"description": "Petrobolos, 5-lb Stone",
 			"tech_level": "3",
@@ -19050,7 +18549,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "72d1e84f-03b2-4ba9-be92-8314e788d2ea",
 			"quantity": 1,
 			"description": "Petrobolos, 5-lb.",
 			"tech_level": "2",
@@ -19098,7 +18596,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "5a9cb34e-16c2-4741-b5aa-ea532e193bf5",
 			"quantity": 1,
 			"description": "Petrobolos, 5-lb. Tripod",
 			"tech_level": "2",
@@ -19112,7 +18609,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "e8a497fa-03d6-41bd-a83e-802dcec149d5",
 			"quantity": 1,
 			"description": "Petrobolos, 40-lb Stone",
 			"tech_level": "3",
@@ -19126,7 +18622,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "73c10053-94b2-4be1-a415-6fd1d49d8712",
 			"quantity": 1,
 			"description": "Petrobolos, 40-lb.",
 			"tech_level": "2",
@@ -19174,7 +18669,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "099bebac-fdfe-4ff4-8065-dda2a4226e61",
 			"quantity": 1,
 			"description": "Petrobolos, 40-lb. Tripod",
 			"tech_level": "2",
@@ -19188,7 +18682,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "f2d8928a-55d4-4112-8b44-b0d2b8ec73b8",
 			"quantity": 1,
 			"description": "Petronel",
 			"tech_level": "4",
@@ -19235,7 +18728,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "9f4db33a-54a0-4865-a0b4-2edf0792b15a",
 			"quantity": 1,
 			"description": "Petronel Bullet",
 			"tech_level": "4",
@@ -19249,7 +18741,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "bd5bb76e-2957-4e8a-ae02-e46f9a540e46",
 			"quantity": 1,
 			"description": "Pick",
 			"tech_level": "3",
@@ -19298,7 +18789,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "d7a5171e-8b0e-4999-8aa7-e36246472568",
 			"quantity": 1,
 			"description": "Piercing, copper",
 			"tech_level": "0",
@@ -19312,7 +18802,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "0586c1a7-4968-4e74-a839-3a0dbe30d1f2",
 			"quantity": 1,
 			"description": "Piercing, gold",
 			"tech_level": "0",
@@ -19326,7 +18815,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "99b59baf-4a06-4d2a-a539-a6f2d4a1a990",
 			"quantity": 1,
 			"description": "Piercing, silver",
 			"tech_level": "0",
@@ -19340,7 +18828,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "d9435865-6672-4b6f-873c-013c6bca556d",
 			"quantity": 1,
 			"description": "Pike",
 			"tech_level": "2",
@@ -19389,7 +18876,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "feeb7933-ac93-42d6-95cc-8774c69eca25",
 			"quantity": 1,
 			"description": "Pilgrim's Kit",
 			"tech_level": "2",
@@ -19403,7 +18889,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "ebd54a9d-211a-4899-a3a5-4548d631670f",
 			"quantity": 1,
 			"description": "Pipe",
 			"tech_level": "0",
@@ -19417,7 +18902,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "16362a11-ed91-419f-9971-59957d374297",
 			"quantity": 1,
 			"description": "Pistol Crossbow",
 			"tech_level": "3",
@@ -19460,7 +18944,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "dd186aae-303a-4025-b6be-05e09da546fc",
 			"quantity": 1,
 			"description": "Pistol Crossbow Dart",
 			"tech_level": "3",
@@ -19475,7 +18958,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "59de617a-9d08-4aea-88ac-dae71e606478",
 			"quantity": 1,
 			"description": "Piton",
 			"tech_level": "2",
@@ -19489,7 +18971,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "01e9154f-03e8-47e9-834e-7b22986d116a",
 			"quantity": 1,
 			"description": "Piton Hammer",
 			"tech_level": "2",
@@ -19503,7 +18984,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "dba0b9bf-4321-4246-b946-b9d8b1122c6c",
 			"quantity": 1,
 			"description": "Plug, copper",
 			"tech_level": "0",
@@ -19517,7 +18997,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "cfbb9a51-8cf6-4b77-a3fc-c2254e580430",
 			"quantity": 1,
 			"description": "Plug, gold",
 			"tech_level": "0",
@@ -19531,7 +19010,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "94480ddf-7a93-4cfb-94ce-c57a27eb049f",
 			"quantity": 1,
 			"description": "Plug, silver",
 			"tech_level": "0",
@@ -19545,7 +19023,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "9e19d8a1-859d-4053-a880-af79e9e4bfe8",
 			"quantity": 1,
 			"description": "Pocket Pistol",
 			"tech_level": "4",
@@ -19592,7 +19069,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "8d7087c3-48ab-4096-8961-90adbe50c09e",
 			"quantity": 1,
 			"description": "Pocket Pistol Bullet",
 			"tech_level": "4",
@@ -19606,7 +19082,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "6c195374-f54a-4c6b-9468-e9fab44111fd",
 			"quantity": 1,
 			"description": "Poleaxe",
 			"tech_level": "3",
@@ -19698,7 +19173,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "37adf331-0b7b-4e6e-bf1e-2c7a08c4567b",
 			"quantity": 1,
 			"description": "Pollaxe",
 			"tech_level": "3",
@@ -19828,7 +19302,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "ee2b12bf-29ae-4f4d-b726-7a17fee22efb",
 			"quantity": 1,
 			"description": "Polybolos",
 			"tech_level": "2",
@@ -19876,7 +19349,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "427728ce-3315-4fba-abac-fb08101bed55",
 			"quantity": 1,
 			"description": "Polybolos Bolt",
 			"tech_level": "3",
@@ -19890,7 +19362,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "67d7f580-7762-41ba-aa1d-62e1df1a36d6",
 			"quantity": 1,
 			"description": "Polybolos Tripod",
 			"tech_level": "2",
@@ -19904,7 +19375,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "9d1ed98d-2418-40de-9e13-4321b1b8370b",
 			"quantity": 1,
 			"description": "Portable Sundial",
 			"tech_level": "2",
@@ -19918,7 +19388,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "5576ba91-52da-416e-89a6-e0b30627d770",
 			"quantity": 1,
 			"description": "Prepared Block",
 			"tech_level": "0",
@@ -19932,7 +19401,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "c43d31ed-233b-4119-8ccd-c376039eb104",
 			"quantity": 1,
 			"description": "Probe, Surgical",
 			"tech_level": "1",
@@ -19945,7 +19413,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "8c349485-17c6-43d5-b7cf-c14f6d40816f",
 			"quantity": 1,
 			"description": "Prodd",
 			"tech_level": "3",
@@ -19987,7 +19454,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "ef116fa4-64fd-40ce-a76a-4d5298a2c3d8",
 			"quantity": 1,
 			"description": "Prodd Pellet",
 			"tech_level": "3",
@@ -20002,7 +19468,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "599eb3a4-8c4a-4482-a21e-fffd6a23468f",
 			"quantity": 1,
 			"description": "Pry-Bar",
 			"tech_level": "2",
@@ -20016,7 +19481,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "60198252-5e22-4013-b1c5-f8a770f89a0f",
 			"quantity": 1,
 			"description": "Pry-Bar, Small",
 			"tech_level": "2",
@@ -20030,7 +19494,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "9fe02001-104d-4646-af19-bfd8e4d776b9",
 			"quantity": 1,
 			"description": "Puckle Gun",
 			"tech_level": "4",
@@ -20078,7 +19541,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "bb19993a-bc3a-4450-97bd-ea352b0e4172",
 			"quantity": 1,
 			"description": "Puckle Gun Bullet",
 			"tech_level": "4",
@@ -20092,7 +19554,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "382091ef-4779-466c-be50-cbe1bd741c4e",
 			"quantity": 1,
 			"description": "Puffer Pistol",
 			"tech_level": "4",
@@ -20139,7 +19600,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "4aab6e14-ced7-42af-8549-96b95000d9ac",
 			"quantity": 1,
 			"description": "Puffer Pistol Bullet",
 			"tech_level": "4",
@@ -20153,7 +19613,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "e32b3ce0-5b9f-4b82-aba6-7bf3c31b5392",
 			"quantity": 1,
 			"description": "Pumice",
 			"tech_level": "1",
@@ -20167,7 +19626,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "aef536e5-4c28-4d98-baa1-3f97feeb429e",
 			"quantity": 1,
 			"description": "Qian Kun Ri Yue Dao",
 			"tech_level": "3",
@@ -20311,7 +19769,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "fbdd7728-ad5c-43f7-a5ce-f53f05de27b9",
 			"quantity": 1,
 			"description": "Quadrens",
 			"tech_level": "2",
@@ -20406,7 +19863,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "52791218-1749-41ff-a1d4-a611c5b0e00b",
 			"quantity": 1,
 			"description": "Quarterstaff",
 			"tech_level": "0",
@@ -20554,7 +20010,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "0931337c-b19f-498e-b515-6db56705280d",
 			"quantity": 1,
 			"description": "Queen Anne Pistol",
 			"tech_level": "4",
@@ -20601,7 +20056,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "0cfb00fa-2974-4d4f-a6ba-f2bcf69cba0f",
 			"quantity": 1,
 			"description": "Queen Anne Pistol Bullet",
 			"tech_level": "4",
@@ -20615,7 +20069,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "1188e071-9e6a-4838-a616-9d022b381dc9",
 			"quantity": 1,
 			"description": "Quick Match",
 			"tech_level": "4",
@@ -20630,7 +20083,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "8729bbf5-3551-4276-8adb-e635652a7789",
 			"quantity": 1,
 			"description": "Quill, Cheap",
 			"tech_level": "3",
@@ -20643,7 +20095,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "819916ff-c4e2-4f15-862e-4ca46bd23596",
 			"quantity": 1,
 			"description": "Quill, Fine",
 			"tech_level": "3",
@@ -20656,7 +20107,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "e2c2ec42-8c4d-4cb6-943b-93b56218a23f",
 			"quantity": 1,
 			"description": "Rabinet",
 			"tech_level": "4",
@@ -20703,7 +20153,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "ca915e0b-14c2-4f87-86fd-4bcc1551f77a",
 			"quantity": 1,
 			"description": "Rabinet Cannonball",
 			"tech_level": "4",
@@ -20717,7 +20166,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "940629c2-fdd6-43e8-8e3a-7ae9960d0bad",
 			"quantity": 1,
 			"description": "Rabinet Truck Carriage Mount",
 			"tech_level": "4",
@@ -20731,7 +20179,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "0eedabf7-2854-4954-8e12-e62bd1392fb1",
 			"quantity": 1,
 			"description": "Raft, 4\" Logs",
 			"tech_level": "0",
@@ -20745,7 +20192,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "0cb0576e-066d-4c78-aaf8-f63d5890c46d",
 			"quantity": 1,
 			"description": "Raft, 6.5\" Reeds",
 			"tech_level": "0",
@@ -20759,7 +20205,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "8893775e-a8a5-4684-95ba-aa5b1ab06fde",
 			"quantity": 1,
 			"description": "Raft, 7\" Logs",
 			"tech_level": "0",
@@ -20773,7 +20218,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "133cf25c-d137-43f2-a91e-27d6001a6e88",
 			"quantity": 1,
 			"description": "Raft, 10\" Logs",
 			"tech_level": "0",
@@ -20787,7 +20231,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "acd966f9-237e-4362-a1ba-c0af9f83d0b4",
 			"quantity": 1,
 			"description": "Raft, 12\" Logs",
 			"tech_level": "0",
@@ -20801,7 +20244,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "54921ce8-3b60-4854-9606-6730131981cb",
 			"quantity": 1,
 			"description": "Rapier",
 			"tech_level": "4",
@@ -20860,7 +20302,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "0bd848df-e875-4d99-b2af-869c087810f0",
 			"quantity": 1,
 			"description": "Razor",
 			"tech_level": "0",
@@ -20874,7 +20315,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "07082431-3e3a-46fa-9f8a-679ae1d01570",
 			"quantity": 1,
 			"description": "Reflex Bow",
 			"tech_level": "1",
@@ -20916,7 +20356,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "e5e71813-87a4-4c68-9b7b-fb9543c471ad",
 			"quantity": 1,
 			"description": "Regular Bow",
 			"tech_level": "0",
@@ -20958,7 +20397,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "4728c682-8ea8-462a-aad7-d5ed963a7eea",
 			"quantity": 1,
 			"description": "Repeating Crossbow",
 			"tech_level": "2",
@@ -21000,7 +20438,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "4b831f2d-5d56-4f71-8d04-eea8898635bc",
 			"quantity": 1,
 			"description": "Riding Crop",
 			"tech_level": "2",
@@ -21014,7 +20451,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "b3459074-1213-4c7c-a731-41e0923a863b",
 			"quantity": 1,
 			"description": "Ring, copper",
 			"tech_level": "0",
@@ -21028,7 +20464,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "03f0bfea-9cff-4939-adfe-1171ee59ee2a",
 			"quantity": 1,
 			"description": "Ring, gold",
 			"tech_level": "0",
@@ -21042,7 +20477,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "91d29863-3a90-4b7b-bcc5-d3af76d29135",
 			"quantity": 1,
 			"description": "Ring, silver",
 			"tech_level": "0",
@@ -21056,7 +20490,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "e9a69704-1b2a-4299-af26-5f57bd0d8231",
 			"quantity": 1,
 			"description": "River Barge, 40'",
 			"tech_level": "1",
@@ -21070,7 +20503,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "ef1705ed-b81e-40ab-bbec-ad58fe1569bf",
 			"quantity": 1,
 			"description": "Rondel Dagger",
 			"tech_level": "3",
@@ -21171,7 +20603,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "5fa6addc-97b9-4615-8698-5ae15d70a66a",
 			"quantity": 1,
 			"description": "Rope Dart",
 			"tech_level": "2",
@@ -21264,7 +20695,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "aa9aa633-f9a1-4974-b21a-19429063af45",
 			"quantity": 1,
 			"description": "Round Hide Boat, 5’",
 			"tech_level": "0",
@@ -21278,7 +20708,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "be8774aa-4b85-49a4-a9c9-43b1f0eb7a57",
 			"quantity": 1,
 			"description": "Round Mace",
 			"tech_level": "0",
@@ -21358,7 +20787,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "0f69d76e-7d65-4600-9c1d-25a3d3b6cbde",
 			"quantity": 1,
 			"description": "Saber",
 			"tech_level": "4",
@@ -21468,7 +20896,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "59fbb5af-1d60-49fb-b55c-973068f5aa11",
 			"quantity": 1,
 			"description": "Saddle, Cushioned",
 			"tech_level": "2",
@@ -21482,7 +20909,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "90f76171-fd94-4e5a-b067-4de32e0295b9",
 			"quantity": 1,
 			"description": "Saddle, Horned",
 			"tech_level": "2",
@@ -21496,7 +20922,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "2ddccc47-3061-4fc0-8d59-09ee4e4bf510",
 			"quantity": 1,
 			"description": "Saddle, Riding",
 			"tech_level": "2",
@@ -21510,7 +20935,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "7df78208-0e0c-4f30-96fd-bbe5257dad10",
 			"quantity": 1,
 			"description": "Saddle, War",
 			"tech_level": "3",
@@ -21524,7 +20948,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "9034d0ef-7239-4e8c-a46c-7629d850f545",
 			"description": "Saddlebags",
 			"tech_level": "2",
 			"value": "100",
@@ -21552,7 +20975,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "7056e685-8acf-4b93-b273-9f1d1e71f4e5",
 			"quantity": 1,
 			"description": "Sai",
 			"tech_level": "3",
@@ -21763,7 +21185,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "0b87aa14-90ce-4dc5-8292-6f8b49ecee8a",
 			"quantity": 1,
 			"description": "Saker",
 			"tech_level": "4",
@@ -21811,7 +21232,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "1257aaeb-8c90-4b37-9416-c25ce3e64b2e",
 			"quantity": 1,
 			"description": "Saker Cannonball",
 			"tech_level": "4",
@@ -21825,7 +21245,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "b8abab76-d759-45a0-a736-d487b46872de",
 			"quantity": 1,
 			"description": "Saker Truck Carriage Mount",
 			"tech_level": "4",
@@ -21839,7 +21258,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "7004a934-645a-4c48-9f98-0a3e7008061c",
 			"quantity": 1,
 			"description": "Saltpeter",
 			"tech_level": "3",
@@ -21853,7 +21271,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "df4b1fe2-a9a1-470f-b64c-3ef06c2faae5",
 			"quantity": 1,
 			"description": "Sampan, 15’",
 			"tech_level": "1",
@@ -21867,7 +21284,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "dd4391e8-0162-4317-a41e-14e20cccb30a",
 			"quantity": 1,
 			"description": "Sandglass",
 			"tech_level": "3",
@@ -21881,7 +21297,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "86272a2e-46ec-424c-bc6f-c3d5df75815e",
 			"quantity": 1,
 			"description": "Scalpel",
 			"tech_level": "1",
@@ -21894,7 +21309,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "972a7385-33f9-4e6e-a8d7-9b94ced2ec32",
 			"quantity": 1,
 			"description": "Scorpion, 9\" Bolt",
 			"tech_level": "2",
@@ -21908,7 +21322,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "c64e9c4c-81b3-4f97-8645-b5e69fc293b8",
 			"quantity": 1,
 			"description": "Scorpion, 9”",
 			"tech_level": "2",
@@ -21947,7 +21360,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "9774d652-3a91-49fc-b535-73aa1241f08c",
 			"quantity": 1,
 			"description": "Scorpion, 13.5\" Bolt",
 			"tech_level": "2",
@@ -21961,7 +21373,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "a18a2003-e5dc-4218-b3f3-688e303be379",
 			"quantity": 1,
 			"description": "Scorpion, 13.5”",
 			"tech_level": "2",
@@ -22000,7 +21411,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "76a16a8b-35e7-4fb2-8702-78d484969e76",
 			"quantity": 1,
 			"description": "Scorpion, 18\" Bolt",
 			"tech_level": "2",
@@ -22014,7 +21424,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "f8079e6f-cd61-4b0a-8446-64d7a4ba7d1a",
 			"quantity": 1,
 			"description": "Scorpion, 18”",
 			"tech_level": "2",
@@ -22053,7 +21462,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "75bc12ab-4a8a-41b5-a72c-77da356237c5",
 			"quantity": 1,
 			"description": "Scorpion, 27\" Bolt",
 			"tech_level": "3",
@@ -22067,7 +21475,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "ab417e1c-699c-4aa5-9027-3b026a93e160",
 			"quantity": 1,
 			"description": "Scorpion, 27”",
 			"tech_level": "2",
@@ -22115,7 +21522,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "7f5a6375-7440-4fbc-96e7-dde00b73936b",
 			"quantity": 1,
 			"description": "Scorpion, 27” Tripod",
 			"tech_level": "2",
@@ -22129,7 +21535,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "b7fb0e92-2bdf-48ef-8103-a454beee568c",
 			"quantity": 1,
 			"description": "Scorpion, 36\" Bolt",
 			"tech_level": "3",
@@ -22143,7 +21548,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "b9581b2f-64f0-4e65-9b9d-e8ece0359ee3",
 			"quantity": 1,
 			"description": "Scorpion, 36”",
 			"tech_level": "2",
@@ -22191,7 +21595,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "74e30812-c8ba-4319-ba64-dcb160069f3f",
 			"quantity": 1,
 			"description": "Scorpion, 36” Tripod",
 			"tech_level": "2",
@@ -22205,7 +21608,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "2035607b-13d5-491b-af44-8bbde07c7881",
 			"quantity": 1,
 			"description": "Scorpion, 45\" Bolt",
 			"tech_level": "3",
@@ -22219,7 +21621,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "f47bc4a2-aee4-43ec-bdb8-d1ac670da24e",
 			"quantity": 1,
 			"description": "Scorpion, 45”",
 			"tech_level": "2",
@@ -22267,7 +21668,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "3e3c61f4-a495-4228-80b5-787c1383ed90",
 			"quantity": 1,
 			"description": "Scorpion, 45” Tripod",
 			"tech_level": "2",
@@ -22281,7 +21681,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "a107e915-34ba-45c3-94e2-cc22d050c666",
 			"quantity": 1,
 			"description": "Scorpion, 54\" Bolt",
 			"tech_level": "3",
@@ -22295,7 +21694,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "480e0abf-d2ca-4eb4-91fa-e6545e75f00b",
 			"quantity": 1,
 			"description": "Scorpion, 54”",
 			"tech_level": "2",
@@ -22343,7 +21741,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "82fc61a2-f010-4317-ba7c-26345a62d326",
 			"quantity": 1,
 			"description": "Scorpion, 54” Tripod",
 			"tech_level": "2",
@@ -22357,7 +21754,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "b4db4680-6fb0-4b7e-a812-285eb0f3daaa",
 			"quantity": 1,
 			"description": "Scorpion, 72\" Bolt",
 			"tech_level": "3",
@@ -22371,7 +21767,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "efa91333-f952-406a-906f-b31feb83e492",
 			"quantity": 1,
 			"description": "Scorpion, 72”",
 			"tech_level": "2",
@@ -22419,7 +21814,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "d6b42056-968e-47a9-b9af-101fd82fadcb",
 			"quantity": 1,
 			"description": "Scorpion, 72” Tripod",
 			"tech_level": "2",
@@ -22433,7 +21827,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "deb474d2-1be7-42a7-9cc7-cb6147603941",
 			"quantity": 1,
 			"description": "Scythe",
 			"tech_level": "1",
@@ -22564,7 +21957,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "cfcf5616-d5d2-4300-a4ec-324e6337d6f2",
 			"quantity": 1,
 			"description": "Scythed Chariot",
 			"tech_level": "2",
@@ -22579,7 +21971,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "154d3e07-db83-4341-8650-895699a182e7",
 			"quantity": 1,
 			"description": "Serpentine Black Powder",
 			"tech_level": "3",
@@ -22594,7 +21985,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "735eebe4-8bca-4694-9112-443b012d3156",
 			"quantity": 1,
 			"description": "Sewn-Plank Riverboat, 30’",
 			"tech_level": "1",
@@ -22608,7 +21998,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "fcc799a5-f82e-4d34-838f-c184d62ffe83",
 			"quantity": 1,
 			"description": "Sewn-Plank Sailboat",
 			"tech_level": "3",
@@ -22622,7 +22011,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "3b6874a1-5eae-4edc-a092-c3bfffa3a18e",
 			"quantity": 1,
 			"description": "Shackles, Iron",
 			"tech_level": "2",
@@ -22636,7 +22024,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "0d5cdb60-4dce-42c7-a319-0cbbcf727b35",
 			"quantity": 1,
 			"description": "Shaped Sling Stone",
 			"tech_level": "0",
@@ -22650,7 +22037,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "816b4996-ce5f-4cc5-80f9-9ff38ae4d41e",
 			"quantity": 1,
 			"description": "Ship's  Gun, 4-lb.",
 			"tech_level": "4",
@@ -22698,7 +22084,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "94a3a710-1dbf-4136-b5ae-e179e9200d06",
 			"quantity": 1,
 			"description": "Ship's  Gun, 9-lb.",
 			"tech_level": "4",
@@ -22746,7 +22131,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "181f0fd9-40de-4d04-86bb-d9a7803b66e4",
 			"quantity": 1,
 			"description": "Ship's  Gun, 18-lb.",
 			"tech_level": "4",
@@ -22794,7 +22178,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "6d5b6f4a-1e53-4c3c-997e-4bc136f722b9",
 			"quantity": 1,
 			"description": "Ship's  Gun, 42-lb.",
 			"tech_level": "4",
@@ -22842,7 +22225,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "1ddf0deb-fd85-4327-9263-a340ed1c29a9",
 			"quantity": 1,
 			"description": "Ship's Gun,4-lb. Cannonball",
 			"tech_level": "4",
@@ -22856,7 +22238,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "b5228881-b0b5-4f2f-b21a-43c3c4c61071",
 			"quantity": 1,
 			"description": "Ship's Gun,9-lb. Cannonball",
 			"tech_level": "4",
@@ -22870,7 +22251,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "e052109b-943d-4eef-be21-0898fa684c49",
 			"quantity": 1,
 			"description": "Ship's Gun,18-lb. Cannonball",
 			"tech_level": "4",
@@ -22884,7 +22264,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "45fca248-a050-4e4a-a5fd-22383106580c",
 			"quantity": 1,
 			"description": "Ship's Gun,42-lb. Cannonball",
 			"tech_level": "4",
@@ -22898,7 +22277,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "d4f5e035-80d8-443e-8ae0-7acdf368a618",
 			"quantity": 1,
 			"description": "Ship’s  Gun, 4-lb. Truck Carriage Mount",
 			"tech_level": "4",
@@ -22912,7 +22290,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "715f58d3-9440-4d53-a7c3-125f46515a4a",
 			"quantity": 1,
 			"description": "Ship’s  Gun, 9-lb. Truck Carriage Mount",
 			"tech_level": "4",
@@ -22926,7 +22303,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "2b57c86f-a73a-4076-b17c-9f26366b6fd1",
 			"quantity": 1,
 			"description": "Ship’s Gun, 18-lb. Truck Carriage Mount",
 			"tech_level": "4",
@@ -22940,7 +22316,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "c5f0d252-b5ae-4160-b05c-3d542753058c",
 			"quantity": 1,
 			"description": "Ship’s Gun, 42-lb. Truck Carriage Mount",
 			"tech_level": "4",
@@ -22954,7 +22329,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "95c6a506-3000-49d7-a476-d0a97f90e011",
 			"quantity": 1,
 			"description": "Shoes, leather",
 			"tech_level": "1",
@@ -22968,7 +22342,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "4321ba95-b017-44b9-94f2-70ee2152202c",
 			"quantity": 1,
 			"description": "Shooting Stick",
 			"tech_level": "4",
@@ -22982,7 +22355,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "b19403e1-bab6-481f-9607-6517a5ff0704",
 			"quantity": 1,
 			"description": "Short Baton",
 			"tech_level": "0",
@@ -23126,7 +22498,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "cb5579f0-8c5b-4ffe-be85-b9e82e5f7975",
 			"quantity": 1,
 			"description": "Short Bow",
 			"tech_level": "0",
@@ -23167,7 +22538,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "9d1258ff-c602-4aa4-a4d6-2d0ad1b0a8c1",
 			"quantity": 1,
 			"description": "Short Spear",
 			"tech_level": "1",
@@ -23248,7 +22618,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "f4bfc2c3-ec8f-4004-96c4-351613bbefde",
 			"quantity": 1,
 			"description": "Short Staff",
 			"tech_level": "0",
@@ -23348,7 +22717,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "330b8445-aeee-44d8-b9d3-1672bd748902",
 			"quantity": 1,
 			"description": "Shortsword",
 			"tech_level": "1",
@@ -23479,7 +22847,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "8745fadf-2e4a-4a6a-ac77-ee70e42765d2",
 			"quantity": 1,
 			"description": "Shotel",
 			"tech_level": "2",
@@ -23592,7 +22959,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "ddef31d9-1a64-430d-88f0-909344d502b1",
 			"quantity": 1,
 			"description": "Sickle",
 			"tech_level": "1",
@@ -23705,7 +23071,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "aa4c0281-fcb2-446e-a459-f73d499c7c3e",
 			"quantity": 1,
 			"description": "Siege Crossbow",
 			"tech_level": "4",
@@ -23748,7 +23113,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "ac71a6dd-8681-413b-84b0-540474cf7fb9",
 			"quantity": 1,
 			"description": "Signet Ring",
 			"tech_level": "2",
@@ -23761,7 +23125,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "48dfe9aa-7dc6-4e20-bc54-50ce8c4df7bb",
 			"quantity": 1,
 			"description": "Slashing Wheel",
 			"tech_level": "3",
@@ -23870,7 +23233,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "c2251d77-75de-4131-a097-4030a2605e1d",
 			"quantity": 1,
 			"description": "Sleigh",
 			"tech_level": "4",
@@ -23885,7 +23247,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "0e554991-c0db-4243-9982-5094653e12a5",
 			"quantity": 1,
 			"description": "Sling",
 			"tech_level": "0",
@@ -23927,7 +23288,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "feeb9616-71dc-4f02-9376-841ee40e3b99",
 			"quantity": 1,
 			"description": "Sling Pellet",
 			"tech_level": "0",
@@ -23942,7 +23302,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "9215086d-1135-4116-91dd-67ca916fb1b0",
 			"quantity": 1,
 			"description": "Sling, Long Arm",
 			"tech_level": "4",
@@ -23956,7 +23315,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "f2c69fcd-cbb8-49b2-9fd2-239169c72af1",
 			"quantity": 1,
 			"description": "Sloop, 21'",
 			"tech_level": "4",
@@ -23970,7 +23328,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "a313a67a-2ead-43bf-92c5-2825d20911ac",
 			"quantity": 1,
 			"description": "Slow Match",
 			"tech_level": "4",
@@ -23985,7 +23342,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "931126c9-268e-4a57-884d-79dd6c6a6933",
 			"quantity": 1,
 			"description": "Slurbow",
 			"tech_level": "3",
@@ -24053,7 +23409,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "fb69e1fd-e25a-4c4a-b033-103c41ab8ef8",
 			"quantity": 1,
 			"description": "Slurbow Dart",
 			"tech_level": "0",
@@ -24068,7 +23423,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "1c4f48e3-2ae8-4386-982f-a5a249f2910a",
 			"quantity": 1,
 			"description": "Small Axe",
 			"tech_level": "0",
@@ -24117,7 +23471,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "a5afb432-074c-468b-a060-a1cfc49ec106",
 			"quantity": 1,
 			"description": "Small Falchion",
 			"tech_level": "2",
@@ -24248,7 +23601,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "14f4c3fc-bfd3-4ff2-a0df-77163d779825",
 			"quantity": 1,
 			"description": "Small Knife",
 			"tech_level": "0",
@@ -24367,7 +23719,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "101f7d5e-dcc4-4eab-b00c-4e943910fa72",
 			"quantity": 1,
 			"description": "Small Mace",
 			"tech_level": "2",
@@ -24442,7 +23793,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "424163af-dcf7-43e9-965e-fab3dd91c4c7",
 			"quantity": 1,
 			"description": "Small Round Mace",
 			"tech_level": "0",
@@ -24517,7 +23867,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "b3513627-1b2d-4552-9b62-5e420fff7de7",
 			"quantity": 1,
 			"description": "Small Throwing Axe",
 			"tech_level": "0",
@@ -24593,7 +23942,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "df95c488-a62f-466e-930f-cfd7debe235d",
 			"quantity": 1,
 			"description": "Small Throwing Knife",
 			"tech_level": "2",
@@ -24753,7 +24101,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "72b01ce5-fbb3-4d1a-ab03-41c9d0c9811f",
 			"quantity": 1,
 			"description": "Smallsword",
 			"tech_level": "4",
@@ -24812,7 +24159,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "9555575a-42ad-49fe-a440-04a5607e5b06",
 			"quantity": 1,
 			"description": "Snaphaunce Pistol",
 			"tech_level": "4",
@@ -24859,7 +24205,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "97ac0d4a-4c56-4692-a698-ec67effcafc5",
 			"quantity": 1,
 			"description": "Snaphaunce Pistol Bullet",
 			"tech_level": "4",
@@ -24873,7 +24218,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "bc8e4060-c47b-4161-861c-9c94588b9edf",
 			"quantity": 1,
 			"description": "Soap, Liquid, Pint",
 			"tech_level": "2",
@@ -24887,7 +24231,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "e2cef6d4-fe83-4057-9d85-fb84a718ce51",
 			"quantity": 1,
 			"description": "Soap, Solid, Bar",
 			"tech_level": "2",
@@ -24901,7 +24244,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "90bfef46-3a2c-4c9d-9ac9-0f425ae291bc",
 			"quantity": 1,
 			"description": "Sodegarami",
 			"tech_level": "3",
@@ -25017,7 +24359,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "3eb1e737-b98d-4957-a69a-9aa2cae2bc41",
 			"quantity": 1,
 			"description": "Spear",
 			"tech_level": "0",
@@ -25136,7 +24477,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "295f5d8c-aef0-4f34-8ce3-e5619a0efd42",
 			"quantity": 1,
 			"description": "Spear w. Thong",
 			"tech_level": "0",
@@ -25255,7 +24595,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "e55c2325-f000-48ea-ae43-0413f513520c",
 			"quantity": 1,
 			"description": "Speculum",
 			"tech_level": "2",
@@ -25269,7 +24608,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "53869271-13e5-4cd2-b95e-53641b1420a5",
 			"quantity": 1,
 			"description": "Spike Shuriken",
 			"tech_level": "3",
@@ -25338,7 +24676,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "ffba2262-ec0e-4bec-b586-f5bd482559fc",
 			"quantity": 1,
 			"description": "Splints, Arm",
 			"tech_level": "0",
@@ -25352,7 +24689,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "7ffd8fe1-c426-410c-81b6-8f1b98ce43a2",
 			"quantity": 1,
 			"description": "Splints, Leg",
 			"tech_level": "0",
@@ -25366,7 +24702,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "2631ff5e-214f-42e6-b4e7-9442859c4a44",
 			"quantity": 1,
 			"description": "Springald",
 			"tech_level": "3",
@@ -25414,7 +24749,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "d71c798c-74c5-46c1-84ac-c16edb131dd5",
 			"quantity": 1,
 			"description": "Springald Bolt",
 			"tech_level": "3",
@@ -25428,7 +24762,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "381ee21a-2bc8-4485-a6b2-c22dedc2c1d4",
 			"quantity": 1,
 			"description": "Spurs",
 			"tech_level": "2",
@@ -25441,7 +24774,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "6d539f67-4f75-4c4c-9c32-ffb0eb3fd8ad",
 			"quantity": 1,
 			"description": "Square-Rigged Sailboat",
 			"tech_level": "2",
@@ -25455,7 +24787,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "4f09f3f0-d594-48ae-954d-cb5b88a9a9ab",
 			"quantity": 1,
 			"description": "Staff Sling",
 			"tech_level": "1",
@@ -25498,7 +24829,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "0d44fec7-501b-4ccf-b879-dad8a2a1ecfa",
 			"quantity": 1,
 			"description": "Star Shuriken",
 			"tech_level": "3",
@@ -25567,7 +24897,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "6d8fac6e-a7c0-4ca2-a0f1-5f5713fc4d27",
 			"quantity": 1,
 			"description": "Stiletto",
 			"tech_level": "3",
@@ -25670,7 +24999,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "4e39a277-4040-499d-9349-2e5b9d16f0ef",
 			"quantity": 1,
 			"description": "Stirrups",
 			"tech_level": "3",
@@ -25684,7 +25012,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "3636589f-28b7-436d-82f2-0d2ce04ec586",
 			"quantity": 1,
 			"description": "Stone-Launching Stick",
 			"tech_level": "0",
@@ -25733,7 +25060,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "0bda6e20-b147-4c8f-b9bf-22b2f8a758e6",
 			"quantity": 1,
 			"description": "Stone-Launching Stick Shaped Stone",
 			"tech_level": "0",
@@ -25749,7 +25075,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "d23facb1-2e56-4b92-9243-b9ca539edef5",
 			"quantity": 1,
 			"description": "Straddle Car",
 			"tech_level": "1",
@@ -25764,7 +25089,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "2b00a041-e77e-4744-a8e3-86a11f611190",
 			"quantity": 1,
 			"description": "Straight Composite Bow",
 			"tech_level": "1",
@@ -25805,7 +25129,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "2aea59ce-5f8a-493f-a464-83e72a08d837",
 			"quantity": 1,
 			"description": "Strigil",
 			"tech_level": "1",
@@ -25819,7 +25142,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "70a79658-e2f4-4fe2-9416-fd71e2d3e1ff",
 			"quantity": 1,
 			"description": "Stylus",
 			"tech_level": "1",
@@ -25832,7 +25154,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "3ed3258f-b8dc-4a9a-8ac5-d3d62f5e71e5",
 			"quantity": 4,
 			"description": "Sulfur Matches",
 			"tech_level": "3",
@@ -25845,7 +25166,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "76bcb94e-a9bc-4a19-b7e6-1aa170254b48",
 			"quantity": 1,
 			"description": "Surgeon Kit, Large",
 			"tech_level": "1",
@@ -25860,7 +25180,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "fbb40efd-0911-41a3-8203-c960bdcca9fe",
 			"quantity": 1,
 			"description": "Surgeon Kit, Small",
 			"tech_level": "1",
@@ -25875,7 +25194,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "e902358a-afca-446b-bbfe-1e0694bb78cf",
 			"quantity": 1,
 			"description": "Surveyor's Kit",
 			"tech_level": "2",
@@ -25889,7 +25207,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "e2e0e10e-2660-4f8d-a56a-46d52b5853f0",
 			"quantity": 1,
 			"description": "Swivel-Gun",
 			"tech_level": "4",
@@ -25936,7 +25253,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "4fe74a57-c188-419b-9f11-3cd62abe3037",
 			"quantity": 1,
 			"description": "Swivel-Gun Cannonball",
 			"tech_level": "4",
@@ -25950,7 +25266,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "35977bca-8204-4e90-9f97-6e69398d2ef2",
 			"quantity": 1,
 			"description": "Swivel-Gun Pintle Mount",
 			"tech_level": "4",
@@ -25964,7 +25279,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "6dbb1031-c310-4f1d-8a19-32ffd9baedb0",
 			"quantity": 1,
 			"description": "Tantsutsu",
 			"tech_level": "4",
@@ -26011,7 +25325,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "0bc06493-a3ed-4ab9-b90a-046e0ed92496",
 			"quantity": 1,
 			"description": "Tantsutsu Bullet",
 			"tech_level": "4",
@@ -26025,7 +25338,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "c4bf6d4c-49f9-4011-a5b8-4f0bbca94eee",
 			"quantity": 1,
 			"description": "Ten-Eyed Gonne",
 			"tech_level": "3",
@@ -26193,7 +25505,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "37b1246d-b308-4d44-9844-cd7f944bbe21",
 			"quantity": 1,
 			"description": "Teppo",
 			"tech_level": "4",
@@ -26240,7 +25551,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "72dd7865-6fad-4b12-8f23-f8e19beec0ba",
 			"quantity": 1,
 			"description": "Teppo Bullet",
 			"tech_level": "4",
@@ -26254,7 +25564,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "9ef43f2b-ddf9-44a0-917b-b62773569061",
 			"quantity": 1,
 			"description": "Tetsubo",
 			"tech_level": "2",
@@ -26412,7 +25721,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "b8e5d411-104c-4640-9a25-069768f8a6d5",
 			"quantity": 1,
 			"description": "Thonged Club",
 			"tech_level": "0",
@@ -26461,7 +25769,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "5bc2187c-ab30-41b8-847b-93c549309529",
 			"quantity": 1,
 			"description": "Three-Part Staff",
 			"tech_level": "2",
@@ -26554,7 +25861,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "1e8e7b87-97bf-40da-a598-4ffd60c3d786",
 			"quantity": 1,
 			"description": "Throwing Axe",
 			"tech_level": "0",
@@ -26668,7 +25974,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "5156e992-82f7-4fe1-ac73-eff27beb55c8",
 			"quantity": 1,
 			"description": "Throwing Dart",
 			"tech_level": "2",
@@ -26714,7 +26019,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "1828e139-36fe-41e0-83fa-484e2731a85a",
 			"quantity": 1,
 			"description": "Throwing Stick",
 			"tech_level": "0",
@@ -26756,7 +26060,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "576c9652-22eb-4831-89d8-fdb2e8b47822",
 			"quantity": 1,
 			"description": "Thrusting Bastard Sword",
 			"tech_level": "3",
@@ -26934,7 +26237,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "5f215cb5-7b83-45fb-abb1-98ae8f36b43f",
 			"quantity": 1,
 			"description": "Thrusting Broadsword",
 			"tech_level": "2",
@@ -27046,7 +26348,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "eb2b5b8a-f004-41fe-b5ec-dc8b36e8cb1d",
 			"quantity": 1,
 			"description": "Thrusting Greatsword",
 			"tech_level": "3",
@@ -27128,7 +26429,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "7baf54c8-3b6c-4763-9248-0cae8827a18d",
 			"quantity": 1,
 			"description": "Tobacco",
 			"tech_level": "0",
@@ -27142,7 +26442,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "90986d69-eb05-4e07-940c-6600aef0cb29",
 			"quantity": 1,
 			"description": "Tonfa",
 			"tech_level": "3",
@@ -27233,7 +26532,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "8b1a46af-7d94-4b15-9cad-62deb51a1ee2",
 			"quantity": 1,
 			"description": "Torc, copper",
 			"tech_level": "0",
@@ -27247,7 +26545,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "eaae27a8-c0e5-45a6-abd5-9fb712403c06",
 			"quantity": 1,
 			"description": "Torc, gold",
 			"tech_level": "0",
@@ -27261,7 +26558,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "c203f79b-2900-45b4-abdc-c52718200d8a",
 			"quantity": 1,
 			"description": "Torc, silver",
 			"tech_level": "0",
@@ -27275,7 +26571,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "2e0769d5-f478-49e3-b642-f93390410412",
 			"quantity": 1,
 			"description": "Torture Kit",
 			"tech_level": "2",
@@ -27289,7 +26584,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "46246230-4e95-48b9-a886-6efb453bdca4",
 			"quantity": 1,
 			"description": "Tourniquet",
 			"tech_level": "0",
@@ -27302,7 +26596,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "0e5c832e-1f84-4813-96aa-528409124fe0",
 			"quantity": 1,
 			"description": "Traction Bench",
 			"tech_level": "2",
@@ -27316,7 +26609,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "9851d281-206e-4ec1-97c0-c3a9f0fbf4ae",
 			"quantity": 1,
 			"description": "Trebuchet, Hinged, Large",
 			"tech_level": "3",
@@ -27360,7 +26652,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "6063e527-247f-48df-9509-765fc8b4b288",
 			"quantity": 1,
 			"description": "Trebuchet, Hinged, Small",
 			"tech_level": "3",
@@ -27404,7 +26695,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "de2fbffb-46c9-4afe-9cf2-1816e4b46a5d",
 			"quantity": 1,
 			"description": "Trebuchet, Large",
 			"tech_level": "3",
@@ -27448,7 +26738,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "ce03267d-5953-4ecc-a657-80063509ef13",
 			"quantity": 1,
 			"description": "Trebuchet, Large Stone",
 			"tech_level": "3",
@@ -27462,7 +26751,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "62301383-abf7-47d4-b46b-1bf0e04296a1",
 			"quantity": 1,
 			"description": "Trebuchet, Small",
 			"tech_level": "3",
@@ -27506,7 +26794,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "bfade0a6-917a-4f2d-909e-2bf498257880",
 			"quantity": 1,
 			"description": "Trebuchet, Small Stone",
 			"tech_level": "3",
@@ -27520,7 +26807,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "cafca4c9-efd3-49c5-bacf-4f48b75189bf",
 			"quantity": 1,
 			"description": "Trephin",
 			"tech_level": "2",
@@ -27534,7 +26820,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "2306fa2f-bb78-41bb-95be-4ca58719776e",
 			"quantity": 1,
 			"description": "Trident",
 			"tech_level": "2",
@@ -27618,7 +26903,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "4b97e295-6779-437d-8396-c2883b791674",
 			"quantity": 1,
 			"description": "Trumpet",
 			"tech_level": "2",
@@ -27632,7 +26916,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "cb9c0335-bb11-4178-9fdd-28b74a5c75b1",
 			"quantity": 1,
 			"description": "Tubular Bow",
 			"tech_level": "4",
@@ -27673,7 +26956,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "fee0319d-f319-49c1-a2e7-c37b2534f9ce",
 			"quantity": 1,
 			"description": "Tweezers",
 			"tech_level": "1",
@@ -27686,7 +26968,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "8c918c65-d9d5-4468-b749-2b2b22a04e17",
 			"quantity": 1,
 			"description": "Two-Handed Macuahuitl",
 			"tech_level": "0",
@@ -27769,7 +27050,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "0e751947-71c7-442e-95f0-59e6c957e56a",
 			"quantity": 1,
 			"description": "Urumi",
 			"tech_level": "3",
@@ -27852,7 +27132,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "16c16da7-6b55-4c39-b1bc-6da8c944fbc7",
 			"quantity": 1,
 			"description": "Vellum, per sheet",
 			"tech_level": "2",
@@ -27866,7 +27145,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "6f652967-925a-468f-ae80-d7a953df69d3",
 			"quantity": 1,
 			"description": "Veuglaire",
 			"tech_level": "3",
@@ -27908,7 +27186,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "37e7da24-5635-4668-bece-c4ba346f6a7f",
 			"quantity": 1,
 			"description": "Veuglaire Stone",
 			"tech_level": "3",
@@ -27922,7 +27199,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "f764d6d9-b1f2-4682-b922-f89128567ace",
 			"quantity": 1,
 			"description": "Viper Venom",
 			"tech_level": "0",
@@ -27936,7 +27212,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "cf1874d7-c61e-46ed-936d-42ae3f29fa18",
 			"quantity": 1,
 			"description": "Voyageur Canoe, 35’",
 			"tech_level": "4",
@@ -27950,7 +27225,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "6d179413-0299-44f6-a406-8adbc16ec841",
 			"quantity": 1,
 			"description": "Wagon",
 			"tech_level": "3",
@@ -27965,7 +27239,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "092b7aca-f2da-44ba-8206-64fd9841908b",
 			"quantity": 1,
 			"description": "Wall Gun",
 			"tech_level": "4",
@@ -28013,7 +27286,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "d5516aad-0070-4c88-994b-ee2c5bf5d089",
 			"quantity": 1,
 			"description": "Wall Gun Bullet",
 			"tech_level": "4",
@@ -28027,7 +27299,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "060cda01-3689-4e99-bb37-67ac5ed82cea",
 			"quantity": 1,
 			"description": "War Canoe, 60’",
 			"tech_level": "0",
@@ -28041,7 +27312,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "356bab10-12fa-4ee4-93b0-9410578bbee7",
 			"quantity": 1,
 			"description": "War Wagon",
 			"tech_level": "3",
@@ -28056,7 +27326,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "338e9fcd-787e-44ec-87a2-06e08f8fcee5",
 			"quantity": 1,
 			"description": "Warhammer",
 			"tech_level": "3",
@@ -28110,7 +27379,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "8b83cee0-32cf-4772-981c-5ec2703912c7",
 			"quantity": 1,
 			"description": "Water Pipe",
 			"tech_level": "2",
@@ -28124,7 +27392,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "1e662c5e-180d-491d-8a27-08d89a7dce43",
 			"quantity": 1,
 			"description": "Wax Tablet, Large",
 			"tech_level": "2",
@@ -28138,7 +27405,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "1148e054-2dcc-4227-917b-ffb8323278b2",
 			"quantity": 1,
 			"description": "Wax Tablet, Small",
 			"tech_level": "2",
@@ -28152,7 +27418,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "41e9d91b-ad5b-4201-8d13-3e9e0dbef7e6",
 			"quantity": 1,
 			"description": "Weighted Scarf",
 			"tech_level": "0",
@@ -28220,7 +27485,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "9669c1bc-0c31-4f10-b9a8-87bfd0fc92ec",
 			"quantity": 1,
 			"description": "Whip, 1 yd",
 			"tech_level": "1",
@@ -28270,7 +27534,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "3cb4c59a-947e-4c82-b3f2-e6d01c006351",
 			"quantity": 1,
 			"description": "Whip, 2 yd",
 			"tech_level": "1",
@@ -28320,7 +27583,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "9505fa66-d55d-4ed4-9a80-15042aa03dd8",
 			"quantity": 1,
 			"description": "Whip, 3 yd",
 			"tech_level": "1",
@@ -28370,7 +27632,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "a40f19f2-efbd-4044-acf4-b99eba0bdbbc",
 			"quantity": 1,
 			"description": "Whip, 4 yd",
 			"tech_level": "1",
@@ -28420,7 +27681,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "0d7b0c05-6f84-4366-bb8c-0734397b0a99",
 			"quantity": 1,
 			"description": "Whip, 5 yd",
 			"tech_level": "1",
@@ -28470,7 +27730,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "1b209070-701e-42c2-a4be-5db368278c84",
 			"quantity": 1,
 			"description": "Whip, 6 yd",
 			"tech_level": "1",
@@ -28520,7 +27779,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "3049da54-8cf1-4d90-b06b-ca0a4bda201f",
 			"quantity": 1,
 			"description": "Whip, 7 yd",
 			"tech_level": "1",
@@ -28570,7 +27828,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "ae844c70-a1d6-446a-987f-456407cd724a",
 			"description": "Wicker Basket, 1 cup",
 			"tech_level": "0",
 			"value": "0.15",
@@ -28599,7 +27856,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "cb5f2d0c-b5e4-44ac-875f-a5b2b2cea82c",
 			"description": "Wicker Basket, 1 gal.",
 			"tech_level": "0",
 			"value": "1.75",
@@ -28628,7 +27884,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "ea377cde-19ad-4e7e-be80-4a461a08e48d",
 			"description": "Wicker Basket, 1 quart",
 			"tech_level": "0",
 			"value": "0.5",
@@ -28657,7 +27912,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "aec7732c-6730-451c-8f59-69f5f5d99911",
 			"description": "Wicker Basket, 1/4 cup",
 			"tech_level": "0",
 			"value": "0.1",
@@ -28685,7 +27939,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "d9f92d35-817e-4fbc-842b-f4ac610efb90",
 			"description": "Wicker Basket, 2 gal.",
 			"tech_level": "0",
 			"value": "3",
@@ -28714,7 +27967,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "e44646bd-b95c-441a-9605-0f949a3a5a87",
 			"description": "Wicker Basket, 6 gal.",
 			"tech_level": "0",
 			"value": "7.5",
@@ -28743,7 +27995,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "0991d81a-3d72-4c41-8932-c6597c333330",
 			"description": "Wicker Basket, 20 gal.",
 			"tech_level": "0",
 			"value": "16",
@@ -28772,7 +28023,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "8174091f-cce9-4c02-86c3-a9cd6bde524c",
 			"description": "Wicker Basket, 40 gal.",
 			"tech_level": "0",
 			"value": "39",
@@ -28801,7 +28051,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "f42d4395-7da1-4693-ad22-04de61bcaecc",
 			"description": "Wicker Basket, 80 gal.",
 			"tech_level": "0",
 			"value": "62",
@@ -28830,7 +28079,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "ac36e770-0fcc-42eb-a6c9-7d149063a9b1",
 			"description": "Wicker Basket, 120 gal.",
 			"tech_level": "0",
 			"value": "108",
@@ -28859,7 +28107,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "4ae610f1-1836-4c6f-9f92-ac23b59e837b",
 			"quantity": 1,
 			"description": "Winged Tiger Gun",
 			"tech_level": "4",
@@ -28906,7 +28153,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "41f9821e-db24-4dca-bc1d-0600fca031a7",
 			"quantity": 1,
 			"description": "Winged Tiger Gun Bullet",
 			"tech_level": "4",
@@ -28920,7 +28166,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "c75353ed-2318-4745-89ec-cafa478b1234",
 			"description": "Wooden Box or Barrel, 1 cup",
 			"tech_level": "0",
 			"value": "1",
@@ -28949,7 +28194,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "742b71b2-9d81-4a8c-bbc8-a253a284b693",
 			"description": "Wooden Box or Barrel, 1 gal.",
 			"tech_level": "0",
 			"value": "10",
@@ -28978,7 +28222,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "b9d103de-c1ed-4e11-8da1-d43df5fe208f",
 			"description": "Wooden Box or Barrel, 1 quart",
 			"tech_level": "0",
 			"value": "3",
@@ -29007,7 +28250,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "899295e7-f0f4-4870-aee4-125d044f40f4",
 			"description": "Wooden Box or Barrel, 1/4 cup",
 			"tech_level": "0",
 			"value": "0.5",
@@ -29036,7 +28278,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "afa5501c-25fc-4247-b3df-454bf0eb4ea8",
 			"description": "Wooden Box or Barrel, 2 gal.",
 			"tech_level": "0",
 			"value": "17",
@@ -29065,7 +28306,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "f933eede-249c-4212-9e4a-109926f4dd24",
 			"description": "Wooden Box or Barrel, 6 gal.",
 			"tech_level": "0",
 			"value": "31",
@@ -29094,7 +28334,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "41dfa742-3c6e-445a-9b12-4db864eb3487",
 			"description": "Wooden Box or Barrel, 20 gal.",
 			"tech_level": "0",
 			"value": "55",
@@ -29123,7 +28362,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "41b02794-4d95-4f31-9482-24f050d468c6",
 			"description": "Wooden Box or Barrel, 40 gal.",
 			"tech_level": "0",
 			"value": "113",
@@ -29152,7 +28390,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "0a282689-c4ad-461d-8e99-244f7eb22338",
 			"description": "Wooden Box or Barrel, 80 gal.",
 			"tech_level": "0",
 			"value": "178",
@@ -29181,7 +28418,6 @@
 		{
 			"type": "equipment_container",
 			"version": 1,
-			"id": "ac69717f-a666-42bf-99ec-9945353237aa",
 			"description": "Wooden Box or Barrel, 120 gal.",
 			"tech_level": "0",
 			"value": "239",
@@ -29210,7 +28446,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "22e11241-9772-4971-ad31-6bdb45ebe04e",
 			"quantity": 1,
 			"description": "Wooden Stake",
 			"tech_level": "0",
@@ -29291,7 +28526,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "5258f199-41c9-4a1b-bc1e-f79545fb914c",
 			"quantity": 1,
 			"description": "Woomera",
 			"tech_level": "0",
@@ -29339,7 +28573,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "878bde4a-ba2c-4113-9279-22597dc5dde3",
 			"quantity": 1,
 			"description": "Parrying Buckler",
 			"tech_level": "0",
@@ -29413,7 +28646,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "f6030aab-27a2-45eb-a505-b651683269ed",
 			"quantity": 1,
 			"description": "Small Shield, Light",
 			"tech_level": "0",
@@ -29487,7 +28719,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "9565a3af-968f-46d4-955e-98efa14edc0c",
 			"quantity": 1,
 			"description": "Comanche Shield",
 			"tech_level": "0",
@@ -29562,7 +28793,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "6fa638fc-cbd0-4d3e-a58b-1045f58e57a8",
 			"quantity": 1,
 			"description": "Medium Shield, Light",
 			"tech_level": "0",
@@ -29636,7 +28866,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "f3149fd8-207f-44de-8a96-28aecfcc201b",
 			"quantity": 1,
 			"description": "Large Shield, Light",
 			"tech_level": "0",
@@ -29710,7 +28939,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "4bc746ac-3fe7-49ac-a666-8b0c68282d11",
 			"quantity": 1,
 			"description": "Mycenaean Shield",
 			"tech_level": "0",
@@ -29784,7 +29012,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "9334ff62-6e77-4c9f-a31e-640ffc9e44f1",
 			"quantity": 1,
 			"description": "Small Shield, Heavy",
 			"tech_level": "1",
@@ -29858,7 +29085,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "d15a35a8-8a54-40b7-9384-55129be13641",
 			"quantity": 1,
 			"description": "Homeric Buckler, Medium",
 			"tech_level": "1",
@@ -29932,7 +29158,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "8c708e6c-dac5-4d8b-b693-cc2dc60758ab",
 			"quantity": 1,
 			"description": "Medium Shield, Heavy",
 			"tech_level": "1",
@@ -30006,7 +29231,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "28b6919f-0138-41a6-8d76-a61f5d239396",
 			"quantity": 1,
 			"description": "Homeric Buckler, Large",
 			"tech_level": "1",
@@ -30080,7 +29304,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "acb94423-d8c6-4609-98c8-60fce8346634",
 			"quantity": 1,
 			"description": "Large Shield, Heavy",
 			"tech_level": "1",
@@ -30154,7 +29377,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "5f2d02c7-a8be-475d-998a-5a7b047e64dc",
 			"quantity": 1,
 			"description": "Argive Shield",
 			"tech_level": "2",
@@ -30229,7 +29451,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "a3d6dd07-08f4-46b0-86d1-66e02c02b7b5",
 			"quantity": 1,
 			"description": "Roman Scutum, Medium",
 			"tech_level": "2",
@@ -30304,7 +29525,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "2c4cfec3-81c3-496d-8a18-c7662e821df5",
 			"quantity": 1,
 			"description": "Roman Scutum, Large",
 			"tech_level": "2",
@@ -30379,7 +29599,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "1ca0975c-2e19-4b9b-98d7-edcc89cea045",
 			"quantity": 1,
 			"description": "Dueling Buckler",
 			"tech_level": "3",
@@ -30437,7 +29656,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "7de1a1d7-5422-46c2-8cac-b519ea9d6e33",
 			"quantity": 1,
 			"description": "Heater Shield",
 			"tech_level": "3",
@@ -30511,7 +29729,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "22c7bc9e-5453-445e-82b5-eaef61c997ad",
 			"quantity": 1,
 			"description": "Kite Shield",
 			"tech_level": "3",
@@ -30585,7 +29802,6 @@
 		{
 			"type": "equipment",
 			"version": 1,
-			"id": "d63c3c87-3430-4e06-9902-63dc705db8ae",
 			"quantity": 1,
 			"description": "Dueling Long Shield",
 			"tech_level": "4",

--- a/Library/Low Tech/Low Tech Equipment.eqp
+++ b/Library/Low Tech/Low Tech Equipment.eqp
@@ -10696,7 +10696,7 @@
 					},
 					"strength": "11†",
 					"usage": "Thrust - tip slash",
-					"reach": "3",
+					"reach": "2,3*",
 					"parry": "0U",
 					"block": "No",
 					"defaults": [


### PR DESCRIPTION
[Low Tech Equipment library] Heavy Spear, Tip Slash Attack: Changed Reach to 2,3* from 3, to match official GURPS Low-Tech Errata (http://www.sjgames.com/errata/gurps/4e/low-tech.html). 
First time submitting a pull request, so apologies for any errors.