### PR TITLE
Programmatically fix one-college prerequisites in spell libraries

### DIFF
--- a/Library/Bio-Tech/Bio-Tech Spells.spl
+++ b/Library/Bio-Tech/Bio-Tech Spells.spl
@@ -669,7 +669,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Magery"
+									"qualifier": "magery"
 								},
 								"level": {
 									"compare": "at_least",
@@ -793,7 +793,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Magery"
+									"qualifier": "magery"
 								},
 								"level": {
 									"compare": "at_least",
@@ -801,7 +801,7 @@
 								},
 								"notes": {
 									"compare": "does_not_contain",
-									"qualifier": "One College"
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -809,15 +809,15 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Magery"
+									"qualifier": "magery"
 								},
 								"level": {
 									"compare": "at_least",
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "is",
-									"qualifier": "One College (Body Control)"
+									"compare": "contains",
+									"qualifier": "one college (body control)"
 								}
 							}
 						]

--- a/Library/Bio-Tech/Bio-Tech Spells.spl
+++ b/Library/Bio-Tech/Bio-Tech Spells.spl
@@ -653,15 +653,15 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Magery"
+									"qualifier": "magery"
 								},
 								"level": {
 									"compare": "at_least",
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "is",
-									"qualifier": "One College (Technology)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -676,8 +676,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "One College"
+									"compare": "contains",
+									"qualifier": "one college (technological)"
 								}
 							}
 						]

--- a/Library/Magic/Magic - Death Spells/Magic - Death Spells Spells.spl
+++ b/Library/Magic/Magic - Death Spells/Magic - Death Spells Spells.spl
@@ -24,6 +24,44 @@
 				"all": true,
 				"prereqs": [
 					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (enchantment)"
+								}
+							}
+						]
+					},
+					{
 						"type": "spell_prereq",
 						"has": true,
 						"sub_type": "name",
@@ -47,18 +85,6 @@
 						"quantity": {
 							"compare": "at_least",
 							"qualifier": 1
-						}
-					},
-					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
 						}
 					}
 				]
@@ -89,6 +115,44 @@
 				"type": "prereq_list",
 				"all": true,
 				"prereqs": [
+					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (fire)"
+								}
+							}
+						]
+					},
 					{
 						"type": "spell_prereq",
 						"has": true,
@@ -127,18 +191,6 @@
 							"compare": "at_least",
 							"qualifier": 1
 						}
-					},
-					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
-						}
 					}
 				]
 			},
@@ -167,6 +219,44 @@
 				"all": true,
 				"prereqs": [
 					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (body control)"
+								}
+							}
+						]
+					},
+					{
 						"type": "spell_prereq",
 						"has": true,
 						"sub_type": "name",
@@ -190,18 +280,6 @@
 						"quantity": {
 							"compare": "at_least",
 							"qualifier": 1
-						}
-					},
-					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
 						}
 					}
 				]
@@ -248,6 +326,44 @@
 				"all": true,
 				"prereqs": [
 					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (animal)"
+								}
+							}
+						]
+					},
+					{
 						"type": "spell_prereq",
 						"has": true,
 						"sub_type": "name",
@@ -258,18 +374,6 @@
 						"quantity": {
 							"compare": "at_least",
 							"qualifier": 1
-						}
-					},
-					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
 						}
 					},
 					{
@@ -313,6 +417,44 @@
 				"all": true,
 				"prereqs": [
 					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (communication & empathy)"
+								}
+							}
+						]
+					},
+					{
 						"type": "spell_prereq",
 						"has": true,
 						"sub_type": "name",
@@ -323,18 +465,6 @@
 						"quantity": {
 							"compare": "at_least",
 							"qualifier": 1
-						}
-					},
-					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
 						}
 					}
 				]
@@ -365,6 +495,44 @@
 				"all": true,
 				"prereqs": [
 					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (food)"
+								}
+							}
+						]
+					},
+					{
 						"type": "spell_prereq",
 						"has": true,
 						"sub_type": "name",
@@ -375,18 +543,6 @@
 						"quantity": {
 							"compare": "at_least",
 							"qualifier": 1
-						}
-					},
-					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
 						}
 					}
 				]
@@ -418,6 +574,44 @@
 				"all": true,
 				"prereqs": [
 					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (body control)"
+								}
+							}
+						]
+					},
+					{
 						"type": "spell_prereq",
 						"has": true,
 						"sub_type": "name",
@@ -441,18 +635,6 @@
 						"quantity": {
 							"compare": "at_least",
 							"qualifier": 1
-						}
-					},
-					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
 						}
 					}
 				]
@@ -483,6 +665,44 @@
 				"all": true,
 				"prereqs": [
 					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (food)"
+								}
+							}
+						]
+					},
+					{
 						"type": "spell_prereq",
 						"has": true,
 						"sub_type": "name",
@@ -506,18 +726,6 @@
 						"quantity": {
 							"compare": "at_least",
 							"qualifier": 1
-						}
-					},
-					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
 						}
 					}
 				]
@@ -548,16 +756,42 @@
 				"all": true,
 				"prereqs": [
 					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
-						}
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (gate)"
+								}
+							}
+						]
 					},
 					{
 						"type": "prereq_list",
@@ -632,6 +866,44 @@
 				"all": true,
 				"prereqs": [
 					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (earth)"
+								}
+							}
+						]
+					},
+					{
 						"type": "spell_prereq",
 						"has": true,
 						"sub_type": "name",
@@ -655,18 +927,6 @@
 						"quantity": {
 							"compare": "at_least",
 							"qualifier": 1
-						}
-					},
-					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
 						}
 					}
 				]
@@ -697,16 +957,42 @@
 				"all": true,
 				"prereqs": [
 					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
-						}
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (air)"
+								}
+							}
+						]
 					},
 					{
 						"type": "spell_prereq",
@@ -813,6 +1099,44 @@
 				"all": true,
 				"prereqs": [
 					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (enchantment)"
+								}
+							}
+						]
+					},
+					{
 						"type": "spell_prereq",
 						"has": true,
 						"sub_type": "name",
@@ -836,18 +1160,6 @@
 						"quantity": {
 							"compare": "at_least",
 							"qualifier": 1
-						}
-					},
-					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
 						}
 					}
 				]
@@ -879,6 +1191,44 @@
 				"all": true,
 				"prereqs": [
 					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (fire)"
+								}
+							}
+						]
+					},
+					{
 						"type": "spell_prereq",
 						"has": true,
 						"sub_type": "name",
@@ -889,18 +1239,6 @@
 						"quantity": {
 							"compare": "at_least",
 							"qualifier": 1
-						}
-					},
-					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
 						}
 					}
 				]
@@ -931,6 +1269,44 @@
 				"all": true,
 				"prereqs": [
 					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (air)"
+								}
+							}
+						]
+					},
+					{
 						"type": "spell_prereq",
 						"has": true,
 						"sub_type": "name",
@@ -954,18 +1330,6 @@
 						"quantity": {
 							"compare": "at_least",
 							"qualifier": 7
-						}
-					},
-					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
 						}
 					}
 				]
@@ -996,6 +1360,44 @@
 				"all": true,
 				"prereqs": [
 					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (communication & empathy)"
+								}
+							}
+						]
+					},
+					{
 						"type": "spell_prereq",
 						"has": true,
 						"sub_type": "name",
@@ -1019,18 +1421,6 @@
 						"quantity": {
 							"compare": "at_least",
 							"qualifier": 1
-						}
-					},
-					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
 						}
 					}
 				]
@@ -1061,6 +1451,44 @@
 				"all": true,
 				"prereqs": [
 					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (animal)"
+								}
+							}
+						]
+					},
+					{
 						"type": "spell_prereq",
 						"has": true,
 						"sub_type": "name",
@@ -1084,18 +1512,6 @@
 						"quantity": {
 							"compare": "at_least",
 							"qualifier": 1
-						}
-					},
-					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
 						}
 					}
 				]
@@ -1126,16 +1542,42 @@
 				"all": true,
 				"prereqs": [
 					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
-						}
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (gate)"
+								}
+							}
+						]
 					},
 					{
 						"type": "spell_prereq",
@@ -1181,6 +1623,38 @@
 						"has": true,
 						"name": {
 							"compare": "is",
+							"qualifier": "magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 1
+						},
+						"notes": {
+							"compare": "does_not_contain",
+							"qualifier": "one college"
+						}
+					},
+					{
+						"type": "advantage_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 1
+						},
+						"notes": {
+							"compare": "contains",
+							"qualifier": "one college (healing)"
+						}
+					},
+					{
+						"type": "advantage_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
 							"qualifier": "Status"
 						}
 					},
@@ -1190,18 +1664,6 @@
 						"name": {
 							"compare": "is",
 							"qualifier": "Spirit Empathy"
-						}
-					},
-					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 1
 						}
 					}
 				]
@@ -1232,16 +1694,42 @@
 				"all": true,
 				"prereqs": [
 					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
-						}
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (knowledge)"
+								}
+							}
+						]
 					},
 					{
 						"type": "spell_prereq",
@@ -1297,6 +1785,44 @@
 				"all": true,
 				"prereqs": [
 					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (knowledge)"
+								}
+							}
+						]
+					},
+					{
 						"type": "spell_prereq",
 						"has": true,
 						"sub_type": "name",
@@ -1307,18 +1833,6 @@
 						"quantity": {
 							"compare": "at_least",
 							"qualifier": 1
-						}
-					},
-					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
 						}
 					}
 				]
@@ -1347,6 +1861,44 @@
 				"type": "prereq_list",
 				"all": true,
 				"prereqs": [
+					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (light & darkness)"
+								}
+							}
+						]
+					},
 					{
 						"type": "spell_prereq",
 						"has": true,
@@ -1384,18 +1936,6 @@
 						"quantity": {
 							"compare": "at_least",
 							"qualifier": 1
-						}
-					},
-					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
 						}
 					},
 					{
@@ -1439,16 +1979,42 @@
 				"all": true,
 				"prereqs": [
 					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
-						}
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (light & darkness)"
+								}
+							}
+						]
 					},
 					{
 						"type": "spell_prereq",
@@ -1508,6 +2074,44 @@
 						"all": false,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (making & breaking)"
+								}
+							}
+						]
+					},
+					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
@@ -1547,18 +2151,6 @@
 							"compare": "at_least",
 							"qualifier": 1
 						}
-					},
-					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
-						}
 					}
 				]
 			},
@@ -1588,16 +2180,42 @@
 				"all": true,
 				"prereqs": [
 					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
-						}
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (making & breaking)"
+								}
+							}
+						]
 					},
 					{
 						"type": "spell_prereq",
@@ -1653,6 +2271,44 @@
 				"all": true,
 				"prereqs": [
 					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (meta)"
+								}
+							}
+						]
+					},
+					{
 						"type": "spell_prereq",
 						"has": true,
 						"sub_type": "name",
@@ -1676,18 +2332,6 @@
 						"quantity": {
 							"compare": "at_least",
 							"qualifier": 1
-						}
-					},
-					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
 						}
 					}
 				]
@@ -1718,16 +2362,42 @@
 				"all": true,
 				"prereqs": [
 					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
-						}
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (meta)"
+								}
+							}
+						]
 					},
 					{
 						"type": "spell_prereq",
@@ -1770,6 +2440,44 @@
 				"all": true,
 				"prereqs": [
 					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (mind control)"
+								}
+							}
+						]
+					},
+					{
 						"type": "spell_prereq",
 						"has": true,
 						"sub_type": "name",
@@ -1793,18 +2501,6 @@
 						"quantity": {
 							"compare": "at_least",
 							"qualifier": 1
-						}
-					},
-					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
 						}
 					}
 				]
@@ -1835,16 +2531,42 @@
 				"all": true,
 				"prereqs": [
 					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
-						}
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (mind control)"
+								}
+							}
+						]
 					},
 					{
 						"type": "spell_prereq",
@@ -1900,6 +2622,44 @@
 				"all": true,
 				"prereqs": [
 					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (movement)"
+								}
+							}
+						]
+					},
+					{
 						"type": "spell_prereq",
 						"has": true,
 						"sub_type": "name",
@@ -1937,18 +2697,6 @@
 							"compare": "at_least",
 							"qualifier": 10
 						}
-					},
-					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
-						}
 					}
 				]
 			},
@@ -1978,16 +2726,42 @@
 				"all": true,
 				"prereqs": [
 					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
-						}
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (movement)"
+								}
+							}
+						]
 					},
 					{
 						"type": "spell_prereq",
@@ -2056,16 +2830,42 @@
 				"all": true,
 				"prereqs": [
 					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
-						}
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (illusion & creation)"
+								}
+							}
+						]
 					},
 					{
 						"type": "spell_prereq",
@@ -2121,6 +2921,44 @@
 				"all": true,
 				"prereqs": [
 					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (illusion & creation)"
+								}
+							}
+						]
+					},
+					{
 						"type": "spell_prereq",
 						"has": true,
 						"sub_type": "name",
@@ -2131,18 +2969,6 @@
 						"quantity": {
 							"compare": "at_least",
 							"qualifier": 1
-						}
-					},
-					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
 						}
 					}
 				]
@@ -2173,6 +2999,44 @@
 				"all": true,
 				"prereqs": [
 					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (necromancy)"
+								}
+							}
+						]
+					},
+					{
 						"type": "spell_prereq",
 						"has": true,
 						"sub_type": "name",
@@ -2196,18 +3060,6 @@
 						"quantity": {
 							"compare": "at_least",
 							"qualifier": 1
-						}
-					},
-					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
 						}
 					}
 				]
@@ -2238,16 +3090,42 @@
 				"all": true,
 				"prereqs": [
 					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
-						}
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (necromancy)"
+								}
+							}
+						]
 					},
 					{
 						"type": "spell_prereq",
@@ -2303,6 +3181,44 @@
 				"all": true,
 				"prereqs": [
 					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (plant)"
+								}
+							}
+						]
+					},
+					{
 						"type": "spell_prereq",
 						"has": true,
 						"sub_type": "name",
@@ -2326,18 +3242,6 @@
 						"quantity": {
 							"compare": "at_least",
 							"qualifier": 1
-						}
-					},
-					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
 						}
 					}
 				]
@@ -2368,16 +3272,42 @@
 				"all": true,
 				"prereqs": [
 					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
-						}
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (plant)"
+								}
+							}
+						]
 					},
 					{
 						"type": "spell_prereq",
@@ -2420,6 +3350,44 @@
 				"all": true,
 				"prereqs": [
 					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (protection & warning)"
+								}
+							}
+						]
+					},
+					{
 						"type": "spell_prereq",
 						"has": true,
 						"sub_type": "name",
@@ -2430,18 +3398,6 @@
 						"quantity": {
 							"compare": "at_least",
 							"qualifier": 1
-						}
-					},
-					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
 						}
 					}
 				]
@@ -2473,6 +3429,44 @@
 				"all": true,
 				"prereqs": [
 					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (sound)"
+								}
+							}
+						]
+					},
+					{
 						"type": "spell_prereq",
 						"has": true,
 						"sub_type": "name",
@@ -2496,18 +3490,6 @@
 						"quantity": {
 							"compare": "at_least",
 							"qualifier": 1
-						}
-					},
-					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
 						}
 					}
 				]
@@ -2538,16 +3520,42 @@
 				"all": true,
 				"prereqs": [
 					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
-						}
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (sound)"
+								}
+							}
+						]
 					},
 					{
 						"type": "spell_prereq",
@@ -2643,16 +3651,42 @@
 				"all": true,
 				"prereqs": [
 					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
-						}
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (technological)"
+								}
+							}
+						]
 					},
 					{
 						"type": "spell_prereq",
@@ -2707,6 +3741,44 @@
 				"type": "prereq_list",
 				"all": true,
 				"prereqs": [
+					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (water)"
+								}
+							}
+						]
+					},
 					{
 						"type": "prereq_list",
 						"all": false,
@@ -2776,18 +3848,6 @@
 								]
 							}
 						]
-					},
-					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
-						}
 					}
 				]
 			},
@@ -2817,16 +3877,42 @@
 				"all": true,
 				"prereqs": [
 					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
-						}
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (water)"
+								}
+							}
+						]
 					},
 					{
 						"type": "spell_prereq",
@@ -2882,6 +3968,44 @@
 				"all": true,
 				"prereqs": [
 					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (weather)"
+								}
+							}
+						]
+					},
+					{
 						"type": "spell_prereq",
 						"has": true,
 						"sub_type": "name",
@@ -2905,18 +4029,6 @@
 						"quantity": {
 							"compare": "at_least",
 							"qualifier": 1
-						}
-					},
-					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
 						}
 					}
 				]
@@ -2947,16 +4059,42 @@
 				"all": true,
 				"prereqs": [
 					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
-						}
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (weather)"
+								}
+							}
+						]
 					},
 					{
 						"type": "spell_prereq",
@@ -2999,16 +4137,42 @@
 				"all": true,
 				"prereqs": [
 					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (necromancy)"
+								}
+							}
+						]
 					}
 				]
 			},
@@ -3039,16 +4203,42 @@
 				"all": true,
 				"prereqs": [
 					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
-						}
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (protection & warning)"
+								}
+							}
+						]
 					},
 					{
 						"type": "spell_prereq",

--- a/Library/Magic/Magic - Death Spells/Magic - Death Spells Spells.spl
+++ b/Library/Magic/Magic - Death Spells/Magic - Death Spells Spells.spl
@@ -470,7 +470,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -1426,7 +1426,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -3335,7 +3335,7 @@
 			"reference": "MDS20",
 			"difficulty": "iq/vh",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -3404,7 +3404,7 @@
 			},
 			"notes": "Resistance: DX or 2x Basic Speed, or any active defense involving teleportation or insubstantiality",
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -4188,7 +4188,7 @@
 			"reference": "MDS20",
 			"difficulty": "iq/vh",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -4256,7 +4256,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		}
 	]

--- a/Library/Magic/Magic - Death Spells/Magic - Death Spells Spells.spl
+++ b/Library/Magic/Magic - Death Spells/Magic - Death Spells Spells.spl
@@ -962,6 +962,10 @@
 						"name": {
 							"compare": "is",
 							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 3
 						}
 					}
 				]

--- a/Library/Magic/Magic - Plant Spells/Magic - Plant Spells Spells.spl
+++ b/Library/Magic/Magic - Plant Spells/Magic - Plant Spells Spells.spl
@@ -194,6 +194,44 @@
 				"all": true,
 				"prereqs": [
 					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (plant)"
+								}
+							}
+						]
+					},
+					{
 						"type": "spell_prereq",
 						"has": true,
 						"sub_type": "name",
@@ -202,18 +240,6 @@
 							"qualifier": "Weaken Blood"
 						},
 						"quantity": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
-					},
-					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
 							"compare": "at_least",
 							"qualifier": 1
 						}
@@ -286,8 +312,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (plant)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -302,8 +328,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (fungus)"
 								}
 							}
 						]
@@ -428,8 +454,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (plant)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -444,8 +470,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (fungus)"
 								}
 							}
 						]
@@ -518,6 +544,60 @@
 				"all": true,
 				"prereqs": [
 					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (movement)"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (plant)"
+								}
+							}
+						]
+					},
+					{
 						"type": "spell_prereq",
 						"has": true,
 						"sub_type": "name",
@@ -526,18 +606,6 @@
 							"qualifier": "Walk Through Plants"
 						},
 						"quantity": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
-					},
-					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
 							"compare": "at_least",
 							"qualifier": 1
 						}
@@ -583,16 +651,42 @@
 				"all": true,
 				"prereqs": [
 					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (plant)"
+								}
+							}
+						]
 					},
 					{
 						"type": "spell_prereq",
@@ -673,16 +767,42 @@
 				"all": true,
 				"prereqs": [
 					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 2
-						}
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (plant)"
+								}
+							}
+						]
 					},
 					{
 						"type": "spell_prereq",
@@ -725,6 +845,60 @@
 				"all": true,
 				"prereqs": [
 					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (body control)"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (fungus)"
+								}
+							}
+						]
+					},
+					{
 						"type": "spell_prereq",
 						"has": true,
 						"sub_type": "name",
@@ -733,18 +907,6 @@
 							"qualifier": "Spore Cloud"
 						},
 						"quantity": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
