### PR TITLE
Fix broken one college prerequisites and rename abbreviated colleges to make it easier

### DIFF
--- a/Library/Magic/Magic Spells.spl
+++ b/Library/Magic/Magic Spells.spl
@@ -4747,7 +4747,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -4784,7 +4784,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -6619,7 +6619,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -6696,7 +6696,7 @@
 								},
 								"notes": {
 									"compare": "contains",
-									"qualifier": "one college (communication)"
+									"qualifier": "one college (communication & empathy)"
 								}
 							},
 							{
@@ -6733,7 +6733,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -7710,7 +7710,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -11454,7 +11454,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -12774,7 +12774,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -12825,7 +12825,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -12876,7 +12876,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -15144,7 +15144,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -18354,7 +18354,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -18421,7 +18421,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -20224,7 +20224,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -20361,7 +20361,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -22066,7 +22066,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -23208,7 +23208,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -23348,7 +23348,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -25106,7 +25106,7 @@
 				]
 			},
 			"categories": [
-				"Communication",
+				"Communication & Empathy",
 				"Technological"
 			]
 		},
@@ -26417,7 +26417,7 @@
 				]
 			},
 			"categories": [
-				"Communication",
+				"Communication & Empathy",
 				"Sound"
 			]
 		},
@@ -26545,7 +26545,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -26583,7 +26583,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -26620,7 +26620,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -28961,7 +28961,7 @@
 								},
 								"notes": {
 									"compare": "contains",
-									"qualifier": "one college (communication)"
+									"qualifier": "one college (communication & empathy)"
 								}
 							},
 							{
@@ -28998,7 +28998,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -29111,7 +29111,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -30373,7 +30373,7 @@
 								},
 								"notes": {
 									"compare": "contains",
-									"qualifier": "one college (communication)"
+									"qualifier": "one college (communication & empathy)"
 								}
 							},
 							{
@@ -30429,7 +30429,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -30716,7 +30716,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -35228,7 +35228,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -37256,7 +37256,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -37274,7 +37274,7 @@
 			"casting_time": "1 sec",
 			"duration": "Instant",
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -37292,7 +37292,7 @@
 			"casting_time": "1 sec",
 			"duration": "Instant",
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -39992,7 +39992,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -44786,7 +44786,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -46374,7 +46374,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -46778,7 +46778,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{

--- a/Library/Magic/Magic Spells.spl
+++ b/Library/Magic/Magic Spells.spl
@@ -3467,6 +3467,10 @@
 						"level": {
 							"compare": "at_least",
 							"qualifier": 1
+						},
+						"notes": {
+							"compare": "does_not_contain",
+							"qualifier": "one college"
 						}
 					}
 				]
@@ -3821,6 +3825,22 @@
 						"type": "prereq_list",
 						"all": false,
 						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (air)"
+								}
+							},
 							{
 								"type": "advantage_prereq",
 								"has": true,
@@ -5014,6 +5034,22 @@
 								},
 								"notes": {
 									"compare": "contains",
+									"qualifier": "one college (radiation)"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
+									"compare": "contains",
 									"qualifier": "one college (technological)"
 								}
 							},
@@ -5347,6 +5383,22 @@
 						"type": "prereq_list",
 						"all": false,
 						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (fire)"
+								}
+							},
 							{
 								"type": "advantage_prereq",
 								"has": true,
@@ -6096,6 +6148,22 @@
 						"type": "prereq_list",
 						"all": false,
 						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (movement)"
+								}
+							},
 							{
 								"type": "advantage_prereq",
 								"has": true,
@@ -6970,6 +7038,22 @@
 						"type": "prereq_list",
 						"all": false,
 						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (energy)"
+								}
+							},
 							{
 								"type": "advantage_prereq",
 								"has": true,
@@ -8207,6 +8291,10 @@
 						"level": {
 							"compare": "at_least",
 							"qualifier": 1
+						},
+						"notes": {
+							"compare": "does_not_contain",
+							"qualifier": "one college"
 						}
 					}
 				]
