### PR TITLE
Fixed (?) Jet Spell attacks from DFRPG

### DIFF
--- a/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Spells.spl
+++ b/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Spells.spl
@@ -7,7 +7,7 @@
 			"type": "spell_container",
 			"id": "206fbafa-e43f-4b29-aeae-e16b640feeba",
 			"name": "Clerical",
-			"open": true,
+			"open": false,
 			"children": [
 				{
 					"type": "spell_container",
@@ -477,7 +477,7 @@
 						{
 							"type": "spell",
 							"id": "88f8d543-8dca-420e-9ec8-e45264b97e93",
-							"name": "Minor healing",
+							"name": "Minor Healing",
 							"reference": "DFS37",
 							"difficulty": "iq/h",
 							"college": [
@@ -1551,6 +1551,11 @@
 											"type": "skill",
 											"name": "Innate Attack",
 											"specialization": "Beam"
+										},
+										{
+											"type": "skill",
+											"name": "Innate Attack",
+											"modifier": -2
 										}
 									]
 								}
@@ -3722,55 +3727,6 @@
 				},
 				{
 					"type": "spell_container",
-					"id": "0a822561-e520-4de8-8bd8-56e5f38be611",
-					"name": "Power Investiture 6",
-					"categories": [
-						"Clerical"
-					],
-					"open": false,
-					"children": [
-						{
-							"type": "spell",
-							"id": "5a08ea88-afb6-475a-8831-c1439ddcfa42",
-							"name": "Sanctuary",
-							"reference": "DFS35",
-							"difficulty": "iq/vh",
-							"college": [
-								"Clerical"
-							],
-							"power_source": "Arcane",
-							"spell_class": "Special",
-							"casting_cost": "5",
-							"maintenance_cost": "Same",
-							"casting_time": "10 sec",
-							"duration": "1 hr",
-							"points": 1,
-							"prereqs": {
-								"type": "prereq_list",
-								"all": true,
-								"prereqs": [
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "Power Investiture"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 6
-										}
-									}
-								]
-							},
-							"categories": [
-								"Clerical"
-							]
-						}
-					]
-				},
-				{
-					"type": "spell_container",
 					"id": "4b9e7948-8196-4430-97a6-a7c179d8b353",
 					"name": "Power Investiture 5",
 					"categories": [
@@ -4007,6 +3963,55 @@
 							]
 						}
 					]
+				},
+				{
+					"type": "spell_container",
+					"id": "0a822561-e520-4de8-8bd8-56e5f38be611",
+					"name": "Power Investiture 6",
+					"categories": [
+						"Clerical"
+					],
+					"open": false,
+					"children": [
+						{
+							"type": "spell",
+							"id": "5a08ea88-afb6-475a-8831-c1439ddcfa42",
+							"name": "Sanctuary",
+							"reference": "DFS35",
+							"difficulty": "iq/vh",
+							"college": [
+								"Clerical"
+							],
+							"power_source": "Arcane",
+							"spell_class": "Special",
+							"casting_cost": "5",
+							"maintenance_cost": "Same",
+							"casting_time": "10 sec",
+							"duration": "1 hr",
+							"points": 1,
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 6
+										}
+									}
+								]
+							},
+							"categories": [
+								"Clerical"
+							]
+						}
+					]
 				}
 			]
 		},
@@ -4023,7 +4028,7 @@
 					"categories": [
 						"Druid"
 					],
-					"open": true,
+					"open": false,
 					"children": [
 						{
 							"type": "spell",
@@ -5061,7 +5066,7 @@
 					"categories": [
 						"Druid"
 					],
-					"open": true,
+					"open": false,
 					"children": [
 						{
 							"type": "spell",
@@ -6463,7 +6468,7 @@
 					"categories": [
 						"Druid"
 					],
-					"open": true,
+					"open": false,
 					"children": [
 						{
 							"type": "spell",
@@ -7354,7 +7359,7 @@
 					"categories": [
 						"Druid"
 					],
-					"open": true,
+					"open": false,
 					"children": [
 						{
 							"type": "spell",
@@ -7732,7 +7737,7 @@
 					"categories": [
 						"Druid"
 					],
-					"open": true,
+					"open": false,
 					"children": [
 						{
 							"type": "spell",
@@ -7881,7 +7886,7 @@
 					"categories": [
 						"Druid"
 					],
-					"open": true,
+					"open": false,
 					"children": [
 						{
 							"type": "spell",
@@ -8093,6 +8098,11 @@
 									"type": "skill",
 									"name": "Innate Attack",
 									"specialization": "Beam"
+								},
+								{
+									"type": "skill",
+									"name": "Innate Attack",
+									"modifier": -2
 								}
 							]
 						}
@@ -12171,8 +12181,8 @@
 					"reference": "DFS66",
 					"difficulty": "iq/h",
 					"college": [
-						"Sound",
-						"Knowledge"
+						"Knowledge",
+						"Sound"
 					],
 					"power_source": "Arcane",
 					"spell_class": "Info",
@@ -12834,6 +12844,11 @@
 									"type": "skill",
 									"name": "Innate Attack",
 									"specialization": "Beam"
+								},
+								{
+									"type": "skill",
+									"name": "Innate Attack",
+									"modifier": -2
 								}
 							]
 						}
@@ -15587,6 +15602,11 @@
 									"type": "skill",
 									"name": "Innate Attack",
 									"specialization": "Beam"
+								},
+								{
+									"type": "skill",
+									"name": "Innate Attack",
+									"modifier": -2
 								}
 							]
 						}
@@ -18082,8 +18102,8 @@
 					"reference": "DFS28",
 					"difficulty": "iq/h",
 					"college": [
-						"Plant",
-						"Earth"
+						"Earth",
+						"Plant"
 					],
 					"power_source": "Arcane",
 					"spell_class": "Area",
@@ -21117,6 +21137,11 @@
 									"type": "skill",
 									"name": "Innate Attack",
 									"specialization": "Beam"
+								},
+								{
+									"type": "skill",
+									"name": "Innate Attack",
+									"modifier": -2
 								}
 							]
 						}
@@ -23546,6 +23571,11 @@
 									"type": "skill",
 									"name": "Innate Attack",
 									"specialization": "Beam"
+								},
+								{
+									"type": "skill",
+									"name": "Innate Attack",
+									"modifier": -2
 								}
 							]
 						}


### PR DESCRIPTION
- Added "Innate Attack (no specialization) -2" as default for Melee Attacks for Jet Spells, since Innate Attacks default to each other at -2.
- Fixed capitalization for "Minor Healing".
- Fixed order of Clerical Spells (switched PI5 and PI6 category order.