### PR TITLE
Fix multiple spelling and reference mistakes

### DIFF
--- a/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Equipment.eqp
+++ b/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Equipment.eqp
@@ -1050,7 +1050,7 @@
 			"description": "Billon Coin",
 			"value": "10",
 			"weight": "0.02 lb",
-			"reference": "DFE73",
+			"reference": "DFX73",
 			"calc": {
 				"extended_value": "10",
 				"extended_weight": "0.02 lb"
@@ -3325,7 +3325,7 @@
 			"description": "Copper Coin",
 			"value": "1",
 			"weight": "0.02 lb",
-			"reference": "DFE73",
+			"reference": "DFX73",
 			"calc": {
 				"extended_value": "1",
 				"extended_weight": "0.02 lb"
@@ -4710,7 +4710,7 @@
 			"description": "Electrum Coin",
 			"value": "200",
 			"weight": "0.02 lb",
-			"reference": "DFE73",
+			"reference": "DFX73",
 			"calc": {
 				"extended_value": "200",
 				"extended_weight": "0.02 lb"
@@ -5696,7 +5696,7 @@
 				{
 					"type": "melee_weapon",
 					"damage": {
-						"type": "see DFE39"
+						"type": "see DFX39"
 					},
 					"reach": "C",
 					"parry": "No",
@@ -5705,7 +5705,7 @@
 						"level": 0,
 						"parry": "No",
 						"block": "No",
-						"damage": "see DFE39"
+						"damage": "see DFX39"
 					},
 					"defaults": [
 						{
@@ -5956,7 +5956,7 @@
 			"description": "Gold Coin",
 			"value": "400",
 			"weight": "0.02 lb",
-			"reference": "DFE73",
+			"reference": "DFX73",
 			"calc": {
 				"extended_value": "400",
 				"extended_weight": "0.02 lb"
@@ -8846,7 +8846,7 @@
 				"extended_value": "40",
 				"extended_weight": "1 lb"
 			},
-			"notes": "Gets +2 to disarm when wielded with Jitte/Sai skill; see pp. DFE37",
+			"notes": "Gets +2 to disarm when wielded with Jitte/Sai skill; see pp. DFX37",
 			"categories": [
 				"Melee Weapon"
 			]
@@ -10145,7 +10145,7 @@
 				{
 					"type": "ranged_weapon",
 					"damage": {
-						"type": "see DFE43-45"
+						"type": "see DFX43-45"
 					},
 					"strength": "11",
 					"accuracy": "1",
@@ -10156,7 +10156,7 @@
 					"calc": {
 						"level": 0,
 						"range": "spec",
-						"damage": "see DFE43-45"
+						"damage": "see DFX43-45"
 					},
 					"defaults": [
 						{
@@ -10521,7 +10521,7 @@
 				{
 					"type": "ranged_weapon",
 					"damage": {
-						"type": "see DFE43-45"
+						"type": "see DFX43-45"
 					},
 					"strength": "7†",
 					"accuracy": "0",
@@ -10532,7 +10532,7 @@
 					"calc": {
 						"level": 0,
 						"range": "spec",
-						"damage": "see DFE43-45"
+						"damage": "see DFX43-45"
 					},
 					"defaults": [
 						{
@@ -14344,7 +14344,7 @@
 				{
 					"type": "ranged_weapon",
 					"damage": {
-						"type": "see DFE43"
+						"type": "see DFX43"
 					},
 					"strength": "8",
 					"accuracy": "1",
@@ -14355,7 +14355,7 @@
 					"calc": {
 						"level": 0,
 						"range": "spec",
-						"damage": "see DFE43"
+						"damage": "see DFX43"
 					},
 					"defaults": [
 						{
@@ -15643,7 +15643,7 @@
 			"description": "Platinum Coin",
 			"value": "800",
 			"weight": "0.02 lb",
-			"reference": "DFE73",
+			"reference": "DFX73",
 			"calc": {
 				"extended_value": "800",
 				"extended_weight": "0.02 lb"
@@ -16830,7 +16830,7 @@
 				"extended_value": "60",
 				"extended_weight": "1.5 lb"
 			},
-			"notes": "Gets +2 to disarm when wielded with Jitte/Sai skill; see DFE37.",
+			"notes": "Gets +2 to disarm when wielded with Jitte/Sai skill; see DFX37.",
 			"categories": [
 				"Melee Weapon"
 			]
@@ -18591,7 +18591,7 @@
 			"description": "Silver Coin",
 			"value": "20",
 			"weight": "0.02 lb",
-			"reference": "DFE73",
+			"reference": "DFX73",
 			"calc": {
 				"extended_value": "20",
 				"extended_weight": "0.02 lb"
@@ -21725,7 +21725,7 @@
 			"description": "Tumbaga Coin",
 			"value": "60",
 			"weight": "0.02 lb",
-			"reference": "DFE73",
+			"reference": "DFX73",
 			"calc": {
 				"extended_value": "60",
 				"extended_weight": "0.02 lb"

--- a/Library/Low Tech/Low Tech Companion 2 Equipment Modifiers.eqm
+++ b/Library/Low Tech/Low Tech Companion 2 Equipment Modifiers.eqm
@@ -360,7 +360,7 @@
 			"id": "d21fdf2c-b610-4d46-baee-a648ac02cc61",
 			"disabled": true,
 			"name": "Shield Modifiers",
-			"reference": "LTC:19",
+			"reference": "LTC2:19",
 			"open": true,
 			"children": [
 				{
@@ -427,7 +427,7 @@
 					"type": "eqp_modifier",
 					"id": "70204d85-d024-45ec-ba58-73c5e97c574a",
 					"name": "Disarming Spikes",
-					"reference": "LCT:20",
+					"reference": "LTC2:20",
 					"cost_type": "to_original_cost",
 					"cost": "+30",
 					"weight_type": "to_base_weight",

--- a/Library/Monster Hunters/Monster Hunters Equipment.eqp
+++ b/Library/Monster Hunters/Monster Hunters Equipment.eqp
@@ -1513,7 +1513,7 @@
 							"tech_level": "8",
 							"value": "4000",
 							"weight": "12 lb",
-							"reference": "LMH8",
+							"reference": "LOMH8",
 							"calc": {
 								"extended_value": "4000",
 								"extended_weight": "12 lb"
@@ -1684,7 +1684,7 @@
 							"tech_level": "8",
 							"value": "1000",
 							"weight": "10 lb",
-							"reference": "LMH7",
+							"reference": "LOMH7",
 							"calc": {
 								"extended_value": "1000",
 								"extended_weight": "10 lb"
@@ -1698,7 +1698,7 @@
 							"tech_level": "8",
 							"value": "200",
 							"weight": "4 lb",
-							"reference": "LMH7",
+							"reference": "LOMH7",
 							"calc": {
 								"extended_value": "200",
 								"extended_weight": "4 lb"

--- a/Library/Tales of the Solar Patrol/Solar Patrol Disadvantages.adq
+++ b/Library/Tales of the Solar Patrol/Solar Patrol Disadvantages.adq
@@ -6,7 +6,7 @@
 		{
 			"type": "advantage",
 			"id": "a0012a07-0880-4fea-acea-71f54748035c",
-			"name": "Last Stand",
+			"name": "Final Stand",
 			"physical": true,
 			"base_points": -10,
 			"reference": "TSP39",


### PR DESCRIPTION
I have checked all affected entries' PDFs for accuracy.

### Changes:
Disambiguates DFE (Dungeon Fantasy - Exploits) from DFE# (Dungeon Fantasy Encounters #) by renaming all DFE references to DFX.
Fix 2 typos in Low Tech's references.
Change 3 reference spellings in Monster Hunter Equipment to match the gurpscharactersheet.com page reference's spelling.
Correct the name of a Solar Patrol disadvantage to match the one found in the PDF.