@@ -10118,6 +10206,10 @@
 						"level": {
 							"compare": "at_least",
 							"qualifier": 1
+						},
+						"notes": {
+							"compare": "does_not_contain",
+							"qualifier": "one college"
 						}
 					}
 				]
@@ -10914,6 +11006,10 @@
 						"level": {
 							"compare": "at_least",
 							"qualifier": 1
+						},
+						"notes": {
+							"compare": "does_not_contain",
+							"qualifier": "one college"
 						}
 					}
 				]
@@ -11548,6 +11644,22 @@
 						"type": "prereq_list",
 						"all": false,
 						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (gate)"
+								}
+							},
 							{
 								"type": "advantage_prereq",
 								"has": true,
@@ -13259,6 +13371,22 @@
 								},
 								"notes": {
 									"compare": "contains",
+									"qualifier": "one college (earth)"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "contains",
 									"qualifier": "one college (water)"
 								}
 							}
@@ -13459,6 +13587,22 @@
 								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (knowledge)"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (sound)"
 								}
 							},
 							{
@@ -14789,6 +14933,10 @@
 								"level": {
 									"compare": "at_least",
 									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							}
 						]
@@ -15404,6 +15552,22 @@
 								},
 								"notes": {
 									"compare": "contains",
+									"qualifier": "one college (radiation)"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
+									"compare": "contains",
 									"qualifier": "one college (technological)"
 								}
 							},
@@ -15629,6 +15793,10 @@
 						"level": {
 							"compare": "at_least",
 							"qualifier": 1
+						},
+						"notes": {
+							"compare": "does_not_contain",
+							"qualifier": "one college"
 						}
 					}
 				]
@@ -15804,6 +15972,22 @@
 								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (food)"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (knowledge)"
 								}
 							},
 							{
@@ -16032,6 +16216,22 @@
 								},
 								"notes": {
 									"compare": "contains",
+									"qualifier": "one college (healing)"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "contains",
 									"qualifier": "one college (necromancy)"
 								}
 							},
@@ -16104,6 +16304,10 @@
 						"level": {
 							"compare": "at_least",
 							"qualifier": 1
+						},
+						"notes": {
+							"compare": "does_not_contain",
+							"qualifier": "one college"
 						}
 					}
 				]
@@ -16976,6 +17180,10 @@
 										"level": {
 											"compare": "at_least",
 											"qualifier": 2
+										},
+										"notes": {
+											"compare": "does_not_contain",
+											"qualifier": "one college"
 										}
 									}
 								]
@@ -20544,6 +20752,22 @@
 									"qualifier": 1
 								},
 								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (food)"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
 									"compare": "does_not_contain",
 									"qualifier": "one college"
 								}
@@ -21423,6 +21647,22 @@
 								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (knowledge)"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (light)"
 								}
 							},
 							{
@@ -23020,6 +23260,22 @@
 								},
 								"notes": {
 									"compare": "contains",
+									"qualifier": "one college (energy)"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
+									"compare": "contains",
 									"qualifier": "one college (technological)"
 								}
 							},
@@ -23544,6 +23800,22 @@
 									"qualifier": 3
 								},
 								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (necromancy)"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
 									"compare": "does_not_contain",
 									"qualifier": "one college"
 								}
@@ -23838,6 +24110,22 @@
 								},
 								"notes": {
 									"compare": "contains",
+									"qualifier": "one college (air)"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "contains",
 									"qualifier": "one college (weather)"
 								}
 							},
@@ -24065,6 +24353,22 @@
 						"type": "prereq_list",
 						"all": false,
 						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (air)"
+								}
+							},
 							{
 								"type": "advantage_prereq",
 								"has": true,
@@ -24343,6 +24647,10 @@
 										"level": {
 											"compare": "at_least",
 											"qualifier": 2
+										},
+										"notes": {
+											"compare": "does_not_contain",
+											"qualifier": "one college"
 										}
 									}
 								]
