### PR TITLE
Update Basic Set Rules to reference Campaigns PDF

### DIFF
--- a/Library/Basic Set/Basic Set Rules.not
+++ b/Library/Basic Set/Basic Set Rules.not
@@ -7,117 +7,117 @@
 			"type": "note_container",
 			"id": "1f05daa9-67cc-4d3f-a0b9-96185664f7e8",
 			"text": "Success Rolls",
-			"reference": "B343",
+			"reference": "BX343",
 			"open": true,
 			"children": [
 				{
 					"type": "note",
 					"id": "c07164b3-b73b-4428-945b-300078bd5255",
 					"text": "When to Roll",
-					"reference": "B343"
+					"reference": "BX343"
 				},
 				{
 					"type": "note",
 					"id": "eeabb12c-4329-474c-8b2d-eadba1ca0ad7",
 					"text": "Base Skill vs Effective Skill",
-					"reference": "B344"
+					"reference": "BX344"
 				},
 				{
 					"type": "note",
 					"id": "346b3eae-5212-4e37-b861-55209aef86ba",
 					"text": "Modifiers",
-					"reference": "B344"
+					"reference": "BX344"
 				},
 				{
 					"type": "note",
 					"id": "33bbd880-7778-4860-bcb1-05f752ee984b",
 					"text": "Sidebar: Default Rolls",
-					"reference": "B344"
+					"reference": "BX344"
 				},
 				{
 					"type": "note",
 					"id": "b7b3af0c-a38d-4242-8184-ec5b3c2ab5ca",
 					"text": "Sidebar: Rule of 20",
-					"reference": "B344"
+					"reference": "BX344"
 				},
 				{
 					"type": "note",
 					"id": "69df78e6-25d2-44ba-af37-0eb59909a3c6",
 					"text": "Sidebar: Equipment Modifiers",
-					"reference": "B345"
+					"reference": "BX345"
 				},
 				{
 					"type": "note",
 					"id": "b2e8f200-83fe-4b18-90a1-2e5b42922aeb",
 					"text": "Task Difficulty",
-					"reference": "B345"
+					"reference": "BX345"
 				},
 				{
 					"type": "note",
 					"id": "3a3602ef-8fcd-4114-ae5c-5ae7204163c2",
 					"text": "Sidebar: Long Tasks",
-					"reference": "B346"
+					"reference": "BX346"
 				},
 				{
 					"type": "note",
 					"id": "390c3d50-7d38-47f7-afa1-0d0dd910d2fe",
 					"text": "Time Spent",
-					"reference": "B346"
+					"reference": "BX346"
 				},
 				{
 					"type": "note",
 					"id": "d072b97c-406b-4cad-a808-9bbb2c63baff",
 					"text": "Critical Success",
-					"reference": "B347"
+					"reference": "BX347"
 				},
 				{
 					"type": "note",
 					"id": "03d0bc72-064b-4c67-a069-48cd7dc5d627",
 					"text": "Degree of Success or Failure",
-					"reference": "B347"
+					"reference": "BX347"
 				},
 				{
 					"type": "note",
 					"id": "6374fd93-10e9-48bd-a0de-c6a4b39b615e",
 					"text": "Sidebar: Influencing Success Rolls",
-					"reference": "B347"
+					"reference": "BX347"
 				},
 				{
 					"type": "note_container",
 					"id": "857a8d6b-cbfc-4981-9874-8e7da64b8509",
 					"text": "Contests",
-					"reference": "B348",
+					"reference": "BX348",
 					"open": true,
 					"children": [
 						{
 							"type": "note",
 							"id": "fdde4c7f-e244-41f5-b103-f4f59014c064",
 							"text": "Margin of Victory",
-							"reference": "B348"
+							"reference": "BX348"
 						},
 						{
 							"type": "note",
 							"id": "7f2b8374-3235-400d-b166-f063037d16f4",
 							"text": "Quick Contests",
-							"reference": "B348"
+							"reference": "BX348"
 						},
 						{
 							"type": "note",
 							"id": "46b435a2-2b9f-4aaf-af8b-4216c01d37ff",
 							"text": "Resistance Rolls",
-							"reference": "B348"
+							"reference": "BX348"
 						},
 						{
 							"type": "note",
 							"id": "9bbc09c4-9519-436f-9a25-3f7ba8037d0c",
 							"text": "Regular Contests",
-							"reference": "B349"
+							"reference": "BX349"
 						},
 						{
 							"type": "note",
 							"id": "f9f7baa4-cb70-404a-a294-a0d02d1aa9c6",
 							"text": "Sidebar: The Rule of 16",
-							"reference": "B349"
+							"reference": "BX349"
 						}
 					]
 				},
@@ -125,136 +125,136 @@
 					"type": "note",
 					"id": "f06e3806-5be7-439f-a72d-119e645f9c3f",
 					"text": "Critical Failure",
-					"reference": "B348"
+					"reference": "BX348"
 				},
 				{
 					"type": "note",
 					"id": "abc62746-7cd7-41fb-804f-571d1ad05fab",
 					"text": "Repeated Attempts",
-					"reference": "B348"
+					"reference": "BX348"
 				},
 				{
 					"type": "note_container",
 					"id": "0e9dc7a5-6a8a-48f0-82c2-f6ab5f895e32",
 					"text": "Physical Feats",
-					"reference": "B349",
+					"reference": "BX349",
 					"open": true,
 					"children": [
 						{
 							"type": "note",
 							"id": "f31c4607-fd67-49e9-bb65-91793429b2e8",
 							"text": "Climbing",
-							"reference": "B349"
+							"reference": "BX349"
 						},
 						{
 							"type": "note",
 							"id": "5b84c17a-296a-4cfb-9db2-8fc0fb57ff79",
 							"text": "Digging",
-							"reference": "B350"
+							"reference": "BX350"
 						},
 						{
 							"type": "note",
 							"id": "8fd86b62-5ca1-441e-b01c-a60ff34dc0a9",
 							"text": "Sidebar: Different Gravity",
-							"reference": "B350"
+							"reference": "BX350"
 						},
 						{
 							"type": "note",
 							"id": "a0a7a304-14e5-4968-bceb-aa10f0bf40bc",
 							"text": "Hiking",
-							"reference": "B351"
+							"reference": "BX351"
 						},
 						{
 							"type": "note",
 							"id": "95058509-4cb9-41f6-9e4b-6cbb9786464c",
 							"text": "Holding Your Breath",
-							"reference": "B351"
+							"reference": "BX351"
 						},
 						{
 							"type": "note",
 							"id": "958f96f4-133e-4619-a8ac-784b1bd63afd",
 							"text": "Jumping",
-							"reference": "B352"
+							"reference": "BX352"
 						},
 						{
 							"type": "note",
 							"id": "93e3c56e-fa11-493b-b9cb-61e064057a42",
 							"text": "Sidebar: Optional Jumping Rules",
-							"reference": "B352"
+							"reference": "BX352"
 						},
 						{
 							"type": "note",
 							"id": "c9774d5e-887c-43d9-8eaf-2dae2ae651d2",
 							"text": "Lifting and Moving Things",
-							"reference": "B353"
+							"reference": "BX353"
 						},
 						{
 							"type": "note",
 							"id": "b9340aba-6cd0-4729-ac45-0c4ed4601c07",
 							"text": "Flying",
-							"reference": "B354"
+							"reference": "BX354"
 						},
 						{
 							"type": "note",
 							"id": "5afd4a48-8e63-48da-b4a0-32cb5b229a13",
 							"text": "Running",
-							"reference": "B354"
+							"reference": "BX354"
 						},
 						{
 							"type": "note",
 							"id": "bfabe207-7864-4968-9e16-60defaaeb770",
 							"text": "Swimming",
-							"reference": "B354"
+							"reference": "BX354"
 						},
 						{
 							"type": "note",
 							"id": "096ffbfc-28d6-46b6-bfbd-b3e6584c5d85",
 							"text": "Catching",
-							"reference": "B355"
+							"reference": "BX355"
 						},
 						{
 							"type": "note",
 							"id": "034acc4a-fff0-4c01-9a5a-ddb3d9b36ac4",
 							"text": "Throwing",
-							"reference": "B355"
+							"reference": "BX355"
 						},
 						{
 							"type": "note_container",
 							"id": "61cc6529-9e2f-4f78-9b84-31a4316995d3",
 							"text": "Extra Effort",
-							"reference": "B356",
+							"reference": "BX356",
 							"open": true,
 							"children": [
 								{
 									"type": "note",
 									"id": "150ff066-a18a-424c-ad2e-84f75b060d7d",
 									"text": "Notes for Specific Physical Tasks",
-									"reference": "B357"
+									"reference": "BX357"
 								},
 								{
 									"type": "note_container",
 									"id": "cc64ee85-b23d-4409-a66c-7d1b4687122a",
 									"text": "Optional Rule: Extra Effort in Combat",
-									"reference": "B357",
+									"reference": "BX357",
 									"open": true,
 									"children": [
 										{
 											"type": "note",
 											"id": "360a7ef7-cf84-4431-b18e-aec9a2040ce4",
 											"text": "Feverish Defense",
-											"reference": "B357"
+											"reference": "BX357"
 										},
 										{
 											"type": "note",
 											"id": "734a5948-40bb-468b-9f82-4a9f864c448f",
 											"text": "Flurry of Blows",
-											"reference": "B357"
+											"reference": "BX357"
 										},
 										{
 											"type": "note",
 											"id": "61fb6bfe-28a1-4bac-9e75-ed1be13b9c03",
 											"text": "Mighty Blows",
-											"reference": "B357"
+											"reference": "BX357"
 										}
 									]
 								}
@@ -266,26 +266,26 @@
 					"type": "note_container",
 					"id": "2164c30d-5a15-4928-95e7-e15844d0823d",
 					"text": "Sense Rolls",
-					"reference": "B358",
+					"reference": "BX358",
 					"open": true,
 					"children": [
 						{
 							"type": "note",
 							"id": "a614eebc-eb03-4cbe-a4b3-509621c89de3",
 							"text": "Hearing",
-							"reference": "B358"
+							"reference": "BX358"
 						},
 						{
 							"type": "note",
 							"id": "5688c946-e5df-4634-b4ca-0b97017576ee",
 							"text": "Taste/Smell",
-							"reference": "B358"
+							"reference": "BX358"
 						},
 						{
 							"type": "note",
 							"id": "37fbe133-c90e-4dba-8455-de8a653f8814",
 							"text": "Vision",
-							"reference": "B358"
+							"reference": "BX358"
 						}
 					]
 				},
@@ -293,20 +293,20 @@
 					"type": "note_container",
 					"id": "e57f54a8-e547-4167-8b8e-784a6005c052",
 					"text": "Influence Rolls",
-					"reference": "B359",
+					"reference": "BX359",
 					"open": true,
 					"children": [
 						{
 							"type": "note",
 							"id": "5a715bdd-8036-40ca-824a-01334421a3e0",
 							"text": "Psychological Warfare",
-							"reference": "B359"
+							"reference": "BX359"
 						},
 						{
 							"type": "note",
 							"id": "eebd33b4-732f-4899-996b-199aa57a96df",
 							"text": "Sidebar: Influencing the PCs",
-							"reference": "B359"
+							"reference": "BX359"
 						}
 					]
 				},
@@ -314,26 +314,26 @@
 					"type": "note_container",
 					"id": "efe4ae1c-6a2d-4faa-a48a-89eec536a820",
 					"text": "Will Rolls",
-					"reference": "B360",
+					"reference": "BX360",
 					"open": true,
 					"children": [
 						{
 							"type": "note",
 							"id": "84f59306-a150-4342-937b-3c0e2e31502c",
 							"text": "Fright Check Table",
-							"reference": "B360"
+							"reference": "BX360"
 						},
 						{
 							"type": "note",
 							"id": "68c456ce-3223-4707-80e2-a54937de202c",
 							"text": "Fright Checks",
-							"reference": "B360"
+							"reference": "BX360"
 						},
 						{
 							"type": "note",
 							"id": "911225b9-5d73-4e23-8d4e-39a8430ff4c8",
 							"text": "The Rule of 14",
-							"reference": "B360"
+							"reference": "BX360"
 						}
 					]
 				}
@@ -343,99 +343,99 @@
 			"type": "note_container",
 			"id": "7a8dccea-5d1e-49a5-aee4-b68cfa0a4124",
 			"text": "Combat",
-			"reference": "B362",
+			"reference": "BX362",
 			"open": true,
 			"children": [
 				{
 					"type": "note",
 					"id": "40f41dfe-81f0-4395-811e-06cd625cf329",
 					"text": "Combat Turn Sequence",
-					"reference": "B362"
+					"reference": "BX362"
 				},
 				{
 					"type": "note_container",
 					"id": "b46b69ab-b066-466d-bb8a-1244c47c553a",
 					"text": "Manoeuvres",
-					"reference": "B363",
+					"reference": "BX363",
 					"open": true,
 					"children": [
 						{
 							"type": "note",
 							"id": "075326c8-15e2-4475-961e-7f64ad5c0543",
 							"text": "Aim",
-							"reference": "B364"
+							"reference": "BX364"
 						},
 						{
 							"type": "note",
 							"id": "f7e5bb4c-8b52-4b7f-8830-8e09f27fe972",
 							"text": "Change Posture",
-							"reference": "B364"
+							"reference": "BX364"
 						},
 						{
 							"type": "note",
 							"id": "7ced124a-cdce-4158-83b9-1d2a30f1d104",
 							"text": "Do Nothing",
-							"reference": "B364"
+							"reference": "BX364"
 						},
 						{
 							"type": "note",
 							"id": "7dcf3754-b5ce-4413-a02a-43fbaa8a86c6",
 							"text": "Evaluate",
-							"reference": "B364"
+							"reference": "BX364"
 						},
 						{
 							"type": "note",
 							"id": "549090c4-e336-4bff-8f9c-cf3485e2c323",
 							"text": "Move",
-							"reference": "B364"
+							"reference": "BX364"
 						},
 						{
 							"type": "note",
 							"id": "03e0d777-121b-4a05-ae37-8d945bd06f06",
 							"text": "All-Out Attack",
-							"reference": "B365"
+							"reference": "BX365"
 						},
 						{
 							"type": "note",
 							"id": "fea63263-38b9-49eb-8245-de8faaab9a2b",
 							"text": "Attack",
-							"reference": "B365"
+							"reference": "BX365"
 						},
 						{
 							"type": "note",
 							"id": "8966803e-9e60-49ee-83fc-c08d010b11ce",
 							"text": "Feint",
-							"reference": "B365"
+							"reference": "BX365"
 						},
 						{
 							"type": "note",
 							"id": "dc3f6f97-9d02-4210-895f-7f14ac91862a",
 							"text": "Move and Attack",
-							"reference": "B365"
+							"reference": "BX365"
 						},
 						{
 							"type": "note",
 							"id": "8e105f64-d529-40f8-b4ea-8703a39b9441",
 							"text": "All-Out Defence",
-							"reference": "B366"
+							"reference": "BX366"
 						},
 						{
 							"type": "note",
 							"id": "03162f00-688e-420e-9bc6-e5fa085dcf5a",
 							"text": "Concentrate",
-							"reference": "B366"
+							"reference": "BX366"
 						},
 						{
 							"type": "note",
 							"id": "dffefdf4-5f5f-4911-bf92-63a3973f9f2f",
 							"text": "Ready",
-							"reference": "B366"
+							"reference": "BX366"
 						},
 						{
 							"type": "note",
 							"id": "04b4fe34-0ea0-4db5-9d5b-ae1c27c416ea",
 							"text": "Wait",
-							"reference": "B366"
+							"reference": "BX366"
 						}
 					]
 				},
@@ -443,38 +443,38 @@
 					"type": "note_container",
 					"id": "2c9c4434-6bb1-4fa5-adee-3f5f95f3dd32",
 					"text": "Movement and Combat",
-					"reference": "B367",
+					"reference": "BX367",
 					"open": true,
 					"children": [
 						{
 							"type": "note",
 							"id": "4780c8ae-f9e5-4a9e-8a19-bf5df1324f59",
 							"text": "Movement",
-							"reference": "B367"
+							"reference": "BX367"
 						},
 						{
 							"type": "note",
 							"id": "d9ef3737-93ee-4511-95a4-affe6c91858e",
 							"text": "Crouching",
-							"reference": "B368"
+							"reference": "BX368"
 						},
 						{
 							"type": "note",
 							"id": "edca79f8-c9ca-4521-8b5c-cf3c71e1675c",
 							"text": "Moving Through Other Characters",
-							"reference": "B368"
+							"reference": "BX368"
 						},
 						{
 							"type": "note",
 							"id": "294de6dc-61cc-4d39-a9a6-4ee405e115f6",
 							"text": "Spacing",
-							"reference": "B368"
+							"reference": "BX368"
 						},
 						{
 							"type": "note",
 							"id": "57f3e012-d8f8-4de0-bfc5-fcd3229b733e",
 							"text": "Step",
-							"reference": "B368"
+							"reference": "BX368"
 						}
 					]
 				},
@@ -482,46 +482,46 @@
 					"type": "note_container",
 					"id": "7dec91bc-f11e-4057-8777-0fd35c1b7af0",
 					"text": "Attacking",
-					"reference": "B369",
+					"reference": "BX369",
 					"open": true,
 					"children": [
 						{
 							"type": "note",
 							"id": "c0dc7b7d-8011-40f1-9b9a-0f3717a78cd5",
 							"text": "Attack Roll",
-							"reference": "B369"
+							"reference": "BX369"
 						},
 						{
 							"type": "note_container",
 							"id": "f9fd459b-b2e0-4d8e-8f5d-47178ba0167e",
 							"text": "Melee Attacks",
-							"reference": "B369",
+							"reference": "BX369",
 							"open": true,
 							"children": [
 								{
 									"type": "note_container",
 									"id": "e52e580c-9f74-4f0f-a9f9-b6f06c7894db",
 									"text": "Melee Attack Options",
-									"reference": "B369",
+									"reference": "BX369",
 									"open": true,
 									"children": [
 										{
 											"type": "note",
 											"id": "b7e6c130-9c25-48c2-9587-1311ed58f671",
 											"text": "Deceptive Attack",
-											"reference": "B369"
+											"reference": "BX369"
 										},
 										{
 											"type": "note",
 											"id": "162d962d-66c4-45d8-8455-10b3966d282b",
 											"text": "Hit Location",
-											"reference": "B369"
+											"reference": "BX369"
 										},
 										{
 											"type": "note",
 											"id": "5e538174-0de9-495d-8647-f7d5baba40e3",
 											"text": "Rapid Strike",
-											"reference": "B370"
+											"reference": "BX370"
 										}
 									]
 								},
@@ -529,63 +529,63 @@
 									"type": "note_container",
 									"id": "b7f0aa71-292d-4408-9206-7f233a0b2928",
 									"text": "Unarmed Combat",
-									"reference": "B370",
+									"reference": "BX370",
 									"open": true,
 									"children": [
 										{
 											"type": "note",
 											"id": "3297c377-e564-413a-ad7c-ab442f50ee12",
 											"text": "Grabbing",
-											"reference": "B370"
+											"reference": "BX370"
 										},
 										{
 											"type": "note_container",
 											"id": "e97194a2-33f7-44fa-bfb1-3a10180e92e6",
 											"text": "Grappling",
-											"reference": "B370",
+											"reference": "BX370",
 											"open": true,
 											"children": [
 												{
 													"type": "note",
 													"id": "75b5aeb7-c6a0-4d3b-bb6b-6f89a1aab423",
 													"text": "Choke or Strangle",
-													"reference": "B370"
+													"reference": "BX370"
 												},
 												{
 													"type": "note",
 													"id": "04248168-46d5-4e54-9668-99351fc754d8",
 													"text": "Pin",
-													"reference": "B370"
+													"reference": "BX370"
 												},
 												{
 													"type": "note",
 													"id": "dfb2a23d-72e4-444b-9a6a-db79d5fe7353",
 													"text": "Takedown",
-													"reference": "B370"
+													"reference": "BX370"
 												},
 												{
 													"type": "note",
 													"id": "51682123-6d28-4588-b863-2443535d3fd3",
 													"text": "Arm Lock",
-													"reference": "B371"
+													"reference": "BX371"
 												},
 												{
 													"type": "note",
 													"id": "eedad0c0-4161-4091-b391-5dfc5c1186e2",
 													"text": "Choke Hold",
-													"reference": "B371"
+													"reference": "BX371"
 												},
 												{
 													"type": "note",
 													"id": "ec3af9f6-a737-473b-8cb6-dc4e42af2815",
 													"text": "Neck Snap or Wrench Limb",
-													"reference": "B371"
+													"reference": "BX371"
 												},
 												{
 													"type": "note",
 													"id": "3d645cca-fc3f-44d6-bba1-84b242ebe938",
 													"text": "Other Actions",
-													"reference": "B371"
+													"reference": "BX371"
 												}
 											]
 										},
@@ -593,19 +593,19 @@
 											"type": "note",
 											"id": "6fa70495-d103-420b-a88f-89223497649e",
 											"text": "Striking",
-											"reference": "B370"
+											"reference": "BX370"
 										},
 										{
 											"type": "note",
 											"id": "e8000fd2-05b9-46c9-ab1d-ee9d0ce0fd44",
 											"text": "Slam",
-											"reference": "B371"
+											"reference": "BX371"
 										},
 										{
 											"type": "note",
 											"id": "97fdce3e-b384-448d-bd94-b49c5cb2c4fa",
 											"text": "Shove",
-											"reference": "B372"
+											"reference": "BX372"
 										}
 									]
 								}
@@ -615,27 +615,27 @@
 							"type": "note_container",
 							"id": "d1c0f344-2997-4d17-a5ae-57f9ae5b40de",
 							"text": "Ranged Attacks",
-							"reference": "B372",
+							"reference": "BX372",
 							"open": true,
 							"children": [
 								{
 									"type": "note_container",
 									"id": "a78f6a07-3a21-4c9a-a531-00e0000b63e2",
 									"text": "Missile Weapon Attacks",
-									"reference": "B373",
+									"reference": "BX373",
 									"open": true,
 									"children": [
 										{
 											"type": "note",
 											"id": "4a37700f-8416-47b0-a5e2-f3a6548f26eb",
 											"text": "Rapid Fire",
-											"reference": "B373"
+											"reference": "BX373"
 										},
 										{
 											"type": "note",
 											"id": "704f4fe4-7ada-43d5-8627-ebff232436d7",
 											"text": "Rate of Fire (ROF)",
-											"reference": "B373"
+											"reference": "BX373"
 										}
 									]
 								},
@@ -643,7 +643,7 @@
 									"type": "note",
 									"id": "593c92d3-f27c-428a-8434-6f66ed01c298",
 									"text": "Thrown Weapon Attacks",
-									"reference": "B373"
+									"reference": "BX373"
 								}
 							]
 						},
