### PR TITLE
Add Increased 1/2 D Range enhancements

### DIFF
--- a/Library/Basic Set/Basic Set Enhancement Modifiers.adm
+++ b/Library/Basic Set/Basic Set Enhancement Modifiers.adm
@@ -14,6 +14,15 @@
 		},
 		{
 			"type": "modifier",
+			"id": "c5243942-ebce-4fcc-82cd-5d0904dc2c79",
+			"name": "2x Increased 1/2 D Range",
+			"reference": "B106",
+			"cost_type": "percentage",
+			"cost": 5,
+			"affects": "total"
+		},
+		{
+			"type": "modifier",
 			"id": "7e78d8eb-520d-425e-bb42-2c20e0bc3379",
 			"name": "3x Duration",
 			"reference": "B105",
@@ -32,6 +41,15 @@
 		},
 		{
 			"type": "modifier",
+			"id": "9a8980a3-f42f-4422-b122-068888d32a54",
+			"name": "5x Increased 1/2 D Range",
+			"reference": "B106",
+			"cost_type": "percentage",
+			"cost": 10,
+			"affects": "total"
+		},
+		{
+			"type": "modifier",
 			"id": "67faee7a-d439-483b-a29b-b6b9a984015d",
 			"name": "10x Duration",
 			"reference": "B105",
@@ -46,6 +64,15 @@
 			"reference": "B106",
 			"cost_type": "percentage",
 			"cost": 30,
+			"affects": "total"
+		},
+		{
+			"type": "modifier",
+			"id": "f54830fe-ff81-41d4-a832-cd0b33da604e",
+			"name": "10x Increased 1/2 D Range",
+			"reference": "B106",
+			"cost_type": "percentage",
+			"cost": 15,
 			"affects": "total"
 		},
 		{


### PR DESCRIPTION
Added Increased 1/2 D Range enhancements.
![image](https://user-images.githubusercontent.com/8931036/152244772-1f927a12-b381-4343-9d1c-76fbe487e57a.png)

I use them a lot with 10x Reduced Range so the attack has no 1/2 D range, and the MAX is 10 yards.