-					},
-					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
 							"compare": "at_least",
 							"qualifier": 1
 						}
@@ -898,8 +1060,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (plant)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -914,8 +1076,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (fungus)"
 								}
 							}
 						]
@@ -947,6 +1109,44 @@
 				"all": true,
 				"prereqs": [
 					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (plant)"
+								}
+							}
+						]
+					},
+					{
 						"type": "spell_prereq",
 						"has": true,
 						"sub_type": "name",
@@ -957,18 +1157,6 @@
 						"quantity": {
 							"compare": "at_least",
 							"qualifier": 1
-						}
-					},
-					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 2
 						}
 					}
 				]
@@ -999,16 +1187,58 @@
 				"all": true,
 				"prereqs": [
 					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
-						}
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (fungus)"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (healing)"
+								}
+							}
+						]
 					},
 					{
 						"type": "spell_prereq",
@@ -1093,23 +1323,49 @@
 				"all": true,
 				"prereqs": [
 					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Plant Empathy"
-						}
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (plant)"
+								}
+							}
+						]
 					},
 					{
 						"type": "advantage_prereq",
 						"has": true,
 						"name": {
 							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
+							"qualifier": "Plant Empathy"
 						}
 					},
 					{
@@ -1211,6 +1467,44 @@
 				"all": true,
 				"prereqs": [
 					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (plant)"
+								}
+							}
+						]
+					},
+					{
 						"type": "spell_prereq",
 						"has": true,
 						"sub_type": "name",
@@ -1219,18 +1513,6 @@
 							"qualifier": "Plant Growth"
 						},
 						"quantity": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
-					},
-					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
 							"compare": "at_least",
 							"qualifier": 1
 						}
@@ -1288,16 +1570,58 @@
 				"all": true,
 				"prereqs": [
 					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (movement)"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (plant)"
+								}
+							}
+						]
 					},
 					{
 						"type": "spell_prereq",
@@ -1460,8 +1784,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (plant)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -1476,8 +1800,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (fungus)"
 								}
 							}
 						]
@@ -1537,8 +1861,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (plant)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -1553,8 +1877,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (fungus)"
 								}
 							}
 						]
@@ -1717,6 +2041,60 @@
 				"all": true,
 				"prereqs": [
 					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (mind control)"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (plant)"
+								}
+							}
+						]
+					},
+					{
 						"type": "spell_prereq",
 						"has": true,
 						"sub_type": "name",
@@ -1727,18 +2105,6 @@
 						"quantity": {
 							"compare": "at_least",
 							"qualifier": 1
-						}
-					},
-					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 2
 						}
 					}
 				]
@@ -1769,16 +2135,42 @@
 				"all": true,
 				"prereqs": [
 					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 2
-						}
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (plant)"
+								}
+							}
+						]
 					},
 					{
 						"type": "spell_prereq",
@@ -1820,6 +2212,44 @@
 				"all": true,
 				"prereqs": [
 					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (plant)"
+								}
+							}
+						]
+					},
+					{
 						"type": "spell_prereq",
 						"has": true,
 						"sub_type": "name",
@@ -1843,18 +2273,6 @@
 						"quantity": {
 							"compare": "at_least",
 							"qualifier": 1
-						}
-					},
-					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 2
 						}
 					}
 				]
@@ -1923,16 +2341,42 @@
 				"all": true,
 				"prereqs": [
 					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (plant)"
+								}
+							}
+						]
 					},
 					{
 						"type": "spell_prereq",
@@ -2039,6 +2483,44 @@
 				"all": true,
 				"prereqs": [
 					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (plant)"
+								}
+							}
+						]
+					},
+					{
 						"type": "spell_prereq",
 						"has": true,
 						"sub_type": "name",
@@ -2060,18 +2542,6 @@
 							"qualifier": "Daze"
 						},
 						"quantity": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
-					},
-					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
 							"compare": "at_least",
 							"qualifier": 1
 						}
@@ -2181,16 +2651,42 @@
 				"all": true,
 				"prereqs": [
 					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 2
-						}
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (plant)"
+								}
+							}
+						]
 					},
 					{
 						"type": "spell_prereq",
@@ -2312,16 +2808,42 @@
 				"all": true,
 				"prereqs": [
 					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 2
-						}
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (plant)"
+								}
+							}
+						]
 					},
 					{
 						"type": "spell_prereq",
@@ -2364,16 +2886,58 @@
 				"all": true,
 				"prereqs": [
 					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 3
-						}
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (fungus)"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (healing)"
+								}
+							}
+						]
 					},
 					{
 						"type": "spell_prereq",
@@ -2433,8 +2997,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (necromancy)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -2449,8 +3013,24 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (fungus)"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (necromancy)"
 								}
 							}
 						]
@@ -2497,6 +3077,44 @@
 				"all": true,
 				"prereqs": [
 					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (plant)"
+								}
+							}
+						]
+					},
+					{
 						"type": "spell_prereq",
 						"has": true,
 						"sub_type": "name",
@@ -2505,18 +3123,6 @@
 							"qualifier": "Shape Plants"
 						},
 						"quantity": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
-					},
-					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
 							"compare": "at_least",
 							"qualifier": 1
 						}
@@ -2548,16 +3154,42 @@
 				"all": true,
 				"prereqs": [
 					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 2
-						}
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (plant)"
+								}
+							}
+						]
 					},
 					{
 						"type": "spell_prereq",
@@ -2612,6 +3244,44 @@
 				"all": true,
 				"prereqs": [
 					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (plant)"
+								}
+							}
+						]
+					},
+					{
 						"type": "spell_prereq",
 						"has": true,
 						"sub_type": "name",
@@ -2633,18 +3303,6 @@
 							"qualifier": "Essential Wood"
 						},
 						"quantity": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
-					},
-					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
 							"compare": "at_least",
 							"qualifier": 1
 						}
@@ -2676,16 +3334,42 @@
 				"all": true,
 				"prereqs": [
 					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (plant)"
+								}
+							}
+						]
 					},
 					{
 						"type": "spell_prereq",
@@ -2727,6 +3411,44 @@
 				"all": true,
 				"prereqs": [
 					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (plant)"
+								}
+							}
+						]
+					},
+					{
 						"type": "spell_prereq",
 						"has": true,
 						"sub_type": "name",
@@ -2735,18 +3457,6 @@
 							"qualifier": "Plant Growth"
 						},
 						"quantity": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
-					},
-					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
 							"compare": "at_least",
 							"qualifier": 1
 						}
@@ -2830,8 +3540,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (necromancy)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -2846,8 +3556,24 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (fungus)"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (necromancy)"
 								}
 							}
 						]
@@ -2922,8 +3648,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (making & breaking)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -2938,8 +3664,24 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (fungus)"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (making & breaking)"
 								}
 							}
 						]
@@ -3027,16 +3769,42 @@
 				"all": true,
 				"prereqs": [
 					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 2
-						}
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (plant)"
+								}
+							}
+						]
 					},
 					{
 						"type": "spell_prereq",
@@ -3197,6 +3965,44 @@
 				"all": true,
 				"prereqs": [
 					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (plant)"
+								}
+							}
+						]
+					},
+					{
 						"type": "spell_prereq",
 						"has": true,
 						"sub_type": "name",
@@ -3205,18 +4011,6 @@
 							"qualifier": "Blade of Grass"
 						},
 						"quantity": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
-					},
-					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
 							"compare": "at_least",
 							"qualifier": 1
 						}
@@ -3396,16 +4190,58 @@
 				"all": true,
 				"prereqs": [
 					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (air)"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (plant)"
+								}
+							}
+						]
 					},
 					{
 						"type": "spell_prereq",
@@ -3501,16 +4337,42 @@
 				"all": true,
 				"prereqs": [
 					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (plant)"
+								}
+							}
+						]
 					},
 					{
 						"type": "spell_prereq",
@@ -3619,16 +4481,42 @@
 				"all": true,
 				"prereqs": [
 					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (plant)"
+								}
+							}
+						]
 					},
 					{
 						"type": "spell_prereq",
@@ -3683,16 +4571,42 @@
 				"all": true,
 				"prereqs": [
 					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 2
-						}
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (plant)"
+								}
+							}
+						]
 					},
 					{
 						"type": "spell_prereq",
@@ -3787,16 +4701,58 @@
 				"all": true,
 				"prereqs": [
 					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 2
-						}
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (illusion & creation)"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (plant)"
+								}
+							}
+						]
 					},
 					{
 						"type": "spell_prereq",
@@ -3907,16 +4863,42 @@
 				"all": true,
 				"prereqs": [
 					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (plant)"
+								}
+							}
+						]
 					},
 					{
 						"type": "spell_prereq",

--- a/Library/Magic/Magic Spells.spl
+++ b/Library/Magic/Magic Spells.spl
@@ -67,8 +67,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (gate)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -83,8 +83,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (gate)"
 								}
 							}
 						]
@@ -551,8 +551,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (body control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -567,8 +567,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (body control)"
 								}
 							}
 						]
@@ -739,8 +739,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (movement)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -771,8 +771,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (movement)"
 								}
 							}
 						]
@@ -1576,7 +1576,6 @@
 			"difficulty": "iq/vh",
 			"tech_level": "",
 			"college": [
-				"Machine",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -1693,8 +1692,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (making & breaking)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -1709,8 +1708,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (making & breaking)"
 								}
 							}
 						]
@@ -1889,8 +1888,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (movement)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -1905,8 +1904,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (movement)"
 								}
 							}
 						]
@@ -1954,8 +1953,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (plant)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -1970,8 +1969,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (plant)"
 								}
 							}
 						]
@@ -2383,7 +2382,6 @@
 			"difficulty": "iq/vh",
 			"tech_level": "",
 			"college": [
-				"Machine",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -2670,8 +2668,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (necromancy)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -2686,8 +2684,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (necromancy)"
 								}
 							}
 						]
@@ -3401,8 +3399,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (meta)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -3417,8 +3415,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (meta)"
 								}
 							}
 						]
@@ -3621,8 +3619,8 @@
 							"qualifier": 1
 						},
 						"notes": {
-							"compare": "contains",
-							"qualifier": "one college (protection & warning)"
+							"compare": "does_not_contain",
+							"qualifier": "one college"
 						}
 					},
 					{
@@ -3637,8 +3635,8 @@
 							"qualifier": 1
 						},
 						"notes": {
-							"compare": "does_not_contain",
-							"qualifier": "one college"
+							"compare": "contains",
+							"qualifier": "one college (protection & warning)"
 						}
 					}
 				]
@@ -4030,6 +4028,22 @@
 									"qualifier": 2
 								},
 								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (air)"
 								}
@@ -4049,22 +4063,6 @@
 									"compare": "contains",
 									"qualifier": "one college (weather)"
 								}
-							},
-							{
-								"type": "advantage_prereq",
-								"has": true,
-								"name": {
-									"compare": "is",
-									"qualifier": "magery"
-								},
-								"level": {
-									"compare": "at_least",
-									"qualifier": 2
-								},
-								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
-								}
 							}
 						]
 					}
@@ -4082,7 +4080,6 @@
 			"reference": "M183",
 			"difficulty": "iq/h",
 			"college": [
-				"Metal",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -4126,8 +4123,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (technological)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -4142,8 +4139,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (technological)"
 								}
 							}
 						]
@@ -4162,7 +4159,6 @@
 			"reference": "M183",
 			"difficulty": "iq/h",
 			"college": [
-				"Plastic",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -4206,8 +4202,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (technological)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -4222,8 +4218,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (technological)"
 								}
 							}
 						]
@@ -4272,8 +4268,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (light & darkness)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -4288,8 +4284,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (light & darkness)"
 								}
 							}
 						]
@@ -4389,8 +4385,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (plant)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -4405,8 +4401,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (plant)"
 								}
 							}
 						]
@@ -4647,8 +4643,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (plant)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -4663,8 +4659,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (plant)"
 								}
 							}
 						]
@@ -5233,7 +5229,6 @@
 			"reference": "M182",
 			"difficulty": "iq/h",
 			"college": [
-				"Radiation",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -5276,8 +5271,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (radiation)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -5294,22 +5289,6 @@
 								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (technological)"
-								}
-							},
-							{
-								"type": "advantage_prereq",
-								"has": true,
-								"name": {
-									"compare": "is",
-									"qualifier": "magery"
-								},
-								"level": {
-									"compare": "at_least",
-									"qualifier": 2
-								},
-								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
 								}
 							}
 						]
@@ -5660,6 +5639,22 @@
 									"qualifier": 2
 								},
 								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (fire)"
 								}
@@ -5678,22 +5673,6 @@
 								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (necromancy)"
-								}
-							},
-							{
-								"type": "advantage_prereq",
-								"has": true,
-								"name": {
-									"compare": "is",
-									"qualifier": "magery"
-								},
-								"level": {
-									"compare": "at_least",
-									"qualifier": 2
-								},
-								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
 								}
 							}
 						]
@@ -5980,8 +5959,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (meta)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -5996,8 +5975,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (meta)"
 								}
 							}
 						]
@@ -6070,8 +6049,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (meta)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -6086,8 +6065,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (meta)"
 								}
 							}
 						]
@@ -6161,8 +6140,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (mind control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -6177,8 +6156,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (mind control)"
 								}
 							}
 						]
@@ -6225,8 +6204,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (body control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -6241,8 +6220,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (body control)"
 								}
 							}
 						]
@@ -6454,6 +6433,22 @@
 									"qualifier": 2
 								},
 								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (movement)"
 								}
@@ -6472,22 +6467,6 @@
 								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (weather)"
-								}
-							},
-							{
-								"type": "advantage_prereq",
-								"has": true,
-								"name": {
-									"compare": "is",
-									"qualifier": "magery"
-								},
-								"level": {
-									"compare": "at_least",
-									"qualifier": 2
-								},
-								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
 								}
 							}
 						]
@@ -6775,8 +6754,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (mind control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -6791,8 +6770,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (mind control)"
 								}
 							}
 						]
@@ -7012,8 +6991,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (communication & empathy)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -7028,8 +7007,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (communication & empathy)"
 								}
 							}
 						]
@@ -7174,8 +7153,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (meta)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -7190,8 +7169,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (meta)"
 								}
 							}
 						]
@@ -7343,7 +7322,6 @@
 			"difficulty": "iq/vh",
 			"tech_level": "",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -7386,8 +7364,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (energy)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -7404,22 +7382,6 @@
 								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (technological)"
-								}
-							},
-							{
-								"type": "advantage_prereq",
-								"has": true,
-								"name": {
-									"compare": "is",
-									"qualifier": "magery"
-								},
-								"level": {
-									"compare": "at_least",
-									"qualifier": 1
-								},
-								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
 								}
 							}
 						]
@@ -7610,8 +7572,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (making & breaking)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -7626,8 +7588,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (making & breaking)"
 								}
 							}
 						]
@@ -7848,8 +7810,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (gate)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -7864,8 +7826,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (gate)"
 								}
 							}
 						]
@@ -7992,8 +7954,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (body control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -8008,8 +7970,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (body control)"
 								}
 							}
 						]
@@ -8188,8 +8150,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (sound)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -8204,8 +8166,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (sound)"
 								}
 							}
 						]
@@ -8547,8 +8509,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (body control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -8563,8 +8525,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (body control)"
 								}
 							}
 						]
@@ -8659,8 +8621,8 @@
 							"qualifier": 1
 						},
 						"notes": {
-							"compare": "contains",
-							"qualifier": "one college (meta)"
+							"compare": "does_not_contain",
+							"qualifier": "one college"
 						}
 					},
 					{
@@ -8675,8 +8637,8 @@
 							"qualifier": 1
 						},
 						"notes": {
-							"compare": "does_not_contain",
-							"qualifier": "one college"
+							"compare": "contains",
+							"qualifier": "one college (meta)"
 						}
 					}
 				]
@@ -9302,7 +9264,6 @@
 			"difficulty": "iq/h",
 			"tech_level": "",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -9521,8 +9482,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (illusion & creation)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -9537,8 +9498,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (illusion & creation)"
 								}
 							}
 						]
@@ -9611,8 +9572,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (illusion & creation)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -9627,8 +9588,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (illusion & creation)"
 								}
 							}
 						]
@@ -9688,8 +9649,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (plant)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -9704,8 +9665,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (plant)"
 								}
 							}
 						]
@@ -9774,8 +9735,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (illusion & creation)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -9790,8 +9751,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (illusion & creation)"
 								}
 							}
 						]
@@ -10279,8 +10240,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (meta)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -10295,8 +10256,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (meta)"
 								}
 							}
 						]
@@ -10343,8 +10304,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (movement)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -10359,8 +10320,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (movement)"
 								}
 							}
 						]
@@ -10391,7 +10352,7 @@
 			"reference": "M67",
 			"difficulty": "iq/h",
 			"college": [
-				"Armor Enchantment"
+				"Enchantment"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Enchantment",
@@ -10651,8 +10612,8 @@
 							"qualifier": 1
 						},
 						"notes": {
-							"compare": "contains",
-							"qualifier": "one college (necromancy)"
+							"compare": "does_not_contain",
+							"qualifier": "one college"
 						}
 					},
 					{
@@ -10667,8 +10628,8 @@
 							"qualifier": 1
 						},
 						"notes": {
-							"compare": "does_not_contain",
-							"qualifier": "one college"
+							"compare": "contains",
+							"qualifier": "one college (necromancy)"
 						}
 					}
 				]
@@ -10809,8 +10770,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (body control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -10825,8 +10786,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (body control)"
 								}
 							}
 						]
@@ -10896,7 +10857,7 @@
 			"reference": "M67",
 			"difficulty": "iq/h",
 			"college": [
-				"Armor Enchantment"
+				"Enchantment"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Enchantment",
@@ -11000,7 +10961,7 @@
 			"reference": "M67",
 			"difficulty": "iq/h",
 			"college": [
-				"Armor Enchantment"
+				"Enchantment"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Enchantment",
@@ -11227,7 +11188,6 @@
 			"reference": "M130",
 			"difficulty": "iq/h",
 			"college": [
-				"Linking",
 				"Meta"
 			],
 			"power_source": "Arcane",
@@ -11266,8 +11226,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (meta)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -11282,8 +11242,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (meta)"
 								}
 							}
 						]
@@ -11357,8 +11317,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (sound)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -11373,8 +11333,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (sound)"
 								}
 							}
 						]
@@ -11495,8 +11455,8 @@
 							"qualifier": 1
 						},
 						"notes": {
-							"compare": "contains",
-							"qualifier": "one college (knowledge)"
+							"compare": "does_not_contain",
+							"qualifier": "one college"
 						}
 					},
 					{
@@ -11511,8 +11471,8 @@
 							"qualifier": 1
 						},
 						"notes": {
-							"compare": "does_not_contain",
-							"qualifier": "one college"
+							"compare": "contains",
+							"qualifier": "one college (knowledge)"
 						}
 					}
 				]
@@ -11732,8 +11692,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (making & breaking)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -11748,8 +11708,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (making & breaking)"
 								}
 							}
 						]
@@ -12059,8 +12019,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (movement)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -12075,8 +12035,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (movement)"
 								}
 							}
 						]
@@ -12192,6 +12152,22 @@
 									"qualifier": 3
 								},
 								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (gate)"
 								}
@@ -12210,22 +12186,6 @@
 								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (movement)"
-								}
-							},
-							{
-								"type": "advantage_prereq",
-								"has": true,
-								"name": {
-									"compare": "is",
-									"qualifier": "magery"
-								},
-								"level": {
-									"compare": "at_least",
-									"qualifier": 3
-								},
-								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
 								}
 							}
 						]