@@ -651,39 +651,39 @@
 							"type": "note_container",
 							"id": "aa5e27f3-28b6-4472-ac27-2990a13ba9a6",
 							"text": "Defending",
-							"reference": "B374",
+							"reference": "BX374",
 							"open": true,
 							"children": [
 								{
 									"type": "note",
 									"id": "a721b9f9-df06-49dd-86f8-88cb08d08475",
 									"text": "Active Defence Rolls",
-									"reference": "B374"
+									"reference": "BX374"
 								},
 								{
 									"type": "note_container",
 									"id": "d6d636a5-92de-4d36-8e87-b1c1124cbf1e",
 									"text": "Dodging",
-									"reference": "B374",
+									"reference": "BX374",
 									"open": true,
 									"children": [
 										{
 											"type": "note",
 											"id": "d2dd1422-c56e-4dc4-8c0b-7d3bd222bfd1",
 											"text": "Acrobatic Dodge",
-											"reference": "B375"
+											"reference": "BX375"
 										},
 										{
 											"type": "note",
 											"id": "6b60b3ee-c438-4464-a327-422d86f95563",
 											"text": "Sacrificial Dodge",
-											"reference": "B375"
+											"reference": "BX375"
 										},
 										{
 											"type": "note",
 											"id": "dba31e65-9d27-402e-aea3-0cb5727a1a90",
 											"text": "Vehicular Dodge",
-											"reference": "B375"
+											"reference": "BX375"
 										}
 									]
 								},
@@ -691,33 +691,33 @@
 									"type": "note_container",
 									"id": "c709ed99-b767-478f-9f4a-fa0892ed8b10",
 									"text": "Blocking",
-									"reference": "B375",
+									"reference": "BX375",
 									"open": true
 								},
 								{
 									"type": "note_container",
 									"id": "fd4fdb34-754a-4824-bcc3-85c89e1ada14",
 									"text": "Parrying",
-									"reference": "B376",
+									"reference": "BX376",
 									"open": true,
 									"children": [
 										{
 											"type": "note",
 											"id": "0c806d5a-8cf3-4aa1-a890-3733cfe0d016",
 											"text": "Parrying Heavy Weapons",
-											"reference": "B376"
+											"reference": "BX376"
 										},
 										{
 											"type": "note",
 											"id": "3262efde-a821-406b-804a-93bf4ae3bff0",
 											"text": "Parrying Unarmed",
-											"reference": "B376"
+											"reference": "BX376"
 										},
 										{
 											"type": "note",
 											"id": "2702a84d-5b42-4d98-93a5-adf9b7325f0f",
 											"text": "Parrying with Improvised Weapons",
-											"reference": "B376"
+											"reference": "BX376"
 										}
 									]
 								},
@@ -725,20 +725,20 @@
 									"type": "note_container",
 									"id": "c55f1f97-80b4-4f6a-8ae6-e46dca2cdc42",
 									"text": "Active Defence Options",
-									"reference": "B377",
+									"reference": "BX377",
 									"open": true,
 									"children": [
 										{
 											"type": "note",
 											"id": "0fa0c60f-0130-4f25-b2e7-4a4a75d33dee",
 											"text": "Dodge and Drop",
-											"reference": "B377"
+											"reference": "BX377"
 										},
 										{
 											"type": "note",
 											"id": "9b56e36e-5f7d-4f00-9015-c3e7f1e21c62",
 											"text": "Retreat",
-											"reference": "B377"
+											"reference": "BX377"
 										}
 									]
 								}
@@ -748,45 +748,45 @@
 							"type": "note_container",
 							"id": "beb69ce6-8ab1-4e5c-9238-8fcd4663d1b7",
 							"text": "Damage and Injury",
-							"reference": "B377",
+							"reference": "BX377",
 							"open": true,
 							"children": [
 								{
 									"type": "note_container",
 									"id": "5d733bd3-b117-4edd-b782-1e8c206f105d",
 									"text": "Damage Resistance (DR) and Penetration",
-									"reference": "B378",
+									"reference": "BX378",
 									"open": true,
 									"children": [
 										{
 											"type": "note",
 											"id": "17156a6a-b871-4f9f-a72d-e97b93ceda37",
 											"text": "Armor Divisors and Pentration Modifiers",
-											"reference": "B378"
+											"reference": "BX378"
 										},
 										{
 											"type": "note",
 											"id": "70d627d3-28bb-482c-8652-64fdb0f0f0d9",
 											"text": "Corrosion",
-											"reference": "B379"
+											"reference": "BX379"
 										},
 										{
 											"type": "note",
 											"id": "848ea9f6-7013-4526-9e96-a625c709d5f9",
 											"text": "Flexible Armor and Blunt Trauma",
-											"reference": "B379"
+											"reference": "BX379"
 										},
 										{
 											"type": "note",
 											"id": "1db5ef2c-32f5-4de6-b89b-1300fe6c6a8e",
 											"text": "Hurting Yourself",
-											"reference": "B379"
+											"reference": "BX379"
 										},
 										{
 											"type": "note",
 											"id": "454cea22-4ad6-4f9d-9edd-4383e1e57f39",
 											"text": "Overpenetration and Cover",
-											"reference": "B379"
+											"reference": "BX379"
 										}
 									]
 								},
@@ -794,26 +794,26 @@
 									"type": "note",
 									"id": "dd69e15f-bbe5-4445-aa98-e1d10a83cdcb",
 									"text": "Damage Roll",
-									"reference": "B378"
+									"reference": "BX378"
 								},
 								{
 									"type": "note",
 									"id": "e8ce5b3a-c071-419d-9678-58fd4f3a22fd",
 									"text": "Knockback",
-									"reference": "B378"
+									"reference": "BX378"
 								},
 								{
 									"type": "note_container",
 									"id": "c9fa8993-3264-4e22-a823-f804eb589535",
 									"text": "Wounding Modifiers and Injury",
-									"reference": "B379",
+									"reference": "BX379",
 									"open": true,
 									"children": [
 										{
 											"type": "note",
 											"id": "0fdf75cb-5ede-47b0-b8d5-0bbec9612392",
 											"text": "Injury to Unliving, Homogenous and Diffuse Targets",
-											"reference": "B380"
+											"reference": "BX380"
 										}
 									]
 								},
@@ -821,26 +821,26 @@
 									"type": "note_container",
 									"id": "46f58cda-15f5-4d7f-90c0-45eaaa31068a",
 									"text": "Effects of Injury",
-									"reference": "B380",
+									"reference": "BX380",
 									"open": true,
 									"children": [
 										{
 											"type": "note",
 											"id": "6811f87e-995c-413e-85da-723d7d6fd77b",
 											"text": "Followup Damage",
-											"reference": "B381"
+											"reference": "BX381"
 										},
 										{
 											"type": "note",
 											"id": "c551bf14-9a41-4960-af92-2a1ac44ec8ea",
 											"text": "Linked Effects",
-											"reference": "B381"
+											"reference": "BX381"
 										},
 										{
 											"type": "note",
 											"id": "12c8955d-c088-4308-ac78-09c73cf115a0",
 											"text": "Special Damage",
-											"reference": "B381"
+											"reference": "BX381"
 										}
 									]
 								},
@@ -848,20 +848,20 @@
 									"type": "note_container",
 									"id": "6e5f2715-3753-40c8-a815-ccb76e60c092",
 									"text": "Critical Hits and Misses",
-									"reference": "B381",
+									"reference": "BX381",
 									"open": true,
 									"children": [
 										{
 											"type": "note",
 											"id": "0034d171-3e5a-432c-97a5-4b32adf63174",
 											"text": "Critical Hits",
-											"reference": "B381"
+											"reference": "BX381"
 										},
 										{
 											"type": "note",
 											"id": "0ea2b576-1472-4afc-a22a-50208b80f055",
 											"text": "Critical Misses",
-											"reference": "B382"
+											"reference": "BX382"
 										}
 									]
 								},
@@ -869,20 +869,20 @@
 									"type": "note_container",
 									"id": "23d296d4-6a82-46b4-ba5e-b710fa382e60",
 									"text": "Other Actions in Combat",
-									"reference": "B382",
+									"reference": "BX382",
 									"open": true,
 									"children": [
 										{
 											"type": "note",
 											"id": "4b50d5c0-56f3-4fc0-b6c2-3aef04b443a9",
 											"text": "Readying Weapons and Other gear",
-											"reference": "B382"
+											"reference": "BX382"
 										},
 										{
 											"type": "note",
 											"id": "a23119d7-9cda-41a9-b70d-e79b181d2b18",
 											"text": "Typical Long Actions",
-											"reference": "B383"
+											"reference": "BX383"
 										}
 									]
 								}
@@ -896,46 +896,46 @@
 			"type": "note_container",
 			"id": "df3ca159-5853-43f5-b225-ee912a039bdb",
 			"text": "Tactical Combat",
