### PR TITLE
trentin_add_computer_mods_ut Updated UT Mods and Equipment

### DIFF
--- a/Library/Ultra Tech/Ultra Tech Equipment Modifiers.eqm
+++ b/Library/Ultra Tech/Ultra Tech Equipment Modifiers.eqm
@@ -4,12 +4,11 @@
 	"id": "b003650a-047f-4586-a399-64c7c46d1203",
 	"rows": [
 		{
-			"type": "eqp_modifier_container",
+			"type": "eqp_modifier",
 			"id": "4d454fb3-1141-48f0-a294-4068b041e489",
 			"disabled": true,
 			"name": "Note",
-			"notes": "Both Cost Factor and Multiplicative Modifiers for equipment are provided here (in sections). \n\nKromm recommends using Cost Factor which was introduced in Low-Tech, rather than the multiplicative cost modifiers. \n\nBut some GMs may wish to use multiplicative.",
-			"open": false
+			"notes": "Both Cost Factor and Multiplicative Modifiers for equipment are provided here (in sections).\n\nKromm recommends using Cost Factor which was introduced in Low-Tech, rather than the multiplicative cost modifiers.\n\nBut some GMs may wish to use multiplicative."
 		},
 		{
 			"type": "eqp_modifier_container",

--- a/Library/Ultra Tech/Ultra Tech Equipment Modifiers.eqm
+++ b/Library/Ultra Tech/Ultra Tech Equipment Modifiers.eqm
@@ -8,1515 +8,1913 @@
 			"id": "4d454fb3-1141-48f0-a294-4068b041e489",
 			"disabled": true,
 			"name": "Note",
-			"notes": "Both Cost Factor and Multiplicative Modifiers for equipment are provided here. Kromm recommends using Cost Factor which was introduced in Low-Tech, rather than the multiplicative cost modifiers. But some GMs may wish to use multiplicative.",
+			"notes": "Both Cost Factor and Multiplicative Modifiers for equipment are provided here (in sections). \n\nKromm recommends using Cost Factor which was introduced in Low-Tech, rather than the multiplicative cost modifiers. \n\nBut some GMs may wish to use multiplicative.",
 			"open": false
 		},
 		{
 			"type": "eqp_modifier_container",
-			"id": "0922be81-a949-4eac-9753-0a32e25690d9",
-			"disabled": true,
-			"name": "Adjusting for SM",
-			"reference": "UT16",
-			"open": false,
-			"children": [
-				{
-					"type": "eqp_modifier",
-					"id": "d4db9f4e-503f-4c5f-bf17-8d821ed67936",
-					"name": "SM +1",
-					"reference": "UT16",
-					"cost_type": "to_final_cost",
-					"cost": "x2",
-					"weight_type": "to_final_weight",
-					"weight": "x2"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "10f30c42-0d96-4676-9dd0-24dfc3f093d1",
-					"name": "SM +2",
-					"reference": "UT16",
-					"cost_type": "to_final_cost",
-					"cost": "x5",
-					"weight_type": "to_final_weight",
-					"weight": "x5"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "2e62df9a-f0eb-4f89-9eaa-2b61ebd17c0f",
-					"name": "SM +3",
-					"reference": "UT16",
-					"cost_type": "to_final_cost",
-					"cost": "x10",
-					"weight_type": "to_final_weight",
-					"weight": "x10"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "3960f0ef-6d40-4c8e-9a02-917acc7598d4",
-					"name": "SM +4",
-					"reference": "UT16",
-					"cost_type": "to_final_cost",
-					"cost": "x20",
-					"weight_type": "to_final_weight",
-					"weight": "x20"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "cb625dad-1d04-4bc9-bb64-9eb19b0717a2",
-					"name": "SM +5",
-					"reference": "UT16",
-					"cost_type": "to_final_cost",
-					"cost": "x50",
-					"weight_type": "to_final_weight",
-					"weight": "x50"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "0e2e7958-5d17-452c-b322-d01cc7e99532",
-					"name": "SM +6",
-					"reference": "UT16",
-					"cost_type": "to_final_cost",
-					"cost": "x100",
-					"weight_type": "to_final_weight",
-					"weight": "x100"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "6f5115c2-0acb-4a4e-b06c-5e60c81ddc5a",
-					"name": "SM +7",
-					"reference": "UT16",
-					"cost_type": "to_final_cost",
-					"cost": "x200",
-					"weight_type": "to_final_weight",
-					"weight": "x200"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "2b638e77-6fd0-4924-ae2c-3d3fc362cbdc",
-					"name": "SM +8",
-					"reference": "UT16",
-					"cost_type": "to_final_cost",
-					"cost": "x500",
-					"weight_type": "to_final_weight",
-					"weight": "x500"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "1a73a6a3-8a01-4a51-8457-383385bc5d5e",
-					"name": "SM +9",
-					"reference": "UT16",
-					"cost_type": "to_final_cost",
-					"cost": "x1000",
-					"weight_type": "to_final_weight",
-					"weight": "x1000"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "6730ee7b-78a5-48d7-9acc-cbdda50929b0",
-					"name": "SM +10",
-					"reference": "UT16",
-					"cost_type": "to_final_cost",
-					"cost": "x2000",
-					"weight_type": "to_final_weight",
-					"weight": "x2000"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "72dbd82f-0fd6-456e-b66e-65c2b222b934",
-					"name": "SM -1",
-					"reference": "UT16",
-					"cost_type": "to_final_cost",
-					"cost": "x0.5",
-					"weight_type": "to_final_weight",
-					"weight": "x1/2"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "59e26b87-6433-4484-8e2d-28c482eca165",
-					"name": "SM -2",
-					"reference": "UT16",
-					"cost_type": "to_final_cost",
-					"cost": "x0.2",
-					"weight_type": "to_final_weight",
-					"weight": "x1/5"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "b6cf0f32-1efa-4a15-929a-e2b69dc01a33",
-					"name": "SM -3",
-					"reference": "UT16",
-					"cost_type": "to_final_cost",
-					"cost": "x0.1",
-					"weight_type": "to_final_weight",
-					"weight": "x1/10"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "da538839-92ad-4052-a84b-86ecfcb23e28",
-					"name": "SM -4",
-					"reference": "UT16",
-					"cost_type": "to_final_cost",
-					"cost": "x0.05",
-					"weight_type": "to_final_weight",
-					"weight": "x1/20"
-				}
-			]
-		},
-		{
-			"type": "eqp_modifier_container",
-			"id": "d2a142a7-eb12-47e2-b2bc-f6c9f4af7d00",
-			"disabled": true,
-			"name": "Integrating and Modifying Equipment",
-			"reference": "UT15",
-			"notes": "Cost Factor Conversion as of LT14",
-			"open": false,
-			"children": [
-				{
-					"type": "eqp_modifier",
-					"id": "ca51e4f1-b1b7-40f2-a0af-3f8de9ae4f60",
-					"name": "Cheap",
-					"reference": "UT15",
-					"cost_type": "to_base_cost",
-					"cost": "-0.5 CF",
-					"weight_type": "to_final_base_weight",
-					"weight": "x1.5"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "f9f0d310-80d1-407a-be71-e843d282002c",
-					"name": "Disguised",
-					"reference": "UT15",
-					"cost_type": "to_base_cost",
-					"cost": "+4 CF",
-					"notes": "Custom-built item"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "6ddbaf28-aff1-4e63-9504-959d4c26abb1",
-					"name": "Disguised",
-					"reference": "UT15",
-					"cost_type": "to_base_cost",
-					"cost": "+1 CF",
-					"notes": "Mass Produced"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "c1f77579-46ae-4454-b617-a54c23e65be1",
-					"name": "Expensive",
-					"reference": "UT15",
-					"cost_type": "to_base_cost",
-					"cost": "+1 CF",
-					"weight_type": "to_base_weight",
-					"weight": "x2/3"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "4c53c9e6-f708-4eaa-a3f0-7f203b585820",
-					"name": "Rugged",
-					"reference": "UT15",
-					"cost_type": "to_base_cost",
-					"cost": "+1 CF",
-					"weight_type": "to_base_weight",
-					"weight": "x1.2"
-				}
-			]
-		},
-		{
-			"type": "eqp_modifier_container",
-			"id": "d858c271-a17b-4bb1-a7fe-8268b0b1afde",
-			"disabled": true,
-			"name": "Warheads and Ammunition",
-			"reference": "UT152",
-			"notes": "Cost Factor Conversion as of LT14",
+			"id": "3bd0f9c0-ed24-4c1e-b38c-d13e5368effb",
+			"name": "Optional Cost Factors",
 			"open": true,
 			"children": [
 				{
 					"type": "eqp_modifier_container",
-					"id": "3bc10894-d156-453a-836b-04d37a83f9f2",
+					"id": "806507b7-f014-49f7-ad37-eae94a20d2b8",
 					"disabled": true,
-					"name": "Antimatter Warhead Antimatter Costs",
-					"reference": "UT157",
-					"open": true,
-					"children": [
-						{
-							"type": "eqp_modifier",
-							"id": "699f234b-f985-48c3-a36c-7a2453d31366",
-							"name": "Antimatter, 0.1 micrograms",
-							"reference": "UT157",
-							"cost_type": "to_final_cost",
-							"cost": "+2500",
-							"tech_level": "9"
-						},
-						{
-							"type": "eqp_modifier",
-							"id": "fd2a3531-d41d-43cb-826f-bf50e1bf5175",
-							"name": "Antimatter, 0.1 micrograms",
-							"reference": "UT157",
-							"cost_type": "to_final_cost",
-							"cost": "+250",
-							"tech_level": "10"
-						},
-						{
-							"type": "eqp_modifier",
-							"id": "f0bb5e34-6111-4525-be59-6379c2c84667",
-							"name": "Antimatter, 0.1 micrograms",
-							"reference": "UT157",
-							"cost_type": "to_final_cost",
-							"cost": "+2.5",
-							"tech_level": "11"
-						},
-						{
-							"type": "eqp_modifier",
-							"id": "d6d90d58-6485-43ed-91df-1bc7bf04c5a4",
-							"name": "Antimatter, 0.1 micrograms",
-							"reference": "UT157",
-							"cost_type": "to_final_cost",
-							"cost": "+0.5",
-							"tech_level": "12"
-						},
-						{
-							"type": "eqp_modifier",
-							"id": "6bd3c384-38cc-4b64-aaf6-53cc3246d1ec",
-							"name": "Antimatter, 1 microgram",
-							"reference": "UT157",
-							"cost_type": "to_final_cost",
-							"cost": "+25000",
-							"tech_level": "9"
-						},
-						{
-							"type": "eqp_modifier",
-							"id": "43af26e6-7633-4a31-90fd-e1939710b448",
-							"name": "Antimatter, 1 microgram",
-							"reference": "UT157",
-							"cost_type": "to_final_cost",
-							"cost": "+2500",
-							"tech_level": "10"
-						},
-						{
-							"type": "eqp_modifier",
-							"id": "906b6415-466d-47c1-a2f9-98d75661aafd",
-							"name": "Antimatter, 1 microgram",
-							"reference": "UT157",
-							"cost_type": "to_final_cost",
-							"cost": "+25",
-							"tech_level": "11"
-						},
-						{
-							"type": "eqp_modifier",
-							"id": "c3c1bed5-0e70-4d8f-83d8-c42fc4318a99",
-							"name": "Antimatter, 1 microgram",
-							"reference": "UT157",
-							"cost_type": "to_final_cost",
-							"cost": "+5",
-							"tech_level": "12"
-						},
-						{
-							"type": "eqp_modifier",
-							"id": "4ead1cca-5099-44e6-aba8-41974318218c",
-							"name": "Antimatter, 10 micrograms",
-							"reference": "UT157",
-							"cost_type": "to_final_cost",
-							"cost": "+250000",
-							"tech_level": "9"
-						},
-						{
-							"type": "eqp_modifier",
-							"id": "aca3289e-1582-428b-bbb9-e9fae7e56f31",
-							"name": "Antimatter, 10 micrograms",
-							"reference": "UT157",
-							"cost_type": "to_final_cost",
-							"cost": "+25000",
-							"tech_level": "10"
-						},
-						{
-							"type": "eqp_modifier",
-							"id": "51241f65-70d5-42cc-953b-6f66c69bf28e",
-							"name": "Antimatter, 10 micrograms",
-							"reference": "UT157",
-							"cost_type": "to_final_cost",
-							"cost": "+250",
-							"tech_level": "11"
-						},
-						{
-							"type": "eqp_modifier",
-							"id": "b1e2585a-4887-44b1-a41c-4478d7f7af6a",
-							"name": "Antimatter, 10 micrograms",
-							"reference": "UT157",
-							"cost_type": "to_base_cost",
-							"cost": "+50 CF",
-							"tech_level": "12"
-						}
-					]
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "8d06974e-52dd-4aac-8134-393cf688ce02",
-					"name": "Armor Piercing Hyperdense Dart",
-					"reference": "UT156",
-					"cost_type": "to_base_cost",
-					"cost": "+9 CF",
-					"tech_level": "9"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "166b72c2-6351-4bbe-ab85-c3e695bb43c6",
-					"name": "Armor-Piercing Enhanced Penetrator",
-					"reference": "UT152",
-					"cost_type": "to_base_cost",
-					"cost": "+9 CF",
-					"tech_level": "9"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "9104287c-81c3-4c45-9ada-155b14845b33",
-					"name": "Armor-Piercing Hardcore",
-					"reference": "UT152",
-					"cost_type": "to_base_cost",
-					"cost": "+1 CF",
-					"tech_level": "9"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "461ba2d2-2daa-486e-b840-c8ba7800762f",
-					"name": "Armor-Piercing Hardcore Explosive",
-					"reference": "UT152",
-					"cost_type": "to_base_cost",
-					"cost": "+3 CF",
-					"tech_level": "9"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "6dd34d2e-b1df-4c6f-9eea-b622cd70e28f",
-					"name": "Biochemical Aerosol",
-					"reference": "UT153",
-					"cost_type": "to_base_cost",
-					"cost": "+0 CF",
-					"tech_level": "9",
-					"notes": "Cost Plus Filler x # of Doses"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "3a21825e-2d3a-4605-aed7-e10ce6e33531",
-					"name": "Biochemical Liquid",
-					"reference": "UT153",
-					"cost_type": "to_base_cost",
-					"cost": "+0 CF",
-					"tech_level": "9",
-					"notes": "Cost Plus Filler x # of Doses"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "172d9860-f275-4c8d-becb-487a1b9b1418",
-					"name": "Burrow Darts",
-					"reference": "UT155",
-					"cost_type": "to_base_cost",
-					"cost": "+2 CF",
-					"tech_level": "10"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "3bd4a659-6372-4d3d-86d2-0b40fd0d4274",
-					"name": "Electrothermal-Chemical",
-					"reference": "UT139",
-					"cost_type": "to_base_cost",
-					"cost": "+1 CF",
-					"tech_level": "9"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "e51e42ae-0572-42ba-bdc9-f429efd1db58",
-					"name": "EMP",
-					"reference": "UT157",
-					"cost_type": "to_base_cost",
-					"cost": "+9 CF",
-					"tech_level": "9"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "4b700304-07f0-4cab-8898-632390effc7f",
-					"name": "Expendable Jammer",
-					"reference": "UT157",
-					"cost_type": "to_base_cost",
-					"cost": "+4 CF",
-					"tech_level": "9"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "e4523cc6-6fae-4997-acf1-c0068f984fbb",
-					"name": "Flare",
-					"reference": "UT153",
-					"cost_type": "to_base_cost",
-					"cost": "+1 CF",
-					"tech_level": "9"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "7654d6ac-5594-49c4-aa53-4f475159ea21",
-					"name": "Force",
-					"reference": "UT158",
-					"cost_type": "to_base_cost",
-					"cost": "+4 CF",
-					"tech_level": "10^"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "f2b48dd3-7d8c-4230-864b-ae6669b2e205",
-					"name": "High Explosive",
-					"reference": "UT153",
-					"cost_type": "to_base_cost",
-					"cost": "+0 CF",
-					"tech_level": "9"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "a8447496-8a3f-4037-85d8-c2e093d4c6c0",
-					"name": "High Explosive Concussion",
-					"reference": "UT154",
-					"cost_type": "to_base_cost",
-					"cost": "+0 CF",
-					"tech_level": "9"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "1d0638d5-ff5f-481e-ac5b-defb04a49963",
-					"name": "High Explosive Multi-Purpose",
-					"reference": "UT155",
-					"cost_type": "to_base_cost",
-					"cost": "+1 CF",
-					"tech_level": "10"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "716390d6-6291-4396-84a3-0c5eea5aef54",
-					"name": "Hollow-Point",
-					"reference": "UT154",
-					"cost_type": "to_base_cost",
-					"cost": "+0 CF",
-					"tech_level": "9"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "0934ff7b-eebf-479e-a63c-8ffd640010df",
-					"name": "Implosion",
-					"reference": "UT158",
-					"cost_type": "to_base_cost",
-					"cost": "+4 CF",
-					"tech_level": "11^"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "be58451f-7eb9-401e-ae4d-a6adfca2040f",
-					"name": "Liquid Propellant",
-					"reference": "UT139",
-					"cost_type": "to_base_cost",
-					"cost": "+0.5 CF",
-					"tech_level": "9",
-					"notes": "1.5x many shots per magazine"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "ebe09b49-f76c-4b56-8de8-447cf58246cb",
-					"name": "Memory Baton",
-					"reference": "UT154",
-					"cost_type": "to_base_cost",
-					"cost": "+4 CF",
-					"tech_level": "9"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "3626d433-5bd1-44e9-ad0f-b1246dae3fbd",
-					"name": "Micro-Antimatter Warhead",
-					"reference": "UT156",
-					"cost_type": "to_base_cost",
-					"cost": "+9 CF",
-					"tech_level": "10"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "943d4699-cd92-40f0-838c-2eb796ea31df",
-					"name": "Mininuke",
-					"reference": "UT156",
-					"cost_type": "to_base_cost",
-					"cost": "+999 CF",
-					"tech_level": "9"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "00d63082-4496-4806-bfe8-a553a5e711f7",
-					"name": "Monochain",
-					"reference": "UT154",
-					"cost_type": "to_base_cost",
-					"cost": "+4 CF",
-					"tech_level": "9^"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "b0b4be9a-8d55-4c22-a03d-3662ee3aafcb",
-					"name": "Plasma",
-					"reference": "UT158",
-					"cost_type": "to_base_cost",
-					"cost": "+9 CF",
-					"tech_level": "10^"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "b0928cb3-b6a1-4150-b045-bf4acfebc359",
-					"name": "Psi-Bomb",
-					"reference": "UT158",
-					"cost_type": "to_base_cost",
-					"cost": "+9 CF",
-					"tech_level": "12^"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "24ce29ae-4c98-4792-826e-e3c29f41dac7",
-					"name": "Psi-Bomb, Message",
-					"reference": "UT159",
-					"cost_type": "to_base_cost",
-					"cost": "+9 CF",
-					"tech_level": "12^"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "d285aab7-b112-4b0a-b700-983954f63bbb",
-					"name": "Psi-Bomb, Terror",
-					"reference": "UT159",
-					"cost_type": "to_base_cost",
-					"cost": "+9 CF",
-					"tech_level": "12^"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "c39d71d4-145e-4a50-8332-5538e83af25c",
-					"name": "Shaped Charge",
-					"reference": "UT154",
-					"cost_type": "to_base_cost",
-					"cost": "+1 CF",
-					"tech_level": "9"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "59fc57a1-a913-4b24-aea8-0fa2e4fbe351",
-					"name": "Shotshell",
-					"reference": "UT154",
-					"cost_type": "to_base_cost",
-					"cost": "+0 CF",
-					"tech_level": "9"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "9395398c-9dd2-4a7d-92c6-8a58271284fc",
-					"name": "Smart Explosively Forged Projectile",
-					"reference": "UT154",
-					"cost_type": "to_base_cost",
-					"cost": "+4 CF",
-					"tech_level": "9"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "ad1bf013-93a7-4db6-9148-9a5f0d18b2f5",
-					"name": "Stasis",
-					"reference": "UT159",
-					"cost_type": "to_base_cost",
-					"cost": "+499 CF",
-					"tech_level": "12^"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "15f9738a-de75-439a-8c6a-439814d4e6e1",
-					"name": "Stingray",
-					"reference": "UT156",
-					"cost_type": "to_base_cost",
-					"cost": "+4 CF",
-					"tech_level": "9"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "7656b475-204b-48b9-a0e6-9f8da2299410",
-					"name": "Strobe",
-					"reference": "UT157",
-					"cost_type": "to_base_cost",
-					"cost": "+3 CF",
-					"tech_level": "9"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "651d7f41-d92c-4029-9f53-8b08dbec7d1c",
-					"name": "Swarm",
-					"reference": "UT156",
-					"cost_type": "to_base_cost",
-					"cost": "+4 CF",
-					"tech_level": "9",
-					"notes": "Plus Cost of Swarm"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "e52717ed-ceb1-4364-a7b4-e184de91746a",
-					"name": "Tangler",
-					"reference": "UT155",
-					"cost_type": "to_base_cost",
-					"cost": "+1 CF",
-					"tech_level": "9"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "01e2b542-3208-410f-8995-766353b03377",
-					"name": "Thermobaric",
-					"reference": "UT155",
-					"cost_type": "to_base_cost",
-					"cost": "+4 CF",
-					"tech_level": "9"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "dff6e663-9154-4979-9bba-0bc9819ae013",
-					"name": "Vortex",
-					"reference": "UT159",
-					"cost_type": "to_base_cost",
-					"cost": "+999 CF",
-					"tech_level": "12^"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "99e1bdf5-4555-4054-b6eb-5a65fa784152",
-					"name": "Warbler",
-					"reference": "UT157",
-					"cost_type": "to_base_cost",
-					"cost": "+3 CF",
-					"tech_level": "9"
-				}
-			]
-		},
-		{
-			"type": "eqp_modifier_container",
-			"id": "5a52df4e-0f53-481c-887c-3def847416a5",
-			"disabled": true,
-			"name": "Tailoring Armor",
-			"reference": "UT174",
-			"notes": "Cost Factor Conversion as of LT14",
-			"open": false,
-			"children": [
-				{
-					"type": "eqp_modifier_container",
-					"id": "e46a6f53-8da7-47b7-a942-b231ef21020e",
-					"disabled": true,
-					"name": "Cut",
-					"open": true,
-					"children": [
-						{
-							"type": "eqp_modifier",
-							"id": "803a5aee-fdf5-4f96-8331-0fca36daed2a",
-							"name": "Fashion Original",
-							"reference": "UT175",
-							"cost_type": "to_base_cost",
-							"cost": "+19 CF"
-						},
-						{
-							"type": "eqp_modifier",
-							"id": "4cc52e81-257d-4ab6-be03-a58bd65a425b",
-							"name": "Stylish",
-							"reference": "UT175",
-							"cost_type": "to_base_cost",
-							"cost": "+3 CF"
-						}
-					]
-				},
-				{
-					"type": "eqp_modifier_container",
-					"id": "92857994-a4f4-46b9-b631-b772b8d9dc06",
-					"disabled": true,
-					"name": "Style",
-					"reference": "UT175",
-					"open": true,
-					"children": [
-						{
-							"type": "eqp_modifier",
-							"id": "971ba995-3bd4-4a7b-aed2-72c6da585837",
-							"name": "Diaphanous",
-							"reference": "UT175",
-							"cost_type": "to_base_cost",
-							"cost": "-0.5 CF",
-							"weight_type": "to_base_weight",
-							"weight": "x0.5",
-							"notes": "Multiply DR by 0.5, Increase LC by 1"
-						},
-						{
-							"type": "eqp_modifier",
-							"id": "8a3d4581-4219-4ac1-a137-dc602e894400",
-							"name": "Heavy",
-							"reference": "UT175",
-							"cost_type": "to_base_cost",
-							"cost": "+0.5 CF",
-							"weight_type": "to_final_base_weight",
-							"weight": "x1.5",
-							"notes": "Multiply DR by 1.5, Reduce LC by 1"
-						},
-						{
-							"type": "eqp_modifier",
-							"id": "12922826-fbdb-48d0-a55e-10a67d8d0488",
-							"name": "Light",
-							"reference": "UT175",
-							"cost_type": "to_base_cost",
-							"cost": "-0.33 CF",
-							"weight_type": "to_final_base_weight",
-							"weight": "x2/3",
-							"notes": "Multiply DR by 2/3, Increase LC by 1"
-						}
-					]
-				}
-			]
-		},
-		{
-			"type": "eqp_modifier_container",
-			"id": "30508cb0-1f69-454f-975b-48180fee9113",
-			"disabled": true,
-			"name": "Melee and Thrown Weapons",
-			"reference": "UT162",
-			"notes": "Cost Factor Conversion as of LT14",
-			"open": false,
-			"children": [
-				{
-					"type": "eqp_modifier",
-					"id": "7d482021-08ac-4c0b-8a67-3fe7f82ed234",
-					"name": "Hyperdense Blade",
-					"reference": "UT164",
-					"cost_type": "to_base_cost",
-					"cost": "+9 CF",
-					"tech_level": "11",
-					"notes": "Cost is higher of: 500x Weight in lb, or 10x normal cost."
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "9dff5609-9ddb-4998-a9c9-39becb2445a5",
-					"name": "Nanothorn Blade",
-					"reference": "UT164",
-					"cost_type": "to_base_cost",
-					"cost": "+19 CF",
-					"tech_level": "11^"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "de21947e-36cb-4df4-a865-b6f85ee5ef4e",
-					"name": "Nanothorn Blade",
-					"reference": "UT164",
-					"cost_type": "to_base_cost",
-					"cost": "+3 CF",
-					"tech_level": "11^",
-					"notes": "Upgrade for Monowire."
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "be556daa-2ef6-4811-9a9a-7864cbf7d645",
-					"name": "Rocket Striker",
-					"reference": "UT163",
-					"cost_type": "to_final_base_cost",
-					"cost": "+500",
-					"weight_type": "to_final_base_weight",
-					"weight": "+1 lb",
-					"tech_level": "9"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "8c0ba25b-60a6-4302-b5c6-55e332d25de9",
-					"name": "Superfine Blade",
-					"reference": "UT163",
-					"cost_type": "to_base_cost",
-					"cost": "+5 CF",
-					"tech_level": "9"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "85098ea0-a1f0-4ae9-9491-c1795cd985b8",
-					"name": "Superfine Vibroblade",
-					"reference": "UT164",
-					"cost_type": "to_base_cost",
-					"cost": "+29 CF",
-					"tech_level": "10"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "f23d0e28-e5e8-4564-9dbb-ca58e89d6ce1",
-					"name": "Vibroblade",
-					"reference": "UT164",
-					"cost_type": "to_base_cost",
-					"cost": "+10 CF",
-					"tech_level": "10"
-				}
-			]
-		},
-		{
-			"type": "eqp_modifier_container",
-			"id": "5096a95c-3468-4736-85c3-93e6d93d34b4",
-			"disabled": true,
-			"name": "Integrating and Modifying Equipment",
-			"reference": "UT15",
-			"notes": "Multiplicative Cost Modifiers as of HT9",
-			"open": false,
-			"children": [
-				{
-					"type": "eqp_modifier",
-					"id": "f6239734-422a-4f8c-8546-34f0f67422ea",
-					"name": "Cheap",
-					"reference": "UT15",
-					"cost_type": "to_final_base_cost",
-					"cost": "x0.5",
-					"weight_type": "to_final_base_weight",
-					"weight": "x1.5"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "4f0b3717-8df2-49ca-8073-9fc735052c64",
-					"name": "Disguised",
-					"reference": "UT15",
-					"cost_type": "to_final_base_cost",
-					"cost": "x5",
-					"notes": "Custom-built item"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "f06165dd-81a7-49f2-90e7-c771ef8e6211",
-					"name": "Disguised",
-					"reference": "UT15",
-					"cost_type": "to_final_base_cost",
-					"cost": "x2",
-					"notes": "Mass Produced"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "b24e07c3-8a94-4ee2-912f-eefd7907ac81",
-					"name": "Expensive",
-					"reference": "UT15",
-					"cost_type": "to_final_base_cost",
-					"cost": "x2",
-					"weight_type": "to_base_weight",
-					"weight": "x2/3"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "137cc002-3386-4654-b56c-a07e0afb8641",
-					"name": "Rugged",
-					"reference": "UT15",
-					"cost_type": "to_final_base_cost",
-					"cost": "x2",
-					"weight_type": "to_base_weight",
-					"weight": "x1.2"
-				}
-			]
-		},
-		{
-			"type": "eqp_modifier_container",
-			"id": "78da040f-a787-400e-95bc-258d9dfcce4b",
-			"disabled": true,
-			"name": "Melee and Thrown Weapons",
-			"reference": "UT162",
-			"notes": "Multiplicative Cost Modifiers as of HT9",
-			"open": false,
-			"children": [
-				{
-					"type": "eqp_modifier",
-					"id": "034777e9-be99-41d2-9ec1-59e15d2b661c",
-					"name": "Hyperdense Blade",
-					"reference": "UT164",
-					"cost_type": "to_final_base_cost",
-					"cost": "x10",
-					"tech_level": "11",
-					"notes": "Cost is higher of: 500x Weight in lb, or 10x normal cost."
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "7edc1ae1-81c8-4df7-b69b-cb4aad057cd3",
-					"name": "Nanothorn Blade",
-					"reference": "UT164",
-					"cost_type": "to_final_base_cost",
-					"cost": "x20",
-					"tech_level": "11^"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "14283962-abcd-4bf0-b6a7-8cfb08656501",
-					"name": "Nanothorn Blade",
-					"reference": "UT164",
-					"cost_type": "to_final_base_cost",
-					"cost": "x4",
-					"tech_level": "11^",
-					"notes": "Upgrade for Monowire."
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "dab133df-6893-4ce5-8cb9-8f1bd549a09e",
-					"name": "Rocket Striker",
-					"reference": "UT163",
-					"cost_type": "to_final_base_cost",
-					"cost": "+500",
-					"weight_type": "to_final_base_weight",
-					"weight": "+1 lb",
-					"tech_level": "9"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "49f4c274-c60c-4018-ba27-f38f5df78be4",
-					"name": "Superfine Blade",
-					"reference": "UT163",
-					"cost_type": "to_final_base_cost",
-					"cost": "x6",
-					"tech_level": "9"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "3a23a441-2d36-49de-96b3-645b71ed6d5f",
-					"name": "Superfine Vibroblade",
-					"reference": "UT164",
-					"cost_type": "to_final_base_cost",
-					"cost": "x30",
-					"tech_level": "10"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "ba757ba0-be29-4601-a766-ee3a7e43bf6e",
-					"name": "Vibroblade",
-					"reference": "UT164",
-					"cost_type": "to_final_base_cost",
-					"cost": "x10",
-					"tech_level": "10"
-				}
-			]
-		},
-		{
-			"type": "eqp_modifier_container",
-			"id": "b52f1f44-4849-4f8e-9ae3-30939c23a7ef",
-			"disabled": true,
-			"name": "Tailoring Armor",
-			"reference": "UT174",
-			"notes": "Multiplicative Cost Modifiers as of HT9",
-			"open": false,
-			"children": [
-				{
-					"type": "eqp_modifier_container",
-					"id": "5204df22-c4c5-4478-857a-da111d394a76",
-					"disabled": true,
-					"name": "Cut",
-					"open": true,
-					"children": [
-						{
-							"type": "eqp_modifier",
-							"id": "3dd5f479-3e69-479b-881e-33ed768b27dc",
-							"name": "Fashion Original",
-							"reference": "UT175",
-							"cost_type": "to_final_base_cost",
-							"cost": "x20"
-						},
-						{
-							"type": "eqp_modifier",
-							"id": "392b7ba1-96a1-42f6-9360-39c95f79ae8d",
-							"name": "Stylish",
-							"reference": "UT175",
-							"cost_type": "to_final_base_cost",
-							"cost": "x4"
-						}
-					]
-				},
-				{
-					"type": "eqp_modifier_container",
-					"id": "3d78b7f2-5498-4277-911d-bef8a7deeec7",
-					"disabled": true,
-					"name": "Style",
-					"reference": "UT175",
-					"open": true,
-					"children": [
-						{
-							"type": "eqp_modifier",
-							"id": "b2e3d948-75bc-46a9-aa25-095f4bdd0525",
-							"name": "Diaphanous",
-							"reference": "UT175",
-							"cost_type": "to_final_base_cost",
-							"cost": "x0.5",
-							"weight_type": "to_base_weight",
-							"weight": "x0.5",
-							"notes": "Multiply DR by 0.5, Increase LC by 1"
-						},
-						{
-							"type": "eqp_modifier",
-							"id": "3cb972cd-60f2-4bc9-8e26-600d067e8f58",
-							"name": "Heavy",
-							"reference": "UT175",
-							"cost_type": "to_final_base_cost",
-							"cost": "x1.5",
-							"weight_type": "to_final_base_weight",
-							"weight": "x1.5",
-							"notes": "Multiply DR by 1.5, Reduce LC by 1"
-						},
-						{
-							"type": "eqp_modifier",
-							"id": "fcf4ba7e-c41d-44f6-952a-6379bb2da999",
-							"name": "Light",
-							"reference": "UT175",
-							"cost_type": "to_final_base_cost",
-							"cost": "x0.67",
-							"weight_type": "to_final_base_weight",
-							"weight": "x2/3",
-							"notes": "Multiply DR by 2/3, Increase LC by 1"
-						}
-					]
-				}
-			]
-		},
-		{
-			"type": "eqp_modifier_container",
-			"id": "f09364e8-b592-4cce-a417-f79ecb05d982",
-			"disabled": true,
-			"name": "Warheads and Ammunition",
-			"reference": "UT152",
-			"notes": "Multiplicative Cost Modifiers as of HT9",
-			"open": false,
-			"children": [
-				{
-					"type": "eqp_modifier_container",
-					"id": "40d2e7dc-9c2e-4346-bc0f-99331e90d167",
-					"disabled": true,
-					"name": "Antimatter Warhead Antimatter Costs",
-					"reference": "UT157",
+					"name": "Adjusting for SM",
+					"reference": "UT16",
+					"notes": "Cost Factor Conversion as of LT14",
 					"open": false,
 					"children": [
 						{
 							"type": "eqp_modifier",
-							"id": "55a46228-ab6b-4535-b6f5-d9313ca90685",
-							"name": "Antimatter, 0.1 micrograms",
-							"reference": "UT157",
-							"cost_type": "to_final_cost",
-							"cost": "+2500",
-							"tech_level": "9"
+							"id": "d4db9f4e-503f-4c5f-bf17-8d821ed67936",
+							"name": "SM +1",
+							"reference": "UT16",
+							"cost_type": "to_base_cost",
+							"cost": "+1 CF",
+							"weight_type": "to_final_weight",
+							"weight": "x2"
 						},
 						{
 							"type": "eqp_modifier",
-							"id": "1768c5e7-3661-4959-9ab2-175fa8882802",
-							"name": "Antimatter, 0.1 micrograms",
-							"reference": "UT157",
-							"cost_type": "to_final_cost",
-							"cost": "+250",
-							"tech_level": "10"
+							"id": "10f30c42-0d96-4676-9dd0-24dfc3f093d1",
+							"name": "SM +2",
+							"reference": "UT16",
+							"cost_type": "to_base_cost",
+							"cost": "+4 CF",
+							"weight_type": "to_final_weight",
+							"weight": "x5"
 						},
 						{
 							"type": "eqp_modifier",
-							"id": "5807708d-678d-4fb0-af9d-88f55f38e5fe",
-							"name": "Antimatter, 0.1 micrograms",
-							"reference": "UT157",
-							"cost_type": "to_final_cost",
-							"cost": "+2.5",
-							"tech_level": "11"
+							"id": "2e62df9a-f0eb-4f89-9eaa-2b61ebd17c0f",
+							"name": "SM +3",
+							"reference": "UT16",
+							"cost_type": "to_base_cost",
+							"cost": "+9 CF",
+							"weight_type": "to_final_weight",
+							"weight": "x10"
 						},
 						{
 							"type": "eqp_modifier",
-							"id": "9b06a9b5-2fff-4950-8285-3ea3c33f29c2",
-							"name": "Antimatter, 0.1 micrograms",
-							"reference": "UT157",
-							"cost_type": "to_final_cost",
-							"cost": "+0.5",
-							"tech_level": "12"
+							"id": "3960f0ef-6d40-4c8e-9a02-917acc7598d4",
+							"name": "SM +4",
+							"reference": "UT16",
+							"cost_type": "to_base_cost",
+							"cost": "+19 CF",
+							"weight_type": "to_final_weight",
+							"weight": "x20"
 						},
 						{
 							"type": "eqp_modifier",
-							"id": "adf86fba-6786-431d-beaa-df2febeb98f7",
-							"name": "Antimatter, 1 microgram",
-							"reference": "UT157",
-							"cost_type": "to_final_cost",
-							"cost": "+25000",
-							"tech_level": "9"
+							"id": "cb625dad-1d04-4bc9-bb64-9eb19b0717a2",
+							"name": "SM +5",
+							"reference": "UT16",
+							"cost_type": "to_base_cost",
+							"cost": "+49 CF",
+							"weight_type": "to_final_weight",
+							"weight": "x50"
 						},
 						{
 							"type": "eqp_modifier",
-							"id": "33a7f100-2d5d-421a-a34a-733a4e5da117",
-							"name": "Antimatter, 1 microgram",
-							"reference": "UT157",
-							"cost_type": "to_final_cost",
-							"cost": "+2500",
-							"tech_level": "10"
+							"id": "0e2e7958-5d17-452c-b322-d01cc7e99532",
+							"name": "SM +6",
+							"reference": "UT16",
+							"cost_type": "to_base_cost",
+							"cost": "+99 CF",
+							"weight_type": "to_final_weight",
+							"weight": "x100"
 						},
 						{
 							"type": "eqp_modifier",
-							"id": "d344efcc-8925-450f-9c17-58675f9b8bf8",
-							"name": "Antimatter, 1 microgram",
-							"reference": "UT157",
-							"cost_type": "to_final_cost",
-							"cost": "+25",
-							"tech_level": "11"
+							"id": "6f5115c2-0acb-4a4e-b06c-5e60c81ddc5a",
+							"name": "SM +7",
+							"reference": "UT16",
+							"cost_type": "to_base_cost",
+							"cost": "+199 CF",
+							"weight_type": "to_final_weight",
+							"weight": "x200"
 						},
 						{
 							"type": "eqp_modifier",
-							"id": "1ab19097-35f7-4f55-b15b-607a393b136d",
-							"name": "Antimatter, 1 microgram",
-							"reference": "UT157",
-							"cost_type": "to_final_cost",
-							"cost": "+5",
-							"tech_level": "12"
+							"id": "2b638e77-6fd0-4924-ae2c-3d3fc362cbdc",
+							"name": "SM +8",
+							"reference": "UT16",
+							"cost_type": "to_base_cost",
+							"cost": "+499 CF",
+							"weight_type": "to_final_weight",
+							"weight": "x500"
 						},
 						{
 							"type": "eqp_modifier",
-							"id": "d433007d-4154-4209-8299-b65e3e35e31e",
-							"name": "Antimatter, 10 micrograms",
-							"reference": "UT157",
-							"cost_type": "to_final_cost",
-							"cost": "+250000",
-							"tech_level": "9"
+							"id": "1a73a6a3-8a01-4a51-8457-383385bc5d5e",
+							"name": "SM +9",
+							"reference": "UT16",
+							"cost_type": "to_base_cost",
+							"cost": "+999 CF",
+							"weight_type": "to_final_weight",
+							"weight": "x1000"
 						},
 						{
 							"type": "eqp_modifier",
-							"id": "3637b4c1-6f7f-42f8-a255-ff29e559c139",
-							"name": "Antimatter, 10 micrograms",
-							"reference": "UT157",
-							"cost_type": "to_final_cost",
-							"cost": "+25000",
-							"tech_level": "10"
+							"id": "6730ee7b-78a5-48d7-9acc-cbdda50929b0",
+							"name": "SM +10",
+							"reference": "UT16",
+							"cost_type": "to_base_cost",
+							"cost": "+1999 CF",
+							"weight_type": "to_final_weight",
+							"weight": "x2000"
 						},
 						{
 							"type": "eqp_modifier",
-							"id": "a49443ef-816f-42e5-9e82-4f3fac9e2d6f",
-							"name": "Antimatter, 10 micrograms",
-							"reference": "UT157",
-							"cost_type": "to_final_cost",
-							"cost": "+250",
-							"tech_level": "11"
+							"id": "72dbd82f-0fd6-456e-b66e-65c2b222b934",
+							"name": "SM -1",
+							"reference": "UT16",
+							"cost_type": "to_base_cost",
+							"cost": "-0.5 CF",
+							"weight_type": "to_final_weight",
+							"weight": "x1/2"
 						},
 						{
 							"type": "eqp_modifier",
-							"id": "b0ff229f-41bf-4cd6-a55b-b1c19ccf8d78",
-							"name": "Antimatter, 10 micrograms",
-							"reference": "UT157",
-							"cost_type": "to_final_base_cost",
-							"cost": "+50",
-							"tech_level": "12"
+							"id": "59e26b87-6433-4484-8e2d-28c482eca165",
+							"name": "SM -2",
+							"reference": "UT16",
+							"cost_type": "to_base_cost",
+							"cost": "-0.8 CF",
+							"weight_type": "to_final_weight",
+							"weight": "x1/5"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "b6cf0f32-1efa-4a15-929a-e2b69dc01a33",
+							"name": "SM -3",
+							"reference": "UT16",
+							"cost_type": "to_base_cost",
+							"cost": "-0.9 CF",
+							"weight_type": "to_final_weight",
+							"weight": "x1/10"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "da538839-92ad-4052-a84b-86ecfcb23e28",
+							"name": "SM -4",
+							"reference": "UT16",
+							"cost_type": "to_base_cost",
+							"cost": "-.95 CF",
+							"weight_type": "to_final_weight",
+							"weight": "x1/20"
 						}
 					]
 				},
 				{
-					"type": "eqp_modifier",
-					"id": "720458d5-d472-4dc0-a267-83b12a367d6b",
-					"name": "Armor Piercing Hyperdense Dart",
-					"reference": "UT156",
-					"cost_type": "to_final_base_cost",
-					"cost": "x10"
+					"type": "eqp_modifier_container",
+					"id": "225d605f-7c6d-4750-b960-83e1350e9809",
+					"disabled": true,
+					"name": "Computer Hardware Modifiers",
+					"notes": "Cost Factor Conversion as of LT14",
+					"open": false,
+					"children": [
+						{
+							"type": "eqp_modifier",
+							"id": "48999219-e28b-4302-812b-66de0c8dff4c",
+							"name": "Compact",
+							"reference": "UT23",
+							"cost_type": "to_base_cost",
+							"cost": "+1 CF",
+							"weight_type": "to_base_weight",
+							"weight": "x0.5",
+							"tech_level": "9",
+							"notes": "Using multipliers"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "802ac390-6662-4f35-8bc9-7de641950c40",
+							"name": "Fast (+1 Complexity)",
+							"reference": "UT23",
+							"cost_type": "to_base_cost",
+							"cost": "+19 CF",
+							"weight_type": "to_base_weight",
+							"weight": "+0 lb",
+							"tech_level": "9",
+							"notes": "Using multipliers"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "2184309a-d907-49a0-aa48-bf891c131253",
+							"name": "FTL (+1 Complexity)",
+							"reference": "UT23",
+							"cost_type": "to_base_cost",
+							"cost": "+99 CF",
+							"weight_type": "to_base_weight",
+							"weight": "x2",
+							"tech_level": "11^",
+							"notes": "Using Mulitpliers, may require Quantum, -1 LC"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "3005976f-8363-4965-93f4-3bc214ff332b",
+							"name": "Hardened",
+							"reference": "UT23",
+							"cost_type": "to_base_cost",
+							"cost": "+1 CF",
+							"weight_type": "to_base_weight",
+							"weight": "x2",
+							"tech_level": "9",
+							"notes": "Using multipliers, +3 HT vs. resist electronic pulses, microwaves, etc."
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "f0e54cc2-90ac-4bba-b62f-c1bd2f4884ab",
+							"name": "High-Capacity",
+							"reference": "UT23",
+							"cost_type": "to_base_cost",
+							"cost": "+.5 CF",
+							"weight_type": "to_base_weight",
+							"weight": "+0 lb",
+							"tech_level": "9",
+							"notes": "Using multipliers, Run 50% more programs simultaneously."
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "a5400427-2dff-4556-821d-e566c83acba5",
+							"name": "Genius (+2 Complexity)",
+							"reference": "UT23",
+							"cost_type": "to_base_cost",
+							"cost": "+499 CF",
+							"tech_level": "9",
+							"notes": "Using Multipliers, -1 LC"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "8be136b0-376f-4709-851f-d4172fde6e9a",
+							"name": "Printed (-1 Complexity)",
+							"reference": "UT23",
+							"cost_type": "to_base_cost",
+							"cost": "+0 CF",
+							"weight_type": "to_base_weight",
+							"weight": "+0 lb",
+							"tech_level": "TL9",
+							"notes": "Using multipliers, -1 Complexity, divide data storage by 1,000"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "1ddd3dc1-df0c-42ff-894e-f8e6ec406bb3",
+							"name": "Quantum",
+							"reference": "UT23",
+							"cost_type": "to_base_cost",
+							"cost": "+9 CF",
+							"weight_type": "to_base_weight",
+							"weight": "x2",
+							"tech_level": "9",
+							"notes": "Using multipliers, -1 LC"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "8862a436-961a-4df6-940e-fa81bd2c2a7a",
+							"name": "Slow (-1 Complexity)",
+							"cost_type": "to_base_cost",
+							"cost": "-0.8 CF",
+							"weight_type": "to_base_weight",
+							"weight": "+0 lb",
+							"tech_level": "9",
+							"notes": "Using multipliers, reduce storage by 1/10"
+						}
+					]
 				},
 				{
-					"type": "eqp_modifier",
-					"id": "21ecda0e-d134-43b4-a849-a54da15af273",
-					"name": "Armor-Piercing Enhanced Penetrator",
+					"type": "eqp_modifier_container",
+					"id": "d2a142a7-eb12-47e2-b2bc-f6c9f4af7d00",
+					"disabled": true,
+					"name": "Integrating and Modifying Equipment",
+					"reference": "UT15",
+					"notes": "Cost Factor Conversion as of LT14",
+					"open": false,
+					"children": [
+						{
+							"type": "eqp_modifier",
+							"id": "ca51e4f1-b1b7-40f2-a0af-3f8de9ae4f60",
+							"name": "Cheap",
+							"reference": "UT15",
+							"cost_type": "to_base_cost",
+							"cost": "-0.5 CF",
+							"weight_type": "to_final_base_weight",
+							"weight": "x1.5"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "f9f0d310-80d1-407a-be71-e843d282002c",
+							"name": "Disguised",
+							"reference": "UT15",
+							"cost_type": "to_base_cost",
+							"cost": "+4 CF",
+							"notes": "Custom-built item"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "6ddbaf28-aff1-4e63-9504-959d4c26abb1",
+							"name": "Disguised",
+							"reference": "UT15",
+							"cost_type": "to_base_cost",
+							"cost": "+1 CF",
+							"notes": "Mass Produced"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "c1f77579-46ae-4454-b617-a54c23e65be1",
+							"name": "Expensive",
+							"reference": "UT15",
+							"cost_type": "to_base_cost",
+							"cost": "+1 CF",
+							"weight_type": "to_base_weight",
+							"weight": "x2/3"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "4c53c9e6-f708-4eaa-a3f0-7f203b585820",
+							"name": "Rugged",
+							"reference": "UT15",
+							"cost_type": "to_base_cost",
+							"cost": "+1 CF",
+							"weight_type": "to_base_weight",
+							"weight": "x1.2"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier_container",
+					"id": "30508cb0-1f69-454f-975b-48180fee9113",
+					"disabled": true,
+					"name": "Melee and Thrown Weapons",
+					"reference": "UT162",
+					"notes": "Cost Factor Conversion as of LT14",
+					"open": false,
+					"children": [
+						{
+							"type": "eqp_modifier",
+							"id": "7d482021-08ac-4c0b-8a67-3fe7f82ed234",
+							"name": "Hyperdense Blade",
+							"reference": "UT164",
+							"cost_type": "to_base_cost",
+							"cost": "+9 CF",
+							"tech_level": "11",
+							"notes": "Cost is higher of: 500x Weight in lb, or 10x normal cost."
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "9dff5609-9ddb-4998-a9c9-39becb2445a5",
+							"name": "Nanothorn Blade",
+							"reference": "UT164",
+							"cost_type": "to_base_cost",
+							"cost": "+19 CF",
+							"tech_level": "11^"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "de21947e-36cb-4df4-a865-b6f85ee5ef4e",
+							"name": "Nanothorn Blade",
+							"reference": "UT164",
+							"cost_type": "to_base_cost",
+							"cost": "+3 CF",
+							"tech_level": "11^",
+							"notes": "Upgrade for Monowire."
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "be556daa-2ef6-4811-9a9a-7864cbf7d645",
+							"name": "Rocket Striker",
+							"reference": "UT163",
+							"cost_type": "to_final_base_cost",
+							"cost": "+500",
+							"weight_type": "to_final_base_weight",
+							"weight": "+1 lb",
+							"tech_level": "9"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "8c0ba25b-60a6-4302-b5c6-55e332d25de9",
+							"name": "Superfine Blade",
+							"reference": "UT163",
+							"cost_type": "to_base_cost",
+							"cost": "+5 CF",
+							"tech_level": "9"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "85098ea0-a1f0-4ae9-9491-c1795cd985b8",
+							"name": "Superfine Vibroblade",
+							"reference": "UT164",
+							"cost_type": "to_base_cost",
+							"cost": "+29 CF",
+							"tech_level": "10"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "f23d0e28-e5e8-4564-9dbb-ca58e89d6ce1",
+							"name": "Vibroblade",
+							"reference": "UT164",
+							"cost_type": "to_base_cost",
+							"cost": "+10 CF",
+							"tech_level": "10"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier_container",
+					"id": "5a52df4e-0f53-481c-887c-3def847416a5",
+					"disabled": true,
+					"name": "Tailoring Armor",
+					"reference": "UT174",
+					"notes": "Cost Factor Conversion as of LT14",
+					"open": false,
+					"children": [
+						{
+							"type": "eqp_modifier_container",
+							"id": "e46a6f53-8da7-47b7-a942-b231ef21020e",
+							"disabled": true,
+							"name": "Cut",
+							"open": true,
+							"children": [
+								{
+									"type": "eqp_modifier",
+									"id": "803a5aee-fdf5-4f96-8331-0fca36daed2a",
+									"name": "Fashion Original",
+									"reference": "UT175",
+									"cost_type": "to_base_cost",
+									"cost": "+19 CF"
+								},
+								{
+									"type": "eqp_modifier",
+									"id": "4cc52e81-257d-4ab6-be03-a58bd65a425b",
+									"name": "Stylish",
+									"reference": "UT175",
+									"cost_type": "to_base_cost",
+									"cost": "+3 CF"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier_container",
+							"id": "92857994-a4f4-46b9-b631-b772b8d9dc06",
+							"disabled": true,
+							"name": "Style",
+							"reference": "UT175",
+							"open": true,
+							"children": [
+								{
+									"type": "eqp_modifier",
+									"id": "971ba995-3bd4-4a7b-aed2-72c6da585837",
+									"name": "Diaphanous",
+									"reference": "UT175",
+									"cost_type": "to_base_cost",
+									"cost": "-0.5 CF",
+									"weight_type": "to_base_weight",
+									"weight": "x0.5",
+									"notes": "Multiply DR by 0.5, Increase LC by 1"
+								},
+								{
+									"type": "eqp_modifier",
+									"id": "8a3d4581-4219-4ac1-a137-dc602e894400",
+									"name": "Heavy",
+									"reference": "UT175",
+									"cost_type": "to_base_cost",
+									"cost": "+0.5 CF",
+									"weight_type": "to_final_base_weight",
+									"weight": "x1.5",
+									"notes": "Multiply DR by 1.5, Reduce LC by 1"
+								},
+								{
+									"type": "eqp_modifier",
+									"id": "12922826-fbdb-48d0-a55e-10a67d8d0488",
+									"name": "Light",
+									"reference": "UT175",
+									"cost_type": "to_base_cost",
+									"cost": "-0.33 CF",
+									"weight_type": "to_final_base_weight",
+									"weight": "x2/3",
+									"notes": "Multiply DR by 2/3, Increase LC by 1"
+								}
+							]
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier_container",
+					"id": "d858c271-a17b-4bb1-a7fe-8268b0b1afde",
+					"disabled": true,
+					"name": "Warheads and Ammunition",
 					"reference": "UT152",
-					"cost_type": "to_final_base_cost",
-					"cost": "x10"
+					"notes": "Cost Factor Conversion as of LT14",
+					"open": false,
+					"children": [
+						{
+							"type": "eqp_modifier_container",
+							"id": "3bc10894-d156-453a-836b-04d37a83f9f2",
+							"disabled": true,
+							"name": "Antimatter Warhead Antimatter Costs",
+							"reference": "UT157",
+							"open": true,
+							"children": [
+								{
+									"type": "eqp_modifier",
+									"id": "699f234b-f985-48c3-a36c-7a2453d31366",
+									"name": "Antimatter, 0.1 micrograms",
+									"reference": "UT157",
+									"cost_type": "to_final_cost",
+									"cost": "+2500",
+									"tech_level": "9"
+								},
+								{
+									"type": "eqp_modifier",
+									"id": "fd2a3531-d41d-43cb-826f-bf50e1bf5175",
+									"name": "Antimatter, 0.1 micrograms",
+									"reference": "UT157",
+									"cost_type": "to_final_cost",
+									"cost": "+250",
+									"tech_level": "10"
+								},
+								{
+									"type": "eqp_modifier",
+									"id": "f0bb5e34-6111-4525-be59-6379c2c84667",
+									"name": "Antimatter, 0.1 micrograms",
+									"reference": "UT157",
+									"cost_type": "to_final_cost",
+									"cost": "+2.5",
+									"tech_level": "11"
+								},
+								{
+									"type": "eqp_modifier",
+									"id": "d6d90d58-6485-43ed-91df-1bc7bf04c5a4",
+									"name": "Antimatter, 0.1 micrograms",
+									"reference": "UT157",
+									"cost_type": "to_final_cost",
+									"cost": "+0.5",
+									"tech_level": "12"
+								},
+								{
+									"type": "eqp_modifier",
+									"id": "6bd3c384-38cc-4b64-aaf6-53cc3246d1ec",
+									"name": "Antimatter, 1 microgram",
+									"reference": "UT157",
+									"cost_type": "to_final_cost",
+									"cost": "+25000",
+									"tech_level": "9"
+								},
+								{
+									"type": "eqp_modifier",
+									"id": "43af26e6-7633-4a31-90fd-e1939710b448",
+									"name": "Antimatter, 1 microgram",
+									"reference": "UT157",
+									"cost_type": "to_final_cost",
+									"cost": "+2500",
+									"tech_level": "10"
+								},
+								{
+									"type": "eqp_modifier",
+									"id": "906b6415-466d-47c1-a2f9-98d75661aafd",
+									"name": "Antimatter, 1 microgram",
+									"reference": "UT157",
+									"cost_type": "to_final_cost",
+									"cost": "+25",
+									"tech_level": "11"
+								},
+								{
+									"type": "eqp_modifier",
+									"id": "c3c1bed5-0e70-4d8f-83d8-c42fc4318a99",
+									"name": "Antimatter, 1 microgram",
+									"reference": "UT157",
+									"cost_type": "to_final_cost",
+									"cost": "+5",
+									"tech_level": "12"
+								},
+								{
+									"type": "eqp_modifier",
+									"id": "4ead1cca-5099-44e6-aba8-41974318218c",
+									"name": "Antimatter, 10 micrograms",
+									"reference": "UT157",
+									"cost_type": "to_final_cost",
+									"cost": "+250000",
+									"tech_level": "9"
+								},
+								{
+									"type": "eqp_modifier",
+									"id": "aca3289e-1582-428b-bbb9-e9fae7e56f31",
+									"name": "Antimatter, 10 micrograms",
+									"reference": "UT157",
+									"cost_type": "to_final_cost",
+									"cost": "+25000",
+									"tech_level": "10"
+								},
+								{
+									"type": "eqp_modifier",
+									"id": "51241f65-70d5-42cc-953b-6f66c69bf28e",
+									"name": "Antimatter, 10 micrograms",
+									"reference": "UT157",
+									"cost_type": "to_final_cost",
+									"cost": "+250",
+									"tech_level": "11"
+								},
+								{
+									"type": "eqp_modifier",
+									"id": "b1e2585a-4887-44b1-a41c-4478d7f7af6a",
+									"name": "Antimatter, 10 micrograms",
+									"reference": "UT157",
+									"cost_type": "to_base_cost",
+									"cost": "+50 CF",
+									"tech_level": "12"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "8d06974e-52dd-4aac-8134-393cf688ce02",
+							"name": "Armor Piercing Hyperdense Dart",
+							"reference": "UT156",
+							"cost_type": "to_base_cost",
+							"cost": "+9 CF",
+							"tech_level": "9"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "166b72c2-6351-4bbe-ab85-c3e695bb43c6",
+							"name": "Armor-Piercing Enhanced Penetrator",
+							"reference": "UT152",
+							"cost_type": "to_base_cost",
+							"cost": "+9 CF",
+							"tech_level": "9"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "9104287c-81c3-4c45-9ada-155b14845b33",
+							"name": "Armor-Piercing Hardcore",
+							"reference": "UT152",
+							"cost_type": "to_base_cost",
+							"cost": "+1 CF",
+							"tech_level": "9"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "461ba2d2-2daa-486e-b840-c8ba7800762f",
+							"name": "Armor-Piercing Hardcore Explosive",
+							"reference": "UT152",
+							"cost_type": "to_base_cost",
+							"cost": "+3 CF",
+							"tech_level": "9"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "6dd34d2e-b1df-4c6f-9eea-b622cd70e28f",
+							"name": "Biochemical Aerosol",
+							"reference": "UT153",
+							"cost_type": "to_base_cost",
+							"cost": "+0 CF",
+							"tech_level": "9",
+							"notes": "Cost Plus Filler x # of Doses"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "3a21825e-2d3a-4605-aed7-e10ce6e33531",
+							"name": "Biochemical Liquid",
+							"reference": "UT153",
+							"cost_type": "to_base_cost",
+							"cost": "+0 CF",
+							"tech_level": "9",
+							"notes": "Cost Plus Filler x # of Doses"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "172d9860-f275-4c8d-becb-487a1b9b1418",
+							"name": "Burrow Darts",
+							"reference": "UT155",
+							"cost_type": "to_base_cost",
+							"cost": "+2 CF",
+							"tech_level": "10"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "3bd4a659-6372-4d3d-86d2-0b40fd0d4274",
+							"name": "Electrothermal-Chemical",
+							"reference": "UT139",
+							"cost_type": "to_base_cost",
+							"cost": "+1 CF",
+							"tech_level": "9"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "e51e42ae-0572-42ba-bdc9-f429efd1db58",
+							"name": "EMP",
+							"reference": "UT157",
+							"cost_type": "to_base_cost",
+							"cost": "+9 CF",
+							"tech_level": "9"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "4b700304-07f0-4cab-8898-632390effc7f",
+							"name": "Expendable Jammer",
+							"reference": "UT157",
+							"cost_type": "to_base_cost",
+							"cost": "+4 CF",
+							"tech_level": "9"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "e4523cc6-6fae-4997-acf1-c0068f984fbb",
+							"name": "Flare",
+							"reference": "UT153",
+							"cost_type": "to_base_cost",
+							"cost": "+1 CF",
+							"tech_level": "9"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "7654d6ac-5594-49c4-aa53-4f475159ea21",
+							"name": "Force",
+							"reference": "UT158",
+							"cost_type": "to_base_cost",
+							"cost": "+4 CF",
+							"tech_level": "10^"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "f2b48dd3-7d8c-4230-864b-ae6669b2e205",
+							"name": "High Explosive",
+							"reference": "UT153",
+							"cost_type": "to_base_cost",
+							"cost": "+0 CF",
+							"tech_level": "9"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "a8447496-8a3f-4037-85d8-c2e093d4c6c0",
+							"name": "High Explosive Concussion",
+							"reference": "UT154",
+							"cost_type": "to_base_cost",
+							"cost": "+0 CF",
+							"tech_level": "9"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "1d0638d5-ff5f-481e-ac5b-defb04a49963",
+							"name": "High Explosive Multi-Purpose",
+							"reference": "UT155",
+							"cost_type": "to_base_cost",
+							"cost": "+1 CF",
+							"tech_level": "10"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "716390d6-6291-4396-84a3-0c5eea5aef54",
+							"name": "Hollow-Point",
+							"reference": "UT154",
+							"cost_type": "to_base_cost",
+							"cost": "+0 CF",
+							"tech_level": "9"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "0934ff7b-eebf-479e-a63c-8ffd640010df",
+							"name": "Implosion",
+							"reference": "UT158",
+							"cost_type": "to_base_cost",
+							"cost": "+4 CF",
+							"tech_level": "11^"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "be58451f-7eb9-401e-ae4d-a6adfca2040f",
+							"name": "Liquid Propellant",
+							"reference": "UT139",
+							"cost_type": "to_base_cost",
+							"cost": "+0.5 CF",
+							"tech_level": "9",
+							"notes": "1.5x many shots per magazine"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "ebe09b49-f76c-4b56-8de8-447cf58246cb",
+							"name": "Memory Baton",
+							"reference": "UT154",
+							"cost_type": "to_base_cost",
+							"cost": "+4 CF",
+							"tech_level": "9"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "3626d433-5bd1-44e9-ad0f-b1246dae3fbd",
+							"name": "Micro-Antimatter Warhead",
+							"reference": "UT156",
+							"cost_type": "to_base_cost",
+							"cost": "+9 CF",
+							"tech_level": "10"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "943d4699-cd92-40f0-838c-2eb796ea31df",
+							"name": "Mininuke",
+							"reference": "UT156",
+							"cost_type": "to_base_cost",
+							"cost": "+999 CF",
+							"tech_level": "9"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "00d63082-4496-4806-bfe8-a553a5e711f7",
+							"name": "Monochain",
+							"reference": "UT154",
+							"cost_type": "to_base_cost",
+							"cost": "+4 CF",
+							"tech_level": "9^"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "b0b4be9a-8d55-4c22-a03d-3662ee3aafcb",
+							"name": "Plasma",
+							"reference": "UT158",
+							"cost_type": "to_base_cost",
+							"cost": "+9 CF",
+							"tech_level": "10^"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "b0928cb3-b6a1-4150-b045-bf4acfebc359",
+							"name": "Psi-Bomb",
+							"reference": "UT158",
+							"cost_type": "to_base_cost",
+							"cost": "+9 CF",
+							"tech_level": "12^"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "24ce29ae-4c98-4792-826e-e3c29f41dac7",
+							"name": "Psi-Bomb, Message",
+							"reference": "UT159",
+							"cost_type": "to_base_cost",
+							"cost": "+9 CF",
+							"tech_level": "12^"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "d285aab7-b112-4b0a-b700-983954f63bbb",
+							"name": "Psi-Bomb, Terror",
+							"reference": "UT159",
+							"cost_type": "to_base_cost",
+							"cost": "+9 CF",
+							"tech_level": "12^"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "c39d71d4-145e-4a50-8332-5538e83af25c",
+							"name": "Shaped Charge",
+							"reference": "UT154",
+							"cost_type": "to_base_cost",
+							"cost": "+1 CF",
+							"tech_level": "9"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "59fc57a1-a913-4b24-aea8-0fa2e4fbe351",
+							"name": "Shotshell",
+							"reference": "UT154",
+							"cost_type": "to_base_cost",
+							"cost": "+0 CF",
+							"tech_level": "9"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "9395398c-9dd2-4a7d-92c6-8a58271284fc",
+							"name": "Smart Explosively Forged Projectile",
+							"reference": "UT154",
+							"cost_type": "to_base_cost",
+							"cost": "+4 CF",
+							"tech_level": "9"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "ad1bf013-93a7-4db6-9148-9a5f0d18b2f5",
+							"name": "Stasis",
+							"reference": "UT159",
+							"cost_type": "to_base_cost",
+							"cost": "+499 CF",
+							"tech_level": "12^"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "15f9738a-de75-439a-8c6a-439814d4e6e1",
+							"name": "Stingray",
+							"reference": "UT156",
+							"cost_type": "to_base_cost",
+							"cost": "+4 CF",
+							"tech_level": "9"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "7656b475-204b-48b9-a0e6-9f8da2299410",
+							"name": "Strobe",
+							"reference": "UT157",
+							"cost_type": "to_base_cost",
+							"cost": "+3 CF",
+							"tech_level": "9"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "651d7f41-d92c-4029-9f53-8b08dbec7d1c",
+							"name": "Swarm",
+							"reference": "UT156",
+							"cost_type": "to_base_cost",
+							"cost": "+4 CF",
+							"tech_level": "9",
+							"notes": "Plus Cost of Swarm"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "e52717ed-ceb1-4364-a7b4-e184de91746a",
+							"name": "Tangler",
+							"reference": "UT155",
+							"cost_type": "to_base_cost",
+							"cost": "+1 CF",
+							"tech_level": "9"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "01e2b542-3208-410f-8995-766353b03377",
+							"name": "Thermobaric",
+							"reference": "UT155",
+							"cost_type": "to_base_cost",
+							"cost": "+4 CF",
+							"tech_level": "9"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "dff6e663-9154-4979-9bba-0bc9819ae013",
+							"name": "Vortex",
+							"reference": "UT159",
+							"cost_type": "to_base_cost",
+							"cost": "+999 CF",
+							"tech_level": "12^"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "99e1bdf5-4555-4054-b6eb-5a65fa784152",
+							"name": "Warbler",
+							"reference": "UT157",
+							"cost_type": "to_base_cost",
+							"cost": "+3 CF",
+							"tech_level": "9"
+						}
+					]
+				}
+			]
+		},
+		{
+			"type": "eqp_modifier_container",
+			"id": "52724ae7-5853-4143-ab81-c851ea8efb7a",
+			"name": "Basic Set Multiplicative",
+			"open": true,
+			"children": [
+				{
+					"type": "eqp_modifier_container",
+					"id": "0922be81-a949-4eac-9753-0a32e25690d9",
+					"disabled": true,
+					"name": "Adjusting for SM",
+					"reference": "UT16",
+					"notes": "Multiplicative Cost Modifiers as of HT9",
+					"open": false,
+					"children": [
+						{
+							"type": "eqp_modifier",
+							"id": "d4db9f4e-503f-4c5f-bf17-8d821ed67936",
+							"name": "SM +1",
+							"reference": "UT16",
+							"cost_type": "to_final_cost",
+							"cost": "x2",
+							"weight_type": "to_final_weight",
+							"weight": "x2"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "10f30c42-0d96-4676-9dd0-24dfc3f093d1",
+							"name": "SM +2",
+							"reference": "UT16",
+							"cost_type": "to_final_cost",
+							"cost": "x5",
+							"weight_type": "to_final_weight",
+							"weight": "x5"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "2e62df9a-f0eb-4f89-9eaa-2b61ebd17c0f",
+							"name": "SM +3",
+							"reference": "UT16",
+							"cost_type": "to_final_cost",
+							"cost": "x10",
+							"weight_type": "to_final_weight",
+							"weight": "x10"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "3960f0ef-6d40-4c8e-9a02-917acc7598d4",
+							"name": "SM +4",
+							"reference": "UT16",
+							"cost_type": "to_final_cost",
+							"cost": "x20",
+							"weight_type": "to_final_weight",
+							"weight": "x20"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "cb625dad-1d04-4bc9-bb64-9eb19b0717a2",
+							"name": "SM +5",
+							"reference": "UT16",
+							"cost_type": "to_final_cost",
+							"cost": "x50",
+							"weight_type": "to_final_weight",
+							"weight": "x50"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "0e2e7958-5d17-452c-b322-d01cc7e99532",
+							"name": "SM +6",
+							"reference": "UT16",
+							"cost_type": "to_final_cost",
+							"cost": "x100",
+							"weight_type": "to_final_weight",
+							"weight": "x100"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "6f5115c2-0acb-4a4e-b06c-5e60c81ddc5a",
+							"name": "SM +7",
+							"reference": "UT16",
+							"cost_type": "to_final_cost",
+							"cost": "x200",
+							"weight_type": "to_final_weight",
+							"weight": "x200"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "2b638e77-6fd0-4924-ae2c-3d3fc362cbdc",
+							"name": "SM +8",
+							"reference": "UT16",
+							"cost_type": "to_final_cost",
+							"cost": "x500",
+							"weight_type": "to_final_weight",
+							"weight": "x500"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "1a73a6a3-8a01-4a51-8457-383385bc5d5e",
+							"name": "SM +9",
+							"reference": "UT16",
+							"cost_type": "to_final_cost",
+							"cost": "x1000",
+							"weight_type": "to_final_weight",
+							"weight": "x1000"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "6730ee7b-78a5-48d7-9acc-cbdda50929b0",
+							"name": "SM +10",
+							"reference": "UT16",
+							"cost_type": "to_final_cost",
+							"cost": "x2000",
+							"weight_type": "to_final_weight",
+							"weight": "x2000"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "72dbd82f-0fd6-456e-b66e-65c2b222b934",
+							"name": "SM -1",
+							"reference": "UT16",
+							"cost_type": "to_final_cost",
+							"cost": "x0.5",
+							"weight_type": "to_final_weight",
+							"weight": "x1/2"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "59e26b87-6433-4484-8e2d-28c482eca165",
+							"name": "SM -2",
+							"reference": "UT16",
+							"cost_type": "to_final_cost",
+							"cost": "x0.2",
+							"weight_type": "to_final_weight",
+							"weight": "x1/5"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "b6cf0f32-1efa-4a15-929a-e2b69dc01a33",
+							"name": "SM -3",
+							"reference": "UT16",
+							"cost_type": "to_final_cost",
+							"cost": "x0.1",
+							"weight_type": "to_final_weight",
+							"weight": "x1/10"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "da538839-92ad-4052-a84b-86ecfcb23e28",
+							"name": "SM -4",
+							"reference": "UT16",
+							"cost_type": "to_final_cost",
+							"cost": "x0.05",
+							"weight_type": "to_final_weight",
+							"weight": "x1/20"
+						}
+					]
 				},
 				{
-					"type": "eqp_modifier",
-					"id": "44eb209b-2ff1-4ae1-8c2c-57039b791fa9",
-					"name": "Armor-Piercing Hardcore",
+					"type": "eqp_modifier_container",
+					"id": "34be09af-956f-46f7-a446-de7fa9404949",
+					"disabled": true,
+					"name": "Computer Hardware Modifiers",
+					"notes": "Multiplicative Cost Modifiers as of HT9",
+					"open": false,
+					"children": [
+						{
+							"type": "eqp_modifier",
+							"id": "48999219-e28b-4302-812b-66de0c8dff4c",
+							"name": "Compact",
+							"reference": "UT23",
+							"cost_type": "to_base_cost",
+							"cost": "x2",
+							"weight_type": "to_base_weight",
+							"weight": "x0.5",
+							"tech_level": "9",
+							"notes": "Using multipliers"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "802ac390-6662-4f35-8bc9-7de641950c40",
+							"name": "Fast (+1 Complexity)",
+							"reference": "UT23",
+							"cost_type": "to_base_cost",
+							"cost": "x20",
+							"weight_type": "to_base_weight",
+							"weight": "+0 lb",
+							"tech_level": "9",
+							"notes": "Using multipliers"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "2184309a-d907-49a0-aa48-bf891c131253",
+							"name": "FTL (+1 Complexity)",
+							"reference": "UT23",
+							"cost_type": "to_base_cost",
+							"cost": "x100",
+							"weight_type": "to_base_weight",
+							"weight": "x2",
+							"tech_level": "11^",
+							"notes": "Using Mulitpliers, may require Quantum, -1 LC"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "3005976f-8363-4965-93f4-3bc214ff332b",
+							"name": "Hardened",
+							"reference": "UT23",
+							"cost_type": "to_base_cost",
+							"cost": "x2",
+							"weight_type": "to_base_weight",
+							"weight": "x2",
+							"tech_level": "9",
+							"notes": "Using multipliers, +3 HT vs. resist electronic pulses, microwaves, etc."
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "f0e54cc2-90ac-4bba-b62f-c1bd2f4884ab",
+							"name": "High-Capacity",
+							"reference": "UT23",
+							"cost_type": "to_base_cost",
+							"cost": "x1.5",
+							"weight_type": "to_base_weight",
+							"weight": "+0 lb",
+							"tech_level": "9",
+							"notes": "Using multipliers, Run 50% more programs simultaneously."
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "a5400427-2dff-4556-821d-e566c83acba5",
+							"name": "Genius (+2 Complexity)",
+							"reference": "UT23",
+							"cost_type": "to_base_cost",
+							"cost": "x500",
+							"tech_level": "9",
+							"notes": "Using Multipliers, -1 LC"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "8be136b0-376f-4709-851f-d4172fde6e9a",
+							"name": "Printed (-1 Complexity)",
+							"reference": "UT23",
+							"cost_type": "to_base_cost",
+							"cost": "+0",
+							"weight_type": "to_base_weight",
+							"weight": "+0 lb",
+							"tech_level": "TL9",
+							"notes": "Using multipliers, -1 Complexity, divide data storage by 1,000"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "1ddd3dc1-df0c-42ff-894e-f8e6ec406bb3",
+							"name": "Quantum",
+							"reference": "UT23",
+							"cost_type": "to_base_cost",
+							"cost": "x10",
+							"weight_type": "to_base_weight",
+							"weight": "x2",
+							"tech_level": "9",
+							"notes": "Using multipliers, -1 LC"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "8862a436-961a-4df6-940e-fa81bd2c2a7a",
+							"name": "Slow (-1 Complexity)",
+							"cost_type": "to_base_cost",
+							"cost": "x0.05",
+							"weight_type": "to_base_weight",
+							"weight": "+0 lb",
+							"tech_level": "9",
+							"notes": "Using multipliers, reduce storage by 1/10"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier_container",
+					"id": "5096a95c-3468-4736-85c3-93e6d93d34b4",
+					"disabled": true,
+					"name": "Integrating and Modifying Equipment",
+					"reference": "UT15",
+					"notes": "Multiplicative Cost Modifiers as of HT9",
+					"open": false,
+					"children": [
+						{
+							"type": "eqp_modifier",
+							"id": "f6239734-422a-4f8c-8546-34f0f67422ea",
+							"name": "Cheap",
+							"reference": "UT15",
+							"cost_type": "to_final_base_cost",
+							"cost": "x0.5",
+							"weight_type": "to_final_base_weight",
+							"weight": "x1.5"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "4f0b3717-8df2-49ca-8073-9fc735052c64",
+							"name": "Disguised",
+							"reference": "UT15",
+							"cost_type": "to_final_base_cost",
+							"cost": "x5",
+							"notes": "Custom-built item"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "f06165dd-81a7-49f2-90e7-c771ef8e6211",
+							"name": "Disguised",
+							"reference": "UT15",
+							"cost_type": "to_final_base_cost",
+							"cost": "x2",
+							"notes": "Mass Produced"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "b24e07c3-8a94-4ee2-912f-eefd7907ac81",
+							"name": "Expensive",
+							"reference": "UT15",
+							"cost_type": "to_final_base_cost",
+							"cost": "x2",
+							"weight_type": "to_base_weight",
+							"weight": "x2/3"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "137cc002-3386-4654-b56c-a07e0afb8641",
+							"name": "Rugged",
+							"reference": "UT15",
+							"cost_type": "to_final_base_cost",
+							"cost": "x2",
+							"weight_type": "to_base_weight",
+							"weight": "x1.2"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier_container",
+					"id": "78da040f-a787-400e-95bc-258d9dfcce4b",
+					"disabled": true,
+					"name": "Melee and Thrown Weapons",
+					"reference": "UT162",
+					"notes": "Multiplicative Cost Modifiers as of HT9",
+					"open": false,
+					"children": [
+						{
+							"type": "eqp_modifier",
+							"id": "034777e9-be99-41d2-9ec1-59e15d2b661c",
+							"name": "Hyperdense Blade",
+							"reference": "UT164",
+							"cost_type": "to_final_base_cost",
+							"cost": "x10",
+							"tech_level": "11",
+							"notes": "Cost is higher of: 500x Weight in lb, or 10x normal cost."
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "7edc1ae1-81c8-4df7-b69b-cb4aad057cd3",
+							"name": "Nanothorn Blade",
+							"reference": "UT164",
+							"cost_type": "to_final_base_cost",
+							"cost": "x20",
+							"tech_level": "11^"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "14283962-abcd-4bf0-b6a7-8cfb08656501",
+							"name": "Nanothorn Blade",
+							"reference": "UT164",
+							"cost_type": "to_final_base_cost",
+							"cost": "x4",
+							"tech_level": "11^",
+							"notes": "Upgrade for Monowire."
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "dab133df-6893-4ce5-8cb9-8f1bd549a09e",
+							"name": "Rocket Striker",
+							"reference": "UT163",
+							"cost_type": "to_final_base_cost",
+							"cost": "+500",
+							"weight_type": "to_final_base_weight",
+							"weight": "+1 lb",
+							"tech_level": "9"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "49f4c274-c60c-4018-ba27-f38f5df78be4",
+							"name": "Superfine Blade",
+							"reference": "UT163",
+							"cost_type": "to_final_base_cost",
+							"cost": "x6",
+							"tech_level": "9"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "3a23a441-2d36-49de-96b3-645b71ed6d5f",
+							"name": "Superfine Vibroblade",
+							"reference": "UT164",
+							"cost_type": "to_final_base_cost",
+							"cost": "x30",
+							"tech_level": "10"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "ba757ba0-be29-4601-a766-ee3a7e43bf6e",
+							"name": "Vibroblade",
+							"reference": "UT164",
+							"cost_type": "to_final_base_cost",
+							"cost": "x10",
+							"tech_level": "10"
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier_container",
+					"id": "b52f1f44-4849-4f8e-9ae3-30939c23a7ef",
+					"disabled": true,
+					"name": "Tailoring Armor",
+					"reference": "UT174",
+					"notes": "Multiplicative Cost Modifiers as of HT9",
+					"open": false,
+					"children": [
+						{
+							"type": "eqp_modifier_container",
+							"id": "5204df22-c4c5-4478-857a-da111d394a76",
+							"disabled": true,
+							"name": "Cut",
+							"open": true,
+							"children": [
+								{
+									"type": "eqp_modifier",
+									"id": "3dd5f479-3e69-479b-881e-33ed768b27dc",
+									"name": "Fashion Original",
+									"reference": "UT175",
+									"cost_type": "to_final_base_cost",
+									"cost": "x20"
+								},
+								{
+									"type": "eqp_modifier",
+									"id": "392b7ba1-96a1-42f6-9360-39c95f79ae8d",
+									"name": "Stylish",
+									"reference": "UT175",
+									"cost_type": "to_final_base_cost",
+									"cost": "x4"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier_container",
+							"id": "3d78b7f2-5498-4277-911d-bef8a7deeec7",
+							"disabled": true,
+							"name": "Style",
+							"reference": "UT175",
+							"open": true,
+							"children": [
+								{
+									"type": "eqp_modifier",
+									"id": "b2e3d948-75bc-46a9-aa25-095f4bdd0525",
+									"name": "Diaphanous",
+									"reference": "UT175",
+									"cost_type": "to_final_base_cost",
+									"cost": "x0.5",
+									"weight_type": "to_base_weight",
+									"weight": "x0.5",
+									"notes": "Multiply DR by 0.5, Increase LC by 1"
+								},
+								{
+									"type": "eqp_modifier",
+									"id": "3cb972cd-60f2-4bc9-8e26-600d067e8f58",
+									"name": "Heavy",
+									"reference": "UT175",
+									"cost_type": "to_final_base_cost",
+									"cost": "x1.5",
+									"weight_type": "to_final_base_weight",
+									"weight": "x1.5",
+									"notes": "Multiply DR by 1.5, Reduce LC by 1"
+								},
+								{
+									"type": "eqp_modifier",
+									"id": "fcf4ba7e-c41d-44f6-952a-6379bb2da999",
+									"name": "Light",
+									"reference": "UT175",
+									"cost_type": "to_final_base_cost",
+									"cost": "x0.67",
+									"weight_type": "to_final_base_weight",
+									"weight": "x2/3",
+									"notes": "Multiply DR by 2/3, Increase LC by 1"
+								}
+							]
+						}
+					]
+				},
+				{
+					"type": "eqp_modifier_container",
+					"id": "f09364e8-b592-4cce-a417-f79ecb05d982",
+					"disabled": true,
+					"name": "Warheads and Ammunition",
 					"reference": "UT152",
-					"cost_type": "to_final_base_cost",
-					"cost": "x2"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "522a0a94-5b58-4cd8-8b1c-048245d2fc2f",
-					"name": "Armor-Piercing Hardcore Explosive",
-					"reference": "UT152",
-					"cost_type": "to_final_base_cost",
-					"cost": "x4"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "20718a77-d579-4056-a975-2c26583883fc",
-					"name": "Biochemical Aerosol",
-					"reference": "UT153",
-					"cost_type": "to_final_base_cost",
-					"cost": "x1",
-					"tech_level": "9",
-					"notes": "Cost Plus Filler x # of Doses"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "587531a7-9e9b-43ba-af1b-845857745f1c",
-					"name": "Biochemical Liquid",
-					"reference": "UT153",
-					"cost_type": "to_final_base_cost",
-					"cost": "x1",
-					"tech_level": "9",
-					"notes": "Cost Plus Filler x # of Doses"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "e137a382-9411-4e1a-8ebc-b608814aafc2",
-					"name": "Burrow Darts",
-					"reference": "UT155",
-					"cost_type": "to_final_base_cost",
-					"cost": "x3",
-					"tech_level": "10"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "6a719cf9-bc39-4e8f-b3bf-75cd6a55c807",
-					"name": "Electrothermal-Chemical",
-					"reference": "UT139",
-					"cost_type": "to_final_base_cost",
-					"cost": "x2",
-					"tech_level": "9"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "9ea041e7-bc4e-4845-b1ef-cedad7f32efd",
-					"name": "EMP",
-					"reference": "UT157",
-					"cost_type": "to_final_base_cost",
-					"cost": "x10",
-					"tech_level": "9"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "93931bf3-a7b0-448a-adc7-eca90afe13de",
-					"name": "Expendable Jammer",
-					"reference": "UT157",
-					"cost_type": "to_final_base_cost",
-					"cost": "x5",
-					"tech_level": "9"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "5df15523-2a8b-428b-9089-c20261b7b64f",
-					"name": "Flare",
-					"reference": "UT153",
-					"cost_type": "to_final_base_cost",
-					"cost": "x2",
-					"tech_level": "9"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "71162503-7093-416b-b953-ae8ad3c77a32",
-					"name": "Force",
-					"reference": "UT158",
-					"cost_type": "to_final_base_cost",
-					"cost": "x5",
-					"tech_level": "10^"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "f6d60738-f89e-4c39-9d20-60f9ba063ff3",
-					"name": "High Explosive",
-					"reference": "UT153",
-					"cost_type": "to_final_base_cost",
-					"cost": "x1",
-					"tech_level": "9"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "0f2a7ead-a1b4-42a5-96b1-9efcb5508026",
-					"name": "High Explosive Concussion",
-					"reference": "UT154",
-					"cost_type": "to_final_base_cost",
-					"cost": "x1",
-					"tech_level": "9"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "07a2b1a9-c484-4531-9fd5-872dd49da29e",
-					"name": "High Explosive Multi-Purpose",
-					"reference": "UT155",
-					"cost_type": "to_final_base_cost",
-					"cost": "x2",
-					"tech_level": "10"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "74c759e5-00b9-4b08-8104-e35f9a002944",
-					"name": "Hollow-Point",
-					"reference": "UT154",
-					"cost_type": "to_final_base_cost",
-					"cost": "x1",
-					"tech_level": "9"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "6f0821a2-749c-4409-8390-67cd8aab1a8a",
-					"name": "Implosion",
-					"reference": "UT158",
-					"cost_type": "to_final_base_cost",
-					"cost": "x5",
-					"tech_level": "11^"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "d02f4da2-ab77-4ee3-8c2a-0bd73cf26860",
-					"name": "Liquid Propellant",
-					"reference": "UT139",
-					"cost_type": "to_final_base_cost",
-					"cost": "x1.5",
-					"tech_level": "9"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "74ef0c7e-e802-4d98-b685-4a0236eb6bb4",
-					"name": "Memory Baton",
-					"reference": "UT154",
-					"cost_type": "to_final_base_cost",
-					"cost": "x5",
-					"tech_level": "9"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "2f089912-5d65-4bfa-99a0-bcc4a5957065",
-					"name": "Micro-Antimatter Warhead",
-					"reference": "UT156",
-					"cost_type": "to_final_base_cost",
-					"cost": "x10",
-					"tech_level": "10"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "f3826ca3-705b-4caa-9359-b2062091a247",
-					"name": "Mininuke",
-					"reference": "UT156",
-					"cost_type": "to_final_base_cost",
-					"cost": "x1000",
-					"tech_level": "9"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "0b8a75fe-5dfc-422b-ae13-087e7e22b5c2",
-					"name": "Monochain",
-					"reference": "UT154",
-					"cost_type": "to_final_base_cost",
-					"cost": "x5",
-					"tech_level": "9^"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "8cd1cf3f-e319-4e07-a0ca-7b212b87a6a4",
-					"name": "Plasma",
-					"reference": "UT158",
-					"cost_type": "to_final_base_cost",
-					"cost": "x10",
-					"tech_level": "10^"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "b6fef98e-baaa-4596-83ea-5fd40569b933",
-					"name": "Psi-Bomb",
-					"reference": "UT158",
-					"cost_type": "to_final_base_cost",
-					"cost": "x10",
-					"tech_level": "12^"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "052984b6-665a-4b91-979a-1c4022a35a8d",
-					"name": "Psi-Bomb, Message",
-					"reference": "UT159",
-					"cost_type": "to_final_base_cost",
-					"cost": "x10",
-					"tech_level": "12^"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "4e7eceb6-c29a-43ad-a122-28c6e1845e12",
-					"name": "Psi-Bomb, Terror",
-					"reference": "UT159",
-					"cost_type": "to_final_base_cost",
-					"cost": "x10",
-					"tech_level": "12^"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "2db9c5d7-b860-48cc-a690-39cfd2b2f855",
-					"name": "Shaped Charge",
-					"reference": "UT154",
-					"cost_type": "to_final_base_cost",
-					"cost": "x2",
-					"tech_level": "9+-"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "8492a0e7-98c0-4910-8c8b-7d25ecc87e3c",
-					"name": "Shotshell",
-					"reference": "UT154",
-					"cost_type": "to_final_base_cost",
-					"cost": "x1",
-					"tech_level": "9"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "13015cce-d461-4cfd-8296-06697e0e0242",
-					"name": "Smart Explosively Forged Projectile",
-					"reference": "UT154",
-					"cost_type": "to_final_base_cost",
-					"cost": "x5",
-					"tech_level": "9"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "27b6cb35-1685-479f-9c9c-aa88804d9ad1",
-					"name": "Stasis",
-					"reference": "UT159",
-					"cost_type": "to_final_base_cost",
-					"cost": "x500",
-					"tech_level": "12^"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "fc9ee77c-f92b-4ef4-b191-055c2ecf35b1",
-					"name": "Stingray",
-					"reference": "UT156",
-					"cost_type": "to_final_base_cost",
-					"cost": "x5",
-					"tech_level": "9"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "30630652-34e4-4f16-8e35-3bfdb4da3a56",
-					"name": "Strobe",
-					"reference": "UT157",
-					"cost_type": "to_final_base_cost",
-					"cost": "x4",
-					"tech_level": "9"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "8de2e5e7-3b8c-420e-b48d-4fb7c516d075",
-					"name": "Swarm",
-					"reference": "UT156",
-					"cost_type": "to_final_base_cost",
-					"cost": "x5",
-					"tech_level": "9",
-					"notes": "Plus Cost of Swarm"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "76d47e70-e41c-464c-834a-d7bfd66d563c",
-					"name": "Tangler",
-					"reference": "UT155",
-					"cost_type": "to_final_base_cost",
-					"cost": "x2",
-					"tech_level": "9"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "f1500c75-2284-48a0-aa39-34c9beca399b",
-					"name": "Thermobaric",
-					"reference": "UT155",
-					"cost_type": "to_final_base_cost",
-					"cost": "x5",
-					"tech_level": "9"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "28083fd4-4048-49f3-9192-94cc9f579020",
-					"name": "Vortex",
-					"reference": "UT159",
-					"cost_type": "to_final_base_cost",
-					"cost": "x1000",
-					"tech_level": "12^"
-				},
-				{
-					"type": "eqp_modifier",
-					"id": "97b8b136-63a7-4c80-9a2a-03d24d193226",
-					"name": "Warbler",
-					"reference": "UT157",
-					"cost_type": "to_final_base_cost",
-					"cost": "x4",
-					"tech_level": "9"
+					"notes": "Multiplicative Cost Modifiers as of HT9",
+					"open": false,
+					"children": [
+						{
+							"type": "eqp_modifier_container",
+							"id": "40d2e7dc-9c2e-4346-bc0f-99331e90d167",
+							"disabled": true,
+							"name": "Antimatter Warhead Antimatter Costs",
+							"reference": "UT157",
+							"open": false,
+							"children": [
+								{
+									"type": "eqp_modifier",
+									"id": "55a46228-ab6b-4535-b6f5-d9313ca90685",
+									"name": "Antimatter, 0.1 micrograms",
+									"reference": "UT157",
+									"cost_type": "to_final_cost",
+									"cost": "+2500",
+									"tech_level": "9"
+								},
+								{
+									"type": "eqp_modifier",
+									"id": "1768c5e7-3661-4959-9ab2-175fa8882802",
+									"name": "Antimatter, 0.1 micrograms",
+									"reference": "UT157",
+									"cost_type": "to_final_cost",
+									"cost": "+250",
+									"tech_level": "10"
+								},
+								{
+									"type": "eqp_modifier",
+									"id": "5807708d-678d-4fb0-af9d-88f55f38e5fe",
+									"name": "Antimatter, 0.1 micrograms",
+									"reference": "UT157",
+									"cost_type": "to_final_cost",
+									"cost": "+2.5",
+									"tech_level": "11"
+								},
+								{
+									"type": "eqp_modifier",
+									"id": "9b06a9b5-2fff-4950-8285-3ea3c33f29c2",
+									"name": "Antimatter, 0.1 micrograms",
+									"reference": "UT157",
+									"cost_type": "to_final_cost",
+									"cost": "+0.5",
+									"tech_level": "12"
+								},
+								{
+									"type": "eqp_modifier",
+									"id": "adf86fba-6786-431d-beaa-df2febeb98f7",
+									"name": "Antimatter, 1 microgram",
+									"reference": "UT157",
+									"cost_type": "to_final_cost",
+									"cost": "+25000",
+									"tech_level": "9"
+								},
+								{
+									"type": "eqp_modifier",
+									"id": "33a7f100-2d5d-421a-a34a-733a4e5da117",
+									"name": "Antimatter, 1 microgram",
+									"reference": "UT157",
+									"cost_type": "to_final_cost",
+									"cost": "+2500",
+									"tech_level": "10"
+								},
+								{
+									"type": "eqp_modifier",
+									"id": "d344efcc-8925-450f-9c17-58675f9b8bf8",
+									"name": "Antimatter, 1 microgram",
+									"reference": "UT157",
+									"cost_type": "to_final_cost",
+									"cost": "+25",
+									"tech_level": "11"
+								},
+								{
+									"type": "eqp_modifier",
+									"id": "1ab19097-35f7-4f55-b15b-607a393b136d",
+									"name": "Antimatter, 1 microgram",
+									"reference": "UT157",
+									"cost_type": "to_final_cost",
+									"cost": "+5",
+									"tech_level": "12"
+								},
+								{
+									"type": "eqp_modifier",
+									"id": "d433007d-4154-4209-8299-b65e3e35e31e",
+									"name": "Antimatter, 10 micrograms",
+									"reference": "UT157",
+									"cost_type": "to_final_cost",
+									"cost": "+250000",
+									"tech_level": "9"
+								},
+								{
+									"type": "eqp_modifier",
+									"id": "3637b4c1-6f7f-42f8-a255-ff29e559c139",
+									"name": "Antimatter, 10 micrograms",
+									"reference": "UT157",
+									"cost_type": "to_final_cost",
+									"cost": "+25000",
+									"tech_level": "10"
+								},
+								{
+									"type": "eqp_modifier",
+									"id": "a49443ef-816f-42e5-9e82-4f3fac9e2d6f",
+									"name": "Antimatter, 10 micrograms",
+									"reference": "UT157",
+									"cost_type": "to_final_cost",
+									"cost": "+250",
+									"tech_level": "11"
+								},
+								{
+									"type": "eqp_modifier",
+									"id": "b0ff229f-41bf-4cd6-a55b-b1c19ccf8d78",
+									"name": "Antimatter, 10 micrograms",
+									"reference": "UT157",
+									"cost_type": "to_final_base_cost",
+									"cost": "+50",
+									"tech_level": "12"
+								}
+							]
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "720458d5-d472-4dc0-a267-83b12a367d6b",
+							"name": "Armor Piercing Hyperdense Dart",
+							"reference": "UT156",
+							"cost_type": "to_final_base_cost",
+							"cost": "x10"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "21ecda0e-d134-43b4-a849-a54da15af273",
+							"name": "Armor-Piercing Enhanced Penetrator",
+							"reference": "UT152",
+							"cost_type": "to_final_base_cost",
+							"cost": "x10"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "44eb209b-2ff1-4ae1-8c2c-57039b791fa9",
+							"name": "Armor-Piercing Hardcore",
+							"reference": "UT152",
+							"cost_type": "to_final_base_cost",
+							"cost": "x2"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "522a0a94-5b58-4cd8-8b1c-048245d2fc2f",
+							"name": "Armor-Piercing Hardcore Explosive",
+							"reference": "UT152",
+							"cost_type": "to_final_base_cost",
+							"cost": "x4"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "20718a77-d579-4056-a975-2c26583883fc",
+							"name": "Biochemical Aerosol",
+							"reference": "UT153",
+							"cost_type": "to_final_base_cost",
+							"cost": "x1",
+							"tech_level": "9",
+							"notes": "Cost Plus Filler x # of Doses"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "587531a7-9e9b-43ba-af1b-845857745f1c",
+							"name": "Biochemical Liquid",
+							"reference": "UT153",
+							"cost_type": "to_final_base_cost",
+							"cost": "x1",
+							"tech_level": "9",
+							"notes": "Cost Plus Filler x # of Doses"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "e137a382-9411-4e1a-8ebc-b608814aafc2",
+							"name": "Burrow Darts",
+							"reference": "UT155",
+							"cost_type": "to_final_base_cost",
+							"cost": "x3",
+							"tech_level": "10"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "6a719cf9-bc39-4e8f-b3bf-75cd6a55c807",
+							"name": "Electrothermal-Chemical",
+							"reference": "UT139",
+							"cost_type": "to_final_base_cost",
+							"cost": "x2",
+							"tech_level": "9"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "9ea041e7-bc4e-4845-b1ef-cedad7f32efd",
+							"name": "EMP",
+							"reference": "UT157",
+							"cost_type": "to_final_base_cost",
+							"cost": "x10",
+							"tech_level": "9"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "93931bf3-a7b0-448a-adc7-eca90afe13de",
+							"name": "Expendable Jammer",
+							"reference": "UT157",
+							"cost_type": "to_final_base_cost",
+							"cost": "x5",
+							"tech_level": "9"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "5df15523-2a8b-428b-9089-c20261b7b64f",
+							"name": "Flare",
+							"reference": "UT153",
+							"cost_type": "to_final_base_cost",
+							"cost": "x2",
+							"tech_level": "9"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "71162503-7093-416b-b953-ae8ad3c77a32",
+							"name": "Force",
+							"reference": "UT158",
+							"cost_type": "to_final_base_cost",
+							"cost": "x5",
+							"tech_level": "10^"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "f6d60738-f89e-4c39-9d20-60f9ba063ff3",
+							"name": "High Explosive",
+							"reference": "UT153",
+							"cost_type": "to_final_base_cost",
+							"cost": "x1",
+							"tech_level": "9"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "0f2a7ead-a1b4-42a5-96b1-9efcb5508026",
+							"name": "High Explosive Concussion",
+							"reference": "UT154",
+							"cost_type": "to_final_base_cost",
+							"cost": "x1",
+							"tech_level": "9"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "07a2b1a9-c484-4531-9fd5-872dd49da29e",
+							"name": "High Explosive Multi-Purpose",
+							"reference": "UT155",
+							"cost_type": "to_final_base_cost",
+							"cost": "x2",
+							"tech_level": "10"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "74c759e5-00b9-4b08-8104-e35f9a002944",
+							"name": "Hollow-Point",
+							"reference": "UT154",
+							"cost_type": "to_final_base_cost",
+							"cost": "x1",
+							"tech_level": "9"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "6f0821a2-749c-4409-8390-67cd8aab1a8a",
+							"name": "Implosion",
+							"reference": "UT158",
+							"cost_type": "to_final_base_cost",
+							"cost": "x5",
+							"tech_level": "11^"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "d02f4da2-ab77-4ee3-8c2a-0bd73cf26860",
+							"name": "Liquid Propellant",
+							"reference": "UT139",
+							"cost_type": "to_final_base_cost",
+							"cost": "x1.5",
+							"tech_level": "9"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "74ef0c7e-e802-4d98-b685-4a0236eb6bb4",
+							"name": "Memory Baton",
+							"reference": "UT154",
+							"cost_type": "to_final_base_cost",
+							"cost": "x5",
+							"tech_level": "9"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "2f089912-5d65-4bfa-99a0-bcc4a5957065",
+							"name": "Micro-Antimatter Warhead",
+							"reference": "UT156",
+							"cost_type": "to_final_base_cost",
+							"cost": "x10",
+							"tech_level": "10"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "f3826ca3-705b-4caa-9359-b2062091a247",
+							"name": "Mininuke",
+							"reference": "UT156",
+							"cost_type": "to_final_base_cost",
+							"cost": "x1000",
+							"tech_level": "9"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "0b8a75fe-5dfc-422b-ae13-087e7e22b5c2",
+							"name": "Monochain",
+							"reference": "UT154",
+							"cost_type": "to_final_base_cost",
+							"cost": "x5",
+							"tech_level": "9^"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "8cd1cf3f-e319-4e07-a0ca-7b212b87a6a4",
+							"name": "Plasma",
+							"reference": "UT158",
+							"cost_type": "to_final_base_cost",
+							"cost": "x10",
+							"tech_level": "10^"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "b6fef98e-baaa-4596-83ea-5fd40569b933",
+							"name": "Psi-Bomb",
+							"reference": "UT158",
+							"cost_type": "to_final_base_cost",
+							"cost": "x10",
+							"tech_level": "12^"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "052984b6-665a-4b91-979a-1c4022a35a8d",
+							"name": "Psi-Bomb, Message",
+							"reference": "UT159",
+							"cost_type": "to_final_base_cost",
+							"cost": "x10",
+							"tech_level": "12^"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "4e7eceb6-c29a-43ad-a122-28c6e1845e12",
+							"name": "Psi-Bomb, Terror",
+							"reference": "UT159",
+							"cost_type": "to_final_base_cost",
+							"cost": "x10",
+							"tech_level": "12^"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "2db9c5d7-b860-48cc-a690-39cfd2b2f855",
+							"name": "Shaped Charge",
+							"reference": "UT154",
+							"cost_type": "to_final_base_cost",
+							"cost": "x2",
+							"tech_level": "9+-"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "8492a0e7-98c0-4910-8c8b-7d25ecc87e3c",
+							"name": "Shotshell",
+							"reference": "UT154",
+							"cost_type": "to_final_base_cost",
+							"cost": "x1",
+							"tech_level": "9"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "13015cce-d461-4cfd-8296-06697e0e0242",
+							"name": "Smart Explosively Forged Projectile",
+							"reference": "UT154",
+							"cost_type": "to_final_base_cost",
+							"cost": "x5",
+							"tech_level": "9"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "27b6cb35-1685-479f-9c9c-aa88804d9ad1",
+							"name": "Stasis",
+							"reference": "UT159",
+							"cost_type": "to_final_base_cost",
+							"cost": "x500",
+							"tech_level": "12^"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "fc9ee77c-f92b-4ef4-b191-055c2ecf35b1",
+							"name": "Stingray",
+							"reference": "UT156",
+							"cost_type": "to_final_base_cost",
+							"cost": "x5",
+							"tech_level": "9"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "30630652-34e4-4f16-8e35-3bfdb4da3a56",
+							"name": "Strobe",
+							"reference": "UT157",
+							"cost_type": "to_final_base_cost",
+							"cost": "x4",
+							"tech_level": "9"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "8de2e5e7-3b8c-420e-b48d-4fb7c516d075",
+							"name": "Swarm",
+							"reference": "UT156",
+							"cost_type": "to_final_base_cost",
+							"cost": "x5",
+							"tech_level": "9",
+							"notes": "Plus Cost of Swarm"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "76d47e70-e41c-464c-834a-d7bfd66d563c",
+							"name": "Tangler",
+							"reference": "UT155",
+							"cost_type": "to_final_base_cost",
+							"cost": "x2",
+							"tech_level": "9"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "f1500c75-2284-48a0-aa39-34c9beca399b",
+							"name": "Thermobaric",
+							"reference": "UT155",
+							"cost_type": "to_final_base_cost",
+							"cost": "x5",
+							"tech_level": "9"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "28083fd4-4048-49f3-9192-94cc9f579020",
+							"name": "Vortex",
+							"reference": "UT159",
+							"cost_type": "to_final_base_cost",
+							"cost": "x1000",
+							"tech_level": "12^"
+						},
+						{
+							"type": "eqp_modifier",
+							"id": "97b8b136-63a7-4c80-9a2a-03d24d193226",
+							"name": "Warbler",
+							"reference": "UT157",
+							"cost_type": "to_final_base_cost",
+							"cost": "x4",
+							"tech_level": "9"
+						}
+					]
 				}
 			]
 		}

--- a/Library/Ultra Tech/Ultra Tech Equipment.eqp
+++ b/Library/Ultra Tech/Ultra Tech Equipment.eqp
@@ -19,6 +19,58 @@
 		},
 		{
 			"type": "equipment",
+			"id": "485fcaf5-7f26-4d16-afc4-69fca6ac3db1",
+			"quantity": 1,
+			"description": "1 TB (Terabyte) Data Storage",
+			"tech_level": "9",
+			"value": "1",
+			"weight": "0.001 lb",
+			"reference": "UT23",
+			"categories": [
+				"Computers"
+			]
+		},
+		{
+			"type": "equipment",
+			"id": "39885418-f37c-465b-a5b8-ab4e0154eddc",
+			"quantity": 1,
+			"description": "1 PB (Petabyte) Data Storage",
+			"tech_level": "10",
+			"value": "1",
+			"weight": "0.001 lb",
+			"reference": "UT23",
+			"categories": [
+				"Computers"
+			]
+		},
+		{
+			"type": "equipment",
+			"id": "9500a58e-4a8e-40d8-852b-432f6ddf3b65",
+			"quantity": 1,
+			"description": "1 EB (Exabyte) Data Storage",
+			"tech_level": "11",
+			"value": "1",
+			"weight": "0.001 lb",
+			"reference": "UT23",
+			"categories": [
+				"Computers"
+			]
+		},
+		{
+			"type": "equipment",
+			"id": "9e916fa1-e1ce-4116-b26c-80290e020983",
+			"quantity": 1,
+			"description": "1 ZB (Zettabyte) Data Storage",
+			"tech_level": "12",
+			"value": "1",
+			"weight": "0.001 lb",
+			"reference": "UT23",
+			"categories": [
+				"Computers"
+			]
+		},
+		{
+			"type": "equipment",
 			"id": "4d69124f-5671-4d96-9ede-56a6f038da09",
 			"quantity": 1,
 			"description": "1/8\" Rope",


### PR DESCRIPTION
added computer hardware mods for x and cf. Added data storage to equipment list.

Also reorganized mod list so there were sections for CF option or Multipliers option (hopefully making them easier to find.)
The equipment was added in alpha order towards the top of the list.