@@ -13058,8 +13018,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (enchantment)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -13074,8 +13034,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (enchantment)"
 								}
 							}
 						]
@@ -13175,8 +13135,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (meta)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -13191,8 +13151,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (meta)"
 								}
 							}
 						]
@@ -13263,7 +13223,6 @@
 			"difficulty": "iq/vh",
 			"tech_level": "",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -14200,6 +14159,22 @@
 									"qualifier": 2
 								},
 								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (knowledge)"
 								}
@@ -14218,22 +14193,6 @@
 								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (sound)"
-								}
-							},
-							{
-								"type": "advantage_prereq",
-								"has": true,
-								"name": {
-									"compare": "is",
-									"qualifier": "magery"
-								},
-								"level": {
-									"compare": "at_least",
-									"qualifier": 2
-								},
-								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
 								}
 							}
 						]
@@ -14321,8 +14280,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (mind control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -14337,8 +14296,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (mind control)"
 								}
 							}
 						]
@@ -14385,8 +14344,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (enchantment)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -14401,8 +14360,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (enchantment)"
 								}
 							}
 						]
@@ -14550,8 +14509,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (enchantment)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -14566,8 +14525,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (enchantment)"
 								}
 							}
 						]
@@ -14653,8 +14612,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (body control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -14669,8 +14628,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (body control)"
 								}
 							}
 						]
@@ -14770,8 +14729,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (body control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -14786,8 +14745,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (body control)"
 								}
 							}
 						]
@@ -15110,8 +15069,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (necromancy)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -15126,8 +15085,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (necromancy)"
 								}
 							}
 						]
@@ -15437,7 +15396,6 @@
 			"difficulty": "iq/h",
 			"tech_level": "",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -15454,7 +15412,7 @@
 					{
 						"type": "spell_prereq",
 						"has": true,
-						"sub_type": "college",
+						"sub_type": "category",
 						"qualifier": {
 							"compare": "contains",
 							"qualifier": "Energy"
@@ -15585,8 +15543,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (movement)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -15601,8 +15559,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (movement)"
 								}
 							}
 						]
@@ -15742,8 +15700,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (necromancy)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -15758,8 +15716,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (necromancy)"
 								}
 							}
 						]
@@ -15902,8 +15860,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (making & breaking)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -15918,8 +15876,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (making & breaking)"
 								}
 							}
 						]
@@ -16114,8 +16072,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (making & breaking)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -16130,8 +16088,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (making & breaking)"
 								}
 							}
 						]
@@ -16188,7 +16146,6 @@
 			"reference": "M181",
 			"difficulty": "iq/h",
 			"college": [
-				"Radiation",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -16257,8 +16214,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (radiation)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -16275,22 +16232,6 @@
 								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (technological)"
-								}
-							},
-							{
-								"type": "advantage_prereq",
-								"has": true,
-								"name": {
-									"compare": "is",
-									"qualifier": "magery"
-								},
-								"level": {
-									"compare": "at_least",
-									"qualifier": 2
-								},
-								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
 								}
 							}
 						]
@@ -16493,8 +16434,8 @@
 							"qualifier": 1
 						},
 						"notes": {
-							"compare": "contains",
-							"qualifier": "one college (knowledge)"
+							"compare": "does_not_contain",
+							"qualifier": "one college"
 						}
 					},
 					{
@@ -16509,8 +16450,8 @@
 							"qualifier": 1
 						},
 						"notes": {
-							"compare": "does_not_contain",
-							"qualifier": "one college"
+							"compare": "contains",
+							"qualifier": "one college (knowledge)"
 						}
 					}
 				]
@@ -16584,8 +16525,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (sound)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -16600,8 +16541,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (sound)"
 								}
 							}
 						]
@@ -16689,6 +16630,22 @@
 									"qualifier": 1
 								},
 								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (food)"
 								}
@@ -16707,22 +16664,6 @@
 								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (knowledge)"
-								}
-							},
-							{
-								"type": "advantage_prereq",
-								"has": true,
-								"name": {
-									"compare": "is",
-									"qualifier": "magery"
-								},
-								"level": {
-									"compare": "at_least",
-									"qualifier": 1
-								},
-								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
 								}
 							}
 						]
@@ -16945,6 +16886,22 @@
 									"qualifier": 1
 								},
 								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (healing)"
 								}
@@ -16963,22 +16920,6 @@
 								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (necromancy)"
-								}
-							},
-							{
-								"type": "advantage_prereq",
-								"has": true,
-								"name": {
-									"compare": "is",
-									"qualifier": "magery"
-								},
-								"level": {
-									"compare": "at_least",
-									"qualifier": 1
-								},
-								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
 								}
 							}
 						]
@@ -17022,8 +16963,8 @@
 							"qualifier": 1
 						},
 						"notes": {
-							"compare": "contains",
-							"qualifier": "one college (knowledge)"
+							"compare": "does_not_contain",
+							"qualifier": "one college"
 						}
 					},
 					{
@@ -17038,8 +16979,8 @@
 							"qualifier": 1
 						},
 						"notes": {
-							"compare": "does_not_contain",
-							"qualifier": "one college"
+							"compare": "contains",
+							"qualifier": "one college (knowledge)"
 						}
 					}
 				]
@@ -17866,8 +17807,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (movement)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -17882,8 +17823,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (movement)"
 								}
 							}
 						]
@@ -17947,8 +17888,8 @@
 											"qualifier": 2
 										},
 										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (movement)"
+											"compare": "does_not_contain",
+											"qualifier": "one college"
 										}
 									},
 									{
@@ -17963,8 +17904,8 @@
 											"qualifier": 2
 										},
 										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
+											"compare": "contains",
+											"qualifier": "one college (movement)"
 										}
 									}
 								]
@@ -18106,8 +18047,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (food)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -18122,8 +18063,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (food)"
 								}
 							}
 						]
@@ -18206,8 +18147,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (protection & warning)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -18222,8 +18163,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (protection & warning)"
 								}
 							}
 						]
@@ -18396,8 +18337,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (mind control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -18412,8 +18353,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (mind control)"
 								}
 							}
 						]
@@ -18431,7 +18372,7 @@
 			"reference": "M66",
 			"difficulty": "iq/h",
 			"college": [
-				"Armor Enchantment"
+				"Enchantment"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Enchantment",
@@ -18941,8 +18882,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (body control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -18957,8 +18898,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (body control)"
 								}
 							}
 						]
@@ -19356,7 +19297,6 @@
 			"difficulty": "iq/h",
 			"tech_level": "",
 			"college": [
-				"Machine",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -19766,8 +19706,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (mind control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -19782,8 +19722,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (mind control)"
 								}
 							}
 						]
@@ -19844,8 +19784,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (mind control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -19860,8 +19800,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (mind control)"
 								}
 							}
 						]
@@ -19930,8 +19870,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (movement)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -19946,8 +19886,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (movement)"
 								}
 							}
 						]
@@ -19994,8 +19934,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (healing)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -20010,8 +19950,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (healing)"
 								}
 							}
 						]
@@ -20106,8 +20046,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (animal)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -20122,8 +20062,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (animal)"
 								}
 							}
 						]
@@ -20236,8 +20176,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (meta)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -20252,8 +20192,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (meta)"
 								}
 							}
 						]
@@ -20310,8 +20250,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (enchantment)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -20326,8 +20266,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (enchantment)"
 								}
 							}
 						]
@@ -20579,8 +20519,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (healing)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -20595,8 +20535,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (healing)"
 								}
 							}
 						]
@@ -20899,8 +20839,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (healing)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -20915,8 +20855,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (healing)"
 								}
 							}
 						]
@@ -21470,8 +21410,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (body control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -21486,8 +21426,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (body control)"
 								}
 							}
 						]
@@ -21599,8 +21539,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (enchantment)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -21615,8 +21555,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (enchantment)"
 								}
 							}
 						]
@@ -21665,6 +21605,22 @@
 									"qualifier": 1
 								},
 								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (body control)"
 								}
@@ -21683,22 +21639,6 @@
 								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (food)"
-								}
-							},
-							{
-								"type": "advantage_prereq",
-								"has": true,
-								"name": {
-									"compare": "is",
-									"qualifier": "magery"
-								},
-								"level": {
-									"compare": "at_least",
-									"qualifier": 1
-								},
-								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
 								}
 							}
 						]
@@ -22319,7 +22259,6 @@
 			"reference": "M182",
 			"difficulty": "iq/h",
 			"college": [
-				"Metal",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -22399,7 +22338,6 @@
 			"reference": "M182",
 			"difficulty": "iq/h",
 			"college": [
-				"Plastic",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -22633,6 +22571,22 @@
 									"qualifier": 2
 								},
 								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (knowledge)"
 								}
@@ -22651,22 +22605,6 @@
 								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (light & darkness)"
-								}
-							},
-							{
-								"type": "advantage_prereq",
-								"has": true,
-								"name": {
-									"compare": "is",
-									"qualifier": "magery"
-								},
-								"level": {
-									"compare": "at_least",
-									"qualifier": 2
-								},
-								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
 								}
 							}
 						]
@@ -23130,8 +23068,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (healing)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -23146,8 +23084,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (healing)"
 								}
 							}
 						]
@@ -23207,8 +23145,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (healing)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -23223,8 +23161,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (healing)"
 								}
 							}
 						]
@@ -23284,8 +23222,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (healing)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -23300,8 +23238,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (healing)"
 								}
 							}
 						]
@@ -23536,7 +23474,6 @@
 			"reference": "M181",
 			"difficulty": "iq/h",
 			"college": [
-				"Radiation",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -23839,8 +23776,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (knowledge)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -23855,8 +23792,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (knowledge)"
 								}
 							}
 						]
@@ -24074,8 +24011,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (knowledge)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -24090,8 +24027,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (knowledge)"
 								}
 							}
 						]
@@ -24177,8 +24114,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (healing)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -24193,8 +24130,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (healing)"
 								}
 							}
 						]
@@ -24273,7 +24210,6 @@
 			"difficulty": "iq/h",
 			"tech_level": "",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -24316,8 +24252,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (energy)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -24334,22 +24270,6 @@
 								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (technological)"
-								}
-							},
-							{
-								"type": "advantage_prereq",
-								"has": true,
-								"name": {
-									"compare": "is",
-									"qualifier": "magery"
-								},
-								"level": {
-									"compare": "at_least",
-									"qualifier": 2
-								},
-								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
 								}
 							}
 						]
@@ -24468,8 +24388,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (meta)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -24484,8 +24404,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (meta)"
 								}
 							}
 						]
@@ -24571,8 +24491,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (body control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -24587,8 +24507,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (body control)"
 								}
 							}
 						]
@@ -24675,8 +24595,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (mind control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -24691,8 +24611,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (mind control)"
 								}
 							}
 						]
@@ -24858,6 +24778,22 @@
 									"qualifier": 3
 								},
 								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (enchantment)"
 								}
@@ -24876,22 +24812,6 @@
 								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (necromancy)"
-								}
-							},
-							{
-								"type": "advantage_prereq",
-								"has": true,
-								"name": {
-									"compare": "is",
-									"qualifier": "magery"
-								},
-								"level": {
-									"compare": "at_least",
-									"qualifier": 3
-								},
-								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
 								}
 							}
 						]
@@ -25072,7 +24992,7 @@
 			"reference": "M67",
 			"difficulty": "iq/h",
 			"college": [
-				"Armor Enchantment"
+				"Enchantment"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Enchantment",
@@ -25207,6 +25127,22 @@
 									"qualifier": 1
 								},
 								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (air)"
 								}
@@ -25225,22 +25161,6 @@
 								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (weather)"
-								}
-							},
-							{
-								"type": "advantage_prereq",
-								"has": true,
-								"name": {
-									"compare": "is",
-									"qualifier": "magery"
-								},
-								"level": {
-									"compare": "at_least",
-									"qualifier": 1
-								},
-								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
 								}
 							}
 						]
@@ -25481,6 +25401,22 @@
 									"qualifier": 2
 								},
 								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (air)"
 								}
@@ -25499,22 +25435,6 @@
 								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (weather)"
-								}
-							},
-							{
-								"type": "advantage_prereq",
-								"has": true,
-								"name": {
-									"compare": "is",
-									"qualifier": "magery"
-								},
-								"level": {
-									"compare": "at_least",
-									"qualifier": 2
-								},
-								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
 								}
 							}
 						]
@@ -25664,7 +25584,6 @@
 			"reference": "M131",
 			"difficulty": "iq/h",
 			"college": [
-				"Linking",
 				"Meta"
 			],
 			"power_source": "Arcane",
@@ -25765,8 +25684,8 @@
 											"qualifier": 2
 										},
 										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (movement)"
+											"compare": "does_not_contain",
+											"qualifier": "one college"
 										}
 									},
 									{
@@ -25781,8 +25700,8 @@
 											"qualifier": 2
 										},
 										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
+											"compare": "contains",
+											"qualifier": "one college (movement)"
 										}
 									}
 								]
@@ -25903,8 +25822,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (movement)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -25919,8 +25838,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (movement)"
 								}
 							}
 						]
@@ -26084,7 +26003,6 @@
 			"difficulty": "iq/h",
 			"tech_level": "",
 			"college": [
-				"Machine",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -26152,7 +26070,6 @@
 			"difficulty": "iq/h",
 			"tech_level": "",
 			"college": [
-				"Machine",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -26269,7 +26186,6 @@
 			"difficulty": "iq/h",
 			"tech_level": "",
 			"college": [
-				"Machine",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -26547,20 +26463,42 @@
 				"all": true,
 				"prereqs": [
 					{
-						"type": "advantage_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "magery"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 1
-						},
-						"notes": {
-							"compare": "contains",
-							"qualifier": "one college (protection & warning)"
-						}
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (protection & warning)"
+								}
+							}
+						]
 					},
 					{
 						"type": "advantage_prereq",
@@ -26630,8 +26568,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (meta)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -26646,8 +26584,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (meta)"
 								}
 							}
 						]
@@ -26665,7 +26603,6 @@
 			"reference": "M181",
 			"difficulty": "iq/h",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -26774,8 +26711,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (healing)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -26790,8 +26727,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (healing)"
 								}
 							}
 						]
@@ -26875,7 +26812,6 @@
 			"difficulty": "iq/h",
 			"tech_level": "",
 			"college": [
-				"Machine",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -26919,8 +26855,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (technological)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -26935,8 +26871,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (technological)"
 								}
 							}
 						]
@@ -27641,7 +27577,6 @@
 			"difficulty": "iq/h",
 			"college": [
 				"Knowledge",
-				"Metal",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -27897,8 +27832,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (mind control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -27913,8 +27848,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (mind control)"
 								}
 							}
 						]
@@ -28440,8 +28375,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (protection & warning)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -28456,8 +28391,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (protection & warning)"
 								}
 							}
 						]
@@ -28621,8 +28556,8 @@
 											"qualifier": 3
 										},
 										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (healing)"
+											"compare": "does_not_contain",
+											"qualifier": "one college"
 										}
 									},
 									{
@@ -28637,8 +28572,8 @@
 											"qualifier": 3
 										},
 										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
+											"compare": "contains",
+											"qualifier": "one college (healing)"
 										}
 									}
 								]
@@ -28831,8 +28766,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (mind control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -28847,8 +28782,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (mind control)"
 								}
 							}
 						]
@@ -28987,8 +28922,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (mind control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -29003,8 +28938,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (mind control)"
 								}
 							}
 						]
@@ -29210,8 +29145,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (body control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -29226,8 +29161,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (body control)"
 								}
 							}
 						]
@@ -29413,8 +29348,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (animal)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -29429,8 +29364,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (animal)"
 								}
 							}
 						]
@@ -29551,8 +29486,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (knowledge)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -29567,8 +29502,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (knowledge)"
 								}
 							}
 						]
@@ -29838,8 +29773,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (illusion & creation)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -29854,8 +29789,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (illusion & creation)"
 								}
 							}
 						]
@@ -29956,8 +29891,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (animal)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -29972,8 +29907,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (animal)"
 								}
 							}
 						]
@@ -30043,8 +29978,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (mind control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -30059,8 +29994,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (mind control)"
 								}
 							}
 						]
@@ -30079,7 +30014,6 @@
 			"difficulty": "iq/vh",
 			"tech_level": "",
 			"college": [
-				"Machine",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -30123,8 +30057,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (technological)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -30139,8 +30073,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (technological)"
 								}
 							}
 						]
@@ -30211,8 +30145,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (mind control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -30227,8 +30161,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (mind control)"
 								}
 							}
 						]
@@ -30276,8 +30210,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (communication & empathy)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -30292,8 +30226,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (communication & empathy)"
 								}
 							}
 						]
@@ -30366,8 +30300,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (animal)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -30382,8 +30316,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (animal)"
 								}
 							}
 						]
@@ -30470,8 +30404,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (necromancy)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -30486,8 +30420,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (necromancy)"
 								}
 							}
 						]
@@ -30560,8 +30494,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (illusion & creation)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -30576,8 +30510,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (illusion & creation)"
 								}
 							}
 						]
@@ -30717,8 +30651,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (gate)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -30733,8 +30667,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (gate)"
 								}
 							}
 						]
@@ -30852,8 +30786,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (gate)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -30868,8 +30802,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (gate)"
 								}
 							}
 						]
@@ -30957,8 +30891,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (gate)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -30973,8 +30907,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (gate)"
 								}
 							}
 						]
@@ -31061,8 +30995,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (gate)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -31077,8 +31011,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (gate)"
 								}
 							}
 						]
@@ -31191,8 +31125,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (plant)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -31207,8 +31141,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (plant)"
 								}
 							}
 						]
@@ -31269,8 +31203,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (plant)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -31285,8 +31219,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (plant)"
 								}
 							}
 						]
@@ -31425,8 +31359,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (plant)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -31441,8 +31375,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (plant)"
 								}
 							}
 						]
@@ -31515,7 +31449,6 @@
 			"difficulty": "iq/h",
 			"college": [
 				"Knowledge",
-				"Plastic",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -31749,8 +31682,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (communication & empathy)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -31765,8 +31698,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (communication & empathy)"
 								}
 							}
 						]
@@ -32158,7 +32091,6 @@
 			"difficulty": "iq/h",
 			"tech_level": "",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -32252,7 +32184,6 @@
 			"difficulty": "iq/h",
 			"tech_level": "",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -32451,8 +32382,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (movement)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -32467,8 +32398,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (movement)"
 								}
 							}
 						]
@@ -32627,7 +32558,6 @@
 			"difficulty": "iq/h",
 			"tech_level": "",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -32749,8 +32679,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (movement)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -32765,8 +32695,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (movement)"
 								}
 							}
 						]
@@ -32901,7 +32831,6 @@
 			"reference": "M182",
 			"difficulty": "iq/h",
 			"college": [
-				"Radiation",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -32955,7 +32884,6 @@
 			"reference": "M181",
 			"difficulty": "iq/h",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -33405,8 +33333,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (plant)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -33421,8 +33349,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (plant)"
 								}
 							}
 						]
@@ -33597,6 +33525,22 @@
 									"qualifier": 3
 								},
 								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (gate)"
 								}
@@ -33615,22 +33559,6 @@
 								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (movement)"
-								}
-							},
-							{
-								"type": "advantage_prereq",
-								"has": true,
-								"name": {
-									"compare": "is",
-									"qualifier": "magery"
-								},
-								"level": {
-									"compare": "at_least",
-									"qualifier": 3
-								},
-								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
 								}
 							}
 						]
@@ -33689,7 +33617,6 @@
 			"difficulty": "iq/vh",
 			"tech_level": "",
 			"college": [
-				"Machine",
 				"Making & Breaking",
 				"Technological"
 			],
@@ -33811,6 +33738,22 @@
 									"qualifier": 3
 								},
 								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (making & breaking)"
 								}
@@ -33829,22 +33772,6 @@
 								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (technological)"