-			"reference": "B384",
+			"reference": "BX384",
 			"open": true,
 			"children": [
 				{
 					"type": "note",
 					"id": "dc39b39b-2c23-4b4b-a110-ece7b8c92877",
 					"text": "Facing",
-					"reference": "B385"
+					"reference": "BX385"
 				},
 				{
 					"type": "note_container",
 					"id": "2d4d3f1f-c116-4a4f-a180-9996627ddf2a",
 					"text": "Maneuvers in Tactical Combat",
-					"reference": "B385",
+					"reference": "BX385",
 					"open": true
 				},
 				{
 					"type": "note",
 					"id": "110b78b2-39f0-4a1c-bb9d-bb354969a5f3",
 					"text": "Sidebar: Wait Maneouvre Strategy",
-					"reference": "B385"
+					"reference": "BX385"
 				},
 				{
 					"type": "note_container",
 					"id": "0fe61f9f-f7dc-439e-8215-6d70e2dd70da",
 					"text": "Movement in Tactical Combat",
-					"reference": "B386",
+					"reference": "BX386",
 					"open": true,
 					"children": [
 						{
 							"type": "note",
 							"id": "e71afeba-9b88-4acb-a45b-6c3f3752a8c0",
 							"text": "Movement and Facing",
-							"reference": "B386"
+							"reference": "BX386"
 						},
 						{
 							"type": "note",
 							"id": "8cdee07f-725a-4331-90d9-15a418775875",
 							"text": "Sidebar: Movement Point Costs",
-							"reference": "B387"
+							"reference": "BX387"
 						}
 					]
 				},
@@ -943,39 +943,39 @@
 					"type": "note_container",
 					"id": "d17ed81e-8396-455e-83bb-7a17d17d6300",
 					"text": "Attacking in Tactical Combat",
-					"reference": "B388",
+					"reference": "BX388",
 					"open": true,
 					"children": [
 						{
 							"type": "note_container",
 							"id": "c85dbab1-4a5a-47ff-aa19-a4847992cdd4",
 							"text": "Melee Attacks",
-							"reference": "B388",
+							"reference": "BX388",
 							"open": true,
 							"children": [
 								{
 									"type": "note",
 									"id": "f6c713cd-77ae-427e-b397-61cbf6d2d23b",
 									"text": "Attacking Through an Occupied Hex",
-									"reference": "B388"
+									"reference": "BX388"
 								},
 								{
 									"type": "note",
 									"id": "712c910c-aec6-43d5-833e-fab6e82f9b36",
 									"text": "Long Weapon Tactics",
-									"reference": "B388"
+									"reference": "BX388"
 								},
 								{
 									"type": "note",
 									"id": "d42c15e3-82a4-40a7-8e79-365920291834",
 									"text": "Reach of a Weapon",
-									"reference": "B388"
+									"reference": "BX388"
 								},
 								{
 									"type": "note",
 									"id": "6433ce3e-e0d6-4cc3-8c6e-915d715a86e2",
 									"text": "Wild Swings",
-									"reference": "B388"
+									"reference": "BX388"
 								}
 							]
 						},
@@ -983,50 +983,50 @@
 							"type": "note_container",
 							"id": "4d6d753b-e14f-4fb4-9eb2-4be66493e18c",
 							"text": "Ranged Attacks",
-							"reference": "B389",
+							"reference": "BX389",
 							"open": true,
 							"children": [
 								{
 									"type": "note",
 									"id": "525957a0-8568-4bdd-a7fa-2a60c5ec4e44",
 									"text": "Arc of Vision",
-									"reference": "B389"
+									"reference": "BX389"
 								},
 								{
 									"type": "note",
 									"id": "646218e0-c596-4a5c-b6b5-a80ef2d7f9dc",
 									"text": "Firing Through an Occupioed Hex",
-									"reference": "B389"
+									"reference": "BX389"
 								},
 								{
 									"type": "note",
 									"id": "e68486ff-1fcc-482b-8a18-0c7e23502c20",
 									"text": "Hitting the Wrong Target",
-									"reference": "B389"
+									"reference": "BX389"
 								},
 								{
 									"type": "note",
 									"id": "07e0ad5f-a9e1-4829-be04-0a43c224a894",
 									"text": "Shooting Blind",
-									"reference": "B389"
+									"reference": "BX389"
 								},
 								{
 									"type": "note",
 									"id": "6de87b7b-1277-40ee-9a89-c8fe65e099cc",
 									"text": "Opportunity Shots",
-									"reference": "B390"
+									"reference": "BX390"
 								},
 								{
 									"type": "note",
 									"id": "9391a612-2b46-4260-96ac-a18413fc5334",
 									"text": "Overshooting and Stray Shots",
-									"reference": "B390"
+									"reference": "BX390"
 								},
 								{
 									"type": "note",
 									"id": "03f9a152-f64a-49c8-aca2-db80b9bf135f",
 									"text": "Sidebar: Pop-Up Attacks",
-									"reference": "B390"
+									"reference": "BX390"
 								}
 							]
 						}
@@ -1036,32 +1036,32 @@
 					"type": "note_container",
 					"id": "38574952-66f9-4e89-8edb-bc60ff030e67",
 					"text": "Defending in Tactical Combat",
-					"reference": "B390",
+					"reference": "BX390",
 					"open": true,
 					"children": [
 						{
 							"type": "note",
 							"id": "19ed5cc9-7d11-4c6b-9717-a6c52d1e6e31",
 							"text": "Defending Against Attacks from the Side",
-							"reference": "B390"
+							"reference": "BX390"
 						},
 						{
 							"type": "note",
 							"id": "f09254e4-a395-48d8-9886-f224ecd466f6",
 							"text": "Defending Against Attacks from the Back",
-							"reference": "B391"
+							"reference": "BX391"
 						},
 						{
 							"type": "note",
 							"id": "5366a0c7-07c7-4a49-b3d5-3cddd0709c87",
 							"text": "Retreating",
-							"reference": "B391"
+							"reference": "BX391"
 						},
 						{
 							"type": "note",
 							"id": "b8757ef3-9df9-4002-8fc6-8b3ed4bbe5fa",
 							"text": "Sidebar: Runaround Attacks",
-							"reference": "B391"
+							"reference": "BX391"
 						}
 					]
 				},
@@ -1069,56 +1069,56 @@
 					"type": "note_container",
 					"id": "521eb491-7e06-4b77-82cb-78b366fb78c0",
 					"text": "Close Combat",
-					"reference": "B391",
+					"reference": "BX391",
 					"open": true,
 					"children": [
 						{
 							"type": "note",
 							"id": "028bb629-c070-4371-8ba6-dfbab3d8f531",
 							"text": "Entering a Foe's Hex",
-							"reference": "B391"
+							"reference": "BX391"
 						},
 						{
 							"type": "note",
 							"id": "d7d6caae-3174-435f-9432-22b5b68da7da",
 							"text": "Leaving a Foe's Hex",
-							"reference": "B391"
+							"reference": "BX391"
 						},
 						{
 							"type": "note",
 							"id": "7c6a5d0b-f33c-4095-a64e-06cfddefb791",
 							"text": "Readying in Close Combat",
-							"reference": "B391"
+							"reference": "BX391"
 						},
 						{
 							"type": "note",
 							"id": "64e0df40-d412-4225-a8cd-0c82c19891af",
 							"text": "Weapons for Close Combat",
-							"reference": "B391"
+							"reference": "BX391"
 						},
 						{
 							"type": "note",
 							"id": "f9434161-e1ca-45c7-bd94-b426d692c720",
 							"text": "Defence in Close Combat",
-							"reference": "B392"
+							"reference": "BX392"
 						},
 						{
 							"type": "note",
 							"id": "80932291-5900-42fa-9a56-e1729005334e",
 							"text": "Multiple Close Combat",
-							"reference": "B392"
+							"reference": "BX392"
 						},
 						{
 							"type": "note",
 							"id": "95fa2543-7694-4254-aeb6-88be177da578",
 							"text": "Shields in Close Combat",
-							"reference": "B392"
+							"reference": "BX392"
 						},
 						{
 							"type": "note",
 							"id": "be0aef6f-5ea2-4d2a-9000-d402a98d80de",
 							"text": "Sidebar: Striking into a Close Combat",
-							"reference": "B392"
+							"reference": "BX392"
 						}
 					]
 				},
@@ -1126,28 +1126,28 @@
 					"type": "note_container",
 					"id": "c16dfc48-9afa-4f77-b4ee-2fd60a5dec0f",
 					"text": "Multi-Hex Figures",
-					"reference": "B392",
+					"reference": "BX392",
 					"open": true,
 					"children": [
 						{
 							"type": "note",
 							"id": "4618dff0-e9b3-48b2-9825-5f18519d681d",
 							"text": "Arc of Vision",
-							"reference": "B392",
+							"reference": "BX392",
 							"notes": "Multihex Figures"
 						},
 						{
 							"type": "note",
 							"id": "9ef5348e-413c-4063-9730-78f136caa058",
 							"text": "Front, Side and Back Hexes",
-							"reference": "B392",
+							"reference": "BX392",
 							"notes": "Multihex Figures"
 						},
 						{
 							"type": "note",
 							"id": "dbc0cbd4-28d6-4409-8924-ab4b440183e1",
 							"text": "Slam and Overrun",
-							"reference": "B392",
+							"reference": "BX392",
 							"notes": "Multi-Hex Figures"
 						}
 					]
@@ -1158,39 +1158,39 @@
 			"type": "note_container",
 			"id": "9c2d5d0e-b58a-4ddb-a7cc-bd8e0a1d9d62",
 			"text": "Special Combat Situations",
-			"reference": "B393",
+			"reference": "BX393",
 			"open": true,
 			"children": [
 				{
 					"type": "note",
 					"id": "72aacbbf-1bd1-4308-82f5-7060f36d7dc3",
 					"text": "Surprise Attacks and Initiative",
-					"reference": "B393"
+					"reference": "BX393"
 				},
 				{
 					"type": "note_container",
 					"id": "8865b51f-883f-40b2-bd51-7136f77fc65b",
 					"text": "Special Movement",
-					"reference": "B394",
+					"reference": "BX394",
 					"open": true,
 					"children": [
 						{
 							"type": "note",
 							"id": "912382b9-07e8-4e32-95ea-fd283196ed6e",
 							"text": "High Speed Movement",
-							"reference": "B394"
+							"reference": "BX394"
 						},
 						{
 							"type": "note",
 							"id": "f337392c-a38f-4ea1-8707-b2d8fd443352",
 							"text": "Mounted Combat",
-							"reference": "B396"
+							"reference": "BX396"
 						},
 						{
 							"type": "note",
 							"id": "de969ed8-c250-41e6-85c9-aca43feaec8e",
 							"text": "Flying Combat",
-							"reference": "B398"
+							"reference": "BX398"
 						}
 					]
 				},
@@ -1198,105 +1198,105 @@
 					"type": "note",
 					"id": "e20b7806-4f77-49bf-a883-de5cd0f59a84",
 					"text": "Torches and Flashlights",
-					"reference": "B394"
+					"reference": "BX394"
 				},
 				{
 					"type": "note",
 					"id": "c93713a0-2e47-4f09-9b13-f3ef86607cd3",
 					"text": "Visibility",
-					"reference": "B394"
+					"reference": "BX394"
 				},
 				{
 					"type": "note",
 					"id": "5de89100-2451-4a43-aedc-a9820b836759",
 					"text": "Hit Location",
-					"reference": "B398"
+					"reference": "BX398"
 				},
 				{
 					"type": "note",
 					"id": "3aec5f7e-26be-4bd9-8a30-79742b56ab95",
 					"text": "Large-Area Injury",
-					"reference": "B400"
+					"reference": "BX400"
 				},
 				{
 					"type": "note",
 					"id": "2733bc91-e558-465b-b3c2-b8ddb4472da4",
 					"text": "Striking at Weapons",
-					"reference": "B400"
+					"reference": "BX400"
 				},
 				{
 					"type": "note_container",
 					"id": "c9a0c729-d03d-4467-b082-5ea592ca7db2",
 					"text": "Special Melee Combat Rules",
-					"reference": "B402",
+					"reference": "BX402",
 					"open": true,
 					"children": [
 						{
 							"type": "note",
 							"id": "e57a49f2-e60d-4dfa-96b7-828067a6639a",
 							"text": "Attacking From Above",
-							"reference": "B402"
+							"reference": "BX402"
 						},
 						{
 							"type": "note",
 							"id": "2fa41b4a-482f-47be-8305-eac0ee833144",
 							"text": "Combat at Different Levels",
-							"reference": "B402"
+							"reference": "BX402"
 						},
 						{
 							"type": "note_container",
 							"id": "930acd46-9ac9-49a9-9d83-58ee092631e3",
 							"text": "Special Unarmed Combat Techniques",
-							"reference": "B403",
+							"reference": "BX403",
 							"open": true,
 							"children": [
 								{
 									"type": "note",
 									"id": "64f20d34-766f-4195-a8b1-2b7472bcb591",
 									"text": "Arm Lock",
-									"reference": "B403"
+									"reference": "BX403"
 								},
 								{
 									"type": "note",
 									"id": "021524ca-35fe-4958-bc9b-df03369a8e76",
 									"text": "Choke Hold",
-									"reference": "B404"
+									"reference": "BX404"
 								},
 								{
 									"type": "note",
 									"id": "c984d9e4-cbfc-45bb-b0d1-cde4bd1e5dbf",
 									"text": "Elbow Strike",
-									"reference": "B404"
+									"reference": "BX404"
 								},
 								{
 									"type": "note",
 									"id": "03372fc0-406d-482b-97d1-da5e398bfa4c",
 									"text": "Knee Strike",
-									"reference": "B404"
+									"reference": "BX404"
 								},
 								{
 									"type": "note",
 									"id": "dc34cc1f-150e-429b-99e9-2aa15ba0e317",
 									"text": "Lethal Strike",
-									"reference": "B404"
+									"reference": "BX404"
 								},
 								{
 									"type": "note",
 									"id": "5e86de8a-f48b-4b1c-b52f-0fe7fd12ec07",
 									"text": "Neck Snap or Wrench Limb",
-									"reference": "B404"
+									"reference": "BX404"
 								},
 								{
 									"type": "note",
 									"id": "765296f9-6835-4d84-a8b8-5aea24f9fd82",
 									"text": "Sidebar: Improvised Weapons",
-									"reference": "B404"
+									"reference": "BX404"
 								},
 								{
 									"type": "note",
 									"id": "af1633a7-94bb-43b3-bcf6-22c74a34dade",
 									"text": "Trampling",
-									"reference": "B404"
+									"reference": "BX404"
 								}
 							]
 						},
@@ -1304,50 +1304,50 @@
 							"type": "note_container",
 							"id": "e0e64e07-3cc0-4d80-8365-a4f4c7b27fb1",
 							"text": "Special Melee Weapon Rules",
-							"reference": "B404",
+							"reference": "BX404",
 							"open": true,
 							"children": [
 								{
 									"type": "note",
 									"id": "6d2c7e20-1902-43ce-86f1-0d1e0b7f0f56",
 									"text": "Cloaks",
-									"reference": "B404"
+									"reference": "BX404"
 								},
 								{
 									"type": "note",
 									"id": "3b2cfec2-4ff3-458d-945c-5aca67ebbdad",
 									"text": "Fencing Weapons",
-									"reference": "B404"
+									"reference": "BX404"
 								},
 								{
 									"type": "note",
 									"id": "40a04b98-0cc1-4176-88f3-a9302cecb42b",
 									"text": "Flails",
-									"reference": "B405"
+									"reference": "BX405"
 								},
 								{
 									"type": "note",
 									"id": "90078097-32de-4e2b-9d09-7db11edc676c",
 									"text": "Garrotes",
-									"reference": "B405"
+									"reference": "BX405"
 								},
 								{
 									"type": "note",
 									"id": "6c72dbfa-fc51-40ee-9165-b4202633f514",
 									"text": "Picks",
-									"reference": "B405"
+									"reference": "BX405"
 								},
 								{
 									"type": "note",
 									"id": "28500b53-cd3f-4ed1-a9f1-b19d3f9aa030",
 									"text": "Shields",
-									"reference": "B406"
+									"reference": "BX406"
 								},
 								{
 									"type": "note",
 									"id": "7041dbb4-f7f9-4546-98b5-e4047e961401",
 									"text": "Whips",
-									"reference": "B406"
+									"reference": "BX406"
 								}
 							]
 						},
@@ -1355,7 +1355,7 @@
 							"type": "note",
 							"id": "9f897a7c-00c8-4b91-9cc8-f01d21b3eeb0",
 							"text": "Sidebar: Dirty Tricks",
-							"reference": "B405"
+							"reference": "BX405"
 						}
 					]
 				},
@@ -1363,69 +1363,69 @@
 					"type": "note_container",
 					"id": "60c75ad6-ca02-4724-ac46-f7b46ffb34f6",
 					"text": "Special Ranged Combat Rules",
