### PR TITLE
a suggestion to standardize on the canonical damage abbreviation type…

### DIFF
--- a/Library/Basic Set/Basic Set Equipment.eqp
+++ b/Library/Basic Set/Basic Set Equipment.eqp
@@ -7365,19 +7365,19 @@
 					"type": "dr_bonus",
 					"amount": -2,
 					"location": "torso",
-					"specialization": "crushing"
+					"specialization": "cr"
 				},
 				{
 					"type": "dr_bonus",
 					"amount": -2,
 					"location": "vitals",
-					"specialization": "crushing"
+					"specialization": "cr"
 				},
 				{
 					"type": "dr_bonus",
 					"amount": -2,
 					"location": "groin",
-					"specialization": "crushing"
+					"specialization": "cr"
 				}
 			],
 			"notes": "Flexible",
@@ -14251,13 +14251,13 @@
 					"type": "dr_bonus",
 					"amount": -2,
 					"location": "skull",
-					"specialization": "crushing"
+					"specialization": "cr"
 				},
 				{
 					"type": "dr_bonus",
 					"amount": -2,
 					"location": "neck",
-					"specialization": "crushing"
+					"specialization": "cr"
 				}
 			],
 			"notes": "Flexible",
@@ -14299,19 +14299,19 @@
 					"type": "dr_bonus",
 					"amount": -2,
 					"location": "torso",
-					"specialization": "crushing"
+					"specialization": "cr"
 				},
 				{
 					"type": "dr_bonus",
 					"amount": -2,
 					"location": "vitals",
-					"specialization": "crushing"
+					"specialization": "cr"
 				},
 				{
 					"type": "dr_bonus",
 					"amount": -2,
 					"location": "groin",
-					"specialization": "crushing"
+					"specialization": "cr"
 				}
 			],
 			"notes": "Flexible",
@@ -14343,7 +14343,7 @@
 					"type": "dr_bonus",
 					"amount": -2,
 					"location": "leg",
-					"specialization": "crushing"
+					"specialization": "cr"
 				}
 			],
 			"notes": "Flexible",
@@ -14379,13 +14379,13 @@
 					"type": "dr_bonus",
 					"amount": -2,
 					"location": "torso",
-					"specialization": "crushing"
+					"specialization": "cr"
 				},
 				{
 					"type": "dr_bonus",
 					"amount": -2,
 					"location": "vitals",
-					"specialization": "crushing"
+					"specialization": "cr"
 				}
 			],
 			"notes": "Flexible, concealable",
@@ -14417,7 +14417,7 @@
 					"type": "dr_bonus",
 					"amount": -2,
 					"location": "arm",
-					"specialization": "crushing"
+					"specialization": "cr"
 				}
 			],
 			"notes": "Flexible",
@@ -23580,13 +23580,13 @@
 					"type": "dr_bonus",
 					"amount": -1,
 					"location": "groin",
-					"specialization": "crushing"
+					"specialization": "cr"
 				},
 				{
 					"type": "dr_bonus",
 					"amount": -1,
 					"location": "leg",
-					"specialization": "crushing"
+					"specialization": "cr"
 				}
 			],
 			"notes": "Flexible",

--- a/Library/Home Brew/Characters/Rudolf Vautour.gcs
+++ b/Library/Home Brew/Characters/Rudolf Vautour.gcs
@@ -363,7 +363,7 @@
 						"roll_range": "3-4",
 						"dr": {
 							"all": 6,
-							"crushing": -2
+							"cr": -2
 						}
 					}
 				},
@@ -394,7 +394,7 @@
 						"roll_range": "6-7",
 						"dr": {
 							"all": 4,
-							"crushing": -2
+							"cr": -2
 						}
 					}
 				},
@@ -410,7 +410,7 @@
 						"roll_range": "8",
 						"dr": {
 							"all": 4,
-							"crushing": -2
+							"cr": -2
 						}
 					}
 				},
@@ -426,7 +426,7 @@
 						"roll_range": "9-10",
 						"dr": {
 							"all": 4,
-							"crushing": -2
+							"cr": -2
 						}
 					}
 				},
@@ -442,7 +442,7 @@
 						"roll_range": "11",
 						"dr": {
 							"all": 4,
-							"crushing": -2
+							"cr": -2
 						}
 					}
 				},
@@ -458,7 +458,7 @@
 						"roll_range": "12",
 						"dr": {
 							"all": 4,
-							"crushing": -2
+							"cr": -2
 						}
 					}
 				},
@@ -474,7 +474,7 @@
 						"roll_range": "13-14",
 						"dr": {
 							"all": 4,
-							"crushing": -2
+							"cr": -2
 						}
 					}
 				},
@@ -520,7 +520,7 @@
 						"roll_range": "17-18",
 						"dr": {
 							"all": 4,
-							"crushing": -2
+							"cr": -2
 						}
 					}
 				},
@@ -536,7 +536,7 @@
 						"roll_range": "-",
 						"dr": {
 							"all": 4,
-							"crushing": -2
+							"cr": -2
 						}
 					}
 				}
@@ -4017,13 +4017,13 @@
 					"type": "dr_bonus",
 					"amount": -2,
 					"location": "skull",
-					"specialization": "crushing"
+					"specialization": "cr"
 				},
 				{
 					"type": "dr_bonus",
 					"amount": -2,
 					"location": "neck",
-					"specialization": "crushing"
+					"specialization": "cr"
 				}
 			],
 			"notes": "Flexible",
@@ -4066,19 +4066,19 @@
 					"type": "dr_bonus",
 					"amount": -2,
 					"location": "torso",
-					"specialization": "crushing"
+					"specialization": "cr"
 				},
 				{
 					"type": "dr_bonus",
 					"amount": -2,
 					"location": "vitals",
-					"specialization": "crushing"
+					"specialization": "cr"
 				},
 				{
 					"type": "dr_bonus",
 					"amount": -2,
 					"location": "groin",
-					"specialization": "crushing"
+					"specialization": "cr"
 				}
 			],
 			"notes": "Flexible",
@@ -4111,7 +4111,7 @@
 					"type": "dr_bonus",
 					"amount": -2,
 					"location": "leg",
-					"specialization": "crushing"
+					"specialization": "cr"
 				}
 			],
 			"notes": "Flexible",
@@ -4144,7 +4144,7 @@
 					"type": "dr_bonus",
 					"amount": -2,
 					"location": "arm",
-					"specialization": "crushing"
+					"specialization": "cr"
 				}
 			],
 			"notes": "Flexible",


### PR DESCRIPTION
…s for split DR

FWIW, I think it'd be easier on downstream consumers of GCS characters if the new split DR feature (thanks again for that!) used the same standard abbreviated damage types as weapons do.

Since some armor types have "DR vs piercing" which means `pi-`, `pi`, `pi+`, _and_ `pi++`, I was thinking that `pi*` might make sense to use in those cases. Thoughts? If you agree, I can follow up with some more equipment file edits to add this kind of split DR.