### PR TITLE
Retracted power source related change for DFRPG spells

### DIFF
--- a/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Spells.spl
+++ b/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Spells.spl
@@ -30,7 +30,7 @@
 							"college": [
 								"Protection & Warning"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "2 per DR",
 							"maintenance_cost": "Half",
@@ -97,7 +97,7 @@
 							"college": [
 								"Knowledge"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Info",
 							"casting_cost": "3",
 							"maintenance_cost": "-",
@@ -179,7 +179,7 @@
 							"college": [
 								"Mind Control"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Area",
 							"resist": "Will-1",
 							"casting_cost": "2",
@@ -302,7 +302,7 @@
 								"Protection & Warning",
 								"Water"
 							],
-							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "2",
 							"maintenance_cost": "1",
@@ -383,7 +383,7 @@
 							"college": [
 								"Knowledge"
 							],
-							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "2",
 							"maintenance_cost": "-",
@@ -462,7 +462,7 @@
 								"Healing",
 								"Protection & Warning"
 							],
-							"power_source": "@Power Source: Clerical/Druidic@",
+							"power_source": "Clerical",
 							"spell_class": "Area/Info",
 							"casting_cost": "2",
 							"maintenance_cost": "-",
@@ -555,7 +555,7 @@
 								"Healing",
 								"Meta"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "1/pt",
 							"maintenance_cost": "-",
@@ -647,7 +647,7 @@
 							"college": [
 								"Light & Darkness"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "1",
 							"maintenance_cost": "1",
@@ -695,7 +695,7 @@
 							"college": [
 								"Body Control"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "2/+ST",
 							"maintenance_cost": "Same",
@@ -801,7 +801,7 @@
 							"college": [
 								"Air"
 							],
-							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+							"power_source": "Clerical",
 							"spell_class": "Area",
 							"casting_cost": "1",
 							"maintenance_cost": "-",
@@ -862,7 +862,7 @@
 							"college": [
 								"Water"
 							],
-							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+							"power_source": "Clerical",
 							"spell_class": "Special",
 							"casting_cost": "1/gal",
 							"maintenance_cost": "-",
@@ -943,7 +943,7 @@
 								"Healing",
 								"Meta"
 							],
-							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+							"power_source": "Clerical",
 							"spell_class": "Special",
 							"casting_cost": "0",
 							"maintenance_cost": "0",
@@ -1029,7 +1029,7 @@
 								"Communication & Empathy",
 								"Meta"
 							],
-							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+							"power_source": "Clerical",
 							"spell_class": "Info/Area",
 							"casting_cost": "1/area, min 2",
 							"maintenance_cost": "-",
@@ -1108,7 +1108,7 @@
 							"college": [
 								"Communication & Empathy"
 							],
-							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+							"power_source": "Clerical",
 							"spell_class": "Info/Area",
 							"casting_cost": "1/2",
 							"maintenance_cost": "-",
@@ -1182,7 +1182,7 @@
 							"college": [
 								"Necromancy"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Info/Area",
 							"casting_cost": "1/2 (min 1)",
 							"maintenance_cost": "-",
@@ -1287,7 +1287,7 @@
 								"Healing",
 								"Meta"
 							],
-							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "2-10",
 							"maintenance_cost": "-",
@@ -1407,7 +1407,7 @@
 							"college": [
 								"Protection & Warning"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "2 per DB",
 							"maintenance_cost": "Half",
@@ -1459,7 +1459,7 @@
 							"college": [
 								"Sound"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Area",
 							"casting_cost": "2",
 							"maintenance_cost": "Half",
@@ -1580,7 +1580,7 @@
 							"college": [
 								"Food"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Info",
 							"casting_cost": "1 or 3",
 							"maintenance_cost": "-",
@@ -1628,7 +1628,7 @@
 							"college": [
 								"Sound"
 							],
-							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "2",
 							"maintenance_cost": "-",
@@ -1724,7 +1724,7 @@
 								"Protection & Warning",
 								"Water"
 							],
-							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "1",
 							"maintenance_cost": "1",
@@ -1824,7 +1824,7 @@
 							"college": [
 								"Body Control"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "2/+HT",
 							"maintenance_cost": "Same",
@@ -1911,7 +1911,7 @@
 								"Fire",
 								"Protection & Warning"
 							],
-							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "2",
 							"maintenance_cost": "1",
@@ -1992,7 +1992,7 @@
 							"college": [
 								"Protection & Warning"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Area",
 							"casting_cost": "1",
 							"maintenance_cost": "Same",
@@ -2109,7 +2109,7 @@
 							"college": [
 								"Mind Control"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Blocking",
 							"resist": "Will",
 							"casting_cost": "2",
@@ -2200,7 +2200,7 @@
 							"college": [
 								"Communication & Empathy"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Info",
 							"resist": "Will",
 							"casting_cost": "4",
@@ -2291,7 +2291,7 @@
 							"college": [
 								"Light & Darkness"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "2 moon, 4 torch, 6 day",
 							"maintenance_cost": "-",
@@ -2358,7 +2358,7 @@
 							"college": [
 								"Water"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "2/gal",
 							"maintenance_cost": "-",
@@ -2425,7 +2425,7 @@
 							"college": [
 								"Light & Darkness"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Area",
 							"casting_cost": "Varies",
 							"maintenance_cost": "-",
@@ -2492,7 +2492,7 @@
 							"college": [
 								"Sound"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "3",
 							"maintenance_cost": "1",
@@ -2626,7 +2626,7 @@
 							"college": [
 								"Communication & Empathy"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "3",
 							"maintenance_cost": "1",
@@ -2727,7 +2727,7 @@
 							"college": [
 								"Light & Darkness"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "2",
 							"maintenance_cost": "1",
@@ -2867,7 +2867,7 @@
 							"college": [
 								"Communication & Empathy"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"resist": "Will",
 							"casting_cost": "Varies",
@@ -2951,7 +2951,7 @@
 								"Meta",
 								"Protection & Warning"
 							],
-							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "1-5",
 							"maintenance_cost": "Half",
@@ -3055,7 +3055,7 @@
 							"college": [
 								"Food"
 							],
-							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "1/lb",
 							"maintenance_cost": "-",
@@ -3216,7 +3216,7 @@
 							"college": [
 								"Fire"
 							],
-							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "2",
 							"maintenance_cost": "Half",
@@ -3337,7 +3337,7 @@
 							"college": [
 								"Fire"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "2#",
 							"maintenance_cost": "Half",
@@ -3406,7 +3406,7 @@
 								"Protection & Warning",
 								"Weather"
 							],
-							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "2",
 							"maintenance_cost": "1",
@@ -3488,7 +3488,7 @@
 							"college": [
 								"Body Control"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "4",
 							"maintenance_cost": "2",
@@ -3760,7 +3760,7 @@
 							"college": [
 								"Knowledge"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Info",
 							"casting_cost": "3",
 							"maintenance_cost": "-",
@@ -3901,7 +3901,7 @@
 							"college": [
 								"Necromancy"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Info",
 							"resist": "Will",
 							"casting_cost": "20",
@@ -3973,7 +3973,7 @@
 							"college": [
 								"Communication & Empathy"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Info",
 							"resist": "Will",
 							"casting_cost": "2",
@@ -4056,7 +4056,7 @@
 							"college": [
 								"Necromancy"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"resist": "Will",
 							"casting_cost": "4",
@@ -4227,7 +4227,7 @@
 								"Knowledge",
 								"Necromancy"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "4",
 							"maintenance_cost": "2",
@@ -4324,7 +4324,7 @@
 								"Air",
 								"Water"
 							],
-							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "4",
 							"maintenance_cost": "2",
@@ -4418,7 +4418,7 @@
 							"college": [
 								"Necromancy"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"resist": "Will",
 							"casting_cost": "Varies",
@@ -4499,7 +4499,7 @@
 							"college": [
 								"Food"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "Varies",
 							"maintenance_cost": "-",
@@ -4579,7 +4579,7 @@
 							"college": [
 								"Healing"
 							],
-							"power_source": "@Power Source: Clerical/Druidic@",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "4",
 							"maintenance_cost": "-",
@@ -4671,7 +4671,7 @@
 							"college": [
 								"Fire"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "4",
 							"maintenance_cost": "1",
@@ -4782,7 +4782,7 @@
 							"college": [
 								"Meta"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"resist": "Will + Spellcasting Talent",
 							"casting_cost": "1-5",
@@ -4850,7 +4850,7 @@
 							"college": [
 								"Healing"
 							],
-							"power_source": "@Power Source: Clerical/Druidic@",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "5",
 							"maintenance_cost": "-",
@@ -4941,7 +4941,7 @@
 							"college": [
 								"Necromancy"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Area",
 							"casting_cost": "4",
 							"maintenance_cost": "Half",
@@ -5060,7 +5060,7 @@
 							"college": [
 								"Knowledge"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "5",
 							"maintenance_cost": "2",
@@ -5155,7 +5155,7 @@
 							"college": [
 								"Sound"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "3",
 							"maintenance_cost": "2",
@@ -5250,7 +5250,7 @@
 							"college": [
 								"Earth"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "10",
 							"maintenance_cost": "-",
@@ -5376,7 +5376,7 @@
 							"college": [
 								"Mind Control"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "1/pt of Will increase",
 							"maintenance_cost": "Half",
@@ -5466,7 +5466,7 @@
 							"college": [
 								"Light & Darkness"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Missile",
 							"casting_cost": "1-3xMagery",
 							"maintenance_cost": "-",
@@ -5573,7 +5573,7 @@
 							"college": [
 								"Light & Darkness"
 							],
-							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+							"power_source": "Clerical",
 							"spell_class": "Area",
 							"casting_cost": "2",
 							"maintenance_cost": "Half",
@@ -5710,7 +5710,7 @@
 							"college": [
 								"Mind Control"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "4/pt of IQ",
 							"maintenance_cost": "Same",
@@ -5803,7 +5803,7 @@
 							"college": [
 								"Necromancy"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Area",
 							"casting_cost": "4",
 							"maintenance_cost": "2",
@@ -5883,7 +5883,7 @@
 							"college": [
 								"Necromancy"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Special",
 							"resist": "Will",
 							"casting_cost": "Varies",
@@ -5951,7 +5951,7 @@
 							"college": [
 								"Meta"
 							],
-							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+							"power_source": "Clerical",
 							"spell_class": "Area",
 							"resist": "Subject spells",
 							"casting_cost": "3",
@@ -6041,7 +6041,7 @@
 							"college": [
 								"Food"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "6",
 							"maintenance_cost": "-",
@@ -6121,7 +6121,7 @@
 							"college": [
 								"Communication & Empathy"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "6",
 							"maintenance_cost": "3",
@@ -6227,7 +6227,7 @@
 							"college": [
 								"Communication & Empathy"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "6",
 							"maintenance_cost": "3",
@@ -6333,7 +6333,7 @@
 							"college": [
 								"Healing"
 							],
-							"power_source": "@Power Source: Clerical/Druidic@",
+							"power_source": "Clerical",
 							"spell_class": "Regular",
 							"casting_cost": "8",
 							"maintenance_cost": "-",
@@ -6591,7 +6591,7 @@
 							"college": [
 								"Earth"
 							],
-							"power_source": "@Power Source: Clerical/Druidic@",
+							"power_source": "Clerical",
 							"spell_class": "Area",
 							"casting_cost": "2",
 							"maintenance_cost": "Same",
@@ -6643,7 +6643,7 @@
 							"college": [
 								"Necromancy"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Special",
 							"casting_cost": "Varies",
 							"maintenance_cost": "Varies",
@@ -6727,7 +6727,7 @@
 							"college": [
 								"Meta"
 							],
-							"power_source": "@Power Source: Arcane/Clerical@",
+							"power_source": "Clerical",
 							"spell_class": "Special",
 							"casting_cost": "1/sq foot",
 							"maintenance_cost": "-",
@@ -6985,7 +6985,7 @@
 								"Protection & Warning",
 								"Water"
 							],
-							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
 							"casting_cost": "2",
 							"maintenance_cost": "1",
@@ -7066,7 +7066,7 @@
 							"college": [
 								"Knowledge"
 							],
-							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
 							"casting_cost": "2",
 							"maintenance_cost": "-",
@@ -7145,7 +7145,7 @@
 								"Healing",
 								"Protection & Warning"
 							],
-							"power_source": "@Power Source: Clerical/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Area/Info",
 							"casting_cost": "2",
 							"maintenance_cost": "-",
@@ -7198,7 +7198,7 @@
 							"college": [
 								"Fire"
 							],
-							"power_source": "@Power Source: Arcane/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Area",
 							"casting_cost": "3",
 							"maintenance_cost": "-",
@@ -7265,7 +7265,7 @@
 							"college": [
 								"Knowledge"
 							],
-							"power_source": "@Power Source: Arcane/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Info",
 							"casting_cost": "2",
 							"maintenance_cost": "-",
@@ -7330,7 +7330,7 @@
 							"college": [
 								"Light & Darkness"
 							],
-							"power_source": "@Power Source: Arcane/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
 							"casting_cost": "2/level",
 							"maintenance_cost": "Half",
@@ -7495,7 +7495,7 @@
 							"college": [
 								"Air"
 							],
-							"power_source": "@Power Source: Arcane/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
 							"casting_cost": "2",
 							"maintenance_cost": "2",
@@ -7562,7 +7562,7 @@
 							"college": [
 								"Air"
 							],
-							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Area",
 							"casting_cost": "1",
 							"maintenance_cost": "-",
@@ -7624,7 +7624,7 @@
 								"Earth",
 								"Plant"
 							],
-							"power_source": "@Power Source: Arcane/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Area",
 							"casting_cost": "2",
 							"maintenance_cost": "-",
@@ -7706,7 +7706,7 @@
 							"college": [
 								"Water"
 							],
-							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Special",
 							"casting_cost": "1/gal",
 							"maintenance_cost": "-",
@@ -7786,7 +7786,7 @@
 							"college": [
 								"Movement"
 							],
-							"power_source": "@Power Source: Arcane/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
 							"casting_cost": "4",
 							"maintenance_cost": "-",
@@ -7858,7 +7858,7 @@
 								"Healing",
 								"Meta"
 							],
-							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Special",
 							"casting_cost": "0",
 							"maintenance_cost": "0",
@@ -7943,7 +7943,7 @@
 							"college": [
 								"Earth"
 							],
-							"power_source": "@Power Source: Arcane/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Info",
 							"casting_cost": "3",
 							"maintenance_cost": "-",
@@ -7991,7 +7991,7 @@
 							"college": [
 								"Food"
 							],
-							"power_source": "@Power Source: Arcane/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Info",
 							"casting_cost": "2",
 							"maintenance_cost": "-",
@@ -8078,7 +8078,7 @@
 							"college": [
 								"Water"
 							],
-							"power_source": "@Power Source: Arcane/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Info",
 							"casting_cost": "2",
 							"maintenance_cost": "-",
@@ -8127,7 +8127,7 @@
 								"Communication & Empathy",
 								"Meta"
 							],
-							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Info/Area",
 							"casting_cost": "1/area, min 2",
 							"maintenance_cost": "-",
@@ -8206,7 +8206,7 @@
 							"college": [
 								"Communication & Empathy"
 							],
-							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Info/Area",
 							"casting_cost": "1/2",
 							"maintenance_cost": "-",
@@ -8281,7 +8281,7 @@
 								"Healing",
 								"Meta"
 							],
-							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
 							"casting_cost": "2-10",
 							"maintenance_cost": "-",
@@ -8362,7 +8362,7 @@
 							"college": [
 								"Knowledge"
 							],
-							"power_source": "@Power Source: Arcane/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Info",
 							"casting_cost": "1",
 							"maintenance_cost": "-",
@@ -8444,7 +8444,7 @@
 							"college": [
 								"Sound"
 							],
-							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
 							"casting_cost": "2",
 							"maintenance_cost": "-",
@@ -8540,7 +8540,7 @@
 								"Protection & Warning",
 								"Water"
 							],
-							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
 							"casting_cost": "1",
 							"maintenance_cost": "1",
@@ -8641,7 +8641,7 @@
 								"Fire",
 								"Protection & Warning"
 							],
-							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
 							"casting_cost": "2",
 							"maintenance_cost": "1",
@@ -9090,7 +9090,7 @@
 							"college": [
 								"Healing"
 							],
-							"power_source": "@Power Source: Clerical/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
 							"casting_cost": "4",
 							"maintenance_cost": "-",
@@ -9142,7 +9142,7 @@
 							"college": [
 								"Fire"
 							],
-							"power_source": "@Power Source: Arcane/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Area",
 							"casting_cost": "3#",
 							"maintenance_cost": "Same",
@@ -9289,7 +9289,7 @@
 							"college": [
 								"Knowledge"
 							],
-							"power_source": "@Power Source: Arcane/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Info",
 							"casting_cost": "2",
 							"maintenance_cost": "-",
@@ -9379,7 +9379,7 @@
 							"college": [
 								"Movement"
 							],
-							"power_source": "@Power Source: Arcane/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
 							"casting_cost": "4",
 							"maintenance_cost": "1",
@@ -9459,7 +9459,7 @@
 							"college": [
 								"Protection & Warning"
 							],
-							"power_source": "@Power Source: Arcane/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Area",
 							"casting_cost": "1",
 							"maintenance_cost": "Same",
@@ -9549,7 +9549,7 @@
 							"college": [
 								"Healing"
 							],
-							"power_source": "@Power Source: Clerical/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
 							"casting_cost": "5",
 							"maintenance_cost": "-",
@@ -9601,7 +9601,7 @@
 							"college": [
 								"Knowledge"
 							],
-							"power_source": "@Power Source: Arcane/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Info",
 							"casting_cost": "4",
 							"maintenance_cost": "-",
@@ -9799,7 +9799,7 @@
 								"Meta",
 								"Protection & Warning"
 							],
-							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
 							"casting_cost": "1-5",
 							"maintenance_cost": "Half",
@@ -9903,7 +9903,7 @@
 							"college": [
 								"Food"
 							],
-							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
 							"casting_cost": "1/lb",
 							"maintenance_cost": "-",
@@ -10295,7 +10295,7 @@
 							"college": [
 								"Air"
 							],
-							"power_source": "@Power Source: Arcane/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
 							"casting_cost": "1-10",
 							"maintenance_cost": "-",
@@ -10362,7 +10362,7 @@
 							"college": [
 								"Earth"
 							],
-							"power_source": "@Power Source: Arcane/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
 							"casting_cost": "1/cu yd",
 							"maintenance_cost": "Half",
@@ -10468,7 +10468,7 @@
 							"college": [
 								"Water"
 							],
-							"power_source": "@Power Source: Arcane/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
 							"casting_cost": "1#",
 							"maintenance_cost": "1",
@@ -10576,7 +10576,7 @@
 							"college": [
 								"Air"
 							],
-							"power_source": "@Power Source: Arcane/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Area",
 							"casting_cost": "2",
 							"maintenance_cost": "Half",
@@ -10694,7 +10694,7 @@
 								"Air",
 								"Water"
 							],
-							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
 							"casting_cost": "4",
 							"maintenance_cost": "2",
@@ -10867,7 +10867,7 @@
 								"Earth",
 								"Knowledge"
 							],
-							"power_source": "@Power Source: Arcane/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
 							"casting_cost": "2/10 yds#",
 							"maintenance_cost": "Same",
@@ -10988,7 +10988,7 @@
 							"college": [
 								"Water"
 							],
-							"power_source": "@Power Source: Arcane/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
 							"casting_cost": "Varies",
 							"maintenance_cost": "-",
@@ -11095,7 +11095,7 @@
 							"college": [
 								"Healing"
 							],
-							"power_source": "@Power Source: Clerical/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
 							"casting_cost": "8",
 							"maintenance_cost": "-",
@@ -11385,7 +11385,7 @@
 							"college": [
 								"Fire"
 							],
-							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
 							"casting_cost": "2",
 							"maintenance_cost": "Half",
@@ -11467,7 +11467,7 @@
 								"Protection & Warning",
 								"Weather"
 							],
-							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
 							"casting_cost": "2",
 							"maintenance_cost": "1",
@@ -11549,7 +11549,7 @@
 							"college": [
 								"Light & Darkness"
 							],
-							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Area",
 							"casting_cost": "2",
 							"maintenance_cost": "Half",
@@ -11647,7 +11647,7 @@
 								"Movement",
 								"Water"
 							],
-							"power_source": "@Power Source: Arcane/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
 							"casting_cost": "6",
 							"maintenance_cost": "3",
@@ -11846,7 +11846,7 @@
 								"Knowledge",
 								"Water"
 							],
-							"power_source": "@Power Source: Arcane/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Info",
 							"casting_cost": "1#",
 							"maintenance_cost": "Same",
@@ -12019,7 +12019,7 @@
 							"college": [
 								"Meta"
 							],
-							"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Area",
 							"resist": "Subject spells",
 							"casting_cost": "3",
@@ -12109,7 +12109,7 @@
 							"college": [
 								"Water"
 							],
-							"power_source": "@Power Source: Arcane/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
 							"resist": "HT",
 							"casting_cost": "1-3",
@@ -12268,7 +12268,7 @@
 								"Air",
 								"Weather"
 							],
-							"power_source": "@Power Source: Arcane/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Missile",
 							"casting_cost": "1-Magery",
 							"maintenance_cost": "-",
@@ -12368,7 +12368,7 @@
 								"Air",
 								"Earth"
 							],
-							"power_source": "@Power Source: Arcane/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Area",
 							"casting_cost": "3",
 							"maintenance_cost": "Half",
@@ -12540,7 +12540,7 @@
 							"college": [
 								"Earth"
 							],
-							"power_source": "@Power Source: Arcane/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Regular",
 							"resist": "HT",
 							"casting_cost": "10#",
@@ -12613,7 +12613,7 @@
 								"Air",
 								"Weather"
 							],
-							"power_source": "@Power Source: Arcane/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Area",
 							"casting_cost": "2/4/6",
 							"maintenance_cost": "Half",
@@ -12723,7 +12723,7 @@
 							"college": [
 								"Earth"
 							],
-							"power_source": "@Power Source: Clerical/Druidic@",
+							"power_source": "Druidic",
 							"spell_class": "Area",
 							"casting_cost": "2",
 							"maintenance_cost": "Same",
@@ -13178,7 +13178,7 @@
 					"college": [
 						"Protection & Warning"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"casting_cost": "2 per DR",
 					"maintenance_cost": "Half",
@@ -13245,7 +13245,7 @@
 					"college": [
 						"Necromancy"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Area",
 					"casting_cost": "4",
 					"maintenance_cost": "2",
@@ -13326,7 +13326,7 @@
 						"Knowledge",
 						"Necromancy"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"casting_cost": "4",
 					"maintenance_cost": "2",
@@ -13422,7 +13422,7 @@
 					"college": [
 						"Knowledge"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Info",
 					"casting_cost": "3",
 					"maintenance_cost": "-",
@@ -13552,7 +13552,7 @@
 					"college": [
 						"Necromancy"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Special",
 					"resist": "Will",
 					"casting_cost": "Varies",
@@ -13999,7 +13999,7 @@
 					"college": [
 						"Mind Control"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Area",
 					"resist": "Will-1",
 					"casting_cost": "2",
@@ -14083,7 +14083,7 @@
 						"Air",
 						"Water"
 					],
-					"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"casting_cost": "4",
 					"maintenance_cost": "2",
@@ -14610,7 +14610,7 @@
 					"college": [
 						"Mind Control"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Blocking",
 					"resist": "Will",
 					"casting_cost": "2",
@@ -14701,7 +14701,7 @@
 					"college": [
 						"Necromancy"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"resist": "Will",
 					"casting_cost": "Varies",
@@ -14782,7 +14782,7 @@
 					"college": [
 						"Communication & Empathy"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Info",
 					"resist": "Will",
 					"casting_cost": "4",
@@ -15039,7 +15039,7 @@
 					"college": [
 						"Light & Darkness"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"casting_cost": "2 moon, 4 torch, 6 day",
 					"maintenance_cost": "-",
@@ -15353,7 +15353,7 @@
 						"Protection & Warning",
 						"Water"
 					],
-					"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"casting_cost": "2",
 					"maintenance_cost": "1",
@@ -15745,7 +15745,7 @@
 					"college": [
 						"Food"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"casting_cost": "Varies",
 					"maintenance_cost": "-",
@@ -15825,7 +15825,7 @@
 					"college": [
 						"Water"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"casting_cost": "2/gal",
 					"maintenance_cost": "-",
@@ -16639,7 +16639,7 @@
 					"college": [
 						"Knowledge"
 					],
-					"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"casting_cost": "2",
 					"maintenance_cost": "-",
@@ -16766,7 +16766,7 @@
 					"college": [
 						"Meta"
 					],
-					"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Area",
 					"resist": "Subject spells",
 					"casting_cost": "3",
@@ -17413,7 +17413,7 @@
 						"Earth",
 						"Knowledge"
 					],
-					"power_source": "@Power Source: Arcane/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"casting_cost": "2/10 yds#",
 					"maintenance_cost": "Same",
@@ -17495,7 +17495,7 @@
 					"college": [
 						"Earth"
 					],
-					"power_source": "@Power Source: Arcane/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"resist": "HT",
 					"casting_cost": "10#",
@@ -17567,7 +17567,7 @@
 					"college": [
 						"Necromancy"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Special",
 					"casting_cost": "Varies",
 					"maintenance_cost": "Varies",
@@ -17651,7 +17651,7 @@
 					"college": [
 						"Food"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"casting_cost": "6",
 					"maintenance_cost": "-",
@@ -17940,7 +17940,7 @@
 					"college": [
 						"Fire"
 					],
-					"power_source": "@Power Source: Arcane/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Area",
 					"casting_cost": "3",
 					"maintenance_cost": "-",
@@ -18385,7 +18385,7 @@
 					"college": [
 						"Knowledge"
 					],
-					"power_source": "@Power Source: Arcane/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Info",
 					"casting_cost": "2",
 					"maintenance_cost": "-",
@@ -18708,7 +18708,7 @@
 					"college": [
 						"Fire"
 					],
-					"power_source": "@Power Source: Arcane/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Area",
 					"casting_cost": "3#",
 					"maintenance_cost": "Same",
@@ -18919,7 +18919,7 @@
 					"college": [
 						"Fire"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"casting_cost": "4",
 					"maintenance_cost": "1",
@@ -19277,7 +19277,7 @@
 					"college": [
 						"Water"
 					],
-					"power_source": "@Power Source: Arcane/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"casting_cost": "Varies",
 					"maintenance_cost": "-",
@@ -19344,7 +19344,7 @@
 					"college": [
 						"Water"
 					],
-					"power_source": "@Power Source: Arcane/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"resist": "HT",
 					"casting_cost": "1-3",
@@ -19506,7 +19506,7 @@
 					"college": [
 						"Communication & Empathy"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"casting_cost": "6",
 					"maintenance_cost": "3",
@@ -19612,7 +19612,7 @@
 					"college": [
 						"Communication & Empathy"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"casting_cost": "6",
 					"maintenance_cost": "3",
@@ -19800,7 +19800,7 @@
 					"college": [
 						"Light & Darkness"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Area",
 					"casting_cost": "Varies",
 					"maintenance_cost": "-",
@@ -20073,7 +20073,7 @@
 					"college": [
 						"Sound"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"casting_cost": "3",
 					"maintenance_cost": "1",
@@ -20256,7 +20256,7 @@
 					"college": [
 						"Light & Darkness"
 					],
-					"power_source": "@Power Source: Arcane/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"casting_cost": "2/level",
 					"maintenance_cost": "Half",
@@ -20533,7 +20533,7 @@
 					"college": [
 						"Communication & Empathy"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"casting_cost": "3",
 					"maintenance_cost": "1",
@@ -22007,7 +22007,7 @@
 					"college": [
 						"Knowledge"
 					],
-					"power_source": "@Power Source: Arcane/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Info",
 					"casting_cost": "2",
 					"maintenance_cost": "-",
@@ -22098,7 +22098,7 @@
 						"Healing",
 						"Meta"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"casting_cost": "1/pt",
 					"maintenance_cost": "-",
@@ -22334,7 +22334,7 @@
 					"college": [
 						"Light & Darkness"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"casting_cost": "1",
 					"maintenance_cost": "1",
@@ -22382,7 +22382,7 @@
 					"college": [
 						"Light & Darkness"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"casting_cost": "2",
 					"maintenance_cost": "1",
@@ -22483,7 +22483,7 @@
 					"college": [
 						"Movement"
 					],
-					"power_source": "@Power Source: Arcane/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"casting_cost": "4",
 					"maintenance_cost": "1",
@@ -22612,7 +22612,7 @@
 						"Air",
 						"Weather"
 					],
-					"power_source": "@Power Source: Arcane/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Missile",
 					"casting_cost": "1-Magery",
 					"maintenance_cost": "-",
@@ -23192,7 +23192,7 @@
 					"college": [
 						"Meta"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"resist": "Will + Spellcasting Talent",
 					"casting_cost": "1-5",
@@ -23642,7 +23642,7 @@
 					"college": [
 						"Body Control"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"casting_cost": "2/+ST",
 					"maintenance_cost": "Same",
@@ -24028,7 +24028,7 @@
 					"college": [
 						"Protection & Warning"
 					],
-					"power_source": "@Power Source: Arcane/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Area",
 					"casting_cost": "1",
 					"maintenance_cost": "Same",
@@ -24282,7 +24282,7 @@
 					"college": [
 						"Air"
 					],
-					"power_source": "@Power Source: Arcane/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"casting_cost": "2",
 					"maintenance_cost": "2",
@@ -24591,7 +24591,7 @@
 					"college": [
 						"Knowledge"
 					],
-					"power_source": "@Power Source: Arcane/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Info",
 					"casting_cost": "4",
 					"maintenance_cost": "-",
@@ -24690,7 +24690,7 @@
 					"college": [
 						"Meta"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Special",
 					"casting_cost": "1/sq foot",
 					"maintenance_cost": "-",
@@ -24809,7 +24809,7 @@
 					"college": [
 						"Communication & Empathy"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"resist": "Will",
 					"casting_cost": "Varies",
@@ -25321,7 +25321,7 @@
 						"Meta",
 						"Protection & Warning"
 					],
-					"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"casting_cost": "1-5",
 					"maintenance_cost": "Half",
@@ -25425,7 +25425,7 @@
 					"college": [
 						"Air"
 					],
-					"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Area",
 					"casting_cost": "1",
 					"maintenance_cost": "-",
@@ -25487,7 +25487,7 @@
 						"Earth",
 						"Plant"
 					],
-					"power_source": "@Power Source: Arcane/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Area",
 					"casting_cost": "2",
 					"maintenance_cost": "-",
@@ -25569,7 +25569,7 @@
 					"college": [
 						"Food"
 					],
-					"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"casting_cost": "1/lb",
 					"maintenance_cost": "-",
@@ -25649,7 +25649,7 @@
 					"college": [
 						"Water"
 					],
-					"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Special",
 					"casting_cost": "1/gal",
 					"maintenance_cost": "-",
@@ -25729,7 +25729,7 @@
 					"college": [
 						"Movement"
 					],
-					"power_source": "@Power Source: Arcane/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"casting_cost": "4",
 					"maintenance_cost": "-",
@@ -25801,7 +25801,7 @@
 						"Healing",
 						"Meta"
 					],
-					"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Special",
 					"casting_cost": "0",
 					"maintenance_cost": "0",
@@ -26157,7 +26157,7 @@
 					"college": [
 						"Necromancy"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Area",
 					"casting_cost": "4",
 					"maintenance_cost": "Half",
@@ -26237,7 +26237,7 @@
 					"college": [
 						"Fire"
 					],
-					"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"casting_cost": "2",
 					"maintenance_cost": "Half",
@@ -26317,7 +26317,7 @@
 					"college": [
 						"Fire"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"casting_cost": "2#",
 					"maintenance_cost": "Half",
@@ -26386,7 +26386,7 @@
 						"Protection & Warning",
 						"Weather"
 					],
-					"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"casting_cost": "2",
 					"maintenance_cost": "1",
@@ -26468,7 +26468,7 @@
 					"college": [
 						"Body Control"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"casting_cost": "4",
 					"maintenance_cost": "2",
@@ -26990,7 +26990,7 @@
 						"Air",
 						"Earth"
 					],
-					"power_source": "@Power Source: Arcane/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Area",
 					"casting_cost": "3",
 					"maintenance_cost": "Half",
@@ -27244,7 +27244,7 @@
 					"college": [
 						"Knowledge"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"casting_cost": "5",
 					"maintenance_cost": "2",
@@ -27339,7 +27339,7 @@
 					"college": [
 						"Earth"
 					],
-					"power_source": "@Power Source: Arcane/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Info",
 					"casting_cost": "3",
 					"maintenance_cost": "-",
@@ -27422,7 +27422,7 @@
 					"college": [
 						"Food"
 					],
-					"power_source": "@Power Source: Arcane/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Info",
 					"casting_cost": "2",
 					"maintenance_cost": "-",
@@ -27592,7 +27592,7 @@
 					"college": [
 						"Water"
 					],
-					"power_source": "@Power Source: Arcane/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Info",
 					"casting_cost": "2",
 					"maintenance_cost": "-",
@@ -27640,7 +27640,7 @@
 					"college": [
 						"Knowledge"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Info",
 					"casting_cost": "3",
 					"maintenance_cost": "-",
@@ -27851,7 +27851,7 @@
 						"Communication & Empathy",
 						"Meta"
 					],
-					"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Info/Area",
 					"casting_cost": "1/area, min 2",
 					"maintenance_cost": "-",
@@ -27978,7 +27978,7 @@
 					"college": [
 						"Communication & Empathy"
 					],
-					"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Info/Area",
 					"casting_cost": "1/2",
 					"maintenance_cost": "-",
@@ -28052,7 +28052,7 @@
 					"college": [
 						"Necromancy"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Info/Area",
 					"casting_cost": "1/2 (min 1)",
 					"maintenance_cost": "-",
@@ -28208,7 +28208,7 @@
 					"college": [
 						"Air"
 					],
-					"power_source": "@Power Source: Arcane/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"casting_cost": "1-10",
 					"maintenance_cost": "-",
@@ -28275,7 +28275,7 @@
 					"college": [
 						"Earth"
 					],
-					"power_source": "@Power Source: Arcane/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"casting_cost": "1/cu yd",
 					"maintenance_cost": "Half",
@@ -28390,7 +28390,7 @@
 					"college": [
 						"Water"
 					],
-					"power_source": "@Power Source: Arcane/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"casting_cost": "1#",
 					"maintenance_cost": "1",
@@ -28458,7 +28458,7 @@
 						"Healing",
 						"Meta"
 					],
-					"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"casting_cost": "2-10",
 					"maintenance_cost": "-",
@@ -28718,7 +28718,7 @@
 					"college": [
 						"Protection & Warning"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"casting_cost": "2 per DB",
 					"maintenance_cost": "Half",
@@ -28921,7 +28921,7 @@
 					"college": [
 						"Sound"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Area",
 					"casting_cost": "2",
 					"maintenance_cost": "Half",
@@ -29003,7 +29003,7 @@
 					"college": [
 						"Sound"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"casting_cost": "3",
 					"maintenance_cost": "2",
@@ -29696,7 +29696,7 @@
 						"Air",
 						"Weather"
 					],
-					"power_source": "@Power Source: Arcane/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Area",
 					"casting_cost": "2/4/6",
 					"maintenance_cost": "Half",
@@ -30201,7 +30201,7 @@
 					"college": [
 						"Earth"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"casting_cost": "10",
 					"maintenance_cost": "-",
@@ -30285,7 +30285,7 @@
 					"college": [
 						"Mind Control"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"casting_cost": "1/pt of Will increase",
 					"maintenance_cost": "Half",
@@ -30597,7 +30597,7 @@
 					"college": [
 						"Necromancy"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Info",
 					"resist": "Will",
 					"casting_cost": "20",
@@ -30669,7 +30669,7 @@
 					"college": [
 						"Light & Darkness"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Missile",
 					"casting_cost": "1-3xMagery",
 					"maintenance_cost": "-",
@@ -30776,7 +30776,7 @@
 					"college": [
 						"Light & Darkness"
 					],
-					"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Area",
 					"casting_cost": "2",
 					"maintenance_cost": "Half",
@@ -30874,7 +30874,7 @@
 						"Movement",
 						"Water"
 					],
-					"power_source": "@Power Source: Arcane/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"casting_cost": "6",
 					"maintenance_cost": "3",
@@ -31130,7 +31130,7 @@
 					"college": [
 						"Knowledge"
 					],
-					"power_source": "@Power Source: Arcane/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Info",
 					"casting_cost": "1",
 					"maintenance_cost": "-",
@@ -31276,7 +31276,7 @@
 					"college": [
 						"Food"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Info",
 					"casting_cost": "1 or 3",
 					"maintenance_cost": "-",
@@ -31387,7 +31387,7 @@
 					"college": [
 						"Sound"
 					],
-					"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"casting_cost": "2",
 					"maintenance_cost": "-",
@@ -31739,7 +31739,7 @@
 					"college": [
 						"Communication & Empathy"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Info",
 					"resist": "Will",
 					"casting_cost": "2",
@@ -31822,7 +31822,7 @@
 					"college": [
 						"Necromancy"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"resist": "Will",
 					"casting_cost": "4",
@@ -31904,7 +31904,7 @@
 						"Protection & Warning",
 						"Water"
 					],
-					"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"casting_cost": "1",
 					"maintenance_cost": "1",
@@ -32053,7 +32053,7 @@
 					"college": [
 						"Body Control"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"casting_cost": "2/+HT",
 					"maintenance_cost": "Same",
@@ -32548,7 +32548,7 @@
 						"Fire",
 						"Protection & Warning"
 					],
-					"power_source": "@Power Source: Arcane/Clerical/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"casting_cost": "2",
 					"maintenance_cost": "1",
@@ -32629,7 +32629,7 @@
 					"college": [
 						"Protection & Warning"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Area",
 					"casting_cost": "1",
 					"maintenance_cost": "Same",
@@ -32779,7 +32779,7 @@
 						"Knowledge",
 						"Water"
 					],
-					"power_source": "@Power Source: Arcane/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Info",
 					"casting_cost": "1#",
 					"maintenance_cost": "Same",
@@ -33000,7 +33000,7 @@
 					"college": [
 						"Air"
 					],
-					"power_source": "@Power Source: Arcane/Druidic@",
+					"power_source": "Arcane",
 					"spell_class": "Area",
 					"casting_cost": "2",
 					"maintenance_cost": "Half",
@@ -33067,7 +33067,7 @@
 					"college": [
 						"Mind Control"
 					],
-					"power_source": "@Power Source: Arcane/Clerical@",
+					"power_source": "Arcane",
 					"spell_class": "Regular",
 					"casting_cost": "4/pt of IQ",
 					"maintenance_cost": "Same",


### PR DESCRIPTION
As per [this comment](https://github.com/richardwilkes/gcs_master_library/pull/73#issuecomment-882080589) by @daliin, I have retracted the change related to DFRPG spells, which forced the user to decide on the spell's power source every time a spell for which power source could be one of two or three options. The power source is now "Clerical" for all spells in the "Clerical" container, "Druidic" for all spells in the "Druidic" container, and "Arcane" for all spells in the "Wizardly" container.