-					"reference": "B407",
+					"reference": "BX407",
 					"open": true,
 					"children": [
 						{
 							"type": "note",
 							"id": "9eb34246-7eec-4101-9b2f-93532baa7664",
 							"text": "Cover",
-							"reference": "B407"
+							"reference": "BX407"
 						},
 						{
 							"type": "note",
 							"id": "a39f17e8-8fc4-4c48-a09d-f073119545a4",
 							"text": "Firing Upward and Downward",
-							"reference": "B407"
+							"reference": "BX407"
 						},
 						{
 							"type": "note",
 							"id": "7e0df4af-7b3a-4e5b-81ce-718c2aa09af8",
 							"text": "Malfunctions",
-							"reference": "B407"
+							"reference": "BX407"
 						},
 						{
 							"type": "note",
 							"id": "31be67b5-1485-42c0-bf9d-92a28999391c",
 							"text": "Overpenetration",
-							"reference": "B408"
+							"reference": "BX408"
 						},
 						{
 							"type": "note_container",
 							"id": "66c4747f-22c2-4b2b-bfca-153838ccecb7",
 							"text": "Special Rules for Rapid Fire",
-							"reference": "B408",
+							"reference": "BX408",
 							"open": true,
 							"children": [
 								{
 									"type": "note",
 									"id": "0c8cf8e4-cfe2-44a7-be70-4c9ea567be04",
 									"text": "Automatic Weapons and Full-Auto Only",
-									"reference": "B408"
+									"reference": "BX408"
 								},
 								{
 									"type": "note",
 									"id": "b3ea97b2-7941-4cf5-b7e9-35697894e453",
 									"text": "Rapid Fire vs Close Stationary Targets",
-									"reference": "B408"
+									"reference": "BX408"
 								},
 								{
 									"type": "note",
 									"id": "7d1ab18f-5a39-4959-b90f-d500388f41b1",
 									"text": "Shotguns and Multiple Projectiles",
-									"reference": "B409"
+									"reference": "BX409"
 								},
 								{
 									"type": "note",
 									"id": "635d9dde-c05a-4082-9eb4-3c92158eb4e7",
 									"text": "Spraying Fire",
-									"reference": "B409"
+									"reference": "BX409"
 								},
 								{
 									"type": "note",
 									"id": "ada0cf7d-7732-4a07-a064-5e61935ac13e",
 									"text": "Suppression Fire",
-									"reference": "B409"
+									"reference": "BX409"
 								}
 							]
 						},
@@ -1433,56 +1433,56 @@
 							"type": "note_container",
 							"id": "578fc477-9ac5-4869-8427-c86bc58e8939",
 							"text": "Special Ranged Weapons",
-							"reference": "B410",
+							"reference": "BX410",
 							"open": true,
 							"children": [
 								{
 									"type": "note",
 									"id": "747d8555-30b5-4570-9cfd-4512dcb0914b",
 									"text": "Bolas",
-									"reference": "B410"
+									"reference": "BX410"
 								},
 								{
 									"type": "note",
 									"id": "cd9e8ae5-9529-47bf-a57c-ec2d15fd7fd6",
 									"text": "Crossbows",
-									"reference": "B410"
+									"reference": "BX410"
 								},
 								{
 									"type": "note",
 									"id": "8eb77d82-e751-44d5-87c8-aecf446f5db3",
 									"text": "Flaming Arrows",
-									"reference": "B410"
+									"reference": "BX410"
 								},
 								{
 									"type": "note",
 									"id": "c7944b05-d4ec-491b-8b89-e676f0bbb406",
 									"text": "Hand Grenades",
-									"reference": "B410"
+									"reference": "BX410"
 								},
 								{
 									"type": "note",
 									"id": "260bbad8-a361-4d31-b2c1-bc48f9d202a4",
 									"text": "Harpoons",
-									"reference": "B411"
+									"reference": "BX411"
 								},
 								{
 									"type": "note",
 									"id": "fbcb4f9c-fe08-470a-8fe9-9344a4534cb4",
 									"text": "Lariats",
-									"reference": "B411"
+									"reference": "BX411"
 								},
 								{
 									"type": "note",
 									"id": "ede7418b-7754-4032-a431-51e4bee62f2b",
 									"text": "Molotov Coctails and Oil Flasks",
-									"reference": "B411"
+									"reference": "BX411"
 								},
 								{
 									"type": "note",
 									"id": "2abcc2b4-1cd8-4a5f-add9-766724672c75",
 									"text": "Nets",
-									"reference": "B411"
+									"reference": "BX411"
 								}
 							]
 						},
@@ -1490,32 +1490,32 @@
 							"type": "note_container",
 							"id": "bc88a648-425d-498b-822f-b6832b5bb30d",
 							"text": "Firearm Accessories",
-							"reference": "B412",
+							"reference": "BX412",
 							"open": true,
 							"children": [
 								{
 									"type": "note",
 									"id": "62ae84c5-8862-4edd-9b34-11d094e6a154",
 									"text": "Bipods and Tripods",
-									"reference": "B412"
+									"reference": "BX412"
 								},
 								{
 									"type": "note",
 									"id": "ecdd9418-22ea-4068-bd01-ab6516d11eae",
 									"text": "Laser Sights",
-									"reference": "B412"
+									"reference": "BX412"
 								},
 								{
 									"type": "note",
 									"id": "d9b99feb-cc41-4920-baab-54d8605ed36f",
 									"text": "Scopes",
-									"reference": "B412"
+									"reference": "BX412"
 								},
 								{
 									"type": "note",
 									"id": "2b964e54-c3f8-467d-9bde-80bb71253a71",
 									"text": "Silencers",
-									"reference": "B412"
+									"reference": "BX412"
 								}
 							]
 						},
@@ -1523,32 +1523,32 @@
 							"type": "note_container",
 							"id": "92dca3a6-f376-457c-8f13-c13a5b647b67",
 							"text": "Guided and Homing Weapons",
-							"reference": "B412",
+							"reference": "BX412",
 							"open": true,
 							"children": [
 								{
 									"type": "note",
 									"id": "b16316ad-dc1f-45e5-ae74-e3b8ca1919a1",
 									"text": "Guided Weapons",
-									"reference": "B412"
+									"reference": "BX412"
 								},
 								{
 									"type": "note",
 									"id": "628d04f7-b691-4fb5-b5af-2ceb4a6403a9",
 									"text": "Sidebar: Semi-Active Homing Weapons",
-									"reference": "B412"
+									"reference": "BX412"
 								},
 								{
 									"type": "note",
 									"id": "f125346a-0e3f-4e78-9110-a90fa64ac95b",
 									"text": "Homing Weapons",
-									"reference": "B413"
+									"reference": "BX413"
 								},
 								{
 									"type": "note",
 									"id": "705d40dd-7008-444c-89e7-44328099b9c2",
 									"text": "Time to Target",
-									"reference": "B413"
+									"reference": "BX413"
 								}
 							]
 						},
@@ -1556,32 +1556,32 @@
 							"type": "note_container",
 							"id": "bd67f3e8-1f42-4631-a77f-ad92b82993f2",
 							"text": "Area and Spreading Attacks",
-							"reference": "B413",
+							"reference": "BX413",
 							"open": true,
 							"children": [
 								{
 									"type": "note",
 									"id": "3b02b52f-6ce6-4d12-ae04-9a056debb230",
 									"text": "Area-Effect Attacks",
-									"reference": "B413"
+									"reference": "BX413"
 								},
 								{
 									"type": "note",
 									"id": "58ff7e83-3916-4901-9de2-5f83f22b9083",
 									"text": "Cone Attacks",
-									"reference": "B413"
+									"reference": "BX413"
 								},
 								{
 									"type": "note",
 									"id": "a7990977-0887-4a94-b2c9-2dc86eb34b71",
 									"text": "Dissipation",
-									"reference": "B413"
+									"reference": "BX413"
 								},
 								{
 									"type": "note",
 									"id": "35ba2c0b-dbe0-438a-af84-7dcc76e48bb4",
 									"text": "Sidebar: Attacking an Area/Scatter",
-									"reference": "B414"
+									"reference": "BX414"
 								}
 							]
 						},
@@ -1589,32 +1589,32 @@
 							"type": "note_container",
 							"id": "6f78abb7-c8ca-4d8c-8cb2-6d976bae74e3",
 							"text": "Explosions",
-							"reference": "B414",
+							"reference": "BX414",
 							"open": true,
 							"children": [
 								{
 									"type": "note",
 									"id": "be3988f8-32f3-45f6-91f9-282eb160cd9d",
 									"text": "Fragmentation Damage",
-									"reference": "B414"
+									"reference": "BX414"
 								},
 								{
 									"type": "note",
 									"id": "930e719a-fd20-48ad-abc3-ef2c0ef2a712",
 									"text": "Demolition",
-									"reference": "B415"
+									"reference": "BX415"
 								},
 								{
 									"type": "note",
 									"id": "a5c6d455-ad9a-4a34-8876-6790fff95db7",
 									"text": "Sidebar: Explosions in Other Environments",
-									"reference": "B415"
+									"reference": "BX415"
 								},
 								{
 									"type": "note",
 									"id": "d5ff6a2a-51f7-44fa-a674-aa0a0c794ec2",
 									"text": "Table: Relative Explosive Force",
-									"reference": "B415"
+									"reference": "BX415"
 								}
 							]
 						},
@@ -1622,45 +1622,45 @@
 							"type": "note_container",
 							"id": "dee55d10-6273-45f4-95f9-09434e06c976",
 							"text": "Special Damage",
-							"reference": "B416",
+							"reference": "BX416",
 							"open": true,
 							"children": [
 								{
 									"type": "note",
 									"id": "a6359fc4-3f2a-4db7-b432-504f91071523",
 									"text": "Afflictions",
-									"reference": "B416"
+									"reference": "BX416"
 								},
 								{
 									"type": "note_container",
 									"id": "687c3fc3-3804-46c2-8897-5c1ae9c61894",
 									"text": "Special Penetration Modifiers",
-									"reference": "B416",
+									"reference": "BX416",
 									"open": true,
 									"children": [
 										{
 											"type": "note",
 											"id": "88a84d22-4321-4878-9c2a-3311337157ea",
 											"text": "Blood Agent",
-											"reference": "B416"
+											"reference": "BX416"
 										},
 										{
 											"type": "note",
 											"id": "78f0c5de-c05a-4e93-a092-dd4200745c96",
 											"text": "Contact Agent",
-											"reference": "B416"
+											"reference": "BX416"
 										},
 										{
 											"type": "note",
 											"id": "115f0464-93ed-453a-a1e6-982c7e721a27",
 											"text": "Respiratory Agent",
-											"reference": "B416"
+											"reference": "BX416"
 										},
 										{
 											"type": "note",
 											"id": "2814b33a-16cb-451e-aa26-313c418e9850",
 											"text": "Sense-based",
-											"reference": "B416"
+											"reference": "BX416"
 										}
 									]
 								}
@@ -1670,62 +1670,62 @@
 							"type": "note_container",
 							"id": "38c206cb-9b0c-4605-b685-2c266bf39472",
 							"text": "Cinematic Combat Rules",
-							"reference": "B417",
+							"reference": "BX417",
 							"open": true,
 							"children": [
 								{
 									"type": "note",
 									"id": "ec860b86-c293-48fa-8b69-700410f64b12",
 									"text": "Bulletproof Nudity",
-									"reference": "B417"
+									"reference": "BX417"
 								},
 								{
 									"type": "note",
 									"id": "38e38b44-4604-4c1b-a1e3-04eacb4603aa",
 									"text": "Cannon Fodder",
-									"reference": "B417"
+									"reference": "BX417"
 								},
 								{
 									"type": "note",
 									"id": "81b49446-123b-4dae-8538-c972e69031e8",
 									"text": "Cinematic Explosions",
-									"reference": "B417"
+									"reference": "BX417"
 								},
 								{
 									"type": "note",
 									"id": "00383dac-086c-4cce-acf9-f1611cfbe228",
 									"text": "Cinematic Knockback",
-									"reference": "B417"
+									"reference": "BX417"
 								},
 								{
 									"type": "note",
 									"id": "37adfe2f-c242-4036-b1cd-37970aa4d9c1",
 									"text": "Flesh Wounds",
-									"reference": "B417"
+									"reference": "BX417"
 								},
 								{
 									"type": "note",
 									"id": "5ebba986-c9e3-4553-8448-7ffc55c8221e",
 									"text": "Infinite Ammunition",
-									"reference": "B417"
+									"reference": "BX417"
 								},
 								{
 									"type": "note",
 									"id": "d38c7e0a-7986-47c6-bc94-980bb8d13f94",
 									"text": "Melee Etiquette",
-									"reference": "B417"
+									"reference": "BX417"
 								},
 								{
 									"type": "note",
 									"id": "10706387-a10f-4b27-a701-042ea17c46d1",
 									"text": "Sidebar: Dual Weapon Attacks",
-									"reference": "B417"
+									"reference": "BX417"
 								},
 								{
 									"type": "note",
 									"id": "6481fe3c-3e03-42bd-80c8-1ec29fa88fe1",
 									"text": "TV Action Violence",
-									"reference": "B417"
+									"reference": "BX417"
 								}
 							]
 						}
@@ -1737,39 +1737,39 @@
 			"type": "note_container",
 			"id": "43977527-9d6d-4c41-a227-fb46f7104952",
 			"text": "Injuries, Illness and Fatigue",
-			"reference": "B418",
+			"reference": "BX418",
 			"open": true,
 			"children": [
 				{
 					"type": "note_container",
 					"id": "4bb3420f-dfd9-4896-8239-928e93c0c7cf",
 					"text": "Crippling Injury",
-					"reference": "B420",
+					"reference": "BX420",
 					"open": true,
 					"children": [
 						{
 							"type": "note",
 							"id": "2f342e20-a5cc-4565-bb27-f15ca28551fa",
 							"text": "Crippling Extra Limbs",
-							"reference": "B421"
+							"reference": "BX421"
 						},
 						{
 							"type": "note",
 							"id": "72286d2a-e4f4-46cc-9c1c-e328495434e7",
 							"text": "Effects of Crippling Injury",
-							"reference": "B421"
+							"reference": "BX421"
 						},
 						{
 							"type": "note",
 							"id": "5b9f5672-839e-4255-93f7-21f70e78d90d",
 							"text": "Duration of Crippling Injuries",
-							"reference": "B422"
+							"reference": "BX422"
 						},
 						{
 							"type": "note",
 							"id": "86dae62d-1266-4867-9c7b-055e10cd5ca1",
 							"text": "Nonhuman Body Parts",
-							"reference": "B422"
+							"reference": "BX422"
 						}
 					]
 				},
@@ -1777,38 +1777,38 @@
 					"type": "note",
 					"id": "fb4e86c5-c757-4a6b-bb35-585b608b5366",
 					"text": "Knockdown and Stunning",
-					"reference": "B420"
+					"reference": "BX420"
 				},
 				{
 					"type": "note",
 					"id": "225e457c-7d25-4af6-a4f2-45f1c47d3d23",
 					"text": "Major Wounds",
-					"reference": "B420"
+					"reference": "BX420"
 				},
 				{
 					"type": "note_container",
 					"id": "0105e1af-e4e0-4cc3-b8e0-37b8f683e203",
 					"text": "Sidebar: Optional Rules for Injury",
-					"reference": "B420",
+					"reference": "BX420",
 					"open": true,
 					"children": [
 						{
 							"type": "note",
 							"id": "685339bc-e6c2-46f2-9422-c27edeb78a41",
 							"text": "Sidebar: Accumulated Wounds",
-							"reference": "B420"
+							"reference": "BX420"
 						},
 						{
 							"type": "note",
 							"id": "7ad95b7b-b75a-43da-ab3d-0f303d2c3450",
 							"text": "Sidebar: Bleeding",
-							"reference": "B420"
+							"reference": "BX420"
 						},
 						{
 							"type": "note",
 							"id": "d437e737-0238-486c-969d-b42eeb5f76be",
 							"text": "Sidebar: Last Wounds",
-							"reference": "B420"
+							"reference": "BX420"
 						}
 					]
 				},
@@ -1816,32 +1816,32 @@
 					"type": "note",
 					"id": "317bb483-fd00-44b6-9b36-07cf39c1277b",
 					"text": "Sidebar: Patient Status",
-					"reference": "B421"
+					"reference": "BX421"
 				},
 				{
 					"type": "note",
 					"id": "0d9370f2-389b-4b86-b461-7c9d99c71dfd",
 					"text": "Sidebar: Temporary Attribute Penalties",
-					"reference": "B421"
+					"reference": "BX421"
 				},
 				{
 					"type": "note_container",
 					"id": "ec4c0517-a0b6-466b-968e-1886f0d7f6af",
 					"text": "Death",
-					"reference": "B423",
+					"reference": "BX423",
 					"open": true,
 					"children": [
 						{
 							"type": "note",
 							"id": "20a53375-c3e8-4184-b0b1-db6f3938c136",
 							"text": "Dying Actions",
-							"reference": "B423"
+							"reference": "BX423"
 						},
 						{
 							"type": "note",
 							"id": "12a4470a-f0cd-46c9-9d4d-20ead0cace2d",
 							"text": "Instant Death",
-							"reference": "B423"
+							"reference": "BX423"
 						}
 					]
 				},
@@ -1849,80 +1849,80 @@
 					"type": "note",
 					"id": "78221f12-37b0-4e6c-b611-a4bbd852cfe5",
 					"text": "Mortal Wounds",