-								}
-							},
-							{
-								"type": "advantage_prereq",
-								"has": true,
-								"name": {
-									"compare": "is",
-									"qualifier": "magery"
-								},
-								"level": {
-									"compare": "at_least",
-									"qualifier": 3
-								},
-								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
 								}
 							}
 						]
@@ -33920,6 +33847,22 @@
 									"qualifier": 2
 								},
 								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (knowledge)"
 								}
@@ -33938,22 +33881,6 @@
 								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (mind control)"
-								}
-							},
-							{
-								"type": "advantage_prereq",
-								"has": true,
-								"name": {
-									"compare": "is",
-									"qualifier": "magery"
-								},
-								"level": {
-									"compare": "at_least",
-									"qualifier": 2
-								},
-								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
 								}
 							}
 						]
@@ -34001,8 +33928,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (knowledge)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -34017,8 +33944,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (knowledge)"
 								}
 							}
 						]
@@ -34091,8 +34018,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (healing)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -34107,8 +34034,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (healing)"
 								}
 							}
 						]
@@ -34219,7 +34146,6 @@
 			"reference": "M132",
 			"difficulty": "iq/h",
 			"college": [
-				"Linking",
 				"Meta"
 			],
 			"power_source": "Arcane",
@@ -34354,8 +34280,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (healing)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -34370,8 +34296,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (healing)"
 								}
 							}
 						]
@@ -34496,8 +34422,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (plant)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -34512,8 +34438,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (plant)"
 								}
 							}
 						]
@@ -34913,8 +34839,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (meta)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -34929,8 +34855,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (meta)"
 								}
 							}
 						]
@@ -35109,8 +35035,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (making & breaking)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -35125,8 +35051,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (making & breaking)"
 								}
 							}
 						]
@@ -35198,8 +35124,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (movement)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -35214,8 +35140,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (movement)"
 								}
 							}
 						]
@@ -35632,8 +35558,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (making & breaking)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -35648,8 +35574,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (making & breaking)"
 								}
 							}
 						]
@@ -35951,8 +35877,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (body control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -35967,8 +35893,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (body control)"
 								}
 							}
 						]
@@ -36080,7 +36006,6 @@
 			"difficulty": "iq/h",
 			"college": [
 				"Protection & Warning",
-				"Radiation",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -36097,7 +36022,7 @@
 					{
 						"type": "spell_prereq",
 						"has": true,
-						"sub_type": "college",
+						"sub_type": "category",
 						"qualifier": {
 							"compare": "contains",
 							"qualifier": "Radiation"
@@ -36878,7 +36803,6 @@
 			"difficulty": "iq/h",
 			"tech_level": "",
 			"college": [
-				"Machine",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -37110,8 +37034,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (making & breaking)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -37126,8 +37050,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (making & breaking)"
 								}
 							}
 						]
@@ -37252,8 +37176,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (necromancy)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -37268,8 +37192,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (necromancy)"
 								}
 							}
 						]
@@ -37408,8 +37332,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (making & breaking)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -37424,8 +37348,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (making & breaking)"
 								}
 							}
 						]
@@ -37646,6 +37570,22 @@
 									"qualifier": 2
 								},
 								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (food)"
 								}
@@ -37664,22 +37604,6 @@
 								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (knowledge)"
-								}
-							},
-							{
-								"type": "advantage_prereq",
-								"has": true,
-								"name": {
-									"compare": "is",
-									"qualifier": "magery"
-								},
-								"level": {
-									"compare": "at_least",
-									"qualifier": 2
-								},
-								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
 								}
 							}
 						]
@@ -37726,7 +37650,6 @@
 			"tech_level": "",
 			"college": [
 				"Knowledge",
-				"Machine",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -37900,8 +37823,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (enchantment)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -37916,8 +37839,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (enchantment)"
 								}
 							}
 						]
@@ -38030,8 +37953,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (meta)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -38046,8 +37969,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (meta)"
 								}
 							}
 						]
@@ -38095,8 +38018,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (meta)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -38111,8 +38034,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (meta)"
 								}
 							}
 						]
@@ -38280,7 +38203,6 @@
 			"reference": "M181",
 			"difficulty": "iq/h",
 			"college": [
-				"Radiation",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -38474,7 +38396,6 @@
 			"difficulty": "iq/h",
 			"tech_level": "",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -38525,8 +38446,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (gate)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -38541,8 +38462,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (gate)"
 								}
 							}
 						]
@@ -38583,7 +38504,6 @@
 			"difficulty": "iq/h",
 			"tech_level": "",
 			"college": [
-				"Machine",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -38703,7 +38623,6 @@
 			"reference": "M182",
 			"difficulty": "iq/h",
 			"college": [
-				"Plastic",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -38726,7 +38645,6 @@
 			"difficulty": "iq/h",
 			"tech_level": "",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -38748,7 +38666,6 @@
 			"reference": "M181",
 			"difficulty": "iq/h",
 			"college": [
-				"Radiation",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -38847,8 +38764,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (knowledge)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -38863,8 +38780,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (knowledge)"
 								}
 							}
 						]
@@ -39145,8 +39062,8 @@
 											"qualifier": 1
 										},
 										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (necromancy)"
+											"compare": "does_not_contain",
+											"qualifier": "one college"
 										}
 									},
 									{
@@ -39161,8 +39078,8 @@
 											"qualifier": 1
 										},
 										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
+											"compare": "contains",
+											"qualifier": "one college (necromancy)"
 										}
 									}
 								]
@@ -39238,8 +39155,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (body control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -39254,8 +39171,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (body control)"
 								}
 							}
 						]
@@ -39533,7 +39450,6 @@
 			"reference": "M182",
 			"difficulty": "iq/h",
 			"college": [
-				"Metal",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -39595,8 +39511,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (technological)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -39611,8 +39527,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (technological)"
 								}
 							}
 						]
@@ -39670,7 +39586,6 @@
 			"reference": "M183",
 			"difficulty": "iq/h",
 			"college": [
-				"Plastic",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -39732,8 +39647,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (technological)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -39748,8 +39663,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (technological)"
 								}
 							}
 						]
@@ -39837,8 +39752,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (animal)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -39853,8 +39768,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (animal)"
 								}
 							}
 						]
@@ -39914,8 +39829,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (animal)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -39930,8 +39845,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (animal)"
 								}
 							}
 						]
@@ -40134,8 +40049,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (making & breaking)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -40150,8 +40065,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (making & breaking)"
 								}
 							}
 						]
@@ -40247,8 +40162,8 @@
 							"qualifier": 2
 						},
 						"notes": {
-							"compare": "contains",
-							"qualifier": "one college (protection & warning)"
+							"compare": "does_not_contain",
+							"qualifier": "one college"
 						}
 					},
 					{
@@ -40263,8 +40178,8 @@
 							"qualifier": 2
 						},
 						"notes": {
-							"compare": "does_not_contain",
-							"qualifier": "one college"
+							"compare": "contains",
+							"qualifier": "one college (protection & warning)"
 						}
 					}
 				]
@@ -40386,8 +40301,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (body control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -40402,8 +40317,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (body control)"
 								}
 							}
 						]
@@ -40503,8 +40418,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (body control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -40519,8 +40434,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (body control)"
 								}
 							}
 						]
@@ -40769,8 +40684,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (enchantment)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -40785,8 +40700,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (enchantment)"
 								}
 							}
 						]
@@ -41005,8 +40920,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (movement)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -41021,8 +40936,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (movement)"
 								}
 							}
 						]
@@ -41187,8 +41102,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (necromancy)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -41203,8 +41118,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (necromancy)"
 								}
 							}
 						]
@@ -41283,8 +41198,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (gate)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -41299,8 +41214,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (gate)"
 								}
 							}
 						]
@@ -41772,8 +41687,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (necromancy)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -41788,8 +41703,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (necromancy)"
 								}
 							}
 						]
@@ -41876,8 +41791,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (enchantment)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -41892,8 +41807,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (enchantment)"
 								}
 							}
 						]
@@ -42259,7 +42174,6 @@
 			"reference": "M181",
 			"difficulty": "iq/h",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -42499,8 +42413,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (meta)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -42515,8 +42429,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (meta)"
 								}
 							}
 						]
@@ -42721,8 +42635,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (animal)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -42737,8 +42651,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (animal)"
 								}
 							}
 						]
@@ -42956,8 +42870,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (necromancy)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -42972,8 +42886,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (necromancy)"
 								}
 							}
 						]
@@ -43112,8 +43026,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (necromancy)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -43128,8 +43042,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (necromancy)"
 								}
 							}
 						]
@@ -43177,8 +43091,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (necromancy)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -43193,8 +43107,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (necromancy)"
 								}
 							}
 						]
@@ -43239,7 +43153,6 @@
 			"difficulty": "iq/vh",
 			"tech_level": "",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -43295,8 +43208,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (energy)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -43313,22 +43226,6 @@
 								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (technological)"
-								}
-							},
-							{
-								"type": "advantage_prereq",
-								"has": true,
-								"name": {
-									"compare": "is",
-									"qualifier": "magery"
-								},
-								"level": {
-									"compare": "at_least",
-									"qualifier": 2
-								},
-								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
 								}
 							}
 						]
@@ -43377,8 +43274,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (necromancy)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -43393,8 +43290,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (necromancy)"
 								}
 							}
 						]
@@ -43534,8 +43431,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (necromancy)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -43550,8 +43447,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (necromancy)"
 								}
 							}
 						]
@@ -43651,8 +43548,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (necromancy)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -43667,8 +43564,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (necromancy)"
 								}
 							}
 						]
@@ -44386,7 +44283,6 @@
 			"reference": "M179",
 			"difficulty": "iq/h",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -44429,8 +44325,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (energy)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -44447,22 +44343,6 @@
 								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (technological)"
-								}
-							},
-							{
-								"type": "advantage_prereq",
-								"has": true,
-								"name": {
-									"compare": "is",
-									"qualifier": "magery"
-								},
-								"level": {
-									"compare": "at_least",
-									"qualifier": 1
-								},
-								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
 								}
 							}
 						]
@@ -44633,8 +44513,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (mind control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -44649,8 +44529,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (mind control)"
 								}
 							}
 						]
@@ -44699,6 +44579,22 @@
 									"qualifier": 1
 								},
 								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (body control)"
 								}
@@ -44717,22 +44613,6 @@
 								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (necromancy)"
-								}
-							},
-							{
-								"type": "advantage_prereq",
-								"has": true,
-								"name": {
-									"compare": "is",
-									"qualifier": "magery"
-								},
-								"level": {
-									"compare": "at_least",
-									"qualifier": 1
-								},
-								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
 								}
 							}
 						]
@@ -45232,8 +45112,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (necromancy)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -45248,8 +45128,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (necromancy)"
 								}
 							}
 						]
@@ -45666,8 +45546,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (necromancy)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -45682,8 +45562,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (necromancy)"
 								}
 							}
 						]
@@ -45956,8 +45836,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (light & darkness)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -45972,8 +45852,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (light & darkness)"
 								}
 							}
 						]
@@ -46056,8 +45936,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (meta)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -46072,8 +45952,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (meta)"
 								}
 							}
 						]
@@ -46178,8 +46058,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (meta)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -46194,8 +46074,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (meta)"
 								}
 							}
 						]
@@ -46353,8 +46233,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (meta)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -46369,8 +46249,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (meta)"
 								}
 							}
 						]
@@ -46431,8 +46311,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (gate)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -46447,8 +46327,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (gate)"
 								}
 							}
 						]
@@ -46768,8 +46648,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (meta)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -46784,8 +46664,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (meta)"
 								}
 							}
 						]
@@ -46938,6 +46818,22 @@
 									"qualifier": 3
 								},
 								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (gate)"
 								}
@@ -46956,22 +46852,6 @@
 								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (movement)"
-								}
-							},
-							{
-								"type": "advantage_prereq",
-								"has": true,
-								"name": {
-									"compare": "is",
-									"qualifier": "magery"
-								},
-								"level": {
-									"compare": "at_least",
-									"qualifier": 3
-								},
-								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
 								}
 							}
 						]
@@ -47235,7 +47115,6 @@
 			"difficulty": "iq/h",
 			"tech_level": "",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -47353,6 +47232,22 @@
 									"qualifier": 1
 								},
 								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (body control)"
 								}
@@ -47371,22 +47266,6 @@
 								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (food)"
-								}
-							},
-							{
-								"type": "advantage_prereq",
-								"has": true,
-								"name": {
-									"compare": "is",
-									"qualifier": "magery"
-								},
-								"level": {
-									"compare": "at_least",
-									"qualifier": 1
-								},
-								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
 								}
 							}
 						]
@@ -47633,8 +47512,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (gate)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -47649,8 +47528,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (gate)"
 								}
 							}
 						]
@@ -47723,8 +47602,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (gate)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -47739,8 +47618,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (gate)"
 								}
 							}
 						]
@@ -48226,8 +48105,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (making & breaking)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -48242,8 +48121,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (making & breaking)"
 								}
 							}
 						]
@@ -48344,8 +48223,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (body control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -48360,8 +48239,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (body control)"
 								}
 							}
 						]
@@ -48803,8 +48682,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (protection & warning)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -48819,8 +48698,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (protection & warning)"
 								}
 							}
 						]
@@ -48986,8 +48865,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (mind control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -49002,8 +48881,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (mind control)"
 								}
 							}
 						]
@@ -49672,8 +49551,8 @@
 							"qualifier": 1
 						},
 						"notes": {
-							"compare": "contains",
-							"qualifier": "one college (meta)"
+							"compare": "does_not_contain",
+							"qualifier": "one college"
 						}
 					},
 					{
@@ -49688,8 +49567,8 @@
 							"qualifier": 1
 						},
 						"notes": {
-							"compare": "does_not_contain",
-							"qualifier": "one college"
+							"compare": "contains",
+							"qualifier": "one college (meta)"
 						}
 					}
 				]
@@ -50197,8 +50076,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (mind control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -50213,8 +50092,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (mind control)"
 								}
 							}
 						]
@@ -50301,8 +50180,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (making & breaking)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -50317,8 +50196,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (making & breaking)"
 								}
 							}
 						]
@@ -50845,8 +50724,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (body control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -50861,8 +50740,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (body control)"
 								}
 							}
 						]
@@ -51296,8 +51175,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (enchantment)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -51312,8 +51191,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (enchantment)"
 								}
 							}
 						]
@@ -51369,8 +51248,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (healing)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -51385,8 +51264,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (healing)"
 								}
 							}
 						]

--- a/Library/Magic/Ritual Magic Spells.spl
+++ b/Library/Magic/Ritual Magic Spells.spl
@@ -723,7 +723,6 @@
 			"difficulty": "H",
 			"tech_level": "",
 			"college": [
-				"Machine",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -887,7 +886,7 @@
 			"reference": "M167",
 			"difficulty": "H",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -899,7 +898,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 3,
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Ritual Magic"
 			]
 		},
@@ -958,7 +957,7 @@
 			"reference": "M169",
 			"difficulty": "H",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area",
@@ -970,7 +969,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 9,
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Ritual Magic"
 			]
 		},
@@ -1074,7 +1073,6 @@
 			"difficulty": "H",
 			"tech_level": "",
 			"college": [
-				"Machine",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -1478,7 +1476,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 3,
 			"categories": [
-				"Light",
+				"Light & Darkness",
 				"Ritual Magic"
 			]
 		},
@@ -1489,7 +1487,7 @@
 			"reference": "M168",
 			"difficulty": "H",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -1501,7 +1499,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 3,
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Ritual Magic"
 			]
 		},
@@ -1654,7 +1652,7 @@
 			"reference": "M166",
 			"difficulty": "H",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Blocking",
@@ -1666,7 +1664,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 1,
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Ritual Magic"
 			]
 		},
@@ -1712,7 +1710,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 3,
 			"categories": [
-				"Light",
+				"Light & Darkness",
 				"Ritual Magic"
 			]
 		},
@@ -1887,7 +1885,6 @@
 			"reference": "M183",
 			"difficulty": "H",
 			"college": [
-				"Metal",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -1912,7 +1909,6 @@
 			"reference": "M183",
 			"difficulty": "H",
 			"college": [
-				"Plastic",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -1949,7 +1945,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 6,
 			"categories": [
-				"Light",
+				"Light & Darkness",
 				"Ritual Magic"
 			]
 		},
@@ -2225,7 +2221,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 4,
 			"categories": [
-				"Communication",
+				"Communication & Empathy",
 				"Ritual Magic"
 			]
 		},
@@ -2248,7 +2244,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 8,
 			"categories": [
-				"Communication",
+				"Communication & Empathy",
 				"Ritual Magic"
 			]
 		},
@@ -2359,7 +2355,6 @@
 			"reference": "M182",
 			"difficulty": "H",
 			"college": [
-				"Radiation",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -2473,7 +2468,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 1,
 			"categories": [
-				"Light",
+				"Light & Darkness",
 				"Ritual Magic"
 			]
 		},
@@ -2627,7 +2622,7 @@
 			"reference": "M168",
 			"difficulty": "H",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Blocking",
@@ -2639,7 +2634,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 3,
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Ritual Magic"
 			]
 		},
@@ -2943,7 +2938,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 1,
 			"categories": [
-				"Light",
+				"Light & Darkness",
 				"Ritual Magic"
 			]
 		},
@@ -3012,7 +3007,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 10,
 			"categories": [
-				"Communication",
+				"Communication & Empathy",
 				"Ritual Magic"
 			]
 		},
@@ -3058,7 +3053,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 6,
 			"categories": [
-				"Communication",
+				"Communication & Empathy",
 				"Ritual Magic"
 			]
 		},
@@ -3214,7 +3209,6 @@
 			"difficulty": "H",
 			"tech_level": "",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -3251,7 +3245,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 1,
 			"categories": [
-				"Light",
+				"Light & Darkness",
 				"Ritual Magic"
 			]
 		},
@@ -3274,7 +3268,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 6,
 			"categories": [
-				"Light",
+				"Light & Darkness",
 				"Ritual Magic"
 			]
 		},
@@ -3297,7 +3291,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 6,
 			"categories": [
-				"Light",
+				"Light & Darkness",
 				"Ritual Magic"
 			]
 		},
@@ -3504,7 +3498,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 5,
 			"categories": [
-				"Communication",
+				"Communication & Empathy",
 				"Ritual Magic"
 			]
 		},
@@ -3631,7 +3625,7 @@
 			"reference": "M187",
 			"difficulty": "H",
 			"college": [
-				"Protection",
+				"Protection & Warning",
 				"Water"
 			],
 			"power_source": "Arcane",
@@ -3644,7 +3638,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 5,
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Ritual Magic",
 				"Water"
 			]
@@ -3996,7 +3990,6 @@
 			"difficulty": "H",
 			"tech_level": "",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -4416,7 +4409,7 @@
 			"reference": "M67",
 			"difficulty": "H",
 			"college": [
-				"Armor Enchantment"
+				"Enchantment"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Enchantment",
@@ -4474,7 +4467,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 2,
 			"categories": [
-				"Light",
+				"Light & Darkness",
 				"Ritual Magic"
 			]
 		},
@@ -4497,7 +4490,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 2,
 			"categories": [
-				"Light",
+				"Light & Darkness",
 				"Ritual Magic"
 			]
 		},