@@ -25076,12 +25384,32 @@
 						"type": "advantage_prereq",
 						"has": true,
 						"name": {
+							"compare": "is",
+							"qualifier": "magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 1
+						},
+						"notes": {
+							"compare": "contains",
+							"qualifier": "one college (protection)"
+						}
+					},
+					{
+						"type": "advantage_prereq",
+						"has": true,
+						"name": {
 							"compare": "contains",
 							"qualifier": "magery"
 						},
 						"level": {
 							"compare": "at_least",
 							"qualifier": 1
+						},
+						"notes": {
+							"compare": "does_not_contain",
+							"qualifier": "one college"
 						}
 					}
 				]
@@ -27050,6 +27378,10 @@
 										"level": {
 											"compare": "at_least",
 											"qualifier": 3
+										},
+										"notes": {
+											"compare": "does_not_contain",
+											"qualifier": "one college"
 										}
 									}
 								]
@@ -31808,6 +32140,22 @@
 									"qualifier": 3
 								},
 								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (movement)"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
 									"compare": "does_not_contain",
 									"qualifier": "one college"
 								}
@@ -31985,6 +32333,22 @@
 								},
 								"notes": {
 									"compare": "contains",
+									"qualifier": "one college (making & breaking)"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
 									"qualifier": "one college (technological)"
 								}
 							},
@@ -32062,6 +32426,22 @@
 						"type": "prereq_list",
 						"all": false,
 						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (knowledge)"
+								}
+							},
 							{
 								"type": "advantage_prereq",
 								"has": true,
@@ -35633,6 +36013,22 @@
 									"qualifier": 2
 								},
 								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (knowledge)"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
 									"compare": "does_not_contain",
 									"qualifier": "one college"
 								}
@@ -37038,6 +37434,10 @@
 										"level": {
 											"compare": "at_least",
 											"qualifier": 1
+										},
+										"notes": {
+											"compare": "does_not_contain",
+											"qualifier": "one college"
 										}
 									}
 								]
@@ -38090,6 +38490,10 @@
 						"level": {
 							"compare": "at_least",
 							"qualifier": 2
+						},
+						"notes": {
+							"compare": "does_not_contain",
+							"qualifier": "one college"
 						}
 					}
 				]
@@ -40968,6 +41372,22 @@
 								},
 								"notes": {
 									"compare": "contains",
+									"qualifier": "one college (energy)"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
+									"compare": "contains",
 									"qualifier": "one college (technological)"
 								}
 							},
@@ -42040,6 +42460,22 @@
 								},
 								"notes": {
 									"compare": "contains",
+									"qualifier": "one college (energy)"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "contains",
 									"qualifier": "one college (technological)"
 								}
 							},
@@ -42283,6 +42719,22 @@
 								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (body control)"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (necromancy)"
 								}
 							},
 							{
@@ -44435,6 +44887,22 @@
 								},
 								"notes": {
 									"compare": "contains",
+									"qualifier": "one college (gate)"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
 									"qualifier": "one college (movement)"
 								}
 							},
@@ -44814,6 +45282,22 @@
 								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (body control)"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (food)"
 								}
 							},
 							{
@@ -47026,6 +47510,10 @@
 						"level": {
 							"compare": "at_least",
 							"qualifier": 1
+						},
+						"notes": {
+							"compare": "does_not_contain",
+							"qualifier": "one college"
 						}
 					}
 				]