-					"reference": "B423"
+					"reference": "BX423"
 				},
 				{
 					"type": "note_container",
 					"id": "96429fee-2155-473a-9d13-48f88d6d7613",
 					"text": "Recovery",
-					"reference": "B423",
+					"reference": "BX423",
 					"open": true,
 					"children": [
 						{
 							"type": "note",
 							"id": "52ee0250-39e2-4310-8b2b-abccb8b279ba",
 							"text": "Recovering from Unconsciousness",
-							"reference": "B423"
+							"reference": "BX423"
 						},
 						{
 							"type": "note",
 							"id": "3d31375a-7e03-4b2b-bffd-61202faab89a",
 							"text": "First Aid/Surgery/Medical Care",
-							"reference": "B424"
+							"reference": "BX424"
 						},
 						{
 							"type": "note",
 							"id": "5eaf80c9-9cd1-4232-a77e-9c6a2ccdf6b4",
 							"text": "Medical Care",
-							"reference": "B424"
+							"reference": "BX424"
 						},
 						{
 							"type": "note",
 							"id": "da478b3a-f4f5-44e1-8203-5f2f0ec26112",
 							"text": "Natural Recovery",
-							"reference": "B424"
+							"reference": "BX424"
 						},
 						{
 							"type": "note",
 							"id": "1118dc35-2066-4522-91be-c812ef459836",
 							"text": "Repairing Lasting Crippling Injuries",
-							"reference": "B424"
+							"reference": "BX424"
 						},
 						{
 							"type": "note",
 							"id": "1659e6ce-4647-41ea-af2a-6a2a84a02466",
 							"text": "Repairing Permanent Crippling Injuries",
-							"reference": "B424"
+							"reference": "BX424"
 						},
 						{
 							"type": "note",
 							"id": "3fa4e5fd-4860-4257-84bc-c7aaa006db51",
 							"text": "Sidebar: High HP and Healing",
-							"reference": "B424"
+							"reference": "BX424"
 						},
 						{
 							"type": "note",
 							"id": "b95ea1d9-4546-41e6-a8f5-8edcb29734f4",
 							"text": "Stabilizing a Mortal Wound",
-							"reference": "B424"
+							"reference": "BX424"
 						},
 						{
 							"type": "note",
 							"id": "2d3e088b-ade9-467d-9fd3-a7fee37345e6",
 							"text": "Resuscitation",
-							"reference": "B425"
+							"reference": "BX425"
 						},
 						{
 							"type": "note",
 							"id": "5bdc1ebf-38ff-4e8a-b6e5-1091bd01fc2b",
 							"text": "Sidebar: Ultratech Drugs",
-							"reference": "B425"
+							"reference": "BX425"
 						},
 						{
 							"type": "note",
 							"id": "486e73d5-3556-4cc7-af6c-612f48d14225",
 							"text": "Table: Medical Help",
-							"reference": "B425"
+							"reference": "BX425"
 						}
 					]
 				},
@@ -1930,50 +1930,50 @@
 					"type": "note_container",
 					"id": "1059deb6-1107-4bff-89de-d9dffd5127bf",
 					"text": "Fatigue",
-					"reference": "B426",
+					"reference": "BX426",
 					"open": true,
 					"children": [
 						{
 							"type": "note",
 							"id": "b2b64665-3060-4ab3-8db9-fae28871a4d3",
 							"text": "Fatigue Costs",
-							"reference": "B426"
+							"reference": "BX426"
 						},
 						{
 							"type": "note",
 							"id": "9428ce38-9536-43b9-9289-be8b94c17c69",
 							"text": "Lost Fatigue Points",
-							"reference": "B426"
+							"reference": "BX426"
 						},
 						{
 							"type": "note",
 							"id": "be3668ad-f338-4d88-ab61-b60f3bad973e",
 							"text": "Starvation, Dehydration, and Missed Sleep",
-							"reference": "B426"
+							"reference": "BX426"
 						},
 						{
 							"type": "note",
 							"id": "58e2a8cd-4e60-4802-9e09-20430c63734f",
 							"text": "Getting Up Early",
-							"reference": "B427"
+							"reference": "BX427"
 						},
 						{
 							"type": "note",
 							"id": "fbd4fa35-15c2-4574-af55-ff4ab00f41bd",
 							"text": "Recovering from Fatigue",
-							"reference": "B427"
+							"reference": "BX427"
 						},
 						{
 							"type": "note",
 							"id": "875f84dc-5acc-4336-a79d-47ebb8c6542f",
 							"text": "Sidebar: Foraging",
-							"reference": "B427"
+							"reference": "BX427"
 						},
 						{
 							"type": "note",
 							"id": "fea7aa72-4712-4508-a195-8524dd30ed57",
 							"text": "Staying Up Late",
-							"reference": "B427"
+							"reference": "BX427"
 						}
 					]
 				},
@@ -1981,70 +1981,70 @@
 					"type": "note_container",
 					"id": "36a76205-3574-47b2-b238-cb944b84bdee",
 					"text": "Hazards",