@@ -4681,7 +4674,7 @@
 			"reference": "M67",
 			"difficulty": "H",
 			"college": [
-				"Armor Enchantment"
+				"Enchantment"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Enchantment",
@@ -4727,7 +4720,7 @@
 			"reference": "M67",
 			"difficulty": "H",
 			"college": [
-				"Armor Enchantment"
+				"Enchantment"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Enchantment",
@@ -4774,7 +4767,7 @@
 			"difficulty": "H",
 			"college": [
 				"Movement",
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Blocking",
@@ -4787,7 +4780,7 @@
 			"prereq_count": 2,
 			"categories": [
 				"Movement",
-				"Protection",
+				"Protection & Warning",
 				"Ritual Magic"
 			]
 		},
@@ -4838,7 +4831,6 @@
 			"reference": "M130",
 			"difficulty": "H",
 			"college": [
-				"Linking",
 				"Meta"
 			],
 			"power_source": "Arcane",
@@ -4956,7 +4948,7 @@
 			"difficulty": "H",
 			"college": [
 				"Healing",
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area/Info",
@@ -4969,7 +4961,7 @@
 			"prereq_count": 1,
 			"categories": [
 				"Healing",
-				"Protection",
+				"Protection & Warning",
 				"Ritual Magic"
 			]
 		},
@@ -5148,7 +5140,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 11,
 			"categories": [
-				"Communication",
+				"Communication & Empathy",
 				"Ritual Magic"
 			]
 		},
@@ -5670,7 +5662,6 @@
 			"difficulty": "H",
 			"tech_level": "",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -5707,7 +5698,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 5,
 			"categories": [
-				"Communication",
+				"Communication & Empathy",
 				"Ritual Magic"
 			]
 		},
@@ -5730,7 +5721,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 4,
 			"categories": [
-				"Communication",
+				"Communication & Empathy",
 				"Ritual Magic"
 			]
 		},
@@ -5753,7 +5744,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 3,
 			"categories": [
-				"Communication",
+				"Communication & Empathy",
 				"Ritual Magic"
 			]
 		},
@@ -6568,7 +6559,6 @@
 			"difficulty": "H",
 			"tech_level": "",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -6731,7 +6721,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 20,
 			"categories": [
-				"Communication",
+				"Communication & Empathy",
 				"Ritual Magic"
 			]
 		},
@@ -6931,7 +6921,6 @@
 			"reference": "M181",
 			"difficulty": "H",
 			"college": [
-				"Radiation",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -7527,7 +7516,7 @@
 			"prereq_count": 2,
 			"notes": "HT roll to resist blinding",
 			"categories": [
-				"Light",
+				"Light & Darkness",
 				"Ritual Magic"
 			]
 		},
@@ -7701,7 +7690,7 @@
 			"reference": "M170",
 			"difficulty": "H",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area",
@@ -7713,7 +7702,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 11,
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Ritual Magic"
 			]
 		},
@@ -7724,7 +7713,7 @@
 			"reference": "M170",
 			"difficulty": "H",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -7736,7 +7725,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 12,
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Ritual Magic"
 			]
 		},
@@ -7793,7 +7782,7 @@
 			"reference": "M66",
 			"difficulty": "H",
 			"college": [
-				"Armor Enchantment"
+				"Enchantment"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Enchantment",
@@ -8102,7 +8091,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 5,
 			"categories": [
-				"Communication",
+				"Communication & Empathy",
 				"Ritual Magic"
 			]
 		},
@@ -8125,7 +8114,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 5,
 			"categories": [
-				"Communication",
+				"Communication & Empathy",
 				"Ritual Magic"
 			]
 		},
@@ -8183,7 +8172,6 @@
 			"difficulty": "H",
 			"tech_level": "",
 			"college": [
-				"Machine",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -8220,7 +8208,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 2,
 			"categories": [
-				"Light",
+				"Light & Darkness",
 				"Ritual Magic"
 			]
 		},
@@ -8243,7 +8231,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 2,
 			"categories": [
-				"Light",
+				"Light & Darkness",
 				"Ritual Magic"
 			]
 		},
@@ -8712,7 +8700,7 @@
 			"reference": "M167",
 			"difficulty": "H",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Blocking",
@@ -8724,7 +8712,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 2,
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Ritual Magic"
 			]
 		},
@@ -8792,7 +8780,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 1,
 			"categories": [
-				"Light",
+				"Light & Darkness",
 				"Ritual Magic"
 			]
 		},
@@ -8907,7 +8895,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 4,
 			"categories": [
-				"Light",
+				"Light & Darkness",
 				"Ritual Magic"
 			]
 		},
@@ -8930,7 +8918,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 2,
 			"categories": [
-				"Communication",
+				"Communication & Empathy",
 				"Ritual Magic"
 			]
 		},
@@ -8999,7 +8987,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 3,
 			"categories": [
-				"Communication",
+				"Communication & Empathy",
 				"Ritual Magic"
 			]
 		},
@@ -9500,7 +9488,6 @@
 			"reference": "M182",
 			"difficulty": "H",
 			"college": [
-				"Metal",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -9547,7 +9534,6 @@
 			"reference": "M182",
 			"difficulty": "H",
 			"college": [
-				"Plastic",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -9791,7 +9777,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 1,
 			"categories": [
-				"Light",
+				"Light & Darkness",
 				"Ritual Magic"
 			]
 		},
@@ -9862,7 +9848,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 10,
 			"categories": [
-				"Communication",
+				"Communication & Empathy",
 				"Ritual Magic"
 			]
 		},
@@ -9976,7 +9962,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 6,
 			"categories": [
-				"Light",
+				"Light & Darkness",
 				"Ritual Magic"
 			]
 		},
@@ -10033,7 +10019,7 @@
 			"reference": "M169",
 			"difficulty": "H",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Blocking",
@@ -10045,7 +10031,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 8,
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Ritual Magic"
 			]
 		},
@@ -10056,7 +10042,6 @@
 			"reference": "M181",
 			"difficulty": "H",
 			"college": [
-				"Radiation",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -10413,7 +10398,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 3,
 			"categories": [
-				"Communication",
+				"Communication & Empathy",
 				"Ritual Magic"
 			]
 		},
@@ -10425,7 +10410,6 @@
 			"difficulty": "H",
 			"tech_level": "",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -10462,7 +10446,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 7,
 			"categories": [
-				"Communication",
+				"Communication & Empathy",
 				"Ritual Magic"
 			]
 		},
@@ -10647,7 +10631,7 @@
 			"points": 0,
 			"base_skill": "Ritual Magic",
 			"categories": [
-				"Light",
+				"Light & Darkness",
 				"Ritual Magic"
 			]
 		},
@@ -10699,7 +10683,7 @@
 			"prereq_count": 2,
 			"notes": "blinds only when darkness penalty is -5 or more",
 			"categories": [
-				"Light",
+				"Light & Darkness",
 				"Ritual Magic"
 			]
 		},
@@ -10733,7 +10717,7 @@
 			"reference": "M67",
 			"difficulty": "H",
 			"college": [
-				"Armor Enchantment"
+				"Enchantment"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Enchantment",
@@ -11047,7 +11031,6 @@
 			"reference": "M131",
 			"difficulty": "H",
 			"college": [
-				"Linking",
 				"Meta"
 			],
 			"power_source": "Arcane",
@@ -11211,7 +11194,6 @@
 			"difficulty": "H",
 			"tech_level": "",
 			"college": [
-				"Machine",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -11237,7 +11219,6 @@
 			"difficulty": "H",
 			"tech_level": "",
 			"college": [
-				"Machine",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -11276,7 +11257,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 13,
 			"categories": [
-				"Communication",
+				"Communication & Empathy",
 				"Ritual Magic",
 				"Technological"
 			]
@@ -11289,7 +11270,6 @@
 			"difficulty": "H",
 			"tech_level": "",
 			"college": [
-				"Machine",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -11349,7 +11329,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 4,
 			"categories": [
-				"Light",
+				"Light & Darkness",
 				"Ritual Magic"
 			]
 		},
@@ -11429,7 +11409,7 @@
 			"reference": "M166",
 			"difficulty": "H",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -11441,7 +11421,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 1,
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Ritual Magic"
 			]
 		},
@@ -11475,7 +11455,6 @@
 			"reference": "M181",
 			"difficulty": "H",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -11570,7 +11549,6 @@
 			"difficulty": "H",
 			"tech_level": "",
 			"college": [
-				"Machine",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -11931,7 +11909,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 12,
 			"categories": [
-				"Communication",
+				"Communication & Empathy",
 				"Ritual Magic",
 				"Sound"
 			]
@@ -11944,7 +11922,6 @@
 			"difficulty": "H",
 			"college": [
 				"Knowledge",
-				"Metal",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -12005,7 +11982,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 3,
 			"categories": [
-				"Communication",
+				"Communication & Empathy",
 				"Ritual Magic"
 			]
 		},
@@ -12028,7 +12005,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 4,
 			"categories": [
-				"Communication",
+				"Communication & Empathy",
 				"Ritual Magic"
 			]
 		},
@@ -12051,7 +12028,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 4,
 			"categories": [
-				"Communication",
+				"Communication & Empathy",
 				"Ritual Magic"
 			]
 		},
@@ -12120,7 +12097,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 2,
 			"categories": [
-				"Light",
+				"Light & Darkness",
 				"Ritual Magic"
 			]
 		},
@@ -12131,7 +12108,7 @@
 			"reference": "M168",
 			"difficulty": "H",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -12143,7 +12120,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 3,
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Ritual Magic"
 			]
 		},
@@ -12300,7 +12277,7 @@
 			"reference": "M168",
 			"difficulty": "H",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area",
@@ -12312,7 +12289,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 3,
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Ritual Magic"
 			]
 		},
@@ -12404,7 +12381,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 1,
 			"categories": [
-				"Light",
+				"Light & Darkness",
 				"Ritual Magic"
 			]
 		},
@@ -12415,7 +12392,7 @@
 			"reference": "M167",
 			"difficulty": "H",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area",
@@ -12427,7 +12404,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 2,
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Ritual Magic"
 			]
 		},
@@ -12956,7 +12933,6 @@
 			"difficulty": "H",
 			"tech_level": "",
 			"college": [
-				"Machine",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -13016,7 +12992,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 9,
 			"categories": [
-				"Communication",
+				"Communication & Empathy",
 				"Ritual Magic"
 			]
 		},
@@ -13062,7 +13038,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 2,
 			"categories": [
-				"Communication",
+				"Communication & Empathy",
 				"Ritual Magic"
 			]
 		},
@@ -13446,7 +13422,6 @@
 			"difficulty": "H",
 			"college": [
 				"Knowledge",
-				"Plastic",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -13596,7 +13571,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 6,
 			"categories": [
-				"Communication",
+				"Communication & Empathy",
 				"Ritual Magic"
 			]
 		},
@@ -13759,7 +13734,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 7,
 			"categories": [
-				"Communication",
+				"Communication & Empathy",
 				"Ritual Magic"
 			]
 		},
@@ -13794,7 +13769,6 @@
 			"difficulty": "H",
 			"tech_level": "",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -13843,7 +13817,6 @@
 			"difficulty": "H",
 			"tech_level": "",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -14008,7 +13981,6 @@
 			"difficulty": "H",
 			"tech_level": "",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -14125,7 +14097,6 @@
 			"reference": "M182",
 			"difficulty": "H",
 			"college": [
-				"Radiation",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -14150,7 +14121,6 @@
 			"reference": "M181",
 			"difficulty": "H",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -14438,7 +14408,6 @@
 			"difficulty": "H",
 			"tech_level": "",
 			"college": [
-				"Machine",
 				"Making & Breaking",
 				"Technological"
 			],
@@ -14559,7 +14528,7 @@
 			"reference": "M168",
 			"difficulty": "H",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Blocking",
@@ -14571,7 +14540,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 3,
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Ritual Magic"
 			]
 		},
@@ -14582,7 +14551,6 @@
 			"reference": "M132",
 			"difficulty": "H",
 			"college": [
-				"Linking",
 				"Meta"
 			],
 			"power_source": "Arcane",
@@ -14920,7 +14888,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 2,
 			"categories": [
-				"Light",
+				"Light & Darkness",
 				"Ritual Magic"
 			]
 		},
@@ -14943,7 +14911,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 1,
 			"categories": [
-				"Light",
+				"Light & Darkness",
 				"Ritual Magic"
 			]
 		},
@@ -15206,7 +15174,7 @@
 			"reference": "M190",
 			"difficulty": "H",
 			"college": [
-				"Protection",
+				"Protection & Warning",
 				"Water"
 			],
 			"power_source": "Arcane",
@@ -15219,7 +15187,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 9,
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Ritual Magic",
 				"Water"
 			]
@@ -15255,7 +15223,7 @@
 			"difficulty": "H",
 			"college": [
 				"Healing",
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -15268,7 +15236,7 @@
 			"prereq_count": 3,
 			"categories": [
 				"Healing",
-				"Protection",
+				"Protection & Warning",
 				"Ritual Magic"
 			]
 		},
@@ -15326,7 +15294,7 @@
 			"difficulty": "H",
 			"college": [
 				"Air",
-				"Protection",
+				"Protection & Warning",
 				"Weather"
 			],
 			"power_source": "Arcane",
@@ -15340,7 +15308,7 @@
 			"prereq_count": 6,
 			"categories": [
 				"Air",
-				"Protection",
+				"Protection & Warning",
 				"Ritual Magic",
 				"Weather"
 			]
@@ -15376,7 +15344,7 @@
 			"difficulty": "H",
 			"college": [
 				"Healing",
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -15389,7 +15357,7 @@
 			"prereq_count": 4,
 			"categories": [
 				"Healing",
-				"Protection",
+				"Protection & Warning",
 				"Ritual Magic"
 			]
 		},
@@ -15400,7 +15368,7 @@
 			"reference": "M169",
 			"difficulty": "H",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -15412,7 +15380,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 9,
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Ritual Magic"
 			]
 		},
@@ -15423,8 +15391,7 @@
 			"reference": "M182",
 			"difficulty": "H",
 			"college": [
-				"Protection",
-				"Radiation",
+				"Protection & Warning",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -15437,7 +15404,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 7,
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Radiation",
 				"Ritual Magic",
 				"Technological"
@@ -15450,7 +15417,7 @@
 			"reference": "M173",
 			"difficulty": "H",
 			"college": [
-				"Protection",
+				"Protection & Warning",
 				"Sound"
 			],
 			"power_source": "Arcane",
@@ -15463,7 +15430,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 4,
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Ritual Magic",
 				"Sound"
 			]
@@ -15475,7 +15442,7 @@
 			"reference": "M186",
 			"difficulty": "H",
 			"college": [
-				"Protection",
+				"Protection & Warning",
 				"Water"
 			],
 			"power_source": "Arcane",
@@ -15488,7 +15455,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 4,
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Ritual Magic",
 				"Water"
 			]
@@ -15721,7 +15688,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 6,
 			"categories": [
-				"Communication",
+				"Communication & Empathy",
 				"Ritual Magic"
 			]
 		},
@@ -15732,7 +15699,7 @@
 			"reference": "M168",
 			"difficulty": "H",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Blocking",
@@ -15744,7 +15711,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 4,
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Ritual Magic"
 			]
 		},
@@ -15756,7 +15723,6 @@
 			"difficulty": "H",
 			"tech_level": "",
 			"college": [
-				"Machine",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -15781,7 +15747,7 @@
 			"reference": "M168",
 			"difficulty": "H",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -15793,7 +15759,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 3,
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Ritual Magic"
 			]
 		},
@@ -16146,7 +16112,6 @@
 			"tech_level": "",
 			"college": [
 				"Knowledge",
-				"Machine",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -16345,7 +16310,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 3,
 			"categories": [
-				"Light",
+				"Light & Darkness",
 				"Ritual Magic"
 			]
 		},
@@ -16356,7 +16321,6 @@
 			"reference": "M181",
 			"difficulty": "H",
 			"college": [
-				"Radiation",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -16515,7 +16479,6 @@
 			"difficulty": "H",
 			"tech_level": "",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -16563,7 +16526,6 @@
 			"difficulty": "H",
 			"tech_level": "",
 			"college": [
-				"Machine",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -16655,7 +16617,6 @@
 			"reference": "M182",
 			"difficulty": "H",
 			"college": [
-				"Plastic",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -16680,7 +16641,6 @@
 			"difficulty": "H",
 			"tech_level": "",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -16704,7 +16664,6 @@
 			"reference": "M181",
 			"difficulty": "H",
 			"college": [
-				"Radiation",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -16774,7 +16733,7 @@
 			"reference": "M166",
 			"difficulty": "H",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Info",
@@ -16786,7 +16745,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 1,
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Ritual Magic"
 			]
 		},
@@ -16809,7 +16768,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 1,
 			"categories": [
-				"Communication",
+				"Communication & Empathy",
 				"Ritual Magic"
 			]
 		},
@@ -16831,7 +16790,7 @@
 			"points": 0,
 			"base_skill": "Ritual Magic",
 			"categories": [
-				"Communication",
+				"Communication & Empathy",
 				"Ritual Magic"
 			]
 		},
@@ -16853,7 +16812,7 @@
 			"points": 0,
 			"base_skill": "Ritual Magic",
 			"categories": [
-				"Communication",
+				"Communication & Empathy",
 				"Ritual Magic"
 			]
 		},
@@ -16887,7 +16846,7 @@
 			"reference": "M167",
 			"difficulty": "H",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area",
@@ -16899,7 +16858,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 2,
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Ritual Magic"
 			]
 		},
@@ -16956,7 +16915,7 @@
 			"reference": "M169",
 			"difficulty": "H",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -16968,7 +16927,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 3,
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Ritual Magic"
 			]
 		},
@@ -17014,7 +16973,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 3,
 			"categories": [
-				"Light",
+				"Light & Darkness",
 				"Ritual Magic"
 			]
 		},
@@ -17083,7 +17042,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 1,
 			"categories": [
-				"Light",
+				"Light & Darkness",
 				"Ritual Magic"
 			]
 		},
@@ -17094,7 +17053,6 @@
 			"reference": "M182",
 			"difficulty": "H",
 			"college": [
-				"Metal",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -17142,7 +17100,6 @@
 			"reference": "M183",
 			"difficulty": "H",
 			"college": [
-				"Plastic",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -17369,7 +17326,7 @@
 			"reference": "M167",
 			"difficulty": "H",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -17381,7 +17338,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 2,
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Ritual Magic"
 			]
 		},
@@ -17835,7 +17792,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 1,
 			"categories": [
-				"Light",
+				"Light & Darkness",
 				"Ritual Magic"
 			]
 		},
@@ -18069,7 +18026,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 4,
 			"categories": [
-				"Communication",
+				"Communication & Empathy",
 				"Ritual Magic"
 			]
 		},
@@ -18308,7 +18265,6 @@
 			"reference": "M181",
 			"difficulty": "H",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -18712,7 +18668,6 @@
 			"difficulty": "H",
 			"tech_level": "",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -19161,7 +19116,6 @@
 			"reference": "M179",
 			"difficulty": "H",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -19624,7 +19578,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 7,
 			"categories": [
-				"Light",
+				"Light & Darkness",
 				"Ritual Magic"
 			]
 		},
@@ -19647,7 +19601,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 5,
 			"categories": [
-				"Light",
+				"Light & Darkness",
 				"Ritual Magic"
 			]
 		},
@@ -19971,7 +19925,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 5,
 			"categories": [
-				"Communication",
+				"Communication & Empathy",
 				"Ritual Magic"
 			]
 		},
@@ -20033,7 +19987,7 @@
 			"difficulty": "H",
 			"college": [
 				"Gate",
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area",
@@ -20046,7 +20000,7 @@
 			"prereq_count": 10,
 			"categories": [
 				"Gate",
-				"Protection",
+				"Protection & Warning",
 				"Ritual Magic"
 			]
 		},
@@ -20171,7 +20125,6 @@
 			"difficulty": "H",
 			"tech_level": "",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -20758,7 +20711,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 2,
 			"categories": [
-				"Communication",
+				"Communication & Empathy",
 				"Ritual Magic"
 			]
 		},
@@ -20769,7 +20722,7 @@
 			"reference": "M167",
 			"difficulty": "H",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Blocking",
@@ -20781,7 +20734,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 2,
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Ritual Magic"
 			]
 		},
@@ -20838,7 +20791,7 @@
 			"reference": "M185",
 			"difficulty": "H",
 			"college": [
-				"Protection",
+				"Protection & Warning",
 				"Water"
 			],
 			"power_source": "Arcane",