--- a/Library/Magic/Magic Spells.spl
+++ b/Library/Magic/Magic Spells.spl
@@ -3112,7 +3112,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -3563,7 +3563,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -4072,7 +4072,7 @@
 								},
 								"notes": {
 									"compare": "contains",
-									"qualifier": "one college (light)"
+									"qualifier": "one college (light & darkness)"
 								}
 							},
 							{
@@ -4122,7 +4122,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -5289,7 +5289,7 @@
 								"sub_type": "college",
 								"qualifier": {
 									"compare": "contains",
-									"qualifier": "Light"
+									"qualifier": "Light & Darkness"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -5301,7 +5301,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -6416,7 +6416,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -7129,7 +7129,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -7179,7 +7179,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -7216,7 +7216,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -10084,7 +10084,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -10121,7 +10121,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -16923,7 +16923,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -18586,7 +18586,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -18623,7 +18623,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -19912,7 +19912,7 @@
 								"sub_type": "college",
 								"qualifier": {
 									"compare": "contains",
-									"qualifier": "Light"
+									"qualifier": "Light & Darkness"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -19924,7 +19924,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -20187,7 +20187,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -21662,7 +21662,7 @@
 								},
 								"notes": {
 									"compare": "contains",
-									"qualifier": "one college (light)"
+									"qualifier": "one college (light & darkness)"
 								}
 							},
 							{
@@ -21903,7 +21903,7 @@
 						"sub_type": "college",
 						"qualifier": {
 							"compare": "contains",
-							"qualifier": "Light"
+							"qualifier": "Light & Darkness"
 						},
 						"quantity": {
 							"compare": "at_least",
@@ -21913,7 +21913,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -22336,7 +22336,7 @@
 						"sub_type": "college",
 						"qualifier": {
 							"compare": "contains",
-							"qualifier": "Light"
+							"qualifier": "Light & Darkness"
 						},
 						"quantity": {
 							"compare": "at_least",
@@ -22359,7 +22359,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -23853,7 +23853,7 @@
 			"casting_time": "1 sec",
 			"duration": "1 min",
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -23926,7 +23926,7 @@
 			},
 			"notes": "blinds only when darkness penalty is -5 or more",
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -25247,7 +25247,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -26770,7 +26770,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -27444,7 +27444,7 @@
 						"sub_type": "college",
 						"qualifier": {
 							"compare": "contains",
-							"qualifier": "Light"
+							"qualifier": "Light & Darkness"
 						},
 						"quantity": {
 							"compare": "at_least",
@@ -27454,7 +27454,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -33495,7 +33495,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -33533,7 +33533,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -36601,7 +36601,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -37673,7 +37673,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -37784,7 +37784,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -39556,7 +39556,7 @@
 								"sub_type": "college",
 								"qualifier": {
 									"compare": "contains",
-									"qualifier": "Light"
+									"qualifier": "Light & Darkness"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -39568,7 +39568,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -43879,7 +43879,7 @@
 						"sub_type": "college",
 						"qualifier": {
 							"compare": "contains",
-							"qualifier": "Light"
+							"qualifier": "Light & Darkness"
 						},
 						"quantity": {
 							"compare": "at_least",
@@ -43902,7 +43902,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -43940,7 +43940,7 @@
 								},
 								"notes": {
 									"compare": "contains",
-									"qualifier": "one college (light)"
+									"qualifier": "one college (light & darkness)"
 								}
 							},
 							{
@@ -43990,7 +43990,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -47313,7 +47313,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{

--- a/Library/Magic/Magic Spells.spl
+++ b/Library/Magic/Magic Spells.spl
@@ -1914,7 +1914,7 @@
 			"name": "Armor",
 			"reference": "M167",
 			"difficulty": "IQ/H",
-			"college": "Protection",
+			"college": "Protection & Warning",
 			"power_source": "Arcane",
 			"spell_class": "Regular",
 			"casting_cost": "2 per DR",
@@ -1941,7 +1941,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -2052,7 +2052,7 @@
 			"name": "Atmosphere Dome",
 			"reference": "M169",
 			"difficulty": "IQ/H",
-			"college": "Protection",
+			"college": "Protection & Warning",
 			"power_source": "Arcane",
 			"spell_class": "Area",
 			"casting_cost": "4",
@@ -2092,7 +2092,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -3122,7 +3122,7 @@
 			"name": "Bladeturning",
 			"reference": "M168",
 			"difficulty": "IQ/H",
-			"college": "Protection",
+			"college": "Protection & Warning",
 			"power_source": "Arcane",
 			"spell_class": "Regular",
 			"casting_cost": "2",
@@ -3162,7 +3162,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -3430,7 +3430,7 @@
 			"name": "Block",
 			"reference": "M166",
 			"difficulty": "IQ/H",
-			"college": "Protection",
+			"college": "Protection & Warning",
 			"power_source": "Arcane",
 			"spell_class": "Blocking",
 			"casting_cost": "1 per DB",
@@ -3454,7 +3454,7 @@
 						},
 						"notes": {
 							"compare": "contains",
-							"qualifier": "one college (protection)"
+							"qualifier": "one college (protection & warning)"
 						}
 					},
 					{
@@ -3476,7 +3476,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -5615,7 +5615,7 @@
 			"name": "Catch Missile",
 			"reference": "M168",
 			"difficulty": "IQ/H",
-			"college": "Protection",
+			"college": "Protection & Warning",
 			"power_source": "Arcane",
 			"spell_class": "Blocking",
 			"casting_cost": "2",
@@ -5642,7 +5642,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -7984,7 +7984,7 @@
 			"name": "Coolness",
 			"reference": "M187",
 			"difficulty": "IQ/H",
-			"college": "Protection or Water",
+			"college": "Protection & Warning or Water",
 			"power_source": "Arcane",
 			"spell_class": "Regular",
 			"casting_cost": "2",
@@ -8011,7 +8011,7 @@
 				]
 			},
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Water"
 			]
 		},
@@ -10635,7 +10635,7 @@
 			"name": "Deflect Missile",
 			"reference": "M143",
 			"difficulty": "IQ/H",
-			"college": "Movement or Protection",
+			"college": "Movement or Protection & Warning",
 			"power_source": "Arcane",
 			"spell_class": "Blocking",
 			"casting_cost": "1",
@@ -10663,7 +10663,7 @@
 			},
 			"categories": [
 				"Movement",
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -11025,7 +11025,7 @@
 			"name": "Detect Poison",
 			"reference": "M166",
 			"difficulty": "IQ/H",
-			"college": "Healing or Protection",
+			"college": "Healing or Protection & Warning",
 			"power_source": "Arcane",
 			"spell_class": "Area/Info",
 			"casting_cost": "2",
@@ -11066,7 +11066,7 @@
 			},
 			"categories": [
 				"Healing",
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -17389,7 +17389,7 @@
 			"name": "Force Dome",
 			"reference": "M170",
 			"difficulty": "IQ/H",
-			"college": "Protection",
+			"college": "Protection & Warning",
 			"power_source": "Arcane",
 			"spell_class": "Area",
 			"casting_cost": "3",
@@ -17417,7 +17417,7 @@
 								},
 								"notes": {
 									"compare": "contains",
-									"qualifier": "one college (protection)"
+									"qualifier": "one college (protection & warning)"
 								}
 							},
 							{
@@ -17467,7 +17467,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -17477,7 +17477,7 @@
 			"name": "Force Wall",
 			"reference": "M170",
 			"difficulty": "IQ/H",
-			"college": "Protection",
+			"college": "Protection & Warning",
 			"power_source": "Arcane",
 			"spell_class": "Regular",
 			"casting_cost": "2/yd",
@@ -17504,7 +17504,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -19778,7 +19778,7 @@
 			"name": "Hardiness",
 			"reference": "M167",
 			"difficulty": "IQ/H",
-			"college": "Protection",
+			"college": "Protection & Warning",
 			"power_source": "Arcane",
 			"spell_class": "Blocking",
 			"casting_cost": "1 per DR",
@@ -19805,7 +19805,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -22469,7 +22469,7 @@
 			"name": "Iron Arm",
 			"reference": "M169",
 			"difficulty": "IQ/H",
-			"college": "Protection",
+			"college": "Protection & Warning",
 			"power_source": "Arcane",
 			"spell_class": "Blocking",
 			"casting_cost": "1",
@@ -22505,7 +22505,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -25368,7 +25368,7 @@
 			"name": "Magelock",
 			"reference": "M166",
 			"difficulty": "IQ/H",
-			"college": "Protection",
+			"college": "Protection & Warning",
 			"power_source": "Arcane",
 			"spell_class": "Regular",
 			"resist": "Lockmaster",
@@ -25393,7 +25393,7 @@
 						},
 						"notes": {
 							"compare": "contains",
-							"qualifier": "one college (protection)"
+							"qualifier": "one college (protection & warning)"
 						}
 					},
 					{
@@ -25415,7 +25415,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -26780,7 +26780,7 @@
 			"name": "Missile Shield",
 			"reference": "M168",
 			"difficulty": "IQ/H",
-			"college": "Protection",
+			"college": "Protection & Warning",
 			"power_source": "Arcane",
 			"spell_class": "Regular",
 			"casting_cost": "5",
@@ -26820,7 +26820,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -27130,7 +27130,7 @@
 			"name": "Mystic Mist",
 			"reference": "M168",
 			"difficulty": "IQ/H",
-			"college": "Protection",
+			"college": "Protection & Warning",
 			"power_source": "Arcane",
 			"spell_class": "Area",
 			"casting_cost": "1",
@@ -27190,7 +27190,7 @@
 								},
 								"notes": {
 									"compare": "contains",
-									"qualifier": "one college (protection)"
+									"qualifier": "one college (protection & warning)"
 								}
 							},
 							{
@@ -27214,7 +27214,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -27464,7 +27464,7 @@
 			"name": "Nightingale",
 			"reference": "M167",
 			"difficulty": "IQ/H",
-			"college": "Protection",
+			"college": "Protection & Warning",
 			"power_source": "Arcane",
 			"spell_class": "Area",
 			"casting_cost": "2",
@@ -27491,7 +27491,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -32691,7 +32691,7 @@
 			"name": "Reflect Gaze",
 			"reference": "M168",
 			"difficulty": "IQ/VH",
-			"college": "Protection",
+			"college": "Protection & Warning",
 			"power_source": "Arcane",
 			"spell_class": "Blocking",
 			"resist": "Gaze attacks",
@@ -32719,7 +32719,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -34121,7 +34121,7 @@
 			"name": "Resist Acid",
 			"reference": "M190",
 			"difficulty": "IQ/H",
-			"college": "Protection or Water",
+			"college": "Protection & Warning or Water",
 			"power_source": "Arcane",
 			"spell_class": "Regular",
 			"casting_cost": "2 or 6",
@@ -34148,7 +34148,7 @@
 				]
 			},
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Water"
 			]
 		},
