### PR TITLE
Reinstate Advantage modifier notes (so Self Control rolls appear in the notes)

### DIFF
--- a/Library/Output Templates/Foundry VTT.xml
+++ b/Library/Output Templates/Foundry VTT.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
 @ENHANCED_KEY_PARSING
-<root release="Foundry" version="GCS-2">
+<root release="Foundry" version="GCS-3">
   <character>
     <name type="string">@NAME</name>
     <portrait>@PORTRAIT</portrait>
@@ -186,7 +186,7 @@
           <name type="string">@DESCRIPTION_PRIMARY</name>
           <points type="number">@POINTS</points>
           <userdesc type="string">@DESCRIPTION_USER</userdesc>
-	    <notes type="string">@DESCRIPTION_NOTES</notes>
+	    <notes type="string">@DESCRIPTION_NOTES @DESCRIPTION_MODIFIER_NOTES_BRACKET</notes>
 	    <pageref>@REF</pageref>
 	    <type>@TYPE</type>
           <uuid>@ID</uuid>


### PR DESCRIPTION
Wow, sorry to throw a change at you so quickly.   But I guess my "cleanup" of version 2 removed a critical key for self control rolls... the genesis of my whole "On-the-Fly" system.    Yes, I thought up the whole OtF system seeing how the self control rolls exported as [CR: 12 Bad Temper] for Fantasy Grounds.   I thought, hey, I could parse text looking for things enclosed in square brackets... and voila, OtF was born.