### PR TITLE
Major reformat of DFRPG Spells

### DIFF
--- a/Library/Dungeon Fantasy RPG/Classes/Bard.gct
+++ b/Library/Dungeon Fantasy RPG/Classes/Bard.gct
@@ -127,8 +127,246 @@
 					"calc": {
 						"points": 399
 					},
-					"open": true,
+					"open": false,
 					"children": [
+						{
+							"type": "advantage",
+							"id": "3376455e-462d-4146-8deb-4f578a67fa98",
+							"name": "Bardic Talent",
+							"mental": true,
+							"levels": "2",
+							"points_per_level": 10,
+							"reference": "DFA17",
+							"calc": {
+								"points": 20
+							},
+							"prereqs": {
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "skill_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Musical Instrument"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 14
+										}
+									},
+									{
+										"type": "skill_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Singing"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 14
+										}
+									}
+								]
+							},
+							"features": [
+								{
+									"type": "skill_bonus",
+									"amount": 1,
+									"per_level": true,
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "musical composition"
+									}
+								},
+								{
+									"type": "skill_bonus",
+									"amount": 1,
+									"per_level": true,
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "musical instrument"
+									}
+								},
+								{
+									"type": "skill_bonus",
+									"amount": 1,
+									"per_level": true,
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "singing"
+									}
+								},
+								{
+									"type": "spell_bonus",
+									"amount": 1,
+									"per_level": true,
+									"match": "power_source_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Arcane"
+									},
+									"category": {
+										"compare": "is",
+										"qualifier": "Bardic"
+									}
+								}
+							],
+							"categories": [
+								"Advantage",
+								"Power"
+							]
+						},
+						{
+							"type": "advantage",
+							"id": "dcaa08a2-94e1-411e-ae3d-8cda8a163e64",
+							"name": "Charisma",
+							"mental": true,
+							"levels": "1",
+							"points_per_level": 5,
+							"reference": "DFA48",
+							"calc": {
+								"points": 5
+							},
+							"features": [
+								{
+									"type": "skill_bonus",
+									"amount": 1,
+									"per_level": true,
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "fortune-telling"
+									}
+								},
+								{
+									"type": "skill_bonus",
+									"amount": 1,
+									"per_level": true,
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "leadership"
+									}
+								},
+								{
+									"type": "skill_bonus",
+									"amount": 1,
+									"per_level": true,
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "panhandling"
+									}
+								},
+								{
+									"type": "skill_bonus",
+									"amount": 1,
+									"per_level": true,
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "public speaking"
+									}
+								}
+							],
+							"notes": "+1/level to Influence rolls",
+							"categories": [
+								"Advantage"
+							]
+						},
+						{
+							"type": "advantage",
+							"id": "76f6ec42-e9ca-4e92-a029-c554325f9ee7",
+							"name": "Voice",
+							"physical": true,
+							"base_points": 10,
+							"reference": "DFA54",
+							"calc": {
+								"points": 10
+							},
+							"features": [
+								{
+									"type": "skill_bonus",
+									"amount": 2,
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "diplomacy"
+									}
+								},
+								{
+									"type": "skill_bonus",
+									"amount": 2,
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "fast-talk"
+									}
+								},
+								{
+									"type": "skill_bonus",
+									"amount": 2,
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "starts_with",
+										"qualifier": "mimicry"
+									}
+								},
+								{
+									"type": "skill_bonus",
+									"amount": 2,
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "performance"
+									}
+								},
+								{
+									"type": "skill_bonus",
+									"amount": 2,
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "politics"
+									}
+								},
+								{
+									"type": "skill_bonus",
+									"amount": 2,
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "public speaking"
+									}
+								},
+								{
+									"type": "skill_bonus",
+									"amount": 2,
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "sex appeal"
+									}
+								},
+								{
+									"type": "skill_bonus",
+									"amount": 2,
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "singing"
+									}
+								}
+							],
+							"categories": [
+								"Advantage"
+							]
+						},
 						{
 							"type": "advantage_container",
 							"id": "fd8686b7-04d9-4016-8c74-2fecac2293bc",
@@ -136,7 +374,7 @@
 							"calc": {
 								"points": 364
 							},
-							"open": true,
+							"open": false,
 							"children": [
 								{
 									"type": "advantage",
@@ -225,7 +463,7 @@
 										{
 											"type": "attribute_bonus",
 											"amount": 0.25,
-                							"decimal": true,
+											"decimal": true,
 											"per_level": true,
 											"attribute": "basic_speed"
 										}
@@ -320,7 +558,7 @@
 								},
 								{
 									"type": "advantage",
-									"id": "6f13040c-bd4d-4a66-9377-157fdeb3e6e7",
+									"id": "e3249916-c731-4179-ae4e-3709550423de",
 									"name": "Bardic Talent",
 									"mental": true,
 									"levels": "1",
@@ -361,56 +599,6 @@
 									},
 									"features": [
 										{
-											"type": "spell_bonus",
-											"amount": 1,
-											"per_level": true,
-											"match": "college_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "Communication & Empathy"
-											}
-										},
-										{
-											"type": "spell_bonus",
-											"amount": 1,
-											"per_level": true,
-											"match": "college_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "Mind Control"
-											}
-										},
-										{
-											"type": "spell_bonus",
-											"amount": 1,
-											"per_level": true,
-											"match": "college_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "Sound"
-											}
-										},
-										{
-											"type": "spell_bonus",
-											"amount": 1,
-											"per_level": true,
-											"match": "college_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "Knowledge"
-											}
-										},
-										{
-											"type": "spell_bonus",
-											"amount": 1,
-											"per_level": true,
-											"match": "spell_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "Protection from Evil"
-											}
-										},
-										{
 											"type": "skill_bonus",
 											"amount": 1,
 											"per_level": true,
@@ -438,6 +626,20 @@
 											"name": {
 												"compare": "is",
 												"qualifier": "singing"
+											}
+										},
+										{
+											"type": "spell_bonus",
+											"amount": 1,
+											"per_level": true,
+											"match": "power_source_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "Arcane"
+											},
+											"category": {
+												"compare": "is",
+												"qualifier": "Bardic"
 											}
 										}
 									],
@@ -1108,280 +1310,6 @@
 									]
 								}
 							]
-						},
-						{
-							"type": "advantage",
-							"id": "e6486f18-9968-4e3c-a87c-b33f3a016809",
-							"name": "Bardic Talent",
-							"mental": true,
-							"levels": "2",
-							"points_per_level": 10,
-							"reference": "DFA17",
-							"calc": {
-								"points": 20
-							},
-							"prereqs": {
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "skill_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "Musical Instrument"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 14
-										}
-									},
-									{
-										"type": "skill_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "Singing"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 14
-										}
-									}
-								]
-							},
-							"features": [
-								{
-									"type": "spell_bonus",
-									"amount": 1,
-									"per_level": true,
-									"match": "college_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Communication & Empathy"
-									}
-								},
-								{
-									"type": "spell_bonus",
-									"amount": 1,
-									"per_level": true,
-									"match": "college_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Mind Control"
-									}
-								},
-								{
-									"type": "spell_bonus",
-									"amount": 1,
-									"per_level": true,
-									"match": "college_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Sound"
-									}
-								},
-								{
-									"type": "spell_bonus",
-									"amount": 1,
-									"per_level": true,
-									"match": "college_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Knowledge"
-									}
-								},
-								{
-									"type": "spell_bonus",
-									"amount": 1,
-									"per_level": true,
-									"match": "spell_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Protection from Evil"
-									}
-								},
-								{
-									"type": "skill_bonus",
-									"amount": 1,
-									"per_level": true,
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "musical composition"
-									}
-								},
-								{
-									"type": "skill_bonus",
-									"amount": 1,
-									"per_level": true,
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "musical instrument"
-									}
-								},
-								{
-									"type": "skill_bonus",
-									"amount": 1,
-									"per_level": true,
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "singing"
-									}
-								}
-							],
-							"categories": [
-								"Advantage",
-								"Power"
-							]
-						},
-						{
-							"type": "advantage",
-							"id": "dcaa08a2-94e1-411e-ae3d-8cda8a163e64",
-							"name": "Charisma",
-							"mental": true,
-							"levels": "1",
-							"points_per_level": 5,
-							"reference": "DFA48",
-							"calc": {
-								"points": 5
-							},
-							"features": [
-								{
-									"type": "skill_bonus",
-									"amount": 1,
-									"per_level": true,
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "fortune-telling"
-									}
-								},
-								{
-									"type": "skill_bonus",
-									"amount": 1,
-									"per_level": true,
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "leadership"
-									}
-								},
-								{
-									"type": "skill_bonus",
-									"amount": 1,
-									"per_level": true,
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "panhandling"
-									}
-								},
-								{
-									"type": "skill_bonus",
-									"amount": 1,
-									"per_level": true,
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "public speaking"
-									}
-								}
-							],
-							"notes": "+1/level to Influence rolls",
-							"categories": [
-								"Advantage"
-							]
-						},
-						{
-							"type": "advantage",
-							"id": "76f6ec42-e9ca-4e92-a029-c554325f9ee7",
-							"name": "Voice",
-							"physical": true,
-							"base_points": 10,
-							"reference": "DFA54",
-							"calc": {
-								"points": 10
-							},
-							"features": [
-								{
-									"type": "skill_bonus",
-									"amount": 2,
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "diplomacy"
-									}
-								},
-								{
-									"type": "skill_bonus",
-									"amount": 2,
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "fast-talk"
-									}
-								},
-								{
-									"type": "skill_bonus",
-									"amount": 2,
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "starts_with",
-										"qualifier": "mimicry"
-									}
-								},
-								{
-									"type": "skill_bonus",
-									"amount": 2,
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "performance"
-									}
-								},
-								{
-									"type": "skill_bonus",
-									"amount": 2,
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "politics"
-									}
-								},
-								{
-									"type": "skill_bonus",
-									"amount": 2,
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "public speaking"
-									}
-								},
-								{
-									"type": "skill_bonus",
-									"amount": 2,
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "sex appeal"
-									}
-								},
-								{
-									"type": "skill_bonus",
-									"amount": 2,
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "singing"
-									}
-								}
-							],
-							"categories": [
-								"Advantage"
-							]
 						}
 					]
 				},
@@ -1392,7 +1320,7 @@
 					"calc": {
 						"points": -125
 					},
-					"open": true,
+					"open": false,
 					"children": [
 						{
 							"type": "advantage_container",
@@ -1401,7 +1329,7 @@
 							"calc": {
 								"points": -50
 							},
-							"open": true,
+							"open": false,
 							"children": [
 								{
 									"type": "advantage",
@@ -1715,7 +1643,7 @@
 								{
 									"type": "attribute_bonus",
 									"amount": 0.25,
-        							"decimal": true,
+									"decimal": true,
 									"per_level": true,
 									"attribute": "basic_speed"
 								}

--- a/Library/Dungeon Fantasy RPG/Classes/Cleric.gct
+++ b/Library/Dungeon Fantasy RPG/Classes/Cleric.gct
@@ -127,8 +127,50 @@
 					"calc": {
 						"points": 358
 					},
-					"open": true,
+					"open": false,
 					"children": [
+						{
+							"type": "advantage",
+							"id": "595b4ea9-0438-4508-9c08-7a85a0ff63c8",
+							"name": "Clerical Investment",
+							"social": true,
+							"base_points": 5,
+							"reference": "DFA22",
+							"calc": {
+								"points": 5
+							},
+							"categories": [
+								"Advantage"
+							]
+						},
+						{
+							"type": "advantage",
+							"id": "8db637ad-c54a-4eda-83b0-8d4df4522364",
+							"name": "Power Investiture",
+							"mental": true,
+							"supernatural": true,
+							"levels": "3",
+							"points_per_level": 10,
+							"reference": "DFA20",
+							"calc": {
+								"points": 30
+							},
+							"features": [
+								{
+									"type": "spell_bonus",
+									"amount": 1,
+									"per_level": true,
+									"match": "power_source_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Clerical"
+									}
+								}
+							],
+							"categories": [
+								"Advantage"
+							]
+						},
 						{
 							"type": "advantage_container",
 							"id": "21e7a0e8-588b-43ee-b75c-68084e486b14",
@@ -136,7 +178,7 @@
 							"calc": {
 								"points": 323
 							},
-							"open": true,
+							"open": false,
 							"children": [
 								{
 									"type": "advantage_container",
@@ -146,7 +188,7 @@
 									"calc": {
 										"points": 154
 									},
-									"open": true,
+									"open": false,
 									"children": [
 										{
 											"type": "advantage",
@@ -797,7 +839,7 @@
 								},
 								{
 									"type": "advantage",
-									"id": "92a452f9-eb10-4e14-855a-d05ef0f8a8f6",
+									"id": "6f42709f-a782-4131-9a8e-9de3f8c29fc5",
 									"name": "Power Investiture",
 									"mental": true,
 									"supernatural": true,
@@ -812,7 +854,7 @@
 											"type": "spell_bonus",
 											"amount": 1,
 											"per_level": true,
-											"match": "college_name",
+											"match": "power_source_name",
 											"name": {
 												"compare": "is",
 												"qualifier": "Clerical"
@@ -868,48 +910,6 @@
 									]
 								}
 							]
-						},
-						{
-							"type": "advantage",
-							"id": "595b4ea9-0438-4508-9c08-7a85a0ff63c8",
-							"name": "Clerical Investment",
-							"social": true,
-							"base_points": 5,
-							"reference": "DFA22",
-							"calc": {
-								"points": 5
-							},
-							"categories": [
-								"Advantage"
-							]
-						},
-						{
-							"type": "advantage",
-							"id": "fadb861a-a325-4b2f-a9d7-d2808ab7e72a",
-							"name": "Power Investiture",
-							"mental": true,
-							"supernatural": true,
-							"levels": "3",
-							"points_per_level": 10,
-							"reference": "DFA20",
-							"calc": {
-								"points": 30
-							},
-							"features": [
-								{
-									"type": "spell_bonus",
-									"amount": 1,
-									"per_level": true,
-									"match": "college_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Clerical"
-									}
-								}
-							],
-							"categories": [
-								"Advantage"
-							]
 						}
 					]
 				},
@@ -920,7 +920,7 @@
 					"calc": {
 						"points": -164
 					},
-					"open": true,
+					"open": false,
 					"children": [
 						{
 							"type": "advantage_container",
@@ -929,7 +929,7 @@
 							"calc": {
 								"points": -30
 							},
-							"open": true,
+							"open": false,
 							"children": [
 								{
 									"type": "advantage",
@@ -1064,7 +1064,7 @@
 								"points": -55
 							},
 							"notes": "or those above",
-							"open": true,
+							"open": false,
 							"children": [
 								{
 									"type": "advantage",
@@ -1670,7 +1670,7 @@
 					"id": "3e24950b-ba51-494f-852f-aa1f8e522f73",
 					"name": "Melee Weapons",
 					"notes": "Choose 1 (12 Points)",
-					"open": true,
+					"open": false,
 					"children": [
 						{
 							"type": "skill_container",
@@ -1713,7 +1713,7 @@
 							"id": "fdceba38-7725-4acd-af87-5d0b86c1cbbc",
 							"name": "One Handed",
 							"notes": "One Weapon and Shield",
-							"open": true,
+							"open": false,
 							"children": [
 								{
 									"type": "skill",

--- a/Library/Dungeon Fantasy RPG/Classes/Druid.gct
+++ b/Library/Dungeon Fantasy RPG/Classes/Druid.gct
@@ -20,7 +20,7 @@
 					"calc": {
 						"points": 160
 					},
-					"open": true,
+					"open": false,
 					"children": [
 						{
 							"type": "advantage",
@@ -127,7 +127,7 @@
 					"calc": {
 						"points": 293
 					},
-					"open": true,
+					"open": false,
 					"children": [
 						{
 							"type": "advantage",
@@ -190,7 +190,7 @@
 						},
 						{
 							"type": "advantage",
-							"id": "e4a23b65-fa52-4a75-b5bd-58cdb214897c",
+							"id": "eaccd4b8-3daf-4e24-93ad-60981467e3e4",
 							"name": "Power Investiture (Druidic)",
 							"mental": true,
 							"supernatural": true,
@@ -205,10 +205,10 @@
 									"type": "spell_bonus",
 									"amount": 1,
 									"per_level": true,
-									"match": "college_name",
+									"match": "power_source_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "Druid"
+										"qualifier": "Druidic"
 									}
 								}
 							],
@@ -223,7 +223,7 @@
 							"calc": {
 								"points": 258
 							},
-							"open": true,
+							"open": false,
 							"children": [
 								{
 									"type": "advantage",
@@ -885,7 +885,7 @@
 								},
 								{
 									"type": "advantage",
-									"id": "e9b1c8ae-1b37-4946-9cbd-0d642cec8703",
+									"id": "fe1175d7-190b-4e0e-a1d7-939d1e7399d1",
 									"name": "Power Investiture (Druidic)",
 									"mental": true,
 									"supernatural": true,
@@ -899,10 +899,11 @@
 										{
 											"type": "spell_bonus",
 											"amount": 1,
-											"match": "college_name",
+											"per_level": true,
+											"match": "power_source_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "Druid"
+												"qualifier": "Druidic"
 											}
 										}
 									],
@@ -1538,7 +1539,7 @@
 								{
 									"type": "attribute_bonus",
 									"amount": -0.25,
-        							"decimal": true,
+									"decimal": true,
 									"per_level": true,
 									"attribute": "basic_speed"
 								}
@@ -2500,7 +2501,7 @@
 					"id": "326e44cd-2213-4246-86cd-22e18dc26bee",
 					"name": "Melee Packages (Choose 1)",
 					"notes": "Should total 12 points",
-					"open": true,
+					"open": false,
 					"children": [
 						{
 							"type": "skill_container",

--- a/Library/Dungeon Fantasy RPG/Classes/Wizard.gct
+++ b/Library/Dungeon Fantasy RPG/Classes/Wizard.gct
@@ -145,7 +145,7 @@
 								{
 									"type": "attribute_bonus",
 									"amount": 0.25,
-        							"decimal": true,
+									"decimal": true,
 									"per_level": true,
 									"attribute": "basic_speed"
 								}
@@ -164,11 +164,11 @@
 					"calc": {
 						"points": 241
 					},
-					"open": true,
+					"open": false,
 					"children": [
 						{
 							"type": "advantage",
-							"id": "d4051fb0-070d-4527-a8c0-243ddcd1acbc",
+							"id": "c3fda037-01e4-4029-b61a-c79359bf51be",
 							"name": "Magery",
 							"mental": true,
 							"supernatural": true,
@@ -184,7 +184,11 @@
 									"type": "spell_bonus",
 									"amount": 1,
 									"per_level": true,
-									"match": "all_colleges"
+									"match": "power_source_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Arcane"
+									}
 								},
 								{
 									"type": "skill_bonus",
@@ -236,7 +240,7 @@
 							"calc": {
 								"points": 197
 							},
-							"open": true,
+							"open": false,
 							"children": [
 								{
 									"type": "advantage",
@@ -610,7 +614,7 @@
 								},
 								{
 									"type": "advantage",
-									"id": "473f4ee4-31c7-4371-a570-6e86632b18ea",
+									"id": "6b206d61-465e-483e-a961-08d191a49e9e",
 									"name": "Magery",
 									"mental": true,
 									"supernatural": true,
@@ -626,7 +630,11 @@
 											"type": "spell_bonus",
 											"amount": 1,
 											"per_level": true,
-											"match": "all_colleges"
+											"match": "power_source_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "Arcane"
+											}
 										},
 										{
 											"type": "skill_bonus",

--- a/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Advantages.adq
+++ b/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Advantages.adq
@@ -921,56 +921,6 @@
 			},
 			"features": [
 				{
-					"type": "spell_bonus",
-					"amount": 1,
-					"per_level": true,
-					"match": "college_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "Communication & Empathy"
-					}
-				},
-				{
-					"type": "spell_bonus",
-					"amount": 1,
-					"per_level": true,
-					"match": "college_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "Mind Control"
-					}
-				},
-				{
-					"type": "spell_bonus",
-					"amount": 1,
-					"per_level": true,
-					"match": "college_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "Sound"
-					}
-				},
-				{
-					"type": "spell_bonus",
-					"amount": 1,
-					"per_level": true,
-					"match": "college_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "Knowledge"
-					}
-				},
-				{
-					"type": "spell_bonus",
-					"amount": 1,
-					"per_level": true,
-					"match": "spell_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "Protection from Evil"
-					}
-				},
-				{
 					"type": "skill_bonus",
 					"amount": 1,
 					"per_level": true,
@@ -998,6 +948,20 @@
 					"name": {
 						"compare": "is",
 						"qualifier": "singing"
+					}
+				},
+				{
+					"type": "spell_bonus",
+					"amount": 1,
+					"per_level": true,
+					"match": "power_source_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Arcane"
+					},
+					"category": {
+						"compare": "is",
+						"qualifier": "Bardic"
 					}
 				}
 			],
@@ -6231,7 +6195,7 @@
 					"type": "spell_bonus",
 					"amount": 1,
 					"per_level": true,
-					"match": "all_colleges"
+					"match": "power_source_name"
 				},
 				{
 					"type": "skill_bonus",
@@ -7233,10 +7197,10 @@
 					"type": "spell_bonus",
 					"amount": 1,
 					"per_level": true,
-					"match": "college_name",
+					"match": "power_source_name",
 					"name": {
 						"compare": "is",
-						"qualifier": "Druid"
+						"qualifier": "Druidic"
 					}
 				}
 			],
@@ -7261,7 +7225,7 @@
 					"type": "spell_bonus",
 					"amount": 1,
 					"per_level": true,
-					"match": "college_name",
+					"match": "power_source_name",
 					"name": {
 						"compare": "is",
 						"qualifier": "Clerical"

--- a/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Advantages.adq
+++ b/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Advantages.adq
@@ -6195,7 +6195,11 @@
 					"type": "spell_bonus",
 					"amount": 1,
 					"per_level": true,
-					"match": "power_source_name"
+					"match": "power_source_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Arcane"
+					}
 				},
 				{
 					"type": "skill_bonus",

--- a/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Spells.spl
+++ b/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Spells.spl
@@ -21162,7 +21162,7 @@
 						"prereqs": [
 							{
 								"type": "prereq_list",
-								"all": true,
+								"all": false,
 								"prereqs": [
 									{
 										"type": "advantage_prereq",

--- a/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Spells.spl
+++ b/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Spells.spl
@@ -13497,6 +13497,54 @@
 				},
 				{
 					"type": "spell",
+					"id": "4069e429-c547-49d1-8b42-f0c96a7bd676",
+					"name": "Balance",
+					"reference": "DFS20",
+					"difficulty": "iq/h",
+					"college": [
+						"Body Control"
+					],
+					"power_source": "Arcane",
+					"spell_class": "Regular",
+					"casting_cost": "5",
+					"maintenance_cost": "3",
+					"casting_time": "1 sec",
+					"duration": "1 min",
+					"points": 1,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "spell_prereq",
+								"has": true,
+								"sub_type": "name",
+								"qualifier": {
+									"compare": "is",
+									"qualifier": "Grace"
+								},
+								"quantity": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							}
+						]
+					},
+					"categories": [
+						"Body Control",
+						"Wizardly"
+					]
+				},
+				{
+					"type": "spell",
 					"id": "70595832-0f57-4a5d-9b1a-7fc992a85c1f",
 					"name": "Banish",
 					"reference": "DFS59",
@@ -15465,6 +15513,45 @@
 					},
 					"categories": [
 						"Making & Breaking",
+						"Wizardly"
+					]
+				},
+				{
+					"type": "spell",
+					"id": "2001d397-58ad-4e3d-8e95-360173c7a4db",
+					"name": "Counterspell",
+					"reference": "DFS51",
+					"difficulty": "iq/h",
+					"college": [
+						"Meta"
+					],
+					"power_source": "Arcane",
+					"spell_class": "Regular",
+					"resist": "Subject spell",
+					"casting_cost": "Half countered spell",
+					"casting_time": "5 sec",
+					"duration": "Instant",
+					"points": 1,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							}
+						]
+					},
+					"categories": [
+						"Meta",
 						"Wizardly"
 					]
 				},

--- a/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Spells.spl
+++ b/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Spells.spl
@@ -10,7 +10,7 @@
 			"categories": [
 				"Clerical"
 			],
-			"open": true,
+			"open": false,
 			"children": [
 				{
 					"type": "spell_container",
@@ -6886,7 +6886,7 @@
 			"categories": [
 				"Druidic"
 			],
-			"open": true,
+			"open": false,
 			"children": [
 				{
 					"type": "spell_container",
@@ -13608,6 +13608,54 @@
 					},
 					"categories": [
 						"Light & Darkness",
+						"Wizardly"
+					]
+				},
+				{
+					"type": "spell",
+					"id": "969d8d49-a5f5-4e2e-aae7-3bb500f9980f",
+					"name": "Bladeturning",
+					"reference": "DFS63",
+					"difficulty": "iq/h",
+					"college": [
+						"Protection & Warning"
+					],
+					"power_source": "Arcane",
+					"spell_class": "Regular",
+					"casting_cost": "2",
+					"maintenance_cost": "2",
+					"casting_time": "1 sec",
+					"duration": "1 min",
+					"points": 1,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "spell_prereq",
+								"has": true,
+								"sub_type": "name",
+								"qualifier": {
+									"compare": "is",
+									"qualifier": "Shield"
+								},
+								"quantity": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							}
+						]
+					},
+					"categories": [
+						"Protection & Warning",
 						"Wizardly"
 					]
 				},

--- a/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Spells.spl
+++ b/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Spells.spl
@@ -1,17 +1,20 @@
 {
 	"type": "spell_list",
 	"version": 2,
-	"id": "01cc27f6-deca-473f-8085-38e72529e885",
+	"id": "7af2879a-9d6a-4e3d-ad5a-9a5a17b4b87b",
 	"rows": [
 		{
 			"type": "spell_container",
-			"id": "206fbafa-e43f-4b29-aeae-e16b640feeba",
+			"id": "49cdee9c-20f0-438a-9323-60dc32accb91",
 			"name": "Clerical",
-			"open": false,
+			"categories": [
+				"Clerical"
+			],
+			"open": true,
 			"children": [
 				{
 					"type": "spell_container",
-					"id": "d7a43ece-de2b-4b7b-893f-49a2e71f87ce",
+					"id": "17c2560e-0f70-49a1-bdac-4ec7719f6399",
 					"name": "Power Investiture 1",
 					"categories": [
 						"Clerical"
@@ -20,14 +23,14 @@
 					"children": [
 						{
 							"type": "spell",
-							"id": "142187fa-fc51-4466-a4e2-786f2f5cebfd",
+							"id": "b8663524-dc97-46fe-8445-61086eb9393e",
 							"name": "Armor",
 							"reference": "DFS63",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Protection & Warning"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Regular",
 							"casting_cost": "2 per DR",
 							"maintenance_cost": "Half",
@@ -49,23 +52,52 @@
 											"compare": "at_least",
 											"qualifier": 1
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Shield"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Protection & Warning",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "8702c34a-f793-4d83-8fec-536a9d29a676",
+							"id": "2095438f-7af6-4c91-82a0-b721c8e0bfb6",
 							"name": "Aura",
 							"reference": "DFS42",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Knowledge"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Info",
 							"casting_cost": "3",
 							"maintenance_cost": "-",
@@ -87,24 +119,69 @@
 											"compare": "at_least",
 											"qualifier": 1
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "prereq_list",
+												"all": false,
+												"prereqs": [
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Magery"
+														}
+													},
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Bardic Talent"
+														}
+													}
+												]
+											},
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Detect Magic"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Bardic",
+								"Clerical",
+								"Knowledge",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "4dd6d71a-fe07-4cbd-800a-0900974dfed5",
+							"id": "ec7586a5-6276-471f-a45a-7879b75e363b",
 							"name": "Bravery",
 							"reference": "DFS53",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Mind Control"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Area",
+							"resist": "Will-1",
 							"casting_cost": "2",
 							"maintenance_cost": "-",
 							"casting_time": "1 sec",
@@ -125,23 +202,67 @@
 											"compare": "at_least",
 											"qualifier": 1
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "prereq_list",
+												"all": false,
+												"prereqs": [
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Magery"
+														}
+													},
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Bardic Talent"
+														}
+													}
+												]
+											},
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Fear"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Bardic",
+								"Clerical",
+								"Mind Control",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "2a7ef888-64c0-4457-82fb-280453535f48",
+							"id": "97443fd8-5a72-47f4-973a-680dbd38fddd",
 							"name": "Cleansing",
 							"reference": "DFS36",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Healing"
 							],
-							"power_source": "Arcane",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "2/4/6",
 							"maintenance_cost": "-",
@@ -167,19 +288,21 @@
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Healing"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "f4b4300a-4691-4d74-814b-84408136917e",
+							"id": "96d927a3-aa88-4f56-b506-d37067bb7d41",
 							"name": "Coolness",
 							"reference": "DFS68",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Protection & Warning",
+								"Water"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 							"spell_class": "Regular",
 							"casting_cost": "2",
 							"maintenance_cost": "1",
@@ -201,23 +324,66 @@
 											"compare": "at_least",
 											"qualifier": 1
 										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture (Druidic)"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Cold"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Druidic",
+								"Protection & Warning",
+								"Water",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "21ea4749-51dd-4d96-8569-525db5ea5667",
+							"id": "6b5082d4-9533-41ca-a444-e5499290f40d",
 							"name": "Detect Magic",
 							"reference": "DFS43",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Knowledge"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 							"spell_class": "Regular",
 							"casting_cost": "2",
 							"maintenance_cost": "-",
@@ -239,24 +405,65 @@
 											"compare": "at_least",
 											"qualifier": 1
 										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture (Druidic)"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Bardic",
+								"Clerical",
+								"Druidic",
+								"Knowledge",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "6794b326-97cf-48ce-8ce2-9b45ca55e434",
+							"id": "c03a0d70-3c4b-4048-a508-50173a9cc889",
 							"name": "Detect Poison",
 							"reference": "DFS36",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Healing",
+								"Protection & Warning"
 							],
-							"power_source": "Arcane",
-							"spell_class": "Area-Info",
+							"power_source": "@Power Source: Clerical/Druidic@",
+							"spell_class": "Area/Info",
 							"casting_cost": "2",
 							"maintenance_cost": "-",
 							"casting_time": "2 sec",
@@ -277,23 +484,38 @@
 											"compare": "at_least",
 											"qualifier": 1
 										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture (Druidic)"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Druidic",
+								"Healing",
+								"Protection & Warning"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "3e22aa08-dc04-464f-86bd-22243f182f04",
+							"id": "dfa381cb-5f24-4fac-976c-5d8e8fd47a68",
 							"name": "Final Rest",
 							"reference": "DFS36",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Healing"
 							],
-							"power_source": "Arcane",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "20",
 							"maintenance_cost": "-",
@@ -319,19 +541,21 @@
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Healing"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "4c3b0ff5-d8e7-44b5-8d04-b29fd071e27d",
+							"id": "4744a3bc-e9b2-44a5-9a4a-d330e8322676",
 							"name": "Lend Energy",
 							"reference": "DFS37",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Healing",
+								"Meta"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Regular",
 							"casting_cost": "1/pt",
 							"maintenance_cost": "-",
@@ -347,6 +571,18 @@
 										"has": true,
 										"name": {
 											"compare": "is",
+											"qualifier": "Magery"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
 											"qualifier": "Power Investiture"
 										},
 										"level": {
@@ -357,19 +593,22 @@
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Healing",
+								"Meta",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "08fca753-752a-4e2e-848d-cb76ac29b69e",
+							"id": "17cd5c4c-5398-4355-a228-7461b9b2c430",
 							"name": "Lend Vitality",
 							"reference": "DFS37",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Healing"
 							],
-							"power_source": "Arcane",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "1/pt",
 							"maintenance_cost": "-",
@@ -395,19 +634,20 @@
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Healing"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "8183b323-78b2-4608-955c-3e4fba3fe887",
+							"id": "ff8e080f-90a6-4906-91d8-c11b4e1c177d",
 							"name": "Light",
 							"reference": "DFS47",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Light & Darkness"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Regular",
 							"casting_cost": "1",
 							"maintenance_cost": "1",
@@ -423,6 +663,14 @@
 										"has": true,
 										"name": {
 											"compare": "is",
+											"qualifier": "Magery"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
 											"qualifier": "Power Investiture"
 										},
 										"level": {
@@ -433,19 +681,21 @@
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Light & Darkness",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "50f4aa48-b78f-4e7d-b9e5-64d1a75eb15b",
+							"id": "d2d8cb5d-1ab3-4b4d-840c-eb79e5fefdb3",
 							"name": "Might",
 							"reference": "DFS21",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Body Control"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Regular",
 							"casting_cost": "2/+ST",
 							"maintenance_cost": "Same",
@@ -467,23 +717,52 @@
 											"compare": "at_least",
 											"qualifier": 1
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Lend Energy"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Body Control",
+								"Clerical",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "88f8d543-8dca-420e-9ec8-e45264b97e93",
+							"id": "627a28bb-3bf6-4af9-8665-c62792dc1f61",
 							"name": "Minor Healing",
 							"reference": "DFS37",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Healing"
 							],
-							"power_source": "Arcane",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "1-3",
 							"maintenance_cost": "-",
@@ -509,19 +788,20 @@
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Healing"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "a7fd1353-ed6f-4581-8038-95b1a8f513bc",
+							"id": "26169113-d884-4c34-a40f-bfbf4ed41e99",
 							"name": "Purify Air",
 							"reference": "DFS16",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Air"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 							"spell_class": "Area",
 							"casting_cost": "1",
 							"maintenance_cost": "-",
@@ -543,23 +823,46 @@
 											"compare": "at_least",
 											"qualifier": 1
 										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture (Druidic)"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Air",
+								"Clerical",
+								"Druidic",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "0673987b-fcdd-435b-857b-2cc89dbd38d5",
+							"id": "57cbee5f-92e7-4f0a-a2df-881556e5fd36",
 							"name": "Purify Water",
 							"reference": "DFS70",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Water"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 							"spell_class": "Special",
 							"casting_cost": "1/gal",
 							"maintenance_cost": "-",
@@ -581,23 +884,66 @@
 											"compare": "at_least",
 											"qualifier": 1
 										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture (Druidic)"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Seek Water"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Druidic",
+								"Water",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "82c90945-eaf9-4472-be5f-11a82287922c",
+							"id": "8e401b03-53b6-4a4b-b43e-122143fe68bf",
 							"name": "Recover Energy",
 							"reference": "DFS38",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Healing",
+								"Meta"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 							"spell_class": "Special",
 							"casting_cost": "0",
 							"maintenance_cost": "0",
@@ -619,25 +965,73 @@
 											"compare": "at_least",
 											"qualifier": 1
 										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture (Druidic)"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Lend Energy"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Druidic",
+								"Healing",
+								"Meta",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "48839a11-3512-4db8-a2f8-163ae740a374",
+							"id": "637faf0b-6bc5-4fbc-b28a-6c86a13a6291",
 							"name": "Sense Evil",
 							"reference": "DFS26",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Communication & Empathy",
+								"Meta"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 							"spell_class": "Info/Area",
-							"casting_cost": "1/2",
+							"casting_cost": "1/area, min 2",
 							"maintenance_cost": "-",
 							"casting_time": "1 sec",
 							"duration": "Instant",
@@ -651,7 +1045,43 @@
 										"has": true,
 										"name": {
 											"compare": "is",
+											"qualifier": "Magery"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 2
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 2
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
 											"qualifier": "Power Investiture"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -661,19 +1091,24 @@
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Bardic",
+								"Clerical",
+								"Communication & Empathy",
+								"Druidic",
+								"Meta",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "1e2a782b-5bc7-4b77-8970-2001e5e7286a",
+							"id": "434f882a-9720-472a-95b7-e1532df5e946",
 							"name": "Sense Life",
 							"reference": "DFS26",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Communication & Empathy"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 							"spell_class": "Info/Area",
 							"casting_cost": "1/2",
 							"maintenance_cost": "-",
@@ -689,7 +1124,39 @@
 										"has": true,
 										"name": {
 											"compare": "is",
+											"qualifier": "Magery"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
 											"qualifier": "Power Investiture"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -699,19 +1166,23 @@
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Bardic",
+								"Clerical",
+								"Communication & Empathy",
+								"Druidic",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "9d1c1d59-2760-4a80-87d5-72bed28851de",
+							"id": "95a66cd4-8c05-402c-b36d-f8c9b3938c26",
 							"name": "Sense Spirit",
 							"reference": "DFS60",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Necromancy"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Info/Area",
 							"casting_cost": "1/2 (min 1)",
 							"maintenance_cost": "-",
@@ -733,23 +1204,90 @@
 											"compare": "at_least",
 											"qualifier": 1
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": false,
+										"prereqs": [
+											{
+												"type": "prereq_list",
+												"all": true,
+												"prereqs": [
+													{
+														"type": "spell_prereq",
+														"has": true,
+														"sub_type": "name",
+														"qualifier": {
+															"compare": "is",
+															"qualifier": "Death Vision"
+														},
+														"quantity": {
+															"compare": "at_least",
+															"qualifier": 1
+														}
+													},
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Magery"
+														}
+													}
+												]
+											},
+											{
+												"type": "prereq_list",
+												"all": true,
+												"prereqs": [
+													{
+														"type": "spell_prereq",
+														"has": true,
+														"sub_type": "name",
+														"qualifier": {
+															"compare": "is",
+															"qualifier": "Sense Life"
+														},
+														"quantity": {
+															"compare": "at_least",
+															"qualifier": 1
+														}
+													},
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Magery"
+														},
+														"level": {
+															"compare": "at_least",
+															"qualifier": 1
+														}
+													}
+												]
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Necromancy",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "6efa3fbd-8943-4205-b238-f38935e24cbd",
+							"id": "42ddc806-8ef1-48ce-90f8-f958f132785b",
 							"name": "Share Energy",
 							"reference": "DFS39",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Healing",
+								"Meta"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 							"spell_class": "Regular",
 							"casting_cost": "2-10",
 							"maintenance_cost": "-",
@@ -758,7 +1296,7 @@
 							"points": 1,
 							"prereqs": {
 								"type": "prereq_list",
-								"all": true,
+								"all": false,
 								"prereqs": [
 									{
 										"type": "advantage_prereq",
@@ -771,23 +1309,66 @@
 											"compare": "at_least",
 											"qualifier": 1
 										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture (Druidic)"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Lend Energy"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Druidic",
+								"Healing",
+								"Meta",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "bae5e118-2bec-4b91-a3cc-044aaed65934",
+							"id": "0b95fd3d-6abe-479e-8112-7bd18681235b",
 							"name": "Share Vitality",
 							"reference": "DFS39",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Healing"
 							],
-							"power_source": "Arcane",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "None",
 							"maintenance_cost": "-",
@@ -813,19 +1394,20 @@
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Healing"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "0c20d8d3-0fee-44ab-b341-b7020195fd78",
+							"id": "43e91f35-3f3b-47de-b262-27abcb72727c",
 							"name": "Shield",
 							"reference": "DFS65",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Protection & Warning"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Regular",
 							"casting_cost": "2 per DB",
 							"maintenance_cost": "Half",
@@ -841,6 +1423,18 @@
 										"has": true,
 										"name": {
 											"compare": "is",
+											"qualifier": "Magery"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 2
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
 											"qualifier": "Power Investiture"
 										},
 										"level": {
@@ -851,19 +1445,21 @@
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Protection & Warning",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "1e1c2c79-8648-411f-bfa1-18fe228ab4aa",
+							"id": "016acb58-81e2-4e9a-8dfe-dc7b396af8e0",
 							"name": "Silence",
 							"reference": "DFS67",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Sound"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Area",
 							"casting_cost": "2",
 							"maintenance_cost": "Half",
@@ -885,23 +1481,67 @@
 											"compare": "at_least",
 											"qualifier": 1
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "prereq_list",
+												"all": false,
+												"prereqs": [
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Magery"
+														}
+													},
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Bardic Talent"
+														}
+													}
+												]
+											},
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Sound"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Bardic",
+								"Clerical",
+								"Sound",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "4c00db87-7747-42eb-982d-0b81ca055bc8",
+							"id": "57f003fd-22eb-4078-93d5-fa3f9831a0a5",
 							"name": "Stop Bleeding",
 							"reference": "DFS39",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Healing"
 							],
-							"power_source": "Arcane",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "1 or 10",
 							"maintenance_cost": "-",
@@ -927,19 +1567,20 @@
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Healing"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "5a21e666-e7bc-4a2d-b329-281df5ced2d8",
+							"id": "a961fdae-527b-4fae-93f1-25ab9005021e",
 							"name": "Test Food",
-							"reference": "DFS33",
+							"reference": "DFS32",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Food"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Info",
 							"casting_cost": "1 or 3",
 							"maintenance_cost": "-",
@@ -961,23 +1602,33 @@
 											"compare": "at_least",
 											"qualifier": 1
 										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Food",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "ad5fc4d3-53a2-427d-83cd-8b1011e5316d",
+							"id": "4c0f6130-8dec-4cba-adf9-9d62de0358b9",
 							"name": "Thunderclap",
 							"reference": "DFS67",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Sound"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 							"spell_class": "Regular",
 							"casting_cost": "2",
 							"maintenance_cost": "-",
@@ -999,23 +1650,81 @@
 											"compare": "at_least",
 											"qualifier": 1
 										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture (Druidic)"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Sound"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "prereq_list",
+												"all": false,
+												"prereqs": [
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Magery"
+														}
+													},
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Bardic Talent"
+														}
+													}
+												]
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Bardic",
+								"Clerical",
+								"Druidic",
+								"Sound",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "414bcd56-2deb-44f0-b306-1dbca33886d4",
+							"id": "23570807-b726-444f-a2cd-6d44763d1cb0",
 							"name": "Umbrella",
 							"reference": "DFS70",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Protection & Warning",
+								"Water"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 							"spell_class": "Regular",
 							"casting_cost": "1",
 							"maintenance_cost": "1",
@@ -1037,23 +1746,85 @@
 											"compare": "at_least",
 											"qualifier": 1
 										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture (Druidic)"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "prereq_list",
+												"all": false,
+												"prereqs": [
+													{
+														"type": "spell_prereq",
+														"has": true,
+														"sub_type": "name",
+														"qualifier": {
+															"compare": "is",
+															"qualifier": "Shape Water"
+														},
+														"quantity": {
+															"compare": "at_least",
+															"qualifier": 1
+														}
+													},
+													{
+														"type": "spell_prereq",
+														"has": true,
+														"sub_type": "name",
+														"qualifier": {
+															"compare": "is",
+															"qualifier": "Shield"
+														},
+														"quantity": {
+															"compare": "at_least",
+															"qualifier": 1
+														}
+													}
+												]
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Druidic",
+								"Protection & Warning",
+								"Water",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "ab814a6b-3c24-41c6-88eb-d361e3e56a63",
+							"id": "8846f809-1870-459c-9cf1-16d3bbc5b2ca",
 							"name": "Vigor",
 							"reference": "DFS23",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Body Control"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Regular",
 							"casting_cost": "2/+HT",
 							"maintenance_cost": "Same",
@@ -1075,23 +1846,72 @@
 											"compare": "at_least",
 											"qualifier": 1
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "prereq_list",
+												"all": false,
+												"prereqs": [
+													{
+														"type": "spell_prereq",
+														"has": true,
+														"sub_type": "name",
+														"qualifier": {
+															"compare": "is",
+															"qualifier": "Might"
+														},
+														"quantity": {
+															"compare": "at_least",
+															"qualifier": 1
+														}
+													},
+													{
+														"type": "spell_prereq",
+														"has": true,
+														"sub_type": "name",
+														"qualifier": {
+															"compare": "is",
+															"qualifier": "Frailty"
+														},
+														"quantity": {
+															"compare": "at_least",
+															"qualifier": 1
+														}
+													}
+												]
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Body Control",
+								"Clerical",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "ff3c9285-12fd-47c1-9e1b-6fa775fa29d1",
+							"id": "4f51e848-ba5d-42a0-a028-0a00c4b19936",
 							"name": "Warmth",
 							"reference": "DFS32",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Fire",
+								"Protection & Warning"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 							"spell_class": "Regular",
 							"casting_cost": "2",
 							"maintenance_cost": "1",
@@ -1113,23 +1933,66 @@
 											"compare": "at_least",
 											"qualifier": 1
 										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture (Druidic)"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Heat"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Druidic",
+								"Fire",
+								"Protection & Warning",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "73d2d4f7-db81-430e-9ba0-8a0497b2f3d9",
+							"id": "e41c7ef8-e0cb-4747-9935-f900ce47d95c",
 							"name": "Watchdog",
 							"reference": "DFS65",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Protection & Warning"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Area",
 							"casting_cost": "1",
 							"maintenance_cost": "Same",
@@ -1151,18 +2014,47 @@
 											"compare": "at_least",
 											"qualifier": 1
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Sense Danger"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Protection & Warning",
+								"Wizardly"
 							]
 						}
 					]
 				},
 				{
 					"type": "spell_container",
-					"id": "eae8dc76-4f6a-401b-b151-14fa1ab0df5e",
+					"id": "02f757e9-42b6-44ad-ba85-d32d0a4c6e8a",
 					"name": "Power Investiture 2",
 					"categories": [
 						"Clerical"
@@ -1171,14 +2063,14 @@
 					"children": [
 						{
 							"type": "spell",
-							"id": "47e7aed8-8021-4d98-b222-4ed583eb6740",
+							"id": "661cbeb3-a580-4096-9715-34c8524e930f",
 							"name": "Awaken",
 							"reference": "DFS36",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Healing"
 							],
-							"power_source": "Arcane",
+							"power_source": "Clerical",
 							"spell_class": "Area",
 							"casting_cost": "1",
 							"maintenance_cost": "-",
@@ -1204,20 +2096,22 @@
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Healing"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "b02b2ca1-cea9-420e-91da-858fa4e5c9e1",
+							"id": "a33880bb-6268-4e0b-a31e-6902d53d4a41",
 							"name": "Command",
 							"reference": "DFS53",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Mind Control"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Blocking",
+							"resist": "Will",
 							"casting_cost": "2",
 							"maintenance_cost": "-",
 							"casting_time": "1 sec",
@@ -1238,24 +2132,77 @@
 											"compare": "at_least",
 											"qualifier": 2
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Forgetfulness"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "prereq_list",
+												"all": false,
+												"prereqs": [
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Magery"
+														},
+														"level": {
+															"compare": "at_least",
+															"qualifier": 2
+														}
+													},
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Bardic Talent"
+														},
+														"level": {
+															"compare": "at_least",
+															"qualifier": 2
+														}
+													}
+												]
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Bardic",
+								"Clerical",
+								"Mind Control",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "7ef6be25-1f7e-4840-aaea-95756b96c71a",
+							"id": "2fdb810c-3148-461b-aca6-e0a3fe05c7e2",
 							"name": "Compel Truth",
 							"reference": "DFS24",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Communication & Empathy"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Info",
+							"resist": "Will",
 							"casting_cost": "4",
 							"maintenance_cost": "2",
 							"casting_time": "1 sec",
@@ -1276,23 +2223,75 @@
 											"compare": "at_least",
 											"qualifier": 2
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Truthsayer"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "prereq_list",
+												"all": false,
+												"prereqs": [
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Bardic Talent"
+														},
+														"level": {
+															"compare": "at_least",
+															"qualifier": 2
+														}
+													},
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Magery"
+														},
+														"level": {
+															"compare": "at_least",
+															"qualifier": 2
+														}
+													}
+												]
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Bardic",
+								"Clerical",
+								"Communication & Empathy",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "74b779b5-7475-45f7-b657-34cc4a7357e6",
+							"id": "7cf8ffd4-1d66-48b2-8813-768563bfddb9",
 							"name": "Continual Light",
 							"reference": "DFS46",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Light & Darkness"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Regular",
 							"casting_cost": "2 moon, 4 torch, 6 day",
 							"maintenance_cost": "-",
@@ -1314,23 +2313,52 @@
 											"compare": "at_least",
 											"qualifier": 2
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Light"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Light & Darkness",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "997abf0e-1841-4999-9b1b-4bdf959f49ed",
+							"id": "a1546347-a06b-4c27-88d0-a9b0e3e1ee2f",
 							"name": "Create Water",
 							"reference": "DFS68",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Water"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Regular",
 							"casting_cost": "2/gal",
 							"maintenance_cost": "-",
@@ -1352,23 +2380,52 @@
 											"compare": "at_least",
 											"qualifier": 2
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Purify Water"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Water",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "aaec6f03-a1d6-47cc-a2b0-f2d7763c9733",
+							"id": "d9bae973-a4db-4ee2-b779-60455d6dd1c3",
 							"name": "Glow",
 							"reference": "DFS46",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Light & Darkness"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Area",
 							"casting_cost": "Varies",
 							"maintenance_cost": "-",
@@ -1390,23 +2447,52 @@
 											"compare": "at_least",
 											"qualifier": 2
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Continual Light"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Light & Darkness",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "dbd9ad0b-8a5b-4cdb-ad4d-6c955fc59f50",
+							"id": "ecf0c330-fa57-482b-ab04-05f9b168b59c",
 							"name": "Great Voice",
 							"reference": "DFS66",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Sound"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Regular",
 							"casting_cost": "3",
 							"maintenance_cost": "1",
@@ -1428,23 +2514,80 @@
 											"compare": "at_least",
 											"qualifier": 2
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Thunderclap"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Voices"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "prereq_list",
+												"all": false,
+												"prereqs": [
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Magery"
+														}
+													},
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Bardic Talent"
+														}
+													}
+												]
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Bardic",
+								"Clerical",
+								"Sound",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "e562ab5a-65e2-4c80-8c94-021b17b8e5cc",
+							"id": "2f024e3f-e637-4355-a2d3-f20cb3b9c2ba",
 							"name": "Healing Slumber",
 							"reference": "DFS37",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Healing"
 							],
-							"power_source": "Arcane",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "6 or 10",
 							"maintenance_cost": "-",
@@ -1470,19 +2613,20 @@
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Healing"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "20391983-e900-41bb-91cf-35615f04f747",
+							"id": "4b988900-d6a8-4b1b-8ac1-ff5bc27da795",
 							"name": "Hide Thoughts",
 							"reference": "DFS25",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Communication & Empathy"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Regular",
 							"casting_cost": "3",
 							"maintenance_cost": "1",
@@ -1504,23 +2648,86 @@
 											"compare": "at_least",
 											"qualifier": 2
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "prereq_list",
+												"all": false,
+												"prereqs": [
+													{
+														"type": "spell_prereq",
+														"has": true,
+														"sub_type": "name",
+														"qualifier": {
+															"compare": "is",
+															"qualifier": "Truthsayer"
+														},
+														"quantity": {
+															"compare": "at_least",
+															"qualifier": 1
+														}
+													},
+													{
+														"type": "spell_prereq",
+														"has": true,
+														"sub_type": "name",
+														"qualifier": {
+															"compare": "is",
+															"qualifier": "Hide Emotion"
+														},
+														"quantity": {
+															"compare": "at_least",
+															"qualifier": 1
+														}
+													}
+												]
+											},
+											{
+												"type": "prereq_list",
+												"all": false,
+												"prereqs": [
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Bardic Talent"
+														}
+													},
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Magery"
+														}
+													}
+												]
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Bardic",
+								"Clerical",
+								"Communication & Empathy",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "7468ec23-ac29-4444-89e0-3ef5b040c316",
+							"id": "ec6a7fb4-4c4a-4dd3-a389-b29eab329df1",
 							"name": "Light Jet",
 							"reference": "DFS47",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Light & Darkness"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Regular",
 							"casting_cost": "2",
 							"maintenance_cost": "1",
@@ -1562,7 +2769,7 @@
 							],
 							"prereqs": {
 								"type": "prereq_list",
-								"all": true,
+								"all": false,
 								"prereqs": [
 									{
 										"type": "advantage_prereq",
@@ -1575,24 +2782,53 @@
 											"compare": "at_least",
 											"qualifier": 2
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Continual Light"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
 									}
 								]
 							},
-							"notes": "blinds only when darkness penalty is -5 or more",
+							"notes": "Blinds only when darkness penalty is -5 or more",
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Light & Darkness",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "af097ea1-6ee5-4bb6-9613-ac96edf8bbec",
+							"id": "ea20e139-e7b8-44ac-8ef0-a029f481fa5e",
 							"name": "Major Healing",
 							"reference": "DFS37",
 							"difficulty": "iq/vh",
 							"college": [
-								"Clerical"
+								"Healing"
 							],
-							"power_source": "Arcane",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "1-4",
 							"maintenance_cost": "-",
@@ -1618,20 +2854,22 @@
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Healing"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "25ce5df3-301a-461b-9c23-adfe847087ab",
+							"id": "2250174d-5c4e-4390-b974-6b70be5f3cec",
 							"name": "Persuasion",
 							"reference": "DFS25",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Communication & Empathy"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Regular",
+							"resist": "Will",
 							"casting_cost": "Varies",
 							"maintenance_cost": "Same",
 							"casting_time": "1 sec",
@@ -1652,23 +2890,68 @@
 											"compare": "at_least",
 											"qualifier": 2
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Sense Emotion"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "prereq_list",
+												"all": false,
+												"prereqs": [
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Magery"
+														}
+													},
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Bardic Talent"
+														}
+													}
+												]
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Bardic",
+								"Clerical",
+								"Communication & Empathy",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "fb815103-ab48-4540-9a2a-d7439c15e5a0",
+							"id": "38a05904-4184-4da7-b1fa-7bc3804b0fe3",
 							"name": "Protection from Evil",
 							"reference": "DFS64",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Meta",
+								"Protection & Warning"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 							"spell_class": "Regular",
 							"casting_cost": "1-5",
 							"maintenance_cost": "Half",
@@ -1677,7 +2960,7 @@
 							"points": 1,
 							"prereqs": {
 								"type": "prereq_list",
-								"all": true,
+								"all": false,
 								"prereqs": [
 									{
 										"type": "advantage_prereq",
@@ -1690,23 +2973,89 @@
 											"compare": "at_least",
 											"qualifier": 2
 										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture (Druidic)"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 2
+										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Sense Evil"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "prereq_list",
+												"all": false,
+												"prereqs": [
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Magery"
+														},
+														"level": {
+															"compare": "at_least",
+															"qualifier": 3
+														}
+													},
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Bardic Talent"
+														},
+														"level": {
+															"compare": "at_least",
+															"qualifier": 3
+														}
+													}
+												]
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Bardic",
+								"Clerical",
+								"Druidic",
+								"Meta",
+								"Protection & Warning",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "6ae9e181-d39b-4a41-84a2-d1d9e5d8d69f",
+							"id": "2ac0e2e8-5bda-488d-888b-68467777dbb0",
 							"name": "Purify Food",
-							"reference": "DFS33",
+							"reference": "DFS32",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Food"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 							"spell_class": "Regular",
 							"casting_cost": "1/lb",
 							"maintenance_cost": "-",
@@ -1728,24 +3077,67 @@
 											"compare": "at_least",
 											"qualifier": 2
 										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture (Druidic)"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 2
+										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Decay"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Druidic",
+								"Food",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "b40aff8c-c655-454c-bcaa-0ba5c3b9fe4e",
+							"id": "f34b09f7-e891-43f0-b5ec-b8f4078f9697",
 							"name": "Relieve Sickness",
 							"reference": "DFS38",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Healing"
 							],
-							"power_source": "Arcane",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
+							"resist": "Subject spell",
 							"casting_cost": "2",
 							"maintenance_cost": "-",
 							"casting_time": "10 sec",
@@ -1770,19 +3162,21 @@
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Healing"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "386eba16-2b22-478d-9cea-6162cf366402",
+							"id": "143980a0-cc59-4c6e-bf41-ddad5c24e9f5",
 							"name": "Resist Acid",
 							"reference": "DFS70",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Protection & Warning",
+								"Water"
 							],
-							"power_source": "Arcane",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "2 or 6",
 							"maintenance_cost": "Half",
@@ -1791,7 +3185,7 @@
 							"points": 1,
 							"prereqs": {
 								"type": "prereq_list",
-								"all": false,
+								"all": true,
 								"prereqs": [
 									{
 										"type": "advantage_prereq",
@@ -1808,19 +3202,21 @@
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Protection & Warning",
+								"Water"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "538a33e8-0f68-453b-8f7c-29c3f33df1e9",
+							"id": "6a11996e-4e65-47bb-a9e0-aee5cbe8e892",
 							"name": "Resist Cold",
 							"reference": "DFS31",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Fire"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 							"spell_class": "Regular",
 							"casting_cost": "2",
 							"maintenance_cost": "Half",
@@ -1842,23 +3238,66 @@
 											"compare": "at_least",
 											"qualifier": 2
 										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture (Druidic)"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 3
+										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Heat"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Druidic",
+								"Fire",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "15f45cc6-0ac7-40aa-82b4-8300bffbfd11",
+							"id": "1ec15c84-230d-4e20-98f5-29cc6607cc04",
 							"name": "Resist Disease",
 							"reference": "DFS38",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Healing",
+								"Protection & Warning"
 							],
-							"power_source": "Arcane",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "4",
 							"maintenance_cost": "3",
@@ -1884,19 +3323,21 @@
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Healing",
+								"Protection & Warning"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "ea69cdfe-3bff-4766-8aff-d7166caa7393",
+							"id": "ea715f0d-89ce-4ef9-8205-da75334b9d22",
 							"name": "Resist Fire",
 							"reference": "DFS31",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Fire"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Regular",
 							"casting_cost": "2#",
 							"maintenance_cost": "Half",
@@ -1918,23 +3359,54 @@
 											"compare": "at_least",
 											"qualifier": 2
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Fireproof"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Fire",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "4b027118-79ac-4a7b-858a-7676f19abf34",
+							"id": "6e4f15e4-cf02-4cf5-9067-2f501f37611d",
 							"name": "Resist Lightning",
 							"reference": "DFS72",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Air",
+								"Protection & Warning",
+								"Weather"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 							"spell_class": "Regular",
 							"casting_cost": "2",
 							"maintenance_cost": "1",
@@ -1956,23 +3428,67 @@
 											"compare": "at_least",
 											"qualifier": 2
 										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture (Druidic)"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 3
+										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "college",
+												"qualifier": {
+													"compare": "contains",
+													"qualifier": "Air"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 6
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Air",
+								"Clerical",
+								"Druidic",
+								"Protection & Warning",
+								"Weather",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "e1111179-88c7-4269-b255-c3454802beee",
+							"id": "25cc886f-3e87-482e-bca4-35db4005e0c3",
 							"name": "Resist Pain",
 							"reference": "DFS22",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Body Control"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Regular",
 							"casting_cost": "4",
 							"maintenance_cost": "2",
@@ -1994,23 +3510,57 @@
 											"compare": "at_least",
 											"qualifier": 2
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Pain"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 2
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Body Control",
+								"Clerical",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "4880c15d-7ce2-4113-a3c4-20f73d207074",
+							"id": "fb41a8fb-2d14-434a-a5b9-b031e3214c3e",
 							"name": "Resist Poison",
 							"reference": "DFS38",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Healing",
+								"Protection & Warning"
 							],
-							"power_source": "Arcane",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "4",
 							"maintenance_cost": "3",
@@ -2019,7 +3569,7 @@
 							"points": 1,
 							"prereqs": {
 								"type": "prereq_list",
-								"all": false,
+								"all": true,
 								"prereqs": [
 									{
 										"type": "advantage_prereq",
@@ -2036,20 +3586,23 @@
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Healing",
+								"Protection & Warning"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "677bc98e-4770-4c2c-88db-2398591ba9d7",
+							"id": "b3b69b2b-c531-4968-baf6-f96176133d88",
 							"name": "Restore Hearing",
 							"reference": "DFS39",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Healing"
 							],
-							"power_source": "Arcane",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
+							"resist": "Subject spell",
 							"casting_cost": "5",
 							"maintenance_cost": "3",
 							"casting_time": "5 sec",
@@ -2057,7 +3610,7 @@
 							"points": 1,
 							"prereqs": {
 								"type": "prereq_list",
-								"all": false,
+								"all": true,
 								"prereqs": [
 									{
 										"type": "advantage_prereq",
@@ -2074,20 +3627,22 @@
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Healing"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "4d865445-6a20-44f7-8881-73764ebb74fb",
+							"id": "d13f217e-8bed-49bc-ab26-b2fdafcecb34",
 							"name": "Restore Memory",
 							"reference": "DFS39",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Healing"
 							],
-							"power_source": "Arcane",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
+							"resist": "Subject spell",
 							"casting_cost": "3",
 							"maintenance_cost": "-",
 							"casting_time": "10 sec",
@@ -2095,7 +3650,7 @@
 							"points": 1,
 							"prereqs": {
 								"type": "prereq_list",
-								"all": false,
+								"all": true,
 								"prereqs": [
 									{
 										"type": "advantage_prereq",
@@ -2112,20 +3667,22 @@
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Healing"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "a94dbb67-5a20-4158-9569-c79e034b79fd",
+							"id": "aede7ddc-64c0-4096-a5b7-dffd02e8fb81",
 							"name": "Restore Sight",
 							"reference": "DFS39",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Healing"
 							],
-							"power_source": "Arcane",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
+							"resist": "Subject spell",
 							"casting_cost": "5",
 							"maintenance_cost": "3",
 							"casting_time": "5 sec",
@@ -2133,7 +3690,7 @@
 							"points": 1,
 							"prereqs": {
 								"type": "prereq_list",
-								"all": false,
+								"all": true,
 								"prereqs": [
 									{
 										"type": "advantage_prereq",
@@ -2150,20 +3707,22 @@
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Healing"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "03aa4bb3-8b6b-4ae1-8736-57039b136d1b",
+							"id": "bbf3c6c6-7cd7-4ce7-864b-b4fabccb5a65",
 							"name": "Restore Speech",
 							"reference": "DFS39",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Healing"
 							],
-							"power_source": "Arcane",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
+							"resist": "Subject spell",
 							"casting_cost": "5",
 							"maintenance_cost": "3",
 							"casting_time": "5 sec",
@@ -2171,7 +3730,7 @@
 							"points": 1,
 							"prereqs": {
 								"type": "prereq_list",
-								"all": false,
+								"all": true,
 								"prereqs": [
 									{
 										"type": "advantage_prereq",
@@ -2188,19 +3747,20 @@
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Healing"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "abf09388-6aad-43aa-abd6-c5c44913ac1b",
+							"id": "84a55f0b-624b-4049-9374-c218fa5dadc4",
 							"name": "Seeker",
 							"reference": "DFS45",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Knowledge"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Info",
 							"casting_cost": "3",
 							"maintenance_cost": "-",
@@ -2222,24 +3782,87 @@
 											"compare": "at_least",
 											"qualifier": 2
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "attribute_prereq",
+												"has": true,
+												"which": "iq",
+												"qualifier": {
+													"compare": "at_least",
+													"qualifier": 12
+												}
+											},
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "starts_with",
+													"qualifier": "Seek "
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 2
+												}
+											},
+											{
+												"type": "prereq_list",
+												"all": false,
+												"prereqs": [
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Magery"
+														},
+														"level": {
+															"compare": "at_least",
+															"qualifier": 1
+														}
+													},
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Bardic Talent"
+														},
+														"level": {
+															"compare": "at_least",
+															"qualifier": 1
+														}
+													}
+												]
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Bardic",
+								"Clerical",
+								"Knowledge",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "9dfda139-2bcf-4392-b0ce-78d01f38f703",
+							"id": "69758e7b-a734-4a35-8648-87f779212f74",
 							"name": "Stop Spasm",
 							"reference": "DFS40",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Body Control",
+								"Healing"
 							],
-							"power_source": "Arcane",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
+							"resist": "Subject Spell",
 							"casting_cost": "1",
 							"maintenance_cost": "-",
 							"casting_time": "1 sec",
@@ -2264,20 +3887,23 @@
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Body Control",
+								"Clerical",
+								"Healing"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "da873315-83c2-48c1-850c-23ae1e61ed10",
+							"id": "92c71749-9bc9-4498-bc60-a3cc8db6cb8d",
 							"name": "Summon Spirit",
 							"reference": "DFS60",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Necromancy"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Info",
+							"resist": "Will",
 							"casting_cost": "20",
 							"maintenance_cost": "10",
 							"casting_time": "5 min",
@@ -2298,24 +3924,58 @@
 											"compare": "at_least",
 											"qualifier": 2
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Death Vision"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 2
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Necromancy",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "bed495cc-ee8f-4289-ac02-5ffe4862eb08",
+							"id": "27b5832f-6c96-4e0d-bc07-05a2f9a9bb25",
 							"name": "Truthsayer",
 							"reference": "DFS26",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Communication & Empathy"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Info",
+							"resist": "Will",
 							"casting_cost": "2",
 							"maintenance_cost": "-",
 							"casting_time": "1 sec",
@@ -2336,24 +3996,69 @@
 											"compare": "at_least",
 											"qualifier": 2
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Sense Emotion"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "prereq_list",
+												"all": false,
+												"prereqs": [
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Magery"
+														}
+													},
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Bardic Talent"
+														}
+													}
+												]
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Bardic",
+								"Clerical",
+								"Communication & Empathy",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "f6f1d94d-8f91-407f-a0da-7544cf8e3078",
+							"id": "189b58f2-9683-47d1-9f49-7f45374ed6d7",
 							"name": "Turn Spirit",
 							"reference": "DFS61",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Necromancy"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Regular",
+							"resist": "Will",
 							"casting_cost": "4",
 							"maintenance_cost": "2",
 							"casting_time": "1 sec",
@@ -2374,23 +4079,65 @@
 											"compare": "at_least",
 											"qualifier": 2
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Fear"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Sense Spirit"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Necromancy",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "a079aae2-72c2-4780-8742-abfc077eee9b",
+							"id": "ba10e3e0-bb3f-4c24-a8e1-ead85a878cd6",
 							"name": "Turn Zombie",
 							"reference": "DFS61",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Nercomancy"
 							],
-							"power_source": "Arcane",
+							"power_source": "Clerical",
 							"spell_class": "Area",
 							"casting_cost": "2",
 							"maintenance_cost": "-",
@@ -2399,7 +4146,7 @@
 							"points": 1,
 							"prereqs": {
 								"type": "prereq_list",
-								"all": false,
+								"all": true,
 								"prereqs": [
 									{
 										"type": "advantage_prereq",
@@ -2416,14 +4163,15 @@
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Necromancy"
 							]
 						}
 					]
 				},
 				{
 					"type": "spell_container",
-					"id": "66423cd4-e058-4999-94b6-6ab037250102",
+					"id": "b515dc05-fa45-46f0-a9fe-d5ef5cf79273",
 					"name": "Power Investiture 3",
 					"categories": [
 						"Clerical"
@@ -2432,14 +4180,14 @@
 					"children": [
 						{
 							"type": "spell",
-							"id": "c7090efe-4e34-4da3-906c-21aa1d8cf680",
+							"id": "747e4384-3add-460e-974d-73074ba1b5bf",
 							"name": "Affect Spirits",
 							"reference": "DFS59",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Necromancy"
 							],
-							"power_source": "Arcane",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "4",
 							"maintenance_cost": "2",
@@ -2465,19 +4213,21 @@
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Necromancy"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "22fedd6f-7a33-4b7d-84ce-7f06418a10c7",
+							"id": "3b80aff0-ba61-4011-a830-0547556fdde3",
 							"name": "Astral Vision",
 							"reference": "DFS42",
 							"difficulty": "iq/vh",
 							"college": [
-								"Clerical"
+								"Knowledge",
+								"Necromancy"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Regular",
 							"casting_cost": "4",
 							"maintenance_cost": "2",
@@ -2499,23 +4249,82 @@
 											"compare": "at_least",
 											"qualifier": 3
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "prereq_list",
+												"all": false,
+												"prereqs": [
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Magery"
+														}
+													},
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Bardic Talent"
+														}
+													}
+												]
+											},
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "See Invisible"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Sense Spirit"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Bardic",
+								"Clerical",
+								"Knowledge",
+								"Necromancy",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "87d8af74-14fc-4740-889a-bb9e50c4686e",
+							"id": "c1dabbfb-9878-4929-a3dc-d06bd4378038",
 							"name": "Breathe Water",
 							"reference": "DFS68",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Air",
+								"Water"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 							"spell_class": "Regular",
 							"casting_cost": "4",
 							"maintenance_cost": "2",
@@ -2537,24 +4346,81 @@
 											"compare": "at_least",
 											"qualifier": 3
 										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture (Druidic)"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 3
+										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											},
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Destroy Water"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Create Air"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Air",
+								"Clerical",
+								"Druidic",
+								"Water",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "2ff35ad9-a8ca-450c-a2bf-e3df61f30a7b",
-							"name": "Command Spirit (@spirit@)",
+							"id": "92aceedf-7584-46de-a875-da5f1c624c82",
+							"name": "Command Spirit (@Spirit@)",
 							"reference": "DFS60",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Necromancy"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Regular",
+							"resist": "Will",
 							"casting_cost": "Varies",
 							"maintenance_cost": "Half",
 							"casting_time": "2 sec",
@@ -2573,25 +4439,67 @@
 										},
 										"level": {
 											"compare": "at_least",
-											"qualifier": 3
+											"qualifier": 4
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Summon Spirit"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Turn Spirit"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Necromancy",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "4603ec53-71f9-435d-b967-76e4e126a4f4",
+							"id": "840f38fe-47c2-449b-9bbf-b9f788a11a83",
 							"name": "Create Food",
 							"reference": "DFS32",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Food"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Regular",
 							"casting_cost": "Varies",
 							"maintenance_cost": "-",
@@ -2613,23 +4521,65 @@
 											"compare": "at_least",
 											"qualifier": 3
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Cook"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Seek Food"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Food",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "7f8c63bc-6cba-42d8-aeb7-67f90431c83c",
+							"id": "bcaf2da0-9382-4a88-a457-f93be13a6312",
 							"name": "Cure Disease",
 							"reference": "DFS36",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Healing"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Clerical/Druidic@",
 							"spell_class": "Regular",
 							"casting_cost": "4",
 							"maintenance_cost": "-",
@@ -2651,24 +4601,39 @@
 											"compare": "at_least",
 											"qualifier": 3
 										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture (Druidic)"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 2
+										}
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Druidic",
+								"Healing"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "a1594675-982f-48db-a80a-47161fac1f30",
+							"id": "5c50d270-6750-4d53-a241-7ef4e124ed32",
 							"name": "Dispel Possession",
 							"reference": "DFS24",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Communication & Empathy"
 							],
-							"power_source": "Arcane",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
+							"resist": "Posession abilities",
 							"casting_cost": "10",
 							"maintenance_cost": "-",
 							"casting_time": "10 sec",
@@ -2693,19 +4658,20 @@
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Communication & Empathy"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "f017489d-4622-46ac-ac95-324461259a57",
+							"id": "1acc443c-2f4c-4fd2-8dc5-c1e95349b0ce",
 							"name": "Flaming Weapon",
 							"reference": "DFS31",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Fire"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Regular",
 							"casting_cost": "4",
 							"maintenance_cost": "1",
@@ -2727,24 +4693,57 @@
 											"compare": "at_least",
 											"qualifier": 3
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Heat"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 2
+												}
+											}
+										]
 									}
 								]
 							},
 							"notes": "+2 points burn damage from attacks with melee weapon",
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Fire",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "10d5ade0-e82b-40c9-8822-e4f88277d932",
+							"id": "4fb4fee9-9512-43fa-a70b-3de500566ec4",
 							"name": "Great Healing",
 							"reference": "DFS37",
 							"difficulty": "iq/vh",
 							"college": [
-								"Clerical"
+								"Healing"
 							],
-							"power_source": "Arcane",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "20",
 							"maintenance_cost": "-",
@@ -2770,20 +4769,22 @@
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Healing"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "36329fda-b765-49c3-adca-7e4e599b913d",
+							"id": "f62fd3e3-f0fb-4e51-815a-8592064007f0",
 							"name": "Magic Resistance",
 							"reference": "DFS51",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Meta"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Regular",
+							"resist": "Will + Spellcasting Talent",
 							"casting_cost": "1-5",
 							"maintenance_cost": "Same",
 							"casting_time": "3 sec",
@@ -2804,23 +4805,52 @@
 											"compare": "at_least",
 											"qualifier": 3
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "college_count",
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 7
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Meta",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "595cc0fc-9602-4667-8493-f573e1f1dea1",
+							"id": "78b7715d-a927-4d9b-8243-4755cae651b8",
 							"name": "Neutralize Poison",
 							"reference": "DFS37",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Healing"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Clerical/Druidic@",
 							"spell_class": "Regular",
 							"casting_cost": "5",
 							"maintenance_cost": "-",
@@ -2842,23 +4872,37 @@
 											"compare": "at_least",
 											"qualifier": 3
 										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture (Druidic)"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 2
+										}
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Druidic",
+								"Healing"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "b421e352-b299-4ab3-9416-b97bd80c6840",
+							"id": "bda5f0ae-9a60-45cf-bac0-953712ddfe32",
 							"name": "Relieve Paralysis",
 							"reference": "DFS38",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Healing"
 							],
-							"power_source": "Arcane",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "Varies",
 							"maintenance_cost": "Same",
@@ -2884,19 +4928,20 @@
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Healing"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "6091f433-f3c2-4226-9390-f229571f648e",
+							"id": "2dd70708-fa26-4249-83f8-5f6278965541",
 							"name": "Repel Spirits",
 							"reference": "DFS60",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Necromancy"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Area",
 							"casting_cost": "4",
 							"maintenance_cost": "Half",
@@ -2918,23 +4963,65 @@
 											"compare": "at_least",
 											"qualifier": 3
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Turn Spirit"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Banish"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Necromancy",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "d5620ecc-3b19-43e7-9545-f912ed3f513c",
+							"id": "834b3547-e460-4dec-90be-d93097e79d7b",
 							"name": "Restoration",
 							"reference": "DFS38",
 							"difficulty": "iq/vh",
 							"college": [
-								"Clerical"
+								"Healing"
 							],
-							"power_source": "Arcane",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "15",
 							"maintenance_cost": "-",
@@ -2960,19 +5047,20 @@
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Healing"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "5dbe0d29-e55e-494f-a7e3-34855163cfc4",
+							"id": "38cacd46-376b-4be9-a523-5f617296589f",
 							"name": "See Secrets",
 							"reference": "DFS44",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Knowledge"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Regular",
 							"casting_cost": "5",
 							"maintenance_cost": "2",
@@ -2994,23 +5082,80 @@
 											"compare": "at_least",
 											"qualifier": 3
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Seeker"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Aura"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "prereq_list",
+												"all": false,
+												"prereqs": [
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Magery"
+														}
+													},
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Bardic Talent"
+														}
+													}
+												]
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Bardic",
+								"Clerical",
+								"Knowledge",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "51864085-0400-4212-b420-690ac9652b93",
+							"id": "856f303a-8c3a-433e-a426-46958e6b3910",
 							"name": "Silver Tongue",
 							"reference": "DFS67",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Sound"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Regular",
 							"casting_cost": "3",
 							"maintenance_cost": "2",
@@ -3032,23 +5177,80 @@
 											"compare": "at_least",
 											"qualifier": 3
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Voices"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "college",
+												"qualifier": {
+													"compare": "contains",
+													"qualifier": "Mind Control"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 5
+												}
+											},
+											{
+												"type": "prereq_list",
+												"all": false,
+												"prereqs": [
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Magery"
+														}
+													},
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Bardic Talent"
+														}
+													}
+												]
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Bardic",
+								"Clerical",
+								"Sound",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "4b2e7229-560e-4444-a7cb-70d381251010",
+							"id": "56e08720-9885-4317-a843-2673f347789f",
 							"name": "Stone to Flesh",
 							"reference": "DFS29",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Earth"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Regular",
 							"casting_cost": "10",
 							"maintenance_cost": "-",
@@ -3070,24 +5272,72 @@
 											"compare": "at_least",
 											"qualifier": 3
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Flesh to Stone"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Stone to Earth"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 2
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Earth",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "776155db-722b-4590-abda-f0b0eae99f0a",
+							"id": "347df735-11c6-4a7a-8960-7bf4db3ec0cd",
 							"name": "Stop Paralysis",
 							"reference": "DFS40",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Body Control",
+								"Healing"
 							],
-							"power_source": "Arcane",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
+							"resist": "Subject Spell",
 							"casting_cost": "1 or 2",
 							"maintenance_cost": "-",
 							"casting_time": "1 sec",
@@ -3112,19 +5362,21 @@
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Body Control",
+								"Clerical",
+								"Healing"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "cf35c420-30e4-4ca8-bbb4-c596b4898218",
+							"id": "f9e20329-a3cb-49a7-883e-b3c6067b277f",
 							"name": "Strengthen Will",
 							"reference": "DFS55",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Mind Control"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Regular",
 							"casting_cost": "1/pt of Will increase",
 							"maintenance_cost": "Half",
@@ -3146,23 +5398,75 @@
 											"compare": "at_least",
 											"qualifier": 3
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "college",
+												"qualifier": {
+													"compare": "contains",
+													"qualifier": "Mind Control"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 6
+												}
+											},
+											{
+												"type": "prereq_list",
+												"all": false,
+												"prereqs": [
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Magery"
+														},
+														"level": {
+															"compare": "at_least",
+															"qualifier": 1
+														}
+													},
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Bardic Talent"
+														},
+														"level": {
+															"compare": "at_least",
+															"qualifier": 1
+														}
+													}
+												]
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Bardic",
+								"Clerical",
+								"Mind Control",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "5494e69c-b5a0-4804-8055-4bd84f083ad5",
+							"id": "d6e2eddb-769b-4765-9dbb-ca4fc6fe46f0",
 							"name": "Sunbolt",
 							"reference": "DFS48",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Light & Darkness"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Missile",
 							"casting_cost": "1-3xMagery",
 							"maintenance_cost": "-",
@@ -3211,23 +5515,65 @@
 											"compare": "at_least",
 											"qualifier": 3
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Sunlight"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "college",
+												"qualifier": {
+													"compare": "contains",
+													"qualifier": "Light & Darkness"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 6
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Light & Darkness",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "ad868375-3954-4ef5-bff3-733343344b31",
+							"id": "6429bec5-6c18-4f53-bc59-9fa0a73d44df",
 							"name": "Sunlight",
 							"reference": "DFS48",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Light & Darkness"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 							"spell_class": "Area",
 							"casting_cost": "2",
 							"maintenance_cost": "Half",
@@ -3249,24 +5595,84 @@
 											"compare": "at_least",
 											"qualifier": 3
 										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture (Druidic)"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 3
+										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Glow"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Colors"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Druidic",
+								"Light & Darkness",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "7781dc0c-8bee-44e6-a344-0aeb702967c3",
+							"id": "8eb4a16b-7d4e-4e1c-a4bd-595be831b35b",
 							"name": "Suspended Animation",
 							"reference": "DFS40",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Healing"
 							],
-							"power_source": "Arcane",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
+							"resist": "HT",
 							"casting_cost": "6",
 							"maintenance_cost": "-",
 							"casting_time": "30 sec",
@@ -3291,19 +5697,20 @@
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Healing"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "02baca9b-f3aa-4dc2-8241-d0b65db83d81",
+							"id": "add6798d-0a0b-4c80-873c-60db6196443d",
 							"name": "Wisdom",
 							"reference": "DFS56",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Mind Control"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Regular",
 							"casting_cost": "4/pt of IQ",
 							"maintenance_cost": "Same",
@@ -3325,18 +5732,62 @@
 											"compare": "at_least",
 											"qualifier": 3
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "college",
+												"qualifier": {
+													"compare": "contains",
+													"qualifier": "Mind Control"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 6
+												}
+											},
+											{
+												"type": "prereq_list",
+												"all": false,
+												"prereqs": [
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Magery"
+														}
+													},
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Bardic Talent"
+														}
+													}
+												]
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Bardic",
+								"Clerical",
+								"Mind Control",
+								"Wizardly"
 							]
 						}
 					]
 				},
 				{
 					"type": "spell_container",
-					"id": "49e7c941-8929-40f8-91f1-13fb2775c148",
+					"id": "cf7b79c4-8574-4f75-8aa9-e0a8c8f7c039",
 					"name": "Power Investiture 4",
 					"categories": [
 						"Clerical"
@@ -3345,17 +5796,17 @@
 					"children": [
 						{
 							"type": "spell",
-							"id": "7a18c314-efe4-47c9-98fd-5f41f81ff861",
+							"id": "becacef9-a966-413c-bb1a-456a01f49be5",
 							"name": "Astral Block",
 							"reference": "DFS59",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Necromancy"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Area",
 							"casting_cost": "4",
-							"maintenance_cost": "Half",
+							"maintenance_cost": "2",
 							"casting_time": "2 sec",
 							"duration": "10 min",
 							"points": 1,
@@ -3374,24 +5825,67 @@
 											"compare": "at_least",
 											"qualifier": 4
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Repel Spirits"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Summon Spirit"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Necromancy",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "45650bb1-766f-4c39-a4b2-f88ef9d352de",
+							"id": "3a3467a7-97f7-43ef-a844-e079f64941bd",
 							"name": "Banish",
 							"reference": "DFS59",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Necromancy"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Special",
+							"resist": "Will",
 							"casting_cost": "Varies",
 							"maintenance_cost": "-",
 							"casting_time": "5 sec",
@@ -3412,24 +5906,54 @@
 											"compare": "at_least",
 											"qualifier": 4
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "college_count",
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 10
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Necromancy",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "8a92e8cc-3ac1-4fdc-9dbe-a6ef34cfc1fc",
+							"id": "227fc3c4-2476-4bd6-a776-eb6b4991a11e",
 							"name": "Dispel Magic",
 							"reference": "DFS51",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Meta"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 							"spell_class": "Area",
+							"resist": "Subject spells",
 							"casting_cost": "3",
 							"maintenance_cost": "-",
 							"casting_time": "sec=cost",
@@ -3450,23 +5974,74 @@
 											"compare": "at_least",
 											"qualifier": 4
 										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture (Druidic)"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 4
+										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											},
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "any",
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 13
+												}
+											},
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Counterspell"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Druidic",
+								"Meta",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "b1400433-b110-4a99-9582-bba9c6f4ac70",
+							"id": "12cda4fe-576c-4d65-9dd4-01cc6a87e691",
 							"name": "Essential Food",
 							"reference": "DFS32",
-							"difficulty": "iq/h",
+							"difficulty": "iq/vh",
 							"college": [
-								"Clerical"
+								"Food"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Regular",
 							"casting_cost": "6",
 							"maintenance_cost": "-",
@@ -3488,26 +6063,68 @@
 											"compare": "at_least",
 											"qualifier": 4
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Create Food"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "college",
+												"qualifier": {
+													"compare": "contains",
+													"qualifier": "Food"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 6
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Food",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "bff3c078-bc36-4b22-8823-445bba1b3ca8",
+							"id": "6e008129-aec6-478b-8161-29a1ce543264",
 							"name": "Gift of Letters",
 							"reference": "DFS24",
 							"difficulty": "iq/vh",
 							"college": [
-								"Clerical"
+								"Communication & Empathy"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Regular",
 							"casting_cost": "6",
-							"maintenance_cost": "Half",
+							"maintenance_cost": "3",
 							"casting_time": "1 sec",
 							"duration": "1 min",
 							"points": 1,
@@ -3526,26 +6143,94 @@
 											"compare": "at_least",
 											"qualifier": 4
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Borrow Language"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Language"
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Language"
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Language"
+												}
+											},
+											{
+												"type": "prereq_list",
+												"all": false,
+												"prereqs": [
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Magery"
+														}
+													},
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Bardic Talent"
+														}
+													}
+												]
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Bardic",
+								"Clerical",
+								"Communication & Empathy",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "92454421-14d2-4457-999d-103099ddb79f",
+							"id": "b14a7b69-56ce-4d10-98d4-0ff36e78f256",
 							"name": "Gift of Tongues",
 							"reference": "DFS24",
 							"difficulty": "iq/vh",
 							"college": [
-								"Clerical"
+								"Communication & Empathy"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Regular",
 							"casting_cost": "6",
-							"maintenance_cost": "Half",
+							"maintenance_cost": "3",
 							"casting_time": "1 sec",
 							"duration": "1 min",
 							"points": 1,
@@ -3564,23 +6249,91 @@
 											"compare": "at_least",
 											"qualifier": 4
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Borrow Language"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Language"
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Language"
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Language"
+												}
+											},
+											{
+												"type": "prereq_list",
+												"all": false,
+												"prereqs": [
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Magery"
+														}
+													},
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Bardic Talent"
+														}
+													}
+												]
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Bardic",
+								"Clerical",
+								"Communication & Empathy",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "81149bcd-cb28-4c28-8621-9b5578b70cb2",
+							"id": "4bd4a878-e16d-4f82-9a68-142faa798349",
 							"name": "Instant Neutralize Poison",
 							"reference": "DFS37",
 							"difficulty": "iq/vh",
 							"college": [
-								"Clerical"
+								"Healing"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Clerical/Druidic@",
 							"spell_class": "Regular",
 							"casting_cost": "8",
 							"maintenance_cost": "-",
@@ -3602,23 +6355,37 @@
 											"compare": "at_least",
 											"qualifier": 4
 										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture (Druidic)"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 3
+										}
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Druidic",
+								"Healing"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "3c5fac01-96f8-453c-84fb-053965faea3d",
+							"id": "a2663f83-2706-46a1-b251-96f91c3fbfda",
 							"name": "Monk's Banquet",
 							"reference": "DFS33",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Food"
 							],
-							"power_source": "Arcane",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "6",
 							"maintenance_cost": "-",
@@ -3644,19 +6411,20 @@
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Food"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "6b9b0830-7273-4744-8779-065e4d845cb0",
+							"id": "0c558916-c382-42d8-82bc-bfc00039c2f0",
 							"name": "Regeneration",
 							"reference": "DFS38",
 							"difficulty": "iq/vh",
 							"college": [
-								"Clerical"
+								"Healing"
 							],
-							"power_source": "Arcane",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "20",
 							"maintenance_cost": "-",
@@ -3682,19 +6450,20 @@
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Healing"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "3afbe4ef-fca6-45e9-b3b3-9f07826a5ef1",
+							"id": "d2982d36-56e6-4cff-a882-18f632785ae6",
 							"name": "Vigil",
 							"reference": "DFS56",
 							"difficulty": "iq/vh",
 							"college": [
-								"Clerical"
+								"Mind Control"
 							],
-							"power_source": "Arcane",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "8",
 							"maintenance_cost": "-",
@@ -3703,7 +6472,7 @@
 							"points": 1,
 							"prereqs": {
 								"type": "prereq_list",
-								"all": false,
+								"all": true,
 								"prereqs": [
 									{
 										"type": "advantage_prereq",
@@ -3720,14 +6489,15 @@
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Mind Control"
 							]
 						}
 					]
 				},
 				{
 					"type": "spell_container",
-					"id": "4b9e7948-8196-4430-97a6-a7c179d8b353",
+					"id": "5d99cbf2-e411-415c-ba20-bab1d8a206ec",
 					"name": "Power Investiture 5",
 					"categories": [
 						"Clerical"
@@ -3736,14 +6506,14 @@
 					"children": [
 						{
 							"type": "spell",
-							"id": "eefdc95f-d4c3-403a-9128-2dbda6503bca",
+							"id": "015712d2-ca1e-4e9c-9f3b-57b5bd64b149",
 							"name": "Bless",
 							"reference": "DFS50",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Meta"
 							],
-							"power_source": "Arcane",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "10 or 50",
 							"maintenance_cost": "-",
@@ -3769,19 +6539,20 @@
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Meta"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "ccb72981-82d0-4543-88a7-9e330631b301",
+							"id": "85138e26-b068-437f-9aa4-e1bf4d94cecd",
 							"name": "Curse",
 							"reference": "DFS51",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Meta"
 							],
-							"power_source": "Arcane",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "3/10/20",
 							"maintenance_cost": "-",
@@ -3807,19 +6578,20 @@
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Meta"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "34c15422-f2f3-422c-8c1b-98fa94511ef8",
+							"id": "60706778-c2a0-4b8b-98fb-ee581c5fd9cd",
 							"name": "Earthquake",
 							"reference": "DFS27",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Earth"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Clerical/Druidic@",
 							"spell_class": "Area",
 							"casting_cost": "2",
 							"maintenance_cost": "Same",
@@ -3841,23 +6613,37 @@
 											"compare": "at_least",
 											"qualifier": 5
 										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture (Druidic)"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 6
+										}
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Druidic",
+								"Earth"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "0d5d6d27-c7fb-4ea7-b0a7-cf1074164c46",
+							"id": "ad455784-1d8c-49af-aae4-dd436d7af8ee",
 							"name": "Entrap Spirit",
 							"reference": "DFS60",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Necromancy"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Special",
 							"casting_cost": "Varies",
 							"maintenance_cost": "Varies",
@@ -3873,29 +6659,75 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture"
+											"qualifier": "Power Invesiture"
 										},
 										"level": {
 											"compare": "at_least",
 											"qualifier": 5
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Turn Spirit"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "college",
+												"qualifier": {
+													"compare": "contains",
+													"qualifier": "Necromancy"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 7
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Necromancy",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "d5d2d020-c155-4a98-ba9c-858402077184",
+							"id": "9c49f75e-88c6-4652-a7b0-1ef44370bdaa",
 							"name": "Pentagram",
 							"reference": "DFS51",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Meta"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical@",
 							"spell_class": "Special",
 							"casting_cost": "1/sq foot",
 							"maintenance_cost": "-",
@@ -3917,24 +6749,54 @@
 											"compare": "at_least",
 											"qualifier": 5
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Spell Shield"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Meta",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "63547507-650e-4f90-bf96-fcdc7f42cb20",
+							"id": "17fcef52-ae4b-450e-a94f-b1d2ed6cb779",
 							"name": "Remove Curse",
 							"reference": "DFS52",
 							"difficulty": "iq/h",
 							"college": [
-								"Clerical"
+								"Meta"
 							],
-							"power_source": "Arcane",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
+							"resist": "Subject curse",
 							"casting_cost": "20",
 							"maintenance_cost": "-",
 							"casting_time": "1 hr",
@@ -3959,14 +6821,15 @@
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Meta"
 							]
 						}
 					]
 				},
 				{
 					"type": "spell_container",
-					"id": "0a822561-e520-4de8-8bd8-56e5f38be611",
+					"id": "10f19b81-eb04-4577-ba63-22e2a5ddb1ec",
 					"name": "Power Investiture 6",
 					"categories": [
 						"Clerical"
@@ -3975,14 +6838,14 @@
 					"children": [
 						{
 							"type": "spell",
-							"id": "5a08ea88-afb6-475a-8831-c1439ddcfa42",
+							"id": "868eec0d-1c75-408b-95b1-7f8162e60797",
 							"name": "Sanctuary",
 							"reference": "DFS35",
 							"difficulty": "iq/vh",
 							"college": [
-								"Clerical"
+								"Gate"
 							],
-							"power_source": "Arcane",
+							"power_source": "Clerical",
 							"spell_class": "Special",
 							"casting_cost": "5",
 							"maintenance_cost": "Same",
@@ -4008,7 +6871,8 @@
 								]
 							},
 							"categories": [
-								"Clerical"
+								"Clerical",
+								"Gate"
 							]
 						}
 					]
@@ -4017,67 +6881,32 @@
 		},
 		{
 			"type": "spell_container",
-			"id": "4bf684db-9a6c-4d00-812d-c55d8548edfd",
+			"id": "5461f513-aa51-493c-a7b7-992501eb6757",
 			"name": "Druidic",
-			"open": false,
+			"categories": [
+				"Druidic"
+			],
+			"open": true,
 			"children": [
 				{
 					"type": "spell_container",
-					"id": "77d95d38-57df-4022-90a7-4f958681d11f",
-					"name": "Power Investiture (Druidic) 1",
+					"id": "233b231c-ccf9-4205-bbdd-5277a321d056",
+					"name": "Power Investiture 1",
 					"categories": [
-						"Druid"
+						"Druidic"
 					],
 					"open": false,
 					"children": [
 						{
 							"type": "spell",
-							"id": "ba615b00-ca5f-453f-99fe-a6fc8c3b7bea",
-							"name": "Beast Soother",
-							"reference": "DFS18",
-							"difficulty": "iq/h",
-							"college": [
-								"Druid"
-							],
-							"power_source": "Arcane",
-							"spell_class": "Regular",
-							"casting_cost": "1 to 3",
-							"maintenance_cost": "-",
-							"casting_time": "1 sec",
-							"duration": "Permanent",
-							"points": 1,
-							"prereqs": {
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "Power Investiture (Druidic)"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 1
-										}
-									}
-								]
-							},
-							"categories": [
-								"Druid"
-							]
-						},
-						{
-							"type": "spell",
-							"id": "3271c16f-63c6-4a61-86a0-b48cf2a6dcc7",
+							"id": "37158869-1a41-4a71-a72b-e4991dba97f4",
 							"name": "Beast-Rouser",
 							"reference": "DFS18",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Animal"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
 							"casting_cost": "1 to 3",
 							"maintenance_cost": "-",
@@ -4103,135 +6932,22 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Animal",
+								"Druidic"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "293e99dd-0b27-4e4e-b510-fb4fd71564fb",
-							"name": "Coolness",
-							"reference": "DFS68",
+							"id": "17ee3c4d-307f-482b-8cd0-3d005ea5d527",
+							"name": "Beast-Soother",
+							"reference": "DFS18",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Animal"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
-							"casting_cost": "2",
-							"maintenance_cost": "1",
-							"casting_time": "10 sec",
-							"duration": "1 hour",
-							"points": 1,
-							"prereqs": {
-								"type": "prereq_list",
-								"all": true,
-								"prereqs": [
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "Power Investiture (Druidic)"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 1
-										}
-									}
-								]
-							},
-							"categories": [
-								"Druid"
-							]
-						},
-						{
-							"type": "spell",
-							"id": "76c602ad-fbdd-43b9-9548-c11d09f44840",
-							"name": "Detect Magic",
-							"reference": "DFS43",
-							"difficulty": "iq/h",
-							"college": [
-								"Druid"
-							],
-							"power_source": "Arcane",
-							"spell_class": "Regular",
-							"casting_cost": "2",
-							"maintenance_cost": "-",
-							"casting_time": "5 sec",
-							"duration": "Instant",
-							"points": 1,
-							"prereqs": {
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "Power Investiture (Druidic)"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 1
-										}
-									}
-								]
-							},
-							"categories": [
-								"Druid"
-							]
-						},
-						{
-							"type": "spell",
-							"id": "b63367a2-f141-4073-96b8-fdbfff5c1833",
-							"name": "Detect Poison",
-							"reference": "DFS36",
-							"difficulty": "iq/h",
-							"college": [
-								"Druid"
-							],
-							"power_source": "Arcane",
-							"spell_class": "Area-Info",
-							"casting_cost": "2",
-							"maintenance_cost": "-",
-							"casting_time": "2 sec",
-							"duration": "-",
-							"points": 1,
-							"prereqs": {
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "Power Investiture (Druidic)"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 1
-										}
-									}
-								]
-							},
-							"categories": [
-								"Druid"
-							]
-						},
-						{
-							"type": "spell",
-							"id": "9b317099-47f4-414d-a181-9552f344f039",
-							"name": "Extinguish Fire",
-							"reference": "DFS30",
-							"difficulty": "iq/h",
-							"college": [
-								"Druid"
-							],
-							"power_source": "Arcane",
-							"spell_class": "Regular",
-							"casting_cost": "3",
+							"casting_cost": "1 to 3",
 							"maintenance_cost": "-",
 							"casting_time": "1 sec",
 							"duration": "Permanent",
@@ -4255,19 +6971,301 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Animal",
+								"Druidic"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "5771e78b-d0e3-41d0-b2be-a456b84be1ea",
+							"id": "e4d637e6-fa68-449e-9ca1-63f2e708f4dc",
+							"name": "Coolness",
+							"reference": "DFS68",
+							"difficulty": "iq/h",
+							"college": [
+								"Protection & Warning",
+								"Water"
+							],
+							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+							"spell_class": "Regular",
+							"casting_cost": "2",
+							"maintenance_cost": "1",
+							"casting_time": "10 sec",
+							"duration": "1 hour",
+							"points": 1,
+							"prereqs": {
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture (Druidic)"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Cold"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
+									}
+								]
+							},
+							"categories": [
+								"Clerical",
+								"Druidic",
+								"Protection & Warning",
+								"Water",
+								"Wizardly"
+							]
+						},
+						{
+							"type": "spell",
+							"id": "8e99cc4e-0024-45ea-90ca-11cae66a4bef",
+							"name": "Detect Magic",
+							"reference": "DFS43",
+							"difficulty": "iq/h",
+							"college": [
+								"Knowledge"
+							],
+							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+							"spell_class": "Regular",
+							"casting_cost": "2",
+							"maintenance_cost": "-",
+							"casting_time": "5 sec",
+							"duration": "Instant",
+							"points": 1,
+							"prereqs": {
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture (Druidic)"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									}
+								]
+							},
+							"categories": [
+								"Bardic",
+								"Clerical",
+								"Druidic",
+								"Knowledge",
+								"Wizardly"
+							]
+						},
+						{
+							"type": "spell",
+							"id": "641e2d67-e726-403d-af03-dc01cf55b99a",
+							"name": "Detect Poison",
+							"reference": "DFS36",
+							"difficulty": "iq/h",
+							"college": [
+								"Healing",
+								"Protection & Warning"
+							],
+							"power_source": "@Power Source: Clerical/Druidic@",
+							"spell_class": "Area/Info",
+							"casting_cost": "2",
+							"maintenance_cost": "-",
+							"casting_time": "2 sec",
+							"duration": "-",
+							"points": 1,
+							"prereqs": {
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture (Druidic)"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									}
+								]
+							},
+							"categories": [
+								"Clerical",
+								"Druidic",
+								"Healing",
+								"Protection & Warning"
+							]
+						},
+						{
+							"type": "spell",
+							"id": "54fa4b80-92b9-4b71-a017-46ea752481b3",
+							"name": "Extinguish Fire",
+							"reference": "DFS30",
+							"difficulty": "iq/h",
+							"college": [
+								"Fire"
+							],
+							"power_source": "@Power Source: Arcane/Druidic@",
+							"spell_class": "Area",
+							"casting_cost": "3",
+							"maintenance_cost": "-",
+							"casting_time": "1 sec",
+							"duration": "Permanent",
+							"points": 1,
+							"prereqs": {
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture (Druidic)"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Ignite Fire"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
+									}
+								]
+							},
+							"categories": [
+								"Druidic",
+								"Fire",
+								"Wizardly"
+							]
+						},
+						{
+							"type": "spell",
+							"id": "04cff9db-967b-4b6a-a8cd-b7e771eb0b1f",
 							"name": "Find Direction",
 							"reference": "DFS43",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Knowledge"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Druidic@",
 							"spell_class": "Info",
 							"casting_cost": "2",
 							"maintenance_cost": "-",
@@ -4289,23 +7287,50 @@
 											"compare": "at_least",
 											"qualifier": 1
 										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
 									}
 								]
 							},
 							"categories": [
-								"Druid"
+								"Bardic",
+								"Druidic",
+								"Knowledge",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "e54b77c2-97a1-4bcd-833d-3d0ce861e2aa",
+							"id": "744694d2-d5ca-4c5c-b588-1766dd1563b5",
 							"name": "Hawk Vision",
 							"reference": "DFS47",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Light & Darkness"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Druidic@",
 							"spell_class": "Regular",
 							"casting_cost": "2/level",
 							"maintenance_cost": "Half",
@@ -4327,23 +7352,71 @@
 											"compare": "at_least",
 											"qualifier": 1
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "prereq_list",
+												"all": false,
+												"prereqs": [
+													{
+														"type": "spell_prereq",
+														"has": true,
+														"sub_type": "name",
+														"qualifier": {
+															"compare": "is",
+															"qualifier": "Keen Vision"
+														},
+														"quantity": {
+															"compare": "at_least",
+															"qualifier": 1
+														}
+													},
+													{
+														"type": "spell_prereq",
+														"has": true,
+														"sub_type": "college",
+														"qualifier": {
+															"compare": "contains",
+															"qualifier": "Light & Darkness"
+														},
+														"quantity": {
+															"compare": "at_least",
+															"qualifier": 5
+														}
+													}
+												]
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Druid"
+								"Druidic",
+								"Light & Darkness",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "c84a1980-609b-4c9c-acbe-dc5db6bad2ed",
+							"id": "37b960cd-2802-4dce-97cf-f47eb472f426",
 							"name": "Identify Plant",
 							"reference": "DFS62",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Plant"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Info",
 							"casting_cost": "2",
 							"maintenance_cost": "-",
@@ -4352,7 +7425,7 @@
 							"points": 1,
 							"prereqs": {
 								"type": "prereq_list",
-								"all": false,
+								"all": true,
 								"prereqs": [
 									{
 										"type": "advantage_prereq",
@@ -4369,20 +7442,22 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Druidic",
+								"Plant"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "79f8a567-8360-4dc3-bfcd-4b88ba51ece8",
+							"id": "c16aa9a7-7e2b-4132-9bd6-acbc614b3599",
 							"name": "Master",
 							"reference": "DFS19",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Animal"
 							],
-							"power_source": "Arcane",
-							"spell_class": "Regular Blocking",
+							"power_source": "Druidic",
+							"spell_class": "Regular/Blocking",
+							"resist": "Will",
 							"casting_cost": "2",
 							"maintenance_cost": "-",
 							"casting_time": "1 sec",
@@ -4407,19 +7482,20 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Animal",
+								"Druidic"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "f103f7fd-9dc5-454e-8aba-53f10f676923",
+							"id": "0cfee5b4-ede5-4acb-8593-12c509f06e77",
 							"name": "No-Smell",
 							"reference": "DFS16",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Air"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Druidic@",
 							"spell_class": "Regular",
 							"casting_cost": "2",
 							"maintenance_cost": "2",
@@ -4441,23 +7517,52 @@
 											"compare": "at_least",
 											"qualifier": 1
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Purify Air"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Druid"
+								"Air",
+								"Druidic",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "b9694e97-aea0-4f11-ab5e-e988731be88c",
+							"id": "74a5a474-85d0-48ef-9c67-cdc9f5bd7bf5",
 							"name": "Purify Air",
 							"reference": "DFS16",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Air"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 							"spell_class": "Area",
 							"casting_cost": "1",
 							"maintenance_cost": "-",
@@ -4473,39 +7578,13 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druidic)"
+											"qualifier": "Power Investiture"
 										},
 										"level": {
 											"compare": "at_least",
 											"qualifier": 1
 										}
-									}
-								]
-							},
-							"categories": [
-								"Druid"
-							]
-						},
-						{
-							"type": "spell",
-							"id": "928c64db-0dad-49ce-a3fb-dc38e84dee70",
-							"name": "Purify Earth",
-							"reference": "DFS28",
-							"difficulty": "iq/h",
-							"college": [
-								"Druid"
-							],
-							"power_source": "Arcane",
-							"spell_class": "Area",
-							"casting_cost": "2",
-							"maintenance_cost": "-",
-							"casting_time": "30 sec",
-							"duration": "Permanent",
-							"points": 1,
-							"prereqs": {
-								"type": "prereq_list",
-								"all": true,
-								"prereqs": [
+									},
 									{
 										"type": "advantage_prereq",
 										"has": true,
@@ -4517,28 +7596,39 @@
 											"compare": "at_least",
 											"qualifier": 1
 										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
 									}
 								]
 							},
-							"notes": "Double casting cost in poor or rocky soil/desert",
 							"categories": [
-								"Druid"
+								"Air",
+								"Clerical",
+								"Druidic",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "7199dfc6-26d5-47ad-b22e-b3218ad252eb",
-							"name": "Purify Water",
-							"reference": "DFS70",
+							"id": "bc4da81e-17f3-4ccc-b707-be828876fd66",
+							"name": "Purify Earth",
+							"reference": "DFS28",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Earth",
+								"Plant"
 							],
-							"power_source": "Arcane",
-							"spell_class": "Special",
-							"casting_cost": "1/gal",
+							"power_source": "@Power Source: Arcane/Druidic@",
+							"spell_class": "Area",
+							"casting_cost": "2",
 							"maintenance_cost": "-",
-							"casting_time": "5-10/gal#",
+							"casting_time": "30 sec",
 							"duration": "Permanent",
 							"points": 1,
 							"prereqs": {
@@ -4556,23 +7646,147 @@
 											"compare": "at_least",
 											"qualifier": 1
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "college",
+												"qualifier": {
+													"compare": "contains",
+													"qualifier": "Earth"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 6
+												}
+											},
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Create Earth"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
 									}
 								]
 							},
+							"notes": "Double casting cost in poor or rocky soil/desert",
 							"categories": [
-								"Druid"
+								"Druidic",
+								"Earth",
+								"Plant",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "40ede10d-766a-4f21-97d8-22d0951cf2a5",
+							"id": "f1f7e4ff-c008-4780-9dcd-e6f163510863",
+							"name": "Purify Water",
+							"reference": "DFS70",
+							"difficulty": "iq/h",
+							"college": [
+								"Water"
+							],
+							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+							"spell_class": "Special",
+							"casting_cost": "1/gal",
+							"maintenance_cost": "-",
+							"casting_time": "5-10/gal#",
+							"duration": "Permanent",
+							"points": 1,
+							"prereqs": {
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture (Druidic)"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Seek Water"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
+									}
+								]
+							},
+							"categories": [
+								"Clerical",
+								"Druidic",
+								"Water",
+								"Wizardly"
+							]
+						},
+						{
+							"type": "spell",
+							"id": "eaf8fe39-65c4-4d2e-8d25-879e690cd338",
 							"name": "Quick March",
 							"reference": "DFS58",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Movement"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Druidic@",
 							"spell_class": "Regular",
 							"casting_cost": "4",
 							"maintenance_cost": "-",
@@ -4594,23 +7808,57 @@
 											"compare": "at_least",
 											"qualifier": 1
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Haste"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Druid"
+								"Druidic",
+								"Movement",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "0dd64bf9-c344-4e1a-a40e-ac8d62ca1b5e",
+							"id": "26402e75-6b13-43a7-8bc2-e32d0ff9cec7",
 							"name": "Recover Energy",
 							"reference": "DFS38",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Healing",
+								"Meta"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 							"spell_class": "Special",
 							"casting_cost": "0",
 							"maintenance_cost": "0",
@@ -4626,29 +7874,76 @@
 										"has": true,
 										"name": {
 											"compare": "is",
+											"qualifier": "Power Investiture"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
 											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
 											"qualifier": 1
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Lend Energy"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Druid"
+								"Clerical",
+								"Druidic",
+								"Healing",
+								"Meta",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "07635241-2550-4797-aa81-9090e6417765",
+							"id": "ccde1de9-2e75-482e-b883-971654f323f0",
 							"name": "Seek Earth",
 							"reference": "DFS28",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Earth"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Druidic@",
 							"spell_class": "Info",
 							"casting_cost": "3",
 							"maintenance_cost": "-",
@@ -4664,6 +7959,14 @@
 										"has": true,
 										"name": {
 											"compare": "is",
+											"qualifier": "Magery"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
 											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
@@ -4674,19 +7977,21 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Druidic",
+								"Earth",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "0273e774-b9c0-4f22-ab65-47edf412ebf3",
+							"id": "63c2244c-510a-429c-b0d4-727fc24fee8e",
 							"name": "Seek Food",
-							"reference": "DFS33",
+							"reference": "DFS32",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Food"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Druidic@",
 							"spell_class": "Info",
 							"casting_cost": "2",
 							"maintenance_cost": "-",
@@ -4708,23 +8013,33 @@
 											"compare": "at_least",
 											"qualifier": 1
 										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
 									}
 								]
 							},
 							"categories": [
-								"Druid"
+								"Druidic",
+								"Food",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "505c6702-e603-4565-ba65-160cb5289fa3",
+							"id": "2cc26ad0-0ddf-4adc-89d5-1b47722d8e05",
 							"name": "Seek Plant",
 							"reference": "DFS62",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Plant"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Info",
 							"casting_cost": "2",
 							"maintenance_cost": "-",
@@ -4733,7 +8048,7 @@
 							"points": 1,
 							"prereqs": {
 								"type": "prereq_list",
-								"all": false,
+								"all": true,
 								"prereqs": [
 									{
 										"type": "advantage_prereq",
@@ -4750,19 +8065,20 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Druidic",
+								"Plant"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "e7745271-89f7-49ef-a7a3-96e580b633da",
+							"id": "61c3b8bd-2b8a-4b76-be61-4fa91ff567ab",
 							"name": "Seek Water",
 							"reference": "DFS70",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Water"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Druidic@",
 							"spell_class": "Info",
 							"casting_cost": "2",
 							"maintenance_cost": "-",
@@ -4784,23 +8100,34 @@
 											"compare": "at_least",
 											"qualifier": 1
 										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
 									}
 								]
 							},
 							"categories": [
-								"Druid"
+								"Druidic",
+								"Water",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "1eb5d843-014a-41cb-8df9-dbac99d13b8a",
+							"id": "415fc31e-e714-4ee9-9c27-2493e0ae7190",
 							"name": "Sense Evil",
 							"reference": "DFS26",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Communication & Empathy",
+								"Meta"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 							"spell_class": "Info/Area",
 							"casting_cost": "1/area, min 2",
 							"maintenance_cost": "-",
@@ -4816,6 +8143,42 @@
 										"has": true,
 										"name": {
 											"compare": "is",
+											"qualifier": "Magery"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 2
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 2
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
 											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
@@ -4826,19 +8189,24 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Bardic",
+								"Clerical",
+								"Communication & Empathy",
+								"Druidic",
+								"Meta",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "40fd0ae8-e033-498f-85d9-eda4a316bdb4",
+							"id": "9f51f19c-4d37-42d8-a12c-55ba1e4ada99",
 							"name": "Sense Life",
 							"reference": "DFS26",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Communication & Empathy"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 							"spell_class": "Info/Area",
 							"casting_cost": "1/2",
 							"maintenance_cost": "-",
@@ -4854,39 +8222,33 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druidic)"
+											"qualifier": "Magery"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
 										},
 										"level": {
 											"compare": "at_least",
 											"qualifier": 1
 										}
-									}
-								]
-							},
-							"categories": [
-								"Druid"
-							]
-						},
-						{
-							"type": "spell",
-							"id": "60cd8fa9-0dc5-46e3-ba9a-367e2ca0da1a",
-							"name": "Share Energy",
-							"reference": "DFS39",
-							"difficulty": "iq/h",
-							"college": [
-								"Druid"
-							],
-							"power_source": "Arcane",
-							"spell_class": "Regular",
-							"casting_cost": "2-10",
-							"maintenance_cost": "-",
-							"casting_time": "1 sec",
-							"duration": "1 sec",
-							"points": 1,
-							"prereqs": {
-								"type": "prereq_list",
-								"all": true,
-								"prereqs": [
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
 									{
 										"type": "advantage_prereq",
 										"has": true,
@@ -4902,19 +8264,105 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Bardic",
+								"Clerical",
+								"Communication & Empathy",
+								"Druidic",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "d5f23ec8-2044-4128-b3fa-8c609a4c6839",
+							"id": "49177b56-1220-4891-8bd4-97e0e82ce644",
+							"name": "Share Energy",
+							"reference": "DFS39",
+							"difficulty": "iq/h",
+							"college": [
+								"Healing",
+								"Meta"
+							],
+							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+							"spell_class": "Regular",
+							"casting_cost": "2-10",
+							"maintenance_cost": "-",
+							"casting_time": "1 sec",
+							"duration": "1 sec",
+							"points": 1,
+							"prereqs": {
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture (Druidic)"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Lend Energy"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
+									}
+								]
+							},
+							"categories": [
+								"Clerical",
+								"Druidic",
+								"Healing",
+								"Meta",
+								"Wizardly"
+							]
+						},
+						{
+							"type": "spell",
+							"id": "2a3991b3-50a8-45f5-9935-c86da0ebc9a2",
 							"name": "Tell Position",
 							"reference": "DFS45",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Knowledge"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Druidic@",
 							"spell_class": "Info",
 							"casting_cost": "1",
 							"maintenance_cost": "-",
@@ -4936,23 +8384,67 @@
 											"compare": "at_least",
 											"qualifier": 1
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Measurement"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "prereq_list",
+												"all": false,
+												"prereqs": [
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Magery"
+														}
+													},
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Bardic Talent"
+														}
+													}
+												]
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Druid"
+								"Bardic",
+								"Druidic",
+								"Knowledge",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "e1732ca0-3d62-45d4-a191-462fab4a8b50",
+							"id": "23e634f3-a48d-4c48-b647-26edaefabfc1",
 							"name": "Thunderclap",
 							"reference": "DFS67",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Sound"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 							"spell_class": "Regular",
 							"casting_cost": "2",
 							"maintenance_cost": "-",
@@ -4961,8 +8453,20 @@
 							"points": 1,
 							"prereqs": {
 								"type": "prereq_list",
-								"all": true,
+								"all": false,
 								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
 									{
 										"type": "advantage_prereq",
 										"has": true,
@@ -4974,23 +8478,69 @@
 											"compare": "at_least",
 											"qualifier": 1
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Sound"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "prereq_list",
+												"all": false,
+												"prereqs": [
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Magery"
+														}
+													},
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Bardic Talent"
+														}
+													}
+												]
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Druid"
+								"Bardic",
+								"Clerical",
+								"Druidic",
+								"Sound",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "f8bf38e9-ae6d-4d09-9bfc-a116b7515539",
+							"id": "8acaef25-877d-4a5c-805b-2cb795801ac6",
 							"name": "Umbrella",
 							"reference": "DFS70",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Protection & Warning",
+								"Water"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 							"spell_class": "Regular",
 							"casting_cost": "1",
 							"maintenance_cost": "1",
@@ -5006,39 +8556,13 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druidic)"
+											"qualifier": "Power Investiture"
 										},
 										"level": {
 											"compare": "at_least",
 											"qualifier": 1
 										}
-									}
-								]
-							},
-							"categories": [
-								"Druid"
-							]
-						},
-						{
-							"type": "spell",
-							"id": "0e465407-9bae-4b89-94c1-b8c8348a4ab2",
-							"name": "Warmth",
-							"reference": "DFS32",
-							"difficulty": "iq/h",
-							"college": [
-								"Druid"
-							],
-							"power_source": "Arcane",
-							"spell_class": "Regular",
-							"casting_cost": "2",
-							"maintenance_cost": "1",
-							"casting_time": "10 sec",
-							"duration": "1 hr",
-							"points": 1,
-							"prereqs": {
-								"type": "prereq_list",
-								"all": true,
-								"prereqs": [
+									},
 									{
 										"type": "advantage_prereq",
 										"has": true,
@@ -5050,35 +8574,168 @@
 											"compare": "at_least",
 											"qualifier": 1
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "prereq_list",
+												"all": false,
+												"prereqs": [
+													{
+														"type": "spell_prereq",
+														"has": true,
+														"sub_type": "name",
+														"qualifier": {
+															"compare": "is",
+															"qualifier": "Shape Water"
+														},
+														"quantity": {
+															"compare": "at_least",
+															"qualifier": 1
+														}
+													},
+													{
+														"type": "spell_prereq",
+														"has": true,
+														"sub_type": "name",
+														"qualifier": {
+															"compare": "is",
+															"qualifier": "Shield"
+														},
+														"quantity": {
+															"compare": "at_least",
+															"qualifier": 1
+														}
+													}
+												]
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Druid"
+								"Clerical",
+								"Druidic",
+								"Protection & Warning",
+								"Water",
+								"Wizardly"
+							]
+						},
+						{
+							"type": "spell",
+							"id": "af3640f1-ef61-49d6-bb60-b5737f264b77",
+							"name": "Warmth",
+							"reference": "DFS32",
+							"difficulty": "iq/h",
+							"college": [
+								"Fire",
+								"Protection & Warning"
+							],
+							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+							"spell_class": "Regular",
+							"casting_cost": "2",
+							"maintenance_cost": "1",
+							"casting_time": "10 sec",
+							"duration": "1 hr",
+							"points": 1,
+							"prereqs": {
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture (Druidic)"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Heat"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
+									}
+								]
+							},
+							"categories": [
+								"Clerical",
+								"Druidic",
+								"Fire",
+								"Protection & Warning",
+								"Wizardly"
 							]
 						}
 					]
 				},
 				{
 					"type": "spell_container",
-					"id": "59d28185-5cbd-4f6e-a99c-1c63d775a757",
-					"name": "Power Investiture (Druidic) 2",
+					"id": "48642d19-5808-46e0-8d44-db43e99b12d0",
+					"name": "Power Investiture 2",
 					"categories": [
-						"Druid"
+						"Druidic"
 					],
 					"open": false,
 					"children": [
 						{
 							"type": "spell",
-							"id": "0ce09565-49bd-490d-9d87-c0284ac1022b",
+							"id": "a8f59125-90a1-4ab0-8f3a-641b04fca4b9",
 							"name": "Animal Control (@Animal@)",
 							"reference": "DFS17",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Animal"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
+							"resist": "Will",
 							"casting_cost": "Variable",
 							"maintenance_cost": "Half",
 							"casting_time": "1 sec",
@@ -5103,20 +8760,22 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Animal",
+								"Druidic"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "98230323-571d-42bc-9a81-ce8a969363fa",
+							"id": "9744472f-a937-44d9-92c2-416c20600225",
 							"name": "Animal Control (Bird)",
 							"reference": "DFS17",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Animal"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
+							"resist": "Will",
 							"casting_cost": "3",
 							"maintenance_cost": "2",
 							"casting_time": "1 sec",
@@ -5141,20 +8800,22 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Animal",
+								"Druidic"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "b070bc10-b083-4d17-b5f0-04e910ea79ad",
+							"id": "69e31044-320a-470c-b356-6c6e99b38afa",
 							"name": "Animal Control (Fish)",
 							"reference": "DFS17",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Animal"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
+							"resist": "Will",
 							"casting_cost": "2",
 							"maintenance_cost": "1",
 							"casting_time": "1 sec",
@@ -5179,20 +8840,22 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Animal",
+								"Druidic"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "f075758f-816c-4995-939f-e2e1894380bf",
+							"id": "a2c52f23-833f-4c35-8b94-58ee35cdda52",
 							"name": "Animal Control (Mammal)",
 							"reference": "DFS17",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Animal"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
+							"resist": "Will",
 							"casting_cost": "5",
 							"maintenance_cost": "3",
 							"casting_time": "1 sec",
@@ -5217,20 +8880,22 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Animal",
+								"Druidic"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "859399d1-1418-484c-b3cb-9602d49880c2",
+							"id": "0e95d66b-304d-466a-9c84-287976834a72",
 							"name": "Animal Control (Reptile)",
 							"reference": "DFS17",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Animal"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
+							"resist": "Will",
 							"casting_cost": "2",
 							"maintenance_cost": "1",
 							"casting_time": "1 sec",
@@ -5255,20 +8920,22 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Animal",
+								"Druidic"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "5aff353e-e7a8-4440-9ec1-d309556cf984",
+							"id": "08276ec8-dffc-4abe-8394-216e7f765743",
 							"name": "Animal Control (Vermin)",
 							"reference": "DFS17",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Animal"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
+							"resist": "Will",
 							"casting_cost": "1",
 							"maintenance_cost": "1",
 							"casting_time": "1 sec",
@@ -5293,19 +8960,20 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Animal",
+								"Druidic"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "4c5f9a50-c36a-4002-90ab-550e11131ecd",
+							"id": "8abb42a4-83ed-4f2c-b3c2-4fe78d4becd8",
 							"name": "Beast Link",
 							"reference": "DFS18",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Animal"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
 							"casting_cost": "3",
 							"maintenance_cost": "-",
@@ -5331,19 +8999,20 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Animal",
+								"Druidic"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "7ed91976-7bac-4289-aed2-1451d1216f17",
+							"id": "3885e5c0-3883-44d0-91c5-011e35e9ba6c",
 							"name": "Beast Seeker",
 							"reference": "DFS18",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Animal"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Info",
 							"casting_cost": "3",
 							"maintenance_cost": "-",
@@ -5369,19 +9038,20 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Animal",
+								"Druidic"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "5d5efeb2-9cf5-4e2f-bd17-1e1b27aa777e",
+							"id": "fec6fef8-78be-4831-b35f-1d66c1a49225",
 							"name": "Beast Speech",
 							"reference": "DFS18",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Animal"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
 							"casting_cost": "4",
 							"maintenance_cost": "2",
@@ -5407,24 +9077,77 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Animal",
+								"Druidic"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "3ea2f8f9-8e8e-4d2a-93a2-7842ee823b6a",
+							"id": "e7f02aea-d340-4c73-8e22-90c12872df1e",
 							"name": "Cure Disease",
 							"reference": "DFS36",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Healing"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Clerical/Druidic@",
 							"spell_class": "Regular",
 							"casting_cost": "4",
 							"maintenance_cost": "-",
 							"casting_time": "10 min",
 							"duration": "Permanent",
+							"points": 1,
+							"prereqs": {
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 3
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture (Druidic)"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 2
+										}
+									}
+								]
+							},
+							"categories": [
+								"Clerical",
+								"Druidic",
+								"Healing"
+							]
+						},
+						{
+							"type": "spell",
+							"id": "fcd8f0b9-7f67-4272-bf51-d74e72e2500b",
+							"name": "Fireproof",
+							"reference": "DFS30",
+							"difficulty": "iq/h",
+							"college": [
+								"Fire"
+							],
+							"power_source": "@Power Source: Arcane/Druidic@",
+							"spell_class": "Area",
+							"casting_cost": "3#",
+							"maintenance_cost": "Same",
+							"casting_time": "5 min",
+							"duration": "1 day",
 							"points": 1,
 							"prereqs": {
 								"type": "prereq_list",
@@ -5441,28 +9164,58 @@
 											"compare": "at_least",
 											"qualifier": 2
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Extinguish Fire"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Druid"
+								"Druidic",
+								"Fire",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "7d2093c0-0952-44c8-8fb0-020b7222c3b1",
-							"name": "Fireproof",
-							"reference": "DFS30",
+							"id": "dc3d9a77-e498-4d03-bba0-9e8bbe41bfb9",
+							"name": "Fog",
+							"reference": "DFS71",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Water",
+								"Weather"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Area",
-							"casting_cost": "3#",
-							"maintenance_cost": "Same",
-							"casting_time": "5 min",
-							"duration": "1 day",
+							"casting_cost": "2",
+							"maintenance_cost": "Half",
+							"casting_time": "1 sec",
+							"duration": "1 min",
 							"points": 1,
 							"prereqs": {
 								"type": "prereq_list",
@@ -5483,57 +9236,21 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Druidic",
+								"Water",
+								"Weather"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "4934c593-1d2d-405e-92fc-d5da753e5bf4",
-							"name": "Fog",
-							"reference": "DFS71",
-							"difficulty": "iq/h",
-							"college": [
-								"Druid"
-							],
-							"power_source": "Arcane",
-							"spell_class": "Area",
-							"casting_cost": "2",
-							"maintenance_cost": "Half",
-							"casting_time": "1 sec",
-							"duration": "1 min",
-							"points": 1,
-							"prereqs": {
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "Power Investiture (Druidic)"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 2
-										}
-									}
-								]
-							},
-							"categories": [
-								"Druid"
-							]
-						},
-						{
-							"type": "spell",
-							"id": "3b830e0a-90cd-4243-9080-f590aacc0077",
+							"id": "b2f72dc1-7597-4d8e-adde-54956938ae77",
 							"name": "Hide Path",
 							"reference": "DFS62",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Plant"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
 							"casting_cost": "2",
 							"maintenance_cost": "1",
@@ -5542,7 +9259,7 @@
 							"points": 1,
 							"prereqs": {
 								"type": "prereq_list",
-								"all": false,
+								"all": true,
 								"prereqs": [
 									{
 										"type": "advantage_prereq",
@@ -5559,19 +9276,20 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Druidic",
+								"Plant"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "ffe74dfb-bf87-48c1-a695-0815ac9b263c",
+							"id": "938fcd8e-79c2-4b3a-8f45-69d323608c8b",
 							"name": "Know Location",
 							"reference": "DFS43",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Knowledge"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Druidic@",
 							"spell_class": "Info",
 							"casting_cost": "2",
 							"maintenance_cost": "-",
@@ -5593,23 +9311,75 @@
 											"compare": "at_least",
 											"qualifier": 2
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Tell Position"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "prereq_list",
+												"all": false,
+												"prereqs": [
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Magery"
+														},
+														"level": {
+															"compare": "at_least",
+															"qualifier": 1
+														}
+													},
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Bardic Talent"
+														},
+														"level": {
+															"compare": "at_least",
+															"qualifier": 1
+														}
+													}
+												]
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Druid"
+								"Bardic",
+								"Druidic",
+								"Knowledge",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "2be5823d-1086-435d-a745-39e61178c849",
+							"id": "41355c79-cdf6-4bb8-a041-1e1debef4be4",
 							"name": "Light Tread",
 							"reference": "DFS57",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Movement"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Druidic@",
 							"spell_class": "Regular",
 							"casting_cost": "4",
 							"maintenance_cost": "1",
@@ -5631,28 +9401,70 @@
 											"compare": "at_least",
 											"qualifier": 2
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Apportation"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Shape Earth"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Druid"
+								"Druidic",
+								"Movement",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "a12830f0-245e-4520-9785-a12f1575ddec",
+							"id": "ad61b7d3-7822-47f6-8138-dbfe91c1b168",
 							"name": "Mystic Mist",
 							"reference": "DFS64",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Protection & Warning"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Druidic@",
 							"spell_class": "Area",
 							"casting_cost": "1",
 							"maintenance_cost": "Same",
 							"casting_time": "5 min",
-							"duration": "10 hr",
+							"duration": "10 hrs",
 							"points": 1,
 							"prereqs": {
 								"type": "prereq_list",
@@ -5669,23 +9481,75 @@
 											"compare": "at_least",
 											"qualifier": 2
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "prereq_list",
+												"all": false,
+												"prereqs": [
+													{
+														"type": "spell_prereq",
+														"has": true,
+														"sub_type": "name",
+														"qualifier": {
+															"compare": "is",
+															"qualifier": "Watchdog"
+														},
+														"quantity": {
+															"compare": "at_least",
+															"qualifier": 1
+														}
+													},
+													{
+														"type": "spell_prereq",
+														"has": true,
+														"sub_type": "name",
+														"qualifier": {
+															"compare": "is",
+															"qualifier": "Shield"
+														},
+														"quantity": {
+															"compare": "at_least",
+															"qualifier": 1
+														}
+													}
+												]
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Druid"
+								"Druidic",
+								"Protection & Warning",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "b7ef22a4-c89b-4bf1-9e60-9808b219af05",
+							"id": "e0825d7b-8f0c-4a33-8e7e-3391bf67c351",
 							"name": "Neutralize Poison",
 							"reference": "DFS37",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Healing"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Clerical/Druidic@",
 							"spell_class": "Regular",
 							"casting_cost": "5",
 							"maintenance_cost": "-",
@@ -5701,6 +9565,18 @@
 										"has": true,
 										"name": {
 											"compare": "is",
+											"qualifier": "Power Investiture"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 3
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
 											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
@@ -5711,19 +9587,21 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Clerical",
+								"Druidic",
+								"Healing"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "6c7d31d6-f762-473a-9f3c-cba96c39e6ad",
+							"id": "cf0c21e1-583b-41e6-9581-149badc33475",
 							"name": "Pathfinder",
 							"reference": "DFS44",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Knowledge"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Druidic@",
 							"spell_class": "Info",
 							"casting_cost": "4",
 							"maintenance_cost": "-",
@@ -5745,23 +9623,85 @@
 											"compare": "at_least",
 											"qualifier": 2
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "attribute_prereq",
+												"has": true,
+												"which": "iq",
+												"qualifier": {
+													"compare": "at_least",
+													"qualifier": 12
+												}
+											},
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "starts_with",
+													"qualifier": "Seek "
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 2
+												}
+											},
+											{
+												"type": "prereq_list",
+												"all": false,
+												"prereqs": [
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Magery"
+														},
+														"level": {
+															"compare": "at_least",
+															"qualifier": 1
+														}
+													},
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Bardic Talent"
+														},
+														"level": {
+															"compare": "at_least",
+															"qualifier": 1
+														}
+													}
+												]
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Druid"
+								"Bardic",
+								"Druidic",
+								"Knowledge",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "243d5886-8a40-4282-9750-1ea4e5646343",
+							"id": "1046a1aa-780b-40ac-bb06-6494358bc393",
 							"name": "Plant Vision",
 							"reference": "DFS62",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Knowledge",
+								"Plant"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
 							"casting_cost": "1 per 10 yards",
 							"maintenance_cost": "Same",
@@ -5787,20 +9727,23 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Druidic",
+								"Knowledge",
+								"Plant"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "023bab0f-dc96-450b-934b-57177638247a",
+							"id": "6f6ac8bb-8fc9-4d38-b3a9-7926591f7625",
 							"name": "Pollen Cloud",
 							"reference": "DFS62",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Plant"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Area",
+							"resist": "HT",
 							"casting_cost": "1",
 							"maintenance_cost": "-",
 							"casting_time": "1 sec",
@@ -5825,7 +9768,7 @@
 							],
 							"prereqs": {
 								"type": "prereq_list",
-								"all": false,
+								"all": true,
 								"prereqs": [
 									{
 										"type": "advantage_prereq",
@@ -5842,19 +9785,21 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Druidic",
+								"Plant"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "69f1e80d-aa3f-44e2-9475-da5afa6de103",
+							"id": "4050e254-5c5d-446f-93c6-24abdb256049",
 							"name": "Protection from Evil",
 							"reference": "DFS64",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Meta",
+								"Protection & Warning"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 							"spell_class": "Regular",
 							"casting_cost": "1-5",
 							"maintenance_cost": "Half",
@@ -5863,42 +9808,102 @@
 							"points": 1,
 							"prereqs": {
 								"type": "prereq_list",
-								"all": true,
+								"all": false,
 								"prereqs": [
 									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 2
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture (Druidic)"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 2
+										}
+									},
+									{
 										"type": "prereq_list",
-										"all": false,
+										"all": true,
 										"prereqs": [
 											{
-												"type": "advantage_prereq",
+												"type": "spell_prereq",
 												"has": true,
-												"name": {
+												"sub_type": "name",
+												"qualifier": {
 													"compare": "is",
-													"qualifier": "Power Investiture (Druidic)"
+													"qualifier": "Sense Evil"
 												},
-												"level": {
+												"quantity": {
 													"compare": "at_least",
-													"qualifier": 2
+													"qualifier": 1
 												}
+											},
+											{
+												"type": "prereq_list",
+												"all": false,
+												"prereqs": [
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Magery"
+														},
+														"level": {
+															"compare": "at_least",
+															"qualifier": 3
+														}
+													},
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Bardic Talent"
+														},
+														"level": {
+															"compare": "at_least",
+															"qualifier": 3
+														}
+													}
+												]
 											}
 										]
 									}
 								]
 							},
 							"categories": [
-								"Druid"
+								"Bardic",
+								"Clerical",
+								"Druidic",
+								"Meta",
+								"Protection & Warning",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "67066f37-1cdb-430a-abdd-54aa8e5a3e8c",
+							"id": "1c974a5c-0967-4daf-8446-8008e4cd41be",
 							"name": "Purify Food",
-							"reference": "DFS33",
+							"reference": "DFS32",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Food"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 							"spell_class": "Regular",
 							"casting_cost": "1/lb",
 							"maintenance_cost": "-",
@@ -5914,29 +9919,71 @@
 										"has": true,
 										"name": {
 											"compare": "is",
+											"qualifier": "Power Investiture"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 2
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
 											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
 											"qualifier": 2
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Decay"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Druid"
+								"Clerical",
+								"Druidic",
+								"Food",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "52e0a491-ba03-4a7a-9c6c-3ca8e7aadd99",
+							"id": "0287d854-f62c-42e6-afdf-9981eea17498",
 							"name": "Repel Animal (@Animal@)",
 							"reference": "DFS19",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Animal"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Area",
 							"casting_cost": "Variable",
 							"maintenance_cost": "-",
@@ -5962,19 +10009,20 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Animal",
+								"Druidic"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "4efab408-520a-4dd5-9fd3-b6a6e0305320",
+							"id": "0f217e4b-e5a7-4378-8adf-5f15cfacaa81",
 							"name": "Repel Animal (Bird)",
 							"reference": "DFS19",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Animal"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Area",
 							"casting_cost": "3",
 							"maintenance_cost": "-",
@@ -6000,19 +10048,20 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Animal",
+								"Druidic"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "55c8cb76-6105-4f96-bb5f-25a4bd6dd237",
+							"id": "c43f7eff-630e-45f7-8329-34269cf82cb7",
 							"name": "Repel Animal (Fish)",
 							"reference": "DFS19",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Animal"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Area",
 							"casting_cost": "2",
 							"maintenance_cost": "-",
@@ -6038,19 +10087,20 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Animal",
+								"Druidic"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "29486912-ac10-44be-b567-5830f37d18fc",
+							"id": "bd17a4b5-1b2c-4831-a42b-3c354fd13425",
 							"name": "Repel Animal (Mammal)",
 							"reference": "DFS19",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Animal"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Area",
 							"casting_cost": "5",
 							"maintenance_cost": "-",
@@ -6059,7 +10109,7 @@
 							"points": 1,
 							"prereqs": {
 								"type": "prereq_list",
-								"all": false,
+								"all": true,
 								"prereqs": [
 									{
 										"type": "advantage_prereq",
@@ -6076,19 +10126,20 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Animal",
+								"Druidic"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "e60a2586-9a32-4c6b-8b3a-01b6a4d231b7",
+							"id": "d539ad91-2217-4338-adcc-c37d94612204",
 							"name": "Repel Animal (Reptile)",
 							"reference": "DFS19",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Animal"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Area",
 							"casting_cost": "2",
 							"maintenance_cost": "-",
@@ -6097,7 +10148,7 @@
 							"points": 1,
 							"prereqs": {
 								"type": "prereq_list",
-								"all": false,
+								"all": true,
 								"prereqs": [
 									{
 										"type": "advantage_prereq",
@@ -6114,19 +10165,20 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Animal",
+								"Druidic"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "e0e96075-286b-4ea5-9d6e-1684c3255e11",
+							"id": "d3640bb4-63ed-4847-ad17-e51214ec7fec",
 							"name": "Repel Animal (Vermin)",
 							"reference": "DFS19",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Animal"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Area",
 							"casting_cost": "1",
 							"maintenance_cost": "-",
@@ -6135,7 +10187,7 @@
 							"points": 1,
 							"prereqs": {
 								"type": "prereq_list",
-								"all": false,
+								"all": true,
 								"prereqs": [
 									{
 										"type": "advantage_prereq",
@@ -6152,19 +10204,20 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Animal",
+								"Druidic"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "7456da5c-915d-41cd-98c2-81f606ea313b",
+							"id": "231279cd-77c3-473e-baea-5865fbb1d23f",
 							"name": "Rider",
 							"reference": "DFS19",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Animal"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
 							"casting_cost": "2",
 							"maintenance_cost": "1",
@@ -6190,19 +10243,20 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Animal",
+								"Druidic"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "e80ee5fa-8491-45ee-8203-1ddec75fd421",
+							"id": "e8bebf89-b4a0-4d65-bf14-1e77621cbbd6",
 							"name": "Rider Within",
 							"reference": "DFS20",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Animal"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
 							"casting_cost": "4",
 							"maintenance_cost": "1",
@@ -6228,19 +10282,20 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Animal",
+								"Druidic"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "fbca854b-4019-4e16-84a6-90b8b7764ecf",
+							"id": "6373a65b-74fd-4222-bc35-2be5c3d2fd7d",
 							"name": "Shape Air",
 							"reference": "DFS17",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Air"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Druidic@",
 							"spell_class": "Regular",
 							"casting_cost": "1-10",
 							"maintenance_cost": "-",
@@ -6262,26 +10317,55 @@
 											"compare": "at_least",
 											"qualifier": 2
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Create Air"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Druid"
+								"Air",
+								"Druidic",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "7c09e57f-a5b5-4a13-988e-2616686ff5b7",
+							"id": "46c1e174-e640-4e28-a04c-815034531563",
 							"name": "Shape Earth",
 							"reference": "DFS28",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Earth"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Druidic@",
 							"spell_class": "Regular",
 							"casting_cost": "1/cu yd",
-							"maintenance_cost": "Same",
+							"maintenance_cost": "Half",
 							"casting_time": "1 sec",
 							"duration": "1 min",
 							"points": 1,
@@ -6300,23 +10384,52 @@
 											"compare": "at_least",
 											"qualifier": 2
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Seek Earth"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Druid"
+								"Druidic",
+								"Earth",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "730cede3-cf84-47d6-b442-5dde2eeff5b4",
+							"id": "a46368e0-0655-4973-9269-6faad520319c",
 							"name": "Shape Plant",
 							"reference": "DFS63",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Plant"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
 							"casting_cost": "6",
 							"maintenance_cost": "2",
@@ -6325,7 +10438,7 @@
 							"points": 1,
 							"prereqs": {
 								"type": "prereq_list",
-								"all": false,
+								"all": true,
 								"prereqs": [
 									{
 										"type": "advantage_prereq",
@@ -6342,19 +10455,20 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Druidic",
+								"Plant"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "01fdf60c-7007-4aa6-85d0-ef10b46c922c",
+							"id": "7f07af4b-3bb6-49fb-b0bd-bc037c89cdd2",
 							"name": "Shape Water",
 							"reference": "DFS70",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Water"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Druidic@",
 							"spell_class": "Regular",
 							"casting_cost": "1#",
 							"maintenance_cost": "1",
@@ -6376,23 +10490,53 @@
 											"compare": "at_least",
 											"qualifier": 2
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Creater Water"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Druid"
+								"Druidic",
+								"Water",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "a7881393-d1a0-4a9c-8a6b-61b3ece35410",
+							"id": "ddb3833f-d568-4846-bb94-5e65cf7c4058",
 							"name": "Weather Dome",
 							"reference": "DFS65",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Protection & Warning",
+								"Weather"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Area",
 							"casting_cost": "3",
 							"maintenance_cost": "2",
@@ -6401,7 +10545,7 @@
 							"points": 1,
 							"prereqs": {
 								"type": "prereq_list",
-								"all": false,
+								"all": true,
 								"prereqs": [
 									{
 										"type": "advantage_prereq",
@@ -6418,19 +10562,21 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Druidic",
+								"Protection & Warning",
+								"Weather"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "c206632b-b753-4994-b7a6-9122e1ead0b9",
+							"id": "1bc18562-4616-489a-b5ee-e60d08a11393",
 							"name": "Windstorm",
 							"reference": "DFS17",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Air"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Druidic@",
 							"spell_class": "Area",
 							"casting_cost": "2",
 							"maintenance_cost": "Half",
@@ -6452,34 +10598,63 @@
 											"compare": "at_least",
 											"qualifier": 2
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Shape Air"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Druid"
+								"Air",
+								"Druidic",
+								"Wizardly"
 							]
 						}
 					]
 				},
 				{
 					"type": "spell_container",
-					"id": "209ed00e-64ba-41fd-a357-e9d47aab7c51",
-					"name": "Power Investiture (Druidic) 3",
+					"id": "097c5d89-1b94-4b73-8791-4357a2ebf8ce",
+					"name": "Power Investiture 3",
 					"categories": [
-						"Druid"
+						"Druidic"
 					],
 					"open": false,
 					"children": [
 						{
 							"type": "spell",
-							"id": "7fd927fb-7936-4ec0-88a3-c7409ada5d05",
+							"id": "96eb16b6-64a1-4314-8340-bb68f9c799d6",
 							"name": "Beast Summoning",
 							"reference": "DFS18",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Animal"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
 							"casting_cost": "3",
 							"maintenance_cost": "2",
@@ -6505,19 +10680,21 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Animal",
+								"Druidic"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "4962ed8f-ad2d-46c3-96ba-f046ce11d0fa",
+							"id": "6a61aa88-b094-4bf3-b139-7afcc79d3e8e",
 							"name": "Breathe Water",
 							"reference": "DFS68",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Air",
+								"Water"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 							"spell_class": "Regular",
 							"casting_cost": "4",
 							"maintenance_cost": "2",
@@ -6526,8 +10703,20 @@
 							"points": 1,
 							"prereqs": {
 								"type": "prereq_list",
-								"all": true,
+								"all": false,
 								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 3
+										}
+									},
 									{
 										"type": "advantage_prereq",
 										"has": true,
@@ -6539,23 +10728,67 @@
 											"compare": "at_least",
 											"qualifier": 3
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											},
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Destroy Water"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Create Air"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Druid"
+								"Air",
+								"Clerical",
+								"Druidic",
+								"Water",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "ad7da22a-5aed-458c-b4ef-3af3fb7541d8",
+							"id": "deffe486-d366-4bdf-bb2f-65fae985e877",
 							"name": "Conceal",
 							"reference": "DFS61",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Plant"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Area",
 							"casting_cost": "Varies",
 							"maintenance_cost": "-",
@@ -6564,7 +10797,7 @@
 							"points": 1,
 							"prereqs": {
 								"type": "prereq_list",
-								"all": false,
+								"all": true,
 								"prereqs": [
 									{
 										"type": "advantage_prereq",
@@ -6581,62 +10814,25 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Druidic",
+								"Plant"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "ba33b0e4-ba02-4fc3-b601-97ed3d951d9a",
+							"id": "e2e1c469-dd83-4e3a-b746-505f51a0e0c3",
 							"name": "Create Plant",
 							"reference": "DFS61",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Plant"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Area",
 							"casting_cost": "Varies",
 							"maintenance_cost": "-",
 							"casting_time": "Varies",
 							"duration": "Permanent",
-							"points": 1,
-							"prereqs": {
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "Power Investiture (Druidic)"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 3
-										}
-									}
-								]
-							},
-							"categories": [
-								"Druid"
-							]
-						},
-						{
-							"type": "spell",
-							"id": "0050fe81-03d7-4579-8bb5-75675495b842",
-							"name": "Earth Vision",
-							"reference": "DFS27",
-							"difficulty": "iq/h",
-							"college": [
-								"Druid"
-							],
-							"power_source": "Arcane",
-							"spell_class": "Regular",
-							"casting_cost": "2/10 yds#",
-							"maintenance_cost": "Same",
-							"casting_time": "1 sec",
-							"duration": "30 sec",
 							"points": 1,
 							"prereqs": {
 								"type": "prereq_list",
@@ -6657,24 +10853,26 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Druidic",
+								"Plant"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "d4f86f34-c4c3-4f07-afc6-e15cb4fc75b6",
-							"name": "Forest Warning",
-							"reference": "DFS61",
+							"id": "92a0cca0-de36-4108-8b29-c053c17236ee",
+							"name": "Earth Vision",
+							"reference": "DFS27",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Earth",
+								"Knowledge"
 							],
-							"power_source": "Arcane",
-							"spell_class": "Area",
-							"casting_cost": "1/2 min 2",
+							"power_source": "@Power Source: Arcane/Druidic@",
+							"spell_class": "Regular",
+							"casting_cost": "2/10 yds#",
 							"maintenance_cost": "Same",
 							"casting_time": "1 sec",
-							"duration": "10 hours",
+							"duration": "30 sec",
 							"points": 1,
 							"prereqs": {
 								"type": "prereq_list",
@@ -6691,23 +10889,106 @@
 											"compare": "at_least",
 											"qualifier": 3
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "prereq_list",
+												"all": false,
+												"prereqs": [
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Magery"
+														}
+													},
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Bardic Talent"
+														}
+													}
+												]
+											},
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Shape Earth"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Druid"
+								"Druidic",
+								"Earth",
+								"Knowledge",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "2abbe79e-fd5e-4363-b90b-27da71af8f15",
+							"id": "8c655450-96c7-4ba2-9f5a-090a7f12c1cd",
+							"name": "Forest Warning",
+							"reference": "DFS61",
+							"difficulty": "iq/h",
+							"college": [
+								"Plant"
+							],
+							"power_source": "Druidic",
+							"spell_class": "Area",
+							"casting_cost": "1/2 min 2",
+							"maintenance_cost": "Same",
+							"casting_time": "1 sec",
+							"duration": "10 hours",
+							"points": 1,
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture (Druidic)"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 3
+										}
+									}
+								]
+							},
+							"categories": [
+								"Druidic",
+								"Plant"
+							]
+						},
+						{
+							"type": "spell",
+							"id": "dd728d6f-3bfe-44de-9279-58c3a31042d6",
 							"name": "Freeze",
 							"reference": "DFS68",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Water"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Druidic@",
 							"spell_class": "Regular",
 							"casting_cost": "Varies",
 							"maintenance_cost": "-",
@@ -6729,24 +11010,54 @@
 											"compare": "at_least",
 											"qualifier": 3
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Shape Water"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Druid"
+								"Druidic",
+								"Water",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "acf77865-5096-4a09-89aa-0835328a4373",
+							"id": "644a318a-da25-43e9-a02f-ca8f3ad6d135",
 							"name": "Hybrid Control",
 							"reference": "DFS19",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Animal"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
+							"resist": "Will",
 							"casting_cost": "6",
 							"maintenance_cost": "3",
 							"casting_time": "1 sec",
@@ -6771,19 +11082,20 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Animal",
+								"Druidic"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "2f3ffde4-852f-478f-a4aa-4bf710f05ab6",
+							"id": "17382feb-ed76-4c4d-b28b-4a689d973332",
 							"name": "Instant Neutralize Poison",
 							"reference": "DFS37",
 							"difficulty": "iq/vh",
 							"college": [
-								"Druid"
+								"Healing"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Clerical/Druidic@",
 							"spell_class": "Regular",
 							"casting_cost": "8",
 							"maintenance_cost": "-",
@@ -6799,6 +11111,18 @@
 										"has": true,
 										"name": {
 											"compare": "is",
+											"qualifier": "Power Investiture"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 4
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
 											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
@@ -6809,20 +11133,23 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Clerical",
+								"Druidic",
+								"Healing"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "915182d2-0331-44fa-aa5d-2aca672005bb",
+							"id": "1e9d4f5a-555a-4665-a7cd-632a90035a5a",
 							"name": "Plant Control",
 							"reference": "DFS62",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Plant"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
+							"resist": "Will",
 							"casting_cost": "3",
 							"maintenance_cost": "1/2 cast",
 							"casting_time": "1 sec",
@@ -6830,7 +11157,7 @@
 							"points": 1,
 							"prereqs": {
 								"type": "prereq_list",
-								"all": false,
+								"all": true,
 								"prereqs": [
 									{
 										"type": "advantage_prereq",
@@ -6847,20 +11174,22 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Druidic",
+								"Plant"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "6bd98993-fdfb-4436-9cad-fdac7d46863e",
+							"id": "ee3acf8c-bcf1-4f6b-97e5-3385bc59c018",
 							"name": "Plant Sense",
 							"reference": "DFS62",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Plant"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
+							"resist": "Hide Path",
 							"casting_cost": "3",
 							"maintenance_cost": "2",
 							"casting_time": "1 sec",
@@ -6868,7 +11197,7 @@
 							"points": 1,
 							"prereqs": {
 								"type": "prereq_list",
-								"all": false,
+								"all": true,
 								"prereqs": [
 									{
 										"type": "advantage_prereq",
@@ -6885,19 +11214,20 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Druidic",
+								"Plant"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "a1d35dc8-8c44-4356-bc40-fb9a4b86d42a",
+							"id": "7b3a6608-fcac-4c3b-b2e6-63b1605596df",
 							"name": "Plant Speech",
 							"reference": "DFS62",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Plant"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
 							"casting_cost": "3",
 							"maintenance_cost": "2",
@@ -6906,7 +11236,7 @@
 							"points": 1,
 							"prereqs": {
 								"type": "prereq_list",
-								"all": false,
+								"all": true,
 								"prereqs": [
 									{
 										"type": "advantage_prereq",
@@ -6923,19 +11253,21 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Druidic",
+								"Plant"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "1578f6b6-d94f-4126-acaf-f0010ee3c552",
+							"id": "2892d8f2-29f2-4070-b2d1-947d3733c786",
 							"name": "Protect Animal",
 							"reference": "DFS19",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Animal",
+								"Protection & Warning"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Area",
 							"casting_cost": "1",
 							"maintenance_cost": "1",
@@ -6961,19 +11293,21 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Animal",
+								"Druidic",
+								"Protection & Warning"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "aaf72fb6-3755-4f10-8bf1-88ed7f597c7a",
+							"id": "3c3576a3-86b1-4f5d-afeb-29b6842b286f",
 							"name": "Remember Path",
 							"reference": "DFS44",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Knowledge"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
 							"casting_cost": "3",
 							"maintenance_cost": "1",
@@ -6999,19 +11333,20 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Druidic",
+								"Knowledge"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "ecdd3b68-f6bf-4901-83a7-630db91c298b",
+							"id": "2ea1ca8d-0837-4de1-9734-402d37cc3c5a",
 							"name": "Repel Hybrids",
 							"reference": "DFS19",
 							"difficulty": "iq/vh",
 							"college": [
-								"Druid"
+								"Animal"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Area",
 							"casting_cost": "6",
 							"maintenance_cost": "3",
@@ -7037,19 +11372,20 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Animal",
+								"Druidic"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "2056bb94-c867-429d-8e00-4c39b2c6f450",
+							"id": "cb7a5f8d-a015-437a-981e-00a729d292a0",
 							"name": "Resist Cold",
 							"reference": "DFS31",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Fire"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 							"spell_class": "Regular",
 							"casting_cost": "2",
 							"maintenance_cost": "Half",
@@ -7065,29 +11401,73 @@
 										"has": true,
 										"name": {
 											"compare": "is",
+											"qualifier": "Power Investiture"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 2
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
 											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
 											"qualifier": 3
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Heat"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Druid"
+								"Clerical",
+								"Druidic",
+								"Fire",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "ecbdbce3-2ee1-43ce-b07e-8ed5d9c0f0c1",
+							"id": "5e40dce2-5c07-4640-b42a-8cb54bf35886",
 							"name": "Resist Lightning",
 							"reference": "DFS72",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Air",
+								"Protection & Warning",
+								"Weather"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 							"spell_class": "Regular",
 							"casting_cost": "2",
 							"maintenance_cost": "1",
@@ -7103,29 +11483,73 @@
 										"has": true,
 										"name": {
 											"compare": "is",
+											"qualifier": "Power Investiture"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 2
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
 											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
 											"qualifier": 3
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "college",
+												"qualifier": {
+													"compare": "contains",
+													"qualifier": "Air"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 6
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Druid"
+								"Air",
+								"Clerical",
+								"Druidic",
+								"Protection & Warning",
+								"Weather",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "74990336-f577-405e-9e67-7b3c55b9a722",
+							"id": "d983ca3b-a292-4c1e-8fdc-7036606f15b1",
 							"name": "Sunlight",
 							"reference": "DFS48",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Light & Darkness"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 							"spell_class": "Area",
 							"casting_cost": "2",
 							"maintenance_cost": "Half",
@@ -7134,22 +11558,72 @@
 							"points": 1,
 							"prereqs": {
 								"type": "prereq_list",
-								"all": true,
+								"all": false,
 								"prereqs": [
 									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 3
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture (Druidic)"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 3
+										}
+									},
+									{
 										"type": "prereq_list",
-										"all": false,
+										"all": true,
 										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Glow"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Colors"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
 											{
 												"type": "advantage_prereq",
 												"has": true,
 												"name": {
 													"compare": "is",
-													"qualifier": "Power Investiture (Druidic)"
+													"qualifier": "Magery"
 												},
 												"level": {
 													"compare": "at_least",
-													"qualifier": 3
+													"qualifier": 1
 												}
 											}
 										]
@@ -7157,19 +11631,23 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Clerical",
+								"Druidic",
+								"Light & Darkness",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "473185b5-877a-4e44-8615-08e83bfaa78f",
+							"id": "75df3506-60d4-485e-ac0f-6a36f23153b0",
 							"name": "Swim",
 							"reference": "DFS70",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Movement",
+								"Water"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Druidic@",
 							"spell_class": "Regular",
 							"casting_cost": "6",
 							"maintenance_cost": "3",
@@ -7191,23 +11669,66 @@
 											"compare": "at_least",
 											"qualifier": 3
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Levitation"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Shape Water"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Druid"
+								"Druidic",
+								"Movement",
+								"Water",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "c7ecefed-23f6-4280-9d53-1177c8bdb66a",
-							"name": "Tangle growth",
+							"id": "58070226-3f41-4205-91ef-4f7582d98a2c",
+							"name": "Tangle Growth",
 							"reference": "DFS63",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Plant"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Area",
 							"casting_cost": "Varies",
 							"maintenance_cost": "1",
@@ -7216,7 +11737,7 @@
 							"points": 1,
 							"prereqs": {
 								"type": "prereq_list",
-								"all": false,
+								"all": true,
 								"prereqs": [
 									{
 										"type": "advantage_prereq",
@@ -7233,19 +11754,20 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Druidic",
+								"Plant"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "6f25ef7b-6f30-47af-bb94-5c29d0bbe30b",
+							"id": "9352fc94-bcc8-475d-8ea7-b8bea0494e8d",
 							"name": "Walk Through Plants",
 							"reference": "DFS63",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Plant"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
 							"casting_cost": "3",
 							"maintenance_cost": "1",
@@ -7254,7 +11776,7 @@
 							"points": 1,
 							"prereqs": {
 								"type": "prereq_list",
-								"all": false,
+								"all": true,
 								"prereqs": [
 									{
 										"type": "advantage_prereq",
@@ -7271,19 +11793,20 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Druidic",
+								"Plant"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "2ddd3a14-be28-48b0-9bd5-3a0c418f25a7",
+							"id": "dc926d37-247a-464f-aed2-1f6d7457e77d",
 							"name": "Walk Through Wood",
 							"reference": "DFS63",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Plant"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
 							"casting_cost": "3",
 							"maintenance_cost": "2",
@@ -7292,7 +11815,7 @@
 							"points": 1,
 							"prereqs": {
 								"type": "prereq_list",
-								"all": false,
+								"all": true,
 								"prereqs": [
 									{
 										"type": "advantage_prereq",
@@ -7309,22 +11832,24 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Druidic",
+								"Plant"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "fac9158d-4e7a-4f37-8e0a-485544a80181",
+							"id": "c5255778-3258-4126-ad12-3b6aacc03df6",
 							"name": "Water Vision",
 							"reference": "DFS71",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Knowledge",
+								"Water"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Druidic@",
 							"spell_class": "Info",
 							"casting_cost": "1#",
-							"maintenance_cost": "1",
+							"maintenance_cost": "Same",
 							"casting_time": "1 sec",
 							"duration": "30 sec",
 							"points": 1,
@@ -7343,35 +11868,81 @@
 											"compare": "at_least",
 											"qualifier": 3
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Shape Water"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "prereq_list",
+												"all": false,
+												"prereqs": [
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Magery"
+														}
+													},
+													{
+														"type": "advantage_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Bardic Talent"
+														}
+													}
+												]
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Druid"
+								"Bardic",
+								"Druidic",
+								"Knowledge",
+								"Water",
+								"Wizardly"
 							]
 						}
 					]
 				},
 				{
 					"type": "spell_container",
-					"id": "b6014498-182c-42c1-be1c-269246a7bb85",
-					"name": "Power Investiture (Druidic) 4",
+					"id": "ebade8c7-439a-48f1-b40a-9d701da6ac72",
+					"name": "Power Investiture 4",
 					"categories": [
-						"Druid"
+						"Druidic"
 					],
 					"open": false,
 					"children": [
 						{
 							"type": "spell",
-							"id": "ad582001-aac9-4d66-93c5-fba6d0856fc9",
+							"id": "6c4bfbd8-2b2c-453e-9160-2d83de6d5c30",
 							"name": "Beast Possession",
 							"reference": "DFS18",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Animal"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
+							"resist": "Will",
 							"casting_cost": "6",
 							"maintenance_cost": "2",
 							"casting_time": "5 sec",
@@ -7396,19 +11967,20 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Animal",
+								"Druidic"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "34b4f12c-d9b2-4480-af56-ec430ab1b211",
+							"id": "be70560f-aa21-41d1-8d26-480df5d53cfb",
 							"name": "Create Animal",
 							"reference": "DFS19",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Animal"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
 							"casting_cost": "Varies",
 							"maintenance_cost": "Half",
@@ -7434,20 +12006,22 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Animal",
+								"Druidic"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "0efaf64b-a336-46d1-bbef-f1c612036a78",
+							"id": "46a9f3b7-4ca6-4a0d-acc9-c4e0c489a3ad",
 							"name": "Dispel Magic",
 							"reference": "DFS51",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Meta"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 							"spell_class": "Area",
+							"resist": "Subject spells",
 							"casting_cost": "3",
 							"maintenance_cost": "-",
 							"casting_time": "sec=cost",
@@ -7462,30 +12036,82 @@
 										"has": true,
 										"name": {
 											"compare": "is",
+											"qualifier": "Power Investiture"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 4
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
 											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
 											"qualifier": 4
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											},
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "any",
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 13
+												}
+											},
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Counterspell"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Druid"
+								"Clerical",
+								"Druidic",
+								"Meta",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "a009e26e-9f6b-4e28-b344-b2e38f3bda31",
+							"id": "bebaa827-53cc-442c-bcf3-fb1d0c1a0ff2",
 							"name": "Frostbite",
 							"reference": "DFS69",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Water"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Druidic@",
 							"spell_class": "Regular",
+							"resist": "HT",
 							"casting_cost": "1-3",
 							"maintenance_cost": "-",
 							"casting_time": "3 sec",
@@ -7523,23 +12149,66 @@
 											"compare": "at_least",
 											"qualifier": 4
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Cold"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Freeze"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Druid"
+								"Druidic",
+								"Water",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "953d0695-186f-4959-bdce-9af7a55e8605",
+							"id": "e54a36c3-f9ff-4137-abbb-3de508d71d2a",
 							"name": "Hail",
 							"reference": "DFS71",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Water",
+								"Weather"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Area",
 							"casting_cost": "1/5#",
 							"maintenance_cost": "Same",
@@ -7584,19 +12253,22 @@
 							},
 							"notes": "base cost 1 for damaging hail",
 							"categories": [
-								"Druid"
+								"Druidic",
+								"Water",
+								"Weather"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "f216e19a-5ada-468b-888d-d6da9d501af0",
+							"id": "ab39534d-8f2c-48b5-9fc7-ded04d527bfd",
 							"name": "Lightning",
 							"reference": "DFS71",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Air",
+								"Weather"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Druidic@",
 							"spell_class": "Missile",
 							"casting_cost": "1-Magery",
 							"maintenance_cost": "-",
@@ -7645,23 +12317,58 @@
 											"compare": "at_least",
 											"qualifier": 4
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "college",
+												"qualifier": {
+													"compare": "contains",
+													"qualifier": "Air"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 6
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Druid"
+								"Air",
+								"Druidic",
+								"Weather",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "bf94a3b8-3e38-4d9a-96a2-c994e4d58595",
+							"id": "297fd61d-ee78-4df8-844b-7342ce7c617b",
 							"name": "Sandstorm",
 							"reference": "DFS16",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Air",
+								"Earth"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Druidic@",
 							"spell_class": "Area",
 							"casting_cost": "3",
 							"maintenance_cost": "Half",
@@ -7683,24 +12390,68 @@
 											"compare": "at_least",
 											"qualifier": 4
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Create Earth"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Windstorm"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Druid"
+								"Air",
+								"Druidic",
+								"Earth",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "2dc489f8-9388-45e7-be0e-b79cee9809c1",
+							"id": "a58ca9b5-c7da-4723-aa4c-e01f2d11617a",
 							"name": "Wither Plant",
 							"reference": "DFS63",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Plant"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Area",
+							"resist": "HT",
 							"casting_cost": "2 or 6",
 							"maintenance_cost": "-",
 							"casting_time": "10 sec",
@@ -7708,7 +12459,7 @@
 							"points": 1,
 							"prereqs": {
 								"type": "prereq_list",
-								"all": false,
+								"all": true,
 								"prereqs": [
 									{
 										"type": "advantage_prereq",
@@ -7725,31 +12476,33 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Druidic",
+								"Plant"
 							]
 						}
 					]
 				},
 				{
 					"type": "spell_container",
-					"id": "ee93da22-9a04-4173-b5ad-825ba83e08bb",
-					"name": "Power Investiture (Druidic) 5",
+					"id": "9f82c9b6-04db-46fc-9223-0864a523fe32",
+					"name": "Power Investiture 5",
 					"categories": [
-						"Druid"
+						"Druidic"
 					],
 					"open": false,
 					"children": [
 						{
 							"type": "spell",
-							"id": "1bc91702-7f29-4b14-a227-4663c436aaa5",
+							"id": "e48dbd75-8ffe-4b45-9ddb-212e827e07b4",
 							"name": "Arboreal Immurement",
 							"reference": "DFS61",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Plant"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
+							"resist": "HT",
 							"casting_cost": "Varies",
 							"maintenance_cost": "-",
 							"casting_time": "3 sec",
@@ -7757,7 +12510,7 @@
 							"points": 1,
 							"prereqs": {
 								"type": "prereq_list",
-								"all": false,
+								"all": true,
 								"prereqs": [
 									{
 										"type": "advantage_prereq",
@@ -7774,20 +12527,22 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Druidic",
+								"Plant"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "6e9dd2f0-a893-43bb-9a98-df064229a67a",
+							"id": "beabbc3a-995f-4f30-8ea9-a62fdbeb95bf",
 							"name": "Entombment",
 							"reference": "DFS27",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Earth"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Druidic@",
 							"spell_class": "Regular",
+							"resist": "HT",
 							"casting_cost": "10#",
 							"maintenance_cost": "-",
 							"casting_time": "3 sec",
@@ -7795,22 +12550,47 @@
 							"points": 1,
 							"prereqs": {
 								"type": "prereq_list",
-								"all": true,
+								"all": false,
 								"prereqs": [
 									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture (Druidic)"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 5
+										}
+									},
+									{
 										"type": "prereq_list",
-										"all": false,
+										"all": true,
 										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "college",
+												"qualifier": {
+													"compare": "contains",
+													"qualifier": "Earth"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 5
+												}
+											},
 											{
 												"type": "advantage_prereq",
 												"has": true,
 												"name": {
 													"compare": "is",
-													"qualifier": "Power Investiture (Druidic)"
+													"qualifier": "Magery"
 												},
 												"level": {
 													"compare": "at_least",
-													"qualifier": 5
+													"qualifier": 2
 												}
 											}
 										]
@@ -7818,19 +12598,22 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Druidic",
+								"Earth",
+								"Wizardly"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "b3d5c017-9dbf-49db-872b-74de47ac37de",
+							"id": "172fd146-af84-443c-86c0-087c096dd214",
 							"name": "Spark Storm",
 							"reference": "DFS72",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Air",
+								"Weather"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Arcane/Druidic@",
 							"spell_class": "Area",
 							"casting_cost": "2/4/6",
 							"maintenance_cost": "Half",
@@ -7857,7 +12640,7 @@
 							],
 							"prereqs": {
 								"type": "prereq_list",
-								"all": true,
+								"all": false,
 								"prereqs": [
 									{
 										"type": "advantage_prereq",
@@ -7870,34 +12653,77 @@
 											"compare": "at_least",
 											"qualifier": 5
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Lightning"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Windstorm"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
 									}
 								]
 							},
 							"categories": [
-								"Druid"
+								"Air",
+								"Druidic",
+								"Weather",
+								"Wizardly"
 							]
 						}
 					]
 				},
 				{
 					"type": "spell_container",
-					"id": "cecd0676-8418-469b-9417-2136b123c3eb",
-					"name": "Power Investiture (Druidic) 6",
+					"id": "558ab83f-e880-4291-aa19-bbde8b7fda61",
+					"name": "Power Investiture 6",
 					"categories": [
-						"Druid"
+						"Druidic"
 					],
 					"open": false,
 					"children": [
 						{
 							"type": "spell",
-							"id": "f80c5222-81dd-4b26-a38c-31836df3fb89",
+							"id": "68f758b2-7825-4a08-87c1-1f99280b3d4a",
 							"name": "Earthquake",
 							"reference": "DFS27",
 							"difficulty": "iq/h",
 							"college": [
-								"Druid"
+								"Earth"
 							],
-							"power_source": "Arcane",
+							"power_source": "@Power Source: Clerical/Druidic@",
 							"spell_class": "Area",
 							"casting_cost": "2",
 							"maintenance_cost": "Same",
@@ -7906,42 +12732,50 @@
 							"points": 1,
 							"prereqs": {
 								"type": "prereq_list",
-								"all": true,
+								"all": false,
 								"prereqs": [
 									{
-										"type": "prereq_list",
-										"all": false,
-										"prereqs": [
-											{
-												"type": "advantage_prereq",
-												"has": true,
-												"name": {
-													"compare": "is",
-													"qualifier": "Power Investiture (Druidic)"
-												},
-												"level": {
-													"compare": "at_least",
-													"qualifier": 6
-												}
-											}
-										]
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 5
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Power Investiture (Druidic)"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 6
+										}
 									}
 								]
 							},
 							"categories": [
-								"Druid"
+								"Clerical",
+								"Druidic",
+								"Earth"
 							]
 						},
 						{
 							"type": "spell",
-							"id": "67a072c1-8112-487e-90c0-f5fdaff1b75f",
+							"id": "8ceb0889-5fb1-453a-b2e0-933f4b12ddd5",
 							"name": "Geyser",
 							"reference": "DFS69",
-							"difficulty": "iq/h",
+							"difficulty": "iq/vh",
 							"college": [
-								"Druid"
+								"Water"
 							],
-							"power_source": "Arcane",
+							"power_source": "Druidic",
 							"spell_class": "Area",
 							"casting_cost": "5",
 							"maintenance_cost": "2",
@@ -7967,7 +12801,8 @@
 								]
 							},
 							"categories": [
-								"Druid"
+								"Druidic",
+								"Water"
 							]
 						}
 					]
@@ -7976,13 +12811,17 @@
 		},
 		{
 			"type": "spell_container",
-			"id": "26c8c1ae-473f-4626-864c-ae7e15251521",
+			"id": "6da60676-0284-452d-afaf-5f23144da6b0",
 			"name": "Wizardly",
+			"categories": [
+				"Bardic",
+				"Wizardly"
+			],
 			"open": false,
 			"children": [
 				{
 					"type": "spell",
-					"id": "08c966c0-ebc3-4569-ba2b-475556df8177",
+					"id": "1114675e-fd71-497e-ba8d-ec411712c6b8",
 					"name": "Agonize",
 					"reference": "DFS20",
 					"difficulty": "iq/h",
@@ -7991,6 +12830,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "HT",
 					"casting_cost": "8",
 					"maintenance_cost": "6",
 					"casting_time": "1 sec",
@@ -8001,42 +12841,16 @@
 						"all": true,
 						"prereqs": [
 							{
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 2
-										},
-										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (body control)"
-										}
-									},
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 2
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
-										}
-									}
-								]
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								}
 							},
 							{
 								"type": "spell_prereq",
@@ -8044,7 +12858,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "sensitize"
+									"qualifier": "Sensitize"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -8054,12 +12868,13 @@
 						]
 					},
 					"categories": [
-						"Body Control"
+						"Body Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "ff8c0f42-37e6-4178-b922-67a881ff67c0",
+					"id": "e988869e-c67d-40da-bfae-e94eb5083cd5",
 					"name": "Air Jet",
 					"reference": "DFS15",
 					"difficulty": "iq/h",
@@ -8082,10 +12897,10 @@
 							},
 							"usage": "Jet",
 							"reach": "1/point",
-							"parry": "No",
+							"parry": "0",
 							"calc": {
 								"level": 0,
-								"parry": "No",
+								"parry": "0",
 								"block": "",
 								"damage": "2d kb/point"
 							},
@@ -8112,12 +12927,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "shape air"
+									"qualifier": "Shape Air"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -8126,13 +12949,15 @@
 							}
 						]
 					},
+					"notes": "Can parry only other jet spells",
 					"categories": [
-						"Air"
+						"Air",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "3414157a-8b02-4937-9256-9931b2576779",
+					"id": "b6ef98c9-fc59-4603-8fdc-c05e4fc646b4",
 					"name": "Alertness",
 					"reference": "DFS53",
 					"difficulty": "iq/vh",
@@ -8151,12 +12976,34 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										}
+									}
+								]
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "starts_with",
-									"qualifier": "keen"
+									"qualifier": "Keen"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -8166,12 +13013,14 @@
 						]
 					},
 					"categories": [
-						"Mind Control"
+						"Bardic",
+						"Mind Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "0af63a42-7a12-402f-8839-a391300b7605",
+					"id": "bc9dedf7-397e-4f3f-9338-95ca664e075a",
 					"name": "Ambidexterity",
 					"reference": "DFS20",
 					"difficulty": "iq/h",
@@ -8190,12 +13039,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "grace"
+									"qualifier": "Grace"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -8205,12 +13062,13 @@
 						]
 					},
 					"categories": [
-						"Body Control"
+						"Body Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "bdd6ea03-e517-4f8f-8bee-1c4f82633815",
+					"id": "47f3eb96-cbd5-4d3d-90de-bec0822674f9",
 					"name": "Analyze Magic",
 					"reference": "DFS42",
 					"difficulty": "iq/h",
@@ -8229,12 +13087,34 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										}
+									}
+								]
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "identify spell"
+									"qualifier": "Identify Spell"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -8244,12 +13124,14 @@
 						]
 					},
 					"categories": [
-						"Knowledge"
+						"Bardic",
+						"Knowledge",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "9c91340c-9994-4f4c-b274-80601a1ed675",
+					"id": "7aab789f-87b5-435f-8af4-6528a9dc8e2c",
 					"name": "Apportation",
 					"reference": "DFS56",
 					"difficulty": "iq/h",
@@ -8258,7 +13140,9 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "ST or Will",
 					"casting_cost": "Varies",
+					"maintenance_cost": "Same",
 					"casting_time": "1 sec",
 					"duration": "1 min",
 					"points": 1,
@@ -8267,59 +13151,34 @@
 						"all": true,
 						"prereqs": [
 							{
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 1
-										},
-										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (movement)"
-										}
-									},
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 1
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
-										}
-									}
-								]
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
 							}
 						]
 					},
 					"categories": [
-						"Movement"
+						"Movement",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "0b0c6a01-2955-4cbe-bc9f-5346003170fa",
+					"id": "22a81a4b-7f25-41f4-b4fe-d78d25fc073d",
 					"name": "Armor",
 					"reference": "DFS63",
 					"difficulty": "iq/h",
 					"college": [
-						"Protection"
+						"Protection & Warning"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical@",
 					"spell_class": "Regular",
 					"casting_cost": "2 per DR",
 					"maintenance_cost": "Half",
@@ -8328,37 +13187,65 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "shield"
+									"qualifier": "Power Investiture"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
 									"qualifier": 1
 								}
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Shield"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Protection"
+						"Clerical",
+						"Protection & Warning",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "d385e7e8-cd6d-49e2-ae72-241d13ced791",
+					"id": "42b0d911-71e1-45f0-bd39-df0621de9cd7",
 					"name": "Astral Block",
 					"reference": "DFS59",
 					"difficulty": "iq/h",
 					"college": [
 						"Necromancy"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical@",
 					"spell_class": "Area",
 					"casting_cost": "4",
 					"maintenance_cost": "2",
@@ -8367,43 +13254,71 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "repel spirits"
+									"qualifier": "Power Investiture"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": 4
 								}
 							},
 							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "summon spirit"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Repel Spirits"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Summon Spirit"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Necromancy"
+						"Clerical",
+						"Necromancy",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "ff28fc9c-5b12-4783-98c1-55a1acbc2c6b",
+					"id": "72bf547c-acf8-412c-9b08-32605058a19f",
 					"name": "Astral Vision",
 					"reference": "DFS42",
 					"difficulty": "iq/vh",
@@ -8411,7 +13326,7 @@
 						"Knowledge",
 						"Necromancy"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical@",
 					"spell_class": "Regular",
 					"casting_cost": "4",
 					"maintenance_cost": "2",
@@ -8420,51 +13335,94 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "sense spirit"
+									"qualifier": "Power Investiture"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": 3
 								}
 							},
 							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "see invisible"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "prereq_list",
+										"all": false,
+										"prereqs": [
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Bardic Talent"
+												}
+											}
+										]
+									},
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "See Invisible"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Sense Spirit"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
+						"Bardic",
+						"Clerical",
 						"Knowledge",
-						"Necromancy"
+						"Necromancy",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "fb8f6aac-db4c-4ea2-a916-69ce0a2958ae",
+					"id": "3777bf02-700d-424b-b820-ecd693f79a3c",
 					"name": "Aura",
 					"reference": "DFS42",
 					"difficulty": "iq/h",
 					"college": [
 						"Knowledge"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical@",
 					"spell_class": "Info",
 					"casting_cost": "3",
 					"maintenance_cost": "-",
@@ -8473,77 +13431,82 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "detect magic"
+									"qualifier": "Power Investiture"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
 									"qualifier": 1
 								}
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "prereq_list",
+										"all": false,
+										"prereqs": [
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Bardic Talent"
+												}
+											}
+										]
+									},
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Detect Magic"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Knowledge"
+						"Bardic",
+						"Clerical",
+						"Knowledge",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "1c1795f8-65b2-4646-9e1e-eaa58c12ce50",
-					"name": "Balance",
-					"reference": "DFS20",
-					"difficulty": "iq/h",
-					"college": [
-						"Body Control"
-					],
-					"power_source": "Arcane",
-					"spell_class": "Regular",
-					"casting_cost": "5",
-					"maintenance_cost": "3",
-					"casting_time": "1 sec",
-					"duration": "1 min",
-					"points": 1,
-					"prereqs": {
-						"type": "prereq_list",
-						"all": true,
-						"prereqs": [
-							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "grace"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
-							}
-						]
-					},
-					"categories": [
-						"Body Control"
-					]
-				},
-				{
-					"type": "spell",
-					"id": "80dc59be-1ffe-4d15-9101-10d7b505ea6e",
+					"id": "70595832-0f57-4a5d-9b1a-7fc992a85c1f",
 					"name": "Banish",
 					"reference": "DFS59",
 					"difficulty": "iq/h",
 					"college": [
 						"Necromancy"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical@",
 					"spell_class": "Special",
+					"resist": "Will",
 					"casting_cost": "Varies",
 					"maintenance_cost": "-",
 					"casting_time": "5 sec",
@@ -8551,26 +13514,31 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 4
+								}
+							},
+							{
 								"type": "prereq_list",
-								"all": false,
+								"all": true,
 								"prereqs": [
 									{
-										"type": "advantage_prereq",
+										"type": "spell_prereq",
 										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
+										"sub_type": "college_count",
+										"quantity": {
 											"compare": "at_least",
-											"qualifier": 1
-										},
-										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (necromancy)"
+											"qualifier": 10
 										}
 									},
 									{
@@ -8578,37 +13546,26 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "magery"
+											"qualifier": "Magery"
 										},
 										"level": {
 											"compare": "at_least",
 											"qualifier": 1
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
 										}
 									}
 								]
-							},
-							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "college_count",
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 10
-								}
 							}
 						]
 					},
 					"categories": [
-						"Necromancy"
+						"Clerical",
+						"Necromancy",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "755b9bce-86d6-4e33-bf2b-2e42a55735d8",
+					"id": "efbef5cd-21cc-4afc-a08d-eaed7eab1c30",
 					"name": "Blackout",
 					"reference": "DFS46",
 					"difficulty": "iq/h",
@@ -8627,51 +13584,20 @@
 						"all": true,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "darkness"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": "Magery"
 								}
-							}
-						]
-					},
-					"categories": [
-						"Light"
-					]
-				},
-				{
-					"type": "spell",
-					"id": "cb72f2d5-c78d-4e3f-9820-15842a57e884",
-					"name": "Bladeturning",
-					"reference": "DFS63",
-					"difficulty": "iq/h",
-					"college": [
-						"Protection"
-					],
-					"power_source": "Arcane",
-					"spell_class": "Regular",
-					"casting_cost": "2",
-					"maintenance_cost": "2",
-					"casting_time": "1 sec",
-					"duration": "1 min",
-					"points": 1,
-					"prereqs": {
-						"type": "prereq_list",
-						"all": false,
-						"prereqs": [
+							},
 							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "shield"
+									"qualifier": "Darkness"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -8681,12 +13607,13 @@
 						]
 					},
 					"categories": [
-						"Protection"
+						"Light & Darkness",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "18d1b52d-fa44-44df-bcb8-700ddfad5e9e",
+					"id": "3b04fbc3-a121-4d2f-b4d5-1c8b2520ad4e",
 					"name": "Blink",
 					"reference": "DFS56",
 					"difficulty": "iq/h",
@@ -8739,15 +13666,16 @@
 					},
 					"categories": [
 						"Gate",
-						"Movement"
+						"Movement",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "23b75147-6d8b-4608-9fb2-cbf088f76e4c",
+					"id": "13c63a6a-9624-4b99-a155-103369302d46",
 					"name": "Blink Other",
 					"reference": "DFS56",
-					"difficulty": "iq/h",
+					"difficulty": "iq/vh",
 					"college": [
 						"Gate",
 						"Movement"
@@ -8764,12 +13692,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "blink"
+									"qualifier": "Blink"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -8780,12 +13716,13 @@
 					},
 					"categories": [
 						"Gate",
-						"Movement"
+						"Movement",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "7126fb84-4f38-472c-b6f2-05feb7d9d236",
+					"id": "1ec01e52-02c9-4ed5-93b9-082d45670339",
 					"name": "Blur",
 					"reference": "DFS46",
 					"difficulty": "iq/h",
@@ -8804,12 +13741,20 @@
 						"all": false,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "darkness"
+									"qualifier": "Darkness"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -8819,12 +13764,13 @@
 						]
 					},
 					"categories": [
-						"Light"
+						"Light & Darkness",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "1230f46e-6e89-4962-ab46-1012a83efe59",
+					"id": "302980e1-72d3-4502-95e0-2791d65ec483",
 					"name": "Borrow Language",
 					"reference": "DFS24",
 					"difficulty": "iq/h",
@@ -8843,12 +13789,34 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									}
+								]
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "lend language"
+									"qualifier": "Leng Language"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -8858,12 +13826,14 @@
 						]
 					},
 					"categories": [
-						"Communication"
+						"Bardic",
+						"Communication & Empathy",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "62487548-5523-4f86-9abb-e0bc29c766ba",
+					"id": "fb6b5033-9730-407f-bbac-0e0f1ecf941b",
 					"name": "Borrow Skill",
 					"reference": "DFS24",
 					"difficulty": "iq/h",
@@ -8882,12 +13852,34 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										}
+									}
+								]
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "lend skill"
+									"qualifier": "Lend Skill"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -8897,20 +13889,23 @@
 						]
 					},
 					"categories": [
-						"Communication"
+						"Bardic",
+						"Communication & Empathy",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "de611f8f-34e6-4d7c-84d3-23558447930c",
+					"id": "c6ca36bc-2f7f-4d9a-ac20-0385fe5947e8",
 					"name": "Bravery",
 					"reference": "DFS53",
 					"difficulty": "iq/h",
 					"college": [
 						"Mind Control"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical@",
 					"spell_class": "Area",
+					"resist": "Will-1",
 					"casting_cost": "2",
 					"maintenance_cost": "-",
 					"casting_time": "1 sec",
@@ -8918,30 +13913,73 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "fear"
+									"qualifier": "Power Investiture"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
 									"qualifier": 1
 								}
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "prereq_list",
+										"all": false,
+										"prereqs": [
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Bardic Talent"
+												}
+											}
+										]
+									},
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Fear"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Mind Control"
+						"Bardic",
+						"Clerical",
+						"Mind Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "7569689c-6a26-4e75-b792-37f06826a753",
+					"id": "8cc47e1d-accc-4048-9fe1-f0c68e4e7a0b",
 					"name": "Breathe Water",
 					"reference": "DFS68",
 					"difficulty": "iq/h",
@@ -8949,7 +13987,7 @@
 						"Air",
 						"Water"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 					"spell_class": "Regular",
 					"casting_cost": "4",
 					"maintenance_cost": "2",
@@ -8958,44 +13996,85 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "destroy water"
+									"qualifier": "Power Investiture"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": 3
 								}
 							},
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "create air"
+									"qualifier": "Power Investiture (Druidic)"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": 3
 								}
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									},
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Destroy Water"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Create Air"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
 						"Air",
-						"Water"
+						"Clerical",
+						"Druidic",
+						"Water",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "7bbf9916-5906-4dae-a6a7-705d8f54ce9f",
+					"id": "a0e783a5-83e0-4c90-b06d-b02a5e2ed561",
 					"name": "Bright Vision",
 					"reference": "DFS46",
 					"difficulty": "iq/h",
@@ -9014,6 +14093,14 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "prereq_list",
 								"all": false,
 								"prereqs": [
@@ -9023,7 +14110,7 @@
 										"sub_type": "name",
 										"qualifier": {
 											"compare": "is",
-											"qualifier": "keen vision"
+											"qualifier": "Keen Vision"
 										},
 										"quantity": {
 											"compare": "at_least",
@@ -9036,7 +14123,7 @@
 										"sub_type": "college",
 										"qualifier": {
 											"compare": "contains",
-											"qualifier": "Light"
+											"qualifier": "Light & Darkness"
 										},
 										"quantity": {
 											"compare": "at_least",
@@ -9048,12 +14135,13 @@
 						]
 					},
 					"categories": [
-						"Light"
+						"Light & Darkness",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "1686a0b6-e64d-4a2e-8f71-e36f4cc205b0",
+					"id": "fbb90d52-4403-492d-bbda-6344f3f4171e",
 					"name": "Burning Touch",
 					"reference": "DFS29",
 					"difficulty": "iq/h",
@@ -9108,42 +14196,16 @@
 						"all": true,
 						"prereqs": [
 							{
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 2
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
-										}
-									},
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 2
-										},
-										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (fire)"
-										}
-									}
-								]
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								}
 							},
 							{
 								"type": "spell_prereq",
@@ -9155,7 +14217,7 @@
 								},
 								"quantity": {
 									"compare": "at_least",
-									"qualifier": 5
+									"qualifier": 6
 								}
 							},
 							{
@@ -9164,7 +14226,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "heat"
+									"qualifier": "Heat"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -9174,12 +14236,13 @@
 						]
 					},
 					"categories": [
-						"Fire"
+						"Fire",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "f8accf87-e555-440e-bc29-a3f33f5f3e44",
+					"id": "a3c2ce6c-76b3-445e-a829-b0788e7d0ab7",
 					"name": "Charm",
 					"reference": "DFS53",
 					"difficulty": "iq/h",
@@ -9188,6 +14251,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "Will",
 					"casting_cost": "6",
 					"maintenance_cost": "3",
 					"casting_time": "3 sec",
@@ -9207,7 +14271,7 @@
 								},
 								"quantity": {
 									"compare": "at_least",
-									"qualifier": 7
+									"qualifier": 8
 								}
 							},
 							{
@@ -9216,7 +14280,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "loyalty"
+									"qualifier": "Loyalty"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -9232,7 +14296,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "bardic talent"
+											"qualifier": "Bardic Talent"
 										},
 										"level": {
 											"compare": "at_least",
@@ -9244,15 +14308,11 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "magery"
+											"qualifier": "Magery"
 										},
 										"level": {
 											"compare": "at_least",
 											"qualifier": 1
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
 										}
 									}
 								]
@@ -9260,12 +14320,14 @@
 						]
 					},
 					"categories": [
-						"Mind Control"
+						"Bardic",
+						"Mind Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "1e92f6c5-99cb-4b30-84ce-c56fad10f992",
+					"id": "7abf00e1-6051-4a23-967d-d8ad3a1b685f",
 					"name": "Climbing",
 					"reference": "DFS20",
 					"difficulty": "iq/h",
@@ -9279,13 +14341,28 @@
 					"casting_time": "1 sec",
 					"duration": "1 min",
 					"points": 1,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							}
+						]
+					},
 					"categories": [
-						"Body Control"
+						"Body Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "5146558b-441c-4a65-a3c0-1222733ba740",
+					"id": "550d6352-1a6d-45f4-bede-e1b57d4ed1f0",
 					"name": "Clumsiness",
 					"reference": "DFS20",
 					"difficulty": "iq/h",
@@ -9294,6 +14371,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "HT",
 					"casting_cost": "1-5",
 					"maintenance_cost": "Half",
 					"casting_time": "1 sec",
@@ -9304,12 +14382,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "spasm"
+									"qualifier": "Spasm"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -9319,12 +14405,13 @@
 						]
 					},
 					"categories": [
-						"Body Control"
+						"Body Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "60753b8c-530c-4645-80ce-c59c1a07b818",
+					"id": "cefef244-5166-473b-9ba8-5566623c7e7b",
 					"name": "Cold",
 					"reference": "DFS29",
 					"difficulty": "iq/h",
@@ -9343,12 +14430,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "heat"
+									"qualifier": "Heat"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -9358,12 +14453,13 @@
 						]
 					},
 					"categories": [
-						"Fire"
+						"Fire",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "a5b3d54d-4dcc-482c-9992-be4b772e06be",
+					"id": "fd389025-ac7f-4d4a-8e20-a30ab7f54f3b",
 					"name": "Colors",
 					"reference": "DFS46",
 					"difficulty": "iq/h",
@@ -9382,12 +14478,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "light"
+									"qualifier": "Light"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -9397,20 +14501,22 @@
 						]
 					},
 					"categories": [
-						"Light"
+						"Light & Darkness",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "b2657152-61ff-4644-a3bc-4196d2dfbd72",
+					"id": "436a56b9-a16d-49fc-b97d-b322ced08eca",
 					"name": "Command",
 					"reference": "DFS53",
 					"difficulty": "iq/h",
 					"college": [
 						"Mind Control"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical@",
 					"spell_class": "Blocking",
+					"resist": "Will",
 					"casting_cost": "2",
 					"maintenance_cost": "-",
 					"casting_time": "1 sec",
@@ -9418,72 +14524,90 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "forgetfulness"
+									"qualifier": "Power Investiture"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": 2
 								}
 							},
 							{
 								"type": "prereq_list",
-								"all": false,
+								"all": true,
 								"prereqs": [
 									{
-										"type": "advantage_prereq",
+										"type": "spell_prereq",
 										"has": true,
-										"name": {
+										"sub_type": "name",
+										"qualifier": {
 											"compare": "is",
-											"qualifier": "bardic talent"
+											"qualifier": "Forgetfulness"
 										},
-										"level": {
+										"quantity": {
 											"compare": "at_least",
-											"qualifier": 2
+											"qualifier": 1
 										}
 									},
 									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 2
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
-										}
+										"type": "prereq_list",
+										"all": false,
+										"prereqs": [
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 2
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Bardic Talent"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 2
+												}
+											}
+										]
 									}
 								]
 							}
 						]
 					},
 					"categories": [
-						"Mind Control"
+						"Bardic",
+						"Clerical",
+						"Mind Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "fe1c5736-b341-49ea-af96-ae8dd06ef396",
-					"name": "Command Spirit (@spirit@)",
+					"id": "4835d827-7341-49da-baae-dcef183c9fd6",
+					"name": "Command Spirit (@Spirit@)",
 					"reference": "DFS60",
 					"difficulty": "iq/h",
 					"college": [
 						"Necromancy"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical@",
 					"spell_class": "Regular",
+					"resist": "Will",
 					"casting_cost": "Varies",
 					"maintenance_cost": "Half",
 					"casting_time": "2 sec",
@@ -9491,74 +14615,48 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "summon spirit"
+									"qualifier": "Power Investiture"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": 4
 								}
 							},
 							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "turn spirit"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
-							}
-						]
-					},
-					"categories": [
-						"Necromancy"
-					]
-				},
-				{
-					"type": "spell",
-					"id": "304999f1-9d4b-49ef-80f7-b6208433f444",
-					"name": "Compel Truth",
-					"reference": "DFS24",
-					"difficulty": "iq/h",
-					"college": [
-						"Communication & Empathy"
-					],
-					"power_source": "Arcane",
-					"spell_class": "Info",
-					"casting_cost": "4",
-					"maintenance_cost": "2",
-					"casting_time": "1 sec",
-					"duration": "5 min",
-					"points": 1,
-					"prereqs": {
-						"type": "prereq_list",
-						"all": true,
-						"prereqs": [
-							{
 								"type": "prereq_list",
-								"all": false,
+								"all": true,
 								"prereqs": [
 									{
-										"type": "advantage_prereq",
+										"type": "spell_prereq",
 										"has": true,
-										"name": {
+										"sub_type": "name",
+										"qualifier": {
 											"compare": "is",
-											"qualifier": "bardic talent"
+											"qualifier": "Summon Spirit"
 										},
-										"level": {
+										"quantity": {
 											"compare": "at_least",
-											"qualifier": 2
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Turn Spirit"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
 										}
 									},
 									{
@@ -9566,41 +14664,113 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 2
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
+											"qualifier": "Magery"
 										}
 									}
 								]
-							},
-							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "truthsayer"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
 							}
 						]
 					},
 					"categories": [
-						"Communication"
+						"Clerical",
+						"Necromancy",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "9c1d686a-23a7-4125-ad8c-e1561c0207c6",
+					"id": "0fabb94c-5cfb-496e-b045-fb3d8fc3bbb4",
+					"name": "Compel Truth",
+					"reference": "DFS24",
+					"difficulty": "iq/h",
+					"college": [
+						"Communication & Empathy"
+					],
+					"power_source": "@Power Source: Arcane/Clerical@",
+					"spell_class": "Info",
+					"resist": "Will",
+					"casting_cost": "4",
+					"maintenance_cost": "2",
+					"casting_time": "1 sec",
+					"duration": "5 min",
+					"points": 1,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								}
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Truthsayer"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "prereq_list",
+										"all": false,
+										"prereqs": [
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Bardic Talent"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 2
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 2
+												}
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					"categories": [
+						"Bardic",
+						"Clerical",
+						"Communication & Empathy",
+						"Wizardly"
+					]
+				},
+				{
+					"type": "spell",
+					"id": "0c09e51d-c20e-413f-847a-9d3127aa5b58",
 					"name": "Complex Illusion",
 					"reference": "DFS40",
 					"difficulty": "iq/h",
@@ -9619,12 +14789,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "sound"
+									"qualifier": "Sound"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -9637,7 +14815,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "simple illusion"
+									"qualifier": "Simple Illusion"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -9647,12 +14825,13 @@
 						]
 					},
 					"categories": [
-						"Illusion"
+						"Illusion",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "e70d866b-0c7d-4b78-9a7b-389b48497671",
+					"id": "74a5a7eb-2d25-43fe-93c1-13280b8a55f9",
 					"name": "Concussion",
 					"reference": "DFS15",
 					"difficulty": "iq/h",
@@ -9699,12 +14878,34 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										}
+									}
+								]
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "shape air"
+									"qualifier": "Shape Air"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -9717,7 +14918,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "thunderclap"
+									"qualifier": "Thunderclap"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -9728,19 +14929,21 @@
 					},
 					"categories": [
 						"Air",
-						"Sound"
+						"Bardic",
+						"Sound",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "d01c3e94-361a-4129-8d02-f74f9aca368b",
+					"id": "c0d0ea96-402f-45ab-92c8-458d3a8c2f33",
 					"name": "Continual Light",
 					"reference": "DFS46",
 					"difficulty": "iq/h",
 					"college": [
 						"Light & Darkness"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical@",
 					"spell_class": "Regular",
 					"casting_cost": "2 moon, 4 torch, 6 day",
 					"maintenance_cost": "-",
@@ -9749,15 +14952,95 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								}
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Light"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									}
+								]
+							}
+						]
+					},
+					"categories": [
+						"Clerical",
+						"Light & Darkness",
+						"Wizardly"
+					]
+				},
+				{
+					"type": "spell",
+					"id": "2117eee6-aefa-4dc5-a658-b99650cc9403",
+					"name": "Control Gate",
+					"reference": "DFS34",
+					"difficulty": "iq/h",
+					"college": [
+						"Gate"
+					],
+					"power_source": "Arcane",
+					"spell_class": "Regular",
+					"resist": "Gate",
+					"casting_cost": "6",
+					"maintenance_cost": "Half",
+					"casting_time": "10 sec",
+					"duration": "1 min",
+					"points": 1,
+					"prereqs": {
+						"type": "prereq_list",
 						"all": true,
 						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								}
+							},
 							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "light"
+									"qualifier": "Seek Gate"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -9767,22 +15050,73 @@
 						]
 					},
 					"categories": [
-						"Light"
+						"Gate",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "d98dc49b-200b-479d-9573-e940fdc16802",
-					"name": "Control Gate",
-					"reference": "DFS34",
+					"id": "21fd01bb-7662-4dd2-a4a7-71db893de5c6",
+					"name": "Control Illusion",
+					"reference": "DFS40",
 					"difficulty": "iq/h",
 					"college": [
-						"Gate"
+						"Illusion"
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "Subject spell",
+					"casting_cost": "1",
+					"maintenance_cost": "-",
+					"casting_time": "2 sec",
+					"duration": "Permanent",
+					"points": 1,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
+								"type": "spell_prereq",
+								"has": true,
+								"sub_type": "name",
+								"qualifier": {
+									"compare": "is",
+									"qualifier": "Perfect Illusion"
+								},
+								"quantity": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							}
+						]
+					},
+					"categories": [
+						"Illusion",
+						"Wizardly"
+					]
+				},
+				{
+					"type": "spell",
+					"id": "2c81b2d0-b5e0-4fd5-b512-2a5b21473c1e",
+					"name": "Control Person",
+					"reference": "DFS24",
+					"difficulty": "iq/h",
+					"college": [
+						"Communication & Empathy"
+					],
+					"power_source": "Arcane",
+					"spell_class": "Regular",
+					"resist": "Will",
 					"casting_cost": "6",
-					"maintenance_cost": "Half",
+					"maintenance_cost": "3",
 					"casting_time": "10 sec",
 					"duration": "1 min",
 					"points": 1,
@@ -9795,19 +15129,43 @@
 								"all": false,
 								"prereqs": [
 									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Telepathy"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Soul Rider"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									}
+								]
+							},
+							{
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
 										"type": "advantage_prereq",
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 3
-										},
-										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (gate)"
+											"qualifier": "Magery"
 										}
 									},
 									{
@@ -9815,132 +15173,22 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 3
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
+											"qualifier": "Bardic Talent"
 										}
 									}
 								]
-							},
-							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "seek gate"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
 							}
 						]
 					},
 					"categories": [
-						"Gate"
+						"Bardic",
+						"Communication & Empathy",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "33f13352-21ba-4dae-bd82-9909b0487567",
-					"name": "Control Illusion",
-					"reference": "DFS40",
-					"difficulty": "iq/h",
-					"college": [
-						"Illusion"
-					],
-					"power_source": "Arcane",
-					"spell_class": "Regular",
-					"casting_cost": "1",
-					"maintenance_cost": "-",
-					"casting_time": "2 sec",
-					"duration": "Permanent",
-					"points": 1,
-					"prereqs": {
-						"type": "prereq_list",
-						"all": true,
-						"prereqs": [
-							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "perfect illusion"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
-							}
-						]
-					},
-					"categories": [
-						"Illusion"
-					]
-				},
-				{
-					"type": "spell",
-					"id": "5ac02049-9dfa-4989-b39c-b8c110ffc362",
-					"name": "Control Person",
-					"reference": "DFS24",
-					"difficulty": "iq/h",
-					"college": [
-						"Communication & Empathy"
-					],
-					"power_source": "Arcane",
-					"spell_class": "Regular",
-					"casting_cost": "6",
-					"maintenance_cost": "3",
-					"casting_time": "10 sec",
-					"duration": "1 min",
-					"points": 1,
-					"prereqs": {
-						"type": "prereq_list",
-						"all": false,
-						"prereqs": [
-							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "soul rider"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
-							},
-							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "telepathy"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
-							}
-						]
-					},
-					"categories": [
-						"Communication"
-					]
-				},
-				{
-					"type": "spell",
-					"id": "5c79f84d-4160-4ed8-b4aa-13f6dba5aaac",
+					"id": "2a522da1-037c-4d78-96c9-f760d0f39745",
 					"name": "Cook",
 					"reference": "DFS32",
 					"difficulty": "iq/h",
@@ -9959,12 +15207,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "test food"
+									"qualifier": "Test Food"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -9977,7 +15233,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "create fire"
+									"qualifier": "Create Fire"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -9987,20 +15243,21 @@
 						]
 					},
 					"categories": [
-						"Food"
+						"Food",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "4ce3d221-cade-44b9-8ac9-586100fb772b",
+					"id": "592d1f44-8bef-43eb-9bcf-6ba73b89af72",
 					"name": "Coolness",
 					"reference": "DFS68",
 					"difficulty": "iq/h",
 					"college": [
-						"Protection",
+						"Protection & Warning",
 						"Water"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 					"spell_class": "Regular",
 					"casting_cost": "2",
 					"maintenance_cost": "1",
@@ -10009,31 +15266,72 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "cold"
+									"qualifier": "Power Investiture"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
 									"qualifier": 1
 								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture (Druidic)"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Cold"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Protection",
-						"Water"
+						"Clerical",
+						"Druidic",
+						"Protection & Warning",
+						"Water",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "7e6426de-1b4a-4d32-b7cb-0e3b9e7bf7da",
+					"id": "58b77b09-e3aa-4a0c-84bb-4db54b1ab5cd",
 					"name": "Copy",
 					"reference": "DFS48",
 					"difficulty": "iq/h",
@@ -10052,12 +15350,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "college",
 								"qualifier": {
 									"compare": "contains",
-									"qualifier": "making"
+									"qualifier": "Making & Breaking"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -10073,7 +15379,7 @@
 										"has": true,
 										"name": {
 											"compare": "starts_with",
-											"qualifier": "Language:"
+											"qualifier": "Language"
 										},
 										"notes": {
 											"compare": "contains",
@@ -10085,7 +15391,7 @@
 										"has": true,
 										"name": {
 											"compare": "starts_with",
-											"qualifier": "Language:"
+											"qualifier": "Language"
 										},
 										"notes": {
 											"compare": "contains",
@@ -10100,7 +15406,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "restore"
+									"qualifier": "Restore"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -10110,65 +15416,13 @@
 						]
 					},
 					"categories": [
-						"Making & Breaking"
+						"Making & Breaking",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "63a42f20-36de-4c85-9118-5416b44dc225",
-					"name": "Counterspell",
-					"reference": "DFS51",
-					"difficulty": "iq/h",
-					"college": [
-						"Meta"
-					],
-					"power_source": "Arcane",
-					"spell_class": "Regular",
-					"casting_cost": "Half countered spell",
-					"casting_time": "5 sec",
-					"duration": "Instant",
-					"points": 1,
-					"prereqs": {
-						"type": "prereq_list",
-						"all": false,
-						"prereqs": [
-							{
-								"type": "advantage_prereq",
-								"has": true,
-								"name": {
-									"compare": "is",
-									"qualifier": "magery"
-								},
-								"level": {
-									"compare": "at_least",
-									"qualifier": 1
-								},
-								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (meta)"
-								}
-							},
-							{
-								"type": "advantage_prereq",
-								"has": true,
-								"name": {
-									"compare": "is",
-									"qualifier": "magery"
-								},
-								"level": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
-							}
-						]
-					},
-					"categories": [
-						"Meta"
-					]
-				},
-				{
-					"type": "spell",
-					"id": "16ffdc77-1793-45e7-bdda-e1baf2bfb813",
+					"id": "59094788-fef0-461c-ae5a-e729ddd1f933",
 					"name": "Create Air",
 					"reference": "DFS16",
 					"difficulty": "iq/h",
@@ -10187,12 +15441,20 @@
 						"all": false,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "purify air"
+									"qualifier": "Purify Air"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -10202,12 +15464,13 @@
 						]
 					},
 					"categories": [
-						"Air"
+						"Air",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "a7538bf7-af24-4e36-9d91-b01b122b9f9c",
+					"id": "f64d1d6f-548b-405c-b680-23fa618093f7",
 					"name": "Create Earth",
 					"reference": "DFS27",
 					"difficulty": "iq/h",
@@ -10226,12 +15489,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "earth to stone"
+									"qualifier": "Earth to Stone"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -10241,12 +15512,13 @@
 						]
 					},
 					"categories": [
-						"Earth"
+						"Earth",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "0d742add-8377-4f07-a01d-ccb5c8218099",
+					"id": "9d19e6b4-ef3b-4eac-b8f9-926351f306ee",
 					"name": "Create Fire",
 					"reference": "DFS29",
 					"difficulty": "iq/h",
@@ -10280,50 +15552,65 @@
 					],
 					"prereqs": {
 						"type": "prereq_list",
-						"all": false,
+						"all": true,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "seek fire"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": "Magery"
 								}
 							},
 							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "ignite fire"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Seek Fire"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Ignite Fire"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Fire"
+						"Fire",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "6368d14d-fba7-4155-94c2-a0230a64c35c",
+					"id": "0d8431fd-3433-4016-b42b-d85d6df64560",
 					"name": "Create Food",
 					"reference": "DFS32",
 					"difficulty": "iq/h",
 					"college": [
 						"Food"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical@",
 					"spell_class": "Regular",
 					"casting_cost": "Varies",
 					"maintenance_cost": "-",
@@ -10332,50 +15619,78 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "cook"
+									"qualifier": "Power Investiture"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": 3
 								}
 							},
 							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "seek food"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Cook"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Seek Food"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Food"
+						"Clerical",
+						"Food",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "cc6cd414-6bda-43f7-bc41-0fa9db42b156",
+					"id": "8d5447c3-2527-44a3-b700-f520430b7870",
 					"name": "Create Water",
 					"reference": "DFS68",
 					"difficulty": "iq/h",
 					"college": [
 						"Water"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical@",
 					"spell_class": "Regular",
 					"casting_cost": "2/gal",
 					"maintenance_cost": "-",
@@ -10384,30 +15699,58 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "purify water"
+									"qualifier": "Power Investiture"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": 2
 								}
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Purify Water"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Water"
+						"Clerical",
+						"Water",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "49ac29d0-7744-41a6-a56e-0e19b18bcf29",
+					"id": "d1c8e838-0322-4435-ac6b-7ea3611fbc32",
 					"name": "Dark Vision",
 					"reference": "DFS46",
 					"difficulty": "iq/h",
@@ -10423,43 +15766,58 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": false,
+						"all": true,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "night vision"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": "Magery"
 								}
 							},
 							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "infravision"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Infravision"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Night Vision"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Light"
+						"Light & Darkness",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "209427b5-cfc3-4c1d-9126-b5a4a8a55922",
+					"id": "d790ca37-b019-44e7-a950-63395a9ced1e",
 					"name": "Darkness",
 					"reference": "DFS46",
 					"difficulty": "iq/h",
@@ -10478,12 +15836,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "continual light"
+									"qualifier": "Continual Light"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -10493,12 +15859,13 @@
 						]
 					},
 					"categories": [
-						"Light"
+						"Light & Darkness",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "591c0a02-4f68-4453-b938-10c2e71e38ae",
+					"id": "8af5d6bd-cd75-4bb7-8f9b-33dc4405ee90",
 					"name": "Daze",
 					"reference": "DFS54",
 					"difficulty": "iq/h",
@@ -10507,6 +15874,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "HT",
 					"casting_cost": "3",
 					"maintenance_cost": "2",
 					"casting_time": "2 sec",
@@ -10517,12 +15885,34 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										}
+									}
+								]
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "foolishness"
+									"qualifier": "Foolishness"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -10532,12 +15922,14 @@
 						]
 					},
 					"categories": [
-						"Mind Control"
+						"Bardic",
+						"Mind Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "ecdb9338-c002-4172-aa38-8c5138669fe0",
+					"id": "dd7379b1-1891-48b3-ba38-98baf2f1ecb3",
 					"name": "Death Vision",
 					"reference": "DFS60",
 					"difficulty": "iq/h",
@@ -10553,30 +15945,14 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": false,
+						"all": true,
 						"prereqs": [
 							{
 								"type": "advantage_prereq",
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "magery"
-								},
-								"level": {
-									"compare": "at_least",
-									"qualifier": 1
-								},
-								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (necromancy)"
-								}
-							},
-							{
-								"type": "advantage_prereq",
-								"has": true,
-								"name": {
-									"compare": "is",
-									"qualifier": "magery"
+									"qualifier": "Magery"
 								},
 								"level": {
 									"compare": "at_least",
@@ -10586,12 +15962,13 @@
 						]
 					},
 					"categories": [
-						"Necromancy"
+						"Necromancy",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "199ff6e4-074c-4e63-9922-9840ee567e39",
+					"id": "17393783-c437-4ae7-b2f1-1089da6463e4",
 					"name": "Deathtouch",
 					"reference": "DFS20",
 					"difficulty": "iq/h",
@@ -10646,6 +16023,14 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
@@ -10661,12 +16046,13 @@
 						]
 					},
 					"categories": [
-						"Body Control"
+						"Body Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "de0579bc-35d1-4583-8cd3-d4ffdab59b09",
+					"id": "27077cbe-bd98-4c84-b36b-bbfcc5609740",
 					"name": "Debility",
 					"reference": "DFS20",
 					"difficulty": "iq/h",
@@ -10675,18 +16061,34 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "HT",
 					"casting_cost": "1/-ST",
 					"maintenance_cost": "Half",
 					"casting_time": "1 sec",
 					"duration": "1 min",
 					"points": 1,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							}
+						]
+					},
 					"categories": [
-						"Body Control"
+						"Body Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "39927bbd-f584-47f0-a741-352bc87df5c8",
+					"id": "4112a7d4-8794-4c24-8c6e-54fe2d22b44c",
 					"name": "Decay",
 					"reference": "DFS32",
 					"difficulty": "iq/h",
@@ -10705,12 +16107,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "test food"
+									"qualifier": "Test Food"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -10720,12 +16130,13 @@
 						]
 					},
 					"categories": [
-						"Food"
+						"Food",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "f4331c71-890a-46b4-a4ac-00876e1ce767",
+					"id": "755b2667-e4e8-4dcc-85e8-a0eb3032931e",
 					"name": "Deflect Energy",
 					"reference": "DFS29",
 					"difficulty": "iq/h",
@@ -10744,42 +16155,16 @@
 						"all": true,
 						"prereqs": [
 							{
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 1
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
-										}
-									},
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 1
-										},
-										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (fire)"
-										}
-									}
-								]
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
 							},
 							{
 								"type": "spell_prereq",
@@ -10787,7 +16172,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "shape fire"
+									"qualifier": "Shape Fire"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -10797,18 +16182,19 @@
 						]
 					},
 					"categories": [
-						"Fire"
+						"Fire",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "8a912a71-f8ff-47ae-9074-90cce2d399b4",
+					"id": "6fdfcff3-6b74-40c8-9a41-99fe84ef383e",
 					"name": "Deflect Missile",
 					"reference": "DFS56",
 					"difficulty": "iq/h",
 					"college": [
 						"Movement",
-						"Protection"
+						"Protection & Warning"
 					],
 					"power_source": "Arcane",
 					"spell_class": "Blocking",
@@ -10822,12 +16208,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "apportation"
+									"qualifier": "Apportation"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -10838,12 +16232,13 @@
 					},
 					"categories": [
 						"Movement",
-						"Protection"
+						"Protection & Warning",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "a28048aa-e393-4cd7-bdcc-e721ec6ea881",
+					"id": "42056e2f-6c31-4fa5-a4dd-1e5cc166365f",
 					"name": "Dehydrate",
 					"reference": "DFS68",
 					"difficulty": "iq/h",
@@ -10852,6 +16247,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "HT",
 					"casting_cost": "1-3",
 					"maintenance_cost": "-",
 					"casting_time": "2 sec",
@@ -10879,12 +16275,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "destroy water"
+									"qualifier": "Destroy Water"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -10907,12 +16311,13 @@
 						]
 					},
 					"categories": [
-						"Water"
+						"Water",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "e5aa79ab-e8ac-488c-8bd4-9807e2edaf72",
+					"id": "b549db90-9707-4b06-87fc-68c85d97404d",
 					"name": "Delayed Message",
 					"reference": "DFS66",
 					"difficulty": "iq/h",
@@ -10936,7 +16341,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "sense life"
+									"qualifier": "Sense Life"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -10949,7 +16354,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "voices"
+									"qualifier": "Voices"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -10965,7 +16370,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "bardic talent"
+											"qualifier": "Magery"
 										},
 										"level": {
 											"compare": "at_least",
@@ -10977,15 +16382,11 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "magery"
+											"qualifier": "Bardic Talent"
 										},
 										"level": {
 											"compare": "at_least",
 											"qualifier": 1
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
 										}
 									}
 								]
@@ -10993,12 +16394,14 @@
 						]
 					},
 					"categories": [
-						"Sound"
+						"Bardic",
+						"Sound",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "56f8aee4-dbc4-473e-81f3-1f9d2b2ca918",
+					"id": "f2bebac3-184a-402c-b739-7fc88d84ca9c",
 					"name": "Destroy Air",
 					"reference": "DFS16",
 					"difficulty": "iq/h",
@@ -11017,12 +16420,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "create air"
+									"qualifier": "Create Air"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -11032,12 +16443,13 @@
 						]
 					},
 					"categories": [
-						"Air"
+						"Air",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "90c10b0c-9f2a-4859-8be2-2230c586c9ef",
+					"id": "ab40f0e5-62b7-4f7e-9fb0-33537a2d0683",
 					"name": "Destroy Water",
 					"reference": "DFS68",
 					"difficulty": "iq/h",
@@ -11056,12 +16468,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "create water"
+									"qualifier": "Create Water"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -11071,19 +16491,20 @@
 						]
 					},
 					"categories": [
-						"Water"
+						"Water",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "b31a7423-416a-461b-b70b-e1e0f36d6ca9",
+					"id": "af55124c-e172-4cde-86c4-fc320e58ab80",
 					"name": "Detect Magic",
 					"reference": "DFS43",
 					"difficulty": "iq/h",
 					"college": [
 						"Knowledge"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 					"spell_class": "Regular",
 					"casting_cost": "2",
 					"maintenance_cost": "-",
@@ -11099,7 +16520,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "bardic talent"
+									"qualifier": "Power Investiture"
 								},
 								"level": {
 									"compare": "at_least",
@@ -11111,7 +16532,31 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "magery"
+									"qualifier": "Power Investiture (Druidic)"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Bardic Talent"
 								},
 								"level": {
 									"compare": "at_least",
@@ -11121,12 +16566,16 @@
 						]
 					},
 					"categories": [
-						"Knowledge"
+						"Bardic",
+						"Clerical",
+						"Druidic",
+						"Knowledge",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "9b621b98-f63d-4527-97d4-4b3b683859b8",
+					"id": "724c5842-e3ff-42c1-99b4-e953d3c5ad6d",
 					"name": "Dispel Illusion",
 					"reference": "DFS40",
 					"difficulty": "iq/h",
@@ -11135,6 +16584,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "Subject spell",
 					"casting_cost": "1",
 					"maintenance_cost": "-",
 					"casting_time": "1 sec",
@@ -11144,6 +16594,14 @@
 						"type": "prereq_list",
 						"all": true,
 						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
 							{
 								"type": "spell_prereq",
 								"has": true,
@@ -11160,20 +16618,22 @@
 						]
 					},
 					"categories": [
-						"Illusion"
+						"Illusion",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "65c00056-e71a-4344-bd2b-cbd460094441",
+					"id": "fb5860b5-5433-4606-aa74-458295a202c8",
 					"name": "Dispel Magic",
 					"reference": "DFS51",
 					"difficulty": "iq/h",
 					"college": [
 						"Meta"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 					"spell_class": "Area",
+					"resist": "Subject spells",
 					"casting_cost": "3",
 					"maintenance_cost": "-",
 					"casting_time": "sec=cost",
@@ -11181,39 +16641,80 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "any",
-								"quantity": {
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture"
+								},
+								"level": {
 									"compare": "at_least",
-									"qualifier": 12
+									"qualifier": 4
 								}
 							},
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "counterspell"
+									"qualifier": "Power Investiture (Druidic)"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": 4
 								}
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									},
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "any",
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 13
+										}
+									},
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Counterspell"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Meta"
+						"Clerical",
+						"Druidic",
+						"Meta",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "3171b514-09b7-426f-a29c-78a5978aaa8f",
+					"id": "2839a98c-a8b5-4dce-8bed-e5bb228954a2",
 					"name": "Divert Teleport",
 					"reference": "DFS34",
 					"difficulty": "iq/vh",
@@ -11223,10 +16724,65 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Blocking",
+					"resist": "Subject Ability",
 					"casting_cost": "8 or 16",
 					"maintenance_cost": "-",
 					"casting_time": "1 sec",
 					"duration": "Instant",
+					"points": 1,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								}
+							},
+							{
+								"type": "spell_prereq",
+								"has": true,
+								"sub_type": "name",
+								"qualifier": {
+									"compare": "is",
+									"qualifier": "Trace Teleport"
+								},
+								"quantity": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							}
+						]
+					},
+					"categories": [
+						"Gate",
+						"Movement",
+						"Wizardly"
+					]
+				},
+				{
+					"type": "spell",
+					"id": "1974ef59-ad84-4deb-a5e9-75b685a5ebf6",
+					"name": "Drunkenness",
+					"reference": "DFS54",
+					"difficulty": "iq/h",
+					"college": [
+						"Mind Control"
+					],
+					"power_source": "Arcane",
+					"spell_class": "Regular",
+					"resist": "Will",
+					"casting_cost": "1/pt of IQ & DX loss",
+					"maintenance_cost": "Half",
+					"casting_time": "2 sec",
+					"duration": "1 min",
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
@@ -11241,15 +16797,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 3
-										},
-										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (movement)"
+											"qualifier": "Magery"
 										}
 									},
 									{
@@ -11257,15 +16805,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 3
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
+											"qualifier": "Bardic Talent"
 										}
 									}
 								]
@@ -11276,47 +16816,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "trace teleport"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
-							}
-						]
-					},
-					"categories": [
-						"Gate",
-						"Movement"
-					]
-				},
-				{
-					"type": "spell",
-					"id": "fe9a6f39-fd51-4d16-99a2-f18922fd3610",
-					"name": "Drunkenness",
-					"reference": "DFS54",
-					"difficulty": "iq/h",
-					"college": [
-						"Mind Control"
-					],
-					"power_source": "Arcane",
-					"spell_class": "Regular",
-					"casting_cost": "1/pt of IQ & DX loss",
-					"maintenance_cost": "Half",
-					"casting_time": "2 sec",
-					"duration": "1 min",
-					"points": 1,
-					"prereqs": {
-						"type": "prereq_list",
-						"all": true,
-						"prereqs": [
-							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "foolishness"
+									"qualifier": "Foolishness"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -11329,7 +16829,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "clumsiness"
+									"qualifier": "Clumsiness"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -11339,12 +16839,14 @@
 						]
 					},
 					"categories": [
-						"Mind Control"
+						"Bardic",
+						"Mind Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "45c09e6f-5359-4b85-8fd8-d5c15afa59ae",
+					"id": "e2615cd7-4630-460b-8c28-e43e0d13a08e",
 					"name": "Dull @Sense@",
 					"reference": "DFS54",
 					"difficulty": "iq/h",
@@ -11353,18 +16855,47 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "HT",
 					"casting_cost": "1/2 pts decrease",
 					"maintenance_cost": "Half",
 					"casting_time": "1 sec",
 					"duration": "30 min",
 					"points": 1,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Bardic Talent"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							}
+						]
+					},
 					"categories": [
-						"Mind Control"
+						"Bardic",
+						"Mind Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "8c26275b-0978-419e-b834-f1ee2f1ca990",
+					"id": "6cd0a642-9425-4152-a9c7-c2d323a3ce4a",
 					"name": "Dull Hearing",
 					"reference": "DFS54",
 					"difficulty": "iq/h",
@@ -11373,18 +16904,47 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "HT",
 					"casting_cost": "1/2 pts decrease",
 					"maintenance_cost": "Half",
 					"casting_time": "1 sec",
 					"duration": "30 min",
 					"points": 1,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Bardic Talent"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							}
+						]
+					},
 					"categories": [
-						"Mind Control"
+						"Bardic",
+						"Mind Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "8580f11a-da07-40fd-a177-bc09a19f1fc6",
+					"id": "56dd15a0-8fab-4ad8-a28b-b7708806e402",
 					"name": "Dull Taste and Smell",
 					"reference": "DFS54",
 					"difficulty": "iq/h",
@@ -11393,18 +16953,47 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "HT",
 					"casting_cost": "1/2 pts decrease",
 					"maintenance_cost": "Half",
 					"casting_time": "1 sec",
 					"duration": "30 min",
 					"points": 1,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Bardic Talent"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							}
+						]
+					},
 					"categories": [
-						"Mind Control"
+						"Bardic",
+						"Mind Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "d1d6a7e8-581b-40c9-a705-9b04af75fbb9",
+					"id": "330642ce-46c9-436e-a6ed-0a471de81570",
 					"name": "Dull Touch",
 					"reference": "DFS54",
 					"difficulty": "iq/h",
@@ -11413,18 +17002,47 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "HT",
 					"casting_cost": "1/2 pts decrease",
 					"maintenance_cost": "Half",
 					"casting_time": "1 sec",
 					"duration": "30 min",
 					"points": 1,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Bardic Talent"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							}
+						]
+					},
 					"categories": [
-						"Mind Control"
+						"Bardic",
+						"Mind Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "093a5c51-d839-40f7-8d70-f03edd606061",
+					"id": "f83ac66f-9a33-44ab-9c58-9ba27f519c17",
 					"name": "Dull Vision",
 					"reference": "DFS54",
 					"difficulty": "iq/h",
@@ -11433,18 +17051,47 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "HT",
 					"casting_cost": "1/2 pts decrease",
 					"maintenance_cost": "Half",
 					"casting_time": "1 sec",
 					"duration": "30 min",
 					"points": 1,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Bardic Talent"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							}
+						]
+					},
 					"categories": [
-						"Mind Control"
+						"Bardic",
+						"Mind Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "49cc74ff-9d0c-4a31-bbc0-e24d56854608",
+					"id": "3d7066a5-5c4f-4412-a291-6d01f3526244",
 					"name": "Dullness",
 					"reference": "DFS54",
 					"difficulty": "iq/vh",
@@ -11453,6 +17100,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "HT",
 					"casting_cost": "2/pt decrease",
 					"maintenance_cost": "Half",
 					"casting_time": "1 sec",
@@ -11463,12 +17111,34 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										}
+									}
+								]
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "starts_with",
-									"qualifier": "dull"
+									"qualifier": "Dull "
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -11478,12 +17148,14 @@
 						]
 					},
 					"categories": [
-						"Mind Control"
+						"Bardic",
+						"Mind Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "539a465e-0d48-45fc-aba2-238f97f39af4",
+					"id": "5e8bab72-6a2c-479b-ac68-d35069b5f300",
 					"name": "Earth to Air",
 					"reference": "DFS16",
 					"difficulty": "iq/h",
@@ -11503,12 +17175,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "shape earth"
+									"qualifier": "Shape Earth"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -11521,7 +17201,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "create air"
+									"qualifier": "Create Air"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -11532,12 +17212,13 @@
 					},
 					"categories": [
 						"Air",
-						"Earth"
+						"Earth",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "52bcdd8f-e484-4347-a0c4-e84ca5a90543",
+					"id": "e423138e-b6f3-4723-a714-648a68060086",
 					"name": "Earth to Stone",
 					"reference": "DFS27",
 					"difficulty": "iq/h",
@@ -11556,42 +17237,16 @@
 						"all": true,
 						"prereqs": [
 							{
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 1
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
-										}
-									},
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 1
-										},
-										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (earth)"
-										}
-									}
-								]
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
 							},
 							{
 								"type": "spell_prereq",
@@ -11599,7 +17254,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "shape earth"
+									"qualifier": "Shape Earth"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -11609,12 +17264,13 @@
 						]
 					},
 					"categories": [
-						"Earth"
+						"Earth",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "47d184a9-a153-40a0-9b4d-32b3197ead99",
+					"id": "74dd33a7-58ed-4849-98ee-3c69cf2bd5cc",
 					"name": "Earth Vision",
 					"reference": "DFS27",
 					"difficulty": "iq/h",
@@ -11622,7 +17278,7 @@
 						"Earth",
 						"Knowledge"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Druidic@",
 					"spell_class": "Regular",
 					"casting_cost": "2/10 yds#",
 					"maintenance_cost": "Same",
@@ -11631,95 +17287,57 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "shape earth"
+									"qualifier": "Power Investiture (Druidic)"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
-									"qualifier": 1
-								}
-							}
-						]
-					},
-					"categories": [
-						"Earth",
-						"Knowledge"
-					]
-				},
-				{
-					"type": "spell",
-					"id": "86a548a5-bcd6-4bec-9d3f-2737fedb4425",
-					"name": "Entombment",
-					"reference": "DFS27",
-					"difficulty": "iq/h",
-					"college": [
-						"Earth"
-					],
-					"power_source": "Arcane",
-					"spell_class": "Regular",
-					"casting_cost": "10#",
-					"maintenance_cost": "-",
-					"casting_time": "3 sec",
-					"duration": "Permanent",
-					"points": 1,
-					"prereqs": {
-						"type": "prereq_list",
-						"all": true,
-						"prereqs": [
-							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "college",
-								"qualifier": {
-									"compare": "contains",
-									"qualifier": "Earth"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 5
+									"qualifier": 3
 								}
 							},
 							{
 								"type": "prereq_list",
-								"all": false,
+								"all": true,
 								"prereqs": [
 									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 2
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
-										}
+										"type": "prereq_list",
+										"all": false,
+										"prereqs": [
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Bardic Talent"
+												}
+											}
+										]
 									},
 									{
-										"type": "advantage_prereq",
+										"type": "spell_prereq",
 										"has": true,
-										"name": {
+										"sub_type": "name",
+										"qualifier": {
 											"compare": "is",
-											"qualifier": "magery"
+											"qualifier": "Shape Earth"
 										},
-										"level": {
+										"quantity": {
 											"compare": "at_least",
-											"qualifier": 2
-										},
-										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (earth)"
+											"qualifier": 1
 										}
 									}
 								]
@@ -11727,19 +17345,94 @@
 						]
 					},
 					"categories": [
-						"Earth"
+						"Druidic",
+						"Earth",
+						"Knowledge",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "53b7b7e2-ece3-4189-8a3e-b26b5147b473",
+					"id": "015d16bf-3e36-4bd4-8cbe-af44fa08d044",
+					"name": "Entombment",
+					"reference": "DFS27",
+					"difficulty": "iq/h",
+					"college": [
+						"Earth"
+					],
+					"power_source": "@Power Source: Arcane/Druidic@",
+					"spell_class": "Regular",
+					"resist": "HT",
+					"casting_cost": "10#",
+					"maintenance_cost": "-",
+					"casting_time": "3 sec",
+					"duration": "Permanent",
+					"points": 1,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture (Druidic)"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 5
+								}
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "college",
+										"qualifier": {
+											"compare": "contains",
+											"qualifier": "Earth"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 5
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 2
+										}
+									}
+								]
+							}
+						]
+					},
+					"categories": [
+						"Druidic",
+						"Earth",
+						"Wizardly"
+					]
+				},
+				{
+					"type": "spell",
+					"id": "db3df098-f8ef-4072-a973-0db99692a6f2",
 					"name": "Entrap Spirit",
 					"reference": "DFS60",
 					"difficulty": "iq/h",
 					"college": [
 						"Necromancy"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical@",
 					"spell_class": "Special",
 					"casting_cost": "Varies",
 					"maintenance_cost": "Varies",
@@ -11748,52 +17441,48 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "college",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "necromancy"
+									"qualifier": "Power Invesiture"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
-									"qualifier": 7
-								}
-							},
-							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "turn spirit"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": 5
 								}
 							},
 							{
 								"type": "prereq_list",
-								"all": false,
+								"all": true,
 								"prereqs": [
 									{
-										"type": "advantage_prereq",
+										"type": "spell_prereq",
 										"has": true,
-										"name": {
+										"sub_type": "name",
+										"qualifier": {
 											"compare": "is",
-											"qualifier": "magery"
+											"qualifier": "Turn Spirit"
 										},
-										"level": {
+										"quantity": {
 											"compare": "at_least",
 											"qualifier": 1
-										},
-										"notes": {
+										}
+									},
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "college",
+										"qualifier": {
 											"compare": "contains",
-											"qualifier": "one college (necromancy)"
+											"qualifier": "Necromancy"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 7
 										}
 									},
 									{
@@ -11801,15 +17490,11 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "magery"
+											"qualifier": "Magery"
 										},
 										"level": {
 											"compare": "at_least",
 											"qualifier": 1
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
 										}
 									}
 								]
@@ -11817,19 +17502,21 @@
 						]
 					},
 					"categories": [
-						"Necromancy"
+						"Clerical",
+						"Necromancy",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "09578399-14ad-4925-8200-fd4bf10f036c",
+					"id": "837f7e85-d29f-40ee-ab19-23c20e99c9d8",
 					"name": "Essential Food",
 					"reference": "DFS32",
-					"difficulty": "iq/h",
+					"difficulty": "iq/vh",
 					"college": [
 						"Food"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical@",
 					"spell_class": "Regular",
 					"casting_cost": "6",
 					"maintenance_cost": "-",
@@ -11838,43 +17525,71 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "college",
-								"qualifier": {
-									"compare": "contains",
-									"qualifier": "Food"
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
-									"qualifier": 6
+									"qualifier": 4
 								}
 							},
 							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "create food"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Create Food"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "college",
+										"qualifier": {
+											"compare": "contains",
+											"qualifier": "Food"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 6
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Food"
+						"Clerical",
+						"Food",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "1e86cfd3-7aad-4ce9-9850-17e0a946909c",
+					"id": "4148e854-61c2-418b-877c-55996839d443",
 					"name": "Ethereal Body",
 					"reference": "DFS57",
 					"difficulty": "iq/vh",
@@ -11893,67 +17608,40 @@
 						"all": true,
 						"prereqs": [
 							{
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 3
-										},
-										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (movement)"
-										}
-									},
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 3
-										}
-									}
-								]
+								"type": "spell_prereq",
+								"has": true,
+								"sub_type": "college",
+								"qualifier": {
+									"compare": "contains",
+									"qualifier": "Movement"
+								},
+								"quantity": {
+									"compare": "at_least",
+									"qualifier": 6
+								}
 							},
 							{
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "spell_prereq",
-										"has": true,
-										"sub_type": "college",
-										"qualifier": {
-											"compare": "contains",
-											"qualifier": "Movement"
-										},
-										"quantity": {
-											"compare": "at_least",
-											"qualifier": 6
-										}
-									}
-								]
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								}
 							}
 						]
 					},
 					"categories": [
-						"Movement"
+						"Movement",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "0e7fc643-56ef-4805-a969-68eff81a3c8f",
+					"id": "5f85ec1b-3d31-4155-98f0-6401e9c29488",
 					"name": "Explosive Fireball",
 					"reference": "DFS29",
 					"difficulty": "iq/h",
@@ -11990,6 +17678,11 @@
 									"type": "skill",
 									"name": "Innate Attack",
 									"specialization": "Projectile"
+								},
+								{
+									"type": "skill",
+									"name": "Innate Attack",
+									"modifier": -2
 								}
 							]
 						}
@@ -11999,12 +17692,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "fireball"
+									"qualifier": "Fireball"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -12014,12 +17715,13 @@
 						]
 					},
 					"categories": [
-						"Fire"
+						"Fire",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "3a31ca07-4f00-4515-b9b4-bce48c675798",
+					"id": "9a264766-f1df-4539-8d97-eb28db0278bf",
 					"name": "Explosive Lightning",
 					"reference": "DFS71",
 					"difficulty": "iq/h",
@@ -12066,12 +17768,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "lightning"
+									"qualifier": "Lightning"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -12082,20 +17792,21 @@
 					},
 					"categories": [
 						"Air",
-						"Weather"
+						"Weather",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "20476f1c-2fc9-42bb-8a38-e962900e6a23",
+					"id": "d5ed49f2-fc6b-48ae-80fe-ba60cf1b0e54",
 					"name": "Extinguish Fire",
 					"reference": "DFS30",
 					"difficulty": "iq/h",
 					"college": [
 						"Fire"
 					],
-					"power_source": "Arcane",
-					"spell_class": "Regular",
+					"power_source": "@Power Source: Arcane/Druidic@",
+					"spell_class": "Area",
 					"casting_cost": "3",
 					"maintenance_cost": "-",
 					"casting_time": "1 sec",
@@ -12103,30 +17814,58 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "ignite fire"
+									"qualifier": "Power Investiture (Druidic)"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
 									"qualifier": 1
 								}
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Ignite Fire"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Fire"
+						"Druidic",
+						"Fire",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "8ecbac57-1b85-46f3-a460-987ef410b2ec",
+					"id": "4df5e624-2b82-4bce-882f-9738049f83e0",
 					"name": "Far-Feeling",
 					"reference": "DFS43",
 					"difficulty": "iq/h",
@@ -12171,12 +17910,14 @@
 						]
 					},
 					"categories": [
-						"Knowledge"
+						"Bardic",
+						"Knowledge",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "fb78e245-bed9-4674-8679-99c8fb17247a",
+					"id": "f969bb50-5442-448e-983e-ce051f7ad1c1",
 					"name": "Far-Hearing",
 					"reference": "DFS66",
 					"difficulty": "iq/h",
@@ -12217,7 +17958,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "bardic talent"
+											"qualifier": "Bardic Talent"
 										},
 										"level": {
 											"compare": "at_least",
@@ -12229,15 +17970,11 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "magery"
+											"qualifier": "Magery"
 										},
 										"level": {
 											"compare": "at_least",
 											"qualifier": 1
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
 										}
 									}
 								]
@@ -12245,12 +17982,15 @@
 						]
 					},
 					"categories": [
-						"Sound"
+						"Bardic",
+						"Knowledge",
+						"Sound",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "69061ad5-1f0e-479f-bfa9-011a2b3149c4",
+					"id": "699a5833-4494-442b-9085-4f8841e2a43e",
 					"name": "Far-Tasting",
 					"reference": "DFS32",
 					"difficulty": "iq/h",
@@ -12270,23 +18010,17 @@
 						"all": true,
 						"prereqs": [
 							{
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "spell_prereq",
-										"has": true,
-										"sub_type": "name",
-										"qualifier": {
-											"compare": "is",
-											"qualifier": "seek food"
-										},
-										"quantity": {
-											"compare": "at_least",
-											"qualifier": 1
-										}
-									}
-								]
+								"type": "spell_prereq",
+								"has": true,
+								"sub_type": "name",
+								"qualifier": {
+									"compare": "is",
+									"qualifier": "Seek Food"
+								},
+								"quantity": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
 							},
 							{
 								"type": "prereq_list",
@@ -12297,7 +18031,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "bardic talent"
+											"qualifier": "Bardic Talent"
 										},
 										"level": {
 											"compare": "at_least",
@@ -12312,15 +18046,11 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "magery"
+											"qualifier": "Magery"
 										},
 										"level": {
 											"compare": "at_least",
 											"qualifier": 1
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
 										}
 									}
 								]
@@ -12328,13 +18058,15 @@
 						]
 					},
 					"categories": [
+						"Bardic",
 						"Food",
-						"Knowledge"
+						"Knowledge",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "1a944a87-70bf-4bd8-a05e-a43ab049b117",
+					"id": "f2fe35f3-5d91-4518-a72e-2a89871d0286",
 					"name": "Fascinate",
 					"reference": "DFS54",
 					"difficulty": "iq/h",
@@ -12343,6 +18075,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular/Blocking",
+					"resist": "Will",
 					"casting_cost": "4",
 					"maintenance_cost": "-",
 					"casting_time": "1 sec",
@@ -12353,12 +18086,34 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										}
+									}
+								]
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "daze"
+									"qualifier": "Daze"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -12368,12 +18123,14 @@
 						]
 					},
 					"categories": [
-						"Mind Control"
+						"Bardic",
+						"Mind Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "59b4dd32-0465-454c-8db1-1d7a1950bf3f",
+					"id": "d03627a2-7661-4275-a59a-02ba1dc3725c",
 					"name": "Fasten",
 					"reference": "DFS48",
 					"difficulty": "iq/h",
@@ -12382,6 +18139,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "Special",
 					"casting_cost": "3 or 4",
 					"maintenance_cost": "-",
 					"casting_time": "1 sec",
@@ -12392,12 +18150,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "knot"
+									"qualifier": "Knot"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -12407,12 +18173,13 @@
 						]
 					},
 					"categories": [
-						"Making & Breaking"
+						"Making & Breaking",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "3cce98a1-e5b5-4abe-bfc0-d71e8cf6dabc",
+					"id": "8da78876-4ede-46d6-831a-aec8a9726561",
 					"name": "Fear",
 					"reference": "DFS54",
 					"difficulty": "iq/h",
@@ -12421,6 +18188,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Area",
+					"resist": "Will",
 					"casting_cost": "1",
 					"maintenance_cost": "-",
 					"casting_time": "1 sec",
@@ -12428,15 +18196,37 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": false,
+						"all": true,
 						"prereqs": [
+							{
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										}
+									}
+								]
+							},
 							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "sense emotion"
+									"qualifier": "Sense Emotion"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -12446,19 +18236,21 @@
 						]
 					},
 					"categories": [
-						"Mind Control"
+						"Bardic",
+						"Mind Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "dc83582e-2772-4ffe-9eee-4708fe6d5313",
+					"id": "923ce267-a512-4340-b0a9-ab00ddadebdf",
 					"name": "Find Direction",
 					"reference": "DFS43",
 					"difficulty": "iq/h",
 					"college": [
 						"Knowledge"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Druidic@",
 					"spell_class": "Info",
 					"casting_cost": "2",
 					"maintenance_cost": "-",
@@ -12474,7 +18266,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "bardic talent"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -12486,7 +18278,19 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "magery"
+									"qualifier": "Bardic Talent"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
 								},
 								"level": {
 									"compare": "at_least",
@@ -12496,12 +18300,15 @@
 						]
 					},
 					"categories": [
-						"Knowledge"
+						"Bardic",
+						"Druidic",
+						"Knowledge",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "1dca0829-2333-4af3-a6c7-f2a555231a0e",
+					"id": "4af9342f-a742-4782-a2b5-a3f10bc87152",
 					"name": "Find Weakness",
 					"reference": "DFS49",
 					"difficulty": "iq/h",
@@ -12519,6 +18326,14 @@
 						"type": "prereq_list",
 						"all": true,
 						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
 							{
 								"type": "spell_prereq",
 								"has": true,
@@ -12574,12 +18389,13 @@
 						]
 					},
 					"categories": [
-						"Making & Breaking"
+						"Making & Breaking",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "5a2775a9-4d9d-44ff-8352-dd0950a3c6ec",
+					"id": "622dbce2-ad16-4045-b07b-6c87cde2e2d5",
 					"name": "Fire Cloud",
 					"reference": "DFS30",
 					"difficulty": "iq/h",
@@ -12616,12 +18432,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "fireball"
+									"qualifier": "Fireball"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -12634,7 +18458,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "shape air"
+									"qualifier": "Shape Air"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -12644,12 +18468,13 @@
 						]
 					},
 					"categories": [
-						"Fire"
+						"Fire",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "d0af584a-be2f-4a6d-af5d-ac989c56d9d3",
+					"id": "c3eb6897-38f2-428a-a116-c853f9f61034",
 					"name": "Fireball",
 					"reference": "DFS30",
 					"difficulty": "iq/h",
@@ -12695,42 +18520,16 @@
 						"all": true,
 						"prereqs": [
 							{
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 1
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
-										}
-									},
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 1
-										},
-										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (fire)"
-										}
-									}
-								]
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
 							},
 							{
 								"type": "spell_prereq",
@@ -12738,7 +18537,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "shape fire"
+									"qualifier": "Create Fire"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -12751,7 +18550,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "create fire"
+									"qualifier": "Shape Fire"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -12761,19 +18560,20 @@
 						]
 					},
 					"categories": [
-						"Fire"
+						"Fire",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "50ee3b51-b3bf-4eb8-89e0-e15bac6cc5bc",
+					"id": "c954a248-5e4d-48da-bf49-5b03188ca320",
 					"name": "Fireproof",
 					"reference": "DFS30",
 					"difficulty": "iq/h",
 					"college": [
 						"Fire"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Druidic@",
 					"spell_class": "Area",
 					"casting_cost": "3#",
 					"maintenance_cost": "Same",
@@ -12782,30 +18582,58 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "extinguish fire"
+									"qualifier": "Power Investiture (Druidic)"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": 2
 								}
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Extinguish Fire"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Fire"
+						"Druidic",
+						"Fire",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "4a8b92e0-bd53-423c-8ca5-109153ffe917",
+					"id": "4d97e30d-569c-4910-a396-b5edeea64364",
 					"name": "Flame Jet",
 					"reference": "DFS30",
 					"difficulty": "iq/h",
@@ -12858,6 +18686,14 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
@@ -12886,12 +18722,13 @@
 						]
 					},
 					"categories": [
-						"Fire"
+						"Fire",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "27afe383-cff1-4344-86fe-8549021131a9",
+					"id": "685c2fa3-2805-42d3-ad2f-a5dab47a84ce",
 					"name": "Flaming Missiles",
 					"reference": "DFS30",
 					"difficulty": "iq/h",
@@ -12910,12 +18747,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "flaming weapon"
+									"qualifier": "Flaming Weapon"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -12926,19 +18771,20 @@
 					},
 					"notes": "+2 points burn damage with missiles fired from weapon",
 					"categories": [
-						"Fire"
+						"Fire",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "229c3bd3-4095-4220-8d1a-21445eedfad9",
+					"id": "f47036da-e422-4bcb-a749-4769e5753ca2",
 					"name": "Flaming Weapon",
 					"reference": "DFS31",
 					"difficulty": "iq/h",
 					"college": [
 						"Fire"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical@",
 					"spell_class": "Regular",
 					"casting_cost": "4",
 					"maintenance_cost": "1",
@@ -12947,26 +18793,35 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								}
+							},
+							{
 								"type": "prereq_list",
-								"all": false,
+								"all": true,
 								"prereqs": [
 									{
-										"type": "advantage_prereq",
+										"type": "spell_prereq",
 										"has": true,
-										"name": {
+										"sub_type": "name",
+										"qualifier": {
 											"compare": "is",
-											"qualifier": "magery"
+											"qualifier": "Heat"
 										},
-										"level": {
+										"quantity": {
 											"compare": "at_least",
-											"qualifier": 2
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
+											"qualifier": 1
 										}
 									},
 									{
@@ -12974,42 +18829,27 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "magery"
+											"qualifier": "Magery"
 										},
 										"level": {
 											"compare": "at_least",
 											"qualifier": 2
-										},
-										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (fire)"
 										}
 									}
 								]
-							},
-							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "heat"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
 							}
 						]
 					},
 					"notes": "+2 points burn damage from attacks with melee weapon",
 					"categories": [
-						"Fire"
+						"Clerical",
+						"Fire",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "dc5b1e94-bb19-4402-8517-4a3df7c4ebfa",
+					"id": "75dcb78e-da96-4e9e-ab36-7539a7d3bea8",
 					"name": "Flesh to Stone",
 					"reference": "DFS27",
 					"difficulty": "iq/h",
@@ -13018,6 +18858,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "HT",
 					"casting_cost": "10#",
 					"maintenance_cost": "-",
 					"casting_time": "2 sec",
@@ -13028,12 +18869,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "earth to stone"
+									"qualifier": "Earth to Stone"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -13043,12 +18892,13 @@
 						]
 					},
 					"categories": [
-						"Earth"
+						"Earth",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "77f0d32d-60eb-4886-851a-e496a9a5df7c",
+					"id": "43085b3f-9664-4bb0-a5d2-4e0f222b7242",
 					"name": "Flight",
 					"reference": "DFS57",
 					"difficulty": "iq/vh",
@@ -13067,42 +18917,16 @@
 						"all": true,
 						"prereqs": [
 							{
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 2
-										},
-										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (movement)"
-										}
-									},
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 2
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
-										}
-									}
-								]
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								}
 							},
 							{
 								"type": "spell_prereq",
@@ -13110,7 +18934,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "levitation"
+									"qualifier": "Levitation"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -13120,12 +18944,13 @@
 						]
 					},
 					"categories": [
-						"Movement"
+						"Movement",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "a55574c1-2709-4bb8-8bad-e80dde57af8e",
+					"id": "871a3c87-a859-45fc-ba7e-2863a09c7a69",
 					"name": "Foolishness",
 					"reference": "DFS54",
 					"difficulty": "iq/h",
@@ -13134,6 +18959,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "Will",
 					"casting_cost": "1-5",
 					"maintenance_cost": "Half",
 					"casting_time": "1 sec",
@@ -13143,6 +18969,32 @@
 						"type": "prereq_list",
 						"all": true,
 						"prereqs": [
+							{
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									}
+								]
+							},
 							{
 								"type": "attribute_prereq",
 								"has": true,
@@ -13155,12 +19007,14 @@
 						]
 					},
 					"categories": [
-						"Mind Control"
+						"Bardic",
+						"Mind Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "757f6e3e-bd77-430a-bf1f-e66927fc634a",
+					"id": "4ae3e19a-20de-4eba-9f8c-dc11df08d221",
 					"name": "Forgetfulness",
 					"reference": "DFS54",
 					"difficulty": "iq/h",
@@ -13169,6 +19023,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "Will or skill",
 					"casting_cost": "3",
 					"maintenance_cost": "3",
 					"casting_time": "10 sec",
@@ -13184,7 +19039,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "foolishness"
+									"qualifier": "Foolishness"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -13200,7 +19055,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "bardic talent"
+											"qualifier": "Bardic Talent"
 										},
 										"level": {
 											"compare": "at_least",
@@ -13212,15 +19067,11 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "magery"
+											"qualifier": "Magery"
 										},
 										"level": {
 											"compare": "at_least",
 											"qualifier": 1
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
 										}
 									}
 								]
@@ -13228,12 +19079,14 @@
 						]
 					},
 					"categories": [
-						"Mind Control"
+						"Bardic",
+						"Mind Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "27201ffd-25a9-4922-84d3-efbe5244ec56",
+					"id": "e972b45f-7c80-4b01-974b-6398584d4a15",
 					"name": "Frailty",
 					"reference": "DFS21",
 					"difficulty": "iq/h",
@@ -13242,6 +19095,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "HT",
 					"casting_cost": "2/-HT",
 					"maintenance_cost": "Same",
 					"casting_time": "1 sec",
@@ -13252,12 +19106,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "lend energy"
+									"qualifier": "Lend Energy"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -13267,19 +19129,20 @@
 						]
 					},
 					"categories": [
-						"Body Control"
+						"Body Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "fb8f7269-baf8-445d-9af5-85c624264cd5",
+					"id": "72c2f94d-ab42-4d98-9d18-f24d06466f99",
 					"name": "Freeze",
 					"reference": "DFS68",
 					"difficulty": "iq/h",
 					"college": [
 						"Water"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Druidic@",
 					"spell_class": "Regular",
 					"casting_cost": "Varies",
 					"maintenance_cost": "-",
@@ -13288,38 +19151,67 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "shape water"
+									"qualifier": "Power Investiture (Druidic)"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": 3
 								}
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Shape Water"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Water"
+						"Druidic",
+						"Water",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "d3c176f1-63b9-4fc9-b0c1-a5f39631a583",
+					"id": "e775232a-90ed-4035-9962-4444609a569c",
 					"name": "Frostbite",
 					"reference": "DFS69",
 					"difficulty": "iq/h",
 					"college": [
 						"Water"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Druidic@",
 					"spell_class": "Regular",
+					"resist": "HT",
 					"casting_cost": "1-3",
 					"maintenance_cost": "-",
 					"casting_time": "3 sec",
@@ -13344,43 +19236,71 @@
 					],
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "cold"
+									"qualifier": "Power Investiture (Druidic)"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": 4
 								}
 							},
 							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "frost"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Cold"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Freeze"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Water"
+						"Druidic",
+						"Water",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "8d129753-5500-403d-b60e-29bf20dcfbd4",
+					"id": "6961b8dd-889d-48b5-9954-3ad75129ad3c",
 					"name": "Garble",
 					"reference": "DFS66",
 					"difficulty": "iq/h",
@@ -13389,6 +19309,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "Will",
 					"casting_cost": "4",
 					"maintenance_cost": "2",
 					"casting_time": "1 sec",
@@ -13399,12 +19320,34 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										}
+									}
+								]
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "voices"
+									"qualifier": "Voices"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -13414,19 +19357,21 @@
 						]
 					},
 					"categories": [
-						"Sound"
+						"Bardic",
+						"Sound",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "fb65a8e1-6cd9-4f6f-89d8-f4198acc6b86",
+					"id": "e8a395ef-d0f5-4d0a-8773-0630985160a9",
 					"name": "Gift of Letters",
 					"reference": "DFS24",
 					"difficulty": "iq/vh",
 					"college": [
 						"Communication & Empathy"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical@",
 					"spell_class": "Regular",
 					"casting_cost": "6",
 					"maintenance_cost": "3",
@@ -13435,12 +19380,37 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 4
+								}
+							},
 							{
 								"type": "prereq_list",
 								"all": true,
 								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Borrow Language"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
 									{
 										"type": "advantage_prereq",
 										"has": true,
@@ -13453,57 +19423,61 @@
 										"type": "advantage_prereq",
 										"has": true,
 										"name": {
-											"compare": "starts_with",
+											"compare": "is",
 											"qualifier": "Language"
-										},
-										"notes": {
-											"compare": "contains",
-											"qualifier": "Written"
 										}
 									},
 									{
 										"type": "advantage_prereq",
 										"has": true,
 										"name": {
-											"compare": "starts_with",
+											"compare": "is",
 											"qualifier": "Language"
-										},
-										"notes": {
-											"compare": "contains",
-											"qualifier": "Written"
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": false,
+										"prereqs": [
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Bardic Talent"
+												}
+											}
+										]
 									}
 								]
-							},
-							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "borrow language"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
 							}
 						]
 					},
 					"categories": [
-						"Communication"
+						"Bardic",
+						"Clerical",
+						"Communication & Empathy",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "cd9e12a1-d4dc-4f59-9c41-fe5cbbf9d60f",
+					"id": "b5435b6a-7de9-4332-913c-2452d58e64f5",
 					"name": "Gift of Tongues",
 					"reference": "DFS24",
 					"difficulty": "iq/vh",
 					"college": [
 						"Communication & Empathy"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical@",
 					"spell_class": "Regular",
 					"casting_cost": "6",
 					"maintenance_cost": "3",
@@ -13512,12 +19486,37 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 4
+								}
+							},
 							{
 								"type": "prereq_list",
 								"all": true,
 								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Borrow Language"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
 									{
 										"type": "advantage_prereq",
 										"has": true,
@@ -13530,50 +19529,54 @@
 										"type": "advantage_prereq",
 										"has": true,
 										"name": {
-											"compare": "starts_with",
+											"compare": "is",
 											"qualifier": "Language"
-										},
-										"notes": {
-											"compare": "contains",
-											"qualifier": "Spoken"
 										}
 									},
 									{
 										"type": "advantage_prereq",
 										"has": true,
 										"name": {
-											"compare": "starts_with",
+											"compare": "is",
 											"qualifier": "Language"
-										},
-										"notes": {
-											"compare": "contains",
-											"qualifier": "Spoken"
 										}
+									},
+									{
+										"type": "prereq_list",
+										"all": false,
+										"prereqs": [
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Bardic Talent"
+												}
+											}
+										]
 									}
 								]
-							},
-							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "borrow language"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
 							}
 						]
 					},
 					"categories": [
-						"Communication"
+						"Bardic",
+						"Clerical",
+						"Communication & Empathy",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "0d761851-2941-432f-828d-63f8ba665b4e",
+					"id": "fa668100-6b29-4c00-a235-d7db54021143",
 					"name": "Glass Wall",
 					"reference": "DFS43",
 					"difficulty": "iq/h",
@@ -13589,50 +19592,80 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": false,
+						"all": true,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "college",
-								"qualifier": {
-									"compare": "contains",
-									"qualifier": "Knowledge"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 5
-								}
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										}
+									}
+								]
 							},
 							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "earth vision"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Earth Vision"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "college",
+										"qualifier": {
+											"compare": "contains",
+											"qualifier": "Knowledge"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 5
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Knowledge"
+						"Bardic",
+						"Knowledge",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "4aae7790-b55b-4c00-9b0e-32b287ad5d5c",
+					"id": "8b5f27a4-7a56-4fca-81eb-bdf19ed299ff",
 					"name": "Glow",
 					"reference": "DFS46",
 					"difficulty": "iq/h",
 					"college": [
 						"Light & Darkness"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical@",
 					"spell_class": "Area",
 					"casting_cost": "Varies",
 					"maintenance_cost": "-",
@@ -13641,30 +19674,58 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "continual light"
+									"qualifier": "Power Investiture"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": 2
 								}
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Continual Light"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Light"
+						"Clerical",
+						"Light & Darkness",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "3cb27828-5fad-4a88-a383-48c1b8aa8465",
+					"id": "0f4de55e-a9b0-4986-a7bf-dd2f430cdaeb",
 					"name": "Glue",
 					"reference": "DFS57",
 					"difficulty": "iq/h",
@@ -13673,6 +19734,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Area",
+					"resist": "ST",
 					"casting_cost": "3",
 					"maintenance_cost": "Same",
 					"casting_time": "1 sec",
@@ -13683,12 +19745,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "haste"
+									"qualifier": "Haste"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -13698,12 +19768,13 @@
 						]
 					},
 					"categories": [
-						"Movement"
+						"Movement",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "b8007038-4cb3-42c0-b10e-5381510291f1",
+					"id": "6365926c-f277-44eb-bca1-c6a0af5da9e0",
 					"name": "Grace",
 					"reference": "DFS21",
 					"difficulty": "iq/h",
@@ -13722,12 +19793,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "clumsiness"
+									"qualifier": "Clumsiness"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -13737,12 +19816,13 @@
 						]
 					},
 					"categories": [
-						"Body Control"
+						"Body Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "7784c431-dcf4-432f-9603-236bde148adf",
+					"id": "6a2592e7-e3f4-4850-9c18-a2fdea3fbcdd",
 					"name": "Grease",
 					"reference": "DFS57",
 					"difficulty": "iq/h",
@@ -13761,12 +19841,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "haste"
+									"qualifier": "Haste"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -13776,12 +19864,13 @@
 						]
 					},
 					"categories": [
-						"Movement"
+						"Movement",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "49fa8301-6cc6-4cd0-8525-ec5eba67e76f",
+					"id": "9c5d135f-0bba-4573-b220-f37f3c0be849",
 					"name": "Great Haste",
 					"reference": "DFS57",
 					"difficulty": "iq/vh",
@@ -13800,12 +19889,24 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "haste"
+									"qualifier": "Haste"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -13820,61 +19921,24 @@
 									"compare": "at_least",
 									"qualifier": 12
 								}
-							},
-							{
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 1
-										},
-										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (movement)"
-										}
-									},
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 1
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
-										}
-									}
-								]
 							}
 						]
 					},
 					"categories": [
-						"Movement"
+						"Movement",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "7a329613-3695-4747-b8f4-96486670f42c",
+					"id": "b93387e1-6708-48e4-8155-6eb477c8bd3c",
 					"name": "Great Voice",
 					"reference": "DFS66",
 					"difficulty": "iq/h",
 					"college": [
 						"Sound"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical@",
 					"spell_class": "Regular",
 					"casting_cost": "3",
 					"maintenance_cost": "1",
@@ -13883,43 +19947,86 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "thunderclap"
+									"qualifier": "Power Investiture"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": 2
 								}
 							},
 							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "voices"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Thunderclap"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Voices"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "prereq_list",
+										"all": false,
+										"prereqs": [
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Bardic Talent"
+												}
+											}
+										]
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Sound"
+						"Bardic",
+						"Clerical",
+						"Sound",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "6755906f-4411-4298-bc51-a09e7f96dad4",
+					"id": "8c68db14-0389-4128-aed0-11973790c0aa",
 					"name": "Great Ward",
 					"reference": "DFS51",
 					"difficulty": "iq/h",
@@ -13928,6 +20035,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Blocking",
+					"resist": "Subject spell",
 					"casting_cost": "1/subject",
 					"maintenance_cost": "-",
 					"casting_time": "1 sec",
@@ -13938,65 +20046,40 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "ward"
+									"qualifier": "Ward"
 								},
 								"quantity": {
 									"compare": "at_least",
 									"qualifier": 1
 								}
-							},
-							{
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 2
-										},
-										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (meta)"
-										}
-									},
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 2
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
-										}
-									}
-								]
 							}
 						]
 					},
 					"categories": [
-						"Meta"
+						"Meta",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "adb13b60-1550-45a0-87d6-00913fc590ad",
+					"id": "0f2fbefe-6d08-48b5-8c2f-ce558f9cfb40",
 					"name": "Haste",
 					"reference": "DFS57",
 					"difficulty": "iq/h",
@@ -14010,20 +20093,35 @@
 					"casting_time": "2 sec",
 					"duration": "1 min",
 					"points": 1,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							}
+						]
+					},
 					"categories": [
-						"Movement"
+						"Movement",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "6e29411a-8d08-4512-a8ef-6cc5dfd61a81",
+					"id": "627605e1-da25-40f6-9b13-a54f59a8fa54",
 					"name": "Hawk Vision",
 					"reference": "DFS47",
 					"difficulty": "iq/h",
 					"college": [
 						"Light & Darkness"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Druidic@",
 					"spell_class": "Regular",
 					"casting_cost": "2/level",
 					"maintenance_cost": "Half",
@@ -14032,36 +20130,62 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture (Druidic)"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							},
+							{
 								"type": "prereq_list",
-								"all": false,
+								"all": true,
 								"prereqs": [
 									{
-										"type": "spell_prereq",
-										"has": true,
-										"sub_type": "name",
-										"qualifier": {
-											"compare": "is",
-											"qualifier": "keen vision"
-										},
-										"quantity": {
-											"compare": "at_least",
-											"qualifier": 1
-										}
+										"type": "prereq_list",
+										"all": false,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Keen Vision"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "college",
+												"qualifier": {
+													"compare": "contains",
+													"qualifier": "Light & Darkness"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 5
+												}
+											}
+										]
 									},
 									{
-										"type": "spell_prereq",
+										"type": "advantage_prereq",
 										"has": true,
-										"sub_type": "college",
-										"qualifier": {
-											"compare": "contains",
-											"qualifier": "Light"
-										},
-										"quantity": {
-											"compare": "at_least",
-											"qualifier": 5
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
 										}
 									}
 								]
@@ -14069,12 +20193,14 @@
 						]
 					},
 					"categories": [
-						"Light"
+						"Druidic",
+						"Light & Darkness",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "d36da9cc-4199-4a95-a674-66eae6853ac9",
+					"id": "d99a0664-c2de-4448-b451-1f2ebafbdcc1",
 					"name": "Heat",
 					"reference": "DFS31",
 					"difficulty": "iq/h",
@@ -14093,12 +20219,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "create fire"
+									"qualifier": "Create Fire"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -14111,7 +20245,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "shape fire"
+									"qualifier": "Shape Fire"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -14121,12 +20255,13 @@
 						]
 					},
 					"categories": [
-						"Fire"
+						"Fire",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "5087cac0-47e7-4317-93e3-328187d04af1",
+					"id": "cfaa2135-0393-48e0-87fd-55828e3654f5",
 					"name": "Hide",
 					"reference": "DFS47",
 					"difficulty": "iq/h",
@@ -14142,43 +20277,58 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": false,
+						"all": true,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "blur"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": "Magery"
 								}
 							},
 							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "forgetfulness"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Blur"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Forgetfulness"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Light"
+						"Light & Darkness",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "5fdd3389-7dfc-4dd6-9f77-27a3b99b1d18",
+					"id": "6b2fba84-0ee2-471f-825e-1b27b9ebfb4e",
 					"name": "Hide Emotion",
 					"reference": "DFS24",
 					"difficulty": "iq/h",
@@ -14197,12 +20347,34 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									}
+								]
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "sense emotion"
+									"qualifier": "Sense Emotion"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -14212,19 +20384,21 @@
 						]
 					},
 					"categories": [
-						"Communication"
+						"Bardic",
+						"Communication & Empathy",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "925295b0-69db-4027-9349-347329e7d6b7",
+					"id": "fb43cb03-52d0-4531-b9c4-3a2221d016ad",
 					"name": "Hide Thoughts",
 					"reference": "DFS25",
 					"difficulty": "iq/h",
 					"college": [
 						"Communication & Empathy"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical@",
 					"spell_class": "Regular",
 					"casting_cost": "3",
 					"maintenance_cost": "1",
@@ -14236,48 +20410,99 @@
 						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "truthsayer"
+									"qualifier": "Power Investiture"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": 2
 								}
 							},
 							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "hide emotion"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "prereq_list",
+										"all": false,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Truthsayer"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Hide Emotion"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											}
+										]
+									},
+									{
+										"type": "prereq_list",
+										"all": false,
+										"prereqs": [
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Bardic Talent"
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											}
+										]
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Communication"
+						"Bardic",
+						"Clerical",
+						"Communication & Empathy",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "e578f255-9dd2-4834-92f3-500cde7c9169",
+					"id": "85f89826-5a57-48c2-9ee0-0ea8b720515c",
 					"name": "Hinder",
 					"reference": "DFS21",
 					"difficulty": "iq/h",
 					"college": [
-						"Body Control"
+						"Body Control",
+						"Movement"
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "HT",
 					"casting_cost": "1-4",
 					"maintenance_cost": "Same",
 					"casting_time": "1 sec",
@@ -14285,43 +20510,59 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": false,
+						"all": true,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "clumsiness"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": "Magery"
 								}
 							},
 							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "haste"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Clumsiness"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Haste"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Body Control"
+						"Body Control",
+						"Movement",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "fa1dbfc1-8ef6-4211-b13d-04d3c243d13e",
+					"id": "d1928676-cd20-425d-9e87-f75232034fef",
 					"name": "History",
 					"reference": "DFS43",
 					"difficulty": "iq/h",
@@ -14339,12 +20580,34 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										}
+									}
+								]
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "trace"
+									"qualifier": "Trace"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -14354,12 +20617,14 @@
 						]
 					},
 					"categories": [
-						"Knowledge"
+						"Bardic",
+						"Knowledge",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "79ecf3d3-1f74-4d23-98a8-46c9173b9b2b",
+					"id": "7512505e-beff-4f77-a63a-01e811b1cf96",
 					"name": "Hold Breath",
 					"reference": "DFS21",
 					"difficulty": "iq/h",
@@ -14378,42 +20643,16 @@
 						"all": true,
 						"prereqs": [
 							{
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 1
-										},
-										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (body control)"
-										}
-									},
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 1
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
-										}
-									}
-								]
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
 							},
 							{
 								"type": "spell_prereq",
@@ -14421,7 +20660,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "vigor"
+									"qualifier": "Vigor"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -14431,12 +20670,13 @@
 						]
 					},
 					"categories": [
-						"Body Control"
+						"Body Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "e87ee4ff-471b-4516-b939-f4b300697c13",
+					"id": "f8bf69c7-9182-4ac7-8190-134fab7218a2",
 					"name": "Hush",
 					"reference": "DFS66",
 					"difficulty": "iq/h",
@@ -14445,6 +20685,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "Will",
 					"casting_cost": "2",
 					"maintenance_cost": "1",
 					"casting_time": "2 sec",
@@ -14455,12 +20696,34 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										}
+									}
+								]
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "silence"
+									"qualifier": "Silence"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -14470,12 +20733,14 @@
 						]
 					},
 					"categories": [
-						"Sound"
+						"Bardic",
+						"Sound",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "a5607a6d-3493-4f01-81fc-33693beeb5b6",
+					"id": "1796101d-3539-4acd-9d0a-78439445d0ad",
 					"name": "Ice Dagger",
 					"reference": "DFS69",
 					"difficulty": "iq/h",
@@ -14518,43 +20783,58 @@
 					],
 					"prereqs": {
 						"type": "prereq_list",
-						"all": false,
+						"all": true,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "water jet"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": "Magery"
 								}
 							},
 							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "ice sphere"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Ice Sphere"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Water Jet"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Water"
+						"Water",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "8435f28f-774b-4567-8aab-8e892d6e46c7",
+					"id": "0e1c34aa-9865-4ef7-9cc9-1ca3508a2deb",
 					"name": "Ice Sphere",
 					"reference": "DFS69",
 					"difficulty": "iq/h",
@@ -14600,12 +20880,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "shape water"
+									"qualifier": "Shape Water"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -14615,12 +20903,13 @@
 						]
 					},
 					"categories": [
-						"Water"
+						"Water",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "c5e0d854-d75a-4dc6-a048-a87a430a70d5",
+					"id": "5af73297-b7f5-41d8-892b-68d1167ac79a",
 					"name": "Icy Missiles",
 					"reference": "DFS69",
 					"difficulty": "iq/h",
@@ -14639,12 +20928,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "icy weapon"
+									"qualifier": "Icy Weapon"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -14655,12 +20952,13 @@
 					},
 					"notes": "+2 freezing damage to missiles fired from weapon",
 					"categories": [
-						"Water"
+						"Water",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "d19e429f-3968-4169-a2c9-6a95ad8689b8",
+					"id": "5ecba130-0382-417b-b53e-d16d0c89ce38",
 					"name": "Icy Weapon",
 					"reference": "DFS69",
 					"difficulty": "iq/h",
@@ -14679,12 +20977,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "create water"
+									"qualifier": "Create Water"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -14695,12 +21001,13 @@
 					},
 					"notes": "+2 freezing damage to melee weapons",
 					"categories": [
-						"Water"
+						"Water",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "e853b453-a6f0-4ec3-bf83-c3fc8e721d3e",
+					"id": "cdc02287-5c55-434a-b64a-e47757c885a2",
 					"name": "Identify Spell",
 					"reference": "DFS43",
 					"difficulty": "iq/h",
@@ -14719,12 +21026,34 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									}
+								]
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "detect magic"
+									"qualifier": "Detect Magic"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -14734,12 +21063,14 @@
 						]
 					},
 					"categories": [
-						"Knowledge"
+						"Bardic",
+						"Knowledge",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "64e7115e-c4a1-4e6e-b128-000b9772c4d6",
+					"id": "af2d03c6-fe66-47c3-8c5f-918b83b0b85c",
 					"name": "Ignite Fire",
 					"reference": "DFS31",
 					"difficulty": "iq/h",
@@ -14753,13 +21084,28 @@
 					"casting_time": "1 sec",
 					"duration": "1 sec",
 					"points": 1,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							}
+						]
+					},
 					"categories": [
-						"Fire"
+						"Fire",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "695160f6-d08d-4a15-8baf-409cb7eb9d92",
+					"id": "d16369a0-3322-4cd3-95d3-5d82eead1bc5",
 					"name": "Illusion Disguise",
 					"reference": "DFS40",
 					"difficulty": "iq/h",
@@ -14778,12 +21124,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "simple illusion"
+									"qualifier": "Simple Illusion"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -14793,12 +21147,13 @@
 						]
 					},
 					"categories": [
-						"Illusion"
+						"Illusion",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "c4993766-644d-42e0-bdf9-d05da2317a97",
+					"id": "bfdeaae0-ef12-4983-a888-70552357109d",
 					"name": "Illusion Shell",
 					"reference": "DFS41",
 					"difficulty": "iq/h",
@@ -14817,12 +21172,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "simple illusion"
+									"qualifier": "Simple Illusion"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -14832,12 +21195,13 @@
 						]
 					},
 					"categories": [
-						"Illusion"
+						"Illusion",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "610f0461-3d93-4d58-84e1-edf3d34b8de8",
+					"id": "5d1849fe-f83f-4134-a8ee-919f7f465cb5",
 					"name": "Independence",
 					"reference": "DFS41",
 					"difficulty": "iq/h",
@@ -14856,12 +21220,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "simple illusion"
+									"qualifier": "Simple Illusion"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -14871,12 +21243,13 @@
 						]
 					},
 					"categories": [
-						"Illusion"
+						"Illusion",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "6ef9b4a5-9f72-48d2-a874-71953518c3bc",
+					"id": "79c5f039-7d52-486a-8f2a-a4d5208d05ed",
 					"name": "Infravision",
 					"reference": "DFS47",
 					"difficulty": "iq/h",
@@ -14892,43 +21265,58 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": false,
+						"all": true,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "keen vision"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": "Magery"
 								}
 							},
 							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "college",
-								"qualifier": {
-									"compare": "contains",
-									"qualifier": "Light"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 5
-								}
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Keen Vision"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "college",
+										"qualifier": {
+											"compare": "contains",
+											"qualifier": "Light & Darkness"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 5
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Light"
+						"Light & Darkness",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "3bdcb339-beaf-4089-9757-ead6877a80a6",
+					"id": "5d341877-fe15-4ccb-8b1a-d7495f986258",
 					"name": "Initiative",
 					"reference": "DFS41",
 					"difficulty": "iq/h",
@@ -14947,12 +21335,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "independence"
+									"qualifier": "Independence"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -14965,7 +21361,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "wisdom"
+									"qualifier": "Wisdom"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -14975,12 +21371,13 @@
 						]
 					},
 					"categories": [
-						"Illusion"
+						"Illusion",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "cdbba810-bb42-4c73-b0e8-3c8b5fbc4613",
+					"id": "15b4391f-4e07-490b-8679-032515648a00",
 					"name": "Invisibility",
 					"reference": "DFS47",
 					"difficulty": "iq/h",
@@ -14999,12 +21396,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "college",
 								"qualifier": {
 									"compare": "contains",
-									"qualifier": "Light"
+									"qualifier": "Light & Darkness"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -15017,7 +21422,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "blur"
+									"qualifier": "Blur"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -15027,17 +21432,18 @@
 						]
 					},
 					"categories": [
-						"Light"
+						"Light & Darkness",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "74ba5469-e5f0-484d-9e51-ab8cdea13c66",
+					"id": "9cd3f35b-d5b8-4b5c-ab48-ec83e25bf57e",
 					"name": "Iron Arm",
 					"reference": "DFS64",
 					"difficulty": "iq/h",
 					"college": [
-						"Protection"
+						"Protection & Warning"
 					],
 					"power_source": "Arcane",
 					"spell_class": "Blocking",
@@ -15051,19 +21457,6 @@
 						"all": true,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "resist pain"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
-							},
-							{
 								"type": "attribute_prereq",
 								"has": true,
 								"which": "dx",
@@ -15071,16 +21464,38 @@
 									"compare": "at_least",
 									"qualifier": 11
 								}
+							},
+							{
+								"type": "spell_prereq",
+								"has": true,
+								"sub_type": "name",
+								"qualifier": {
+									"compare": "is",
+									"qualifier": "Resist Pain"
+								},
+								"quantity": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
 							}
 						]
 					},
 					"categories": [
-						"Protection"
+						"Protection & Warning",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "8ef832f9-9b0b-4a0b-881e-7f173f704fda",
+					"id": "1db7e8fd-8cfc-4778-97b3-6bfc1e4d0fa7",
 					"name": "Itch",
 					"reference": "DFS21",
 					"difficulty": "iq/h",
@@ -15089,18 +21504,34 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "HT",
 					"casting_cost": "2",
 					"maintenance_cost": "-",
 					"casting_time": "1 sec",
 					"duration": "Until scratched",
 					"points": 1,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							}
+						]
+					},
 					"categories": [
-						"Body Control"
+						"Body Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "0ec5d1c1-0e35-495b-b568-c24eb6a44e4e",
+					"id": "a6abbed8-cd93-4d6c-8646-ef207983b488",
 					"name": "Keen @Sense@",
 					"reference": "DFS54",
 					"difficulty": "iq/h",
@@ -15114,13 +21545,37 @@
 					"casting_time": "1 sec",
 					"duration": "30 min",
 					"points": 1,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Bardic Talent"
+								}
+							}
+						]
+					},
 					"categories": [
-						"Mind Control"
+						"Bardic",
+						"Mind Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "dd752c83-cbd8-408b-b95e-358bc721c531",
+					"id": "94336dbc-6615-4262-bb0d-4997de8f0257",
 					"name": "Keen Hearing",
 					"reference": "DFS54",
 					"difficulty": "iq/h",
@@ -15135,14 +21590,42 @@
 					"casting_time": "1 sec",
 					"duration": "30 min",
 					"points": 1,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Bardic Talent"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							}
+						]
+					},
 					"categories": [
+						"Bardic",
 						"Mind Control",
-						"Sound"
+						"Sound",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "5a8911e0-d3cb-4b20-9fcc-9baa606b99f0",
+					"id": "7d1aa7f0-a01b-485e-9fdd-bf72647157bd",
 					"name": "Keen Taste and Smell",
 					"reference": "DFS54",
 					"difficulty": "iq/h",
@@ -15156,13 +21639,41 @@
 					"casting_time": "1 sec",
 					"duration": "30 min",
 					"points": 1,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Bardic Talent"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							}
+						]
+					},
 					"categories": [
-						"Mind Control"
+						"Bardic",
+						"Mind Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "91dee369-b451-4745-900f-f0c12dc817ac",
+					"id": "e91499f2-66bb-438b-b071-41242d9ecd31",
 					"name": "Keen Touch",
 					"reference": "DFS54",
 					"difficulty": "iq/h",
@@ -15176,13 +21687,41 @@
 					"casting_time": "1 sec",
 					"duration": "30 min",
 					"points": 1,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Bardic Talent"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							}
+						]
+					},
 					"categories": [
-						"Mind Control"
+						"Bardic",
+						"Mind Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "cb717f39-406e-44bd-8f88-c1a922df3385",
+					"id": "26709afc-1d3d-4f0d-b31a-ad678b693c04",
 					"name": "Keen Vision",
 					"reference": "DFS54",
 					"difficulty": "iq/h",
@@ -15196,13 +21735,41 @@
 					"casting_time": "1 sec",
 					"duration": "30 min",
 					"points": 1,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Bardic Talent"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							}
+						]
+					},
 					"categories": [
-						"Mind Control"
+						"Bardic",
+						"Mind Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "765d7007-6aaf-4f9b-aefa-0140cc606110",
+					"id": "dc79084a-60dd-49a1-bab6-613bdfc99d07",
 					"name": "Knot",
 					"reference": "DFS49",
 					"difficulty": "iq/h",
@@ -15221,12 +21788,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "stiffen"
+									"qualifier": "Stiffen"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -15236,12 +21811,13 @@
 						]
 					},
 					"categories": [
-						"Making & Breaking"
+						"Making & Breaking",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "219f95d1-5331-4f68-a1ec-eae3120578e5",
+					"id": "ca868889-ee6a-4328-aa29-8855f8e2286d",
 					"name": "Know Illusion",
 					"reference": "DFS41",
 					"difficulty": "iq/h",
@@ -15260,12 +21836,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "simple illusion"
+									"qualifier": "Simple Illusion"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -15275,19 +21859,20 @@
 						]
 					},
 					"categories": [
-						"Illusion"
+						"Illusion",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "0aade990-a53d-4051-b5e0-44d248fbe7d7",
+					"id": "26dd4db9-cf2c-42ca-b102-2d76243d2fcc",
 					"name": "Know Location",
 					"reference": "DFS43",
 					"difficulty": "iq/h",
 					"college": [
 						"Knowledge"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Druidic@",
 					"spell_class": "Info",
 					"casting_cost": "2",
 					"maintenance_cost": "-",
@@ -15296,71 +21881,89 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture (Druidic)"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								}
+							},
+							{
 								"type": "prereq_list",
-								"all": false,
+								"all": true,
 								"prereqs": [
 									{
-										"type": "advantage_prereq",
+										"type": "spell_prereq",
 										"has": true,
-										"name": {
+										"sub_type": "name",
+										"qualifier": {
 											"compare": "is",
-											"qualifier": "bardic talent"
+											"qualifier": "Tell Position"
 										},
-										"level": {
+										"quantity": {
 											"compare": "at_least",
 											"qualifier": 1
 										}
 									},
 									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 1
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
-										}
+										"type": "prereq_list",
+										"all": false,
+										"prereqs": [
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Bardic Talent"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											}
+										]
 									}
 								]
-							},
-							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "tell position"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
 							}
 						]
 					},
 					"categories": [
-						"Knowledge"
+						"Bardic",
+						"Druidic",
+						"Knowledge",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "1c893276-5ddf-43c4-b2a9-6ab48ce82445",
+					"id": "301841c1-f664-403a-ad3f-ae682848ade4",
 					"name": "Lend Energy",
 					"reference": "DFS37",
 					"difficulty": "iq/h",
 					"college": [
-						"Healing"
+						"Healing",
+						"Meta"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical@",
 					"spell_class": "Regular",
 					"casting_cost": "1/pt",
 					"maintenance_cost": "-",
@@ -15372,52 +21975,41 @@
 						"all": false,
 						"prereqs": [
 							{
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 1
-										},
-										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (healing)"
-										}
-									},
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 1
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
-										}
-									}
-								]
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
 							}
 						]
 					},
 					"categories": [
-						"Healing"
+						"Clerical",
+						"Healing",
+						"Meta",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "21ac763f-cf19-425b-b059-ce7c06894698",
+					"id": "0fe0ae04-8c4f-4cfa-9c30-795c6280b807",
 					"name": "Lend Language",
 					"reference": "DFS25",
 					"difficulty": "iq/h",
@@ -15436,6 +22028,28 @@
 						"all": false,
 						"prereqs": [
 							{
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										}
+									}
+								]
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "college",
@@ -15451,12 +22065,13 @@
 						]
 					},
 					"categories": [
-						"Communication"
+						"Communication & Empathy",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "bd42f47d-c532-450e-ae2d-b24082b937b8",
+					"id": "6b26a15e-36a7-4764-870a-ca14a9543bce",
 					"name": "Lend Skill",
 					"reference": "DFS25",
 					"difficulty": "iq/h",
@@ -15475,37 +22090,60 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "spell_prereq",
+								"has": true,
+								"sub_type": "name",
+								"qualifier": {
+									"compare": "is",
+									"qualifier": "Mind-Sending"
+								},
+								"quantity": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							},
+							{
 								"type": "attribute_prereq",
 								"has": true,
 								"which": "iq",
-								"combined_with": "iq",
 								"qualifier": {
 									"compare": "at_least",
 									"qualifier": 11
 								}
 							},
 							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "mind-sending"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Communication"
+						"Bardic",
+						"Communication & Empathy",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "191724bf-71dc-48e5-af75-0bd90ab95cad",
+					"id": "1db07eac-e57d-48ee-935e-47af245cb5e7",
 					"name": "Levitation",
 					"reference": "DFS57",
 					"difficulty": "iq/h",
@@ -15514,6 +22152,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "ST or Will",
 					"casting_cost": "1 per 80 lbs",
 					"maintenance_cost": "Half",
 					"casting_time": "2 sec",
@@ -15524,12 +22163,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "apportation"
+									"qualifier": "Apportation"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -15539,39 +22186,68 @@
 						]
 					},
 					"categories": [
-						"Movement"
+						"Movement",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "766b14ec-748b-4e84-8cdf-cf390ac3bd4e",
+					"id": "3dd4c561-372b-4284-a901-669201028ef6",
 					"name": "Light",
 					"reference": "DFS47",
 					"difficulty": "iq/h",
 					"college": [
 						"Light & Darkness"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical@",
 					"spell_class": "Regular",
 					"casting_cost": "1",
 					"maintenance_cost": "1",
 					"casting_time": "1 sec",
 					"duration": "1 min",
 					"points": 1,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							}
+						]
+					},
 					"categories": [
-						"Light"
+						"Clerical",
+						"Light & Darkness",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "d4aea047-e6ab-4b18-9643-6ec8720b21a0",
+					"id": "4b77356b-ba5e-4d18-ab8d-735389677850",
 					"name": "Light Jet",
 					"reference": "DFS47",
 					"difficulty": "iq/h",
 					"college": [
 						"Light & Darkness"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical@",
 					"spell_class": "Regular",
 					"casting_cost": "2",
 					"maintenance_cost": "1",
@@ -15613,38 +22289,66 @@
 					],
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "continual light"
+									"qualifier": "Power Investiture"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": 2
 								}
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Continual Light"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									}
+								]
 							}
 						]
 					},
-					"notes": "blinds only when darkness penalty is -5 or more",
+					"notes": "Blinds only when darkness penalty is -5 or more",
 					"categories": [
-						"Light"
+						"Clerical",
+						"Light & Darkness",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "20b43540-0e49-4272-9746-92ec0a3978d0",
+					"id": "965f4ccf-79e8-40d1-ae8a-5d84b7a17132",
 					"name": "Light Tread",
 					"reference": "DFS57",
 					"difficulty": "iq/h",
 					"college": [
 						"Movement"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Druidic@",
 					"spell_class": "Regular",
 					"casting_cost": "4",
 					"maintenance_cost": "1",
@@ -15653,43 +22357,71 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "apportation"
+									"qualifier": "Power Investiture (Druidic)"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": 2
 								}
 							},
 							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "shape earth"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Apportation"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Shape Earth"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Movement"
+						"Druidic",
+						"Movement",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "28013d14-d80a-4616-bc84-a8f5a09e9566",
+					"id": "d5439a2e-1dcb-4eb4-a209-f9712035fd30",
 					"name": "Lighten Burden",
 					"reference": "DFS58",
 					"difficulty": "iq/h",
@@ -15708,12 +22440,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "apportation"
+									"qualifier": "Apportation"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -15723,12 +22463,13 @@
 						]
 					},
 					"categories": [
-						"Movement"
+						"Movement",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "1a46e09a-786a-4de7-814a-cda44d142632",
+					"id": "4510c456-cfb6-440c-8645-db9e650b8840",
 					"name": "Lightning",
 					"reference": "DFS71",
 					"difficulty": "iq/h",
@@ -15736,7 +22477,7 @@
 						"Air",
 						"Weather"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Druidic@",
 					"spell_class": "Missile",
 					"casting_cost": "1-Magery",
 					"maintenance_cost": "-",
@@ -15772,26 +22513,35 @@
 					],
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture (Druidic)"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 4
+								}
+							},
+							{
 								"type": "prereq_list",
-								"all": false,
+								"all": true,
 								"prereqs": [
 									{
-										"type": "advantage_prereq",
+										"type": "spell_prereq",
 										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 1
-										},
-										"notes": {
+										"sub_type": "college",
+										"qualifier": {
 											"compare": "contains",
-											"qualifier": "one college (weather)"
+											"qualifier": "Air"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 6
 										}
 									},
 									{
@@ -15799,42 +22549,27 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "magery"
+											"qualifier": "Magery"
 										},
 										"level": {
 											"compare": "at_least",
 											"qualifier": 1
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
 										}
 									}
 								]
-							},
-							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "college",
-								"qualifier": {
-									"compare": "contains",
-									"qualifier": "Air"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 6
-								}
 							}
 						]
 					},
 					"categories": [
 						"Air",
-						"Weather"
+						"Druidic",
+						"Weather",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "2e2a02e0-4f6d-4b8f-b167-33a033ff116d",
+					"id": "e01f715b-751b-4f22-9093-0c9585bee1b1",
 					"name": "Lightning Missiles",
 					"reference": "DFS72",
 					"difficulty": "iq/h",
@@ -15854,12 +22589,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "lightning weapon"
+									"qualifier": "Lightning Weapon"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -15871,12 +22614,13 @@
 					"notes": "+2 points burn damage to missiles fired with weapon",
 					"categories": [
 						"Air",
-						"Weather"
+						"Weather",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "a7619ae4-ed28-40a1-9127-aac36e71d07b",
+					"id": "f5a687d4-6672-4fc3-b363-8bf1c6a3490f",
 					"name": "Lightning Weapon",
 					"reference": "DFS72",
 					"difficulty": "iq/h",
@@ -15896,42 +22640,16 @@
 						"all": true,
 						"prereqs": [
 							{
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 2
-										},
-										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (weather)"
-										}
-									},
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 2
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
-										}
-									}
-								]
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								}
 							},
 							{
 								"type": "spell_prereq",
@@ -15951,12 +22669,13 @@
 					"notes": "+2 burn damage with melee weapon",
 					"categories": [
 						"Air",
-						"Weather"
+						"Weather",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "8afa3e52-d6ef-4100-9ad3-e86812a92bd8",
+					"id": "d14ed40b-31e5-4d66-a3ec-b44fef1a1c08",
 					"name": "Lockmaster",
 					"reference": "DFS58",
 					"difficulty": "iq/h",
@@ -15965,6 +22684,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "Magelock",
 					"casting_cost": "3",
 					"maintenance_cost": "-",
 					"casting_time": "10 sec",
@@ -15975,19 +22695,6 @@
 						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "locksmith"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
-							},
-							{
 								"type": "prereq_list",
 								"all": true,
 								"prereqs": [
@@ -15997,7 +22704,7 @@
 										"sub_type": "name",
 										"qualifier": {
 											"compare": "is",
-											"qualifier": "apportation"
+											"qualifier": "Locksmith"
 										},
 										"quantity": {
 											"compare": "at_least",
@@ -16005,50 +22712,56 @@
 										}
 									},
 									{
-										"type": "prereq_list",
-										"all": false,
-										"prereqs": [
-											{
-												"type": "advantage_prereq",
-												"has": true,
-												"name": {
-													"compare": "is",
-													"qualifier": "magery"
-												},
-												"level": {
-													"compare": "at_least",
-													"qualifier": 2
-												},
-												"notes": {
-													"compare": "contains",
-													"qualifier": "one college (movement)"
-												}
-											},
-											{
-												"type": "advantage_prereq",
-												"has": true,
-												"name": {
-													"compare": "is",
-													"qualifier": "magery"
-												},
-												"level": {
-													"compare": "at_least",
-													"qualifier": 2
-												}
-											}
-										]
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									}
+								]
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 2
+										}
+									},
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Apportation"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
 									}
 								]
 							}
 						]
 					},
 					"categories": [
-						"Movement"
+						"Movement",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "dceeb07b-1673-417e-b98c-894a1d39c196",
+					"id": "67a30d1e-eb91-42de-a72b-c2545bec0fbb",
 					"name": "Locksmith",
 					"reference": "DFS58",
 					"difficulty": "iq/h",
@@ -16067,12 +22780,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "apportation"
+									"qualifier": "Apportation"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -16082,12 +22803,13 @@
 						]
 					},
 					"categories": [
-						"Movement"
+						"Movement",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "c72a6f6d-e975-41c3-810b-131bf5bad60e",
+					"id": "4f001ee3-cc09-4e52-9c80-0b3fe30aec84",
 					"name": "Loyalty",
 					"reference": "DFS55",
 					"difficulty": "iq/h",
@@ -16096,6 +22818,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "Will",
 					"casting_cost": "2",
 					"maintenance_cost": "2",
 					"casting_time": "2 sec",
@@ -16106,12 +22829,34 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										}
+									}
+								]
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "bravery"
+									"qualifier": "Bravery"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -16128,18 +22873,20 @@
 								},
 								"quantity": {
 									"compare": "at_least",
-									"qualifier": 2
+									"qualifier": 3
 								}
 							}
 						]
 					},
 					"categories": [
-						"Mind Control"
+						"Bardic",
+						"Mind Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "e7d7899a-a54f-49f0-b45c-85bdb6d7547b",
+					"id": "ce17c1ab-4bc0-4621-b32d-fae791e92a31",
 					"name": "Mage Sight",
 					"reference": "DFS44",
 					"difficulty": "iq/h",
@@ -16158,12 +22905,34 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										}
+									}
+								]
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "detect magic"
+									"qualifier": "Detect Magic"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -16173,12 +22942,14 @@
 						]
 					},
 					"categories": [
-						"Knowledge"
+						"Bardic",
+						"Knowledge",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "9c438bf6-99a6-499a-8179-a4c9535fc8be",
+					"id": "bc52c505-6312-4f51-8358-952f188078bb",
 					"name": "Mage-Stealth",
 					"reference": "DFS66",
 					"difficulty": "iq/h",
@@ -16197,12 +22968,34 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										}
+									}
+								]
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "hush"
+									"qualifier": "Hush"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -16212,17 +23005,18 @@
 						]
 					},
 					"categories": [
-						"Sound"
+						"Sound",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "f1c375cf-f766-4ce5-8f3c-70080a06aaf2",
+					"id": "b6029e79-e21e-43f8-82fc-da0cdf47c52a",
 					"name": "Magelock",
 					"reference": "DFS64",
 					"difficulty": "iq/h",
 					"college": [
-						"Protection"
+						"Protection & Warning"
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
@@ -16250,20 +23044,22 @@
 						]
 					},
 					"categories": [
-						"Protection"
+						"Protection & Warning",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "2c2f8da2-96fc-4b80-91dd-4b2f1fef7dee",
+					"id": "94b882e9-1064-46e3-af25-7f310dc0a69c",
 					"name": "Magic Resistance",
 					"reference": "DFS51",
 					"difficulty": "iq/h",
 					"college": [
 						"Meta"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical@",
 					"spell_class": "Regular",
+					"resist": "Will + Spellcasting Talent",
 					"casting_cost": "1-5",
 					"maintenance_cost": "Same",
 					"casting_time": "3 sec",
@@ -16271,35 +23067,31 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "college_count",
-								"quantity": {
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture"
+								},
+								"level": {
 									"compare": "at_least",
-									"qualifier": 7
+									"qualifier": 3
 								}
 							},
 							{
 								"type": "prereq_list",
-								"all": false,
+								"all": true,
 								"prereqs": [
 									{
-										"type": "advantage_prereq",
+										"type": "spell_prereq",
 										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
+										"sub_type": "college_count",
+										"quantity": {
 											"compare": "at_least",
-											"qualifier": 1
-										},
-										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (meta)"
+											"qualifier": 7
 										}
 									},
 									{
@@ -16307,15 +23099,11 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "magery"
+											"qualifier": "Magery"
 										},
 										"level": {
 											"compare": "at_least",
 											"qualifier": 1
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
 										}
 									}
 								]
@@ -16323,12 +23111,14 @@
 						]
 					},
 					"categories": [
-						"Meta"
+						"Clerical",
+						"Meta",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "71ffb75a-1688-4b9d-812a-dada31e9982d",
+					"id": "041aafad-2a2c-4fde-aadb-bbb902a06758",
 					"name": "Manipulate",
 					"reference": "DFS58",
 					"difficulty": "iq/h",
@@ -16347,12 +23137,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "locksmith"
+									"qualifier": "Locksmith"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -16362,12 +23160,13 @@
 						]
 					},
 					"categories": [
-						"Movement"
+						"Movement",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "a2f4215e-8f2e-431f-98fb-94161c676069",
+					"id": "f9032819-1c7d-4d72-91a6-bfc19cdcb21d",
 					"name": "Mapmaker",
 					"reference": "DFS49",
 					"difficulty": "iq/h",
@@ -16386,12 +23185,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "copy"
+									"qualifier": "Copy"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -16404,7 +23211,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "measurement"
+									"qualifier": "Measurement"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -16414,12 +23221,13 @@
 						]
 					},
 					"categories": [
-						"Making & Breaking"
+						"Making & Breaking",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "c0ca4b79-5fec-4f2c-bd4b-84c5ce5020fc",
+					"id": "cd4adab3-7ae3-4800-bc32-e579f9d2ca91",
 					"name": "Mass Daze",
 					"reference": "DFS55",
 					"difficulty": "iq/h",
@@ -16428,6 +23236,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Area",
+					"resist": "HT",
 					"casting_cost": "2",
 					"maintenance_cost": "1",
 					"casting_time": "sec=cost",
@@ -16438,12 +23247,34 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										}
+									}
+								]
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "daze"
+									"qualifier": "Daze"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -16462,12 +23293,14 @@
 						]
 					},
 					"categories": [
-						"Mind Control"
+						"Bardic",
+						"Mind Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "0e252e26-8033-43ef-8a89-81c6077fec34",
+					"id": "87488a4e-4935-450a-8e96-1610053e0c52",
 					"name": "Mass Sleep",
 					"reference": "DFS55",
 					"difficulty": "iq/h",
@@ -16476,6 +23309,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Area",
+					"resist": "HT",
 					"casting_cost": "3",
 					"maintenance_cost": "-",
 					"casting_time": "sec=cost",
@@ -16485,6 +23319,28 @@
 						"type": "prereq_list",
 						"all": true,
 						"prereqs": [
+							{
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										}
+									}
+								]
+							},
 							{
 								"type": "spell_prereq",
 								"has": true,
@@ -16510,12 +23366,14 @@
 						]
 					},
 					"categories": [
-						"Mind Control"
+						"Bardic",
+						"Mind Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "b8ea593e-42b2-49ed-be13-69d838d56106",
+					"id": "7a22b596-102a-473d-ba0a-a8c36fa8609d",
 					"name": "Measurement",
 					"reference": "DFS44",
 					"difficulty": "iq/h",
@@ -16529,13 +23387,41 @@
 					"casting_time": "1 sec",
 					"duration": "Instant",
 					"points": 1,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Bardic Talent"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							}
+						]
+					},
 					"categories": [
-						"Knowledge"
+						"Bardic",
+						"Knowledge",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "050231f2-ff92-48fa-97ec-f0b5285f276c",
+					"id": "4a56f48c-8174-4a5b-906d-6fb752101487",
 					"name": "Message",
 					"reference": "DFS67",
 					"difficulty": "iq/h",
@@ -16545,6 +23431,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "Spells that block sound",
 					"casting_cost": "1/15 sec",
 					"maintenance_cost": "-",
 					"casting_time": "Varies",
@@ -16555,12 +23442,34 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										}
+									}
+								]
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "seeker"
+									"qualifier": "Seeker"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -16573,7 +23482,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "great voice"
+									"qualifier": "Great Voice"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -16583,20 +23492,22 @@
 						]
 					},
 					"categories": [
-						"Communication",
-						"Sound"
+						"Bardic",
+						"Communication & Empathy",
+						"Sound",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "e26ab014-336c-40a0-92b8-f14296265398",
+					"id": "fec1e6fb-3e85-402d-8181-eb46c48ea1c1",
 					"name": "Might",
 					"reference": "DFS21",
 					"difficulty": "iq/h",
 					"college": [
 						"Body Control"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical@",
 					"spell_class": "Regular",
 					"casting_cost": "2/+ST",
 					"maintenance_cost": "Same",
@@ -16605,30 +23516,58 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "lend energy"
+									"qualifier": "Power Investiture"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
 									"qualifier": 1
 								}
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Lend Energy"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Body Control"
+						"Body Control",
+						"Clerical",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "3e2e0579-dc62-4a30-a3c5-f5c7b05ae736",
+					"id": "f00e6b7b-4456-470f-a977-69cae9840391",
 					"name": "Mind-Reading",
 					"reference": "DFS25",
 					"difficulty": "iq/h",
@@ -16637,6 +23576,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "Will",
 					"casting_cost": "4",
 					"maintenance_cost": "2",
 					"casting_time": "10 sec",
@@ -16644,43 +23584,73 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": false,
+						"all": true,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "truthsayer"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										}
+									}
+								]
 							},
 							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "borrow language"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Truthsayer"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Borrow Language"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Communication"
+						"Bardic",
+						"Communication & Empathy",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "0dcdb000-1b85-4265-bb51-8d9052e24648",
+					"id": "e8045e50-39bb-4e84-b067-25317171d175",
 					"name": "Mind-Search",
 					"reference": "DFS25",
 					"difficulty": "iq/vh",
@@ -16689,6 +23659,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "Will",
 					"casting_cost": "6",
 					"maintenance_cost": "3",
 					"casting_time": "1 min",
@@ -16704,22 +23675,46 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "mind-reading"
+									"qualifier": "Mind-Reading"
 								},
 								"quantity": {
 									"compare": "at_least",
 									"qualifier": 1
 								}
+							},
+							{
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Communication"
+						"Bardic",
+						"Communication & Empathy",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "9d115a03-5bbb-423f-8275-dae3d8ce1546",
+					"id": "57ff1172-ef44-49bd-8ca7-1949add70b34",
 					"name": "Mind-Sending",
 					"reference": "DFS25",
 					"difficulty": "iq/h",
@@ -16743,22 +23738,46 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "mind-reading"
+									"qualifier": "Mind-Reading"
 								},
 								"quantity": {
 									"compare": "at_least",
 									"qualifier": 1
 								}
+							},
+							{
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Communication"
+						"Bardic",
+						"Communication & Empathy",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "e370a62b-c872-42d0-907d-4db645b58e66",
+					"id": "79e2a0ff-26b6-40bc-8f91-c0a308827ada",
 					"name": "Mirror",
 					"reference": "DFS47",
 					"difficulty": "iq/h",
@@ -16777,12 +23796,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "colors"
+									"qualifier": "Colors"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -16792,17 +23819,18 @@
 						]
 					},
 					"categories": [
-						"Light"
+						"Light & Darkness",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "3f1886b4-dae9-40db-a366-5039d279ec5d",
+					"id": "ad980b18-b958-4687-b254-6a268d7e4144",
 					"name": "Missile Shield",
 					"reference": "DFS64",
 					"difficulty": "iq/h",
 					"college": [
-						"Protection"
+						"Protection & Warning"
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
@@ -16816,12 +23844,20 @@
 						"all": false,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "apportation"
+									"qualifier": "Apportation"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -16834,7 +23870,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "shield"
+									"qualifier": "Shield"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -16844,19 +23880,20 @@
 						]
 					},
 					"categories": [
-						"Protection"
+						"Protection & Warning",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "b66c6954-7397-4cb3-b152-62408f21124b",
+					"id": "5b40993d-2b4a-45b7-b17f-d38c95ebbb4e",
 					"name": "Mystic Mist",
 					"reference": "DFS64",
 					"difficulty": "iq/h",
 					"college": [
-						"Protection"
+						"Protection & Warning"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Druidic@",
 					"spell_class": "Area",
 					"casting_cost": "1",
 					"maintenance_cost": "Same",
@@ -16865,74 +23902,66 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "spell_prereq",
-										"has": true,
-										"sub_type": "name",
-										"qualifier": {
-											"compare": "is",
-											"qualifier": "watchdog"
-										},
-										"quantity": {
-											"compare": "at_least",
-											"qualifier": 1
-										}
-									},
-									{
-										"type": "spell_prereq",
-										"has": true,
-										"sub_type": "name",
-										"qualifier": {
-											"compare": "is",
-											"qualifier": "shield"
-										},
-										"quantity": {
-											"compare": "at_least",
-											"qualifier": 1
-										}
-									}
-								]
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture (Druidic)"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								}
 							},
 							{
 								"type": "prereq_list",
-								"all": false,
+								"all": true,
 								"prereqs": [
 									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 1
-										},
-										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (protection)"
-										}
+										"type": "prereq_list",
+										"all": false,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Watchdog"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Shield"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											}
+										]
 									},
 									{
 										"type": "advantage_prereq",
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "magery"
+											"qualifier": "Magery"
 										},
 										"level": {
 											"compare": "at_least",
 											"qualifier": 1
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
 										}
 									}
 								]
@@ -16940,12 +23969,14 @@
 						]
 					},
 					"categories": [
-						"Protection"
+						"Druidic",
+						"Protection & Warning",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "11458e5a-bd53-4f88-9774-58dd98f12b47",
+					"id": "57e976ef-8f6d-4d6d-b797-3217024f8b50",
 					"name": "Nauseate",
 					"reference": "DFS21",
 					"difficulty": "iq/h",
@@ -16954,6 +23985,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "HT",
 					"casting_cost": "2",
 					"maintenance_cost": "2",
 					"casting_time": "1 sec",
@@ -16963,6 +23995,14 @@
 						"type": "prereq_list",
 						"all": true,
 						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
 							{
 								"type": "spell_prereq",
 								"has": true,
@@ -16979,12 +24019,13 @@
 						]
 					},
 					"categories": [
-						"Body Control"
+						"Body Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "e46eeb5b-2a30-4c05-8db1-53080b13508f",
+					"id": "f1b8fb97-5916-4263-b514-842727c27021",
 					"name": "Night Vision",
 					"reference": "DFS47",
 					"difficulty": "iq/h",
@@ -17000,48 +24041,63 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": false,
+						"all": true,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "keen vision"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": "Magery"
 								}
 							},
 							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "college",
-								"qualifier": {
-									"compare": "contains",
-									"qualifier": "Light"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 5
-								}
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Keen Vision"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "college",
+										"qualifier": {
+											"compare": "contains",
+											"qualifier": "Light & Darkness"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 5
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Light"
+						"Light & Darkness",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "f9966eee-8f3f-4f1a-b28b-12acda444d89",
+					"id": "aa075703-ef36-477a-8cd2-7ed15478dbd9",
 					"name": "Nightingale",
 					"reference": "DFS64",
 					"difficulty": "iq/h",
 					"college": [
-						"Protection"
+						"Protection & Warning"
 					],
 					"power_source": "Arcane",
 					"spell_class": "Area",
@@ -17055,12 +24111,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "sense danger"
+									"qualifier": "Sense Danger"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -17070,19 +24134,20 @@
 						]
 					},
 					"categories": [
-						"Protection"
+						"Protection & Warning",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "08ef6243-2bba-4954-a45d-1d636766926c",
+					"id": "1001599d-5b0a-4293-a1dc-cc2e15d98453",
 					"name": "No-Smell",
 					"reference": "DFS16",
 					"difficulty": "iq/h",
 					"college": [
 						"Air"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Druidic@",
 					"spell_class": "Regular",
 					"casting_cost": "2",
 					"maintenance_cost": "2",
@@ -17094,27 +24159,55 @@
 						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "purify air"
+									"qualifier": "Power Investiture (Druidic)"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
 									"qualifier": 1
 								}
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Purify Air"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Air"
+						"Air",
+						"Druidic",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "84a9748b-4ada-48a7-bd69-fae48d465a31",
+					"id": "068419fa-d802-40e8-9772-fe923658d617",
 					"name": "Noise",
 					"reference": "DFS67",
 					"difficulty": "iq/h",
@@ -17133,12 +24226,34 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										}
+									}
+								]
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "wall of silence"
+									"qualifier": "Wall of Silence"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -17148,12 +24263,14 @@
 						]
 					},
 					"categories": [
-						"Sound"
+						"Bardic",
+						"Sound",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "ac9a3e41-9aa0-4196-88b7-0de54668ac87",
+					"id": "3da8baef-e3c9-4561-a7e7-af4323391cc9",
 					"name": "Pain",
 					"reference": "DFS21",
 					"difficulty": "iq/h",
@@ -17162,6 +24279,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "HT",
 					"casting_cost": "2",
 					"maintenance_cost": "-",
 					"casting_time": "2 sec",
@@ -17172,12 +24290,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "spasm"
+									"qualifier": "Spasm"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -17187,12 +24313,13 @@
 						]
 					},
 					"categories": [
-						"Body Control"
+						"Body Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "b3907ddc-d3a0-4806-919e-9ed6ba35f8cc",
+					"id": "349b6495-46f1-4ba7-ae1c-ad57f29192a4",
 					"name": "Panic",
 					"reference": "DFS55",
 					"difficulty": "iq/h",
@@ -17201,47 +24328,9 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Area",
+					"resist": "Will",
 					"casting_cost": "4",
 					"maintenance_cost": "2",
-					"casting_time": "1 sec",
-					"duration": "1 min",
-					"points": 1,
-					"prereqs": {
-						"type": "prereq_list",
-						"all": true,
-						"prereqs": [
-							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "fear"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
-							}
-						]
-					},
-					"categories": [
-						"Mind Control"
-					]
-				},
-				{
-					"type": "spell",
-					"id": "1a75437d-c2b0-434f-8c42-ceb191bf78ea",
-					"name": "Paralyze Limb",
-					"reference": "DFS21",
-					"difficulty": "iq/h",
-					"college": [
-						"Body Control"
-					],
-					"power_source": "Arcane",
-					"spell_class": "Melee",
-					"casting_cost": "3",
-					"maintenance_cost": "-",
 					"casting_time": "1 sec",
 					"duration": "1 min",
 					"points": 1,
@@ -17258,15 +24347,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 1
-										},
-										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (body control)"
+											"qualifier": "Magery"
 										}
 									},
 									{
@@ -17274,18 +24355,64 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 1
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
+											"qualifier": "Bardic Talent"
 										}
 									}
 								]
+							},
+							{
+								"type": "spell_prereq",
+								"has": true,
+								"sub_type": "name",
+								"qualifier": {
+									"compare": "is",
+									"qualifier": "Fear"
+								},
+								"quantity": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							}
+						]
+					},
+					"categories": [
+						"Bardic",
+						"Mind Control",
+						"Wizardly"
+					]
+				},
+				{
+					"type": "spell",
+					"id": "dc04a301-13a4-4fc7-be19-46f6b8444e71",
+					"name": "Paralyze Limb",
+					"reference": "DFS21",
+					"difficulty": "iq/h",
+					"college": [
+						"Body Control"
+					],
+					"power_source": "Arcane",
+					"spell_class": "Melee",
+					"resist": "HT",
+					"casting_cost": "3",
+					"maintenance_cost": "-",
+					"casting_time": "1 sec",
+					"duration": "1 min",
+					"points": 1,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
 							},
 							{
 								"type": "spell_prereq",
@@ -17306,7 +24433,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "clumsiness"
+									"qualifier": "Clumsiness"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -17316,19 +24443,20 @@
 						]
 					},
 					"categories": [
-						"Body Control"
+						"Body Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "8855e49f-6a74-431d-8362-2314e6f832b9",
+					"id": "e139f1ec-5610-4be6-bbff-ac1226f14778",
 					"name": "Pathfinder",
 					"reference": "DFS44",
 					"difficulty": "iq/h",
 					"college": [
 						"Knowledge"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Druidic@",
 					"spell_class": "Info",
 					"casting_cost": "4",
 					"maintenance_cost": "-",
@@ -17337,29 +24465,132 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "attribute_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"which": "iq",
-								"qualifier": {
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture (Druidic)"
+								},
+								"level": {
 									"compare": "at_least",
-									"qualifier": 12
+									"qualifier": 2
 								}
 							},
 							{
 								"type": "prereq_list",
-								"all": false,
+								"all": true,
 								"prereqs": [
 									{
-										"type": "advantage_prereq",
+										"type": "attribute_prereq",
 										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "bardic talent"
+										"which": "iq",
+										"qualifier": {
+											"compare": "at_least",
+											"qualifier": 12
+										}
+									},
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "starts_with",
+											"qualifier": "Seek "
 										},
-										"level": {
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 2
+										}
+									},
+									{
+										"type": "prereq_list",
+										"all": false,
+										"prereqs": [
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Bardic Talent"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					"categories": [
+						"Bardic",
+						"Druidic",
+						"Knowledge",
+						"Wizardly"
+					]
+				},
+				{
+					"type": "spell",
+					"id": "fae91264-6056-4c12-b155-e739da962193",
+					"name": "Pentagram",
+					"reference": "DFS51",
+					"difficulty": "iq/h",
+					"college": [
+						"Meta"
+					],
+					"power_source": "@Power Source: Arcane/Clerical@",
+					"spell_class": "Special",
+					"casting_cost": "1/sq foot",
+					"maintenance_cost": "-",
+					"casting_time": "1 sec/sq foot",
+					"duration": "Permanent",
+					"points": 1,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 5
+								}
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Spell Shield"
+										},
+										"quantity": {
 											"compare": "at_least",
 											"qualifier": 1
 										}
@@ -17369,80 +24600,22 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 1
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
+											"qualifier": "Magery"
 										}
 									}
 								]
-							},
-							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "contains",
-									"qualifier": "seek"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 2
-								}
 							}
 						]
 					},
 					"categories": [
-						"Knowledge"
+						"Clerical",
+						"Meta",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "169d7a68-6ce3-4bfb-b3c9-f78896674e1f",
-					"name": "Pentagram",
-					"reference": "DFS51",
-					"difficulty": "iq/h",
-					"college": [
-						"Meta"
-					],
-					"power_source": "Arcane",
-					"spell_class": "Special",
-					"casting_cost": "1/sq foot",
-					"maintenance_cost": "-",
-					"casting_time": "1 sec/sq foot",
-					"duration": "Permanent",
-					"points": 1,
-					"prereqs": {
-						"type": "prereq_list",
-						"all": true,
-						"prereqs": [
-							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "spell shield"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
-							}
-						]
-					},
-					"categories": [
-						"Meta"
-					]
-				},
-				{
-					"type": "spell",
-					"id": "5e9f77fa-eb0c-4060-ba2a-4ecfd7730b4f",
+					"id": "258e258a-4b80-4471-b5e2-c71630c6245f",
 					"name": "Perfect Illusion",
 					"reference": "DFS41",
 					"difficulty": "iq/h",
@@ -17466,7 +24639,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "complex illusion"
+									"qualifier": "Complex Illusion"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -17474,78 +24647,13 @@
 								}
 							},
 							{
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 1
-										},
-										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (illusion & creation)"
-										}
-									},
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 1
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
-										}
-									}
-								]
-							}
-						]
-					},
-					"categories": [
-						"Illusion"
-					]
-				},
-				{
-					"type": "spell",
-					"id": "6924ebfd-bf4b-42e3-b0fa-6be2c5160c0f",
-					"name": "Persuasion",
-					"reference": "DFS25",
-					"difficulty": "iq/h",
-					"college": [
-						"Communication & Empathy"
-					],
-					"power_source": "Arcane",
-					"spell_class": "Regular",
-					"casting_cost": "Varies",
-					"maintenance_cost": "Same",
-					"casting_time": "1 sec",
-					"duration": "1 min",
-					"points": 1,
-					"prereqs": {
-						"type": "prereq_list",
-						"all": true,
-						"prereqs": [
-							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "sense emotion"
+									"qualifier": "Magery"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
 									"qualifier": 1
 								}
@@ -17553,12 +24661,96 @@
 						]
 					},
 					"categories": [
-						"Communication"
+						"Illusion",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "4330e135-0aa0-478d-a71c-b35312ac59f0",
+					"id": "d9921764-ae2d-4c3f-94ad-2a971a4a8f6b",
+					"name": "Persuasion",
+					"reference": "DFS25",
+					"difficulty": "iq/h",
+					"college": [
+						"Communication & Empathy"
+					],
+					"power_source": "@Power Source: Arcane/Clerical@",
+					"spell_class": "Regular",
+					"resist": "Will",
+					"casting_cost": "Varies",
+					"maintenance_cost": "Same",
+					"casting_time": "1 sec",
+					"duration": "1 min",
+					"points": 1,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								}
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Sense Emotion"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "prereq_list",
+										"all": false,
+										"prereqs": [
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Bardic Talent"
+												}
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					"categories": [
+						"Bardic",
+						"Clerical",
+						"Communication & Empathy",
+						"Wizardly"
+					]
+				},
+				{
+					"type": "spell",
+					"id": "88d59e28-9ccd-4022-88c6-e05684656cdd",
 					"name": "Phantom",
 					"reference": "DFS41",
 					"difficulty": "iq/vh",
@@ -17577,42 +24769,16 @@
 						"all": true,
 						"prereqs": [
 							{
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 2
-										},
-										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (illusion & creation)"
-										}
-									},
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 2
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
-										}
-									}
-								]
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								}
 							},
 							{
 								"type": "spell_prereq",
@@ -17620,7 +24786,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "perfect illusion"
+									"qualifier": "Perfect Illusion"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -17633,7 +24799,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "hinder"
+									"qualifier": "Hinder"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -17646,7 +24812,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "apportation"
+									"qualifier": "Apportation"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -17656,12 +24822,13 @@
 						]
 					},
 					"categories": [
-						"Illusion"
+						"Illusion",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "2a08ffae-3b4f-4d16-9298-f8585ed908fb",
+					"id": "d2d80f57-0c56-4309-93a0-d44090e36e3e",
 					"name": "Phase",
 					"reference": "DFS34",
 					"difficulty": "iq/h",
@@ -17680,42 +24847,16 @@
 						"all": true,
 						"prereqs": [
 							{
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 3
-										},
-										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (gate)"
-										}
-									},
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 3
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
-										}
-									}
-								]
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								}
 							},
 							{
 								"type": "prereq_list",
@@ -17727,7 +24868,7 @@
 										"sub_type": "name",
 										"qualifier": {
 											"compare": "is",
-											"qualifier": "ethereal body"
+											"qualifier": "Ethereal Body"
 										},
 										"quantity": {
 											"compare": "at_least",
@@ -17739,12 +24880,13 @@
 						]
 					},
 					"categories": [
-						"Gate"
+						"Gate",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "f3c97a43-e98f-4461-b7d4-61540f6e135b",
+					"id": "b57ec784-d0fd-4039-9046-5fb5a4f28ce8",
 					"name": "Phase Other",
 					"reference": "DFS34",
 					"difficulty": "iq/vh",
@@ -17763,12 +24905,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "phase"
+									"qualifier": "Phase"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -17778,12 +24928,13 @@
 						]
 					},
 					"categories": [
-						"Gate"
+						"Gate",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "cc9efd2c-0f7e-40ab-bc6e-00577d4b9aeb",
+					"id": "8893f388-8b39-4d2b-a21e-91adda43fb71",
 					"name": "Poison Food",
 					"reference": "DFS32",
 					"difficulty": "iq/h",
@@ -17802,12 +24953,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "purify food"
+									"qualifier": "Purify Food"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -17817,12 +24976,13 @@
 						]
 					},
 					"categories": [
-						"Food"
+						"Food",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "f3e10dd3-d240-4338-a74a-97eab9e768d1",
+					"id": "5c24178f-475f-4cb6-b226-9da76f9185ab",
 					"name": "Possession",
 					"reference": "DFS25",
 					"difficulty": "iq/vh",
@@ -17831,6 +24991,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "Will",
 					"casting_cost": "10",
 					"maintenance_cost": "4",
 					"casting_time": "1 min",
@@ -17841,6 +25002,19 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "spell_prereq",
+								"has": true,
+								"sub_type": "name",
+								"qualifier": {
+									"compare": "is",
+									"qualifier": "Control Person"
+								},
+								"quantity": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							},
+							{
 								"type": "prereq_list",
 								"all": false,
 								"prereqs": [
@@ -17849,7 +25023,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "bardic talent"
+											"qualifier": "Magery"
 										},
 										"level": {
 											"compare": "at_least",
@@ -17861,32 +25035,9 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "magery"
+											"qualifier": "Bardic Talent"
 										},
 										"level": {
-											"compare": "at_least",
-											"qualifier": 1
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
-										}
-									}
-								]
-							},
-							{
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "spell_prereq",
-										"has": true,
-										"sub_type": "name",
-										"qualifier": {
-											"compare": "is",
-											"qualifier": "control person"
-										},
-										"quantity": {
 											"compare": "at_least",
 											"qualifier": 1
 										}
@@ -17896,12 +25047,14 @@
 						]
 					},
 					"categories": [
-						"Communication"
+						"Bardic",
+						"Communication & Empathy",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "e248af1b-f426-4d9d-b2b1-1a496ff19cd7",
+					"id": "c229048e-6eea-4b1c-9664-7108449f8be5",
 					"name": "Prepare Game",
 					"reference": "DFS32",
 					"difficulty": "iq/h",
@@ -17920,12 +25073,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "purify food"
+									"qualifier": "Purify Food"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -17935,12 +25096,13 @@
 						]
 					},
 					"categories": [
-						"Food"
+						"Food",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "e790246f-322e-4e34-8f0b-5e8c23529db3",
+					"id": "9ec6490c-3cc9-4bf1-a955-8666df77516b",
 					"name": "Projection",
 					"reference": "DFS44",
 					"difficulty": "iq/h",
@@ -17961,19 +25123,6 @@
 							{
 								"type": "spell_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "sense spirit"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
-							},
-							{
-								"type": "spell_prereq",
-								"has": true,
 								"sub_type": "college",
 								"qualifier": {
 									"compare": "contains",
@@ -17983,33 +25132,20 @@
 									"compare": "at_least",
 									"qualifier": 4
 								}
-							}
-						]
-					},
-					"categories": [
-						"Knowledge"
-					]
-				},
-				{
-					"type": "spell",
-					"id": "69f53566-845b-40e6-bc38-bfb6e4ecf757",
-					"name": "Protection from Evil",
-					"reference": "DFS64",
-					"difficulty": "iq/h",
-					"college": [
-						"Protection"
-					],
-					"power_source": "Arcane",
-					"spell_class": "Regular",
-					"casting_cost": "1-5",
-					"maintenance_cost": "Half",
-					"casting_time": "1 sec",
-					"duration": "1 min",
-					"points": 1,
-					"prereqs": {
-						"type": "prereq_list",
-						"all": true,
-						"prereqs": [
+							},
+							{
+								"type": "spell_prereq",
+								"has": true,
+								"sub_type": "name",
+								"qualifier": {
+									"compare": "is",
+									"qualifier": "Sense Spirit"
+								},
+								"quantity": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							},
 							{
 								"type": "prereq_list",
 								"all": false,
@@ -18019,11 +25155,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "bardic talent"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 3
+											"qualifier": "Magery"
 										}
 									},
 									{
@@ -18031,46 +25163,134 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 3
+											"qualifier": "Bardic Talent"
 										}
 									}
 								]
-							},
-							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "sense evil"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
 							}
 						]
 					},
 					"categories": [
-						"Protection"
+						"Bardic",
+						"Knowledge",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "9a077463-4574-4026-9aed-6ee80a5353bc",
+					"id": "5d6371c7-54bf-4b7f-8604-dffb831b660d",
+					"name": "Protection from Evil",
+					"reference": "DFS64",
+					"difficulty": "iq/h",
+					"college": [
+						"Meta",
+						"Protection & Warning"
+					],
+					"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+					"spell_class": "Regular",
+					"casting_cost": "1-5",
+					"maintenance_cost": "Half",
+					"casting_time": "1 sec",
+					"duration": "1 min",
+					"points": 1,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture (Druidic)"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								}
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Sense Evil"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "prereq_list",
+										"all": false,
+										"prereqs": [
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 3
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Bardic Talent"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 3
+												}
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					"categories": [
+						"Bardic",
+						"Clerical",
+						"Druidic",
+						"Meta",
+						"Protection & Warning",
+						"Wizardly"
+					]
+				},
+				{
+					"type": "spell",
+					"id": "f97c2b01-a85a-4498-854e-8d1a00e8330b",
 					"name": "Purify Air",
 					"reference": "DFS16",
 					"difficulty": "iq/h",
 					"college": [
-						"Air",
-						"Clerical",
-						"Druidic"
+						"Air"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 					"spell_class": "Area",
 					"casting_cost": "1",
 					"maintenance_cost": "-",
@@ -18086,18 +25306,45 @@
 								"has": true,
 								"name": {
 									"compare": "is",
+									"qualifier": "Power Investiture"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture (Druidic)"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
 									"qualifier": "Magery"
 								}
 							}
 						]
 					},
 					"categories": [
-						"Air"
+						"Air",
+						"Clerical",
+						"Druidic",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "b5b3befe-27a9-4d09-8843-891b4c417fb6",
+					"id": "80f46d7a-8d73-4b5b-8d02-534c70ff2329",
 					"name": "Purify Earth",
 					"reference": "DFS28",
 					"difficulty": "iq/h",
@@ -18105,7 +25352,7 @@
 						"Earth",
 						"Plant"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Druidic@",
 					"spell_class": "Area",
 					"casting_cost": "2",
 					"maintenance_cost": "-",
@@ -18114,52 +25361,80 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "create earth"
+									"qualifier": "Power Investiture (Druidic)"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
 									"qualifier": 1
 								}
 							},
 							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "college",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "earth"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 6
-								}
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "college",
+										"qualifier": {
+											"compare": "contains",
+											"qualifier": "Earth"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 6
+										}
+									},
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Create Earth"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									}
+								]
 							}
 						]
 					},
 					"notes": "Double casting cost in poor or rocky soil/desert",
 					"categories": [
+						"Druidic",
 						"Earth",
-						"Plant"
+						"Plant",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "dfc23076-85d8-4dcf-b6a8-4579cfcc521e",
+					"id": "d9cf7410-ad1d-4b53-8166-5d73c3776fe3",
 					"name": "Purify Food",
 					"reference": "DFS32",
 					"difficulty": "iq/h",
 					"college": [
 						"Food"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 					"spell_class": "Regular",
 					"casting_cost": "1/lb",
 					"maintenance_cost": "-",
@@ -18168,37 +25443,78 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "decay"
+									"qualifier": "Power Investiture"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": 2
 								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture (Druidic)"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								}
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Decay"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Food"
+						"Clerical",
+						"Druidic",
+						"Food",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "a0d1c3a3-e027-432b-a1a8-cbcea7170052",
+					"id": "8b8e070f-0921-451a-8851-b181ce67444b",
 					"name": "Purify Water",
 					"reference": "DFS70",
 					"difficulty": "iq/h",
 					"college": [
 						"Water"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 					"spell_class": "Special",
 					"casting_cost": "1/gal",
 					"maintenance_cost": "-",
@@ -18207,37 +25523,78 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "seek water"
+									"qualifier": "Power Investiture"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
 									"qualifier": 1
 								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture (Druidic)"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Seek Water"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Water"
+						"Clerical",
+						"Druidic",
+						"Water",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "7eb5a10f-23d4-4019-86b5-62c72fbc69c3",
+					"id": "82b5ba30-8662-43c9-84ab-8fcbe0a2364d",
 					"name": "Quick March",
 					"reference": "DFS58",
 					"difficulty": "iq/h",
 					"college": [
 						"Movement"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Druidic@",
 					"spell_class": "Regular",
 					"casting_cost": "4",
 					"maintenance_cost": "-",
@@ -18246,26 +25603,35 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture (Druidic)"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							},
+							{
 								"type": "prereq_list",
-								"all": false,
+								"all": true,
 								"prereqs": [
 									{
-										"type": "advantage_prereq",
+										"type": "spell_prereq",
 										"has": true,
-										"name": {
+										"sub_type": "name",
+										"qualifier": {
 											"compare": "is",
-											"qualifier": "magery"
+											"qualifier": "Haste"
 										},
-										"level": {
+										"quantity": {
 											"compare": "at_least",
 											"qualifier": 1
-										},
-										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (movement)"
 										}
 									},
 									{
@@ -18273,48 +25639,34 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "magery"
+											"qualifier": "Magery"
 										},
 										"level": {
 											"compare": "at_least",
 											"qualifier": 1
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
 										}
 									}
 								]
-							},
-							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "haste"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
 							}
 						]
 					},
 					"categories": [
-						"Movement"
+						"Druidic",
+						"Movement",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "6c1e0fbd-d319-4228-ad32-6ff1131884db",
+					"id": "8af3b883-2aa6-4ecc-af3a-f516ed53625f",
 					"name": "Recover Energy",
 					"reference": "DFS38",
 					"difficulty": "iq/h",
 					"college": [
-						"Healing"
+						"Healing",
+						"Meta"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 					"spell_class": "Special",
 					"casting_cost": "0",
 					"maintenance_cost": "0",
@@ -18323,26 +25675,47 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture (Druidic)"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							},
+							{
 								"type": "prereq_list",
-								"all": false,
+								"all": true,
 								"prereqs": [
 									{
-										"type": "advantage_prereq",
+										"type": "spell_prereq",
 										"has": true,
-										"name": {
+										"sub_type": "name",
+										"qualifier": {
 											"compare": "is",
-											"qualifier": "magery"
+											"qualifier": "Lend Energy"
 										},
-										"level": {
+										"quantity": {
 											"compare": "at_least",
 											"qualifier": 1
-										},
-										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (healing)"
 										}
 									},
 									{
@@ -18350,41 +25723,28 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "magery"
+											"qualifier": "Magery"
 										},
 										"level": {
 											"compare": "at_least",
 											"qualifier": 1
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
 										}
 									}
 								]
-							},
-							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "lend energy"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
 							}
 						]
 					},
 					"categories": [
-						"Healing"
+						"Clerical",
+						"Druidic",
+						"Healing",
+						"Meta",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "6513560f-cf91-46b5-ba99-a3e8f110861d",
+					"id": "37acd780-f6a7-4dc9-ab76-a2316302e732",
 					"name": "Reflect",
 					"reference": "DFS52",
 					"difficulty": "iq/h",
@@ -18393,6 +25753,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Blocking",
+					"resist": "Subject spell",
 					"casting_cost": "4 or 6",
 					"maintenance_cost": "-",
 					"casting_time": "1 sec",
@@ -18403,12 +25764,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "ward"
+									"qualifier": "Ward"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -18418,17 +25787,18 @@
 						]
 					},
 					"categories": [
-						"Meta"
+						"Meta",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "9334563e-4b79-48e2-b175-9979203f1640",
+					"id": "c20fe60d-aee7-4c5b-a543-ad4497f86f07",
 					"name": "Reflect Gaze",
 					"reference": "DFS65",
 					"difficulty": "iq/vh",
 					"college": [
-						"Protection"
+						"Protection & Warning"
 					],
 					"power_source": "Arcane",
 					"spell_class": "Blocking",
@@ -18442,12 +25812,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "mirror"
+									"qualifier": "Mirror"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -18457,12 +25835,13 @@
 						]
 					},
 					"categories": [
-						"Protection"
+						"Protection & Warning",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "30412f3f-5ff1-4ee0-9ca4-d6dee62e277e",
+					"id": "42b99ba5-374f-4ab1-9585-c40a62976e2b",
 					"name": "Reflexes",
 					"reference": "DFS22",
 					"difficulty": "iq/h",
@@ -18481,12 +25860,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "grace"
+									"qualifier": "Grace"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -18499,7 +25886,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "haste"
+									"qualifier": "Haste"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -18509,12 +25896,13 @@
 						]
 					},
 					"categories": [
-						"Body Control"
+						"Body Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "29f688e7-0209-4614-97d5-ac62ce83c436",
+					"id": "ab43efb5-b10e-4bd8-8d72-4344b9f70af5",
 					"name": "Rejoin",
 					"reference": "DFS49",
 					"difficulty": "iq/h",
@@ -18533,12 +25921,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "weaken"
+									"qualifier": "Weaken"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -18551,7 +25947,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "restore"
+									"qualifier": "Restore"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -18561,12 +25957,13 @@
 						]
 					},
 					"categories": [
-						"Making & Breaking"
+						"Making & Breaking",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "7fe4b3e8-28db-43bb-b2b1-11464848cdb2",
+					"id": "6b15f9ec-f7d4-4b0f-95c2-4190abae35c4",
 					"name": "Repair",
 					"reference": "DFS49",
 					"difficulty": "iq/h",
@@ -18585,72 +25982,47 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "rejoin"
+									"qualifier": "Rejoin"
 								},
 								"quantity": {
 									"compare": "at_least",
 									"qualifier": 1
 								}
-							},
-							{
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 2
-										},
-										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (making & breaking)"
-										}
-									},
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 2
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
-										}
-									}
-								]
 							}
 						]
 					},
 					"categories": [
-						"Making & Breaking"
+						"Making & Breaking",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "43912690-2d2c-42ff-82b8-c21515650dac",
+					"id": "9b1980dd-8b08-45dd-99a1-43357d7805f9",
 					"name": "Repel Spirits",
 					"reference": "DFS60",
 					"difficulty": "iq/h",
 					"college": [
 						"Necromancy"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical@",
 					"spell_class": "Area",
 					"casting_cost": "4",
 					"maintenance_cost": "Half",
@@ -18659,50 +26031,78 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "banish"
+									"qualifier": "Power Investiture"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": 3
 								}
 							},
 							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "turn spirit"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Turn Spirit"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Banish"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Necromancy"
+						"Clerical",
+						"Necromancy",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "6aeddd2c-f8f6-4d2f-bcc7-247a7b7dc576",
+					"id": "02e0535e-92e3-4bc3-82fd-de4b48a08294",
 					"name": "Resist Cold",
 					"reference": "DFS31",
 					"difficulty": "iq/h",
 					"college": [
 						"Fire"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 					"spell_class": "Regular",
 					"casting_cost": "2",
 					"maintenance_cost": "Half",
@@ -18711,37 +26111,78 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "heat"
+									"qualifier": "Power Investiture"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": 2
 								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture (Druidic)"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								}
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Heat"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Fire"
+						"Clerical",
+						"Druidic",
+						"Fire",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "8ed6df7e-21ff-4fe2-8ff5-52617bb4c102",
+					"id": "6b6994a7-b575-4420-91b6-c1a64d1917af",
 					"name": "Resist Fire",
 					"reference": "DFS31",
 					"difficulty": "iq/h",
 					"college": [
 						"Fire"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical@",
 					"spell_class": "Regular",
 					"casting_cost": "2#",
 					"maintenance_cost": "Half",
@@ -18750,39 +26191,67 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "fireproof"
+									"qualifier": "Power Investiture"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": 2
 								}
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Fireproof"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Fire"
+						"Clerical",
+						"Fire",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "92f6d53f-7687-4a60-a299-bd314c94df9c",
+					"id": "a27f978f-c41f-4469-a1d7-7d8b2c38b7ac",
 					"name": "Resist Lightning",
 					"reference": "DFS72",
 					"difficulty": "iq/h",
 					"college": [
 						"Air",
-						"Protection",
+						"Protection & Warning",
 						"Weather"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 					"spell_class": "Regular",
 					"casting_cost": "2",
 					"maintenance_cost": "1",
@@ -18791,39 +26260,80 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "college",
-								"qualifier": {
-									"compare": "contains",
-									"qualifier": "Air"
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
-									"qualifier": 6
+									"qualifier": 2
 								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture (Druidic)"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								}
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "college",
+										"qualifier": {
+											"compare": "contains",
+											"qualifier": "Air"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 6
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
 						"Air",
-						"Protection",
-						"Weather"
+						"Clerical",
+						"Druidic",
+						"Protection & Warning",
+						"Weather",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "be9fb1d3-5d8b-496c-bfe3-ac8d1dd3f927",
+					"id": "3d5a41a9-241f-4459-8afb-ce91727a7f8c",
 					"name": "Resist Pain",
 					"reference": "DFS22",
 					"difficulty": "iq/h",
 					"college": [
 						"Body Control"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical@",
 					"spell_class": "Regular",
 					"casting_cost": "4",
 					"maintenance_cost": "2",
@@ -18832,26 +26342,35 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								}
+							},
+							{
 								"type": "prereq_list",
-								"all": false,
+								"all": true,
 								"prereqs": [
 									{
-										"type": "advantage_prereq",
+										"type": "spell_prereq",
 										"has": true,
-										"name": {
+										"sub_type": "name",
+										"qualifier": {
 											"compare": "is",
-											"qualifier": "magery"
+											"qualifier": "Pain"
 										},
-										"level": {
+										"quantity": {
 											"compare": "at_least",
-											"qualifier": 2
-										},
-										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (body control)"
+											"qualifier": 1
 										}
 									},
 									{
@@ -18859,46 +26378,31 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "magery"
+											"qualifier": "Magery"
 										},
 										"level": {
 											"compare": "at_least",
 											"qualifier": 2
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
 										}
 									}
 								]
-							},
-							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "pain"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
 							}
 						]
 					},
 					"categories": [
-						"Body Control"
+						"Body Control",
+						"Clerical",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "5bd2af1e-91fc-4c11-9cab-103ea46a85b9",
+					"id": "22cb8a85-dc1c-430c-8d7d-87a792f84b0d",
 					"name": "Resist Sound",
 					"reference": "DFS67",
 					"difficulty": "iq/h",
 					"college": [
-						"Protection",
+						"Protection & Warning",
 						"Sound"
 					],
 					"power_source": "Arcane",
@@ -18912,6 +26416,28 @@
 						"type": "prereq_list",
 						"all": true,
 						"prereqs": [
+							{
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										}
+									}
+								]
+							},
 							{
 								"type": "spell_prereq",
 								"has": true,
@@ -18928,18 +26454,20 @@
 						]
 					},
 					"categories": [
-						"Protection",
-						"Sound"
+						"Bardic",
+						"Protection & Warning",
+						"Sound",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "dbae526b-c12a-45e5-bbc9-871335ac6fb7",
+					"id": "36de65d0-a4d3-40e3-bbe0-9c5d22035abb",
 					"name": "Resist Water",
 					"reference": "DFS70",
 					"difficulty": "iq/h",
 					"college": [
-						"Protection",
+						"Protection & Warning",
 						"Water"
 					],
 					"power_source": "Arcane",
@@ -18951,11 +26479,11 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": false,
+						"all": true,
 						"prereqs": [
 							{
 								"type": "prereq_list",
-								"all": true,
+								"all": false,
 								"prereqs": [
 									{
 										"type": "spell_prereq",
@@ -18963,7 +26491,7 @@
 										"sub_type": "name",
 										"qualifier": {
 											"compare": "is",
-											"qualifier": "shape water"
+											"qualifier": "Umbrella"
 										},
 										"quantity": {
 											"compare": "at_least",
@@ -18971,43 +26499,58 @@
 										}
 									},
 									{
-										"type": "spell_prereq",
-										"has": true,
-										"sub_type": "name",
-										"qualifier": {
-											"compare": "is",
-											"qualifier": "destroy water"
-										},
-										"quantity": {
-											"compare": "at_least",
-											"qualifier": 1
-										}
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Destroy Water"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Shape Water"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											}
+										]
 									}
 								]
 							},
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "umbrella"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": "Magery"
 								}
 							}
 						]
 					},
 					"categories": [
-						"Protection",
-						"Water"
+						"Protection & Warning",
+						"Water",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "3a025075-ef73-426c-a346-e6ff9198fd69",
+					"id": "b4e0621d-071f-40ab-9798-f7206746fa6d",
 					"name": "Restore",
 					"reference": "DFS49",
 					"difficulty": "iq/h",
@@ -19023,43 +26566,58 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": false,
+						"all": true,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "find weakness"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": "Magery"
 								}
 							},
 							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "simple illusion"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Find Weakness"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Simple Illusion"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Making & Breaking"
+						"Making & Breaking",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "aaba2c6c-e328-4bf6-858e-c6fd7780d5a4",
+					"id": "96233ae2-4538-434e-b033-e05591346e49",
 					"name": "Retch",
 					"reference": "DFS22",
 					"difficulty": "iq/h",
@@ -19068,6 +26626,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "HT",
 					"casting_cost": "3",
 					"maintenance_cost": "-",
 					"casting_time": "4 sec",
@@ -19078,12 +26637,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "nauseate"
+									"qualifier": "Nauseate"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -19096,7 +26663,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "spasm"
+									"qualifier": "Spasm"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -19106,12 +26673,13 @@
 						]
 					},
 					"categories": [
-						"Body Control"
+						"Body Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "e9645318-0c0d-438b-9895-583a1f223f95",
+					"id": "e2177a44-1fd1-4f11-88e7-1eb069806be6",
 					"name": "Rive",
 					"reference": "DFS49",
 					"difficulty": "iq/vh",
@@ -19147,66 +26715,41 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "shatter"
+									"qualifier": "Shatter"
 								},
 								"quantity": {
 									"compare": "at_least",
 									"qualifier": 1
 								}
-							},
-							{
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 2
-										},
-										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (making & breaking)"
-										}
-									},
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 2
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
-										}
-									}
-								]
 							}
 						]
 					},
 					"notes": "only affects inanimate objects",
 					"categories": [
-						"Making & Breaking"
+						"Making & Breaking",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "cbf78f7f-ff6b-4916-929b-9d892321e217",
+					"id": "819d582a-3da3-45f0-a366-14651a7a6856",
 					"name": "Rooted Feet",
 					"reference": "DFS22",
 					"difficulty": "iq/h",
@@ -19215,6 +26758,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "ST",
 					"casting_cost": "3",
 					"maintenance_cost": "-",
 					"casting_time": "1 sec",
@@ -19225,12 +26769,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "hinder"
+									"qualifier": "Hinder"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -19240,12 +26792,13 @@
 						]
 					},
 					"categories": [
-						"Body Control"
+						"Body Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "ea93df10-b362-4609-9581-8fec0bd78739",
+					"id": "c90f6c98-5ca0-42e0-b9e1-58d3c5ad22e4",
 					"name": "Roundabout",
 					"reference": "DFS22",
 					"difficulty": "iq/h",
@@ -19254,6 +26807,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "HT",
 					"casting_cost": "3",
 					"maintenance_cost": "-",
 					"casting_time": "1 sec",
@@ -19264,56 +26818,11 @@
 						"all": true,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "tanglefoot"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
-							}
-						]
-					},
-					"categories": [
-						"Body Control"
-					]
-				},
-				{
-					"type": "spell",
-					"id": "8849249c-80b4-437a-ba33-b8f474b4a883",
-					"name": "Sandstorm",
-					"reference": "DFS16",
-					"difficulty": "iq/h",
-					"college": [
-						"Air",
-						"Earth"
-					],
-					"power_source": "Arcane",
-					"spell_class": "Area",
-					"casting_cost": "3",
-					"maintenance_cost": "Half",
-					"casting_time": "Instant#",
-					"duration": "1 min#",
-					"points": 1,
-					"prereqs": {
-						"type": "prereq_list",
-						"all": true,
-						"prereqs": [
-							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "create earth"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": "Magery"
 								}
 							},
 							{
@@ -19322,7 +26831,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "windstorm"
+									"qualifier": "Tanglefoot"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -19332,13 +26841,95 @@
 						]
 					},
 					"categories": [
-						"Air",
-						"Earth"
+						"Body Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "dca9fa8f-b425-45f9-9a3f-a615f11949f5",
+					"id": "07742485-bac3-48ca-a7fd-b5e8d9d50f52",
+					"name": "Sandstorm",
+					"reference": "DFS16",
+					"difficulty": "iq/h",
+					"college": [
+						"Air",
+						"Earth"
+					],
+					"power_source": "@Power Source: Arcane/Druidic@",
+					"spell_class": "Area",
+					"casting_cost": "3",
+					"maintenance_cost": "Half",
+					"casting_time": "Instant#",
+					"duration": "1 min#",
+					"points": 1,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture (Druidic)"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 4
+								}
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Create Earth"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Windstorm"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									}
+								]
+							}
+						]
+					},
+					"categories": [
+						"Air",
+						"Druidic",
+						"Earth",
+						"Wizardly"
+					]
+				},
+				{
+					"type": "spell",
+					"id": "50bc96ef-0a3e-4053-9adc-ffba6542f692",
 					"name": "Scry Gate",
 					"reference": "DFS35",
 					"difficulty": "iq/h",
@@ -19357,12 +26948,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "seek gate"
+									"qualifier": "Seek Gate"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -19372,12 +26971,13 @@
 						]
 					},
 					"categories": [
-						"Gate"
+						"Gate",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "1bdc1760-99f6-494a-acb4-8fb9890a3ce1",
+					"id": "7913f24c-b694-4c65-a608-af501a9583dc",
 					"name": "Scryguard",
 					"reference": "DFS52",
 					"difficulty": "iq/h",
@@ -19396,39 +26996,99 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							}
+						]
+					},
+					"categories": [
+						"Meta",
+						"Wizardly"
+					]
+				},
+				{
+					"type": "spell",
+					"id": "847003e5-65ff-4c31-a9f0-00c5492c5a5d",
+					"name": "See Invisible",
+					"reference": "DFS48",
+					"difficulty": "iq/h",
+					"college": [
+						"Light & Darkness"
+					],
+					"power_source": "Arcane",
+					"spell_class": "Regular",
+					"casting_cost": "4",
+					"maintenance_cost": "2",
+					"casting_time": "1 sec",
+					"duration": "1 min",
+					"points": 1,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "prereq_list",
 								"all": false,
 								"prereqs": [
 									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 1
-										},
-										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (meta)"
-										}
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Dark Vision"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Infravision"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											}
+										]
 									},
 									{
-										"type": "advantage_prereq",
+										"type": "spell_prereq",
 										"has": true,
-										"name": {
+										"sub_type": "name",
+										"qualifier": {
 											"compare": "is",
-											"qualifier": "magery"
+											"qualifier": "Invisibility"
 										},
-										"level": {
+										"quantity": {
 											"compare": "at_least",
 											"qualifier": 1
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
 										}
 									}
 								]
@@ -19436,19 +27096,20 @@
 						]
 					},
 					"categories": [
-						"Meta"
+						"Light & Darkness",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "9c7220c5-c5d9-4b6f-a34b-c903c575e524",
+					"id": "2d3e4725-d159-43f7-a8c8-223f6379ec60",
 					"name": "See Secrets",
 					"reference": "DFS44",
 					"difficulty": "iq/h",
 					"college": [
 						"Knowledge"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical@",
 					"spell_class": "Regular",
 					"casting_cost": "5",
 					"maintenance_cost": "2",
@@ -19457,30 +27118,119 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "aura"
+									"qualifier": "Power Investiture"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": 3
 								}
 							},
 							{
-								"type": "spell_prereq",
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Seeker"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Aura"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "prereq_list",
+										"all": false,
+										"prereqs": [
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Bardic Talent"
+												}
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					"categories": [
+						"Bardic",
+						"Clerical",
+						"Knowledge",
+						"Wizardly"
+					]
+				},
+				{
+					"type": "spell",
+					"id": "63b0473b-6a2c-4ed3-bf98-b94fba0174ba",
+					"name": "Seek Earth",
+					"reference": "DFS28",
+					"difficulty": "iq/h",
+					"college": [
+						"Earth"
+					],
+					"power_source": "@Power Source: Arcane/Druidic@",
+					"spell_class": "Info",
+					"casting_cost": "3",
+					"maintenance_cost": "-",
+					"casting_time": "10 sec",
+					"duration": "Instant",
+					"points": 1,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "seeker"
+									"qualifier": "Magery"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture (Druidic)"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
 									"qualifier": 1
 								}
@@ -19488,32 +27238,14 @@
 						]
 					},
 					"categories": [
-						"Knowledge"
+						"Druidic",
+						"Earth",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "3d89074e-5113-4cdf-948d-332f96b6acd6",
-					"name": "Seek Earth",
-					"reference": "DFS28",
-					"difficulty": "iq/h",
-					"college": [
-						"Earth"
-					],
-					"power_source": "Arcane",
-					"spell_class": "Info",
-					"casting_cost": "3",
-					"maintenance_cost": "-",
-					"casting_time": "10 sec",
-					"duration": "Instant",
-					"points": 1,
-					"categories": [
-						"Earth"
-					]
-				},
-				{
-					"type": "spell",
-					"id": "30d1301c-a467-4f90-8359-f32a6d38061a",
+					"id": "16f106c1-70da-45f1-b6a1-3b681c979e03",
 					"name": "Seek Fire",
 					"reference": "DFS31",
 					"difficulty": "iq/h",
@@ -19527,33 +27259,76 @@
 					"casting_time": "1 sec",
 					"duration": "Instant",
 					"points": 1,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							}
+						]
+					},
 					"categories": [
-						"Fire"
+						"Fire",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "7d3c37c0-ef9b-419c-ad29-f268cb6de0b3",
+					"id": "e64c1c77-20ec-4196-8d04-7a8705062d5e",
 					"name": "Seek Food",
 					"reference": "DFS32",
 					"difficulty": "iq/h",
 					"college": [
 						"Food"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Druidic@",
 					"spell_class": "Info",
 					"casting_cost": "2",
 					"maintenance_cost": "-",
 					"casting_time": "1 sec",
 					"duration": "Instant",
 					"points": 1,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture (Druidic)"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							}
+						]
+					},
 					"categories": [
-						"Food"
+						"Druidic",
+						"Food",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "6cdf7be7-a16d-4102-80ac-966c71cc8d78",
+					"id": "6566663e-c176-4af0-97e6-0f9a0b077f59",
 					"name": "Seek Gate",
 					"reference": "DFS35",
 					"difficulty": "iq/h",
@@ -19572,42 +27347,12 @@
 						"all": true,
 						"prereqs": [
 							{
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 2
-										},
-										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (gate)"
-										}
-									},
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 2
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
-										}
-									}
-								]
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
 							},
 							{
 								"type": "spell_prereq",
@@ -19615,7 +27360,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "seek magic"
+									"qualifier": "Seek Magic"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -19634,17 +27379,19 @@
 						]
 					},
 					"categories": [
-						"Gate"
+						"Gate",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "df210cf6-bfae-4c3f-9213-0460075e50ef",
+					"id": "4e3f96d6-8fdf-46fe-a0af-3b3fb59f5248",
 					"name": "Seek Magic",
 					"reference": "DFS45",
 					"difficulty": "iq/h",
 					"college": [
-						"Knowledge"
+						"Knowledge",
+						"Meta"
 					],
 					"power_source": "Arcane",
 					"spell_class": "Info",
@@ -19658,12 +27405,34 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										}
+									}
+								]
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "detect magic"
+									"qualifier": "Detect Magic"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -19673,37 +27442,167 @@
 						]
 					},
 					"categories": [
-						"Knowledge"
+						"Bardic",
+						"Knowledge",
+						"Meta",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "9ebca1d4-ff5f-46bf-b22c-455e1059e4ac",
+					"id": "9fa23599-eb34-4f47-9c0c-b73e49802214",
 					"name": "Seek Water",
 					"reference": "DFS70",
 					"difficulty": "iq/h",
 					"college": [
 						"Water"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Druidic@",
 					"spell_class": "Info",
 					"casting_cost": "2",
 					"maintenance_cost": "-",
 					"casting_time": "1 sec",
 					"duration": "Instant",
 					"points": 1,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture (Druidic)"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							}
+						]
+					},
 					"categories": [
-						"Water"
+						"Druidic",
+						"Water",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "754d7e68-eea8-4652-a017-b363979bab65",
+					"id": "5c85b4d4-4e59-4342-b076-afa7f20daee6",
 					"name": "Seeker",
 					"reference": "DFS45",
 					"difficulty": "iq/h",
 					"college": [
 						"Knowledge"
+					],
+					"power_source": "@Power Source: Arcane/Clerical@",
+					"spell_class": "Info",
+					"casting_cost": "3",
+					"maintenance_cost": "-",
+					"casting_time": "1 sec",
+					"duration": "Instant",
+					"points": 1,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								}
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "attribute_prereq",
+										"has": true,
+										"which": "iq",
+										"qualifier": {
+											"compare": "at_least",
+											"qualifier": 12
+										}
+									},
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "starts_with",
+											"qualifier": "Seek "
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 2
+										}
+									},
+									{
+										"type": "prereq_list",
+										"all": false,
+										"prereqs": [
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Bardic Talent"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					"categories": [
+						"Bardic",
+						"Clerical",
+						"Knowledge",
+						"Wizardly"
+					]
+				},
+				{
+					"type": "spell",
+					"id": "69c410fd-a60f-4e1c-a26f-bba9deb4c44c",
+					"name": "Sense Danger",
+					"reference": "DFS65",
+					"difficulty": "iq/h",
+					"college": [
+						"Protection & Warning"
 					],
 					"power_source": "Arcane",
 					"spell_class": "Info",
@@ -19717,94 +27616,20 @@
 						"all": true,
 						"prereqs": [
 							{
-								"type": "attribute_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"which": "iq",
-								"qualifier": {
-									"compare": "at_least",
-									"qualifier": 12
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
 								}
 							},
-							{
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "bardic talent"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 1
-										}
-									},
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 1
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
-										}
-									}
-								]
-							},
-							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "contains",
-									"qualifier": "seek"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 2
-								}
-							}
-						]
-					},
-					"categories": [
-						"Knowledge"
-					]
-				},
-				{
-					"type": "spell",
-					"id": "8f66530c-5725-4f9c-b485-87f6f265d8eb",
-					"name": "Sense Danger",
-					"reference": "DFS65",
-					"difficulty": "iq/h",
-					"college": [
-						"Protection"
-					],
-					"power_source": "Arcane",
-					"spell_class": "Info",
-					"casting_cost": "3",
-					"maintenance_cost": "-",
-					"casting_time": "1 sec",
-					"duration": "Instant",
-					"points": 1,
-					"prereqs": {
-						"type": "prereq_list",
-						"all": false,
-						"prereqs": [
 							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "sense foes"
+									"qualifier": "Sense Foes"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -19814,12 +27639,13 @@
 						]
 					},
 					"categories": [
-						"Protection"
+						"Protection & Warning",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "883be16d-b8b1-4109-abc6-686b79d195f5",
+					"id": "aee665ef-6b05-4949-805a-d55ce16a34e7",
 					"name": "Sense Emotion",
 					"reference": "DFS26",
 					"difficulty": "iq/h",
@@ -19843,29 +27669,54 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "sense foes"
+									"qualifier": "Sense Foes"
 								},
 								"quantity": {
 									"compare": "at_least",
 									"qualifier": 1
 								}
+							},
+							{
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Communication"
+						"Bardic",
+						"Communication & Empathy",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "3f064855-a461-49a6-8628-605aeb4566d0",
+					"id": "68a42f31-d717-40b6-ae12-e188bd65c0b9",
 					"name": "Sense Evil",
 					"reference": "DFS26",
 					"difficulty": "iq/h",
 					"college": [
-						"Communication & Empathy"
+						"Communication & Empathy",
+						"Meta"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 					"spell_class": "Info/Area",
 					"casting_cost": "1/area, min 2",
 					"maintenance_cost": "-",
@@ -19881,7 +27732,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "bardic talent"
+									"qualifier": "Magery"
 								},
 								"level": {
 									"compare": "at_least",
@@ -19893,22 +27744,51 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Magery"
+									"qualifier": "Bardic Talent"
 								},
 								"level": {
 									"compare": "at_least",
 									"qualifier": 2
 								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture (Druidic)"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
 							}
 						]
 					},
 					"categories": [
-						"Communication"
+						"Bardic",
+						"Clerical",
+						"Communication & Empathy",
+						"Druidic",
+						"Meta",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "4a8e9c13-7213-46c2-86b3-ba13dec66581",
+					"id": "0f45835c-cd69-427a-95c8-e1e7a4c54481",
 					"name": "Sense Foes",
 					"reference": "DFS26",
 					"difficulty": "iq/h",
@@ -19922,40 +27802,122 @@
 					"casting_time": "1 sec",
 					"duration": "Instant",
 					"points": 1,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Bardic Talent"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							}
+						]
+					},
 					"categories": [
-						"Communication"
+						"Bardic",
+						"Communication & Empathy",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "78662f48-9f9f-4232-a08f-bb54509296e4",
+					"id": "565c635b-e67c-468e-a822-1af301eacf60",
 					"name": "Sense Life",
 					"reference": "DFS26",
 					"difficulty": "iq/h",
 					"college": [
 						"Communication & Empathy"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 					"spell_class": "Info/Area",
 					"casting_cost": "1/2",
 					"maintenance_cost": "-",
 					"casting_time": "1 sec",
 					"duration": "Instant",
 					"points": 1,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Bardic Talent"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture (Druidic)"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							}
+						]
+					},
 					"categories": [
-						"Communication"
+						"Bardic",
+						"Clerical",
+						"Communication & Empathy",
+						"Druidic",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "dbd4214e-9f3e-4bf3-bd76-8a2c90ae204b",
+					"id": "aaca3119-cb8d-4f85-a2d3-1463b4c94e42",
 					"name": "Sense Spirit",
 					"reference": "DFS60",
 					"difficulty": "iq/h",
 					"college": [
 						"Necromancy"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical@",
 					"spell_class": "Info/Area",
 					"casting_cost": "1/2 (min 1)",
 					"maintenance_cost": "-",
@@ -19967,27 +27929,36 @@
 						"all": false,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							},
+							{
 								"type": "prereq_list",
-								"all": true,
+								"all": false,
 								"prereqs": [
 									{
 										"type": "prereq_list",
-										"all": false,
+										"all": true,
 										"prereqs": [
 											{
-												"type": "advantage_prereq",
+												"type": "spell_prereq",
 												"has": true,
-												"name": {
+												"sub_type": "name",
+												"qualifier": {
 													"compare": "is",
-													"qualifier": "magery"
+													"qualifier": "Death Vision"
 												},
-												"level": {
+												"quantity": {
 													"compare": "at_least",
 													"qualifier": 1
-												},
-												"notes": {
-													"compare": "contains",
-													"qualifier": "one college (necromancy)"
 												}
 											},
 											{
@@ -19995,7 +27966,34 @@
 												"has": true,
 												"name": {
 													"compare": "is",
-													"qualifier": "magery"
+													"qualifier": "Magery"
+												}
+											}
+										]
+									},
+									{
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Sense Life"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
 												},
 												"level": {
 													"compare": "at_least",
@@ -20003,44 +28001,20 @@
 												}
 											}
 										]
-									},
-									{
-										"type": "spell_prereq",
-										"has": true,
-										"sub_type": "name",
-										"qualifier": {
-											"compare": "is",
-											"qualifier": "sense life"
-										},
-										"quantity": {
-											"compare": "at_least",
-											"qualifier": 1
-										}
 									}
 								]
-							},
-							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "death vision"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
 							}
 						]
 					},
 					"categories": [
-						"Necromancy"
+						"Clerical",
+						"Necromancy",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "4f450296-4736-4ea6-b86b-e7be1333e4ae",
+					"id": "623e7c5e-dfb9-49ab-9ce3-9163d48b948b",
 					"name": "Sensitize",
 					"reference": "DFS22",
 					"difficulty": "iq/h",
@@ -20059,42 +28033,16 @@
 						"all": true,
 						"prereqs": [
 							{
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 1
-										},
-										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (body control)"
-										}
-									},
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 1
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
-										}
-									}
-								]
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
 							},
 							{
 								"type": "spell_prereq",
@@ -20102,7 +28050,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "stun"
+									"qualifier": "Stun"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -20112,19 +28060,20 @@
 						]
 					},
 					"categories": [
-						"Body Control"
+						"Body Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "ccab7118-d01a-4971-9ddc-58ee5caf40ab",
+					"id": "fe67be61-2de1-4b40-88b1-97650fc4a1ee",
 					"name": "Shape Air",
 					"reference": "DFS17",
 					"difficulty": "iq/h",
 					"college": [
 						"Air"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Druidic@",
 					"spell_class": "Regular",
 					"casting_cost": "1-10",
 					"maintenance_cost": "-",
@@ -20133,69 +28082,125 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "create air"
+									"qualifier": "Power Investiture (Druidic)"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": 2
 								}
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Create Air"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Air"
+						"Air",
+						"Druidic",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "4f588494-89cc-476d-9ca9-20497de9029c",
+					"id": "4335b9e5-0910-4fd3-8edc-d53d3ef82168",
 					"name": "Shape Earth",
 					"reference": "DFS28",
 					"difficulty": "iq/h",
 					"college": [
 						"Earth"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Druidic@",
 					"spell_class": "Regular",
-					"casting_cost": "1/1 cu yd",
+					"casting_cost": "1/cu yd",
 					"maintenance_cost": "Half",
 					"casting_time": "1 sec",
 					"duration": "1 min",
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "seek earth"
+									"qualifier": "Power Investiture (Druidic)"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": 2
 								}
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Seek Earth"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Earth"
+						"Druidic",
+						"Earth",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "dd942dcc-5173-45f3-862f-b49687e00d52",
+					"id": "eb71dba2-7a9f-4c7b-9138-4ee0bee2c458",
 					"name": "Shape Fire",
 					"reference": "DFS31",
 					"difficulty": "iq/h",
@@ -20214,12 +28219,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "ignite fire"
+									"qualifier": "Ignite Fire"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -20229,19 +28242,20 @@
 						]
 					},
 					"categories": [
-						"Fire"
+						"Fire",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "1609ea9b-4138-4a63-b787-6397661a8161",
+					"id": "badbb11f-5cb9-4ab0-b833-fffe827c7235",
 					"name": "Shape Water",
 					"reference": "DFS70",
 					"difficulty": "iq/h",
 					"college": [
 						"Water"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Druidic@",
 					"spell_class": "Regular",
 					"casting_cost": "1#",
 					"maintenance_cost": "1",
@@ -20250,37 +28264,66 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "create water"
+									"qualifier": "Power Investiture (Druidic)"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": 2
 								}
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Creater Water"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Water"
+						"Druidic",
+						"Water",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "89332ebf-c74a-4f02-934b-4f2860d0b3ea",
+					"id": "a6a58659-c94b-49b1-bd0d-be812abe0d15",
 					"name": "Share Energy",
 					"reference": "DFS39",
 					"difficulty": "iq/h",
 					"college": [
-						"Healing"
+						"Healing",
+						"Meta"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 					"spell_class": "Regular",
 					"casting_cost": "2-10",
 					"maintenance_cost": "-",
@@ -20289,30 +28332,72 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "lend energy"
+									"qualifier": "Power Investiture"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
 									"qualifier": 1
 								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture (Druidic)"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Lend Energy"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Healing"
+						"Clerical",
+						"Druidic",
+						"Healing",
+						"Meta",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "5d043a6c-ffe3-4321-aceb-1b0f72c47814",
+					"id": "ce9500aa-f3f3-4ed4-a536-d64f519b44d5",
 					"name": "Sharpen",
 					"reference": "DFS50",
 					"difficulty": "iq/h",
@@ -20331,12 +28416,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "repair"
+									"qualifier": "Repair"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -20346,12 +28439,13 @@
 						]
 					},
 					"categories": [
-						"Making & Breaking"
+						"Making & Breaking",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "f241df2d-1b96-497a-9e69-9f89965ca75b",
+					"id": "04b501ae-f30c-4327-b357-1fb335a14e32",
 					"name": "Shatter",
 					"reference": "DFS50",
 					"difficulty": "iq/vh",
@@ -20387,66 +28481,41 @@
 						"all": true,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "weaken"
+									"qualifier": "Magery"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
 									"qualifier": 1
 								}
 							},
 							{
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 1
-										},
-										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (making & breaking)"
-										}
-									},
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 1
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
-										}
-									}
-								]
+								"type": "spell_prereq",
+								"has": true,
+								"sub_type": "name",
+								"qualifier": {
+									"compare": "is",
+									"qualifier": "Weaken"
+								},
+								"quantity": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
 							}
 						]
 					},
 					"notes": "only affects inanimate objects",
 					"categories": [
-						"Making & Breaking"
+						"Making & Breaking",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "35a818a2-be53-45c5-93ee-ebf64578a7e4",
+					"id": "5b4f404e-7fed-4d23-a69d-a48707abb6e2",
 					"name": "Shatterproof",
 					"reference": "DFS50",
 					"difficulty": "iq/h",
@@ -20465,12 +28534,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "repair"
+									"qualifier": "Repair"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -20483,7 +28560,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "shatter"
+									"qualifier": "Shatter"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -20493,19 +28570,20 @@
 						]
 					},
 					"categories": [
-						"Making & Breaking"
+						"Making & Breaking",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "bd470fa2-647c-46e8-a87e-cd1a8480e01c",
+					"id": "6b1677bb-bfb7-4bd1-ac4e-882763386dd5",
 					"name": "Shield",
 					"reference": "DFS65",
 					"difficulty": "iq/h",
 					"college": [
-						"Protection"
+						"Protection & Warning"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical@",
 					"spell_class": "Regular",
 					"casting_cost": "2 per DB",
 					"maintenance_cost": "Half",
@@ -20521,15 +28599,11 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "magery"
+									"qualifier": "Magery"
 								},
 								"level": {
 									"compare": "at_least",
 									"qualifier": 2
-								},
-								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (protection)"
 								}
 							},
 							{
@@ -20537,22 +28611,24 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "magery"
+									"qualifier": "Power Investiture"
 								},
 								"level": {
 									"compare": "at_least",
-									"qualifier": 2
+									"qualifier": 1
 								}
 							}
 						]
 					},
 					"categories": [
-						"Protection"
+						"Clerical",
+						"Protection & Warning",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "f4e8c140-f709-4951-b9bd-81e6126be270",
+					"id": "a223a14f-09ee-47e1-864e-23d5bb47ca54",
 					"name": "Shocking Touch",
 					"reference": "DFS72",
 					"difficulty": "iq/h",
@@ -20607,12 +28683,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "lightning"
+									"qualifier": "Lightning"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -20623,12 +28707,13 @@
 					},
 					"categories": [
 						"Air",
-						"Weather"
+						"Weather",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "04915788-101d-458a-acb2-378296b93951",
+					"id": "edbddb14-4c67-4f6b-ae13-e06c4e8fd9cd",
 					"name": "Sickness",
 					"reference": "DFS55",
 					"difficulty": "iq/h",
@@ -20638,6 +28723,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "HT",
 					"casting_cost": "3",
 					"maintenance_cost": "3",
 					"casting_time": "4 sec",
@@ -20645,15 +28731,37 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": false,
+						"all": true,
 						"prereqs": [
+							{
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										}
+									}
+								]
+							},
 							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "drunkenness"
+									"qualifier": "Drunkenness"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -20663,20 +28771,22 @@
 						]
 					},
 					"categories": [
+						"Bardic",
 						"Body Control",
-						"Mind Control"
+						"Mind Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "530512f9-2caf-4932-8ef9-e238e50a07c1",
+					"id": "c9d27671-2d32-4db0-95d2-c4fddffbc04d",
 					"name": "Silence",
 					"reference": "DFS67",
 					"difficulty": "iq/h",
 					"college": [
 						"Sound"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical@",
 					"spell_class": "Area",
 					"casting_cost": "2",
 					"maintenance_cost": "Half",
@@ -20685,37 +28795,80 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "sound"
+									"qualifier": "Power Investiture"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
 									"qualifier": 1
 								}
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "prereq_list",
+										"all": false,
+										"prereqs": [
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Bardic Talent"
+												}
+											}
+										]
+									},
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Sound"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Sound"
+						"Bardic",
+						"Clerical",
+						"Sound",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "fd333a8a-6549-4e7e-94f5-20bcf33a538c",
+					"id": "a4d0cc7b-7514-45be-adf9-ec9b92652a2b",
 					"name": "Silver Tongue",
 					"reference": "DFS67",
 					"difficulty": "iq/h",
 					"college": [
 						"Sound"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical@",
 					"spell_class": "Regular",
 					"casting_cost": "3",
 					"maintenance_cost": "2",
@@ -20724,43 +28877,86 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "college",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "mind control"
+									"qualifier": "Power Investiture"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
-									"qualifier": 5
+									"qualifier": 3
 								}
 							},
 							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "voices"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Voices"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "college",
+										"qualifier": {
+											"compare": "contains",
+											"qualifier": "Mind Control"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 5
+										}
+									},
+									{
+										"type": "prereq_list",
+										"all": false,
+										"prereqs": [
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Bardic Talent"
+												}
+											}
+										]
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Sound"
+						"Bardic",
+						"Clerical",
+						"Sound",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "5e61fcc0-4f1e-45e8-a6e2-695b919b356c",
+					"id": "07c53be6-2b30-439d-bde9-db966bf404ba",
 					"name": "Simple Illusion",
 					"reference": "DFS42",
 					"difficulty": "iq/h",
@@ -20780,10 +28976,18 @@
 						"prereqs": [
 							{
 								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
+								"type": "advantage_prereq",
 								"has": false,
 								"name": {
 									"compare": "starts_with",
-									"qualifier": "blind"
+									"qualifier": "Blind"
 								}
 							},
 							{
@@ -20798,12 +29002,13 @@
 						]
 					},
 					"categories": [
-						"Illusion"
+						"Illusion",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "2fb09c01-732c-4b83-8903-950e0890f877",
+					"id": "da362dbb-e1c7-4de1-9c55-76d58f6e8ab3",
 					"name": "Sleep",
 					"reference": "DFS55",
 					"difficulty": "iq/h",
@@ -20812,49 +29017,11 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "HT",
 					"casting_cost": "4",
 					"maintenance_cost": "-",
 					"casting_time": "3 sec",
 					"duration": "Until awakened",
-					"points": 1,
-					"prereqs": {
-						"type": "prereq_list",
-						"all": true,
-						"prereqs": [
-							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "daze"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
-							}
-						]
-					},
-					"categories": [
-						"Mind Control"
-					]
-				},
-				{
-					"type": "spell",
-					"id": "12281cb5-a39d-414d-b83a-3a7cd074fe2f",
-					"name": "Slow",
-					"reference": "DFS58",
-					"difficulty": "iq/h",
-					"college": [
-						"Movement"
-					],
-					"power_source": "Arcane",
-					"spell_class": "Regular",
-					"casting_cost": "5",
-					"maintenance_cost": "4",
-					"casting_time": "3 sec",
-					"duration": "10 sec",
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
@@ -20869,15 +29036,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 1
-										},
-										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (movement)"
+											"qualifier": "Magery"
 										}
 									},
 									{
@@ -20885,15 +29044,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 1
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
+											"qualifier": "Bardic Talent"
 										}
 									}
 								]
@@ -20904,7 +29055,61 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "haste"
+									"qualifier": "Daze"
+								},
+								"quantity": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							}
+						]
+					},
+					"categories": [
+						"Bardic",
+						"Mind Control",
+						"Wizardly"
+					]
+				},
+				{
+					"type": "spell",
+					"id": "8c5e70de-0201-4dae-b9c2-cfb6a0610fe9",
+					"name": "Slow",
+					"reference": "DFS58",
+					"difficulty": "iq/h",
+					"college": [
+						"Movement"
+					],
+					"power_source": "Arcane",
+					"spell_class": "Regular",
+					"resist": "HT",
+					"casting_cost": "5",
+					"maintenance_cost": "4",
+					"casting_time": "3 sec",
+					"duration": "10 sec",
+					"points": 1,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							},
+							{
+								"type": "spell_prereq",
+								"has": true,
+								"sub_type": "name",
+								"qualifier": {
+									"compare": "is",
+									"qualifier": "Haste"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -20917,7 +29122,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "hinder"
+									"qualifier": "Hinder"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -20927,12 +29132,13 @@
 						]
 					},
 					"categories": [
-						"Movement"
+						"Movement",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "552de0bd-084d-4854-9ca9-ab6d6b283dfa",
+					"id": "6c5ae37e-8bb4-4be3-a4e6-c7326e9b4b89",
 					"name": "Slow Fall",
 					"reference": "DFS58",
 					"difficulty": "iq/h",
@@ -20951,12 +29157,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "apportation"
+									"qualifier": "Apportation"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -20966,12 +29180,13 @@
 						]
 					},
 					"categories": [
-						"Movement"
+						"Movement",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "33bb7fd4-5833-45e7-9d27-1c25bafd81c9",
+					"id": "ab6b6e08-ab10-468e-8269-050c5ab17c73",
 					"name": "Smoke",
 					"reference": "DFS32",
 					"difficulty": "iq/h",
@@ -21007,12 +29222,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "extinguish fire"
+									"qualifier": "Extinguish Fire"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -21025,7 +29248,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "shape fire"
+									"qualifier": "Shape Fire"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -21035,12 +29258,13 @@
 						]
 					},
 					"categories": [
-						"Fire"
+						"Fire",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "aace1a01-be37-43b2-99bd-8cd26636f0a3",
+					"id": "16fd00f3-d3cd-48a7-acb5-d12e636993d5",
 					"name": "Soul Rider",
 					"reference": "DFS26",
 					"difficulty": "iq/h",
@@ -21049,6 +29273,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "Will",
 					"casting_cost": "5",
 					"maintenance_cost": "2",
 					"casting_time": "3 sec",
@@ -21064,22 +29289,46 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "mind-reading"
+									"qualifier": "Mind-Reading"
 								},
 								"quantity": {
 									"compare": "at_least",
 									"qualifier": 1
 								}
+							},
+							{
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Communication"
+						"Bardic",
+						"Communication & Empathy",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "32308756-16ed-4302-b1b7-6d50f9f8166e",
+					"id": "d31f13e3-874d-436d-b3f5-d39b154002ad",
 					"name": "Sound",
 					"reference": "DFS67",
 					"difficulty": "iq/h",
@@ -21093,13 +29342,41 @@
 					"casting_time": "1 sec",
 					"duration": "Varies",
 					"points": 1,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Bardic Talent"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							}
+						]
+					},
 					"categories": [
-						"Sound"
+						"Bardic",
+						"Sound",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "56a1546b-bc5e-47be-8d6c-31e93f814d69",
+					"id": "44824902-6717-47de-84cd-56aa8018fd9d",
 					"name": "Sound Jet",
 					"reference": "DFS67",
 					"difficulty": "iq/h",
@@ -21151,12 +29428,34 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										}
+									}
+								]
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "great voice"
+									"qualifier": "Great Voice"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -21166,12 +29465,14 @@
 						]
 					},
 					"categories": [
-						"Sound"
+						"Bardic",
+						"Sound",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "b00134db-476c-48c2-9184-5f894d897cbe",
+					"id": "00eb6f97-de62-4d85-a7a6-86b964ed203c",
 					"name": "Spark Cloud",
 					"reference": "DFS72",
 					"difficulty": "iq/h",
@@ -21209,12 +29510,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "lightning"
+									"qualifier": "Lightning"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -21227,7 +29536,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "shape air"
+									"qualifier": "Shape Air"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -21238,12 +29547,13 @@
 					},
 					"categories": [
 						"Air",
-						"Weather"
+						"Weather",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "06ad9a91-ea07-4995-b071-3a6842cb7b56",
+					"id": "0d45147c-5d56-46a4-baf0-987258eea117",
 					"name": "Spark Storm",
 					"reference": "DFS72",
 					"difficulty": "iq/h",
@@ -21251,7 +29561,7 @@
 						"Air",
 						"Weather"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Druidic@",
 					"spell_class": "Area",
 					"casting_cost": "2/4/6",
 					"maintenance_cost": "Half",
@@ -21278,44 +29588,72 @@
 					],
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "lightning"
+									"qualifier": "Power Investiture (Druidic)"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": 5
 								}
 							},
 							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "windstorm"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Lightning"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Windstorm"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
 						"Air",
-						"Weather"
+						"Druidic",
+						"Weather",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "78f09586-41db-4d82-9fcd-ce95c903d1be",
+					"id": "59b037ac-8a53-42f4-96bf-6e263c9dfe32",
 					"name": "Spasm",
 					"reference": "DFS22",
 					"difficulty": "iq/h",
@@ -21324,6 +29662,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "HT",
 					"casting_cost": "2",
 					"maintenance_cost": "-",
 					"casting_time": "1 sec",
@@ -21334,12 +29673,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "itch"
+									"qualifier": "Itch"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -21349,12 +29696,13 @@
 						]
 					},
 					"categories": [
-						"Body Control"
+						"Body Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "bb4d7677-3130-4afb-986d-721a8ff36094",
+					"id": "56ae7985-01f8-4ff2-bad3-057782a712e2",
 					"name": "Spell Shield",
 					"reference": "DFS52",
 					"difficulty": "iq/h",
@@ -21373,12 +29721,24 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "scryguard"
+									"qualifier": "Scryguard"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -21391,60 +29751,23 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "magic resistance"
+									"qualifier": "Magic Resistance"
 								},
 								"quantity": {
 									"compare": "at_least",
 									"qualifier": 1
 								}
-							},
-							{
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 2
-										},
-										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (meta)"
-										}
-									},
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 2
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
-										}
-									}
-								]
 							}
 						]
 					},
 					"categories": [
-						"Meta"
+						"Meta",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "8608ca45-e117-434e-876f-f71f50e01626",
+					"id": "2f215b01-75e4-4c8e-8036-bccb01e3beaf",
 					"name": "Steelwraith",
 					"reference": "DFS28",
 					"difficulty": "iq/h",
@@ -21453,6 +29776,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "HT",
 					"casting_cost": "7",
 					"maintenance_cost": "4",
 					"casting_time": "2 sec",
@@ -21463,42 +29787,16 @@
 						"all": true,
 						"prereqs": [
 							{
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 2
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
-										}
-									},
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 2
-										},
-										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (earth)"
-										}
-									}
-								]
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								}
 							},
 							{
 								"type": "spell_prereq",
@@ -21506,7 +29804,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "walk through earth"
+									"qualifier": "Walk Through Earth"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -21516,12 +29814,13 @@
 						]
 					},
 					"categories": [
-						"Earth"
+						"Earth",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "e3b409be-2a1b-4efe-8e06-7648e0af3566",
+					"id": "bddd5ca7-d53e-4f69-8865-1cc4c9668612",
 					"name": "Stench",
 					"reference": "DFS17",
 					"difficulty": "iq/h",
@@ -21540,6 +29839,14 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
@@ -21555,12 +29862,13 @@
 						]
 					},
 					"categories": [
-						"Air"
+						"Air",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "14c5ff71-7780-41e9-b2d2-4cf9c743eca3",
+					"id": "c99c3829-dfaa-46a4-8481-086bfe83c663",
 					"name": "Stiffen",
 					"reference": "DFS50",
 					"difficulty": "iq/h",
@@ -21569,6 +29877,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "Special",
 					"casting_cost": "1/lb",
 					"maintenance_cost": "Half",
 					"casting_time": "2 sec/lb",
@@ -21579,12 +29888,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "rejoin"
+									"qualifier": "Rejoin"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -21594,12 +29911,13 @@
 						]
 					},
 					"categories": [
-						"Making & Breaking"
+						"Making & Breaking",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "8fbd3216-7f2a-44cc-b643-662e2081480f",
+					"id": "be044195-9609-4fe0-bcab-fb13cbe37b38",
 					"name": "Stone Missile",
 					"reference": "DFS28",
 					"difficulty": "iq/h",
@@ -21645,12 +29963,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "create earth"
+									"qualifier": "Create Earth"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -21660,12 +29986,13 @@
 						]
 					},
 					"categories": [
-						"Earth"
+						"Earth",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "f64d0062-ac1e-4ebd-881c-49960c2e1ee5",
+					"id": "ea79f3c5-539e-41cd-aec6-82f4e735e52e",
 					"name": "Stone to Earth",
 					"reference": "DFS28",
 					"difficulty": "iq/h",
@@ -21681,50 +30008,65 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": false,
+						"all": true,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "college",
-								"qualifier": {
-									"compare": "contains",
-									"qualifier": "Earth"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 4
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
 								}
 							},
 							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "earth to stone"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "college",
+										"qualifier": {
+											"compare": "contains",
+											"qualifier": "Earth"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 4
+										}
+									},
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Earth to Stone"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Earth"
+						"Earth",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "3243d3e3-64dc-4fc1-96de-3619b07a4c70",
+					"id": "4973821c-d59b-4a6e-a75b-46345f0ca46c",
 					"name": "Stone to Flesh",
 					"reference": "DFS29",
 					"difficulty": "iq/h",
 					"college": [
 						"Earth"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical@",
 					"spell_class": "Regular",
 					"casting_cost": "10",
 					"maintenance_cost": "-",
@@ -21733,26 +30075,48 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								}
+							},
+							{
 								"type": "prereq_list",
-								"all": false,
+								"all": true,
 								"prereqs": [
 									{
-										"type": "advantage_prereq",
+										"type": "spell_prereq",
 										"has": true,
-										"name": {
+										"sub_type": "name",
+										"qualifier": {
 											"compare": "is",
-											"qualifier": "magery"
+											"qualifier": "Flesh to Stone"
 										},
-										"level": {
+										"quantity": {
 											"compare": "at_least",
-											"qualifier": 2
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Stone to Earth"
 										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
 										}
 									},
 									{
@@ -21760,61 +30124,33 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "magery"
+											"qualifier": "Magery"
 										},
 										"level": {
 											"compare": "at_least",
 											"qualifier": 2
-										},
-										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (earth)"
 										}
 									}
 								]
-							},
-							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "stone to earth"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
-							},
-							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "flesh to stone"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
 							}
 						]
 					},
 					"categories": [
-						"Earth"
+						"Clerical",
+						"Earth",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "0d2fcbee-d035-4e4d-a18c-dea90fb4fbfa",
+					"id": "6e974ab5-0c22-483e-bb89-a424a0b2f31a",
 					"name": "Strengthen Will",
 					"reference": "DFS55",
 					"difficulty": "iq/h",
 					"college": [
 						"Mind Control"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical@",
 					"spell_class": "Regular",
 					"casting_cost": "1/pt of Will increase",
 					"maintenance_cost": "Half",
@@ -21823,64 +30159,81 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "college",
-								"qualifier": {
-									"compare": "contains",
-									"qualifier": "Mind Control"
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
-									"qualifier": 6
+									"qualifier": 3
 								}
 							},
 							{
 								"type": "prereq_list",
-								"all": false,
+								"all": true,
 								"prereqs": [
 									{
-										"type": "advantage_prereq",
+										"type": "spell_prereq",
 										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "bardic talent"
+										"sub_type": "college",
+										"qualifier": {
+											"compare": "contains",
+											"qualifier": "Mind Control"
 										},
-										"level": {
+										"quantity": {
 											"compare": "at_least",
-											"qualifier": 1
+											"qualifier": 6
 										}
 									},
 									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 1
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
-										}
+										"type": "prereq_list",
+										"all": false,
+										"prereqs": [
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Bardic Talent"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											}
+										]
 									}
 								]
 							}
 						]
 					},
 					"categories": [
-						"Mind Control"
+						"Bardic",
+						"Clerical",
+						"Mind Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "63cfe987-0d0a-4d65-ba36-6a07e4b84d10",
+					"id": "4f2e7278-abc0-4f60-b04d-e19df1c24441",
 					"name": "Strike Blind",
 					"reference": "DFS22",
 					"difficulty": "iq/h",
@@ -21889,6 +30242,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "HT",
 					"casting_cost": "4",
 					"maintenance_cost": "2",
 					"casting_time": "1 sec",
@@ -21898,6 +30252,14 @@
 						"type": "prereq_list",
 						"all": true,
 						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
 							{
 								"type": "spell_prereq",
 								"has": true,
@@ -21917,7 +30279,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "spasm"
+									"qualifier": "Spasm"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -21927,12 +30289,13 @@
 						]
 					},
 					"categories": [
-						"Body Control"
+						"Body Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "b137c89f-6657-41e0-be6f-fc116734fffa",
+					"id": "df12dce4-8fa5-446f-8435-dc7fe8c72850",
 					"name": "Strike Deaf",
 					"reference": "DFS22",
 					"difficulty": "iq/h",
@@ -21941,6 +30304,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "HT",
 					"casting_cost": "3",
 					"maintenance_cost": "1",
 					"casting_time": "1 sec",
@@ -21950,6 +30314,14 @@
 						"type": "prereq_list",
 						"all": true,
 						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
 							{
 								"type": "spell_prereq",
 								"has": true,
@@ -21979,12 +30351,13 @@
 						]
 					},
 					"categories": [
-						"Body Control"
+						"Body Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "aef5b130-cc9c-4cef-9cc4-7241a77baca0",
+					"id": "4988f22d-4e9e-4e6a-93ed-a5ce3e17fa03",
 					"name": "Strike Dumb",
 					"reference": "DFS23",
 					"difficulty": "iq/h",
@@ -21993,6 +30366,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "HT",
 					"casting_cost": "3",
 					"maintenance_cost": "1",
 					"casting_time": "1 sec",
@@ -22003,12 +30377,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "spasm"
+									"qualifier": "Spasm"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -22018,12 +30400,13 @@
 						]
 					},
 					"categories": [
-						"Body Control"
+						"Body Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "9e35938f-6b0a-4de4-8414-0e5b9d56df3a",
+					"id": "7a07a1a8-db48-4907-bc2c-b9e3c43292d0",
 					"name": "Stun",
 					"reference": "DFS23",
 					"difficulty": "iq/h",
@@ -22032,6 +30415,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "HT",
 					"casting_cost": "2",
 					"maintenance_cost": "-",
 					"casting_time": "1 sec",
@@ -22042,12 +30426,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "pain"
+									"qualifier": "Pain"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -22057,20 +30449,22 @@
 						]
 					},
 					"categories": [
-						"Body Control"
+						"Body Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "85d80d81-5536-4110-b6d2-c6cb44b238f2",
+					"id": "fae66848-b731-4079-9ee4-5440080bbd00",
 					"name": "Summon Spirit",
 					"reference": "DFS60",
 					"difficulty": "iq/h",
 					"college": [
 						"Necromancy"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical@",
 					"spell_class": "Info",
+					"resist": "Will",
 					"casting_cost": "20",
 					"maintenance_cost": "10",
 					"casting_time": "5 min",
@@ -22078,39 +30472,35 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "death vision"
+									"qualifier": "Power Investiture"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": 2
 								}
 							},
 							{
 								"type": "prereq_list",
-								"all": false,
+								"all": true,
 								"prereqs": [
 									{
-										"type": "advantage_prereq",
+										"type": "spell_prereq",
 										"has": true,
-										"name": {
+										"sub_type": "name",
+										"qualifier": {
 											"compare": "is",
-											"qualifier": "magery"
+											"qualifier": "Death Vision"
 										},
-										"level": {
+										"quantity": {
 											"compare": "at_least",
-											"qualifier": 2
-										},
-										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (necromancy)"
+											"qualifier": 1
 										}
 									},
 									{
@@ -22118,15 +30508,11 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "magery"
+											"qualifier": "Magery"
 										},
 										"level": {
 											"compare": "at_least",
 											"qualifier": 2
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
 										}
 									}
 								]
@@ -22134,19 +30520,21 @@
 						]
 					},
 					"categories": [
-						"Necromancy"
+						"Clerical",
+						"Necromancy",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "ecbd4ead-5367-4336-8c00-cc5091abffa2",
+					"id": "4dda9654-cbc6-4611-b394-1b8f3d2154d9",
 					"name": "Sunbolt",
 					"reference": "DFS48",
 					"difficulty": "iq/h",
 					"college": [
 						"Light & Darkness"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical@",
 					"spell_class": "Missile",
 					"casting_cost": "1-3xMagery",
 					"maintenance_cost": "-",
@@ -22182,50 +30570,78 @@
 					],
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "college",
-								"qualifier": {
-									"compare": "contains",
-									"qualifier": "Light"
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
-									"qualifier": 6
+									"qualifier": 3
 								}
 							},
 							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "sunlight"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Sunlight"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "college",
+										"qualifier": {
+											"compare": "contains",
+											"qualifier": "Light & Darkness"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 6
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Light"
+						"Clerical",
+						"Light & Darkness",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "7cce8bc2-b35c-4c06-89bc-35eba5a288a2",
+					"id": "fa943658-4a02-40c7-8a06-342c8091b6a0",
 					"name": "Sunlight",
 					"reference": "DFS48",
 					"difficulty": "iq/h",
 					"college": [
 						"Light & Darkness"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 					"spell_class": "Area",
 					"casting_cost": "2",
 					"maintenance_cost": "Half",
@@ -22234,26 +30650,60 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture (Druidic)"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								}
+							},
+							{
 								"type": "prereq_list",
-								"all": false,
+								"all": true,
 								"prereqs": [
 									{
-										"type": "advantage_prereq",
+										"type": "spell_prereq",
 										"has": true,
-										"name": {
+										"sub_type": "name",
+										"qualifier": {
 											"compare": "is",
-											"qualifier": "magery"
+											"qualifier": "Glow"
 										},
-										"level": {
+										"quantity": {
 											"compare": "at_least",
 											"qualifier": 1
+										}
+									},
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Colors"
 										},
-										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (light)"
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
 										}
 									},
 									{
@@ -22261,54 +30711,27 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "magery"
+											"qualifier": "Magery"
 										},
 										"level": {
 											"compare": "at_least",
 											"qualifier": 1
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
 										}
 									}
 								]
-							},
-							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "glow"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
-							},
-							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "colors"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
 							}
 						]
 					},
 					"categories": [
-						"Light"
+						"Clerical",
+						"Druidic",
+						"Light & Darkness",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "776d0f93-69bc-4123-8380-ce3e077bf56c",
+					"id": "888590d2-b423-487a-ad87-5bfd62834cfb",
 					"name": "Swim",
 					"reference": "DFS70",
 					"difficulty": "iq/h",
@@ -22316,7 +30739,7 @@
 						"Movement",
 						"Water"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Druidic@",
 					"spell_class": "Regular",
 					"casting_cost": "6",
 					"maintenance_cost": "3",
@@ -22325,44 +30748,72 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "levitation"
+									"qualifier": "Power Investiture (Druidic)"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": 3
 								}
 							},
 							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "shape water"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Levitation"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Shape Water"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
+						"Druidic",
 						"Movement",
-						"Water"
+						"Water",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "be5a4cd4-d583-44a4-b4f3-d02456909e6a",
+					"id": "2d9fa787-abdc-480e-a00a-384563ee8aab",
 					"name": "Tanglefoot",
 					"reference": "DFS23",
 					"difficulty": "iq/h",
@@ -22371,6 +30822,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "DX",
 					"casting_cost": "2",
 					"maintenance_cost": "-",
 					"casting_time": "1 sec",
@@ -22381,12 +30833,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "clumsiness"
+									"qualifier": "Clumsiness"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -22396,12 +30856,13 @@
 						]
 					},
 					"categories": [
-						"Body Control"
+						"Body Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "1294a914-0bb0-45ee-bd10-68e1f217dd8e",
+					"id": "e9089bd8-b658-4dd9-93b0-229998a0c137",
 					"name": "Telepathy",
 					"reference": "DFS26",
 					"difficulty": "iq/vh",
@@ -22425,28 +30886,52 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "mind-sending"
+									"qualifier": "Mind-Sending"
 								},
 								"quantity": {
 									"compare": "at_least",
 									"qualifier": 1
 								}
+							},
+							{
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Communication"
+						"Bardic",
+						"Communication & Empathy",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "fa565521-3b39-40d0-b86a-2ddf2e59df73",
+					"id": "b1e7cc89-2f29-4d19-905c-8da8ff7734cb",
 					"name": "Teleport Shield",
 					"reference": "DFS65",
 					"difficulty": "iq/h",
 					"college": [
 						"Gate",
-						"Protection"
+						"Protection & Warning"
 					],
 					"power_source": "Arcane",
 					"spell_class": "Area",
@@ -22465,7 +30950,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "watchdog"
+									"qualifier": "Watchdog"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -22473,41 +30958,44 @@
 								}
 							},
 							{
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "spell_prereq",
-										"has": true,
-										"sub_type": "name",
-										"qualifier": {
-											"compare": "is",
-											"qualifier": "spell shield"
-										},
-										"quantity": {
-											"compare": "at_least",
-											"qualifier": 1
-										}
-									}
-								]
+								"type": "spell_prereq",
+								"has": true,
+								"sub_type": "name",
+								"qualifier": {
+									"compare": "is",
+									"qualifier": "Spell Shield"
+								},
+								"quantity": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
 							}
 						]
 					},
 					"categories": [
 						"Gate",
-						"Protection"
+						"Protection & Warning",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "37b7765f-09c8-46a1-8c2c-f140da264057",
+					"id": "6289f8c2-5e0c-4bff-889f-0203c72413d0",
 					"name": "Tell Position",
 					"reference": "DFS45",
 					"difficulty": "iq/h",
 					"college": [
 						"Knowledge"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Druidic@",
 					"spell_class": "Info",
 					"casting_cost": "1",
 					"maintenance_cost": "-",
@@ -22516,30 +31004,73 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "measurement"
+									"qualifier": "Power Investiture (Druidic)"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
 									"qualifier": 1
 								}
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Measurement"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "prereq_list",
+										"all": false,
+										"prereqs": [
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Bardic Talent"
+												}
+											}
+										]
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Knowledge"
+						"Bardic",
+						"Druidic",
+						"Knowledge",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "2c8da232-7a40-4764-8afe-f226040e8659",
+					"id": "c5f041a3-a96e-465f-910d-ccf7004cc628",
 					"name": "Terror",
 					"reference": "DFS56",
 					"difficulty": "iq/h",
@@ -22548,6 +31079,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Area",
+					"resist": "Will",
 					"casting_cost": "4",
 					"maintenance_cost": "-",
 					"casting_time": "1 sec",
@@ -22558,12 +31090,34 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										}
+									}
+								]
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "fear"
+									"qualifier": "Fear"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -22573,32 +31127,62 @@
 						]
 					},
 					"categories": [
-						"Mind Control"
+						"Bardic",
+						"Mind Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "0cf5d038-d208-4529-a689-665fccdaf66e",
+					"id": "1f04d2d3-ebad-40a5-80f8-bf323feb359d",
 					"name": "Test Food",
 					"reference": "DFS32",
 					"difficulty": "iq/h",
 					"college": [
 						"Food"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical@",
 					"spell_class": "Info",
 					"casting_cost": "1 or 3",
 					"maintenance_cost": "-",
 					"casting_time": "1 sec",
 					"duration": "Instant",
 					"points": 1,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							}
+						]
+					},
 					"categories": [
-						"Food"
+						"Clerical",
+						"Food",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "a94bbdb0-20ac-47ec-ba6b-5cf7b8b62e8b",
+					"id": "85c38570-e41f-4f19-81c3-27d5a1a69e8c",
 					"name": "Test Load",
 					"reference": "DFS45",
 					"difficulty": "iq/h",
@@ -22622,29 +31206,53 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "measurement"
+									"qualifier": "Measurement"
 								},
 								"quantity": {
 									"compare": "at_least",
 									"qualifier": 1
 								}
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Knowledge"
+						"Bardic",
+						"Knowledge",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "201026f1-cda9-4f24-b302-2797011b87c6",
+					"id": "a607f222-f670-472f-b1d5-c9a380beae75",
 					"name": "Thunderclap",
 					"reference": "DFS67",
 					"difficulty": "iq/h",
 					"college": [
 						"Sound"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 					"spell_class": "Regular",
 					"casting_cost": "2",
 					"maintenance_cost": "-",
@@ -22653,30 +31261,86 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "sound"
+									"qualifier": "Power Investiture"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
 									"qualifier": 1
 								}
+							},
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture (Druidic)"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Sound"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "prereq_list",
+										"all": false,
+										"prereqs": [
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Bardic Talent"
+												}
+											}
+										]
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Sound"
+						"Bardic",
+						"Clerical",
+						"Druidic",
+						"Sound",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "1b164ef2-b19b-4a79-87aa-1124ec44accf",
+					"id": "bdb5e091-f313-4fb9-9a8e-e495f7aed096",
 					"name": "Tickle",
 					"reference": "DFS23",
 					"difficulty": "iq/h",
@@ -22685,6 +31349,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "Will",
 					"casting_cost": "5",
 					"maintenance_cost": "5",
 					"casting_time": "1 sec",
@@ -22695,12 +31360,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "spasm"
+									"qualifier": "Spasm"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -22710,12 +31383,13 @@
 						]
 					},
 					"categories": [
-						"Body Control"
+						"Body Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "9c325ec5-38fe-4630-9a30-cbf6351b1c51",
+					"id": "59fbd3e9-6573-43ab-b396-0b42cfbf182c",
 					"name": "Total Paralysis",
 					"reference": "DFS23",
 					"difficulty": "iq/h",
@@ -22724,6 +31398,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Melee",
+					"resist": "HT",
 					"casting_cost": "5",
 					"maintenance_cost": "-",
 					"casting_time": "1 sec",
@@ -22770,12 +31445,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "paralyze limb"
+									"qualifier": "Paralyze Limb"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -22785,12 +31468,13 @@
 						]
 					},
 					"categories": [
-						"Body Control"
+						"Body Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "0bd09425-653e-4caf-95e7-4c71f883b10e",
+					"id": "ada18fa4-ee73-4bda-9913-d3e1bfe90b2e",
 					"name": "Trace",
 					"reference": "DFS45",
 					"difficulty": "iq/h",
@@ -22809,12 +31493,34 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										}
+									}
+								]
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "seeker"
+									"qualifier": "Seeker"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -22824,12 +31530,14 @@
 						]
 					},
 					"categories": [
-						"Knowledge"
+						"Bardic",
+						"Knowledge",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "c6447842-5836-4ef3-b44a-50dbc80aef60",
+					"id": "566e22f3-a09d-41fb-8d32-88a6fad6a613",
 					"name": "Trace Teleport",
 					"reference": "DFS35",
 					"difficulty": "iq/h",
@@ -22839,6 +31547,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Info",
+					"resist": "Subject Ability",
 					"casting_cost": "3",
 					"maintenance_cost": "-",
 					"casting_time": "1 sec",
@@ -22882,20 +31591,22 @@
 					},
 					"categories": [
 						"Gate",
-						"Movement"
+						"Movement",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "a231159d-0e7a-4f58-b829-31aeacf7088e",
+					"id": "d0bb01f5-41ae-4faf-a559-277253357292",
 					"name": "Truthsayer",
 					"reference": "DFS26",
 					"difficulty": "iq/h",
 					"college": [
 						"Communication & Empathy"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical@",
 					"spell_class": "Info",
+					"resist": "Will",
 					"casting_cost": "2",
 					"maintenance_cost": "-",
 					"casting_time": "1 sec",
@@ -22903,38 +31614,82 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "sense emotion"
+									"qualifier": "Power Investiture"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": 2
 								}
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Sense Emotion"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "prereq_list",
+										"all": false,
+										"prereqs": [
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Bardic Talent"
+												}
+											}
+										]
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Communication"
+						"Bardic",
+						"Clerical",
+						"Communication & Empathy",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "89d0e32e-6c0a-418f-a232-31de34a38a32",
+					"id": "e43bff42-636e-4dd1-9556-c6979649305f",
 					"name": "Turn Spirit",
 					"reference": "DFS61",
 					"difficulty": "iq/h",
 					"college": [
 						"Necromancy"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical@",
 					"spell_class": "Regular",
+					"resist": "Will",
 					"casting_cost": "4",
 					"maintenance_cost": "2",
 					"casting_time": "1 sec",
@@ -22942,51 +31697,79 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "fear"
+									"qualifier": "Power Investiture"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": 2
 								}
 							},
 							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "sense spirit"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Fear"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Sense Spirit"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Necromancy"
+						"Clerical",
+						"Necromancy",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "c53aa1fc-a93e-42f9-8e54-424436c1bdfe",
+					"id": "0e9539ee-87e3-4c70-a8e7-9d3314c98223",
 					"name": "Umbrella",
 					"reference": "DFS70",
 					"difficulty": "iq/h",
 					"college": [
-						"Protection",
+						"Protection & Warning",
 						"Water"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical/Druidic@",
 					"spell_class": "Regular",
 					"casting_cost": "1",
 					"maintenance_cost": "1",
@@ -22998,41 +31781,88 @@
 						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "shield"
+									"qualifier": "Power Investiture"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
 									"qualifier": 1
 								}
 							},
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "shape water"
+									"qualifier": "Power Investiture (Druidic)"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
 									"qualifier": 1
 								}
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "prereq_list",
+										"all": false,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Shape Water"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Shield"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											}
+										]
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Protection",
-						"Water"
+						"Clerical",
+						"Druidic",
+						"Protection & Warning",
+						"Water",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "c037e2c4-a967-4789-8231-1de8d962d9c2",
+					"id": "52b42c6d-2141-4241-925f-e030c8c14b52",
 					"name": "Undo",
 					"reference": "DFS59",
 					"difficulty": "iq/h",
@@ -23041,6 +31871,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "Special",
 					"casting_cost": "Varies",
 					"maintenance_cost": "Varies",
 					"casting_time": "1 sec",
@@ -23051,12 +31882,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "locksmith"
+									"qualifier": "Locksmith"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -23066,19 +31905,20 @@
 						]
 					},
 					"categories": [
-						"Movement"
+						"Movement",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "1b8283fe-3f1c-45d3-9757-f698864b957e",
+					"id": "129aa607-8262-43d5-b376-d32d28a1764d",
 					"name": "Vigor",
 					"reference": "DFS23",
 					"difficulty": "iq/h",
 					"college": [
 						"Body Control"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical@",
 					"spell_class": "Regular",
 					"casting_cost": "2/+HT",
 					"maintenance_cost": "Same",
@@ -23090,40 +31930,74 @@
 						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "might"
+									"qualifier": "Power Investiture"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
 									"qualifier": 1
 								}
 							},
 							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "frailty"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "prereq_list",
+										"all": false,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Might"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "spell_prereq",
+												"has": true,
+												"sub_type": "name",
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "Frailty"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											}
+										]
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Body Control"
+						"Body Control",
+						"Clerical",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "aa899db5-8cd7-40a5-886c-81487b2aae38",
+					"id": "bd17f9cb-1ad2-45fe-9168-33c2debaa99b",
 					"name": "Voices",
 					"reference": "DFS68",
 					"difficulty": "iq/h",
@@ -23147,22 +32021,46 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "sound"
+									"qualifier": "Sound"
 								},
 								"quantity": {
 									"compare": "at_least",
 									"qualifier": 1
 								}
+							},
+							{
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Sound"
+						"Bardic",
+						"Sound",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "af74a5e2-ebd4-4084-a2aa-bfd07ee859a0",
+					"id": "8128fc4b-99be-4af5-96da-4afbd11d9e9e",
 					"name": "Walk on Air",
 					"reference": "DFS17",
 					"difficulty": "iq/h",
@@ -23181,12 +32079,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "shape air"
+									"qualifier": "Shape Air"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -23196,12 +32102,13 @@
 						]
 					},
 					"categories": [
-						"Air"
+						"Air",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "71d41d92-0eda-4480-b283-59ccadb3f08b",
+					"id": "8fe53498-e6a0-4a0c-98b3-def00684689a",
 					"name": "Walk on Water",
 					"reference": "DFS71",
 					"difficulty": "iq/h",
@@ -23220,12 +32127,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "shape water"
+									"qualifier": "Shape Water"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -23235,12 +32150,13 @@
 						]
 					},
 					"categories": [
-						"Water"
+						"Water",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "78439403-e63d-4235-a177-4b4d50eba456",
+					"id": "eed0478d-ea96-4f9a-90fb-9d423867b475",
 					"name": "Walk Through Earth",
 					"reference": "DFS29",
 					"difficulty": "iq/h",
@@ -23259,6 +32175,14 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "college",
@@ -23274,12 +32198,13 @@
 						]
 					},
 					"categories": [
-						"Earth"
+						"Earth",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "3090978f-4690-40e6-a2ae-c5445025d5f5",
+					"id": "fb273ba6-e01f-4934-86d3-e2753fbe1ee6",
 					"name": "Wall of Lightning",
 					"reference": "DFS72",
 					"difficulty": "iq/h",
@@ -23299,12 +32224,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "lightning"
+									"qualifier": "Lightning"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -23315,12 +32248,13 @@
 					},
 					"categories": [
 						"Air",
-						"Weather"
+						"Weather",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "aca9dffe-317f-4cc1-a532-0a5f00866b5d",
+					"id": "c5894003-63f9-4f49-bbf1-8275af258a48",
 					"name": "Wall of Silence",
 					"reference": "DFS68",
 					"difficulty": "iq/h",
@@ -23344,22 +32278,46 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "silence"
+									"qualifier": "Silence"
 								},
 								"quantity": {
 									"compare": "at_least",
 									"qualifier": 1
 								}
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Sound"
+						"Bardic",
+						"Sound",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "af82be3d-54fd-4942-bf63-c3d01b92a66c",
+					"id": "945bba2c-6849-46bd-9d8a-21aee27460eb",
 					"name": "Wallwalker",
 					"reference": "DFS59",
 					"difficulty": "iq/h",
@@ -23378,12 +32336,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "apportation"
+									"qualifier": "Apportation"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -23393,12 +32359,13 @@
 						]
 					},
 					"categories": [
-						"Movement"
+						"Movement",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "1af51780-189b-4ba4-9087-a3de714e257d",
+					"id": "c028a839-e0f1-4515-9936-9d8b7f63bb18",
 					"name": "Ward",
 					"reference": "DFS53",
 					"difficulty": "iq/h",
@@ -23407,10 +32374,51 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Blocking",
+					"resist": "Subject spell",
 					"casting_cost": "2 or 3",
 					"maintenance_cost": "-",
 					"casting_time": "1 sec",
 					"duration": "Instant",
+					"points": 1,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							}
+						]
+					},
+					"categories": [
+						"Meta",
+						"Wizardly"
+					]
+				},
+				{
+					"type": "spell",
+					"id": "56ffecaa-2c79-41f9-83d3-3eada674133a",
+					"name": "Warmth",
+					"reference": "DFS32",
+					"difficulty": "iq/h",
+					"college": [
+						"Fire",
+						"Protection & Warning"
+					],
+					"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+					"spell_class": "Regular",
+					"casting_cost": "2",
+					"maintenance_cost": "1",
+					"casting_time": "10 sec",
+					"duration": "1 hr",
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
@@ -23421,15 +32429,11 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "magery"
+									"qualifier": "Power Investiture"
 								},
 								"level": {
 									"compare": "at_least",
 									"qualifier": 1
-								},
-								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (meta)"
 								}
 							},
 							{
@@ -23437,70 +32441,60 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "magery"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
 									"qualifier": 1
 								}
-							}
-						]
-					},
-					"categories": [
-						"Meta"
-					]
-				},
-				{
-					"type": "spell",
-					"id": "6c6b49a8-9e77-4f6b-83fa-371ebe142db7",
-					"name": "Warmth",
-					"reference": "DFS32",
-					"difficulty": "iq/h",
-					"college": [
-						"Fire",
-						"Protection"
-					],
-					"power_source": "Arcane",
-					"spell_class": "Regular",
-					"casting_cost": "2",
-					"maintenance_cost": "1",
-					"casting_time": "10 sec",
-					"duration": "1 hr",
-					"points": 1,
-					"prereqs": {
-						"type": "prereq_list",
-						"all": true,
-						"prereqs": [
+							},
 							{
-								"type": "spell_prereq",
-								"has": true,
-								"sub_type": "name",
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "heat"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Heat"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
+						"Clerical",
+						"Druidic",
 						"Fire",
-						"Protection"
+						"Protection & Warning",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "7b7a29d7-5389-4ab4-aace-ffcce15f8a05",
+					"id": "d6002288-35c9-46d1-a9ce-f50c38bbc694",
 					"name": "Watchdog",
 					"reference": "DFS65",
 					"difficulty": "iq/h",
 					"college": [
-						"Protection"
+						"Protection & Warning"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical@",
 					"spell_class": "Area",
 					"casting_cost": "1",
 					"maintenance_cost": "Same",
@@ -23509,30 +32503,58 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "sense danger"
+									"qualifier": "Power Investiture"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
 									"qualifier": 1
 								}
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Sense Danger"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Protection"
+						"Clerical",
+						"Protection & Warning",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "bf8ab802-49a9-4e29-b2a7-cead64aa849c",
+					"id": "6713121d-95bb-47fb-855f-b2ef8035e7a9",
 					"name": "Water Jet",
 					"reference": "DFS71",
 					"difficulty": "iq/h",
@@ -23585,12 +32607,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "shape water"
+									"qualifier": "Shape Waterr"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -23600,12 +32630,13 @@
 						]
 					},
 					"categories": [
-						"Water"
+						"Water",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "964401ba-326e-40f6-87d5-313f4e446927",
+					"id": "97513f19-8bfb-49f3-8f20-6d9789329715",
 					"name": "Water Vision",
 					"reference": "DFS71",
 					"difficulty": "iq/h",
@@ -23613,7 +32644,7 @@
 						"Knowledge",
 						"Water"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Druidic@",
 					"spell_class": "Info",
 					"casting_cost": "1#",
 					"maintenance_cost": "Same",
@@ -23622,31 +32653,74 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "shape water"
+									"qualifier": "Power Investiture (Druidic)"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": 3
 								}
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Shape Water"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "prereq_list",
+										"all": false,
+										"prereqs": [
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Bardic Talent"
+												}
+											}
+										]
+									}
+								]
 							}
 						]
 					},
 					"categories": [
+						"Bardic",
+						"Druidic",
 						"Knowledge",
-						"Water"
+						"Water",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "46c75cf0-02d4-4182-a7c0-7affcf91d058",
+					"id": "4370a916-70e0-416c-b1bc-4b7001cebf0e",
 					"name": "Weaken",
 					"reference": "DFS50",
 					"difficulty": "iq/h",
@@ -23682,12 +32756,20 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								}
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "find weakness"
+									"qualifier": "Find Weakness"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -23698,12 +32780,13 @@
 					},
 					"notes": "affects only inanimate objects",
 					"categories": [
-						"Making & Breaking"
+						"Making & Breaking",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "fdf9f02c-8f6a-4ac4-a763-04951c9b6704",
+					"id": "dd422ac4-f777-4778-b940-28d952a12d82",
 					"name": "Weaken Will",
 					"reference": "DFS56",
 					"difficulty": "iq/h",
@@ -23712,6 +32795,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Regular",
+					"resist": "Will",
 					"casting_cost": "2/pt of Will decrease",
 					"maintenance_cost": "Half",
 					"casting_time": "1 sec",
@@ -23727,7 +32811,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "foolishness"
+									"qualifier": "Foolishness"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -23743,7 +32827,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "bardic talent"
+											"qualifier": "Bardic Talent"
 										},
 										"level": {
 											"compare": "at_least",
@@ -23755,15 +32839,11 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "magery"
+											"qualifier": "Magery"
 										},
 										"level": {
 											"compare": "at_least",
 											"qualifier": 1
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
 										}
 									}
 								]
@@ -23771,19 +32851,21 @@
 						]
 					},
 					"categories": [
-						"Mind Control"
+						"Bardic",
+						"Mind Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "bf38f6be-ed15-41bb-81e2-4f3c496b50f8",
+					"id": "5d8dc711-5412-4903-ba94-0cfa975c7aa6",
 					"name": "Windstorm",
 					"reference": "DFS17",
 					"difficulty": "iq/h",
 					"college": [
 						"Air"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Druidic@",
 					"spell_class": "Area",
 					"casting_cost": "2",
 					"maintenance_cost": "Half",
@@ -23792,37 +32874,65 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "name",
-								"qualifier": {
+								"name": {
 									"compare": "is",
-									"qualifier": "shape air"
+									"qualifier": "Power Investiture (Druidic)"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": 2
 								}
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "name",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": "Shape Air"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Air"
+						"Air",
+						"Druidic",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "d354311d-821a-4f1e-b00f-68ea1c18ac48",
+					"id": "4026edec-698a-4f4c-9b6b-dbea9024ebd9",
 					"name": "Wisdom",
 					"reference": "DFS56",
 					"difficulty": "iq/h",
 					"college": [
 						"Mind Control"
 					],
-					"power_source": "Arcane",
+					"power_source": "@Power Source: Arcane/Clerical@",
 					"spell_class": "Regular",
 					"casting_cost": "4/pt of IQ",
 					"maintenance_cost": "Same",
@@ -23831,30 +32941,73 @@
 					"points": 1,
 					"prereqs": {
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
-								"type": "spell_prereq",
+								"type": "advantage_prereq",
 								"has": true,
-								"sub_type": "college",
-								"qualifier": {
-									"compare": "contains",
-									"qualifier": "Mind Control"
+								"name": {
+									"compare": "is",
+									"qualifier": "Power Investiture"
 								},
-								"quantity": {
+								"level": {
 									"compare": "at_least",
-									"qualifier": 6
+									"qualifier": 3
 								}
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "spell_prereq",
+										"has": true,
+										"sub_type": "college",
+										"qualifier": {
+											"compare": "contains",
+											"qualifier": "Mind Control"
+										},
+										"quantity": {
+											"compare": "at_least",
+											"qualifier": 6
+										}
+									},
+									{
+										"type": "prereq_list",
+										"all": false,
+										"prereqs": [
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												}
+											},
+											{
+												"type": "advantage_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Bardic Talent"
+												}
+											}
+										]
+									}
+								]
 							}
 						]
 					},
 					"categories": [
-						"Mind Control"
+						"Bardic",
+						"Clerical",
+						"Mind Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "4d4d653d-b515-4900-9329-0953491fd23f",
+					"id": "71c37410-d9a0-4ec2-8ecd-fafa7230eb45",
 					"name": "Wither Limb",
 					"reference": "DFS23",
 					"difficulty": "iq/h",
@@ -23863,6 +33016,7 @@
 					],
 					"power_source": "Arcane",
 					"spell_class": "Melee",
+					"resist": "HT",
 					"casting_cost": "5",
 					"maintenance_cost": "-",
 					"casting_time": "1 sec",
@@ -23909,42 +33063,16 @@
 						"all": true,
 						"prereqs": [
 							{
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 2
-										},
-										"notes": {
-											"compare": "contains",
-											"qualifier": "one college (body control)"
-										}
-									},
-									{
-										"type": "advantage_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "magery"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 2
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "one college"
-										}
-									}
-								]
+								"type": "advantage_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								}
 							},
 							{
 								"type": "spell_prereq",
@@ -23952,7 +33080,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "paralyze limb"
+									"qualifier": "Paralyze Limb"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -23962,12 +33090,13 @@
 						]
 					},
 					"categories": [
-						"Body Control"
+						"Body Control",
+						"Wizardly"
 					]
 				},
 				{
 					"type": "spell",
-					"id": "f3e43324-5029-4b5c-b721-77f0f2326d26",
+					"id": "87a55652-02ec-4e6a-a7fe-d6424d5eae05",
 					"name": "Wizard Eye",
 					"reference": "DFS45",
 					"difficulty": "iq/h",
@@ -23986,12 +33115,34 @@
 						"all": true,
 						"prereqs": [
 							{
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										}
+									},
+									{
+										"type": "advantage_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Bardic Talent"
+										}
+									}
+								]
+							},
+							{
 								"type": "spell_prereq",
 								"has": true,
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "apportation"
+									"qualifier": "Apportation"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -24004,7 +33155,7 @@
 								"sub_type": "name",
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "keen vision"
+									"qualifier": "Keen Vision"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -24014,7 +33165,9 @@
 						]
 					},
 					"categories": [
-						"Knowledge"
+						"Bardic",
+						"Knowledge",
+						"Wizardly"
 					]
 				}
 			]

--- a/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Spells.spl
+++ b/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Spells.spl
@@ -19,7 +19,7 @@
 					"categories": [
 						"Clerical"
 					],
-					"open": false,
+					"open": true,
 					"children": [
 						{
 							"type": "spell",
@@ -2059,7 +2059,7 @@
 					"categories": [
 						"Clerical"
 					],
-					"open": false,
+					"open": true,
 					"children": [
 						{
 							"type": "spell",
@@ -4176,7 +4176,7 @@
 					"categories": [
 						"Clerical"
 					],
-					"open": false,
+					"open": true,
 					"children": [
 						{
 							"type": "spell",
@@ -5792,7 +5792,7 @@
 					"categories": [
 						"Clerical"
 					],
-					"open": false,
+					"open": true,
 					"children": [
 						{
 							"type": "spell",
@@ -6502,7 +6502,7 @@
 					"categories": [
 						"Clerical"
 					],
-					"open": false,
+					"open": true,
 					"children": [
 						{
 							"type": "spell",
@@ -6834,7 +6834,7 @@
 					"categories": [
 						"Clerical"
 					],
-					"open": false,
+					"open": true,
 					"children": [
 						{
 							"type": "spell",
@@ -6895,7 +6895,7 @@
 					"categories": [
 						"Druidic"
 					],
-					"open": false,
+					"open": true,
 					"children": [
 						{
 							"type": "spell",
@@ -8722,7 +8722,7 @@
 					"categories": [
 						"Druidic"
 					],
-					"open": false,
+					"open": true,
 					"children": [
 						{
 							"type": "spell",
@@ -10501,7 +10501,7 @@
 												"sub_type": "name",
 												"qualifier": {
 													"compare": "is",
-													"qualifier": "Creater Water"
+													"qualifier": "Create Water"
 												},
 												"quantity": {
 													"compare": "at_least",
@@ -10643,7 +10643,7 @@
 					"categories": [
 						"Druidic"
 					],
-					"open": false,
+					"open": true,
 					"children": [
 						{
 							"type": "spell",
@@ -11929,7 +11929,7 @@
 					"categories": [
 						"Druidic"
 					],
-					"open": false,
+					"open": true,
 					"children": [
 						{
 							"type": "spell",
@@ -12489,7 +12489,7 @@
 					"categories": [
 						"Druidic"
 					],
-					"open": false,
+					"open": true,
 					"children": [
 						{
 							"type": "spell",
@@ -12712,7 +12712,7 @@
 					"categories": [
 						"Druidic"
 					],
-					"open": false,
+					"open": true,
 					"children": [
 						{
 							"type": "spell",
@@ -28423,7 +28423,7 @@
 										"sub_type": "name",
 										"qualifier": {
 											"compare": "is",
-											"qualifier": "Creater Water"
+											"qualifier": "Create Water"
 										},
 										"quantity": {
 											"compare": "at_least",

--- a/Library/Dungeon Fantasy RPG/Races/Elf.gct
+++ b/Library/Dungeon Fantasy RPG/Races/Elf.gct
@@ -131,7 +131,7 @@
 				},
 				{
 					"type": "advantage",
-					"id": "d0e7ab87-4770-46b5-814e-6e03e43a8e28",
+					"id": "9a03a9c1-6c75-4e80-942c-c24c24d16fa7",
 					"name": "Magery",
 					"mental": true,
 					"supernatural": true,
@@ -147,7 +147,11 @@
 							"type": "spell_bonus",
 							"amount": 1,
 							"per_level": true,
-							"match": "all_colleges"
+							"match": "power_source_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Arcane"
+							}
 						},
 						{
 							"type": "skill_bonus",
@@ -157,36 +161,6 @@
 							"name": {
 								"compare": "is",
 								"qualifier": "thaumatology"
-							}
-						},
-						{
-							"type": "spell_bonus",
-							"amount": -1,
-							"per_level": true,
-							"match": "college_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Clerical"
-							}
-						},
-						{
-							"type": "spell_bonus",
-							"amount": -1,
-							"per_level": true,
-							"match": "college_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Druid"
-							}
-						},
-						{
-							"type": "spell_bonus",
-							"amount": -1,
-							"per_level": true,
-							"match": "college_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Unholy"
 							}
 						}
 					],

--- a/Library/Dungeon Fantasy RPG/Races/Half-Elf.gct
+++ b/Library/Dungeon Fantasy RPG/Races/Half-Elf.gct
@@ -49,7 +49,7 @@
 				},
 				{
 					"type": "advantage",
-					"id": "b8c5ca70-feba-4c97-8bfd-8356d54dffc6",
+					"id": "f40b36f6-6b64-499b-9a61-f2c2f13ba445",
 					"name": "Magery",
 					"mental": true,
 					"supernatural": true,
@@ -65,7 +65,11 @@
 							"type": "spell_bonus",
 							"amount": 1,
 							"per_level": true,
-							"match": "all_colleges"
+							"match": "power_source_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Arcane"
+							}
 						},
 						{
 							"type": "skill_bonus",
@@ -75,36 +79,6 @@
 							"name": {
 								"compare": "is",
 								"qualifier": "thaumatology"
-							}
-						},
-						{
-							"type": "spell_bonus",
-							"amount": -1,
-							"per_level": true,
-							"match": "college_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Clerical"
-							}
-						},
-						{
-							"type": "spell_bonus",
-							"amount": -1,
-							"per_level": true,
-							"match": "college_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Druid"
-							}
-						},
-						{
-							"type": "spell_bonus",
-							"amount": -1,
-							"per_level": true,
-							"match": "college_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Unholy"
 							}
 						}
 					],

--- a/Library/Norðlond/Races/Eldhuð.gct
+++ b/Library/Norðlond/Races/Eldhuð.gct
@@ -9,7 +9,7 @@
 			"container_type": "race",
 			"name": "Eldhuð",
 			"calc": {
-				"points": 113
+				"points": 24
 			},
 			"open": true,
 			"children": [
@@ -104,273 +104,352 @@
 					"calc": {
 						"points": 15
 					}
+				}
+			]
+		},
+		{
+			"type": "advantage_container",
+			"id": "4f61b674-4e1c-40a3-aa46-5be3f8fdb735",
+			"name": "Eldhuð Gifts",
+			"calc": {
+				"points": 89
+			},
+			"notes": "8 Points",
+			"open": true,
+			"children": [
+				{
+					"type": "advantage",
+					"id": "29368219-3b8c-4eb0-9788-af549af3e1c2",
+					"name": "Demon's Horns (Crushing)",
+					"physical": true,
+					"base_points": 5,
+					"weapons": [
+						{
+							"type": "melee_weapon",
+							"damage": {
+								"type": "cr",
+								"st": "thr",
+								"modifier_per_die": 1
+							},
+							"reach": "C",
+							"parry": "0",
+							"calc": {
+								"level": 0,
+								"parry": "0",
+								"block": "",
+								"damage": "thr (+1 per die) cr"
+							},
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Brawling"
+								},
+								{
+									"type": "skill",
+									"name": "Karate"
+								}
+							]
+						}
+					],
+					"calc": {
+						"points": 5
+					}
+				},
+				{
+					"type": "advantage",
+					"id": "58e4a1e0-9ffd-44d4-af1b-955e64c37df5",
+					"name": "Demon's Horns (Impaling)",
+					"physical": true,
+					"base_points": 8,
+					"weapons": [
+						{
+							"type": "melee_weapon",
+							"damage": {
+								"type": "imp",
+								"st": "thr",
+								"modifier_per_die": 1
+							},
+							"calc": {
+								"level": 0,
+								"parry": "",
+								"block": "",
+								"damage": "thr (+1 per die) imp"
+							},
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Brawling"
+								},
+								{
+									"type": "skill",
+									"name": "Karate"
+								}
+							]
+						}
+					],
+					"calc": {
+						"points": 8
+					}
+				},
+				{
+					"type": "advantage",
+					"id": "ed988c4e-f3f0-483a-8625-7814b7312820",
+					"name": "Extinguishing Touch",
+					"physical": true,
+					"base_points": 2,
+					"calc": {
+						"points": 2
+					}
+				},
+				{
+					"type": "advantage",
+					"id": "f0eb7a08-c1a7-439f-9127-29c3448e9716",
+					"name": "Fire Resistance",
+					"physical": true,
+					"levels": "6",
+					"points_per_level": 3,
+					"calc": {
+						"points": 18
+					}
+				},
+				{
+					"type": "advantage",
+					"id": "b29a1fdc-5d53-4d6e-a1ce-1de5644f007c",
+					"name": "Flaming Touch",
+					"physical": true,
+					"base_points": 2,
+					"calc": {
+						"points": 2
+					},
+					"features": [
+						{
+							"type": "weapon_bonus",
+							"amount": 1,
+							"selection_type": "weapons_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Natural Attacks"
+							}
+						}
+					]
+				},
+				{
+					"type": "advantage",
+					"id": "3fb76191-b5f5-44c6-bd2a-2d1deb0fa2bf",
+					"name": "Imp's Tail (Piercing)",
+					"physical": true,
+					"base_points": 5,
+					"weapons": [
+						{
+							"type": "melee_weapon",
+							"damage": {
+								"type": "pi",
+								"st": "thr",
+								"modifier_per_die": 1
+							},
+							"reach": "C",
+							"calc": {
+								"level": 0,
+								"parry": "",
+								"block": "",
+								"damage": "thr (+1 per die) pi"
+							}
+						}
+					],
+					"calc": {
+						"points": 5
+					}
+				},
+				{
+					"type": "advantage",
+					"id": "8e4ff4b2-5ef2-4fa8-b346-e880bc89dce2",
+					"name": "Imp's Tail (Large Piercing)",
+					"physical": true,
+					"base_points": 6,
+					"weapons": [
+						{
+							"type": "melee_weapon",
+							"damage": {
+								"type": "pi+",
+								"st": "thr",
+								"modifier_per_die": 1
+							},
+							"reach": "C",
+							"calc": {
+								"level": 0,
+								"parry": "",
+								"block": "",
+								"damage": "thr (+1 per die) pi+"
+							}
+						}
+					],
+					"calc": {
+						"points": 6
+					}
+				},
+				{
+					"type": "advantage",
+					"id": "143e749a-74e7-4641-b129-bb45cd024866",
+					"name": "Imp's Tail (Impaling)",
+					"physical": true,
+					"base_points": 8,
+					"weapons": [
+						{
+							"type": "melee_weapon",
+							"damage": {
+								"type": "imp",
+								"st": "thr",
+								"modifier_per_die": 1
+							},
+							"reach": "C",
+							"calc": {
+								"level": 0,
+								"parry": "",
+								"block": "",
+								"damage": "thr (+1 per die) imp"
+							}
+						}
+					],
+					"calc": {
+						"points": 8
+					}
+				},
+				{
+					"type": "advantage",
+					"id": "3fcb6754-3efd-4a24-8338-932bce927314",
+					"name": "Nimble Tail",
+					"physical": true,
+					"base_points": 5,
+					"calc": {
+						"points": 5
+					}
+				},
+				{
+					"type": "advantage",
+					"id": "aec58b60-8ba2-45b6-9878-8932c32bb7f8",
+					"name": "Passing Appearance",
+					"physical": true,
+					"base_points": 2,
+					"calc": {
+						"points": 2
+					}
+				},
+				{
+					"type": "advantage",
+					"id": "eaa6bb4b-d2ac-438d-b122-a6f7f21cbda7",
+					"name": "Teeth, Sharp",
+					"physical": true,
+					"exotic": true,
+					"base_points": 1,
+					"weapons": [
+						{
+							"type": "melee_weapon",
+							"damage": {
+								"type": "cut",
+								"st": "thr",
+								"base": "-1"
+							},
+							"usage": "Bite",
+							"reach": "C",
+							"parry": "No",
+							"block": "No",
+							"calc": {
+								"level": 0,
+								"parry": "No",
+								"block": "No",
+								"damage": "thr-1 cut"
+							},
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Brawling"
+								},
+								{
+									"type": "dx"
+								}
+							]
+						}
+					],
+					"reference": "DFA43",
+					"calc": {
+						"points": 1
+					},
+					"categories": [
+						"Advantage"
+					]
+				},
+				{
+					"type": "advantage",
+					"id": "d8e8bdbe-963f-4e0f-b5ab-166cae2c392a",
+					"name": "Fangs",
+					"physical": true,
+					"exotic": true,
+					"base_points": 2,
+					"weapons": [
+						{
+							"type": "melee_weapon",
+							"damage": {
+								"type": "imp",
+								"st": "thr",
+								"base": "-1"
+							},
+							"usage": "Bite",
+							"reach": "C",
+							"parry": "No",
+							"block": "No",
+							"calc": {
+								"level": 0,
+								"parry": "No",
+								"block": "No",
+								"damage": "thr-1 imp"
+							},
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Brawling"
+								},
+								{
+									"type": "dx"
+								}
+							]
+						}
+					],
+					"reference": "B91",
+					"calc": {
+						"points": 2
+					},
+					"categories": [
+						"Advantage"
+					]
 				},
 				{
 					"type": "advantage_container",
-					"id": "4f61b674-4e1c-40a3-aa46-5be3f8fdb735",
-					"name": "Eldhuð Gifts",
+					"id": "6797cbec-dfc7-4a97-afe2-08e8870c3e19",
+					"name": "Succubus' Features",
 					"calc": {
-						"points": 89
+						"points": 24
 					},
-					"notes": "8 Points",
-					"open": true,
+					"notes": "Replaces Appearance (Attractive)",
+					"open": false,
 					"children": [
 						{
 							"type": "advantage",
-							"id": "29368219-3b8c-4eb0-9788-af549af3e1c2",
-							"name": "Demon's Horns (Crushing)",
+							"id": "eab73f6a-96f6-4e53-8221-7af680d1c489",
+							"name": "Appearance",
 							"physical": true,
-							"base_points": 5,
-							"weapons": [
+							"modifiers": [
 								{
-									"type": "melee_weapon",
-									"damage": {
-										"type": "cr",
-										"st": "thr",
-										"modifier_per_die": 1
-									},
-									"reach": "C",
-									"parry": "0",
-									"calc": {
-										"level": 0,
-										"parry": "0",
-										"block": "",
-										"damage": "thr (+1 per die) cr"
-									},
-									"defaults": [
-										{
-											"type": "skill",
-											"name": "Brawling"
-										},
-										{
-											"type": "skill",
-											"name": "Karate"
-										}
-									]
+									"type": "modifier",
+									"id": "f18269d6-86e0-4a11-a9a3-e4d10a5e3ec7",
+									"name": "Beautiful",
+									"cost_type": "points",
+									"cost": 12,
+									"affects": "total"
 								}
 							],
+							"reference": "DFA47",
 							"calc": {
-								"points": 5
-							}
-						},
-						{
-							"type": "advantage",
-							"id": "58e4a1e0-9ffd-44d4-af1b-955e64c37df5",
-							"name": "Demon's Horns (Impaling)",
-							"physical": true,
-							"base_points": 8,
-							"weapons": [
-								{
-									"type": "melee_weapon",
-									"damage": {
-										"type": "imp",
-										"st": "thr",
-										"modifier_per_die": 1
-									},
-									"calc": {
-										"level": 0,
-										"parry": "",
-										"block": "",
-										"damage": "thr (+1 per die) imp"
-									},
-									"defaults": [
-										{
-											"type": "skill",
-											"name": "Brawling"
-										},
-										{
-											"type": "skill",
-											"name": "Karate"
-										}
-									]
-								}
-							],
-							"calc": {
-								"points": 8
-							}
-						},
-						{
-							"type": "advantage",
-							"id": "ed988c4e-f3f0-483a-8625-7814b7312820",
-							"name": "Extinguishing Touch",
-							"physical": true,
-							"base_points": 2,
-							"calc": {
-								"points": 2
-							}
-						},
-						{
-							"type": "advantage",
-							"id": "f0eb7a08-c1a7-439f-9127-29c3448e9716",
-							"name": "Fire Resistance",
-							"physical": true,
-							"levels": "6",
-							"points_per_level": 3,
-							"calc": {
-								"points": 18
-							}
-						},
-						{
-							"type": "advantage",
-							"id": "b29a1fdc-5d53-4d6e-a1ce-1de5644f007c",
-							"name": "Flaming Touch",
-							"physical": true,
-							"base_points": 2,
-							"calc": {
-								"points": 2
-							},
-							"features": [
-								{
-									"type": "weapon_bonus",
-									"amount": 1,
-									"selection_type": "weapons_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Natural Attacks"
-									}
-								}
-							]
-						},
-						{
-							"type": "advantage",
-							"id": "3fb76191-b5f5-44c6-bd2a-2d1deb0fa2bf",
-							"name": "Imp's Tail (Piercing)",
-							"physical": true,
-							"base_points": 5,
-							"weapons": [
-								{
-									"type": "melee_weapon",
-									"damage": {
-										"type": "pi",
-										"st": "thr",
-										"modifier_per_die": 1
-									},
-									"reach": "C",
-									"calc": {
-										"level": 0,
-										"parry": "",
-										"block": "",
-										"damage": "thr (+1 per die) pi"
-									}
-								}
-							],
-							"calc": {
-								"points": 5
-							}
-						},
-						{
-							"type": "advantage",
-							"id": "8e4ff4b2-5ef2-4fa8-b346-e880bc89dce2",
-							"name": "Imp's Tail (Large Piercing)",
-							"physical": true,
-							"base_points": 6,
-							"weapons": [
-								{
-									"type": "melee_weapon",
-									"damage": {
-										"type": "pi+",
-										"st": "thr",
-										"modifier_per_die": 1
-									},
-									"reach": "C",
-									"calc": {
-										"level": 0,
-										"parry": "",
-										"block": "",
-										"damage": "thr (+1 per die) pi+"
-									}
-								}
-							],
-							"calc": {
-								"points": 6
-							}
-						},
-						{
-							"type": "advantage",
-							"id": "143e749a-74e7-4641-b129-bb45cd024866",
-							"name": "Imp's Tail (Impaling)",
-							"physical": true,
-							"base_points": 8,
-							"weapons": [
-								{
-									"type": "melee_weapon",
-									"damage": {
-										"type": "imp",
-										"st": "thr",
-										"modifier_per_die": 1
-									},
-									"reach": "C",
-									"calc": {
-										"level": 0,
-										"parry": "",
-										"block": "",
-										"damage": "thr (+1 per die) imp"
-									}
-								}
-							],
-							"calc": {
-								"points": 8
-							}
-						},
-						{
-							"type": "advantage",
-							"id": "3fcb6754-3efd-4a24-8338-932bce927314",
-							"name": "Nimble Tail",
-							"physical": true,
-							"base_points": 5,
-							"calc": {
-								"points": 5
-							}
-						},
-						{
-							"type": "advantage",
-							"id": "aec58b60-8ba2-45b6-9878-8932c32bb7f8",
-							"name": "Passing Appearance",
-							"physical": true,
-							"base_points": 2,
-							"calc": {
-								"points": 2
-							}
-						},
-						{
-							"type": "advantage",
-							"id": "eaa6bb4b-d2ac-438d-b122-a6f7f21cbda7",
-							"name": "Teeth, Sharp",
-							"physical": true,
-							"exotic": true,
-							"base_points": 1,
-							"weapons": [
-								{
-									"type": "melee_weapon",
-									"damage": {
-										"type": "cut",
-										"st": "thr",
-										"base": "-1"
-									},
-									"usage": "Bite",
-									"reach": "C",
-									"parry": "No",
-									"block": "No",
-									"calc": {
-										"level": 0,
-										"parry": "No",
-										"block": "No",
-										"damage": "thr-1 cut"
-									},
-									"defaults": [
-										{
-											"type": "skill",
-											"name": "Brawling"
-										},
-										{
-											"type": "dx"
-										}
-									]
-								}
-							],
-							"reference": "DFA43",
-							"calc": {
-								"points": 1
+								"points": 12
 							},
 							"categories": [
 								"Advantage"
@@ -378,121 +457,42 @@
 						},
 						{
 							"type": "advantage",
-							"id": "d8e8bdbe-963f-4e0f-b5ab-166cae2c392a",
-							"name": "Fangs",
+							"id": "01dc6ad5-0b44-49f2-bd49-748f97d4d5c5",
+							"name": "Appearance",
 							"physical": true,
-							"exotic": true,
-							"base_points": 2,
-							"weapons": [
+							"modifiers": [
 								{
-									"type": "melee_weapon",
-									"damage": {
-										"type": "imp",
-										"st": "thr",
-										"base": "-1"
-									},
-									"usage": "Bite",
-									"reach": "C",
-									"parry": "No",
-									"block": "No",
-									"calc": {
-										"level": 0,
-										"parry": "No",
-										"block": "No",
-										"damage": "thr-1 imp"
-									},
-									"defaults": [
-										{
-											"type": "skill",
-											"name": "Brawling"
-										},
-										{
-											"type": "dx"
-										}
-									]
+									"type": "modifier",
+									"id": "b67d818c-f5b4-4f64-b77d-de70232b341a",
+									"name": "Handsome",
+									"cost_type": "points",
+									"cost": 12,
+									"affects": "total"
 								}
 							],
-							"reference": "B91",
+							"reference": "DFA47",
 							"calc": {
-								"points": 2
-							},
-							"categories": [
-								"Advantage"
-							]
-						},
-						{
-							"type": "advantage_container",
-							"id": "6797cbec-dfc7-4a97-afe2-08e8870c3e19",
-							"name": "Succubus' Features",
-							"calc": {
-								"points": 24
-							},
-							"notes": "Replaces Appearance (Attractive)",
-							"open": false,
-							"children": [
-								{
-									"type": "advantage",
-									"id": "eab73f6a-96f6-4e53-8221-7af680d1c489",
-									"name": "Appearance",
-									"physical": true,
-									"modifiers": [
-										{
-											"type": "modifier",
-											"id": "f18269d6-86e0-4a11-a9a3-e4d10a5e3ec7",
-											"name": "Beautiful",
-											"cost_type": "points",
-											"cost": 12,
-											"affects": "total"
-										}
-									],
-									"reference": "DFA47",
-									"calc": {
-										"points": 12
-									},
-									"categories": [
-										"Advantage"
-									]
-								},
-								{
-									"type": "advantage",
-									"id": "01dc6ad5-0b44-49f2-bd49-748f97d4d5c5",
-									"name": "Appearance",
-									"physical": true,
-									"modifiers": [
-										{
-											"type": "modifier",
-											"id": "b67d818c-f5b4-4f64-b77d-de70232b341a",
-											"name": "Handsome",
-											"cost_type": "points",
-											"cost": 12,
-											"affects": "total"
-										}
-									],
-									"reference": "DFA47",
-									"calc": {
-										"points": 12
-									},
-									"categories": [
-										"Advantage"
-									]
-								}
-							]
-						},
-						{
-							"type": "advantage",
-							"id": "e4590915-eb95-4ef9-9f0d-4897e0d0014d",
-							"name": "Temperature Tolerance (Hot)",
-							"physical": true,
-							"levels": "1",
-							"points_per_level": 1,
-							"reference": "DFA16",
-							"calc": {
-								"points": 1
+								"points": 12
 							},
 							"categories": [
 								"Advantage"
 							]
 						}
+					]
+				},
+				{
+					"type": "advantage",
+					"id": "e4590915-eb95-4ef9-9f0d-4897e0d0014d",
+					"name": "Temperature Tolerance (Hot)",
+					"physical": true,
+					"levels": "1",
+					"points_per_level": 1,
+					"reference": "DFA16",
+					"calc": {
+						"points": 1
+					},
+					"categories": [
+						"Advantage"
 					]
 				}
 			]

--- a/Library/Norðlond/Races/Elfàrd.gct
+++ b/Library/Norðlond/Races/Elfàrd.gct
@@ -349,7 +349,7 @@
 				},
 				{
 					"type": "advantage",
-					"id": "a10ccf74-c112-45e3-8b9c-f07f254f9975",
+					"id": "8a9cb371-759c-48e7-ae8c-5f9b5b87e6db",
 					"name": "Magery",
 					"mental": true,
 					"supernatural": true,
@@ -365,7 +365,11 @@
 							"type": "spell_bonus",
 							"amount": 1,
 							"per_level": true,
-							"match": "all_colleges"
+							"match": "power_source_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Arcane"
+							}
 						},
 						{
 							"type": "skill_bonus",
@@ -477,7 +481,7 @@
 				},
 				{
 					"type": "advantage",
-					"id": "3ddb1f3e-fd1c-4e45-a027-0a0942cb5b65",
+					"id": "0c5469b4-0bb6-4f87-a199-ee70c078c8ff",
 					"name": "Magery",
 					"mental": true,
 					"supernatural": true,
@@ -493,7 +497,11 @@
 							"type": "spell_bonus",
 							"amount": 1,
 							"per_level": true,
-							"match": "all_colleges"
+							"match": "power_source_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Arcane"
+							}
 						},
 						{
 							"type": "skill_bonus",

--- a/Library/Norðlond/Races/Hálfálfar.gct
+++ b/Library/Norðlond/Races/Hálfálfar.gct
@@ -9,7 +9,7 @@
 			"container_type": "race",
 			"name": "Hálfálfar",
 			"calc": {
-				"points": 49
+				"points": 20
 			},
 			"open": true,
 			"children": [
@@ -134,7 +134,7 @@
 				},
 				{
 					"type": "advantage",
-					"id": "18a80cea-76a3-4795-a64b-6faba6581a7b",
+					"id": "e541c44e-8b56-4801-908c-874874086ab8",
 					"name": "Magery",
 					"mental": true,
 					"supernatural": true,
@@ -150,7 +150,11 @@
 							"type": "spell_bonus",
 							"amount": 1,
 							"per_level": true,
-							"match": "all_colleges"
+							"match": "power_source_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Arcane"
+							}
 						},
 						{
 							"type": "skill_bonus",
@@ -211,121 +215,125 @@
 					"calc": {
 						"points": 0
 					}
+				}
+			]
+		},
+		{
+			"type": "advantage_container",
+			"id": "fc79e918-4602-423c-9cf7-472c93832444",
+			"name": "Hálfálfar Gifts",
+			"calc": {
+				"points": 29
+			},
+			"open": true,
+			"children": [
+				{
+					"type": "advantage",
+					"id": "4229d056-c793-44b5-bf76-880740e1ac2b",
+					"name": "Acute Mage Sense",
+					"physical": true,
+					"levels": "2",
+					"points_per_level": 2,
+					"calc": {
+						"points": 4
+					},
+					"notes": "+1/level to Perception rolls ot sense changes in mana level or detect magical items."
 				},
 				{
-					"type": "advantage_container",
-					"id": "fc79e918-4602-423c-9cf7-472c93832444",
-					"name": "Hálfálfar Gifts",
+					"type": "advantage",
+					"id": "99584fdb-7d8a-4cfd-81c1-9a2c71395090",
+					"name": "Charisma",
+					"mental": true,
+					"levels": "2",
+					"points_per_level": 5,
+					"reference": "DFA48",
 					"calc": {
-						"points": 29
+						"points": 10
 					},
-					"open": false,
-					"children": [
+					"features": [
 						{
-							"type": "advantage",
-							"id": "4229d056-c793-44b5-bf76-880740e1ac2b",
-							"name": "Acute Mage Sense",
-							"physical": true,
-							"levels": "2",
-							"points_per_level": 2,
-							"calc": {
-								"points": 4
-							},
-							"notes": "+1/level to Perception rolls ot sense changes in mana level or detect magical items."
+							"type": "skill_bonus",
+							"amount": 1,
+							"per_level": true,
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "fortune-telling"
+							}
 						},
 						{
-							"type": "advantage",
-							"id": "99584fdb-7d8a-4cfd-81c1-9a2c71395090",
-							"name": "Charisma",
-							"mental": true,
-							"levels": "2",
-							"points_per_level": 5,
-							"reference": "DFA48",
-							"calc": {
-								"points": 10
-							},
-							"features": [
-								{
-									"type": "skill_bonus",
-									"amount": 1,
-									"per_level": true,
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "fortune-telling"
-									}
-								},
-								{
-									"type": "skill_bonus",
-									"amount": 1,
-									"per_level": true,
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "leadership"
-									}
-								},
-								{
-									"type": "skill_bonus",
-									"amount": 1,
-									"per_level": true,
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "panhandling"
-									}
-								},
-								{
-									"type": "skill_bonus",
-									"amount": 1,
-									"per_level": true,
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "public speaking"
-									}
-								}
-							],
-							"notes": "+1/level to Influence rolls",
-							"categories": [
-								"Advantage"
-							]
+							"type": "skill_bonus",
+							"amount": 1,
+							"per_level": true,
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "leadership"
+							}
 						},
 						{
-							"type": "advantage",
-							"id": "2bd404e4-083f-425d-bff9-eee657fd9a90",
-							"name": "Magery",
-							"mental": true,
-							"supernatural": true,
-							"levels": "1",
-							"base_points": 5,
-							"points_per_level": 10,
-							"reference": "DFA41",
-							"calc": {
-								"points": 15
-							},
-							"features": [
-								{
-									"type": "spell_bonus",
-									"amount": 1,
-									"per_level": true,
-									"match": "all_colleges"
-								},
-								{
-									"type": "skill_bonus",
-									"amount": 1,
-									"per_level": true,
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "thaumatology"
-									}
-								}
-							],
-							"categories": [
-								"Advantage"
-							]
+							"type": "skill_bonus",
+							"amount": 1,
+							"per_level": true,
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "panhandling"
+							}
+						},
+						{
+							"type": "skill_bonus",
+							"amount": 1,
+							"per_level": true,
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "public speaking"
+							}
 						}
+					],
+					"notes": "+1/level to Influence rolls",
+					"categories": [
+						"Advantage"
+					]
+				},
+				{
+					"type": "advantage",
+					"id": "38dee798-48e0-4477-8580-92eaea3026a9",
+					"name": "Magery",
+					"mental": true,
+					"supernatural": true,
+					"levels": "1",
+					"base_points": 5,
+					"points_per_level": 10,
+					"reference": "DFA41",
+					"calc": {
+						"points": 15
+					},
+					"features": [
+						{
+							"type": "spell_bonus",
+							"amount": 1,
+							"per_level": true,
+							"match": "power_source_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Arcane"
+							}
+						},
+						{
+							"type": "skill_bonus",
+							"amount": 1,
+							"per_level": true,
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "thaumatology"
+							}
+						}
+					],
+					"categories": [
+						"Advantage"
 					]
 				}
 			]

--- a/Library/Norðlond/Races/Vandræðagemsi.gct
+++ b/Library/Norðlond/Races/Vandræðagemsi.gct
@@ -192,7 +192,7 @@
 				},
 				{
 					"type": "advantage",
-					"id": "5893aad7-9d90-4ecb-ada9-2e4d5b8e2e83",
+					"id": "147967de-9e8c-41db-8e41-ea4bfd854dd2",
 					"name": "Magery",
 					"mental": true,
 					"supernatural": true,
@@ -208,7 +208,11 @@
 							"type": "spell_bonus",
 							"amount": 1,
 							"per_level": true,
-							"match": "all_colleges"
+							"match": "power_source_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Arcane"
+							}
 						},
 						{
 							"type": "skill_bonus",


### PR DESCRIPTION
Re-formatted the DFRPG Spells Library.
- All instances of spells with multiple spellcasting talent types (e.g. Clerical _and_ Wizardly), which were previously listed as different versions of the same spell, have been merged.
- Re-formatted all pre-requisite lists to accommodate the above. All multiple-spellcasting-talent spells now have prerequisite lists with a top level **or** group which effectively splits between the spellcasting talent types. The prerequisite of Magery 0 (and Bardic Talent, where appropriate) has been added to all Wizardly spells to make this possible. What all this means is that if a spell is, for example, both Clerical and Wizardly, that the prerequisite list has the following format: (PI **X**) or (Magery and other wizardly prerequisites).
- Added a user-entry field "@<!-- -->Power Source: Arcane/Clerical/Druidic@" and variations thereof where appropriate to spells available to multiple spellcasting professions. Further, changed the features section of spellcasting talent Advantages such as Magery and Power Investiture to add their level only to spells of a specified Power Source. This is done to prevent overlap for characters with spells which fall under multiple spellcasting talent categories.
- Removed "Clerical" and "Druid" from the "college" entries of various spells, to go with the above mentioned changes.
- Filled "Resistance" entries for all spells which did not have them previously.
- Added a few missing spells.
- Fixed various previous user input errors.