@@ -34196,7 +34196,7 @@
 			"name": "Resist Disease",
 			"reference": "M90",
 			"difficulty": "IQ/H",
-			"college": "Healing or Protection",
+			"college": "Healing or Protection & Warning",
 			"power_source": "Arcane",
 			"spell_class": "Regular",
 			"casting_cost": "4",
@@ -34237,7 +34237,7 @@
 			},
 			"categories": [
 				"Healing",
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -34321,7 +34321,7 @@
 			"name": "Resist Lightning",
 			"reference": "M196",
 			"difficulty": "IQ/H",
-			"college": "Air or Protection or Weather",
+			"college": "Air or Protection & Warning or Weather",
 			"power_source": "Arcane",
 			"spell_class": "Regular",
 			"casting_cost": "2",
@@ -34349,7 +34349,7 @@
 			},
 			"categories": [
 				"Air",
-				"Protection",
+				"Protection & Warning",
 				"Weather"
 			]
 		},
@@ -34435,7 +34435,7 @@
 			"name": "Resist Poison",
 			"reference": "M91",
 			"difficulty": "IQ/H",
-			"college": "Healing or Protection",
+			"college": "Healing or Protection & Warning",
 			"power_source": "Arcane",
 			"spell_class": "Regular",
 			"casting_cost": "4",
