### PR TITLE
Add Illiteracy; adjust Research

### DIFF
--- a/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Advantages.adq
+++ b/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Advantages.adq
@@ -4760,6 +4760,19 @@
 		{
 			"type": "advantage",
 			"version": 1,
+			"id": "5da5b487-a52b-4418-8e77-09766c232acf",
+			"name": "Illiteracy",
+			"mental": true,
+			"base_points": -3,
+			"reference": "DFA61",
+			"categories": [
+				"Disadvantage",
+				"Language"
+			]
+		},
+		{
+			"type": "advantage",
+			"version": 1,
 			"id": "39ae24b1-2eee-411d-a416-fef7ef1a1df5",
 			"name": "Immunity",
 			"physical": true,

--- a/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl
+++ b/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl
@@ -3694,64 +3694,12 @@
 				"all": true,
 				"prereqs": [
 					{
-						"type": "prereq_list",
-						"all": true,
-						"when_tl": {
-							"compare": "at_least",
-							"qualifier": 8
-						},
-						"prereqs": [
-							{
-								"type": "skill_prereq",
-								"has": true,
-								"name": {
-									"compare": "is",
-									"qualifier": "Computer Operation"
-								}
-							}
-						]
-					},
-					{
-						"type": "prereq_list",
-						"all": false,
-						"prereqs": [
-							{
-								"type": "advantage_prereq",
-								"has": true,
-								"name": {
-									"compare": "starts_with",
-									"qualifier": "Language"
-								},
-								"notes": {
-									"compare": "contains",
-									"qualifier": "Written (Native"
-								}
-							},
-							{
-								"type": "advantage_prereq",
-								"has": true,
-								"name": {
-									"compare": "starts_with",
-									"qualifier": "Language"
-								},
-								"notes": {
-									"compare": "contains",
-									"qualifier": "Written (Accented)"
-								}
-							},
-							{
-								"type": "advantage_prereq",
-								"has": true,
-								"name": {
-									"compare": "starts_with",
-									"qualifier": "Language"
-								},
-								"notes": {
-									"compare": "contains",
-									"qualifier": "Written (Broken)"
-								}
-							}
-						]
+						"type": "advantage_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Illiteracy"
+						}
 					}
 				]
 			},


### PR DESCRIPTION
Added the Illiteracy disadvantage from DFRPG Adventurers (p. 61).
Adjusted the Research skill to replace the prereqs from Basic with the correct one from DFRPG (namely, that the character does not have the Illiteracy disadvantage).