-					"reference": "B428",
+					"reference": "BX428",
 					"open": true,
 					"children": [
 						{
 							"type": "note",
 							"id": "3833902b-bfa7-4871-a050-8bf43f436fc7",
 							"text": "Acid",
-							"reference": "B428"
+							"reference": "BX428"
 						},
 						{
 							"type": "note_container",
 							"id": "2ee4da93-e0e6-40dc-85d3-712a480586f3",
 							"text": "Afflictions",
-							"reference": "B428",
+							"reference": "BX428",
 							"open": true,
 							"children": [
 								{
 									"type": "note_container",
 									"id": "4f596180-55e7-47f0-8270-84cb725cd517",
 									"text": "Incapacitating Conditions",
-									"reference": "B428",
+									"reference": "BX428",
 									"open": true,
 									"children": [
 										{
 											"type": "note",
 											"id": "f626d1c9-f90d-4223-99f8-d7b7e4e2660d",
 											"text": "Agony",
-											"reference": "B428"
+											"reference": "BX428"
 										},
 										{
 											"type": "note",
 											"id": "eebfa0ac-930d-4bbb-8335-5d1849e7be49",
 											"text": "Choking",
-											"reference": "B428"
+											"reference": "BX428"
 										},
 										{
 											"type": "note",
 											"id": "d61501e3-00f8-43ef-afc3-989436653528",
 											"text": "Daze",
-											"reference": "B428"
+											"reference": "BX428"
 										},
 										{
 											"type": "note",
 											"id": "73c1b91f-66c7-4754-b378-24e88bb1b74f",
 											"text": "Ecstasy",
-											"reference": "B428"
+											"reference": "BX428"
 										},
 										{
 											"type": "note",
 											"id": "c4fcbb47-f1f0-41d2-bdaa-11bbca6c8006",
 											"text": "Hallucinating",
-											"reference": "B429"
+											"reference": "BX429"
 										},
 										{
 											"type": "note",
 											"id": "69249a98-a18e-4c0d-bde6-a4cd612ecbdb",
 											"text": "Paralysis",
-											"reference": "B429"
+											"reference": "BX429"
 										},
 										{
 											"type": "note",
 											"id": "a76b9f97-e9a7-4d90-8069-5fa818cc1b55",
 											"text": "Retching",
-											"reference": "B429",
+											"reference": "BX429",
 											"features": [
 												{
 													"type": "attribute_bonus",
@@ -2068,13 +2068,13 @@
 											"type": "note",
 											"id": "d54088ec-c0d0-41f9-934b-4474b3c7db2c",
 											"text": "Seizure",
-											"reference": "B429"
+											"reference": "BX429"
 										},
 										{
 											"type": "note",
 											"id": "bc78c31d-d393-46c9-8ed8-15f3eb89f5c0",
 											"text": "Unconsciousness",
-											"reference": "B429"
+											"reference": "BX429"
 										}
 									]
 								},
@@ -2082,14 +2082,14 @@
 									"type": "note_container",
 									"id": "ba8ca8b8-ec60-4a69-9f33-ff870ac6a837",
 									"text": "Irritating Conditions",
-									"reference": "B428",
+									"reference": "BX428",
 									"open": true,
 									"children": [
 										{
 											"type": "note",
 											"id": "3ed390cb-e5f1-443c-97db-144db84dcbc9",
 											"text": "Coughing or Sneezing",
-											"reference": "B428",
+											"reference": "BX428",
 											"features": [
 												{
 													"type": "attribute_bonus",
@@ -2108,7 +2108,7 @@
 											"type": "note",
 											"id": "21bed2ce-4f7a-40a5-8935-784bf1793432",
 											"text": "Drowsy",
-											"reference": "B428",
+											"reference": "BX428",
 											"features": [
 												{
 													"type": "attribute_bonus",
@@ -2127,7 +2127,7 @@
 											"type": "note",
 											"id": "1c1e6ada-362b-440f-88b5-2fdd1d7271d7",
 											"text": "Drunk",
-											"reference": "B428",
+											"reference": "BX428",
 											"features": [
 												{
 													"type": "attribute_bonus",
@@ -2146,7 +2146,7 @@
 											"type": "note",
 											"id": "cb34026e-cdfa-4276-b70c-ca9b18594093",
 											"text": "Euphoria",
-											"reference": "B428",
+											"reference": "BX428",
 											"features": [
 												{
 													"type": "attribute_bonus",
@@ -2173,7 +2173,7 @@
 											"type": "note",
 											"id": "545c977e-bda7-488c-9344-2f9eb32e9463",
 											"text": "Nauseated",
-											"reference": "B428",
+											"reference": "BX428",
 											"features": [
 												{
 													"type": "skill_bonus",
@@ -2224,14 +2224,14 @@
 											"type": "note",
 											"id": "7dd3833d-0988-4ec4-9bdc-aae3b380a979",
 											"text": "Pain",
-											"reference": "B428",
+											"reference": "BX428",
 											"notes": "self control rolls as per description"
 										},
 										{
 											"type": "note",
 											"id": "c5ab7136-aea7-4ede-a8fb-66f514f00799",
 											"text": "Tipsy",
-											"reference": "B428",
+											"reference": "BX428",
 											"features": [
 												{
 													"type": "attribute_bonus",
@@ -2252,20 +2252,20 @@
 									"type": "note_container",
 									"id": "cb2faa9b-9380-40a0-8911-74818b4ecddd",
 									"text": "Mortal Conditions",
-									"reference": "B428",
+									"reference": "BX428",
 									"open": true,
 									"children": [
 										{
 											"type": "note",
 											"id": "fb2a5c4d-5544-4c93-b398-be7bbb555fda",
 											"text": "Coma",
-											"reference": "B429"
+											"reference": "BX429"
 										},
 										{
 											"type": "note",
 											"id": "c8dcee9f-03c2-4c3c-93f6-822fb5d338a1",
 											"text": "Heart Attack",
-											"reference": "B429"
+											"reference": "BX429"
 										}
 									]
 								}
@@ -2275,80 +2275,80 @@
 							"type": "note",
 							"id": "64acc509-5f1f-47f6-bb7f-bbe42c7d793c",
 							"text": "Atmospheric Pressure",
-							"reference": "B429"
+							"reference": "BX429"
 						},
 						{
 							"type": "note",
 							"id": "e9c0e681-c279-47e5-8a3e-bc1d1bf680bb",
 							"text": "Sidebar: Hazardous Atmospheres",
-							"reference": "B429"
+							"reference": "BX429"
 						},
 						{
 							"type": "note",
 							"id": "10cf5bbf-21e1-449d-8858-e59eb0656c4b",
 							"text": "Cold",
-							"reference": "B430"
+							"reference": "BX430"
 						},
 						{
 							"type": "note_container",
 							"id": "9c793f5c-f049-4deb-9266-d85bc566d9a9",
 							"text": "Collisions and Falls",
-							"reference": "B430",
+							"reference": "BX430",
 							"open": true,
 							"children": [
 								{
 									"type": "note",
 									"id": "e4aef45b-bf07-48de-89cb-b85bd749b957",
 									"text": "Damage from Collisions",
-									"reference": "B430"
+									"reference": "BX430"
 								},
 								{
 									"type": "note",
 									"id": "6a489d55-d9e8-4842-b16c-6ef70fe635e7",
 									"text": "Damage from Falling Objects",
-									"reference": "B431"
+									"reference": "BX431"
 								},
 								{
 									"type": "note",
 									"id": "a74afb76-869d-40de-8d23-dd13dc228f58",
 									"text": "Falling",
-									"reference": "B431"
+									"reference": "BX431"
 								},
 								{
 									"type": "note",
 									"id": "baf079bf-cbc1-4b24-9473-15e73aea6e3f",
 									"text": "Immovable Objects",
-									"reference": "B431"
+									"reference": "BX431"
 								},
 								{
 									"type": "note",
 									"id": "30ec6525-2c4b-410a-b9b1-89ea305f2931",
 									"text": "Sidebar: Hit Location from a Fall",
-									"reference": "B431"
+									"reference": "BX431"
 								},
 								{
 									"type": "note",
 									"id": "eb7a49b0-ff36-424d-afb5-3c7d1c4e1cae",
 									"text": "Table: Falling Velocity",
-									"reference": "B431"
+									"reference": "BX431"
 								},
 								{
 									"type": "note",
 									"id": "4741aaee-d563-4faf-92dd-8743e252dfb3",
 									"text": "Collision Angle",
-									"reference": "B432"
+									"reference": "BX432"
 								},
 								{
 									"type": "note",
 									"id": "50fa1724-d5fa-4025-a91c-cc2ad522c634",
 									"text": "Overruns",
-									"reference": "B432"
+									"reference": "BX432"
 								},
 								{
 									"type": "note",
 									"id": "f3609855-d249-4bd8-a40f-1bced5a7fccc",
 									"text": "Whiplash and Collision",
-									"reference": "B432"
+									"reference": "BX432"
 								}
 							]
 						},
@@ -2356,20 +2356,20 @@
 							"type": "note_container",
 							"id": "1421544a-0cd5-44cb-8032-3c214c739918",
 							"text": "Electricity",
-							"reference": "B432",
+							"reference": "BX432",
 							"open": true,
 							"children": [
 								{
 									"type": "note",
 									"id": "77d53610-9413-4b10-a169-b64ed2edebfe",
 									"text": "Lethal Electrical Damage",
-									"reference": "B432"
+									"reference": "BX432"
 								},
 								{
 									"type": "note",
 									"id": "6f360be0-77b3-40b0-8d19-ec3f51c23b33",
 									"text": "Nonlethal Electrical Damage",
-									"reference": "B432"
+									"reference": "BX432"
 								}
 							]
 						},
@@ -2377,26 +2377,26 @@
 							"type": "note_container",
 							"id": "45a3f529-5ade-408f-ad1d-547dd6c564a2",
 							"text": "Flame",
-							"reference": "B433",
+							"reference": "BX433",
 							"open": true,
 							"children": [
 								{
 									"type": "note",
 									"id": "43851f9b-54b8-4fa0-8138-97278845bedf",
 									"text": "Catching Fire",
-									"reference": "B433"
+									"reference": "BX433"
 								},
 								{
 									"type": "note",
 									"id": "d0f03f56-34c7-479a-915a-7375c33f07c7",
 									"text": "Fire Sources",
-									"reference": "B433"
+									"reference": "BX433"
 								},
 								{
 									"type": "note",
 									"id": "0ba852fe-3ee6-4128-9ce6-63407f0e2462",
 									"text": "Sidebar: Making Things Burn",
-									"reference": "B433"
+									"reference": "BX433"
 								}
 							]
 						},
@@ -2404,20 +2404,20 @@
 							"type": "note_container",
 							"id": "f3d9d202-8c65-4c08-8f8e-38104469dccf",
 							"text": "Gravity and Acceleration",
-							"reference": "B434",
+							"reference": "BX434",
 							"open": true,
 							"children": [
 								{
 									"type": "note",
 									"id": "f734ca79-6612-4e1c-94f8-1cbe70fd853c",
 									"text": "High Acceleration",
-									"reference": "B434"
+									"reference": "BX434"
 								},
 								{
 									"type": "note",
 									"id": "f5a9b966-d832-4e36-9bf7-5a90dcc3b564",
 									"text": "Space Adaptation Syndrome (\"Space Sickness\")",
-									"reference": "B434"
+									"reference": "BX434"
 								}
 							]
 						},
@@ -2425,56 +2425,56 @@
 							"type": "note",
 							"id": "b3c5599a-7ce5-4827-aae9-c8263bf28f39",
 							"text": "Heat",
-							"reference": "B434"
+							"reference": "BX434"
 						},
 						{
 							"type": "note",
 							"id": "fce9e937-3173-4a85-9d2a-4a86a0b0a762",
 							"text": "Pressure",
-							"reference": "B435"
+							"reference": "BX435"
 						},
 						{
 							"type": "note_container",
 							"id": "fb3e1e82-9e7c-405b-b9c7-d0b642aef885",
 							"text": "Radiation",
-							"reference": "B435",
+							"reference": "BX435",
 							"open": true,
 							"children": [
 								{
 									"type": "note",
 									"id": "dbf83045-b2b2-4320-875f-160a1195ae8f",
 									"text": "Sidebar: Radiation Hazards",
-									"reference": "B435"
+									"reference": "BX435"
 								},
 								{
 									"type": "note",
 									"id": "b1bad7b8-7a8b-4a67-b6b3-3e5ef5be9b05",
 									"text": "Effects of Radiation on Living Things",
-									"reference": "B436"
+									"reference": "BX436"
 								},
 								{
 									"type": "note",
 									"id": "d632190a-69e1-44e7-86fe-ec642fa5c8b6",
 									"text": "Radiation and Nonhumans",
-									"reference": "B436"
+									"reference": "BX436"
 								},
 								{
 									"type": "note",
 									"id": "503fe263-3bf7-49d4-bede-17a8f2e5a50d",
 									"text": "Radiation Protection",
-									"reference": "B436"
+									"reference": "BX436"
 								},
 								{
 									"type": "note",
 									"id": "62070f08-82f7-4cf4-9fb3-a9453ec963d0",
 									"text": "Radiation Treatment",
-									"reference": "B436"
+									"reference": "BX436"
 								},
 								{
 									"type": "note",
 									"id": "8e51f981-7869-4040-8115-207c48254080",
 									"text": "Table: Radiation Effects",
-									"reference": "B436"
+									"reference": "BX436"
 								}
 							]
 						},
@@ -2482,19 +2482,19 @@
 							"type": "note",
 							"id": "18fc3e7d-de11-476c-8ef6-a861235b8ce8",
 							"text": "Seasickness",
-							"reference": "B436"
+							"reference": "BX436"
 						},
 						{
 							"type": "note",
 							"id": "c4a2f97c-3622-406f-8e36-931b3855590b",
 							"text": "Suffocation",
-							"reference": "B436"
+							"reference": "BX436"
 						},
 						{
 							"type": "note",
 							"id": "5cbdcbba-6e20-4502-bce9-a4c1c114f716",
 							"text": "Vacuum",
-							"reference": "B437"
+							"reference": "BX437"
 						}
 					]
 				},
@@ -2502,32 +2502,32 @@
 					"type": "note_container",
 					"id": "7b7c775d-e11f-450e-a968-ec8f59300d54",
 					"text": "Poison",
-					"reference": "B437",
+					"reference": "BX437",
 					"open": true,
 					"children": [
 						{
 							"type": "note",
 							"id": "3c96fab7-b500-456c-9507-ade3d0e07a72",
 							"text": "Describing Poisons",
-							"reference": "B437"
+							"reference": "BX437"
 						},
 						{
 							"type": "note",
 							"id": "2f00aae1-95dc-4219-a393-e8c164bbfbdf",
 							"text": "Poison Examples",
-							"reference": "B439"
+							"reference": "BX439"
 						},
 						{
 							"type": "note",
 							"id": "6a0d1191-1e83-4032-b230-f86bcfa9cc32",
 							"text": "Addictive Drugs and Drug Withdrawal",
-							"reference": "B440"
+							"reference": "BX440"
 						},
 						{
 							"type": "note",
 							"id": "1b67bd99-cca1-4ecd-8fca-9f8c0f3cfc48",
 							"text": "Drinking and Intoxication",
-							"reference": "B439"
+							"reference": "BX439"
 						}
 					]
 				},
@@ -2535,27 +2535,27 @@
 					"type": "note",
 					"id": "b472998d-17e9-420e-889e-6e4153a78f77",
 					"text": "Age and Aging",
-					"reference": "B444"
+					"reference": "BX444"
 				},
 				{
 					"type": "note_container",
 					"id": "613845fe-ca08-42f7-9aea-491683904736",
 					"text": "Animals and Monsters",
-					"reference": "B455",
+					"reference": "BX455",
 					"open": true,
 					"children": [
 						{
 							"type": "note_container",
 							"id": "34603617-c9d1-4bad-9a2b-3fcba9ef266e",
 							"text": "Pets and Trained Animals",
-							"reference": "B458",
+							"reference": "BX458",
 							"open": true,
 							"children": [
 								{
 									"type": "note",
 									"id": "a9d5f469-894b-4b7f-9b3e-eae470a9561a",
 									"text": "Animal Training",
-									"reference": "B458"
+									"reference": "BX458"
 								}
 							]
 						},
@@ -2563,53 +2563,53 @@
 							"type": "note",
 							"id": "27294612-5bb8-4bb5-929b-15e2ed4d4c5a",
 							"text": "Sidebar: Individualizing Animals",
-							"reference": "B457"
+							"reference": "BX457"
 						},
 						{
 							"type": "note_container",
 							"id": "62d77f96-2fc4-4685-b6bf-1531b9260a3b",
 							"text": "Common Animals",
-							"reference": "B455",
+							"reference": "BX455",
 							"open": true
 						},
 						{
 							"type": "note_container",
 							"id": "a17873e4-dade-4924-83db-863c84984b06",
 							"text": "Riding and Draft Animals",
-							"reference": "B459",
+							"reference": "BX459",
 							"open": true
 						},
 						{
 							"type": "note_container",
 							"id": "4fe22e80-9b8b-4d3e-9c4f-fb1fff2ccc34",
 							"text": "Fantasy Monsters",
-							"reference": "B460",
+							"reference": "BX460",
 							"open": true
 						},
 						{
 							"type": "note",
 							"id": "db8e6784-b321-4176-b648-c0c7a6926438",
 							"text": "Sidebar: Damage for Animals",
-							"reference": "B460"
+							"reference": "BX460"
 						},
 						{
 							"type": "note_container",
 							"id": "f88c4357-ed40-417b-a937-b067645952ae",
 							"text": "Animals in Combat",
-							"reference": "B461",
+							"reference": "BX461",
 							"open": true,
 							"children": [
 								{
 									"type": "note",
 									"id": "87c4d406-dfe9-4c73-9508-6685a25d3159",
 									"text": "Swarm Attack",
-									"reference": "B461"
+									"reference": "BX461"
 								},
 								{
 									"type": "note",
 									"id": "d2a090fc-0083-4871-8b3d-96a6be9f7f99",
 									"text": "Sidebar: Swarm Attack Examples",
-									"reference": "B461"
+									"reference": "BX461"
 								}
 							]
 						}
@@ -2619,26 +2619,26 @@
 					"type": "note_container",
 					"id": "8a1ae95a-2bf8-4bd2-85cd-a4c18a2a4b3f",
 					"text": "Illness",
-					"reference": "B442",
+					"reference": "BX442",
 					"open": true,
 					"children": [
 						{
 							"type": "note",
 							"id": "70294556-6dac-4674-b025-4eca319a831b",
 							"text": "Disease",
-							"reference": "B442"
+							"reference": "BX442"
 						},
 						{
 							"type": "note",
 							"id": "7afee8c1-4d6c-4424-ad69-9917f6201d43",
 							"text": "Sidebar: Contagion",
-							"reference": "B443"
+							"reference": "BX443"
 						},
 						{
 							"type": "note",
 							"id": "21655763-8e5b-44cd-83f9-6eabd78950ba",
 							"text": "Infection",
-							"reference": "B444"
+							"reference": "BX444"
 						}
 					]
 				},
@@ -2646,21 +2646,21 @@
 					"type": "note_container",
 					"id": "a617b743-6c53-418e-9e14-3d072b68fac6",
 					"text": "Creating Templates",
-					"reference": "B445",
+					"reference": "BX445",
 					"open": true,
 					"children": [
 						{
 							"type": "note_container",
 							"id": "112b4815-ec8f-4d44-9fab-aae2e9719c4d",
 							"text": "Character Templates",
-							"reference": "B445",
+							"reference": "BX445",
 							"open": true
 						},
 						{
 							"type": "note_container",
 							"id": "bd971406-fa58-4098-8447-e3242dfcad09",
 							"text": "Racial Templates",
-							"reference": "B450",
+							"reference": "BX450",
 							"open": true
 						}
 					]
@@ -2671,70 +2671,70 @@
 			"type": "note_container",
 			"id": "153abff8-be2b-4fe8-8699-0fc499c3fa46",
 			"text": "Technology and Artifacts",
-			"reference": "B462",
+			"reference": "BX462",
 			"open": true,
 			"children": [
 				{
 					"type": "note_container",
 					"id": "d1877b07-141a-4450-9231-4ee82ad34686",
 					"text": "Vehicles",
-					"reference": "B462",
+					"reference": "BX462",
 					"open": true,
 					"children": [
 						{
 							"type": "note",
 							"id": "64f73e8c-a861-45c6-9e4b-d4fb910ed6ba",
 							"text": "Vehicle Statistics",
-							"reference": "B462"
+							"reference": "BX462"
 						},
 						{
 							"type": "note_container",
 							"id": "a47310e6-9589-4b9a-8eab-a089a43fc69c",
 							"text": "Basic Vehicle Movement",
-							"reference": "B463",
+							"reference": "BX463",
 							"open": true,
 							"children": [
 								{
 									"type": "note",
 									"id": "95d7bb8e-6094-4888-ad77-ac6a1eb3a8bd",
 									"text": "Long-Distance Movement",
-									"reference": "B463"
+									"reference": "BX463"
 								},
 								{
 									"type": "note",
 									"id": "1874f277-656e-4ea2-8b56-8ab6387a1f77",
 									"text": "Tables: Vehicles",
-									"reference": "B464"
+									"reference": "BX464"
 								},
 								{
 									"type": "note",
 									"id": "8e372f74-e655-451d-9555-e94390fe6777",
 									"text": "Vehicle Control Rolls",
-									"reference": "B466"
+									"reference": "BX466"
 								},
 								{
 									"type": "note",
 									"id": "9cfda99f-4a83-4693-a2d5-008206787342",
 									"text": "Vehicle Ground Travel",
-									"reference": "B466"
+									"reference": "BX466"
 								},
 								{
 									"type": "note",
 									"id": "bca2ba47-1a96-42db-a3e5-1884c320fb47",
 									"text": "Vehicle Water Travel",
-									"reference": "B466"
+									"reference": "BX466"
 								},
 								{
 									"type": "note",
 									"id": "052e0084-83a4-4962-8dac-89c64f4b6016",
 									"text": "Vehicle Air Travel",
-									"reference": "B466"
+									"reference": "BX466"
 								},
 								{
 									"type": "note",
 									"id": "bf792272-3fa3-4644-ba44-843e3fe1e4b5",
 									"text": "Vehicle Space Travel",
-									"reference": "B466"
+									"reference": "BX466"
 								}
 							]
 						},
@@ -2742,80 +2742,80 @@
 							"type": "note_container",
 							"id": "6ccb3ac9-9c28-483b-a823-684abcb5827b",
 							"text": "Basic Vehicle Combat",
-							"reference": "B467",
+							"reference": "BX467",
 							"open": true,
 							"children": [
 								{
 									"type": "note",
 									"id": "f22c40a8-e9f4-4c49-b758-2cabdc8a7371",
 									"text": "Maneuvers",
-									"reference": "B467"
+									"reference": "BX467"
 								},
 								{
 									"type": "note",
 									"id": "8ae99ff4-f948-4a51-b2a1-43dd24c0808b",
 									"text": "Sidebar: Vehicle Weapon Mounts",
-									"reference": "B467"
+									"reference": "BX467"
 								},
 								{
 									"type": "note",
 									"id": "bdeabbe9-33d0-416d-b172-ef8b66de87b8",
 									"text": "Vehicle Movement During Combat",
-									"reference": "B468"
+									"reference": "BX468"
 								},
 								{
 									"type": "note",
 									"id": "89c66803-de2c-471f-8633-b157ab1f4282",
 									"text": "Vehicle Control Rolls",
-									"reference": "B469"
+									"reference": "BX469"
 								},
 								{
 									"type": "note",
 									"id": "106bff2d-2372-4845-8b28-dde01887d6a3",
 									"text": "Vehicle Attacks",
-									"reference": "B469"
+									"reference": "BX469"
 								},
 								{
 									"type": "note",
 									"id": "6d6300eb-b3a7-42dc-b94a-8bb47a986186",
 									"text": "Sidebar: Weapon Fire from a Moving Vehicle",
-									"reference": "B469"
+									"reference": "BX469"
 								},
 								{
 									"type": "note",
 									"id": "c471821b-8200-4f79-a094-18593b6089d1",
 									"text": "Vehicle Defence",
-									"reference": "B470"
+									"reference": "BX470"
 								},
 								{
 									"type": "note",
 									"id": "49401d62-057b-4575-8257-a3b1fa06749d",
 									"text": "Combat Results and Hit Location",
-									"reference": "B470"
+									"reference": "BX470"
 								},
 								{
 									"type": "note",
 									"id": "0dd295da-950b-4f57-979a-3872d98cb944",
 									"text": "Vehicle Collisions",
-									"reference": "B470"
+									"reference": "BX470"
 								},
 								{
 									"type": "note",
 									"id": "872b6bf3-5ddf-4d00-ae53-20c670b2ea7f",
 									"text": "Who's at the Wheel",
-									"reference": "B470"
+									"reference": "BX470"
 								},
 								{
 									"type": "note",
 									"id": "ab71e7ec-2d9f-4388-b8a7-fa4af781810d",
 									"text": "Vehicle Leaking",
-									"reference": "B470"
+									"reference": "BX470"
 								},
 								{
 									"type": "note",
 									"id": "b2d6bc6f-dbfe-4466-8db1-88bfcb2a7424",
 									"text": "Sidebar: Scaling Damage",
-									"reference": "B470"
+									"reference": "BX470"
 								}
 							]
 						}
@@ -2825,39 +2825,39 @@
 					"type": "note_container",
 					"id": "4e5e35ae-6b0f-470b-98e5-6155bba116a4",
 					"text": "Electronics",
-					"reference": "B471",
+					"reference": "BX471",
 					"open": true,
 					"children": [
 						{
 							"type": "note",
 							"id": "f1bb30b4-339d-4a99-90cc-ff7b0c3e9d3b",
 							"text": "Communicators",
-							"reference": "B471"
+							"reference": "BX471"
 						},
 						{
 							"type": "note_container",
 							"id": "b501d426-b41c-43fd-b5da-a99d7f244119",
 							"text": "Sensors",
-							"reference": "B471",
+							"reference": "BX471",
 							"open": true,
 							"children": [
 								{
 									"type": "note",
 									"id": "91621227-3be7-4333-b71b-baa6c89dcc6a",
 									"text": "Using Sensors",
-									"reference": "B471"
+									"reference": "BX471"
 								},
 								{
 									"type": "note",
 									"id": "73b6d0ab-1e71-461b-94f7-b9f8e4fe290f",
 									"text": "Passive Visual Sensors",
-									"reference": "B471"
+									"reference": "BX471"
 								},
 								{
 									"type": "note",
 									"id": "215f4487-4ea8-4309-8917-2a0c5c3269ec",
 									"text": "Active Sensors",
-									"reference": "B172"
+									"reference": "BX172"
 								}
 							]
 						}
@@ -2867,32 +2867,32 @@
 					"type": "note_container",
 					"id": "3ce60d99-3045-469e-bb68-c4b4c141d036",
 					"text": "Computers",
-					"reference": "B472",
+					"reference": "BX472",
 					"open": true,
 					"children": [
 						{
 							"type": "note",
 							"id": "c9b2ce72-08eb-4200-9a8b-8c4cbc7b02c5",
 							"text": "Complexity",
-							"reference": "B472"
+							"reference": "BX472"
 						},
 						{
 							"type": "note",
 							"id": "678042ce-0a23-48a5-ab95-266d9b6b8834",
 							"text": "Data Storage",
-							"reference": "B472"
+							"reference": "BX472"
 						},
 						{
 							"type": "note",
 							"id": "2c5d9c93-6cfe-44f5-a7e7-eb8c3e5c2eba",
 							"text": "Software",
-							"reference": "B472"
+							"reference": "BX472"
 						},
 						{
 							"type": "note",
 							"id": "f33bbf74-ffd7-486a-8113-3c34243b2278",
 							"text": "Other Software",
-							"reference": "B472"
+							"reference": "BX472"
 						}
 					]
 				},
@@ -2900,26 +2900,26 @@
 					"type": "note_container",
 					"id": "5c3d5c44-ab60-4bb7-a429-3d980d8553c9",
 					"text": "New Inventions",
-					"reference": "B473",
+					"reference": "BX473",
 					"open": true,
 					"children": [
 						{
 							"type": "note",
 							"id": "41cf54d9-717f-4f14-8b1d-737e6ae745b2",
 							"text": "Complexity, Concept and Prototypes",
-							"reference": "B473"
+							"reference": "BX473"
 						},
 						{
 							"type": "note",
 							"id": "7b0a26ef-86cf-4153-8c8d-b2c74e41107f",
 							"text": "Testing, Bugs and Production",
-							"reference": "B474"
+							"reference": "BX474"
 						},
 						{
 							"type": "note",
 							"id": "c6bfb029-da9c-43b4-8689-2c9e1b16c37c",
 							"text": "Sidebar: Funding",
-							"reference": "B474"
+							"reference": "BX474"
 						}
 					]
 				},
@@ -2927,38 +2927,38 @@
 					"type": "note_container",
 					"id": "18585472-31ec-48a9-b7a8-6a627e5ee86d",
 					"text": "Gadgeteering",
-					"reference": "B475",
+					"reference": "BX475",
 					"open": true,
 					"children": [
 						{
 							"type": "note",
 							"id": "77da52c4-7bbd-4065-a8b0-72f6d81126f2",
 							"text": "Inventing Gadgets",
-							"reference": "B475"
+							"reference": "BX475"
 						},
 						{
 							"type": "note",
 							"id": "726c46ea-253d-449b-9a95-395ff4e2edcd",
 							"text": "Quick Gadgeteering",
-							"reference": "B476"
+							"reference": "BX476"
 						},
 						{
 							"type": "note",
 							"id": "00cdf74e-1551-4f28-92c7-0167f1b34456",
 							"text": "Gadgeteering during Adventures",
-							"reference": "B477"
+							"reference": "BX477"
 						},
 						{
 							"type": "note",
 							"id": "ef523b6a-440c-48ab-89fb-92d9c9a9e22b",
 							"text": "Sidebar: Gadgets for Non-Gadgeteers",
-							"reference": "B477"
+							"reference": "BX477"
 						},
 						{
 							"type": "note",
 							"id": "3b7950f9-9757-4a90-864f-16bc217eee5b",
 							"text": "Sidebar: Gadget Bugs Table",
-							"reference": "B476"
+							"reference": "BX476"
 						}
 					]
 				},
@@ -2966,20 +2966,20 @@
 					"type": "note_container",
 					"id": "f050c406-0b36-471f-8e87-6acf935945a0",
 					"text": "Futuristic and Alien Artifacts",
-					"reference": "B478",
+					"reference": "BX478",
 					"open": true,
 					"children": [
 						{
 							"type": "note",
 							"id": "2a8c30a5-bf15-4c94-ab64-3107562a2d19",
 							"text": "Enigmatic Device Table",
-							"reference": "B478"
+							"reference": "BX478"
 						},
 						{
 							"type": "note",
 							"id": "a924bc13-be24-43a4-8540-80667a0e74f0",
 							"text": "Weird Technology",
-							"reference": "B479"
+							"reference": "BX479"
 						}
 					]
 				},
@@ -2987,69 +2987,69 @@
 					"type": "note_container",
 					"id": "d214a991-d4d0-4066-b6aa-5deb1ea87613",
 					"text": "Magic Items",
-					"reference": "B480",
+					"reference": "BX480",
 					"open": true,
 					"children": [
 						{
 							"type": "note",
 							"id": "3ac59fe5-3666-4791-ac0c-b90b88b5b211",
 							"text": "Enchantment Spells",
-							"reference": "B480"
+							"reference": "BX480"
 						},
 						{
 							"type": "note",
 							"id": "dfbea6bd-903b-46c2-9028-374813abf4d3",
 							"text": "Buying Magic Items",
-							"reference": "B482"
+							"reference": "BX482"
 						},
 						{
 							"type": "note",
 							"id": "0d358c76-be60-4752-acc0-d731cbda1afa",
 							"text": "Using Magic Items",
-							"reference": "B482"
+							"reference": "BX482"
 						},
 						{
 							"type": "note_container",
 							"id": "46871867-79b3-4239-9c42-1123b3d418e0",
 							"text": "Enchanting",
-							"reference": "B481",
+							"reference": "BX481",
 							"open": true,
 							"children": [
 								{
 									"type": "note",
 									"id": "7696549b-2bb2-4684-9363-f7361fce684c",
 									"text": "Power of a Magic Item",
-									"reference": "B481"
+									"reference": "BX481"
 								},
 								{
 									"type": "note",
 									"id": "f6148348-bb8b-43b4-8106-00b073f3d963",
 									"text": "Quick and Dirty Enchantment",
-									"reference": "B481"
+									"reference": "BX481"
 								},
 								{
 									"type": "note",
 									"id": "a3b02181-aed8-4d3a-b16a-f340205920b7",
 									"text": "Success Rolls for Enchanting",
-									"reference": "B481"
+									"reference": "BX481"
 								},
 								{
 									"type": "note",
 									"id": "ef767c88-0f9b-40ee-a1d1-a9d6fafa50c0",
 									"text": "Slow and Sure Enchantment",
-									"reference": "B481"
+									"reference": "BX481"
 								},
 								{
 									"type": "note",
 									"id": "99dc47c6-d463-4c82-b47e-65720450121b",
 									"text": "Sidebar: Interruptions",
-									"reference": "B481"
+									"reference": "BX481"
 								},
 								{
 									"type": "note",
 									"id": "c7de1899-30bd-4fad-82d0-9c578bb50b8a",
 									"text": "Spells for Enchantment",
-									"reference": "B482"
+									"reference": "BX482"
 								}
 							]
 						}
@@ -3059,44 +3059,44 @@
 					"type": "note_container",
 					"id": "52dbbb20-d62e-4d91-9486-44750f9757eb",
 					"text": "Damage to Objects",
-					"reference": "B483",
+					"reference": "BX483",
 					"open": true,
 					"children": [
 						{
 							"type": "note",
 							"id": "789b6343-a870-418a-bfe3-b4c51bf4483f",
 							"text": "Effects of Injury",
-							"reference": "B483"
+							"reference": "BX483"
 						},
 						{
 							"type": "note",
 							"id": "49de3419-f103-481a-8cbd-0c904c9b05d6",
 							"text": "Damage to Buildings and Structures",
-							"reference": "B484"
+							"reference": "BX484"
 						},
 						{
 							"type": "note",
 							"id": "6cdf2b3f-7371-4067-802e-69bad427b2be",
 							"text": "Sidebar: Damage to Shields",
-							"reference": "B484"
+							"reference": "BX484"
 						},
 						{
 							"type": "note",
 							"id": "5b76f33f-1b8e-4251-b795-929934326e8e",
 							"text": "Repairs",
-							"reference": "B484"
+							"reference": "BX484"
 						},
 						{
 							"type": "note",
 							"id": "23dc2e16-b811-4273-b14c-7af823f0279b",
 							"text": "Breakdowns",
-							"reference": "B485"
+							"reference": "BX485"
 						},
 						{
 							"type": "note",
 							"id": "bb9b6347-15cb-4d49-a5ce-1b5b59aa16f5",
 							"text": "Sidebar: Broken Weapons",
-							"reference": "B485"
+							"reference": "BX485"
 						}
 					]
 				}
@@ -3106,70 +3106,70 @@
 			"type": "note_container",
 			"id": "aafcad4f-32ce-4ad8-89a3-eb40695e753f",
 			"text": "Game Mastering",
-			"reference": "B486",
+			"reference": "BX486",
 			"open": true,
 			"children": [
 				{
 					"type": "note_container",
 					"id": "2776b76e-6c96-41a7-bcc2-830c83301e39",
 					"text": "Running the Game",
-					"reference": "B492",
+					"reference": "BX492",
 					"open": true,
 					"children": [
 						{
 							"type": "note",
 							"id": "e682e530-5e17-42c2-b498-0187ad5034bf",
 							"text": "Settling Rules Questions",
-							"reference": "B492"
+							"reference": "BX492"
 						},
 						{
 							"type": "note",
 							"id": "75f73d12-36c8-4248-aff2-38c80d9cb185",
 							"text": "Dealing with the Players",
-							"reference": "B493"
+							"reference": "BX493"
 						},
 						{
 							"type": "note",
 							"id": "d9b37db2-9c16-4c0a-bdbb-419577ab3ba1",
 							"text": "Playing the NPC's",
-							"reference": "B493"
+							"reference": "BX493"
 						},
 						{
 							"type": "note",
 							"id": "d73f8739-255a-44b0-a38a-7e3dde4171f2",
 							"text": "Sidebar: Gaming Online",
-							"reference": "B494"
+							"reference": "BX494"
 						},
 						{
 							"type": "note_container",
 							"id": "093f2197-74f4-4108-9f05-a7e31a44126f",
 							"text": "Ending a Play Session",
-							"reference": "B498",
+							"reference": "BX498",
 							"open": true,
 							"children": [
 								{
 									"type": "note",
 									"id": "62dc2c05-a187-4326-b008-aa8bd31d7653",
 									"text": "Awarding Character Points",
-									"reference": "B498"
+									"reference": "BX498"
 								},
 								{
 									"type": "note",
 									"id": "e92943ca-a301-4dcb-abeb-d8e7ee2a110a",
 									"text": "Sidebar: Time Use Sheets",
-									"reference": "B499"
+									"reference": "BX499"
 								},
 								{
 									"type": "note",
 									"id": "bf252d9a-aa9d-46cd-9f85-af9bfc584a19",
 									"text": "Avoiding Character Inflation",
-									"reference": "B498"
+									"reference": "BX498"
 								},
 								{
 									"type": "note",
 									"id": "378888b3-c240-47b7-8ac8-e72bf9896180",
 									"text": "Controlling Character Development",
-									"reference": "B499"
+									"reference": "BX499"
 								}
 							]
 						},
@@ -3177,26 +3177,26 @@
 							"type": "note_container",
 							"id": "0e7a90d1-04d2-4ae0-9f28-5022797b3261",
 							"text": "Reaction Rolls",
-							"reference": "B494",
+							"reference": "BX494",
 							"open": true,
 							"children": [
 								{
 									"type": "note",
 									"id": "ebcbc2da-9c95-45bd-aa98-576c909251de",
 									"text": "Predetermined Actions",
-									"reference": "B495"
+									"reference": "BX495"
 								},
 								{
 									"type": "note",
 									"id": "575518a4-41a5-4896-86c0-1a1f4d7b9cb4",
 									"text": "Second Reaction Rolls",
-									"reference": "B495"
+									"reference": "BX495"
 								},
 								{
 									"type": "note",
 									"id": "32077233-3274-4c98-b21b-a97ade362b44",
 									"text": "Influence Skills",
-									"reference": "B495"
+									"reference": "BX495"
 								}
 							]
 						},
@@ -3204,20 +3204,20 @@
 							"type": "note_container",
 							"id": "30bb9086-19e8-44f3-8b9d-efc74ffc6326",
 							"text": "Knowledge",
-							"reference": "B495",
+							"reference": "BX495",
 							"open": true,
 							"children": [
 								{
 									"type": "note",
 									"id": "0d68ef85-8048-48cf-8d74-fce1742da072",
 									"text": "PC Knowledge",
-									"reference": "B495"
+									"reference": "BX495"
 								},
 								{
 									"type": "note",
 									"id": "03668bdb-dcc0-4ccf-9c73-99401861fc0e",
 									"text": "NPC Knowledge",
-									"reference": "B496"
+									"reference": "BX496"
 								}
 							]
 						},
@@ -3225,38 +3225,38 @@
 							"type": "note",
 							"id": "19c877c4-7269-428f-8dc5-20f3d538c9c4",
 							"text": "Keeping the Characters Alive",
-							"reference": "B496"
+							"reference": "BX496"
 						},
 						{
 							"type": "note_container",
 							"id": "b0a4b550-f137-4d41-b476-f1352612e2b4",
 							"text": "Game Time",
-							"reference": "B497",
+							"reference": "BX497",
 							"open": true,
 							"children": [
 								{
 									"type": "note",
 									"id": "67244969-5791-4043-b338-17485cb71320",
 									"text": "Time During Adventures",
-									"reference": "B497"
+									"reference": "BX497"
 								},
 								{
 									"type": "note",
 									"id": "293d334d-355c-49a1-820f-c9ee3b7438e8",
 									"text": "Time Between Sessions",
-									"reference": "B497"
+									"reference": "BX497"
 								},
 								{
 									"type": "note",
 									"id": "e614cc43-06aa-447a-a128-977bf6d5585a",
 									"text": "Sidebar: When in Doubt, Roll and Shout",
-									"reference": "B497"
+									"reference": "BX497"
 								},
 								{
 									"type": "note",
 									"id": "7c6c99e4-7e7b-4046-9ab9-772f50ea7fc1",
 									"text": "Time Between Adventures",
-									"reference": "B498"
+									"reference": "BX498"
 								}
 							]
 						}
@@ -3266,56 +3266,56 @@
 					"type": "note",
 					"id": "005a81db-792c-42ad-b784-cc9f7c0c2855",
 					"text": "Sidebar: Customizing the Rules",
-					"reference": "B486"
+					"reference": "BX486"
 				},
 				{
 					"type": "note_container",
 					"id": "590acfff-fbf8-4139-a878-8e7e7a5d31ac",
 					"text": "Starting a Game Session",
-					"reference": "B490",
+					"reference": "BX490",
 					"open": true,
 					"children": [
 						{
 							"type": "note",
 							"id": "53f642c3-7943-461f-b96e-d2b07bc896f7",
 							"text": "Sidebar: Advance Preparation",
-							"reference": "B490"
+							"reference": "BX490"
 						},
 						{
 							"type": "note",
 							"id": "b9667ffc-8667-48a7-a636-4a0b95d0a753",
 							"text": "Maps",
-							"reference": "B490"
+							"reference": "BX490"
 						},
 						{
 							"type": "note",
 							"id": "0d4f7adc-4925-433b-8214-f7fd5a3a8ae6",
 							"text": "Sidebar: Player-Made Maps",
-							"reference": "B491"
+							"reference": "BX491"
 						},
 						{
 							"type": "note",
 							"id": "4e240dd9-4d73-42f2-94bc-115060ae9eb8",
 							"text": "Travel Maps",
-							"reference": "B491"
+							"reference": "BX491"
 						},
 						{
 							"type": "note",
 							"id": "f4b9ee54-afb4-4037-b3bd-f29b6f896200",
 							"text": "Area Maps",
-							"reference": "B491"
+							"reference": "BX491"
 						},
 						{
 							"type": "note",
 							"id": "54f66d37-5773-4393-a3fb-5c1610b25753",
 							"text": "Room Maps",
-							"reference": "B492"
+							"reference": "BX492"
 						},
 						{
 							"type": "note",
 							"id": "f665ec18-dd9a-4eea-a9d7-7373b446ba34",
 							"text": "Combat Maps",
-							"reference": "B492"
+							"reference": "BX492"
 						}
 					]
 				},
@@ -3323,32 +3323,32 @@
 					"type": "note_container",
 					"id": "7a3a990c-e78e-4b3e-8ff8-9f1c1512d0b3",
 					"text": "Choosing a Campaign Type",
-					"reference": "B486",
+					"reference": "BX486",
 					"open": true,
 					"children": [
 						{
 							"type": "note",
 							"id": "04575e2f-c7f6-4290-b90e-694f4d38a742",
 							"text": "Power Level",
-							"reference": "B487"
+							"reference": "BX487"
 						},
 						{
 							"type": "note",
 							"id": "8c2d614e-5cdf-48fa-a9df-3d8c5ff3a7d5",
 							"text": "High Powers Campaigns",
-							"reference": "B487"
+							"reference": "BX487"
 						},
 						{
 							"type": "note",
 							"id": "160551aa-d9e6-4dc5-a2e2-30935cbfb7b8",
 							"text": "The Cinematic Campaign",
-							"reference": "B488"
+							"reference": "BX488"
 						},
 						{
 							"type": "note",
 							"id": "4de43cec-1fd9-4bb8-9134-19cec81e50ae",
 							"text": "Sidebar: Damn the Rules, Full Speed Ahead!",
-							"reference": "B489"
+							"reference": "BX489"
 						}
 					]
 				},
@@ -3356,7 +3356,7 @@
 					"type": "note_container",
 					"id": "4a4ae2cf-54a2-48b3-a47d-41a67ac4a302",
 					"text": "Writing Your Own Adventures",
-					"reference": "B500",
+					"reference": "BX500",
 					"notes": "Included for Reference only",
 					"open": true
 				}
@@ -3366,27 +3366,27 @@
 			"type": "note_container",
 			"id": "bb8579fe-e922-41c3-8db9-0b7c9c1c003c",
 			"text": "Game Worlds",
-			"reference": "B505",
+			"reference": "BX505",
 			"open": true,
 			"children": [
 				{
 					"type": "note_container",
 					"id": "ddb769ea-2785-456e-8ba3-85e5448d20fb",
 					"text": "Cultures and Languages",
-					"reference": "B505",
+					"reference": "BX505",
 					"open": true,
 					"children": [
 						{
 							"type": "note",
 							"id": "c8c0170f-90f2-4338-8423-21d9168e4a50",
 							"text": "Culture",
-							"reference": "B505"
+							"reference": "BX505"
 						},
 						{
 							"type": "note",
 							"id": "17cf5977-6cf0-4319-9985-1bd6b4e4f658",
 							"text": "Language",
-							"reference": "B506"
+							"reference": "BX506"
 						}
 					]
 				},
@@ -3394,69 +3394,69 @@
 					"type": "note_container",
 					"id": "3e46d8d6-ed9e-493e-b026-dda5c8ef8951",
 					"text": "Laws and Customs",
-					"reference": "B506",
+					"reference": "BX506",
 					"open": true,
 					"children": [
 						{
 							"type": "note",
 							"id": "66de3d14-cdda-4b00-80f9-a546ddf50562",
 							"text": "Control Rating",
-							"reference": "B506"
+							"reference": "BX506"
 						},
 						{
 							"type": "note",
 							"id": "a611eb71-271a-4ec3-a702-26729e14f067",
 							"text": "Sidebar: Travel Etiquette",
-							"reference": "B506"
+							"reference": "BX506"
 						},
 						{
 							"type": "note",
 							"id": "3cf6ddc5-37f6-4184-9cd9-2298ee43099d",
 							"text": "Law Enforcement and Jail",
-							"reference": "B507"
+							"reference": "BX507"
 						},
 						{
 							"type": "note",
 							"id": "5c8be9cd-fba9-49df-b7ff-a4fff908f34b",
 							"text": "Legality",
-							"reference": "B507"
+							"reference": "BX507"
 						},
 						{
 							"type": "note_container",
 							"id": "794b2c78-c2eb-47ce-a605-57b6b01597e5",
 							"text": "Trials",
-							"reference": "B508",
+							"reference": "BX508",
 							"open": true,
 							"children": [
 								{
 									"type": "note",
 									"id": "4ab998e1-2186-4d4c-abea-fe03e27fdc84",
 									"text": "Trial by Ordeal",
-									"reference": "B508"
+									"reference": "BX508"
 								},
 								{
 									"type": "note",
 									"id": "f9cf4db6-8248-4d8a-9009-c6ebb2168843",
 									"text": "Trial by Judge",
-									"reference": "B508"
+									"reference": "BX508"
 								},
 								{
 									"type": "note",
 									"id": "a3bf1763-67c8-4670-9a67-f1f8da41d4b4",
 									"text": "Trial by Combat",
-									"reference": "B508"
+									"reference": "BX508"
 								},
 								{
 									"type": "note",
 									"id": "3f5cf958-3f31-43e8-a5e0-2b1cd7ae7533",
 									"text": "Adversarial Trials",
-									"reference": "B508"
+									"reference": "BX508"
 								},
 								{
 									"type": "note",
 									"id": "fc186c38-84ba-42fa-a9ae-4c8aa02ff2e8",
 									"text": "Sidebar: Bribery",
-									"reference": "B508"
+									"reference": "BX508"
 								}
 							]
 						},
@@ -3464,7 +3464,7 @@
 							"type": "note",
 							"id": "9c9c6110-ad2f-4048-8657-a4e888d7c84a",
 							"text": "Criminal Punishment",
-							"reference": "B508"
+							"reference": "BX508"
 						}
 					]
 				},
@@ -3472,51 +3472,51 @@
 					"type": "note_container",
 					"id": "b55f11b3-b6e1-4f98-80b5-0200dd4009d7",
 					"text": "Society and Government Types",
-					"reference": "B509",
+					"reference": "BX509",
 					"open": true
 				},
 				{
 					"type": "note_container",
 					"id": "3c5dbaf9-504a-4d66-8a15-9a5b44337349",
 					"text": "Tech Levels",
-					"reference": "B511",
+					"reference": "BX511",
 					"open": true,
 					"children": [
 						{
 							"type": "note",
 							"id": "a9159d45-ce8b-468d-bcf6-a5d2a8ae87dd",
 							"text": "Variations within a Tech Level",
-							"reference": "B511"
+							"reference": "BX511"
 						},
 						{
 							"type": "note",
 							"id": "1f0ed0e9-7989-447b-96b4-77216da91e65",
 							"text": "Sidebar: Tech Level by Field",
-							"reference": "B512"
+							"reference": "BX512"
 						},
 						{
 							"type": "note",
 							"id": "952fbc95-1ff7-4888-af7f-23068e3ef077",
 							"text": "Building up Local Technology",
-							"reference": "B513"
+							"reference": "BX513"
 						},
 						{
 							"type": "note",
 							"id": "4d0dec9b-c8a6-4b97-9e98-288e41b5d129",
 							"text": "Different Technologies",
-							"reference": "B513"
+							"reference": "BX513"
 						},
 						{
 							"type": "note",
 							"id": "ac352dbd-772e-4434-a9ad-657090932867",
 							"text": "Tech Level and Genre",
-							"reference": "B514"
+							"reference": "BX514"
 						},
 						{
 							"type": "note",
 							"id": "f9482bed-4c45-4510-80a7-baed2348196e",
 							"text": "Sidebar: Improving Skills in Alternate Tech Levels",
-							"reference": "B513"
+							"reference": "BX513"
 						}
 					]
 				},
@@ -3524,80 +3524,80 @@
 					"type": "note_container",
 					"id": "fd73b0f3-9c26-44dd-8cfc-390f4a24a0bf",
 					"text": "Economics",
-					"reference": "B514",
+					"reference": "BX514",
 					"open": true,
 					"children": [
 						{
 							"type": "note",
 							"id": "63524439-3b99-43f4-93a0-fe4cb23ec4ee",
 							"text": "Buying and Selling",
-							"reference": "B514"
+							"reference": "BX514"
 						},
 						{
 							"type": "note",
 							"id": "a060fdee-81bd-490b-9608-416ba2dccae2",
 							"text": "Sidebar: Gold and Silver",
-							"reference": "B515"
+							"reference": "BX515"
 						},
 						{
 							"type": "note",
 							"id": "e4453ebf-160e-4f47-80df-61e54e05b0bb",
 							"text": "Loot, and Disposing of It",
-							"reference": "B515"
+							"reference": "BX515"
 						},
 						{
 							"type": "note",
 							"id": "db489ddd-994c-4667-8ac5-e9125b929aa4",
 							"text": "Sidebar: Making Your Own Goods",
-							"reference": "B515"
+							"reference": "BX515"
 						},
 						{
 							"type": "note",
 							"id": "89622a36-759a-4daf-a6aa-5b22d9bf8337",
 							"text": "Jobs",
-							"reference": "B516"
+							"reference": "BX516"
 						},
 						{
 							"type": "note",
 							"id": "18770ce4-c438-4242-89ee-aa6878fbc7e1",
 							"text": "Wealth and Status",
-							"reference": "B516"
+							"reference": "BX516"
 						},
 						{
 							"type": "note",
 							"id": "b1541ae7-873a-46b3-80c3-8163f36f8951",
 							"text": "Hirelings",
-							"reference": "B517"
+							"reference": "BX517"
 						},
 						{
 							"type": "note",
 							"id": "69e83b81-1922-4b82-b9af-c6ce2f90b7eb",
 							"text": "Sidebar: Finding a Job",
-							"reference": "B518"
+							"reference": "BX518"
 						},
 						{
 							"type": "note",
 							"id": "8eb33f55-7ac3-430d-9da1-0219cbc00c4b",
 							"text": "Slaves",
-							"reference": "B518"
+							"reference": "BX518"
 						},
 						{
 							"type": "note",
 							"id": "7c582852-1e2f-4ab6-8283-445907bf61d1",
 							"text": "Sidebar: Loyalty Checks",
-							"reference": "B519"
+							"reference": "BX519"
 						},
 						{
 							"type": "note",
 							"id": "c8b99a90-6ead-4fc0-b0d1-cab586e87ffc",
 							"text": "Sidebar: Moving Money Between Worlds",
-							"reference": "B514"
+							"reference": "BX514"
 						},
 						{
 							"type": "note",
 							"id": "e383ea81-87d0-4182-8067-79adec8a9669",
 							"text": "Table: Monthly Pay",
-							"reference": "B517"
+							"reference": "BX517"
 						}
 					]
 				},
@@ -3605,32 +3605,32 @@
 					"type": "note_container",
 					"id": "7725b78e-c18b-4737-be1a-dd3fc1c59f83",
 					"text": "Other Planes of Existence",
-					"reference": "B519",
+					"reference": "BX519",
 					"open": true,
 					"children": [
 						{
 							"type": "note",
 							"id": "5c62ac63-0001-4108-81c3-1a072ea2957b",
 							"text": "Sidebar: Travel Between Game Worlds",
-							"reference": "B520"
+							"reference": "BX520"
 						},
 						{
 							"type": "note",
 							"id": "fb69cd82-1150-4fbc-afb9-9b775dbbfc2f",
 							"text": "Types of Realities",
-							"reference": "B520"
+							"reference": "BX520"
 						},
 						{
 							"type": "note",
 							"id": "7b6a440e-645a-4b84-8908-bf54519d52d1",
 							"text": "PlanarCosmology",
-							"reference": "B521"
+							"reference": "BX521"
 						},
 						{
 							"type": "note",
 							"id": "71a6cd7b-d30e-4310-8847-a85c392d11a4",
 							"text": "Interplanar Travel",
-							"reference": "B522"
+							"reference": "BX522"
 						}
 					]
 				}