@@ -34463,7 +34463,7 @@
 			},
 			"categories": [
 				"Healing",
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -34473,7 +34473,7 @@
 			"name": "Resist Pressure",
 			"reference": "M169",
 			"difficulty": "IQ/H",
-			"college": "Protection",
+			"college": "Protection & Warning",
 			"power_source": "Arcane",
 			"spell_class": "Regular",
 			"casting_cost": "Varies",
@@ -34500,7 +34500,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -34510,7 +34510,7 @@
 			"name": "Resist Radiation",
 			"reference": "M182",
 			"difficulty": "IQ/H",
-			"college": "Protection or Technological or Radiation",
+			"college": "Protection & Warning or Technological or Radiation",
 			"power_source": "Arcane",
 			"spell_class": "Regular",
 			"casting_cost": "Varies",
@@ -34537,7 +34537,7 @@
 				]
 			},
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Radiation",
 				"Technological"
 			]
@@ -34549,7 +34549,7 @@
 			"name": "Resist Sound",
 			"reference": "M173",
 			"difficulty": "IQ/H",
-			"college": "Protection or Sound",
+			"college": "Protection & Warning or Sound",
 			"power_source": "Arcane",
 			"spell_class": "Regular",
 			"casting_cost": "2",
@@ -34576,7 +34576,7 @@
 				]
 			},
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Sound"
 			]
 		},