@@ -20851,7 +20804,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 3,
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Ritual Magic",
 				"Water"
 			]
@@ -20886,7 +20839,7 @@
 			"reference": "M170",
 			"difficulty": "H",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area",
@@ -20898,7 +20851,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 16,
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Ritual Magic"
 			]
 		},
@@ -20909,7 +20862,7 @@
 			"reference": "M170",
 			"difficulty": "H",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -20921,7 +20874,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 18,
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Ritual Magic"
 			]
 		},
@@ -20944,7 +20897,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 2,
 			"categories": [
-				"Communication",
+				"Communication & Empathy",
 				"Ritual Magic"
 			]
 		},
@@ -21197,7 +21150,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 2,
 			"categories": [
-				"Light",
+				"Light & Darkness",
 				"Ritual Magic"
 			]
 		},
@@ -21351,7 +21304,7 @@
 			"difficulty": "H",
 			"college": [
 				"Fire",
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -21364,7 +21317,7 @@
 			"prereq_count": 4,
 			"categories": [
 				"Fire",
-				"Protection",
+				"Protection & Warning",
 				"Ritual Magic"
 			]
 		},
@@ -21375,7 +21328,7 @@
 			"reference": "M167",
 			"difficulty": "H",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area",
@@ -21387,7 +21340,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 2,
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Ritual Magic"
 			]
 		},
@@ -21659,7 +21612,7 @@
 			"reference": "M169",
 			"difficulty": "H",
 			"college": [
-				"Protection",
+				"Protection & Warning",
 				"Weather"
 			],
 			"power_source": "Arcane",
@@ -21672,7 +21625,7 @@
 			"base_skill": "Ritual Magic",
 			"prereq_count": 8,
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Ritual Magic",
 				"Weather"
 			]

--- a/Library/Pyramid Magazine/Pyramid 115/Pyramid 115 Spells.spl
+++ b/Library/Pyramid Magazine/Pyramid 115/Pyramid 115 Spells.spl
@@ -203,16 +203,42 @@
 						"all": true,
 						"prereqs": [
 							{
-								"type": "advantage_prereq",
-								"has": true,
-								"name": {
-									"compare": "is",
-									"qualifier": "Magery"
-								},
-								"level": {
-									"compare": "at_least",
-									"qualifier": 3
-								}
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "magery"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 3
+										},
+										"notes": {
+											"compare": "does_not_contain",
+											"qualifier": "one college"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "magery"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 3
+										},
+										"notes": {
+											"compare": "contains",
+											"qualifier": "one college (illusion & creation)"
+										}
+									}
+								]
 							}
 						]
 					}

--- a/Library/Pyramid Magazine/Pyramid 115/Pyramid 115 Spells.spl
+++ b/Library/Pyramid Magazine/Pyramid 115/Pyramid 115 Spells.spl
@@ -124,7 +124,7 @@
 						"sub_type": "college",
 						"qualifier": {
 							"compare": "contains",
-							"qualifier": "Light"
+							"qualifier": "Light & Darkness"
 						},
 						"quantity": {
 							"compare": "at_least",
@@ -147,7 +147,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -284,7 +284,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -294,7 +294,6 @@
 			"reference": "PY115:14",
 			"difficulty": "iq/h",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -335,7 +334,6 @@
 			"reference": "PY115:14",
 			"difficulty": "iq/h",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -450,7 +448,7 @@
 						"sub_type": "college",
 						"qualifier": {
 							"compare": "contains",
-							"qualifier": "Light"
+							"qualifier": "Light & Darkness"
 						},
 						"quantity": {
 							"compare": "at_least",
@@ -474,7 +472,7 @@
 			},
 			"notes": "For double energy, you can cast an ROF 2 version that fires from both eyes.",
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -527,7 +525,7 @@
 			},
 			"notes": "Max range of 200 yards; for each doubling of energy, you can increase range by a factor of 10",
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -537,7 +535,6 @@
 			"reference": "PY115:22",
 			"difficulty": "iq/h",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -639,7 +636,6 @@
 			"reference": "PY115:14",
 			"difficulty": "iq/h",
 			"college": [
-				"Machine",
 				"Movement",
 				"Technological"
 			],
@@ -744,7 +740,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -820,7 +816,6 @@
 			"difficulty": "iq/h",
 			"college": [
 				"Light & Darkness",
-				"Radiation",
 				"Technologica"
 			],
 			"power_source": "Arcane",
@@ -910,7 +905,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		}
 	]

--- a/Library/Pyramid Magazine/Pyramid 120/Magic Spells (Based on QN).spl
+++ b/Library/Pyramid Magazine/Pyramid 120/Magic Spells (Based on QN).spl
@@ -1630,7 +1630,6 @@
 			"difficulty": "qn/vh",
 			"tech_level": "",
 			"college": [
-				"Machine",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -2464,7 +2463,6 @@
 			"difficulty": "qn/vh",
 			"tech_level": "",
 			"college": [
-				"Machine",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -4208,7 +4206,6 @@
 			"reference": "M183",
 			"difficulty": "qn/h",
 			"college": [
-				"Metal",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -4297,7 +4294,6 @@
 			"reference": "M183",
 			"difficulty": "qn/h",
 			"college": [
-				"Plastic",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -5422,7 +5418,6 @@
 			"reference": "M182",
 			"difficulty": "qn/h",
 			"college": [
-				"Radiation",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -7640,7 +7635,6 @@
 			"difficulty": "qn/vh",
 			"tech_level": "",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -9689,7 +9683,6 @@
 			"difficulty": "qn/h",
 			"tech_level": "",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -10841,7 +10834,7 @@
 			"reference": "M67",
 			"difficulty": "qn/h",
 			"college": [
-				"Armor Enchantment"
+				"Enchantment"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Enchantment",
@@ -11364,7 +11357,7 @@
 			"reference": "M67",
 			"difficulty": "qn/h",
 			"college": [
-				"Armor Enchantment"
+				"Enchantment"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Enchantment",
@@ -11468,7 +11461,7 @@
 			"reference": "M67",
 			"difficulty": "qn/h",
 			"college": [
-				"Armor Enchantment"
+				"Enchantment"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Enchantment",
@@ -11704,7 +11697,6 @@
 			"reference": "M130",
 			"difficulty": "qn/h",
 			"college": [
-				"Linking",
 				"Meta"
 			],
 			"power_source": "Arcane",
@@ -13812,7 +13804,6 @@
 			"difficulty": "qn/vh",
 			"tech_level": "",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -16085,7 +16076,6 @@
 			"difficulty": "qn/h",
 			"tech_level": "",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -16102,7 +16092,7 @@
 					{
 						"type": "spell_prereq",
 						"has": true,
-						"sub_type": "college",
+						"sub_type": "category",
 						"qualifier": {
 							"compare": "contains",
 							"qualifier": "Energy"
@@ -16872,7 +16862,6 @@
 			"reference": "M181",
 			"difficulty": "qn/h",
 			"college": [
-				"Radiation",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -19250,7 +19239,7 @@
 			"reference": "M66",
 			"difficulty": "qn/h",
 			"college": [
-				"Armor Enchantment"
+				"Enchantment"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Enchantment",
@@ -20184,7 +20173,6 @@
 			"difficulty": "qn/h",
 			"tech_level": "",
 			"college": [
-				"Machine",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -23273,7 +23261,6 @@
 			"reference": "M182",
 			"difficulty": "qn/h",
 			"college": [
-				"Metal",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -23353,7 +23340,6 @@
 			"reference": "M182",
 			"difficulty": "qn/h",
 			"college": [
-				"Plastic",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -24526,7 +24512,6 @@
 			"reference": "M181",
 			"difficulty": "qn/h",
 			"college": [
-				"Radiation",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -25290,7 +25275,6 @@
 			"difficulty": "qn/h",
 			"tech_level": "",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -26134,7 +26118,7 @@
 			"reference": "M67",
 			"difficulty": "qn/h",
 			"college": [
-				"Armor Enchantment"
+				"Enchantment"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Enchantment",
@@ -26744,7 +26728,6 @@
 			"reference": "M131",
 			"difficulty": "qn/h",
 			"college": [
-				"Linking",
 				"Meta"
 			],
 			"power_source": "Arcane",
@@ -27182,7 +27165,6 @@
 			"difficulty": "qn/h",
 			"tech_level": "",
 			"college": [
-				"Machine",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -27250,7 +27232,6 @@
 			"difficulty": "qn/h",
 			"tech_level": "",
 			"college": [
-				"Machine",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -27367,7 +27348,6 @@
 			"difficulty": "qn/h",
 			"tech_level": "",
 			"college": [
-				"Machine",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -27772,7 +27752,6 @@
 			"reference": "M181",
 			"difficulty": "qn/h",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -27991,7 +27970,6 @@
 			"difficulty": "qn/h",
 			"tech_level": "",
 			"college": [
-				"Machine",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -28766,7 +28744,6 @@
 			"difficulty": "qn/h",
 			"college": [
 				"Knowledge",
-				"Metal",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -31303,7 +31280,6 @@
 			"difficulty": "qn/vh",
 			"tech_level": "",
 			"college": [
-				"Machine",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -32856,7 +32832,6 @@
 			"difficulty": "qn/h",
 			"college": [
 				"Knowledge",
-				"Plastic",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -33508,7 +33483,6 @@
 			"difficulty": "qn/h",
 			"tech_level": "",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -33602,7 +33576,6 @@
 			"difficulty": "qn/h",
 			"tech_level": "",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -33986,7 +33959,6 @@
 			"difficulty": "qn/h",
 			"tech_level": "",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -34269,7 +34241,6 @@
 			"reference": "M182",
 			"difficulty": "qn/h",
 			"college": [
-				"Radiation",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -34323,7 +34294,6 @@
 			"reference": "M181",
 			"difficulty": "qn/h",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -35111,7 +35081,6 @@
 			"difficulty": "qn/vh",
 			"tech_level": "",
 			"college": [
-				"Machine",
 				"Making & Breaking",
 				"Technological"
 			],
@@ -35677,7 +35646,6 @@
 			"reference": "M132",
 			"difficulty": "qn/h",
 			"college": [
-				"Linking",
 				"Meta"
 			],
 			"power_source": "Arcane",
@@ -37601,7 +37569,6 @@
 			"difficulty": "qn/h",
 			"college": [
 				"Protection & Warning",
-				"Radiation",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -37618,7 +37585,7 @@
 					{
 						"type": "spell_prereq",
 						"has": true,
-						"sub_type": "college",
+						"sub_type": "category",
 						"qualifier": {
 							"compare": "contains",
 							"qualifier": "Radiation"
@@ -38399,7 +38366,6 @@
 			"difficulty": "qn/h",
 			"tech_level": "",
 			"college": [
-				"Machine",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -39283,7 +39249,6 @@
 			"tech_level": "",
 			"college": [
 				"Knowledge",
-				"Machine",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -39864,7 +39829,6 @@
 			"reference": "M181",
 			"difficulty": "qn/h",
 			"college": [
-				"Radiation",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -40058,7 +40022,6 @@
 			"difficulty": "qn/h",
 			"tech_level": "",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -40176,7 +40139,6 @@
 			"difficulty": "qn/h",
 			"tech_level": "",
 			"college": [
-				"Machine",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -40296,7 +40258,6 @@
 			"reference": "M182",
 			"difficulty": "qn/h",
 			"college": [
-				"Plastic",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -40319,7 +40280,6 @@
 			"difficulty": "qn/h",
 			"tech_level": "",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -40341,7 +40301,6 @@
 			"reference": "M181",
 			"difficulty": "qn/h",
 			"college": [
-				"Radiation",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -41153,7 +41112,6 @@
 			"reference": "M182",
 			"difficulty": "qn/h",
 			"college": [
-				"Metal",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -41299,7 +41257,6 @@
 			"reference": "M183",
 			"difficulty": "qn/h",
 			"college": [
-				"Plastic",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -43996,7 +43953,6 @@
 			"reference": "M181",
 			"difficulty": "qn/h",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -45030,7 +44986,6 @@
 			"difficulty": "qn/vh",
 			"tech_level": "",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -46231,7 +46186,6 @@
 			"reference": "M179",
 			"difficulty": "qn/h",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -49224,7 +49178,6 @@
 			"difficulty": "qn/h",
 			"tech_level": "",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",

--- a/Library/Pyramid Magazine/Pyramid 4/Pyramid 4 Spells.spl
+++ b/Library/Pyramid Magazine/Pyramid 4/Pyramid 4 Spells.spl
@@ -32,7 +32,7 @@
 			"difficulty": "iq/h",
 			"college": [
 				"Movement",
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Blocking",
@@ -43,7 +43,7 @@
 			"notes": "Style - Six Strengths of Siegecraft",
 			"categories": [
 				"Movement",
-				"Protection",
+				"Protection & Warning",
 				"Secret"
 			]
 		},
@@ -54,7 +54,7 @@
 			"reference": "PY4:9",
 			"difficulty": "iq/h",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area",
@@ -64,7 +64,7 @@
 			"points": 1,
 			"notes": "Style - Six Strengths of Siegecraft",
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Secret"
 			]
 		},
@@ -75,7 +75,7 @@
 			"reference": "PY4:9",
 			"difficulty": "iq/h",
 			"college": [
-				"Protection",
+				"Protection & Warning",
 				"Water"
 			],
 			"power_source": "Arcane",
@@ -87,7 +87,7 @@
 			"points": 1,
 			"notes": "Style - Six Strengths of Siegecraft",
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Secret",
 				"Water"
 			]
@@ -100,7 +100,7 @@
 			"difficulty": "iq/h",
 			"college": [
 				"Healing",
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area",
@@ -112,7 +112,7 @@
 			"notes": "Style - Six Strengths of Siegecraft",
 			"categories": [
 				"Healing",
-				"Protection",
+				"Protection & Warning",
 				"Secret"
 			]
 		},
@@ -146,7 +146,7 @@
 			"difficulty": "iq/h",
 			"college": [
 				"Air",
-				"Protection",
+				"Protection & Warning",
 				"Weather"
 			],
 			"power_source": "Arcane",
@@ -159,7 +159,7 @@
 			"notes": "Style - Six Strengths of Siegecraft",
 			"categories": [
 				"Air",
-				"Protection",
+				"Protection & Warning",
 				"Secret",
 				"Weather"
 			]
@@ -172,7 +172,7 @@
 			"difficulty": "iq/h",
 			"college": [
 				"Healing",
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area",
@@ -184,7 +184,7 @@
 			"notes": "Style - Six Strengths of Siegecraft",
 			"categories": [
 				"Healing",
-				"Protection",
+				"Protection & Warning",
 				"Secret"
 			]
 		}

--- a/Library/Pyramid Magazine/Pyramid 91/Pyramid 91 Spells.spl
+++ b/Library/Pyramid Magazine/Pyramid 91/Pyramid 91 Spells.spl
@@ -46,39 +46,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Magery"
-								},
-								"level": {
-									"compare": "at_least",
-									"qualifier": 1
-								},
-								"notes": {
-									"compare": "contains",
-									"qualifier": "One College (Making & Breaking)"
-								}
-							},
-							{
-								"type": "advantage_prereq",
-								"has": true,
-								"name": {
-									"compare": "is",
-									"qualifier": "Magery"
-								},
-								"level": {
-									"compare": "at_least",
-									"qualifier": 1
-								},
-								"notes": {
-									"compare": "contains",
-									"qualifier": "One College (Metal)"
-								}
-							},
-							{
-								"type": "advantage_prereq",
-								"has": true,
-								"name": {
-									"compare": "is",
-									"qualifier": "Magery"
+									"qualifier": "magery"
 								},
 								"level": {
 									"compare": "at_least",
@@ -86,7 +54,39 @@
 								},
 								"notes": {
 									"compare": "does_not_contain",
-									"qualifier": "One College"
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (making & breaking)"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (metal)"
 								}
 							}
 						]
@@ -126,23 +126,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Magery"
-								},
-								"level": {
-									"compare": "at_least",
-									"qualifier": 3
-								},
-								"notes": {
-									"compare": "contains",
-									"qualifier": "One College (Metal)"
-								}
-							},
-							{
-								"type": "advantage_prereq",
-								"has": true,
-								"name": {
-									"compare": "is",
-									"qualifier": "Magery"
+									"qualifier": "magery"
 								},
 								"level": {
 									"compare": "at_least",
@@ -150,7 +134,23 @@
 								},
 								"notes": {
 									"compare": "does_not_contain",
-									"qualifier": "One College"
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (metal)"
 								}
 							}
 						]
@@ -332,23 +332,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Magery"
-								},
-								"level": {
-									"compare": "at_least",
-									"qualifier": 2
-								},
-								"notes": {
-									"compare": "contains",
-									"qualifier": "One College (Metal)"
-								}
-							},
-							{
-								"type": "advantage_prereq",
-								"has": true,
-								"name": {
-									"compare": "is",
-									"qualifier": "Magery"
+									"qualifier": "magery"
 								},
 								"level": {
 									"compare": "at_least",
@@ -356,7 +340,23 @@
 								},
 								"notes": {
 									"compare": "does_not_contain",
-									"qualifier": "One College"
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (metal)"
 								}
 							}
 						]
@@ -526,7 +526,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Magery"
+									"qualifier": "magery"
 								},
 								"level": {
 									"compare": "at_least",
@@ -534,7 +534,7 @@
 								},
 								"notes": {
 									"compare": "does_not_contain",
-									"qualifier": "One College"
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -542,7 +542,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Magery"
+									"qualifier": "magery"
 								},
 								"level": {
 									"compare": "at_least",
@@ -550,7 +550,7 @@
 								},
 								"notes": {
 									"compare": "contains",
-									"qualifier": "One College (Metal)"
+									"qualifier": "one college (metal)"
 								}
 							}
 						]
@@ -946,7 +946,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Magery"
+									"qualifier": "magery"
 								},
 								"level": {
 									"compare": "at_least",
@@ -954,7 +954,7 @@
 								},
 								"notes": {
 									"compare": "does_not_contain",
-									"qualifier": "One College"
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -962,7 +962,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Magery"
+									"qualifier": "magery"
 								},
 								"level": {
 									"compare": "at_least",
@@ -970,7 +970,7 @@
 								},
 								"notes": {
 									"compare": "contains",
-									"qualifier": "One College (Making & Breaking)"
+									"qualifier": "one college (making & breaking)"
 								}
 							},
 							{
@@ -978,7 +978,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Magery"
+									"qualifier": "magery"
 								},
 								"level": {
 									"compare": "at_least",
@@ -986,7 +986,7 @@
 								},
 								"notes": {
 									"compare": "contains",
-									"qualifier": "One College (Metal)"
+									"qualifier": "one college (metal)"
 								}
 							}
 						]
@@ -1155,7 +1155,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Magery"
+									"qualifier": "magery"
 								},
 								"level": {
 									"compare": "at_least",
@@ -1163,7 +1163,7 @@
 								},
 								"notes": {
 									"compare": "does_not_contain",
-									"qualifier": "One College"
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -1171,7 +1171,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Magery"
+									"qualifier": "magery"
 								},
 								"level": {
 									"compare": "at_least",
@@ -1179,7 +1179,7 @@
 								},
 								"notes": {
 									"compare": "contains",
-									"qualifier": "One College (Earth)"
+									"qualifier": "one college (earth)"
 								}
 							},
 							{
@@ -1187,7 +1187,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Magery"
+									"qualifier": "magery"
 								},
 								"level": {
 									"compare": "at_least",
@@ -1195,7 +1195,7 @@
 								},
 								"notes": {
 									"compare": "contains",
-									"qualifier": "One College (metal)"
+									"qualifier": "one college (metal)"
 								}
 							}
 						]
@@ -1249,7 +1249,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Magery"
+									"qualifier": "magery"
 								},
 								"level": {
 									"compare": "at_least",
@@ -1257,7 +1257,7 @@
 								},
 								"notes": {
 									"compare": "does_not_contain",
-									"qualifier": "One College"
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -1265,7 +1265,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Magery"
+									"qualifier": "magery"
 								},
 								"level": {
 									"compare": "at_least",
@@ -1273,7 +1273,7 @@
 								},
 								"notes": {
 									"compare": "contains",
-									"qualifier": "One College (Metal)"
+									"qualifier": "one college (metal)"
 								}
 							}
 						]

--- a/Library/Pyramid Magazine/Pyramid 91/Pyramid 91 Spells.spl
+++ b/Library/Pyramid Magazine/Pyramid 91/Pyramid 91 Spells.spl
@@ -64,6 +64,10 @@
 									"compare": "is",
 									"qualifier": "Magery"
 								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
 								"notes": {
 									"compare": "contains",
 									"qualifier": "One College (Metal)"

--- a/Library/Wizardy Redefined/Wizardry Redefined Spells.spl
+++ b/Library/Wizardy Redefined/Wizardry Redefined Spells.spl
@@ -301,8 +301,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (body control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -317,8 +317,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (body control)"
 								}
 							}
 						]
@@ -488,8 +488,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (movement)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -520,8 +520,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (movement)"
 								}
 							}
 						]
@@ -1042,7 +1042,6 @@
 			"difficulty": "iq/vh",
 			"tech_level": "",
 			"college": [
-				"Machine",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -1157,8 +1156,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (making & breaking)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -1173,8 +1172,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (making & breaking)"
 								}
 							}
 						]
@@ -1311,8 +1310,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (movement)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -1327,8 +1326,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (movement)"
 								}
 							}
 						]
@@ -1346,7 +1345,7 @@
 			"reference": "M167",
 			"difficulty": "iq/h",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -1375,7 +1374,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -1491,7 +1490,7 @@
 			"reference": "M169",
 			"difficulty": "iq/h",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area",
@@ -1533,7 +1532,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -1838,8 +1837,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (necromancy)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -1854,8 +1853,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (necromancy)"
 								}
 							}
 						]