@@ -3640,7 +3640,7 @@
 			"type": "note_container",
 			"id": "296f904e-53d1-4b36-8ccc-e711825ba871",
 			"text": "Infinite Worlds",
-			"reference": "B523",
+			"reference": "BX523",
 			"notes": "included for Reference only",
 			"open": true
 		},
@@ -3648,51 +3648,51 @@
 			"type": "note_container",
 			"id": "ee902b95-be8d-491e-a8e5-0d8d204a190d",
 			"text": "Tables",
-			"reference": "B547",
+			"reference": "BX547",
 			"open": true,
 			"children": [
 				{
 					"type": "note_container",
 					"id": "f0d873ea-c74c-4568-8caa-6720dae41750",
 					"text": "Combat Modifiers",
-					"reference": "B547",
+					"reference": "BX547",
 					"open": true,
 					"children": [
 						{
 							"type": "note",
 							"id": "b0b781d8-3c77-40bd-839c-0d7780245362",
 							"text": "Melee Attack Modifiers",
-							"reference": "B547"
+							"reference": "BX547"
 						},
 						{
 							"type": "note",
 							"id": "d865ed85-fe28-4e64-bce4-6a678136dbac",
 							"text": "Active Defence Modifiers",
-							"reference": "B548"
+							"reference": "BX548"
 						},
 						{
 							"type": "note",
 							"id": "3c08a2d9-808f-47ff-bc93-d1881c90c00c",
 							"text": "Ranged Attack Modifiers",
-							"reference": "B548"
+							"reference": "BX548"
 						},
 						{
 							"type": "note",
 							"id": "dc420efa-dc3d-4459-bbdf-048f6c61aded",
 							"text": "Size and Speed/Range Table",
-							"reference": "B550"
+							"reference": "BX550"
 						},
 						{
 							"type": "note",
 							"id": "15a7e8aa-88ff-4432-9cc8-3005a9ee6cfb",
 							"text": "Maneuvers/Manoeuvres",
-							"reference": "B551"
+							"reference": "BX551"
 						},
 						{
 							"type": "note",
 							"id": "24c98e02-f9b7-4de8-afb8-32544dee9cfe",
 							"text": "Postures",
-							"reference": "B551"
+							"reference": "BX551"
 						}
 					]
 				},
@@ -3700,32 +3700,32 @@
 					"type": "note_container",
 					"id": "6ca9e94f-569d-4094-822d-38f618a5b1f7",
 					"text": "Hit Location Tables",
-					"reference": "B552",
+					"reference": "BX552",
 					"open": true,
 					"children": [
 						{
 							"type": "note",
 							"id": "0d80bc2d-c145-4658-9de0-3addc4ef19b2",
 							"text": "Human and Humanoid Hit Location Table",
-							"reference": "B552"
+							"reference": "BX552"
 						},
 						{
 							"type": "note",
 							"id": "c9bb032d-d58f-42c1-a3b7-ef4068c65ae5",
 							"text": "Non-Humanoid Hit Location Tables",
-							"reference": "B552"
+							"reference": "BX552"
 						},
 						{
 							"type": "note",
 							"id": "d2f9d366-272c-4a46-9b10-a38661e9d7f4",
 							"text": "Vehicle Hit Location Table",
-							"reference": "B554"
+							"reference": "BX554"
 						},
 						{
 							"type": "note",
 							"id": "4a487f19-7260-4956-b86f-29f70e26860e",
 							"text": "Occupant Hit Table",
-							"reference": "B555"
+							"reference": "BX555"
 						}
 					]
 				},
