### PR TITLE
Add RSL to Spell export

### DIFF
--- a/Library/Output Templates/Foundry VTT.xml
+++ b/Library/Output Templates/Foundry VTT.xml
@@ -13,7 +13,7 @@
           <relativelevel type="string">@RSL</relativelevel>
           <points type="number">@POINTS</points>
           <notes type="string">@DESCRIPTION_NOTES</notes>
-	    <pageref>@REF</pageref>
+          <pageref>@REF</pageref>
           <uuid>@ID</uuid>
           <parentuuid>@PARENT_ID</parentuuid>
         </id-@ID>@SKILLS_LOOP_END
@@ -24,7 +24,7 @@
           <class type="string">@CLASS</class>
           <college type="string">@COLLEGE</college>
           <cost type="string">@MANA_CAST</cost>
-	    <maintain type="string">@MANA_MAINTAIN</maintain>
+          <maintain type="string">@MANA_MAINTAIN</maintain>
           <duration type="string">@DURATION</duration>
           <level type="number">@SL</level>
           <name type="string">@DESCRIPTION_PRIMARY</name>
@@ -32,8 +32,9 @@
           <resist type="string">@RESIST</resist>
           <time type="string">@TIME_CAST</time>
           <difficulty type="string">@DIFFICULTY</difficulty>
+          <relativelevel type="string">@RSL</relativelevel>
           <notes type="string">@DESCRIPTION_NOTES</notes>
-	    <pageref type="string">@REF</pageref>
+          <pageref type="string">@REF</pageref>
           <uuid>@ID</uuid>
           <parentuuid>@PARENT_ID</parentuuid>
        </id-@ID>@SPELLS_LOOP_END


### PR DESCRIPTION
Odd, but I never exported RSL for Spells.    Since we may start using RSL (instead of SL) in the future, I should export it.   Also, I removed a few tabs and replaced with spaces to match the other lines.