@@ -2043,7 +2042,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -2053,7 +2052,7 @@
 			"reference": "M168",
 			"difficulty": "iq/h",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -2095,7 +2094,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -2135,6 +2134,22 @@
 									"qualifier": 3
 								},
 								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (gate)"
 								}
@@ -2153,22 +2168,6 @@
 								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (movement)"
-								}
-							},
-							{
-								"type": "advantage_prereq",
-								"has": true,
-								"name": {
-									"compare": "is",
-									"qualifier": "magery"
-								},
-								"level": {
-									"compare": "at_least",
-									"qualifier": 3
-								},
-								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
 								}
 							}
 						]
@@ -2246,7 +2245,7 @@
 			"reference": "M166",
 			"difficulty": "iq/h",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Blocking",
@@ -2271,8 +2270,8 @@
 							"qualifier": 1
 						},
 						"notes": {
-							"compare": "contains",
-							"qualifier": "one college (protection)"
+							"compare": "does_not_contain",
+							"qualifier": "one college"
 						}
 					},
 					{
@@ -2285,12 +2284,16 @@
 						"level": {
 							"compare": "at_least",
 							"qualifier": 1
+						},
+						"notes": {
+							"compare": "contains",
+							"qualifier": "one college (protection & warning)"
 						}
 					}
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -2342,7 +2345,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -2632,8 +2635,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (air)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -2648,8 +2651,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (air)"
 								}
 							}
 						]
@@ -2667,7 +2670,6 @@
 			"reference": "M183",
 			"difficulty": "iq/h",
 			"college": [
-				"Metal",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -2710,8 +2712,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (technological)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -2726,8 +2728,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (technological)"
 								}
 							}
 						]
@@ -2775,8 +2777,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (light)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -2791,8 +2793,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (light & darkness)"
 								}
 							}
 						]
@@ -2826,7 +2828,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -3250,7 +3252,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -3289,7 +3291,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -3728,7 +3730,7 @@
 								"sub_type": "college",
 								"qualifier": {
 									"compare": "contains",
-									"qualifier": "Light"
+									"qualifier": "Light & Darkness"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -3740,7 +3742,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -3842,8 +3844,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (necromancy)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -3858,8 +3860,24 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (fire)"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (necromancy)"
 								}
 							}
 						]
@@ -4056,7 +4074,7 @@
 			"reference": "M168",
 			"difficulty": "iq/h",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Blocking",
@@ -4085,7 +4103,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -4146,8 +4164,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (meta)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -4162,8 +4180,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (meta)"
 								}
 							}
 						]
@@ -4236,8 +4254,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (mind control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -4252,8 +4270,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (mind control)"
 								}
 							}
 						]
@@ -4300,8 +4318,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (body control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -4316,8 +4334,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (body control)"
 								}
 							}
 						]
@@ -4475,8 +4493,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (movement)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -4491,8 +4509,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (movement)"
 								}
 							}
 						]
@@ -4669,7 +4687,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -4721,8 +4739,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (mind control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -4737,8 +4755,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (mind control)"
 								}
 							}
 						]
@@ -4876,7 +4894,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -4954,8 +4972,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (communication)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -4970,8 +4988,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (communication & empathy)"
 								}
 							}
 						]
@@ -4992,7 +5010,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -5096,8 +5114,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (meta)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -5112,8 +5130,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (meta)"
 								}
 							}
 						]
@@ -5265,7 +5283,6 @@
 			"difficulty": "iq/vh",
 			"tech_level": "",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -5308,8 +5325,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (technological)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -5324,8 +5341,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (technological)"
 								}
 							}
 						]
@@ -5373,7 +5390,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -5425,7 +5442,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -5464,7 +5481,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -5516,8 +5533,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (making & breaking)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -5532,8 +5549,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (making & breaking)"
 								}
 							}
 						]
@@ -5736,8 +5753,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (gate)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -5752,8 +5769,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (gate)"
 								}
 							}
 						]
@@ -5878,8 +5895,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (body control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -5894,8 +5911,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (body control)"
 								}
 							}
 						]
@@ -5955,7 +5972,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -6071,8 +6088,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (sound)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -6087,8 +6104,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (sound)"
 								}
 							}
 						]
@@ -6184,7 +6201,7 @@
 			"reference": "M187",
 			"difficulty": "iq/h",
 			"college": [
-				"Protection",
+				"Protection & Warning",
 				"Water"
 			],
 			"power_source": "Arcane",
@@ -6214,7 +6231,7 @@
 				]
 			},
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Water"
 			]
 		},
@@ -6323,8 +6340,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (body control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -6339,8 +6356,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (body control)"
 								}
 							}
 						]
@@ -6434,8 +6451,8 @@
 							"qualifier": 1
 						},
 						"notes": {
-							"compare": "contains",
-							"qualifier": "one college (meta)"
+							"compare": "does_not_contain",
+							"qualifier": "one college"
 						}
 					},
 					{
@@ -6448,6 +6465,10 @@
 						"level": {
 							"compare": "at_least",
 							"qualifier": 1
+						},
+						"notes": {
+							"compare": "contains",
+							"qualifier": "one college (meta)"
 						}
 					}
 				]
@@ -6960,7 +6981,6 @@
 			"difficulty": "iq/h",
 			"tech_level": "",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -7108,8 +7128,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (illusion & creation)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -7124,8 +7144,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (illusion & creation)"
 								}
 							}
 						]
@@ -7194,8 +7214,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (illusion & creation)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -7210,8 +7230,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (illusion & creation)"
 								}
 							}
 						]
@@ -7452,8 +7472,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (movement)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -7468,8 +7488,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (movement)"
 								}
 							}
 						]
@@ -7542,7 +7562,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -7581,7 +7601,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -7655,8 +7675,8 @@
 							"qualifier": 1
 						},
 						"notes": {
-							"compare": "contains",
-							"qualifier": "one college (necromancy)"
+							"compare": "does_not_contain",
+							"qualifier": "one college"
 						}
 					},
 					{
@@ -7669,6 +7689,10 @@
 						"level": {
 							"compare": "at_least",
 							"qualifier": 1
+						},
+						"notes": {
+							"compare": "contains",
+							"qualifier": "one college (necromancy)"
 						}
 					}
 				]
@@ -7808,8 +7832,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (body control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -7824,8 +7848,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (body control)"
 								}
 							}
 						]
@@ -7973,7 +7997,7 @@
 			"difficulty": "iq/h",
 			"college": [
 				"Movement",
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Blocking",
@@ -8003,7 +8027,7 @@
 			},
 			"categories": [
 				"Movement",
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -8082,7 +8106,6 @@
 			"reference": "M130",
 			"difficulty": "iq/h",
 			"college": [
-				"Linking",
 				"Meta"
 			],
 			"power_source": "Arcane",
@@ -8121,8 +8144,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (meta)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -8137,8 +8160,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (meta)"
 								}
 							}
 						]
@@ -8212,8 +8235,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (sound)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -8228,8 +8251,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (sound)"
 								}
 							}
 						]
@@ -8350,8 +8373,8 @@
 							"qualifier": 1
 						},
 						"notes": {
-							"compare": "contains",
-							"qualifier": "one college (knowledge)"
+							"compare": "does_not_contain",
+							"qualifier": "one college"
 						}
 					},
 					{
@@ -8364,6 +8387,10 @@
 						"level": {
 							"compare": "at_least",
 							"qualifier": 1
+						},
+						"notes": {
+							"compare": "contains",
+							"qualifier": "one college (knowledge)"
 						}
 					}
 				]
@@ -8529,8 +8556,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (making & breaking)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -8545,8 +8572,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (making & breaking)"
 								}
 							}
 						]
@@ -8798,8 +8825,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (movement)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -8814,8 +8841,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (movement)"
 								}
 							}
 						]
@@ -8930,8 +8957,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (movement)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -8946,8 +8973,24 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (gate)"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (movement)"
 								}
 							}
 						]
@@ -9819,8 +9862,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (meta)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -9835,8 +9878,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (meta)"
 								}
 							}
 						]
@@ -9935,7 +9978,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -9987,7 +10030,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -10039,7 +10082,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -10522,6 +10565,22 @@
 								},
 								"notes": {
 									"compare": "contains",
+									"qualifier": "one college (earth)"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
+									"compare": "contains",
 									"qualifier": "one college (water)"
 								}
 							}
@@ -10728,6 +10787,22 @@
 									"qualifier": 2
 								},
 								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (knowledge)"
 								}
@@ -10744,8 +10819,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (sound)"
 								}
 							}
 						]
@@ -10832,8 +10907,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (mind control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -10848,8 +10923,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (mind control)"
 								}
 							}
 						]
@@ -10987,8 +11062,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (body control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -11003,8 +11078,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (body control)"
 								}
 							}
 						]
@@ -11103,8 +11178,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (body control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -11119,8 +11194,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (body control)"
 								}
 							}
 						]
@@ -11400,8 +11475,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (necromancy)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -11416,8 +11491,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (necromancy)"
 								}
 							}
 						]
@@ -11727,7 +11802,6 @@
 			"difficulty": "iq/h",
 			"tech_level": "",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -11744,7 +11818,7 @@
 					{
 						"type": "spell_prereq",
 						"has": true,
-						"sub_type": "college",
+						"sub_type": "category",
 						"qualifier": {
 							"compare": "contains",
 							"qualifier": "Energy"
@@ -11836,8 +11910,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (movement)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -11850,6 +11924,10 @@
 								"level": {
 									"compare": "at_least",
 									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (movement)"
 								}
 							}
 						]
@@ -11988,8 +12066,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (necromancy)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -12004,8 +12082,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (necromancy)"
 								}
 							}
 						]
@@ -12095,8 +12173,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (making & breaking)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -12111,8 +12189,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (making & breaking)"
 								}
 							}
 						]
@@ -12305,8 +12383,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (making & breaking)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -12321,8 +12399,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (making & breaking)"
 								}
 							}
 						]
@@ -12508,8 +12586,8 @@
 							"qualifier": 1
 						},
 						"notes": {
-							"compare": "contains",
-							"qualifier": "one college (knowledge)"
+							"compare": "does_not_contain",
+							"qualifier": "one college"
 						}
 					},
 					{
@@ -12522,6 +12600,10 @@
 						"level": {
 							"compare": "at_least",
 							"qualifier": 1
+						},
+						"notes": {
+							"compare": "contains",
+							"qualifier": "one college (knowledge)"
 						}
 					}
 				]
@@ -12595,8 +12677,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (sound)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -12611,8 +12693,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (sound)"
 								}
 							}
 						]
@@ -12700,6 +12782,22 @@
 									"qualifier": 1
 								},
 								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (food)"
 								}
@@ -12716,8 +12814,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (knowledge)"
 								}
 							}
 						]
@@ -12925,8 +13023,8 @@
 							"qualifier": 1
 						},
 						"notes": {
-							"compare": "contains",
-							"qualifier": "one college (knowledge)"
+							"compare": "does_not_contain",
+							"qualifier": "one college"
 						}
 					},
 					{
@@ -12939,6 +13037,10 @@
 						"level": {
 							"compare": "at_least",
 							"qualifier": 1
+						},
+						"notes": {
+							"compare": "contains",
+							"qualifier": "one college (knowledge)"
 						}
 					}
 				]
@@ -13595,7 +13697,7 @@
 			},
 			"notes": "HT roll to resist blinding",
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -13763,8 +13865,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (movement)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -13779,8 +13881,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (movement)"
 								}
 							}
 						]
@@ -13844,8 +13946,8 @@
 											"qualifier": 2
 										},
 										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (movement)"
+											"compare": "does_not_contain",
+											"qualifier": "one college"
 										}
 									},
 									{
@@ -13858,6 +13960,10 @@
 										"level": {
 											"compare": "at_least",
 											"qualifier": 2
+										},
+										"notes": {
+											"compare": "contains",
+											"qualifier": "one college (movement)"
 										}
 									}
 								]
@@ -13958,8 +14064,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (food)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -13974,8 +14080,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (food)"
 								}
 							}
 						]
@@ -14028,7 +14134,7 @@
 			"reference": "M170",
 			"difficulty": "iq/h",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area",
@@ -14057,8 +14163,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (protection)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -14073,8 +14179,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (protection & warning)"
 								}
 							}
 						]
@@ -14147,7 +14253,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -14157,7 +14263,7 @@
 			"reference": "M170",
 			"difficulty": "iq/h",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -14186,7 +14292,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -14238,8 +14344,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (mind control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -14254,8 +14360,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (mind control)"
 								}
 							}
 						]
@@ -14273,7 +14379,7 @@
 			"reference": "M66",
 			"difficulty": "iq/h",
 			"college": [
-				"Armor Enchantment"
+				"Enchantment"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Enchantment",
@@ -14724,8 +14830,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (body control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -14740,8 +14846,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (body control)"
 								}
 							}
 						]
@@ -14915,7 +15021,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -14984,7 +15090,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -15086,7 +15192,6 @@
 			"difficulty": "iq/h",
 			"tech_level": "",
 			"college": [
-				"Machine",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -15156,7 +15261,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -15195,7 +15300,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -15429,8 +15534,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (mind control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -15445,8 +15550,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (mind control)"
 								}
 							}
 						]
@@ -15506,8 +15611,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (mind control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -15522,8 +15627,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (mind control)"
 								}
 							}
 						]
@@ -15592,8 +15697,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (movement)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -15608,8 +15713,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (movement)"
 								}
 							}
 						]
@@ -15721,8 +15826,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (meta)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -15737,8 +15842,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (meta)"
 								}
 							}
 						]
@@ -15925,7 +16030,7 @@
 			"reference": "M167",
 			"difficulty": "iq/h",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Blocking",
@@ -15954,7 +16059,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -16067,7 +16172,7 @@
 								"sub_type": "college",
 								"qualifier": {
 									"compare": "contains",
-									"qualifier": "Light"
+									"qualifier": "Light & Darkness"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -16079,7 +16184,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -16183,7 +16288,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -16222,7 +16327,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -16326,7 +16431,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -16455,8 +16560,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (body control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -16471,8 +16576,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (body control)"
 								}
 							}
 						]
@@ -16572,6 +16677,22 @@
 									"qualifier": 1
 								},
 								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (body control)"
 								}
@@ -16588,8 +16709,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (food)"
 								}
 							}
 						]
@@ -17169,7 +17290,6 @@
 			"reference": "M182",
 			"difficulty": "iq/h",
 			"college": [
-				"Metal",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -17403,6 +17523,22 @@
 									"qualifier": 2
 								},
 								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (knowledge)"
 								}
@@ -17419,8 +17555,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (light & darkness)"
 								}
 							}
 						]
@@ -17653,7 +17789,7 @@
 						"sub_type": "college",
 						"qualifier": {
 							"compare": "contains",
-							"qualifier": "Light"
+							"qualifier": "Light & Darkness"
 						},
 						"quantity": {
 							"compare": "at_least",
@@ -17663,7 +17799,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -17821,7 +17957,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -17870,7 +18006,7 @@
 						"sub_type": "college",
 						"qualifier": {
 							"compare": "contains",
-							"qualifier": "Light"
+							"qualifier": "Light & Darkness"
 						},
 						"quantity": {
 							"compare": "at_least",
@@ -17894,7 +18030,7 @@
 			},
 			"notes": "Ends instantly on violent action (DF1:20)",
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -18008,7 +18144,7 @@
 			"reference": "M169",
 			"difficulty": "iq/h",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Blocking",
@@ -18046,7 +18182,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -18324,8 +18460,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (knowledge)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -18340,8 +18476,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (knowledge)"
 								}
 							}
 						]
@@ -18558,8 +18694,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (knowledge)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -18574,8 +18710,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (knowledge)"
 								}
 							}
 						]
@@ -18618,8 +18754,8 @@
 							"qualifier": 1
 						},
 						"notes": {
-							"compare": "contains",
-							"qualifier": "one college (meta)"
+							"compare": "does_not_contain",
+							"qualifier": "one college"
 						}
 					},
 					{
@@ -18634,8 +18770,8 @@
 							"qualifier": 1
 						},
 						"notes": {
-							"compare": "does_not_contain",
-							"qualifier": "one college"
+							"compare": "contains",
+							"qualifier": "one college (meta-spell)"
 						}
 					}
 				]
@@ -18693,7 +18829,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -18704,7 +18840,6 @@
 			"difficulty": "iq/h",
 			"tech_level": "",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -18747,8 +18882,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (technological)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -18763,8 +18898,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (technological)"
 								}
 							}
 						]
@@ -18822,7 +18957,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -18883,8 +19018,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (meta)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -18899,8 +19034,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (meta)"
 								}
 							}
 						]
@@ -18947,8 +19082,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (body control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -18963,8 +19098,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (body control)"
 								}
 							}
 						]
@@ -19050,8 +19185,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (mind control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -19066,8 +19201,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (mind control)"
 								}
 							}
 						]
@@ -19134,7 +19269,7 @@
 			"duration": "1 min",
 			"points": 1,
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -19215,7 +19350,7 @@
 			},
 			"notes": "blinds only when darkness penalty is -5 or more",
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -19372,8 +19507,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (air)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -19388,8 +19523,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (air)"
 								}
 							}
 						]
@@ -19622,8 +19757,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (air)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -19638,8 +19773,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (air)"
 								}
 							}
 						]
@@ -19747,7 +19882,6 @@
 			"reference": "M131",
 			"difficulty": "iq/h",
 			"college": [
-				"Linking",
 				"Meta"
 			],
 			"power_source": "Arcane",
@@ -19847,8 +19981,8 @@
 											"qualifier": 2
 										},
 										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (movement)"
+											"compare": "does_not_contain",
+											"qualifier": "one college"
 										}
 									},
 									{
@@ -19861,6 +19995,10 @@
 										"level": {
 											"compare": "at_least",
 											"qualifier": 2
+										},
+										"notes": {
+											"compare": "contains",
+											"qualifier": "one college (movement)"
 										}
 									}
 								]