@@ -3733,32 +3733,32 @@
 					"type": "note_container",
 					"id": "eda5f0a0-26c3-40e1-b43e-88108d7b74e4",
 					"text": "Critical Success and Failure",
-					"reference": "B556",
+					"reference": "BX556",
 					"open": true,
 					"children": [
 						{
 							"type": "note",
 							"id": "74d703a2-3dfa-4e6a-9d2a-d04960d9df40",
 							"text": "Critical Head Blow Table",
-							"reference": "B556"
+							"reference": "BX556"
 						},
 						{
 							"type": "note",
 							"id": "f12ecf96-dffa-41c7-b295-b944e7db22f3",
 							"text": "Critical Hit Table",
-							"reference": "B556"
+							"reference": "BX556"
 						},
 						{
 							"type": "note",
 							"id": "b9918b25-68e0-4996-ada5-08304dede265",
 							"text": "Critical Miss Table",
-							"reference": "B556"
+							"reference": "BX556"
 						},
 						{
 							"type": "note",
 							"id": "3f2d2c93-2c88-4add-8df5-48ea30514ad4",
 							"text": "Unarmed Critical Miss Table",
-							"reference": "B557"
+							"reference": "BX557"
 						}
 					]
 				},
@@ -3766,20 +3766,20 @@
 					"type": "note_container",
 					"id": "599f2a6d-5b23-446f-8888-fe0437102b4c",
 					"text": "HP and DR of Objects and Covers",
-					"reference": "B557",
+					"reference": "BX557",
 					"open": true,
 					"children": [
 						{
 							"type": "note",
 							"id": "924f9a71-27cf-48f0-830d-0f550de2f848",
 							"text": "HP and DR of Structures",
-							"reference": "B558"
+							"reference": "BX558"
 						},
 						{
 							"type": "note",
 							"id": "da81e56b-5107-4ca3-ac58-c9ce729811b0",
 							"text": "Cover DR",
-							"reference": "B559"
+							"reference": "BX559"
 						}
 					]
 				},
@@ -3787,51 +3787,51 @@
 					"type": "note_container",
 					"id": "a74f320e-43b7-4a51-8e35-614f716edaaf",
 					"text": "NPC Reactions",
-					"reference": "B559",
+					"reference": "BX559",
 					"open": true,
 					"children": [
 						{
 							"type": "note_container",
 							"id": "041192df-9b68-4033-ac72-ad47e506c58c",
 							"text": "Reaction Table",
-							"reference": "B560",
+							"reference": "BX560",
 							"open": true,
 							"children": [
 								{
 									"type": "note",
 									"id": "c396d7c4-a7ce-4a1b-bc2f-627ed0a57d7c",
 									"text": "Potental Combat Situations (and Morale Checks)",
-									"reference": "B561"
+									"reference": "BX561"
 								},
 								{
 									"type": "note",
 									"id": "1c111df6-ce20-4343-9390-4d0f55d0c8e5",
 									"text": "Commercial Transactions",
-									"reference": "B562"
+									"reference": "BX562"
 								},
 								{
 									"type": "note",
 									"id": "698b0baf-99bf-49c3-ad36-07f9e56c7696",
 									"text": "Loyalty",
-									"reference": "B562"
+									"reference": "BX562"
 								},
 								{
 									"type": "note",
 									"id": "97faa7b1-5785-45a9-8f78-2898c9a31a14",
 									"text": "Requests for Aid",
-									"reference": "B562"
+									"reference": "BX562"
 								},
 								{
 									"type": "note",
 									"id": "58de3a4c-778d-434c-b877-fe26f594ec37",
 									"text": "Requests for Information",
-									"reference": "B562"
+									"reference": "BX562"
 								},
 								{
 									"type": "note",
 									"id": "e8e0d52c-9317-4bf9-a959-bffe4977a755",
 									"text": "General Reaction",
-									"reference": "B651"
+									"reference": "BX651"
 								}
 							]
 						}
@@ -3843,14 +3843,14 @@
 			"type": "note_container",
 			"id": "1b3a474e-e6ae-4b6f-8c1d-0582e6c61418",
 			"text": "Glossary",
-			"reference": "B563",
+			"reference": "BX563",
 			"open": true
 		},
 		{
 			"type": "note_container",
 			"id": "eb4d1ea8-ace7-46de-9a09-4417649e6723",
 			"text": "Index",
-			"reference": "B570",
+			"reference": "BX570",
 			"open": true
 		}
 	]


### PR DESCRIPTION
This change updates the Basic Set Rules notes library to reference a different document than the standard Basic document, for the purpose of being able to jump to the right page when the documents are separate from each other. Users with a combined PDF can achieve the same effect by pointing both prefixes to the same document.
This introduces a new prefix: BX, which is for Basic Set Campaigns.