### PR TITLE
Fixed user errors regarding some Wizardly/Bardic spells

### DIFF
--- a/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Spells.spl
+++ b/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Spells.spl
@@ -19,7 +19,7 @@
 					"categories": [
 						"Clerical"
 					],
-					"open": true,
+					"open": false,
 					"children": [
 						{
 							"type": "spell",
@@ -2059,7 +2059,7 @@
 					"categories": [
 						"Clerical"
 					],
-					"open": true,
+					"open": false,
 					"children": [
 						{
 							"type": "spell",
@@ -4176,7 +4176,7 @@
 					"categories": [
 						"Clerical"
 					],
-					"open": true,
+					"open": false,
 					"children": [
 						{
 							"type": "spell",
@@ -5792,7 +5792,7 @@
 					"categories": [
 						"Clerical"
 					],
-					"open": true,
+					"open": false,
 					"children": [
 						{
 							"type": "spell",
@@ -6502,7 +6502,7 @@
 					"categories": [
 						"Clerical"
 					],
-					"open": true,
+					"open": false,
 					"children": [
 						{
 							"type": "spell",
@@ -6834,7 +6834,7 @@
 					"categories": [
 						"Clerical"
 					],
-					"open": true,
+					"open": false,
 					"children": [
 						{
 							"type": "spell",
@@ -6895,7 +6895,7 @@
 					"categories": [
 						"Druidic"
 					],
-					"open": true,
+					"open": false,
 					"children": [
 						{
 							"type": "spell",
@@ -8722,7 +8722,7 @@
 					"categories": [
 						"Druidic"
 					],
-					"open": true,
+					"open": false,
 					"children": [
 						{
 							"type": "spell",
@@ -10643,7 +10643,7 @@
 					"categories": [
 						"Druidic"
 					],
-					"open": true,
+					"open": false,
 					"children": [
 						{
 							"type": "spell",
@@ -11929,7 +11929,7 @@
 					"categories": [
 						"Druidic"
 					],
-					"open": true,
+					"open": false,
 					"children": [
 						{
 							"type": "spell",
@@ -12489,7 +12489,7 @@
 					"categories": [
 						"Druidic"
 					],
-					"open": true,
+					"open": false,
 					"children": [
 						{
 							"type": "spell",
@@ -12712,7 +12712,7 @@
 					"categories": [
 						"Druidic"
 					],
-					"open": true,
+					"open": false,
 					"children": [
 						{
 							"type": "spell",
@@ -12977,7 +12977,7 @@
 						"prereqs": [
 							{
 								"type": "prereq_list",
-								"all": true,
+								"all": false,
 								"prereqs": [
 									{
 										"type": "advantage_prereq",
@@ -22965,7 +22965,7 @@
 						"prereqs": [
 							{
 								"type": "prereq_list",
-								"all": true,
+								"all": false,
 								"prereqs": [
 									{
 										"type": "advantage_prereq",
@@ -23578,7 +23578,7 @@
 						"prereqs": [
 							{
 								"type": "prereq_list",
-								"all": true,
+								"all": false,
 								"prereqs": [
 									{
 										"type": "advantage_prereq",
@@ -31350,7 +31350,7 @@
 							},
 							{
 								"type": "prereq_list",
-								"all": true,
+								"all": false,
 								"prereqs": [
 									{
 										"type": "advantage_prereq",
@@ -32422,7 +32422,7 @@
 							},
 							{
 								"type": "prereq_list",
-								"all": true,
+								"all": false,
 								"prereqs": [
 									{
 										"type": "advantage_prereq",


### PR DESCRIPTION
Fixed a few instances of spells requiring Magery *and* Bardic Talent, when they should require only one.
Spells affected include:
- Alertness
- Loyalty
- Message
- Test Load
- Wall of Silence