@@ -34587,7 +34587,7 @@
 			"name": "Resist Water",
 			"reference": "M186",
 			"difficulty": "IQ/H",
-			"college": "Protection or Water",
+			"college": "Protection & Warning or Water",
 			"power_source": "Arcane",
 			"spell_class": "Regular",
 			"casting_cost": "2",
@@ -34646,7 +34646,7 @@
 				]
 			},
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Water"
 			]
 		},
@@ -35238,7 +35238,7 @@
 			"name": "Return Missile",
 			"reference": "M168",
 			"difficulty": "IQ/H",
-			"college": "Protection",
+			"college": "Protection & Warning",
 			"power_source": "Arcane",
 			"spell_class": "Blocking",
 			"casting_cost": "2",
@@ -35265,7 +35265,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -35315,7 +35315,7 @@
 			"name": "Reverse Missiles",
 			"reference": "M168",
 			"difficulty": "IQ/H",
-			"college": "Protection",
+			"college": "Protection & Warning",
 			"power_source": "Arcane",
 			"spell_class": "Regular",
 			"casting_cost": "7",
@@ -35355,7 +35355,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -37184,7 +37184,7 @@
 			"name": "Sense Danger",
 			"reference": "M166",
 			"difficulty": "IQ/H",
-			"college": "Protection",
+			"college": "Protection & Warning",
 			"power_source": "Arcane",
 			"spell_class": "Info",
 			"casting_cost": "3",
@@ -37219,7 +37219,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -37339,7 +37339,7 @@
 			"name": "Sense Observation",
 			"reference": "M167",
 			"difficulty": "IQ/H",
-			"college": "Protection",
+			"college": "Protection & Warning",
 			"power_source": "Arcane",
 			"spell_class": "Area",
 			"casting_cost": "1 or 3",
@@ -37379,7 +37379,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -37559,7 +37559,7 @@
 			"name": "Shade",
 			"reference": "M169",
 			"difficulty": "IQ/H",
-			"college": "Protection",
+			"college": "Protection & Warning",
 			"power_source": "Arcane",
 			"spell_class": "Regular",
 			"casting_cost": "1",
@@ -37599,7 +37599,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -38453,7 +38453,7 @@
 			"name": "Shield",
 			"reference": "M167",
 			"difficulty": "IQ/H",
-			"college": "Protection",
+			"college": "Protection & Warning",
 			"power_source": "Arcane",
 			"spell_class": "Regular",
 			"casting_cost": "2 per DB",