@@ -19980,8 +20118,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (movement)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -19996,8 +20134,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (movement)"
 								}
 							}
 						]
@@ -20107,7 +20245,6 @@
 			"difficulty": "iq/h",
 			"tech_level": "",
 			"college": [
-				"Machine",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -20175,7 +20312,6 @@
 			"difficulty": "iq/h",
 			"tech_level": "",
 			"college": [
-				"Machine",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -20249,7 +20385,6 @@
 			"difficulty": "iq/h",
 			"tech_level": "",
 			"college": [
-				"Machine",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -20384,7 +20519,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -20511,7 +20646,7 @@
 			"reference": "M166",
 			"difficulty": "iq/h",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -20539,7 +20674,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -20587,8 +20722,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (meta)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -20603,8 +20738,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (meta)"
 								}
 							}
 						]
@@ -20622,7 +20757,6 @@
 			"reference": "M181",
 			"difficulty": "iq/h",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -20703,7 +20837,6 @@
 			"difficulty": "iq/h",
 			"tech_level": "",
 			"college": [
-				"Machine",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -20746,8 +20879,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (technological)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -20762,8 +20895,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (technological)"
 								}
 							}
 						]
@@ -21371,7 +21504,7 @@
 				]
 			},
 			"categories": [
-				"Communication",
+				"Communication & Empathy",
 				"Sound"
 			]
 		},
@@ -21383,7 +21516,6 @@
 			"difficulty": "iq/h",
 			"college": [
 				"Knowledge",
-				"Metal",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -21506,7 +21638,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -21545,7 +21677,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -21584,7 +21716,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -21636,8 +21768,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (mind control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -21652,8 +21784,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (mind control)"
 								}
 							}
 						]
@@ -21700,7 +21832,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -21710,7 +21842,7 @@
 			"reference": "M168",
 			"difficulty": "iq/h",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -21752,7 +21884,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -21988,7 +22120,7 @@
 			"reference": "M168",
 			"difficulty": "iq/h",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area",
@@ -22049,8 +22181,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (protection)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -22065,8 +22197,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (protection & warning)"
 								}
 							}
 						]
@@ -22074,7 +22206,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -22168,7 +22300,7 @@
 						"sub_type": "college",
 						"qualifier": {
 							"compare": "contains",
-							"qualifier": "Light"
+							"qualifier": "Light & Darkness"
 						},
 						"quantity": {
 							"compare": "at_least",
@@ -22178,7 +22310,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -22188,7 +22320,7 @@
 			"reference": "M167",
 			"difficulty": "iq/h",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area",
@@ -22217,7 +22349,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -22295,8 +22427,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (mind control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -22311,8 +22443,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (mind control)"
 								}
 							}
 						]
@@ -22450,8 +22582,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (mind control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -22466,8 +22598,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (mind control)"
 								}
 							}
 						]
@@ -22631,8 +22763,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (body control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -22647,8 +22779,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (body control)"
 								}
 							}
 						]
@@ -22841,8 +22973,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (knowledge)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -22857,8 +22989,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (knowledge)"
 								}
 							}
 						]
@@ -23074,8 +23206,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (illusion & creation)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -23090,8 +23222,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (illusion & creation)"
 								}
 							}
 						]
@@ -23199,8 +23331,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (mind control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -23215,8 +23347,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (mind control)"
 								}
 							}
 						]
@@ -23285,8 +23417,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (mind control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -23301,8 +23433,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (mind control)"
 								}
 							}
 						]
@@ -23349,7 +23481,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -23388,8 +23520,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (necromancy)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -23404,8 +23536,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (necromancy)"
 								}
 							}
 						]
@@ -23478,8 +23610,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (illusion & creation)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -23494,8 +23626,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (illusion & creation)"
 								}
 							}
 						]
@@ -23635,8 +23767,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (gate)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -23651,8 +23783,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (gate)"
 								}
 							}
 						]
@@ -23770,8 +23902,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (gate)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -23786,8 +23918,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (gate)"
 								}
 							}
 						]
@@ -23875,8 +24007,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (gate)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -23891,8 +24023,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (gate)"
 								}
 							}
 						]
@@ -23978,8 +24110,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (gate)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -23994,8 +24126,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (gate)"
 								}
 							}
 						]
@@ -24159,8 +24291,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (communication)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -24175,8 +24307,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (communication & empathy)"
 								}
 							}
 						]
@@ -24216,7 +24348,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -24385,7 +24517,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -24435,7 +24567,6 @@
 			"difficulty": "iq/h",
 			"tech_level": "",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -24556,8 +24687,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (movement)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -24572,8 +24703,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (movement)"
 								}
 							}
 						]
@@ -24732,7 +24863,6 @@
 			"difficulty": "iq/h",
 			"tech_level": "",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -24854,8 +24984,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (movement)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -24870,8 +25000,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (movement)"
 								}
 							}
 						]
@@ -25348,7 +25478,6 @@
 			"difficulty": "iq/vh",
 			"tech_level": "",
 			"college": [
-				"Machine",
 				"Making & Breaking",
 				"Technological"
 			],
@@ -25470,8 +25599,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (technological)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -25486,8 +25615,24 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (making & breaking)"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (technological)"
 								}
 							}
 						]
@@ -25563,8 +25708,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (mind control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -25579,8 +25724,24 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (knowledge)"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (mind control)"
 								}
 							}
 						]
@@ -25628,8 +25789,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (knowledge)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -25644,8 +25805,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (knowledge)"
 								}
 							}
 						]
@@ -25718,8 +25879,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (meta)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -25734,8 +25895,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (meta-spell)"
 								}
 							}
 						]
@@ -25805,7 +25966,7 @@
 			"reference": "M168",
 			"difficulty": "iq/vh",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Blocking",
@@ -25834,7 +25995,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -25844,7 +26005,6 @@
 			"reference": "M132",
 			"difficulty": "iq/h",
 			"college": [
-				"Linking",
 				"Meta"
 			],
 			"power_source": "Arcane",
@@ -26144,8 +26304,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (meta)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -26160,8 +26320,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (meta)"
 								}
 							}
 						]
@@ -26208,7 +26368,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -26247,7 +26407,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -26299,8 +26459,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (making & breaking)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -26315,8 +26475,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (making & breaking)"
 								}
 							}
 						]
@@ -26388,8 +26548,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (movement)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -26404,8 +26564,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (movement)"
 								}
 							}
 						]
@@ -26549,8 +26709,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (making & breaking)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -26565,8 +26725,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (making & breaking)"
 								}
 							}
 						]
@@ -26584,7 +26744,7 @@
 			"reference": "M190",
 			"difficulty": "iq/h",
 			"college": [
-				"Protection",
+				"Protection & Warning",
 				"Water"
 			],
 			"power_source": "Arcane",
@@ -26614,7 +26774,7 @@
 				]
 			},
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Water"
 			]
 		},
@@ -26704,7 +26864,7 @@
 			"difficulty": "iq/h",
 			"college": [
 				"Air",
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -26734,7 +26894,7 @@
 			},
 			"categories": [
 				"Air",
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -26773,8 +26933,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (body control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -26789,8 +26949,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (body control)"
 								}
 							}
 						]
@@ -26821,7 +26981,7 @@
 			"reference": "M169",
 			"difficulty": "iq/h",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -26850,7 +27010,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -26860,7 +27020,7 @@
 			"reference": "M173",
 			"difficulty": "iq/h",
 			"college": [
-				"Protection",
+				"Protection & Warning",
 				"Sound"
 			],
 			"power_source": "Arcane",
@@ -26890,7 +27050,7 @@
 				]
 			},
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Sound"
 			]
 		},
@@ -26901,7 +27061,7 @@
 			"reference": "M186",
 			"difficulty": "iq/h",
 			"college": [
-				"Protection",
+				"Protection & Warning",
 				"Water"
 			],
 			"power_source": "Arcane",
@@ -26963,7 +27123,7 @@
 				]
 			},
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Water"
 			]
 		},
@@ -27172,7 +27332,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -27182,7 +27342,7 @@
 			"reference": "M168",
 			"difficulty": "iq/h",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Blocking",
@@ -27211,7 +27371,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -27222,7 +27382,6 @@
 			"difficulty": "iq/h",
 			"tech_level": "",
 			"college": [
-				"Machine",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -27263,7 +27422,7 @@
 			"reference": "M168",
 			"difficulty": "iq/h",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -27305,7 +27464,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -27374,8 +27533,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (making & breaking)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -27390,8 +27549,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (making & breaking)"
 								}
 							}
 						]
@@ -27514,8 +27673,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (necromancy)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -27530,8 +27689,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (necromancy)"
 								}
 							}
 						]
@@ -27669,8 +27828,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (making & breaking)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -27685,8 +27844,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (making & breaking)"
 								}
 							}
 						]
@@ -27907,6 +28066,22 @@
 									"qualifier": 2
 								},
 								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (food)"
 								}
@@ -27923,8 +28098,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (knowledge)"
 								}
 							}
 						]
@@ -27971,7 +28146,6 @@
 			"tech_level": "",
 			"college": [
 				"Knowledge",
-				"Machine",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -28180,8 +28354,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (meta)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -28196,8 +28370,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (meta)"
 								}
 							}
 						]
@@ -28244,8 +28418,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (meta)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -28260,8 +28434,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (meta)"
 								}
 							}
 						]
@@ -28418,7 +28592,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -28600,7 +28774,6 @@
 			"difficulty": "iq/h",
 			"tech_level": "",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -28651,8 +28824,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (gate)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -28667,8 +28840,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (gate)"
 								}
 							}
 						]
@@ -28709,7 +28882,6 @@
 			"difficulty": "iq/h",
 			"tech_level": "",
 			"college": [
-				"Machine",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -28810,7 +28982,6 @@
 			"difficulty": "iq/h",
 			"tech_level": "",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -28890,8 +29061,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (knowledge)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -28906,8 +29077,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (knowledge)"
 								}
 							}
 						]
@@ -28938,7 +29109,7 @@
 			"reference": "M166",
 			"difficulty": "iq/h",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Info",
@@ -28967,7 +29138,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -29006,7 +29177,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -29026,7 +29197,7 @@
 			"duration": "Instant",
 			"points": 1,
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -29046,7 +29217,7 @@
 			"duration": "Instant",
 			"points": 1,
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -29095,7 +29266,7 @@
 			"reference": "M167",
 			"difficulty": "iq/h",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area",
@@ -29137,7 +29308,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -29180,8 +29351,8 @@
 											"qualifier": 1
 										},
 										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (necromancy)"
+											"compare": "does_not_contain",
+											"qualifier": "one college"
 										}
 									},
 									{
@@ -29194,6 +29365,10 @@
 										"level": {
 											"compare": "at_least",
 											"qualifier": 1
+										},
+										"notes": {
+											"compare": "contains",
+											"qualifier": "one college (necromancy)"
 										}
 									}
 								]
@@ -29268,8 +29443,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (body control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -29284,8 +29459,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (body control)"
 								}
 							}
 						]
@@ -29316,7 +29491,7 @@
 			"reference": "M169",
 			"difficulty": "iq/h",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -29358,7 +29533,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -29436,7 +29611,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -29553,7 +29728,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -29563,7 +29738,6 @@
 			"reference": "M182",
 			"difficulty": "iq/h",
 			"college": [
-				"Metal",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -29625,8 +29799,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (technological)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -29641,8 +29815,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (technological)"
 								}
 							}
 						]
@@ -29837,8 +30011,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (making & breaking)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -29853,8 +30027,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (making & breaking)"
 								}
 							}
 						]
@@ -29925,7 +30099,7 @@
 			"reference": "M167",
 			"difficulty": "iq/h",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -29950,8 +30124,8 @@
 							"qualifier": 2
 						},
 						"notes": {
-							"compare": "contains",
-							"qualifier": "one college (protection)"
+							"compare": "does_not_contain",
+							"qualifier": "one college"
 						}
 					},
 					{
@@ -29964,12 +30138,16 @@
 						"level": {
 							"compare": "at_least",
 							"qualifier": 2
+						},
+						"notes": {
+							"compare": "contains",
+							"qualifier": "one college (protection & warning)"
 						}
 					}
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -30083,8 +30261,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (body control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -30099,8 +30277,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (body control)"
 								}
 							}
 						]
@@ -30199,8 +30377,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (body control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -30215,8 +30393,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (body control)"
 								}
 							}
 						]
@@ -30594,8 +30772,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (movement)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -30610,8 +30788,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (movement)"
 								}
 							}
 						]
@@ -30775,8 +30953,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (necromancy)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -30791,8 +30969,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (necromancy)"
 								}
 							}
 						]
@@ -30867,7 +31045,7 @@
 								"sub_type": "college",
 								"qualifier": {
 									"compare": "contains",
-									"qualifier": "Light"
+									"qualifier": "Light & Darkness"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -30879,7 +31057,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -31211,8 +31389,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (necromancy)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -31227,8 +31405,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (necromancy)"
 								}
 							}
 						]
@@ -31275,7 +31453,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -31602,7 +31780,6 @@
 			"reference": "M181",
 			"difficulty": "iq/h",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -31698,8 +31875,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (meta)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -31714,8 +31891,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (meta)"
 								}
 							}
 						]
@@ -31959,8 +32136,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (necromancy)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -31975,8 +32152,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (necromancy)"
 								}
 							}
 						]
@@ -32075,8 +32252,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (necromancy)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -32091,8 +32268,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (necromancy)"
 								}
 							}
 						]
@@ -32191,8 +32368,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (necromancy)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -32207,8 +32384,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (necromancy)"
 								}
 							}
 						]
@@ -32281,8 +32458,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (necromancy)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -32297,8 +32474,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (necromancy)"
 								}
 							}
 						]
@@ -32436,8 +32613,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (necromancy)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -32452,8 +32629,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (necromancy)"
 								}
 							}
 						]
@@ -32552,8 +32729,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (necromancy)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -32568,8 +32745,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (necromancy)"
 								}
 							}
 						]
@@ -33096,7 +33273,6 @@
 			"reference": "M179",
 			"difficulty": "iq/h",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -33139,8 +33315,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (technological)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -33155,8 +33331,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (technological)"
 								}
 							}
 						]
@@ -33217,8 +33393,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (mind control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -33233,8 +33409,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (mind control)"
 								}
 							}
 						]
@@ -33282,6 +33458,22 @@
 									"qualifier": 1
 								},
 								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (body control)"
 								}
@@ -33298,8 +33490,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (necromancy)"
 								}
 							}
 						]
@@ -33793,8 +33985,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (necromancy)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -33809,8 +34001,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (necromancy)"
 								}
 							}
 						]
@@ -34225,8 +34417,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (necromancy)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -34241,8 +34433,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (necromancy)"
 								}
 							}
 						]
@@ -34453,7 +34645,7 @@
 						"sub_type": "college",
 						"qualifier": {
 							"compare": "contains",
-							"qualifier": "Light"
+							"qualifier": "Light & Darkness"
 						},
 						"quantity": {
 							"compare": "at_least",
@@ -34476,7 +34668,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -34515,8 +34707,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (light)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -34531,8 +34723,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (light & darkness)"
 								}
 							}
 						]
@@ -34566,7 +34758,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -34614,8 +34806,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (meta)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -34630,8 +34822,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (meta)"
 								}
 							}
 						]
@@ -34696,8 +34888,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (meta)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -34712,8 +34904,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (meta)"
 								}
 							}
 						]
@@ -34869,8 +35061,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (meta)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -34885,8 +35077,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (meta)"
 								}
 							}
 						]
@@ -35061,8 +35253,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (meta)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -35077,8 +35269,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (meta)"
 								}
 							}
 						]
@@ -35125,7 +35317,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -35136,7 +35328,7 @@
 			"difficulty": "iq/h",
 			"college": [
 				"Gate",
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area",
@@ -35198,7 +35390,7 @@
 			},
 			"categories": [
 				"Gate",
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -35327,7 +35519,6 @@
 			"difficulty": "iq/h",
 			"tech_level": "",
 			"college": [
-				"Energy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -35405,6 +35596,22 @@
 									"qualifier": 1
 								},
 								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								},
+								"notes": {
 									"compare": "contains",
 									"qualifier": "one college (body control)"
 								}
@@ -35421,8 +35628,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (food)"
 								}
 							}
 						]
@@ -36023,8 +36230,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (making & breaking)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -36039,8 +36246,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (making & breaking)"
 								}
 							}
 						]
@@ -36139,8 +36346,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (body control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -36155,8 +36362,8 @@
 									"qualifier": 3
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (body control)"
 								}
 							}
 						]
@@ -36294,7 +36501,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -36304,7 +36511,7 @@
 			"reference": "M167",
 			"difficulty": "iq/h",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Blocking",
@@ -36346,7 +36553,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -36408,7 +36615,7 @@
 			"reference": "M185",
 			"difficulty": "iq/h",
 			"college": [
-				"Protection",
+				"Protection & Warning",
 				"Water"
 			],
 			"power_source": "Arcane",
@@ -36451,7 +36658,7 @@
 				]
 			},
 			"categories": [
-				"Protection",
+				"Protection & Warning",
 				"Water"
 			]
 		},
@@ -36501,7 +36708,7 @@
 			"reference": "M170",
 			"difficulty": "iq/h",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area",
@@ -36556,8 +36763,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (protection)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -36572,8 +36779,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (protection & warning)"
 								}
 							}
 						]
@@ -36581,7 +36788,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -36591,7 +36798,7 @@
 			"reference": "M170",
 			"difficulty": "iq/h",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -36633,7 +36840,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -36672,7 +36879,7 @@
 				]
 			},
 			"categories": [
-				"Communication"
+				"Communication & Empathy"
 			]
 		},
 		{
@@ -37048,7 +37255,7 @@
 				]
 			},
 			"categories": [
-				"Light"
+				"Light & Darkness"
 			]
 		},
 		{
@@ -37239,8 +37446,8 @@
 							"qualifier": 1
 						},
 						"notes": {
-							"compare": "contains",
-							"qualifier": "one college (meta)"
+							"compare": "does_not_contain",
+							"qualifier": "one college"
 						}
 					},
 					{
@@ -37253,6 +37460,10 @@
 						"level": {
 							"compare": "at_least",
 							"qualifier": 1
+						},
+						"notes": {
+							"compare": "contains",
+							"qualifier": "one college (meta)"
 						}
 					}
 				]
@@ -37269,7 +37480,7 @@
 			"difficulty": "iq/h",
 			"college": [
 				"Fire",
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -37299,7 +37510,7 @@
 			},
 			"categories": [
 				"Fire",
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -37309,7 +37520,7 @@
 			"reference": "M167",
 			"difficulty": "iq/h",
 			"college": [
-				"Protection"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area",
@@ -37338,7 +37549,7 @@
 				]
 			},
 			"categories": [
-				"Protection"
+				"Protection & Warning"
 			]
 		},
 		{
@@ -37663,8 +37874,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (mind control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -37679,8 +37890,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (mind control)"
 								}
 							}
 						]
@@ -37766,8 +37977,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (making & breaking)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -37782,8 +37993,8 @@
 									"qualifier": 2
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (making & breaking)"
 								}
 							}
 						]
@@ -38087,8 +38298,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (body control)"
+									"compare": "does_not_contain",
+									"qualifier": "one college"
 								}
 							},
 							{
@@ -38103,8 +38314,8 @@
 									"qualifier": 1
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
+									"compare": "contains",
+									"qualifier": "one college (body control)"
 								}
 							}
 						]


### PR DESCRIPTION
This is the same fix-ups from https://github.com/richardwilkes/gcs_master_library/pull/66 but programmatically applied to other Magic spell libraries.
There's also a lot of noise in reordering of prerequisites as a result of normalising them to coming first and being in order of no college then colleges in alphabetical order.
The easy changes have been split out into separate commits, but the last one is a mix of noise, renames and college removals.

If it helps to review I can provide the script, or take the last commit back and try to split it up further.