### PR TITLE
Fixed Freeze-Dried Food/Added Hygiene Items from HT221

### DIFF
--- a/Library/High Tech/High Tech Equipment.eqp
+++ b/Library/High Tech/High Tech Equipment.eqp
@@ -22368,6 +22368,20 @@
 		},
 		{
 			"type": "equipment",
+			"id": "de9d0062-22fb-48ca-8393-22ac49df7b7a",
+			"quantity": 1,
+			"description": "Foot Powder",
+			"tech_level": "6",
+			"value": "4",
+			"weight": "0.5 lb",
+			"reference": "HT221",
+			"notes": "Week's supply",
+			"categories": [
+				"General Equipment"
+			]
+		},
+		{
+			"type": "equipment",
 			"id": "057efbcb-b589-4dd8-bd97-c577b7472610",
 			"quantity": 1,
 			"description": "Football Helmet",
@@ -22848,12 +22862,12 @@
 		},
 		{
 			"type": "equipment",
-			"id": "ab3fdf79-c8e5-4557-a8a3-1bbcc2f73697",
+			"id": "d64bcef6-9765-4439-977f-e7465ffb9e87",
 			"quantity": 1,
 			"description": "Freeze-Dried Food",
 			"tech_level": "7",
-			"value": "0.25",
-			"weight": "4 lb",
+			"value": "4",
+			"weight": "0.25 lb",
 			"reference": "HT35",
 			"categories": [
 				"General Equipment"
@@ -28537,6 +28551,20 @@
 		},
 		{
 			"type": "equipment",
+			"id": "30946430-0554-44ea-8cd7-d20f1625d8ea",
+			"quantity": 1,
+			"description": "Hand Sanitizer Gel",
+			"tech_level": "8",
+			"value": "1",
+			"weight": "0.01 lb",
+			"reference": "HT221",
+			"notes": "Week's supply.",
+			"categories": [
+				"General Equipment"
+			]
+		},
+		{
+			"type": "equipment",
 			"id": "7eaa3898-bfcd-409e-80c3-b91f1627b86a",
 			"quantity": 1,
 			"description": "Handheld Metal Detector",
@@ -30590,6 +30618,20 @@
 			"value": "30",
 			"reference": "HT44",
 			"notes": "24-36 exposures/roll.",
+			"categories": [
+				"General Equipment"
+			]
+		},
+		{
+			"type": "equipment",
+			"id": "46395ce0-460a-481d-bc49-1d43406ed0f3",
+			"quantity": 1,
+			"description": "Insect Repellant",
+			"tech_level": "6",
+			"value": "2",
+			"weight": "0.25 lb",
+			"reference": "HT221",
+			"notes": "10 uses.",
 			"categories": [
 				"General Equipment"
 			]
@@ -47854,6 +47896,20 @@
 		},
 		{
 			"type": "equipment",
+			"id": "3c0861f0-8862-4b11-8fb3-26eb8684f0d3",
+			"quantity": 1,
+			"description": "Salt Tablets",
+			"tech_level": "6",
+			"value": "1",
+			"weight": "0.1 lb",
+			"reference": "HT221",
+			"notes": "50 tablets.",
+			"categories": [
+				"General Equipment"
+			]
+		},
+		{
+			"type": "equipment",
 			"id": "502be474-dbaf-4587-9571-a1ef91e44914",
 			"quantity": 1,
 			"description": "Rotary Press",
@@ -53937,6 +53993,20 @@
 		},
 		{
 			"type": "equipment",
+			"id": "55182a97-1d27-4f8e-a3e9-833c0954b21d",
+			"quantity": 1,
+			"description": "Soap",
+			"tech_level": "5",
+			"value": "1",
+			"weight": "0.25 lb",
+			"reference": "HT221",
+			"notes": "Month's supply",
+			"categories": [
+				"General Equipment"
+			]
+		},
+		{
+			"type": "equipment",
 			"id": "59a197dd-3ebf-4073-bfd7-86996028a033",
 			"quantity": 1,
 			"description": "Soft Iron Spike",
@@ -56396,6 +56466,20 @@
 			],
 			"categories": [
 				"Defenses"
+			]
+		},
+		{
+			"type": "equipment",
+			"id": "1a1a6fdf-3cde-430e-9766-16711f73d986",
+			"quantity": 1,
+			"description": "Sunscreen",
+			"tech_level": "6",
+			"value": "2",
+			"weight": "0.25 lb",
+			"reference": "HT221",
+			"notes": "4 uses.",
+			"categories": [
+				"General Equipment"
 			]
 		},
 		{
@@ -60810,6 +60894,20 @@
 			"weight": "5 lb",
 			"reference": "HT45",
 			"notes": "External power.",
+			"categories": [
+				"General Equipment"
+			]
+		},
+		{
+			"type": "equipment",
+			"id": "8c14b4c8-4d6d-4333-9a66-c857ff3c2cc0",
+			"quantity": 1,
+			"description": "Vitamin Pills",
+			"tech_level": "7",
+			"value": "3",
+			"weight": "0.1 lb",
+			"reference": "HT221",
+			"notes": "Month's supply.",
 			"categories": [
 				"General Equipment"
 			]


### PR DESCRIPTION
Added items from the "Hygiene and Healthcare" block on HT221 and corrected Freeze-Dried Food. HT35 has Freeze-Dried Food statted as $4/0.25lb whereas the GCS Master Library has it listed as $0.25/4lbs.