### PR TITLE
correct page refs to ACT1 bang skills

### DIFF
--- a/Library/Action/Action Skills.skl
+++ b/Library/Action/Action Skills.skl
@@ -629,7 +629,7 @@
 			"type": "skill",
 			"id": "aac2a379-2580-43a5-bc01-ff260700dc35",
 			"name": "Assassin!",
-			"reference": "ACT1:13",
+			"reference": "ACT1:23",
 			"difficulty": "dx/w",
 			"points": 1,
 			"categories": [
@@ -1232,7 +1232,7 @@
 			"type": "skill",
 			"id": "993a3ddf-26e9-491c-aa94-129fa1c531f7",
 			"name": "Cleaner!",
-			"reference": "ACT1:13",
+			"reference": "ACT1:23",
 			"difficulty": "iq/w",
 			"points": 1,
 			"categories": [
@@ -1992,7 +1992,7 @@
 			"type": "skill",
 			"id": "927ef9be-7b39-4164-8174-4eb4f7ef8f27",
 			"name": "Demolition Man!",
-			"reference": "ACT1:13",
+			"reference": "ACT1:23",
 			"difficulty": "iq/w",
 			"points": 1,
 			"categories": [
@@ -4965,7 +4965,7 @@
 			"type": "skill",
 			"id": "e9ce1860-dfb8-4336-a0a3-9d01cd73d177",
 			"name": "Face Man!",
-			"reference": "ACT1:13",
+			"reference": "ACT1:23",
 			"difficulty": "dx/w",
 			"points": 1,
 			"categories": [
@@ -6141,7 +6141,7 @@
 			"type": "skill",
 			"id": "b8a0ec1b-09f9-4919-a8fe-5ee89c007d51",
 			"name": "Hacker!",
-			"reference": "ACT1:13",
+			"reference": "ACT1:23",
 			"difficulty": "iq/w",
 			"points": 1,
 			"categories": [
@@ -6305,7 +6305,7 @@
 			"type": "skill",
 			"id": "e2285de3-281d-4474-a81e-935b74f1da03",
 			"name": "Infiltrator!",
-			"reference": "ACT1:13",
+			"reference": "ACT1:23",
 			"difficulty": "dx/w",
 			"points": 1,
 			"categories": [
@@ -6394,7 +6394,7 @@
 			"type": "skill",
 			"id": "37fe485d-a31f-4c82-8088-9b17738ba77c",
 			"name": "Investigator!",
-			"reference": "ACT1:13",
+			"reference": "ACT1:23",
 			"difficulty": "iq/w",
 			"points": 1,
 			"categories": [
@@ -13419,7 +13419,7 @@
 			"type": "skill",
 			"id": "f6cc8279-6763-420d-a312-1a1da025a391",
 			"name": "Medic!",
-			"reference": "ACT1:13",
+			"reference": "ACT1:23",
 			"difficulty": "iq/w",
 			"points": 1,
 			"categories": [
@@ -15909,7 +15909,7 @@
 			"type": "skill",
 			"id": "8f0e2b5e-118c-4608-a830-cf09c609f910",
 			"name": "Shooter!",
-			"reference": "ACT1:13",
+			"reference": "ACT1:23",
 			"difficulty": "dx/w",
 			"points": 1,
 			"categories": [
@@ -18291,7 +18291,7 @@
 			"type": "skill",
 			"id": "b7201434-1064-46e0-b1b2-a1ee3bb8fe47",
 			"name": "Wheel Man!",
-			"reference": "ACT1:13",
+			"reference": "ACT1:23",
 			"difficulty": "dx/w",
 			"points": 1,
 			"categories": [
@@ -18302,7 +18302,7 @@
 			"type": "skill",
 			"id": "e2cf0acf-754d-4a85-beae-2d713bb09804",
 			"name": "Wire Rat!",
-			"reference": "ACT1:13",
+			"reference": "ACT1:23",
 			"difficulty": "iq/w",
 			"points": 1,
 			"categories": [


### PR DESCRIPTION
I believe the Action 1 Heroes "bang" skills e.g. _Assassin!_ are incorrectly referencing 13 instead of 23 (per my copy).