@@ -38477,7 +38477,7 @@
 						},
 						"notes": {
 							"compare": "contains",
-							"qualifier": "one college (protection)"
+							"qualifier": "one college (protection & warning)"
 						}
 					},
 					{
@@ -38499,7 +38499,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -44951,7 +44951,7 @@
 			"name": "Teleport Shield",
 			"reference": "M170",
 			"difficulty": "IQ/H",
-			"college": "Gate or Protection",
+			"college": "Gate or Protection & Warning",
 			"power_source": "Arcane",
 			"spell_class": "Area",
 			"casting_cost": "1#",
@@ -45011,7 +45011,7 @@
 			},
 			"categories": [
 				"Gate",
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -46384,7 +46384,7 @@
 			"name": "Turn Blade",
 			"reference": "M167",
 			"difficulty": "IQ/H",
-			"college": "Protection",
+			"college": "Protection & Warning",
 			"power_source": "Arcane",
 			"spell_class": "Blocking",
 			"casting_cost": "1",
@@ -46424,7 +46424,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -46522,7 +46522,7 @@
 			"name": "Umbrella",
 			"reference": "M185",
 			"difficulty": "IQ/H",
-			"college": "Protection or Water",
+			"college": "Protection & Warning or Water",
 			"power_source": "Arcane",
 			"spell_class": "Regular",
 			"casting_cost": "1",
@@ -46562,7 +46562,7 @@
 				]
 			},
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Water"
 			]
 		},
@@ -46611,7 +46611,7 @@
 			"name": "Utter Dome",
 			"reference": "M170",
 			"difficulty": "IQ/H",
-			"college": "Protection",
+			"college": "Protection & Warning",
 			"power_source": "Arcane",
 			"spell_class": "Area",
 			"casting_cost": "6",
@@ -46665,7 +46665,7 @@
 								},
 								"notes": {
 									"compare": "contains",
-									"qualifier": "one college (protection)"
+									"qualifier": "one college (protection & warning)"
 								}
 							},
 							{
@@ -46689,7 +46689,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -46699,7 +46699,7 @@
 			"name": "Utter Wall",
 			"reference": "M170",
 			"difficulty": "IQ/H",
-			"college": "Protection",
+			"college": "Protection & Warning",
 			"power_source": "Arcane",
 			"spell_class": "Regular",
 			"resist": "Intruding spells",
@@ -46740,7 +46740,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -47580,7 +47580,7 @@
 			"name": "Warmth",
 			"reference": "M74",
 			"difficulty": "IQ/H",
-			"college": "Fire or Protection",
+			"college": "Fire or Protection & Warning",
 			"power_source": "Arcane",
 			"spell_class": "Regular",
 			"casting_cost": "2",
@@ -47608,7 +47608,7 @@
 			},
 			"categories": [
 				"Fire",
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -47618,7 +47618,7 @@
 			"name": "Watchdog",
 			"reference": "M167",
 			"difficulty": "IQ/H",
-			"college": "Protection",
+			"college": "Protection & Warning",
 			"power_source": "Arcane",
 			"spell_class": "Area",
 			"casting_cost": "1",
@@ -47645,7 +47645,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -48171,7 +48171,7 @@
 			"name": "Weather Dome",
 			"reference": "M169",
 			"difficulty": "IQ/H",
-			"college": "Protection or Weather",
+			"college": "Protection & Warning or Weather",
 			"power_source": "Arcane",
 			"spell_class": "Area",
 			"casting_cost": "3",
@@ -48237,7 +48237,7 @@
 				]
 			},
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Weather"
 			]
 		},


### PR DESCRIPTION
A few spells had broken one college magery prerequisites which would permit with levels of one college magery in the wrong college because the clause that they required magery without a college limit was omitted.

This also led to discovering that one college prerequisites sometimes used abbreviated names for the colleges, which you wouldn't know if you'd picked the full name when adding the one college limit, and the college name is the only place the name of the college is advertised to the user.

In the process this also fixes a few bugs where the college names were inconsistent.

As an aside, if the next time there's a non-backwards-compatible change all the libraries could be re-saved to normalise to the canonical lower-case value names for spell difficulty, that would make putting together clean commits nicer.