### PR TITLE
Updated HTML - PC Output Template

### DIFF
--- a/Library/Output Templates/HTML - PC.html
+++ b/Library/Output Templates/HTML - PC.html
@@ -191,6 +191,10 @@ defined by the Mozilla Public License, version 2.0.
 			font: var(--font-page-primary-labels);
 		}
 
+		.header:not(.entry-parent) {
+			padding: var(--padding-header);
+		}
+
 		.fieldblock {
 			display: grid;
 			grid-template-columns: 0fr 1fr;
@@ -276,8 +280,8 @@ defined by the Mozilla Public License, version 2.0.
 			background-position: center;
 			background-repeat: no-repeat;
 			background-size: cover;
-			width: 6.75em;
-			height: 9em;
+			width: 111px;
+			height: 148px;
 		}
 
 		#identity {
@@ -326,6 +330,7 @@ defined by the Mozilla Public License, version 2.0.
 
 		#points .field {
 			text-align: right;
+			padding: var(--padding-standard);
 		}
 
 		#points .fieldblock .field:nth-child(4n-1),
@@ -414,6 +419,10 @@ defined by the Mozilla Public License, version 2.0.
 		#hit-locations .dr:not(.header) {
 			color: rgba(var(--color-on-editable), 0.6);
 			font: var(--font-page-primary-fields);
+		}
+
+		#hit-locations .penalty:not(.header) {
+			text-align: right;
 		}
 
 		#hit-locations .roll:not(.header),
@@ -524,7 +533,11 @@ defined by the Mozilla Public License, version 2.0.
 		}
 
 		#encumbrance .current {
-			background-color: rgb(var(--color-marker));
+			background-color: rgb(var(--color-marker)) !important;
+		}
+
+		#encumbrance .current.level {
+			color: rgb(var(--color-on-marker)) !important;
 		}
 
 		svg path.shape-equipped-0 {
@@ -796,6 +809,10 @@ defined by the Mozilla Public License, version 2.0.
 
 		#spells .header {
 			grid-area: auto;
+		}
+
+		#spells span[class=""] {
+			display: none;
 		}
 
 		#spells .entry-parent:nth-child(14n+1):not(.header),
@@ -1416,8 +1433,8 @@ defined by the Mozilla Public License, version 2.0.
 				<div class="desc" style="padding-left: calc(20px * @DEPTHx1 + 4px)">
 					@DESCRIPTION_PRIMARY
 					<div class="item-notes">
-						@DESCRIPTION_MODIFIER_NOTES
-						@DESCRIPTION_NOTES
+						<span class="@DESCRIPTION_MODIFIER_NOTES">@DESCRIPTION_MODIFIER_NOTES<br></span>
+						<span class="@DESCRIPTION_NOTES">@DESCRIPTION_NOTES<br></span>
 						Class: @CLASS; Cost: @MANA_CAST; Maintain: @MANA_MAINTAIN; Time: @TIME_CAST; Duration:
 						@DURATION;
 					</div>
@@ -1575,7 +1592,7 @@ defined by the Mozilla Public License, version 2.0.
 				</div>
 				<div class="uses max@MAX_USES">@USES</div>
 				<div class="tech-level">@TL</div>
-				<div class="legality-class">@LEGALITY_CLASS</div>
+				<div class="legality-class @LEGALITY_CLASS"></div>
 				<div class="value">@COST</div>
 				<div class="weight">@WEIGHT</div>
 				<div class="extended-value">@COST_SUMMARY</div>

--- a/Library/Output Templates/HTML - PC.html
+++ b/Library/Output Templates/HTML - PC.html
@@ -755,10 +755,13 @@ defined by the Mozilla Public License, version 2.0.
 		}
 
 		#traits .desc:not(.header),
-		#traits .points:not(.header),
-		#traits .reference:not(.header) {
+		#traits .points:not(.header) {
 			border-bottom: 1px solid rgb(var(--color-header));
 			border-right: 1px solid rgb(var(--color-header));
+		}
+
+		#traits .reference:not(.header) {
+			border-bottom: 1px solid rgb(var(--color-header));
 		}
 
 
@@ -908,10 +911,13 @@ defined by the Mozilla Public License, version 2.0.
 		#equipment .weight:not(.header),
 		#equipment .value:not(.header),
 		#equipment .extended-weight:not(.header),
-		#equipment .extended-value:not(.header),
-		#equipment .reference:not(.header) {
+		#equipment .extended-value:not(.header) {
 			border-bottom: 1px solid rgb(var(--color-header));
 			border-right: 1px solid rgb(var(--color-header));
+		}
+
+		#equipment .reference:not(.header) {
+			border-bottom: 1px solid rbg(var(--color-header));
 		}
 
 		#equipment :nth-last-child(-n+11) {
@@ -954,10 +960,13 @@ defined by the Mozilla Public License, version 2.0.
 		#other-equipment .weight:not(.header),
 		#other-equipment .value:not(.header),
 		#other-equipment .extended-weight:not(.header),
-		#other-equipment .extended-value:not(.header),
-		#other-equipment .reference:not(.header) {
+		#other-equipment .extended-value:not(.header) {
 			border-bottom: 1px solid rgb(var(--color-header));
 			border-right: 1px solid rgb(var(--color-header));
+		}
+
+		#other-equipment .reference:not(.header) {
+			border-bottom: 1px solid rgb(var(--color-header));
 		}
 
 		#other-equipment :nth-last-child(-n+10) {

--- a/Library/Output Templates/HTML - PC.html
+++ b/Library/Output Templates/HTML - PC.html
@@ -336,7 +336,6 @@ defined by the Mozilla Public License, version 2.0.
 		#points .fieldblock .field:nth-child(4n-1),
 		#points .fieldblock .label:nth-child(4n) {
 			background-color: rgb(var(--color-banding));
-			color: rgb(var(--color-on-banding));
 		}
 
 		#stats {

--- a/Library/Output Templates/HTML - PC.html
+++ b/Library/Output Templates/HTML - PC.html
@@ -242,10 +242,6 @@ defined by the Mozilla Public License, version 2.0.
             border-bottom: none;
         }
 
-        .dropdown {
-            background-color: transparent;
-        }
-
         #sheet {
             background-color: rgb(var(--color-page));
             padding: var(--padding-header);
@@ -755,7 +751,6 @@ defined by the Mozilla Public License, version 2.0.
             color: rgb(var(--color-on-banding));
         }
 
-        #traits .dropdown:not(.header),
         #traits .desc:not(.header),
         #traits .points:not(.header),
         #traits .reference:not(.header) {
@@ -763,22 +758,9 @@ defined by the Mozilla Public License, version 2.0.
             border-right: 1px solid rgb(var(--color-header));
         }
 
-        #traits .dropdown:not(.header).reference,
-        #traits .dropdown:not(.header).dropdown,
-        #traits .desc:not(.header).reference,
-        #traits .desc:not(.header).dropdown,
-        #traits .points:not(.header).reference,
-        #traits .points:not(.header).dropdown,
-        #traits .reference:not(.header).reference,
-        #traits .reference:not(.header).dropdown {
-            border-right: none;
-        }
 
-        #traits .dropdown:not(.header):nth-last-child(-n+4),
-        #traits .desc:not(.header):nth-last-child(-n+4),
-        #traits .points:not(.header):nth-last-child(-n+4),
-        #traits .reference:not(.header):nth-last-child(-n+4) {
-            border-bottom: none;
+        #traits :nth-last-child(-n+4) {
+            border-bottom: none !important;
         }
 
         #skills {
@@ -800,7 +782,6 @@ defined by the Mozilla Public License, version 2.0.
             color: rgb(var(--color-on-banding));
         }
 
-        #skills .dropdown:not(.header),
         #skills .desc:not(.header),
         #skills .level:not(.header),
         #skills .rsl:not(.header),
@@ -810,28 +791,8 @@ defined by the Mozilla Public License, version 2.0.
             border-right: 1px solid rgb(var(--color-header));
         }
 
-        #skills .dropdown:not(.header).reference,
-        #skills .dropdown:not(.header).dropdown,
-        #skills .desc:not(.header).reference,
-        #skills .desc:not(.header).dropdown,
-        #skills .level:not(.header).reference,
-        #skills .level:not(.header).dropdown,
-        #skills .rsl:not(.header).reference,
-        #skills .rsl:not(.header).dropdown,
-        #skills .points:not(.header).reference,
-        #skills .points:not(.header).dropdown,
-        #skills .reference:not(.header).reference,
-        #skills .reference:not(.header).dropdown {
-            border-right: none;
-        }
-
-        #skills .dropdown:not(.header):nth-last-child(-n+6),
-        #skills .desc:not(.header):nth-last-child(-n+6),
-        #skills .level:not(.header):nth-last-child(-n+6),
-        #skills .rsl:not(.header):nth-last-child(-n+6),
-        #skills .points:not(.header):nth-last-child(-n+6),
-        #skills .reference:not(.header):nth-last-child(-n+6) {
-            border-bottom: none;
+        #skills :nth-last-child(-n+6) {
+            border-bottom: none !important;
         }
 
         #spells {
@@ -854,7 +815,6 @@ defined by the Mozilla Public License, version 2.0.
             color: rgb(var(--color-on-banding));
         }
 
-        #spells .dropdown:not(.header),
         #spells .desc:not(.header),
         #spells .college:not(.header),
         #spells .level:not(.header),
@@ -865,31 +825,8 @@ defined by the Mozilla Public License, version 2.0.
             border-right: 1px solid rgb(var(--color-header));
         }
 
-        #spells .dropdown:not(.header).reference,
-        #spells .dropdown:not(.header).dropdown,
-        #spells .desc:not(.header).reference,
-        #spells .desc:not(.header).dropdown,
-        #spells .college:not(.header).reference,
-        #spells .college:not(.header).dropdown,
-        #spells .level:not(.header).reference,
-        #spells .level:not(.header).dropdown,
-        #spells .rsl:not(.header).reference,
-        #spells .rsl:not(.header).dropdown,
-        #spells .points:not(.header).reference,
-        #spells .points:not(.header).dropdown,
-        #spells .reference:not(.header).reference,
-        #spells .reference:not(.header).dropdown {
-            border-right: none;
-        }
-
-        #spells .dropdown:not(.header):nth-last-child(-n+12),
-        #spells .desc:not(.header):nth-last-child(-n+12),
-        #spells .college:not(.header):nth-last-child(-n+12),
-        #spells .level:not(.header):nth-last-child(-n+12),
-        #spells .rsl:not(.header):nth-last-child(-n+12),
-        #spells .points:not(.header):nth-last-child(-n+12),
-        #spells .reference:not(.header):nth-last-child(-n+12) {
-            border-bottom: none;
+        #spells :nth-last-child(-n+7) {
+            border-bottom: none !important;
         }
 
         #equipment {
@@ -912,10 +849,10 @@ defined by the Mozilla Public License, version 2.0.
         #equipment .uses:nth-child(24n+5):not(.header),
         #equipment .tech-level:nth-child(24n+6):not(.header),
         #equipment .legality-class:nth-child(24n+7):not(.header),
-        #equipment .weight:nth-child(24n+8):not(.header),
-        #equipment .value:nth-child(24n+9):not(.header),
-        #equipment .extended-weight:nth-child(24n+10):not(.header),
-        #equipment .extended-value:nth-child(24n+11):not(.header),
+        #equipment .value:nth-child(24n+8):not(.header),
+        #equipment .weight:nth-child(24n+9):not(.header),
+        #equipment .extended-value:nth-child(24n+10):not(.header),
+        #equipment .extended-weight:nth-child(24n+11):not(.header),
         #equipment .reference:nth-child(24n+12):not(.header) {
             background-color: rgb(var(--color-banding));
             color: rgb(var(--color-on-banding));
@@ -923,7 +860,6 @@ defined by the Mozilla Public License, version 2.0.
 
         #equipment .equipped:not(.header),
         #equipment .quantity:not(.header),
-        #equipment .dropdown:not(.header),
         #equipment .desc:not(.header),
         #equipment .uses:not(.header),
         #equipment .tech-level:not(.header),
@@ -937,48 +873,10 @@ defined by the Mozilla Public License, version 2.0.
             border-right: 1px solid rgb(var(--color-header));
         }
 
-        #equipment .equipped:not(.header).reference,
-        #equipment .equipped:not(.header).dropdown,
-        #equipment .quantity:not(.header).reference,
-        #equipment .quantity:not(.header).dropdown,
-        #equipment .dropdown:not(.header).reference,
-        #equipment .dropdown:not(.header).dropdown,
-        #equipment .desc:not(.header).reference,
-        #equipment .desc:not(.header).dropdown,
-        #equipment .uses:not(.header).reference,
-        #equipment .uses:not(.header).dropdown,
-        #equipment .tech-level:not(.header).reference,
-        #equipment .tech-level:not(.header).dropdown,
-        #equipment .legality-class:not(.header).reference,
-        #equipment .legality-class:not(.header).dropdown,
-        #equipment .weight:not(.header).reference,
-        #equipment .weight:not(.header).dropdown,
-        #equipment .value:not(.header).reference,
-        #equipment .value:not(.header).dropdown,
-        #equipment .extended-weight:not(.header).reference,
-        #equipment .extended-weight:not(.header).dropdown,
-        #equipment .extended-value:not(.header).reference,
-        #equipment .extended-value:not(.header).dropdown,
-        #equipment .reference:not(.header).reference,
-        #equipment .reference:not(.header).dropdown {
-            border-right: none;
+        #equipment :nth-last-child(-n+10) {
+            border-bottom: none !important;
         }
-
-        #equipment .equipped:not(.header):nth-last-child(-n+11),
-        #equipment .quantity:not(.header):nth-last-child(-n+11),
-        #equipment .dropdown:not(.header):nth-last-child(-n+11),
-        #equipment .desc:not(.header):nth-last-child(-n+11),
-        #equipment .uses:not(.header):nth-last-child(-n+11),
-        #equipment .tech-level:not(.header):nth-last-child(-n+11),
-        #equipment .legality-class:not(.header):nth-last-child(-n+11),
-        #equipment .weight:not(.header):nth-last-child(-n+11),
-        #equipment .value:not(.header):nth-last-child(-n+11),
-        #equipment .extended-weight:not(.header):nth-last-child(-n+11),
-        #equipment .extended-value:not(.header):nth-last-child(-n+11),
-        #equipment .reference:not(.header):nth-last-child(-n+11) {
-            border-bottom: none;
-        }
-
+        
         #equipment .equipped {
             padding: var(--padding-header);
         }
@@ -998,17 +896,16 @@ defined by the Mozilla Public License, version 2.0.
         #other-equipment .uses:nth-child(22n+4):not(.header),
         #other-equipment .tech-level:nth-child(22n+5):not(.header),
         #other-equipment .legality-class:nth-child(22n+6):not(.header),
-        #other-equipment .weight:nth-child(22n+7):not(.header),
-        #other-equipment .value:nth-child(22n+8):not(.header),
-        #other-equipment .extended-weight:nth-child(22n+9):not(.header),
-        #other-equipment .extended-value:nth-child(22n+10):not(.header),
+        #other-equipment .value:nth-child(22n+7):not(.header),
+        #other-equipment .weight:nth-child(22n+8):not(.header),
+        #other-equipment .extended-value:nth-child(22n+9):not(.header),
+        #other-equipment .extended-weight:nth-child(22n+10):not(.header),
         #other-equipment .reference:nth-child(22n+11):not(.header) {
             background-color: rgb(var(--color-banding));
             color: rgb(var(--color-on-banding));
         }
 
         #other-equipment .quantity:not(.header),
-        #other-equipment .dropdown:not(.header),
         #other-equipment .desc:not(.header),
         #other-equipment .uses:not(.header),
         #other-equipment .tech-level:not(.header),
@@ -1022,43 +919,8 @@ defined by the Mozilla Public License, version 2.0.
             border-right: 1px solid rgb(var(--color-header));
         }
 
-        #other-equipment .quantity:not(.header).reference,
-        #other-equipment .quantity:not(.header).dropdown,
-        #other-equipment .dropdown:not(.header).reference,
-        #other-equipment .dropdown:not(.header).dropdown,
-        #other-equipment .desc:not(.header).reference,
-        #other-equipment .desc:not(.header).dropdown,
-        #other-equipment .uses:not(.header).reference,
-        #other-equipment .uses:not(.header).dropdown,
-        #other-equipment .tech-level:not(.header).reference,
-        #other-equipment .tech-level:not(.header).dropdown,
-        #other-equipment .legality-class:not(.header).reference,
-        #other-equipment .legality-class:not(.header).dropdown,
-        #other-equipment .weight:not(.header).reference,
-        #other-equipment .weight:not(.header).dropdown,
-        #other-equipment .value:not(.header).reference,
-        #other-equipment .value:not(.header).dropdown,
-        #other-equipment .extended-weight:not(.header).reference,
-        #other-equipment .extended-weight:not(.header).dropdown,
-        #other-equipment .extended-value:not(.header).reference,
-        #other-equipment .extended-value:not(.header).dropdown,
-        #other-equipment .reference:not(.header).reference,
-        #other-equipment .reference:not(.header).dropdown {
-            border-right: none;
-        }
-
-        #other-equipment .quantity:not(.header):nth-last-child(-n+10),
-        #other-equipment .dropdown:not(.header):nth-last-child(-n+10),
-        #other-equipment .desc:not(.header):nth-last-child(-n+10),
-        #other-equipment .uses:not(.header):nth-last-child(-n+10),
-        #other-equipment .tech-level:not(.header):nth-last-child(-n+10),
-        #other-equipment .legality-class:not(.header):nth-last-child(-n+10),
-        #other-equipment .weight:not(.header):nth-last-child(-n+10),
-        #other-equipment .value:not(.header):nth-last-child(-n+10),
-        #other-equipment .extended-weight:not(.header):nth-last-child(-n+10),
-        #other-equipment .extended-value:not(.header):nth-last-child(-n+10),
-        #other-equipment .reference:not(.header):nth-last-child(-n+10) {
-            border-bottom: none;
+        #other-equipment :nth-last-child(-n+10) {
+            border-bottom: none !important;
         }
 
         #notes {
@@ -1083,23 +945,13 @@ defined by the Mozilla Public License, version 2.0.
             border-right: 1px solid rgb(var(--color-header));
         }
 
-        #notes .desc:not(.header).reference,
-        #notes .refrence:not(.header).reference {
-            border-right: none;
-        }
-
-        #notes .desc:not(.header):nth-last-child(-n+2),
-        #notes .refrence:not(.header):nth-last-child(-n+2) {
-            border-bottom: none;
+        #notes :nth-last-child(-n+3) {
+            border-bottom: none !important;
         }
 
         #embeds>div {
             display: grid;
             grid-template-rows: repeat(1000, auto) 1fr;
-        }
-
-        #embeds>div>.desc .dropdown {
-            margin-right: 6px;
         }
 
         #embeds>div>.desc .item-notes {
@@ -1160,16 +1012,6 @@ defined by the Mozilla Public License, version 2.0.
         #embeds .item-notes {
             font: var(--font-page-secondary-fields);
             background-color: transparent;
-        }
-
-        #embeds .dropdown i {
-            background-color: inherit;
-        }
-
-        #embeds .dropdown i svg {
-            background-color: inherit;
-            fill: rgb(var(--color-on-content));
-            width: 0.75em;
         }
 
         div {
@@ -1318,10 +1160,10 @@ defined by the Mozilla Public License, version 2.0.
                     <div class="header">Basic Damage</div>
                     <div class="fieldblock3">
                         <div class="points">[20]</div>
-                        <div class="field">@THRUST</div>
+                        <div class="field noedit">@THRUST</div>
                         <div class="label">Basic Thrust</div>
                         <div class="points">[20]</div>
-                        <div class="field">@SWING</div>
+                        <div class="field noedit">@SWING</div>
                         <div class="label">Basic Swing</div>
                     </div>
                 </div>

--- a/Library/Output Templates/HTML - PC.html
+++ b/Library/Output Templates/HTML - PC.html
@@ -14,7 +14,7 @@ defined by the Mozilla Public License, version 2.0.
 -->
 
 <head>
-    <meta charset="ut-8" />
+    <meta charset="utf-8" />
     <title>@NAME</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -103,67 +103,66 @@ defined by the Mozilla Public License, version 2.0.
             --shape-stack: path("M232.5 5.171a56.026 56.026 0 0 1 47 0L498.1 106.2c8.5 3.9 13.9 12.4 13.9 20.9 0 10.2-5.4 18.7-13.9 22.7l-218.6 101c-14.9 6.9-32.1 6.9-47 0l-218.57-101C5.438 145.8 0 137.3 0 127.1c0-8.5 5.437-17 13.93-20.9L232.5 5.171zM498.1 234.2c8.5 3.9 13.9 12.4 13.9 20.9 0 10.2-5.4 18.7-13.9 22.7l-218.6 101c-14.9 6.9-32.1 6.9-47 0l-218.57-101C5.438 273.8 0 265.3 0 255.1c0-8.5 5.437-17 13.93-20.9l53.2-24.6 151.97 70.2c23.4 10.9 50.4 10.9 73.8 0l152-70.2 53.2 24.6zM292.9 407.8l152-70.2 53.2 24.6c8.5 3.9 13.9 12.4 13.9 20.9 0 10.2-5.4 18.7-13.9 22.7l-218.6 101c-14.9 6.9-32.1 6.9-47 0l-218.57-101C5.438 401.8 0 393.3 0 383.1c0-8.5 5.437-17 13.93-20.9l53.2-24.6 151.97 70.2c23.4 10.9 50.4 10.9 73.8 0z");
         }
 
-        /* @media (prefers-color-scheme: dark) { */
-        /* :root {
-            --color-background: 50, 50, 50;
-            --color-on-background: 221, 221, 221;
-            --color-content: 32, 32, 32;
-            --color-on-content: 221, 221, 221;
-            --color-banding: 42, 42, 42;
-            --color-on-banding: 221, 221, 221;
-            --color-header: 64, 64, 64;
-            --color-on-header: 192, 192, 192;
-            --color-focused-tab: 68, 102, 0;
-            --color-on-focused-tab: 221, 221, 221;
-            --color-current-tab: 41, 61, 0;
-            --color-on-current-tab: 221, 221, 221;
-            --color-editable: 24, 24, 24;
-            --color-on-editable: 100, 153, 153;
-            --color-editable-border: 96, 96, 96;
-            --color-focused-editable-border: 0, 102, 102;
-            --color-selection: 0, 96, 160;
-            --color-on-selection: 255, 255, 255;
-            --color-inactive-selection: 0, 64, 128;
-            --color-on-inactive-selection: 228, 228, 228;
-            --color-inactive-selection: 0, 64, 128;
-            --color-on-inactive-selection: 228, 228, 228;
-            --color-scroll: 128, 128, 128, 0.5;
-            --color-scroll-rollover: 128, 128, 128;
-            --color-scroll-edge: 160, 160, 160;
-            --color-accent: 100, 153, 153;
-            --color-control: 64, 64, 64;
-            --color-on-control: 221, 221, 221;
-            --color-pressed-control: 0, 96, 160;
-            --color-on-pressed-control: 255, 255, 255;
-            --color-control-edge: 96, 96, 96;
-            --color-divider: 102, 102, 102;
-            --color-icon-button: 128, 128, 128;
-            --color-icon-button-rollover: 192, 192, 192;
-            --color-pressed-icon-button: 0, 96, 160;
-            --color-drop-area: 255, 0, 0;
-            --color-toolip: 252, 252, 196;
-            --color-on-tooltip: 0, 0, 0;
-            --color-search-list: 0, 43, 43;
-            --color-on-search-list: 204, 204, 204;
-            --color-marker: 0, 51, 0;
-            --color-on-marker: 221, 221, 221;
-            --color-error: 115, 37, 37;
-            --color-on-error: 221, 221, 221;
-            --color-warning: 192, 96, 0;
-            --color-on-warning: 221, 221, 221;
-            --color-overloaded: 115, 37, 37;
-            --color-on-overloaded: 221, 221, 221;
-            --color-page: 16, 16, 16;
-            --color-on-page: 160, 160, 160;
-            --color-page-void: 0, 0, 0;
-            --color-hint: 64, 64, 64;
-            --color-link: 0, 255, 127;
-            --color-on-link: 0, 0, 0;
-            --color-pdf-link-highlight: 0, 255, 127;
-            --color-pdf-marker-highlight: 255, 255, 0;
+        /* @media (prefers-color-scheme: dark) {
+            :root {
+                --color-background: 50, 50, 50;
+                --color-on-background: 221, 221, 221;
+                --color-content: 32, 32, 32;
+                --color-on-content: 221, 221, 221;
+                --color-banding: 42, 42, 42;
+                --color-on-banding: 221, 221, 221;
+                --color-header: 64, 64, 64;
+                --color-on-header: 192, 192, 192;
+                --color-focused-tab: 68, 102, 0;
+                --color-on-focused-tab: 221, 221, 221;
+                --color-current-tab: 41, 61, 0;
+                --color-on-current-tab: 221, 221, 221;
+                --color-editable: 24, 24, 24;
+                --color-on-editable: 100, 153, 153;
+                --color-editable-border: 96, 96, 96;
+                --color-focused-editable-border: 0, 102, 102;
+                --color-selection: 0, 96, 160;
+                --color-on-selection: 255, 255, 255;
+                --color-inactive-selection: 0, 64, 128;
+                --color-on-inactive-selection: 228, 228, 228;
+                --color-inactive-selection: 0, 64, 128;
+                --color-on-inactive-selection: 228, 228, 228;
+                --color-scroll: 128, 128, 128, 0.5;
+                --color-scroll-rollover: 128, 128, 128;
+                --color-scroll-edge: 160, 160, 160;
+                --color-accent: 100, 153, 153;
+                --color-control: 64, 64, 64;
+                --color-on-control: 221, 221, 221;
+                --color-pressed-control: 0, 96, 160;
+                --color-on-pressed-control: 255, 255, 255;
+                --color-control-edge: 96, 96, 96;
+                --color-divider: 102, 102, 102;
+                --color-icon-button: 128, 128, 128;
+                --color-icon-button-rollover: 192, 192, 192;
+                --color-pressed-icon-button: 0, 96, 160;
+                --color-drop-area: 255, 0, 0;
+                --color-toolip: 252, 252, 196;
+                --color-on-tooltip: 0, 0, 0;
+                --color-search-list: 0, 43, 43;
+                --color-on-search-list: 204, 204, 204;
+                --color-marker: 0, 51, 0;
+                --color-on-marker: 221, 221, 221;
+                --color-error: 115, 37, 37;
+                --color-on-error: 221, 221, 221;
+                --color-warning: 192, 96, 0;
+                --color-on-warning: 221, 221, 221;
+                --color-overloaded: 115, 37, 37;
+                --color-on-overloaded: 221, 221, 221;
+                --color-page: 16, 16, 16;
+                --color-on-page: 160, 160, 160;
+                --color-page-void: 0, 0, 0;
+                --color-hint: 64, 64, 64;
+                --color-link: 0, 255, 127;
+                --color-on-link: 0, 0, 0;
+                --color-pdf-link-highlight: 0, 255, 127;
+                --color-pdf-marker-highlight: 255, 255, 0;
+            }
         } */
-
-        /* } */
 
         svg {
             width: 1em;
@@ -790,7 +789,7 @@ defined by the Mozilla Public License, version 2.0.
             border-bottom: 1px solid rgb(var(--color-header));
             border-right: 1px solid rgb(var(--color-header));
         }
-        
+
         #skills .reference:not(.header) {
             border-bottom: 1px solid rgb(var(--color-header));
         }

--- a/Library/Output Templates/HTML - PC.html
+++ b/Library/Output Templates/HTML - PC.html
@@ -14,854 +14,829 @@ defined by the Mozilla Public License, version 2.0.
 -->
 
 <head>
-    <meta charset="utf-8" />
-    <title>@NAME</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap" rel="stylesheet">
-    <style>
-        :root {
-            --section-gap: 1px;
-            --header-font-size: 80%;
-            --padding-standard: 0px 4px;
-            --padding-header: 1px 8px;
-            --standard-border: 1px solid rgb(var(--color-header));
+	<meta charset="utf-8" />
+	<title>@NAME</title>
+	<link rel="preconnect" href="https://fonts.googleapis.com">
+	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+	<link href="https://fonts.googleapis.com/css2?family=Roboto:wght&#64;400;500&display=swap" rel="stylesheet">
+	<style>
+		:root {
+			--section-gap: 1px;
+			--header-font-size: 80%;
+			--padding-standard: 0px 4px;
+			--padding-header: 1px 8px;
+			--standard-border: 1px solid rgb(var(--color-header));
 
-            --font-page-primary-fields: 500 var(--font-size-14) 'Roboto', sans-serif;
-            --font-page-secondary-fields: 400 var(--font-size-12) 'Roboto', sans-serif;
-            --font-page-primary-labels: 400 var(--font-size-14) 'Roboto', sans-serif;
-            --font-page-secondary-lables: 400 var(--font-size-12) 'Roboto', sans-serif;
-            --font-page-primary-footer: 500 var(--font-size-12) 'Roboto', sans-serif;
-            --font-page-secondary-footer: 400 var(--font-size-11) 'Roboto', sans-serif;
+			--font-page-primary-fields: 500 var(--font-size-14) 'Roboto', sans-serif;
+			--font-page-secondary-fields: 400 var(--font-size-12) 'Roboto', sans-serif;
+			--font-page-primary-labels: 400 var(--font-size-14) 'Roboto', sans-serif;
+			--font-page-secondary-lables: 400 var(--font-size-12) 'Roboto', sans-serif;
+			--font-page-primary-footer: 500 var(--font-size-12) 'Roboto', sans-serif;
+			--font-page-secondary-footer: 400 var(--font-size-11) 'Roboto', sans-serif;
 
-            --font-size-14: 0.875rem;
-            --font-size-12: 0.75rem;
-            --font-size-11: 0.6875rem;
+			--font-size-14: 0.875rem;
+			--font-size-12: 0.75rem;
+			--font-size-11: 0.6875rem;
 
-            --color-background: 238, 238, 238;
-            --color-on-background: 0, 0, 0;
-            --color-content: 255, 255, 255;
-            --color-on-content: 0, 0, 0;
-            --color-banding: 235, 235, 220;
-            --color-on-banding: 0, 0, 0;
-            --color-header: 43, 43, 43;
-            --color-on-header: 255, 255, 255;
-            --color-focused-tab: 224, 212, 175;
-            --color-on-focused-tab: 0, 0, 0;
-            --color-current-tab: 211, 207, 197;
-            --color-on-current-tab: 0, 0, 0;
-            --color-editable: 255, 255, 255;
-            --color-on-editable: 0, 0, 160;
-            --color-editable-border: 192, 192, 192;
-            --color-focused-editable-border: 0, 0, 192;
-            --color-selection: 0, 96, 160;
-            --color-on-selection: 255, 255, 255;
-            --color-inactive-selection: 0, 64, 128;
-            --color-on-inactive-selection: 228, 228, 228;
-            --color-inactive-selection: 0, 64, 128;
-            --color-on-inactive-selection: 0, 0, 0;
-            --color-scroll: 192, 192, 192, 0.5;
-            --color-scroll-rollover: 192, 192, 192;
-            --color-scroll-edge: 128, 128, 128;
-            --color-accent: 0, 102, 102;
-            --color-control: 248, 248, 255;
-            --color-on-control: 0, 0, 0;
-            --color-pressed-control: 0, 96, 160;
-            --color-on-pressed-control: 255, 255, 255;
-            --color-control-edge: 96, 96, 96;
-            --color-divider: 192, 192, 192;
-            --color-icon-button: 96, 96, 96;
-            --color-icon-button-rollover: 0, 0, 0;
-            --color-pressed-icon-button: 0, 96, 160;
-            --color-drop-area: 204, 0, 51;
-            --color-toolip: 252, 252, 196;
-            --color-on-tooltip: 0, 0, 0;
-            --color-search-list: 224, 255, 255;
-            --color-on-search-list: 0, 0, 0;
-            --color-marker: 252, 242, 196;
-            --color-on-marker: 0, 0, 0;
-            --color-error: 192, 64, 64;
-            --color-on-error: 255, 255, 255;
-            --color-warning: 224, 128, 0;
-            --color-on-warning: 255, 255, 255;
-            --color-overloaded: 192, 64, 64;
-            --color-on-overloaded: 255, 255, 255;
-            --color-page: 255, 255, 255;
-            --color-on-page: 0, 0, 0;
-            --color-page-void: 128, 128, 128;
-            --color-hint: 128, 128, 128;
-            --color-link: 0, 255, 127;
-            --color-on-link: 0, 0, 0;
-            --color-pdf-link-highlight: 0, 255, 127;
-            --color-pdf-marker-highlight: 255, 255, 0;
+			--color-background: 238, 238, 238;
+			--color-on-background: 0, 0, 0;
+			--color-content: 255, 255, 255;
+			--color-on-content: 0, 0, 0;
+			--color-banding: 235, 235, 220;
+			--color-on-banding: 0, 0, 0;
+			--color-header: 43, 43, 43;
+			--color-on-header: 255, 255, 255;
+			--color-focused-tab: 224, 212, 175;
+			--color-on-focused-tab: 0, 0, 0;
+			--color-current-tab: 211, 207, 197;
+			--color-on-current-tab: 0, 0, 0;
+			--color-editable: 255, 255, 255;
+			--color-on-editable: 0, 0, 160;
+			--color-editable-border: 192, 192, 192;
+			--color-focused-editable-border: 0, 0, 192;
+			--color-selection: 0, 96, 160;
+			--color-on-selection: 255, 255, 255;
+			--color-inactive-selection: 0, 64, 128;
+			--color-on-inactive-selection: 228, 228, 228;
+			--color-inactive-selection: 0, 64, 128;
+			--color-on-inactive-selection: 0, 0, 0;
+			--color-scroll: 192, 192, 192, 0.5;
+			--color-scroll-rollover: 192, 192, 192;
+			--color-scroll-edge: 128, 128, 128;
+			--color-accent: 0, 102, 102;
+			--color-control: 248, 248, 255;
+			--color-on-control: 0, 0, 0;
+			--color-pressed-control: 0, 96, 160;
+			--color-on-pressed-control: 255, 255, 255;
+			--color-control-edge: 96, 96, 96;
+			--color-divider: 192, 192, 192;
+			--color-icon-button: 96, 96, 96;
+			--color-icon-button-rollover: 0, 0, 0;
+			--color-pressed-icon-button: 0, 96, 160;
+			--color-drop-area: 204, 0, 51;
+			--color-toolip: 252, 252, 196;
+			--color-on-tooltip: 0, 0, 0;
+			--color-search-list: 224, 255, 255;
+			--color-on-search-list: 0, 0, 0;
+			--color-marker: 252, 242, 196;
+			--color-on-marker: 0, 0, 0;
+			--color-error: 192, 64, 64;
+			--color-on-error: 255, 255, 255;
+			--color-warning: 224, 128, 0;
+			--color-on-warning: 255, 255, 255;
+			--color-overloaded: 192, 64, 64;
+			--color-on-overloaded: 255, 255, 255;
+			--color-page: 255, 255, 255;
+			--color-on-page: 0, 0, 0;
+			--color-page-void: 128, 128, 128;
+			--color-hint: 128, 128, 128;
+			--color-link: 0, 255, 127;
+			--color-on-link: 0, 0, 0;
+			--color-pdf-link-highlight: 0, 255, 127;
+			--color-pdf-marker-highlight: 255, 255, 0;
+		}
 
 
-            --shape-weight: path("m510.3 445.9-73-292.1c-3.8-15.3-16.5-25.8-30.9-25.8h-60.3c3.625-9.1 5.875-20.75 5.875-32 0-53-42.1-96-96-96S159.1 43 159.1 96c0 11.25 2.25 22 5.875 32H105.6c-14.38 0-27.13 10.5-30.88 25.75L1.71 445.85C-6.641 479.1 16.36 512 47.99 512h416c31.61 0 54.61-32.9 46.31-66.1zM256 128c-17.6 0-32.9-14.4-32.9-32s15.3-32 32.9-32c17.63 0 32 14.38 32 32s-14.4 32-32 32z");
-            --shape-bookmark: path("M384 48v464L192 400 0 512V48C0 21.5 21.5 0 48 0h288c26.5 0 48 21.5 48 48z");
-            --shape-checkmark: path("M 492.1883,51.561176 447.69973,21.315702 C 435.38472,12.98066 418.51958,16.176634 410.28207,28.39411 L 192.1793,350.02095 91.94873,249.79038 c -10.469445,-10.46569 -27.533399,-10.46569 -37.999091,0 L 15.849269,287.887 c -10.4656924,10.46569 -10.4656924,27.52965 0,38.09662 L 169.97628,480.10687 c 8.62763,8.62763 22.19551,15.22215 34.40924,15.22215 12.21748,0 24.52498,-7.65984 32.47365,-19.19461 L 499.36048,88.881308 c 8.33505,-12.213725 5.13907,-28.98509 -7.17594,-37.323883 z");
-            --shape-coins: path("M512 80c0 18.01-14.3 34.6-38.4 48-29.1 16.1-72.4 27.5-122.3 30.9-3.6-1.7-7.4-3.4-11.2-5C300.6 137.4 248.2 128 192 128c-8.3 0-16.4.2-24.5.6l-1.1-.6C142.3 114.6 128 98.01 128 80c0-44.18 85.1-80 192-80 106 0 192 35.82 192 80zm-351.3 81.1c10.2-.7 20.6-1.1 31.3-1.1 62.2 0 117.4 12.3 152.5 31.4 24.8 13.5 39.5 30.3 39.5 48.6 0 3.1-.7 7.9-2.1 11.7-4.6 13.2-17.8 25.3-35 35.6-.1 0-.3.1-.4.2-.3.2-.6.3-.9.5-35 19.4-90.8 32-153.6 32-59.6 0-112.94-11.3-148.16-29.1-1.87-1-3.69-2.8-5.45-2.9C14.28 274.6 0 258 0 240c0-34.8 53.43-64.5 128-75.4 10.5-1.6 21.4-2.8 32.7-3.5zm231.2 25.5c28.3-4.4 54.2-11.4 76.2-20.5 16.3-6.8 31.4-15.2 43.9-25.5V176c0 19.3-16.5 37.1-43.8 50.9-14.7 7.4-32.4 13.6-52.4 18.4.1-1.7.2-3.5.2-5.3 0-21.9-10.6-39.9-24.1-53.4zM384 336c0 18-14.3 34.6-38.4 48-1.8.1-3.6 1.9-5.4 2.9C304.9 404.7 251.6 416 192 416c-62.8 0-118.58-12.6-153.61-32C14.28 370.6 0 354 0 336v-35.4c12.45 10.3 27.62 18.7 43.93 25.5C83.44 342.6 135.8 352 192 352c56.2 0 108.6-9.4 148.1-25.9 7.8-3.2 15.3-6.9 22.4-10.9 6.1-3.4 11.8-7.2 17.2-11.2 1.5-1.1 2.9-2.3 4.3-3.4V336zm32-57.9c18.1-5 36.5-9.5 52.1-16 16.3-6.8 31.4-15.2 43.9-25.5V272c0 10.5-5 21-14.9 30.9-16.3 16.3-45 29.7-81.3 38.4.1-1.7.2-3.5.2-5.3v-57.9zM192 448c56.2 0 108.6-9.4 148.1-25.9 16.3-6.8 31.4-15.2 43.9-25.5V432c0 44.2-86 80-192 80C85.96 512 0 476.2 0 432v-35.4c12.45 10.3 27.62 18.7 43.93 25.5C83.44 438.6 135.8 448 192 448z");
-            --shape-stack: path("M232.5 5.171a56.026 56.026 0 0 1 47 0L498.1 106.2c8.5 3.9 13.9 12.4 13.9 20.9 0 10.2-5.4 18.7-13.9 22.7l-218.6 101c-14.9 6.9-32.1 6.9-47 0l-218.57-101C5.438 145.8 0 137.3 0 127.1c0-8.5 5.437-17 13.93-20.9L232.5 5.171zM498.1 234.2c8.5 3.9 13.9 12.4 13.9 20.9 0 10.2-5.4 18.7-13.9 22.7l-218.6 101c-14.9 6.9-32.1 6.9-47 0l-218.57-101C5.438 273.8 0 265.3 0 255.1c0-8.5 5.437-17 13.93-20.9l53.2-24.6 151.97 70.2c23.4 10.9 50.4 10.9 73.8 0l152-70.2 53.2 24.6zM292.9 407.8l152-70.2 53.2 24.6c8.5 3.9 13.9 12.4 13.9 20.9 0 10.2-5.4 18.7-13.9 22.7l-218.6 101c-14.9 6.9-32.1 6.9-47 0l-218.57-101C5.438 401.8 0 393.3 0 383.1c0-8.5 5.437-17 13.93-20.9l53.2-24.6 151.97 70.2c23.4 10.9 50.4 10.9 73.8 0z");
-        }
+		/* @media (prefers-color-scheme: dark) { */
+		/* 	:root { */
+		/* 		--color-background: 50, 50, 50; */
+		/* 		--color-on-background: 221, 221, 221; */
+		/* 		--color-content: 32, 32, 32; */
+		/* 		--color-on-content: 221, 221, 221; */
+		/* 		--color-banding: 42, 42, 42; */
+		/* 		--color-on-banding: 221, 221, 221; */
+		/* 		--color-header: 64, 64, 64; */
+		/* 		--color-on-header: 192, 192, 192; */
+		/* 		--color-focused-tab: 68, 102, 0; */
+		/* 		--color-on-focused-tab: 221, 221, 221; */
+		/* 		--color-current-tab: 41, 61, 0; */
+		/* 		--color-on-current-tab: 221, 221, 221; */
+		/* 		--color-editable: 24, 24, 24; */
+		/* 		--color-on-editable: 100, 153, 153; */
+		/* 		--color-editable-border: 96, 96, 96; */
+		/* 		--color-focused-editable-border: 0, 102, 102; */
+		/* 		--color-selection: 0, 96, 160; */
+		/* 		--color-on-selection: 255, 255, 255; */
+		/* 		--color-inactive-selection: 0, 64, 128; */
+		/* 		--color-on-inactive-selection: 228, 228, 228; */
+		/* 		--color-inactive-selection: 0, 64, 128; */
+		/* 		--color-on-inactive-selection: 228, 228, 228; */
+		/* 		--color-scroll: 128, 128, 128, 0.5; */
+		/* 		--color-scroll-rollover: 128, 128, 128; */
+		/* 		--color-scroll-edge: 160, 160, 160; */
+		/* 		--color-accent: 100, 153, 153; */
+		/* 		--color-control: 64, 64, 64; */
+		/* 		--color-on-control: 221, 221, 221; */
+		/* 		--color-pressed-control: 0, 96, 160; */
+		/* 		--color-on-pressed-control: 255, 255, 255; */
+		/* 		--color-control-edge: 96, 96, 96; */
+		/* 		--color-divider: 102, 102, 102; */
+		/* 		--color-icon-button: 128, 128, 128; */
+		/* 		--color-icon-button-rollover: 192, 192, 192; */
+		/* 		--color-pressed-icon-button: 0, 96, 160; */
+		/* 		--color-drop-area: 255, 0, 0; */
+		/* 		--color-toolip: 252, 252, 196; */
+		/* 		--color-on-tooltip: 0, 0, 0; */
+		/* 		--color-search-list: 0, 43, 43; */
+		/* 		--color-on-search-list: 204, 204, 204; */
+		/* 		--color-marker: 0, 51, 0; */
+		/* 		--color-on-marker: 221, 221, 221; */
+		/* 		--color-error: 115, 37, 37; */
+		/* 		--color-on-error: 221, 221, 221; */
+		/* 		--color-warning: 192, 96, 0; */
+		/* 		--color-on-warning: 221, 221, 221; */
+		/* 		--color-overloaded: 115, 37, 37; */
+		/* 		--color-on-overloaded: 221, 221, 221; */
+		/* 		--color-page: 16, 16, 16; */
+		/* 		--color-on-page: 160, 160, 160; */
+		/* 		--color-page-void: 0, 0, 0; */
+		/* 		--color-hint: 64, 64, 64; */
+		/* 		--color-link: 0, 255, 127; */
+		/* 		--color-on-link: 0, 0, 0; */
+		/* 		--color-pdf-link-highlight: 0, 255, 127; */
+		/* 		--color-pdf-marker-highlight: 255, 255, 0; */
+		/* 	} */
+		/* } */
 
-        /* @media (prefers-color-scheme: dark) {
-            :root {
-                --color-background: 50, 50, 50;
-                --color-on-background: 221, 221, 221;
-                --color-content: 32, 32, 32;
-                --color-on-content: 221, 221, 221;
-                --color-banding: 42, 42, 42;
-                --color-on-banding: 221, 221, 221;
-                --color-header: 64, 64, 64;
-                --color-on-header: 192, 192, 192;
-                --color-focused-tab: 68, 102, 0;
-                --color-on-focused-tab: 221, 221, 221;
-                --color-current-tab: 41, 61, 0;
-                --color-on-current-tab: 221, 221, 221;
-                --color-editable: 24, 24, 24;
-                --color-on-editable: 100, 153, 153;
-                --color-editable-border: 96, 96, 96;
-                --color-focused-editable-border: 0, 102, 102;
-                --color-selection: 0, 96, 160;
-                --color-on-selection: 255, 255, 255;
-                --color-inactive-selection: 0, 64, 128;
-                --color-on-inactive-selection: 228, 228, 228;
-                --color-inactive-selection: 0, 64, 128;
-                --color-on-inactive-selection: 228, 228, 228;
-                --color-scroll: 128, 128, 128, 0.5;
-                --color-scroll-rollover: 128, 128, 128;
-                --color-scroll-edge: 160, 160, 160;
-                --color-accent: 100, 153, 153;
-                --color-control: 64, 64, 64;
-                --color-on-control: 221, 221, 221;
-                --color-pressed-control: 0, 96, 160;
-                --color-on-pressed-control: 255, 255, 255;
-                --color-control-edge: 96, 96, 96;
-                --color-divider: 102, 102, 102;
-                --color-icon-button: 128, 128, 128;
-                --color-icon-button-rollover: 192, 192, 192;
-                --color-pressed-icon-button: 0, 96, 160;
-                --color-drop-area: 255, 0, 0;
-                --color-toolip: 252, 252, 196;
-                --color-on-tooltip: 0, 0, 0;
-                --color-search-list: 0, 43, 43;
-                --color-on-search-list: 204, 204, 204;
-                --color-marker: 0, 51, 0;
-                --color-on-marker: 221, 221, 221;
-                --color-error: 115, 37, 37;
-                --color-on-error: 221, 221, 221;
-                --color-warning: 192, 96, 0;
-                --color-on-warning: 221, 221, 221;
-                --color-overloaded: 115, 37, 37;
-                --color-on-overloaded: 221, 221, 221;
-                --color-page: 16, 16, 16;
-                --color-on-page: 160, 160, 160;
-                --color-page-void: 0, 0, 0;
-                --color-hint: 64, 64, 64;
-                --color-link: 0, 255, 127;
-                --color-on-link: 0, 0, 0;
-                --color-pdf-link-highlight: 0, 255, 127;
-                --color-pdf-marker-highlight: 255, 255, 0;
-            }
-        } */
+		svg {
+			width: 1em;
+			height: 1em;
+			background-color: transparent;
+		}
 
-        svg {
-            width: 1em;
-            background-color: transparent;
-        }
+		body {
+			background-color: rgb(var(--color-page));
+			color: rgb(var(--color-on-page));
+			margin: 0.25in;
+			margin-bottom: calc(0.25in - 1em);
+		}
 
-        body {
-            background-color: rgb(var(--color-page));
-            color: rgb(var(--color-on-page));
-            margin: 0.25in;
-            margin-bottom: calc(0.25in - 1em);
-        }
+		#sheet {
+			background-color: rgb(var(--color-page));
+			padding: var(--padding-header);
 
-        #sheet {
-            background-color: rgb(var(--color-page));
-            padding: var(--padding-header);
+			display: flex;
+			flex-flow: column nowrap;
+			justify-content: start;
+			gap: var(--section-gap);
+		}
 
-            display: flex;
-            flex-flow: column nowrap;
-            justify-content: start;
-            gap: var(--section-gap);
-        }
+		.header {
+			grid-area: header;
+			background-color: rgb(var(--color-header));
+			color: rgb(var(--color-on-header));
+			justify-content: center;
+			text-align: center;
+			padding-bottom: 2px;
+			font: var(--font-page-primary-labels);
+		}
 
-        .header {
-            grid-area: header;
-            background-color: rgb(var(--color-header));
-            color: rgb(var(--color-on-header));
-            justify-content: center;
-            text-align: center;
-            padding-bottom: 2px;
-            font: var(--font-page-primary-labels);
-        }
+		.fieldblock {
+			display: grid;
+			grid-template-columns: 0fr 1fr;
+			align-items: end;
+			text-align: left;
+			white-space: nowrap;
+			align-self: stretch;
+			background-color: rgb(var(--color-content));
+			color: rgb(var(--color-on-content));
+		}
 
-        .fieldblock {
-            display: grid;
-            grid-template-columns: 0fr 1fr;
-            align-items: end;
-            text-align: left;
-            white-space: nowrap;
-            align-self: stretch;
-            background-color: rgb(var(--color-content));
-            color: rgb(var(--color-on-content));
-        }
+		.fieldblock3 {
+			display: grid;
+			grid-template-columns: 0fr 0fr 1fr;
+			white-space: nowrap;
+			background-color: rgb(var(--color-content));
+			color: rgb(var(--color-on-content));
+		}
 
-        .fieldblock3 {
-            display: grid;
-            grid-template-columns: 0fr 0fr 1fr;
-            white-space: nowrap;
-            background-color: rgb(var(--color-content));
-            color: rgb(var(--color-on-content));
-        }
-
-		.fieldblock3 > * {
+		.fieldblock3>* {
 			padding: var(--padding-standard);
 		}
 
-        .fieldblock5 {
-            display: grid;
-            grid-template-columns: repeat(5, 0fr);
-            white-space: nowrap;
-            background-color: rgb(var(--color-content));
-            color: rgb(var(--color-on-content));
-        }
+		.fieldblock5 {
+			display: grid;
+			grid-template-columns: repeat(5, 0fr);
+			white-space: nowrap;
+			background-color: rgb(var(--color-content));
+			color: rgb(var(--color-on-content));
+		}
 
-		.fieldblock5 > * {
+		.fieldblock5>* {
 			padding: var(--padding-standard);
 		}
 
-        .label {
-            font: var(--font-page-primary-labels);
-            padding: var(--padding-standard);
-        }
-
-        .field {
-            font: var(--font-page-primary-fields);
-            padding: 0;
-            border: none;
-            border-bottom: 1px solid rgb(var(--color-control-edge));
-            border-radius: 0;
-            color: rgb(var(--color-on-editable));
-        }
-
-        .field.noedit {
-            background-color: rgb(var(--color-content));
-            border-bottom: none;
-        }
-
-        #sheet {
-            background-color: rgb(var(--color-page));
-            padding: var(--padding-header);
-            display: flex;
-            flex-flow: column nowrap;
-            justify-content: start;
-            gap: var(--section-gap);
-        }
-
-        #personal {
-            grid-area: personal;
-            display: grid;
-            grid-template: "portrait identity miscellaneous points""portrait description description points";
-            grid-template-rows: 0fr;
-            grid-template-columns: min-content auto auto 0fr;
-            gap: var(--section-gap);
-        }
-
-        #portrait {
-            grid-area: portrait;
-            display: grid;
-            grid-template: "header""portrait";
-            grid-template-rows: 0fr auto;
-            border: var(--standard-border);
-        }
-
-        .portrait {
-            background-image: url(@PORTRAIT_EMBEDDED);
-            background-position: center;
-            background-repeat: no-repeat;
-            background-size: cover;
-            width: 6.75em;
-            height: 9em;
-        }
-
-        #identity {
-            grid-area: identity;
-            display: grid;
-            grid-template: "header""block";
-            grid-template-rows: 0fr 1fr;
-            border: var(--standard-border);
-        }
-
-        #identity .label {
-            text-align: right;
-        }
-
-        #miscellaneous {
-            grid-area: miscellaneous;
-            display: grid;
-            grid-template: "header""block";
-            grid-template-rows: 0fr 1fr;
-            border: var(--standard-border);
-        }
-
-        #miscellaneous .label {
-            text-align: right;
-        }
-
-        #description {
-            grid-area: description;
-            display: grid;
-            grid-template: "header header header""block block block";
-            grid-template-columns: 1fr 1fr 1fr;
-            border: var(--standard-border);
-        }
-
-        #description .label {
-            text-align: right;
-        }
-
-        #points {
-            grid-area: points;
-            display: grid;
-            grid-template: "header""block";
-            grid-template-rows: 0fr 1fr;
-            border: var(--standard-border);
-        }
-
-        #points .field {
-            text-align: right;
-        }
-
-        #points .fieldblock .field:nth-child(4n-1),
-        #points .fieldblock .label:nth-child(4n) {
-            background-color: rgb(var(--color-banding));
-            color: rgb(var(--color-on-banding));
-        }
-
-        #stats {
-            grid-area: stats;
-            display: grid;
-            grid-template: "attributes hit-locations encumbrance-lifting";
-            gap: var(--section-gap);
-        }
-
-        #attributes {
-            grid-area: attributes;
-            display: grid;
-            grid-template: "primary-attributes secondary-attributes""basic-damage secondary-attributes""pool-attributes pool-attributes";
-            grid-template-columns: 1fr 1fr;
-            gap: var(--section-gap);
-        }
-
-        #primary-attributes {
-            grid-area: primary-attributes;
-        }
-
-        #secondary-attributes {
-            grid-area: secondary-attributes;
-        }
-
-        #pool-attributes {
-            grid-area: pool-attributes;
-        }
-
-        #basic-damage {
-            grid-area: basic-damage;
-        }
-
-        #basic-damage .fieldblock3 .points {
-            color: transparent;
-        }
-
-        #basic-damage .fieldblock3 .label:nth-child(6n),
-        #basic-damage .fieldblock3 .field:nth-child(6n-1),
-        #basic-damage .fieldblock3 .points:nth-child(6n-2) {
-            background-color: rgb(var(--color-banding));
-        }
-
-        #attributes .points {
-            font: var(--font-page-secondary-fields);
-            color: rgba(var(--color-on-editable), 0.6);
-        }
-
-        #attributes .label {
-            font: var(--font-page-primary-labels);
-            color: rgb(var(--color-on-content));
-        }
-
-        #attributes .field {
-            text-align: right;
-        }
-
-        #hit-locations {
-            grid-area: hit-locations;
-            display: grid;
-            grid-template: "title title title title title""entry-parent roll location penalty dr";
-            grid-template-columns: min-content min-content 1fr min-content min-content;
-            grid-template-rows: 0fr;
-            white-space: nowrap;
-        }
-
-        #hit-locations .header {
-            grid-area: auto;
-        }
-
-        #hit-locations .header.body-plan {
-            grid-area: title;
-        }
-
-        #hit-locations .header.location {
-            grid-column: span 2;
-        }
-
-        #hit-locations .penalty:not(.header),
-        #hit-locations .dr:not(.header) {
-            color: rgba(var(--color-on-editable), 0.6);
-            font: var(--font-page-primary-fields);
-        }
-
-        #hit-locations .roll:not(.header),
-        #hit-locations .location:not(.header) {
-            color: rgb(var(--color-on-content));
-            font: var(--font-page-primary-labels);
-        }
-
-        #hit-locations .dr,
-        #hit-locations .roll {
-            text-align: center;
-        }
-
-        #hit-locations .roll,
-        #hit-locations .penalty {
-            border-right: 1px solid rgb(var(--color-header));
-        }
-
-        #hit-locations :not(.header):not(.entry-parent) {
-            padding: var(--padding-standard);
-        }
-
-        #hit-locations .entry-parent:nth-child(10n+1):not(.header),
-        #hit-locations .roll:nth-child(10n+2):not(.header),
-        #hit-locations .location:nth-child(10n+3):not(.header),
-        #hit-locations .penalty:nth-child(10n+4):not(.header),
-        #hit-locations .dr:nth-child(10n+5):not(.header) {
-            background-color: rgb(var(--color-banding));
-        }
-
-        #encumbrance-lifting {
-            grid-area: encumbrance-lifting;
-            display: grid;
-            grid-template: "encumbrance""lifting";
-            gap: var(--section-gap);
-        }
-
-        #encumbrance {
-            grid-area: encumbrance;
-            display: grid;
-            grid-template: "title title title title title title""header1 header1 header1 header2 header3 header4""encumbrance-marker level-number level max-load move dodge";
-            grid-template-columns: min-content min-content 1fr min-content min-content min-content;
-            grid-template-rows: 0fr 0fr;
-            align-content: baseline;
-            white-space: nowrap;
-            font: var(--font-page-primary-fields);
-            background-color: rgb(var(--color-content));
-            color: rgba(var(--color-on-editable), 0.6);
-            text-align: right;
-        }
-
-        #encumbrance .encumbrance-marker {
-            color: rgb(var(--color-on-content));
-        }
-
-        #encumbrance .level:not(.header) {
-            color: rgb(var(--color-on-content));
-            font: var(--font-page-primary-labels);
-            text-align: left;
-        }
-
-        .level-number.enc0:after {
-            content: "0";
-        }
-
-        .level-number.enc1:after {
-            content: "1";
-        }
-
-        .level-number.enc2:after {
-            content: "2";
-        }
-
-        .level-number.enc3:after {
-            content: "3";
-        }
-
-        .level-number.enc4:after {
-            content: "4";
-        }
-
-        .level.enc0:after {
-            content: "None";
-        }
-
-        .level.enc1:after {
-            content: "Light";
-        }
-
-        .level.enc2:after {
-            content: "Medium";
-        }
-
-        .level.enc3:after {
-            content: "Heavy";
-        }
-
-        .level.enc4:after {
-            content: "X-Heavy";
-        }
-
-        #encumbrance .current {
-            background-color: rgb(var(--color-marker));
-        }
-
-        #encumbrance .current svg path {
-            d: var(--shape-weight);
-        }
-
-        svg path.shape-bookmark {
-            d: var(--shape-bookmark);
-        }
-
-        svg path.shape-weight {
-            d: var(--shape-weight);
-        }
-
-        svg path.shape-coins {
-            d: var(--shape-coins);
-        }
-
-        svg path.shape-stack {
-            d: var(--shape-stack);
-        }
-
-        svg path.shape-equipped-1 {
-            d: var(--shape-checkmark);
-        }
-
-        #encumbrance .header {
-            grid-area: auto;
-            text-align: center;
-        }
-
-        #encumbrance .title {
-            grid-area: title;
-        }
-
-        #encumbrance .level.header {
-            grid-column: 1/span 3;
-        }
-
-        #encumbrance .level,
-        #encumbrance .max-load,
-        #encumbrance .move {
-            border-right: 1px solid rgb(var(--color-header));
-        }
-
-        #encumbrance> :not(.header) {
-            padding: var(--padding-standard);
-        }
-
-        #encumbrance .encumbrance-marker:nth-child(12n):not(.header),
-        #encumbrance .level-number:nth-child(12n+1):not(.header),
-        #encumbrance .level:nth-child(12n+2):not(.header),
-        #encumbrance .max-load:nth-child(12n+3):not(.header),
-        #encumbrance .move:nth-child(12n+4):not(.header),
-        #encumbrance .dodge:nth-child(12n+5):not(.header) {
-            background-color: rgb(var(--color-banding));
-        }
-
-
-        #lifting {
-            grid-area: lifting;
-            display: grid;
-            grid-template: "header header""lift label";
-            grid-template-rows: 0fr;
-        }
-
-        #lifting .lift {
-            font: var(--font-page-primary-fields);
-            color: rgba(var(--color-on-editable), 0.6);
-            text-align: right;
-        }
-
-        #lifting .label {
-            font: var(--font-page-primary-labels);
-            color: rgb(var(--color-on-content));
-        }
-
-        #lifting .lift:nth-child(4n),
-        #lifting .label:nth-child(4n+1) {
-            background-color: rgb(var(--color-banding));
-        }
-
-        #embeds {
-            display: grid;
-            grid-auto-columns: 1fr 1fr;
-            gap: var(--section-gap);
-            grid-template:
-                @GRID_TEMPLATE ;
-        }
-
-        #melee {
-            grid-area: melee;
-            grid-template-columns: min-content 1fr repeat(7, auto);
-        }
-
-        #melee .entry-parent:nth-child(18n+1):not(.header),
-        #melee .desc:nth-child(18n+2):not(.header),
-        #melee .usage:nth-child(18n+3):not(.header),
-        #melee .level:nth-child(18n+4):not(.header),
-        #melee .parry:nth-child(18n+5):not(.header),
-        #melee .block:nth-child(18n+6):not(.header),
-        #melee .damage:nth-child(18n+7):not(.header),
-        #melee .reach:nth-child(18n+8):not(.header),
-        #melee .st:nth-child(18n+9):not(.header) {
-            background-color: rgb(var(--color-banding));
-            color: rgb(var(--color-on-banding));
-        }
-
-        #melee .desc:not(.header),
-        #melee .usage:not(.header),
-        #melee .level:not(.header),
-        #melee .parry:not(.header),
-        #melee .block:not(.header),
-        #melee .damage:not(.header),
-        #melee .reach:not(.header) {
-            border-bottom: 1px solid rgb(var(--color-header));
-            border-right: 1px solid rgb(var(--color-header));
-        }
-
-        #melee .st:not(.header) {
-            border-bottom: 1px solid rgb(var(--color-header));
-        }
-
-        #melee :nth-last-child(-n+9) {
-            border-bottom: none !important;
-        }
-
-        #ranged {
-            grid-area: ranged;
-            grid-template-columns: min-content 1fr repeat(10, auto);
-        }
-
-        #ranged .entry-parent:nth-child(24n+1):not(.header),
-        #ranged .desc:nth-child(24n+2):not(.header),
-        #ranged .usage:nth-child(24n+3):not(.header),
-        #ranged .level:nth-child(24n+4):not(.header),
-        #ranged .acc:nth-child(24n+5):not(.header),
-        #ranged .range:nth-child(24n+6):not(.header),
-        #ranged .damage:nth-child(24n+7):not(.header),
-        #ranged .rof:nth-child(24n+8):not(.header),
-        #ranged .shots:nth-child(24n+9):not(.header),
-        #ranged .bulk:nth-child(24n+10):not(.header),
-        #ranged .recoil:nth-child(24n+11):not(.header),
-        #ranged .st:nth-child(24n+12):not(.header) {
-            background-color: rgb(var(--color-banding));
-            color: rgb(var(--color-on-banding));
-        }
-
-        #ranged .desc:not(.header),
-        #ranged .usage:not(.header),
-        #ranged .level:not(.header),
-        #ranged .acc:not(.header),
-        #ranged .range:not(.header),
-        #ranged .damage:not(.header),
-        #ranged .rof:not(.header),
-        #ranged .shots:not(.header),
-        #ranged .bulk:not(.header),
-        #ranged .recoil:not(.header) {
-            border-bottom: 1px solid rgb(var(--color-header));
-            border-right: 1px solid rgb(var(--color-header));
-        }
-
-        #ranged .st:not(.header) {
-            border-bottom: 1px solid rgb(var(--color-header));
-        }
-
-        #ranged :nth-last-child(-n+12) {
-            border-bottom: none !important;
-        }
-
-        #reactions {
-            grid-area: reactions;
-            grid-template-columns: min-content min-content auto;
-        }
-
-        #reactions .entry-parent:nth-child(6n+1):not(.header),
-        #reactions .modifier:nth-child(6n+2):not(.header),
-        #reactions .situation:nth-child(6n+3):not(.header) {
-            background-color: rgb(var(--color-banding));
-            color: rgb(var(--color-on-banding));
-        }
-
-        #reactions .modifier:not(.header) {
-            border-bottom: 1px solid rgb(var(--color-header));
-            border-right: 1px solid rgb(var(--color-header));
-        }
-
-        #reactions .situation:not(.header) {
-            border-bottom: 1px solid rgb(var(--color-header));
-        }
-
-        #reactions :nth-last-child(-n+3) {
-            border-bottom: none !important;
-        }
-
-        #conditional-modifiers {
-            grid-area: conditional_modifiers;
-            grid-template-columns: min-content min-content auto;
-        }
-
-        #conditional-modifiers .entry-parent:nth-child(6n+1):not(.header),
-        #conditional-modifiers .modifier:nth-child(6n+2):not(.header),
-        #conditional-modifiers .situation:nth-child(6n+3):not(.header) {
-            background-color: rgb(var(--color-banding));
-            color: rgb(var(--color-on-banding));
-        }
-
-        #conditional-modifiers .modifier:not(.header) {
-            border-bottom: 1px solid rgb(var(--color-header));
-            border-right: 1px solid rgb(var(--color-header));
-        }
-
-        #conditional-modifiers .situation:not(.header) {
-            border-bottom: 1px solid rgb(var(--color-header));
-        }
-
-        #conditional-modifiers :nth-last-child(-n+3) {
-            border-bottom: none !important;
-        }
-
-        #traits {
-            grid-area: advantages;
-            grid-template-columns: min-content 1fr repeat(2, auto);
-        }
-
-        #embeds>div>.header {
-            grid-area: auto;
-        }
-
-        #traits .entry-parent:nth-child(8n+1):not(.header),
-        #traits .desc:nth-child(8n+2):not(.header),
-        #traits .points:nth-child(8n+3):not(.header),
-        #traits .reference:nth-child(8n+4):not(.header) {
-            background-color: rgb(var(--color-banding));
-            color: rgb(var(--color-on-banding));
-        }
-
-        #traits .desc:not(.header),
-        #traits .points:not(.header),
-        #traits .reference:not(.header) {
-            border-bottom: 1px solid rgb(var(--color-header));
-            border-right: 1px solid rgb(var(--color-header));
-        }
-
-
-        #traits :nth-last-child(-n+4) {
-            border-bottom: none !important;
-        }
-
-        #skills {
-            grid-area: skills;
-            grid-template-columns: min-content 1fr repeat(4, auto);
-        }
-
-        #skills .header {
-            grid-area: auto;
-        }
-
-        #skills .entry-parent:nth-child(12n+1):not(.header),
-        #skills .desc:nth-child(12n+2):not(.header),
-        #skills .level:nth-child(12n+3):not(.header),
-        #skills .rsl:nth-child(12n+4):not(.header),
-        #skills .points:nth-child(12n+5):not(.header),
-        #skills .reference:nth-child(12n+6):not(.header) {
-            background-color: rgb(var(--color-banding));
-            color: rgb(var(--color-on-banding));
-        }
-
-        #skills .desc:not(.header),
-        #skills .level:not(.header),
-        #skills .rsl:not(.header),
-        #skills .points:not(.header) {
-            border-bottom: 1px solid rgb(var(--color-header));
-            border-right: 1px solid rgb(var(--color-header));
-        }
-
-        #skills .reference:not(.header) {
-            border-bottom: 1px solid rgb(var(--color-header));
-        }
-
-        #skills :nth-last-child(-n+6) {
-            border-bottom: none !important;
-        }
-
-        #spells {
-            grid-area: spells;
-            grid-template-columns: min-content 1fr repeat(5, auto);
-        }
-
-        #spells .header {
-            grid-area: auto;
-        }
-
-        #spells .entry-parent:nth-child(14n+1):not(.header),
-        #spells .desc:nth-child(14n+2):not(.header),
-        #spells .college:nth-child(14n+3):not(.header),
-        #spells .level:nth-child(14n+4):not(.header),
-        #spells .rsl:nth-child(14n+5):not(.header),
-        #spells .points:nth-child(14n+6):not(.header),
-        #spells .reference:nth-child(14n+7):not(.header) {
-            background-color: rgb(var(--color-banding));
-            color: rgb(var(--color-on-banding));
-        }
-
-        #spells .desc:not(.header),
-        #spells .college:not(.header),
-        #spells .level:not(.header),
-        #spells .rsl:not(.header),
-        #spells .points:not(.header) {
-            border-bottom: 1px solid rgb(var(--color-header));
-            border-right: 1px solid rgb(var(--color-header));
-        }
-
-
-        #spells .reference:not(.header) {
-            border-bottom: 1px solid rgb(var(--color-header));
-        }
-
-
-        #spells :nth-last-child(-n+7) {
-            border-bottom: none !important;
-        }
-
-        #equipment {
-            grid-area: equipment;
-            grid-template-columns: min-content auto auto 1fr repeat(8, auto);
-        }
-
-        #equipment .header {
-            grid-area: auto;
-        }
-
-        #embeds #equipment>div>.equipped:not(.header) {
-            padding: var(--padding-header);
-        }
+		.label {
+			font: var(--font-page-primary-labels);
+			padding: var(--padding-standard);
+		}
+
+		.field {
+			font: var(--font-page-primary-fields);
+			padding: 0;
+			border: none;
+			border-bottom: 1px solid rgb(var(--color-control-edge));
+			border-radius: 0;
+			color: rgb(var(--color-on-editable));
+		}
+
+		.field.noedit {
+			background-color: rgb(var(--color-content));
+			border-bottom: none;
+		}
+
+		#sheet {
+			background-color: rgb(var(--color-page));
+			padding: var(--padding-header);
+			display: flex;
+			flex-flow: column nowrap;
+			justify-content: start;
+			gap: var(--section-gap);
+		}
+
+		#personal {
+			grid-area: personal;
+			display: grid;
+			grid-template: "portrait identity miscellaneous points""portrait description description points";
+			grid-template-rows: 0fr;
+			grid-template-columns: min-content auto auto 0fr;
+			gap: var(--section-gap);
+		}
+
+		#portrait {
+			grid-area: portrait;
+			display: grid;
+			grid-template: "header""portrait";
+			grid-template-rows: 0fr auto;
+			border: var(--standard-border);
+		}
+
+		.portrait {
+			background-image: url(@PORTRAIT_EMBEDDED);
+			background-position: center;
+			background-repeat: no-repeat;
+			background-size: cover;
+			width: 6.75em;
+			height: 9em;
+		}
+
+		#identity {
+			grid-area: identity;
+			display: grid;
+			grid-template: "header""block";
+			grid-template-rows: 0fr 1fr;
+			border: var(--standard-border);
+		}
+
+		#identity .label {
+			text-align: right;
+		}
+
+		#miscellaneous {
+			grid-area: miscellaneous;
+			display: grid;
+			grid-template: "header""block";
+			grid-template-rows: 0fr 1fr;
+			border: var(--standard-border);
+		}
+
+		#miscellaneous .label {
+			text-align: right;
+		}
+
+		#description {
+			grid-area: description;
+			display: grid;
+			grid-template: "header header header""block block block";
+			grid-template-columns: 1fr 1fr 1fr;
+			border: var(--standard-border);
+		}
+
+		#description .label {
+			text-align: right;
+		}
+
+		#points {
+			grid-area: points;
+			display: grid;
+			grid-template: "header""block";
+			grid-template-rows: 0fr 1fr;
+			border: var(--standard-border);
+		}
+
+		#points .field {
+			text-align: right;
+		}
+
+		#points .fieldblock .field:nth-child(4n-1),
+		#points .fieldblock .label:nth-child(4n) {
+			background-color: rgb(var(--color-banding));
+			color: rgb(var(--color-on-banding));
+		}
+
+		#stats {
+			grid-area: stats;
+			display: grid;
+			grid-template: "attributes hit-locations encumbrance-lifting";
+			gap: var(--section-gap);
+		}
+
+		#attributes {
+			grid-area: attributes;
+			display: grid;
+			grid-template: "primary-attributes secondary-attributes""basic-damage secondary-attributes""pool-attributes pool-attributes";
+			grid-template-columns: 1fr 1fr;
+			gap: var(--section-gap);
+		}
+
+		#primary-attributes {
+			grid-area: primary-attributes;
+		}
+
+		#secondary-attributes {
+			grid-area: secondary-attributes;
+		}
+
+		#pool-attributes {
+			grid-area: pool-attributes;
+		}
+
+		#basic-damage {
+			grid-area: basic-damage;
+		}
+
+		#basic-damage .fieldblock3 .points {
+			color: transparent;
+		}
+
+		#basic-damage .fieldblock3 .label:nth-child(6n),
+		#basic-damage .fieldblock3 .field:nth-child(6n-1),
+		#basic-damage .fieldblock3 .points:nth-child(6n-2) {
+			background-color: rgb(var(--color-banding));
+		}
+
+		#attributes .points {
+			font: var(--font-page-secondary-fields);
+			color: rgba(var(--color-on-editable), 0.6);
+		}
+
+		#attributes .label {
+			font: var(--font-page-primary-labels);
+			color: rgb(var(--color-on-content));
+		}
+
+		#attributes .field {
+			text-align: right;
+		}
+
+		#hit-locations {
+			grid-area: hit-locations;
+			display: grid;
+			grid-template: "title title title title title""entry-parent roll location penalty dr";
+			grid-template-columns: min-content min-content 1fr min-content min-content;
+			grid-template-rows: 0fr;
+			white-space: nowrap;
+		}
+
+		#hit-locations .header {
+			grid-area: auto;
+		}
+
+		#hit-locations .header.body-plan {
+			grid-area: title;
+		}
+
+		#hit-locations .header.location {
+			grid-column: span 2;
+		}
+
+		#hit-locations .penalty:not(.header),
+		#hit-locations .dr:not(.header) {
+			color: rgba(var(--color-on-editable), 0.6);
+			font: var(--font-page-primary-fields);
+		}
+
+		#hit-locations .roll:not(.header),
+		#hit-locations .location:not(.header) {
+			color: rgb(var(--color-on-content));
+			font: var(--font-page-primary-labels);
+		}
+
+		#hit-locations .dr,
+		#hit-locations .roll {
+			text-align: center;
+		}
+
+		#hit-locations .roll,
+		#hit-locations .penalty {
+			border-right: 1px solid rgb(var(--color-header));
+		}
+
+		#hit-locations :not(.header):not(.entry-parent) {
+			padding: var(--padding-standard);
+		}
+
+		#hit-locations .entry-parent:nth-child(10n+1):not(.header),
+		#hit-locations .roll:nth-child(10n+2):not(.header),
+		#hit-locations .location:nth-child(10n+3):not(.header),
+		#hit-locations .penalty:nth-child(10n+4):not(.header),
+		#hit-locations .dr:nth-child(10n+5):not(.header) {
+			background-color: rgb(var(--color-banding));
+		}
+
+		#encumbrance-lifting {
+			grid-area: encumbrance-lifting;
+			display: grid;
+			grid-template: "encumbrance""lifting";
+			gap: var(--section-gap);
+		}
+
+		#encumbrance {
+			grid-area: encumbrance;
+			display: grid;
+			grid-template: "title title title title title title""header1 header1 header1 header2 header3 header4""encumbrance-marker level-number level max-load move dodge";
+			grid-template-columns: min-content min-content 1fr min-content min-content min-content;
+			grid-template-rows: 0fr 0fr;
+			align-content: baseline;
+			white-space: nowrap;
+			font: var(--font-page-primary-fields);
+			background-color: rgb(var(--color-content));
+			color: rgba(var(--color-on-editable), 0.6);
+			text-align: right;
+		}
+
+		#encumbrance .encumbrance-marker {
+			color: rgb(var(--color-on-content));
+		}
+
+		#encumbrance .level:not(.header) {
+			color: rgb(var(--color-on-content));
+			font: var(--font-page-primary-labels);
+			text-align: left;
+		}
+
+		.level-number.enc0:after {
+			content: "0";
+		}
+
+		.level-number.enc1:after {
+			content: "1";
+		}
+
+		.level-number.enc2:after {
+			content: "2";
+		}
+
+		.level-number.enc3:after {
+			content: "3";
+		}
+
+		.level-number.enc4:after {
+			content: "4";
+		}
+
+		.level.enc0:after {
+			content: "None";
+		}
+
+		.level.enc1:after {
+			content: "Light";
+		}
+
+		.level.enc2:after {
+			content: "Medium";
+		}
+
+		.level.enc3:after {
+			content: "Heavy";
+		}
+
+		.level.enc4:after {
+			content: "X-Heavy";
+		}
+
+		#encumbrance .current {
+			background-color: rgb(var(--color-marker));
+		}
+
+		svg path.shape-equipped-0 {
+			display: none;
+		}
+
+		#encumbrance .header {
+			grid-area: auto;
+			text-align: center;
+		}
+
+		#encumbrance .title {
+			grid-area: title;
+		}
+
+		#encumbrance .level.header {
+			grid-column: 1/span 3;
+		}
+
+		#encumbrance .level,
+		#encumbrance .max-load,
+		#encumbrance .move {
+			border-right: 1px solid rgb(var(--color-header));
+		}
+
+		#encumbrance> :not(.header) {
+			padding: var(--padding-standard);
+		}
+
+		#encumbrance .encumbrance-marker:nth-child(12n):not(.header),
+		#encumbrance .level-number:nth-child(12n+1):not(.header),
+		#encumbrance .level:nth-child(12n+2):not(.header),
+		#encumbrance .max-load:nth-child(12n+3):not(.header),
+		#encumbrance .move:nth-child(12n+4):not(.header),
+		#encumbrance .dodge:nth-child(12n+5):not(.header) {
+			background-color: rgb(var(--color-banding));
+		}
+
+
+		#lifting {
+			grid-area: lifting;
+			display: grid;
+			grid-template: "header header""lift label";
+			grid-template-rows: 0fr;
+		}
+
+		#lifting .lift {
+			font: var(--font-page-primary-fields);
+			color: rgba(var(--color-on-editable), 0.6);
+			text-align: right;
+		}
+
+		#lifting .label {
+			font: var(--font-page-primary-labels);
+			color: rgb(var(--color-on-content));
+		}
+
+		#lifting .lift:nth-child(4n),
+		#lifting .label:nth-child(4n+1) {
+			background-color: rgb(var(--color-banding));
+		}
+
+		#embeds {
+			display: grid;
+			grid-auto-columns: 1fr 1fr;
+			gap: var(--section-gap);
+			grid-template:
+				@GRID_TEMPLATE ;
+		}
+
+		#melee {
+			grid-area: melee;
+			grid-template-columns: min-content 1fr repeat(7, auto);
+		}
+
+		#melee .entry-parent:nth-child(18n+1):not(.header),
+		#melee .desc:nth-child(18n+2):not(.header),
+		#melee .usage:nth-child(18n+3):not(.header),
+		#melee .level:nth-child(18n+4):not(.header),
+		#melee .parry:nth-child(18n+5):not(.header),
+		#melee .block:nth-child(18n+6):not(.header),
+		#melee .damage:nth-child(18n+7):not(.header),
+		#melee .reach:nth-child(18n+8):not(.header),
+		#melee .st:nth-child(18n+9):not(.header) {
+			background-color: rgb(var(--color-banding));
+			color: rgb(var(--color-on-banding));
+		}
+
+		#melee .desc:not(.header),
+		#melee .usage:not(.header),
+		#melee .level:not(.header),
+		#melee .parry:not(.header),
+		#melee .block:not(.header),
+		#melee .damage:not(.header),
+		#melee .reach:not(.header) {
+			border-bottom: 1px solid rgb(var(--color-header));
+			border-right: 1px solid rgb(var(--color-header));
+		}
+
+		#melee .st:not(.header) {
+			border-bottom: 1px solid rgb(var(--color-header));
+		}
+
+		#melee :nth-last-child(-n+9) {
+			border-bottom: none !important;
+		}
+
+		#ranged {
+			grid-area: ranged;
+			grid-template-columns: min-content 1fr repeat(10, auto);
+		}
+
+		#ranged .entry-parent:nth-child(24n+1):not(.header),
+		#ranged .desc:nth-child(24n+2):not(.header),
+		#ranged .usage:nth-child(24n+3):not(.header),
+		#ranged .level:nth-child(24n+4):not(.header),
+		#ranged .acc:nth-child(24n+5):not(.header),
+		#ranged .range:nth-child(24n+6):not(.header),
+		#ranged .damage:nth-child(24n+7):not(.header),
+		#ranged .rof:nth-child(24n+8):not(.header),
+		#ranged .shots:nth-child(24n+9):not(.header),
+		#ranged .bulk:nth-child(24n+10):not(.header),
+		#ranged .recoil:nth-child(24n+11):not(.header),
+		#ranged .st:nth-child(24n+12):not(.header) {
+			background-color: rgb(var(--color-banding));
+			color: rgb(var(--color-on-banding));
+		}
+
+		#ranged .desc:not(.header),
+		#ranged .usage:not(.header),
+		#ranged .level:not(.header),
+		#ranged .acc:not(.header),
+		#ranged .range:not(.header),
+		#ranged .damage:not(.header),
+		#ranged .rof:not(.header),
+		#ranged .shots:not(.header),
+		#ranged .bulk:not(.header),
+		#ranged .recoil:not(.header) {
+			border-bottom: 1px solid rgb(var(--color-header));
+			border-right: 1px solid rgb(var(--color-header));
+		}
+
+		#ranged .st:not(.header) {
+			border-bottom: 1px solid rgb(var(--color-header));
+		}
+
+		#ranged :nth-last-child(-n+12) {
+			border-bottom: none !important;
+		}
+
+		#reactions {
+			grid-area: reactions;
+			grid-template-columns: min-content min-content auto;
+		}
+
+		#reactions .entry-parent:nth-child(6n+1):not(.header),
+		#reactions .modifier:nth-child(6n+2):not(.header),
+		#reactions .situation:nth-child(6n+3):not(.header) {
+			background-color: rgb(var(--color-banding));
+			color: rgb(var(--color-on-banding));
+		}
+
+		#reactions .modifier:not(.header) {
+			border-bottom: 1px solid rgb(var(--color-header));
+			border-right: 1px solid rgb(var(--color-header));
+		}
+
+		#reactions .situation:not(.header) {
+			border-bottom: 1px solid rgb(var(--color-header));
+		}
+
+		#reactions :nth-last-child(-n+3) {
+			border-bottom: none !important;
+		}
+
+		#conditional-modifiers {
+			grid-area: conditional_modifiers;
+			grid-template-columns: min-content min-content auto;
+		}
+
+		#conditional-modifiers .entry-parent:nth-child(6n+1):not(.header),
+		#conditional-modifiers .modifier:nth-child(6n+2):not(.header),
+		#conditional-modifiers .situation:nth-child(6n+3):not(.header) {
+			background-color: rgb(var(--color-banding));
+			color: rgb(var(--color-on-banding));
+		}
+
+		#conditional-modifiers .modifier:not(.header) {
+			border-bottom: 1px solid rgb(var(--color-header));
+			border-right: 1px solid rgb(var(--color-header));
+		}
+
+		#conditional-modifiers .situation:not(.header) {
+			border-bottom: 1px solid rgb(var(--color-header));
+		}
+
+		#conditional-modifiers :nth-last-child(-n+3) {
+			border-bottom: none !important;
+		}
+
+		#traits {
+			grid-area: advantages;
+			grid-template-columns: min-content 1fr repeat(2, auto);
+		}
+
+		#embeds>div>.header {
+			grid-area: auto;
+		}
+
+		#traits .entry-parent:nth-child(8n+1):not(.header),
+		#traits .desc:nth-child(8n+2):not(.header),
+		#traits .points:nth-child(8n+3):not(.header),
+		#traits .reference:nth-child(8n+4):not(.header) {
+			background-color: rgb(var(--color-banding));
+			color: rgb(var(--color-on-banding));
+		}
+
+		#traits .desc:not(.header),
+		#traits .points:not(.header),
+		#traits .reference:not(.header) {
+			border-bottom: 1px solid rgb(var(--color-header));
+			border-right: 1px solid rgb(var(--color-header));
+		}
+
+
+		#traits :nth-last-child(-n+4) {
+			border-bottom: none !important;
+		}
+
+		#skills {
+			grid-area: skills;
+			grid-template-columns: min-content 1fr repeat(4, auto);
+		}
+
+		#skills .header {
+			grid-area: auto;
+		}
+
+		#skills .entry-parent:nth-child(12n+1):not(.header),
+		#skills .desc:nth-child(12n+2):not(.header),
+		#skills .level:nth-child(12n+3):not(.header),
+		#skills .rsl:nth-child(12n+4):not(.header),
+		#skills .points:nth-child(12n+5):not(.header),
+		#skills .reference:nth-child(12n+6):not(.header) {
+			background-color: rgb(var(--color-banding));
+			color: rgb(var(--color-on-banding));
+		}
+
+		#skills .desc:not(.header),
+		#skills .level:not(.header),
+		#skills .rsl:not(.header),
+		#skills .points:not(.header) {
+			border-bottom: 1px solid rgb(var(--color-header));
+			border-right: 1px solid rgb(var(--color-header));
+		}
+
+		#skills .reference:not(.header) {
+			border-bottom: 1px solid rgb(var(--color-header));
+		}
+
+		#skills :nth-last-child(-n+6) {
+			border-bottom: none !important;
+		}
+
+		#spells {
+			grid-area: spells;
+			grid-template-columns: min-content 1fr repeat(5, auto);
+		}
+
+		#spells .header {
+			grid-area: auto;
+		}
+
+		#spells .entry-parent:nth-child(14n+1):not(.header),
+		#spells .desc:nth-child(14n+2):not(.header),
+		#spells .college:nth-child(14n+3):not(.header),
+		#spells .level:nth-child(14n+4):not(.header),
+		#spells .rsl:nth-child(14n+5):not(.header),
+		#spells .points:nth-child(14n+6):not(.header),
+		#spells .reference:nth-child(14n+7):not(.header) {
+			background-color: rgb(var(--color-banding));
+			color: rgb(var(--color-on-banding));
+		}
+
+		#spells .desc:not(.header),
+		#spells .college:not(.header),
+		#spells .level:not(.header),
+		#spells .rsl:not(.header),
+		#spells .points:not(.header) {
+			border-bottom: 1px solid rgb(var(--color-header));
+			border-right: 1px solid rgb(var(--color-header));
+		}
+
+
+		#spells .reference:not(.header) {
+			border-bottom: 1px solid rgb(var(--color-header));
+		}
+
+
+		#spells :nth-last-child(-n+7) {
+			border-bottom: none !important;
+		}
+
+		#equipment {
+			grid-area: equipment;
+			grid-template-columns: min-content auto auto 1fr repeat(8, auto);
+		}
+
+		#equipment .header {
+			grid-area: auto;
+		}
+
+		#embeds #equipment>div>.equipped:not(.header) {
+			padding: var(--padding-header);
+		}
 
 		.legality-class.Open::after {
-			content:"4";
+			content: "4";
 		}
-		
+
 		.legality-class.Licensed::after {
 			content: "3";
 		}
@@ -884,715 +859,741 @@ defined by the Mozilla Public License, version 2.0.
 			overflow: hidden;
 		}
 
-        #equipment .entry-parent:nth-child(24n+1):not(.header),
-        #equipment .equipped:nth-child(24n+2):not(.header),
-        #equipment .quantity:nth-child(24n+3):not(.header),
-        #equipment .desc:nth-child(24n+4):not(.header),
-        #equipment .uses:nth-child(24n+5):not(.header),
-        #equipment .tech-level:nth-child(24n+6):not(.header),
-        #equipment .legality-class:nth-child(24n+7):not(.header),
-        #equipment .value:nth-child(24n+8):not(.header),
-        #equipment .weight:nth-child(24n+9):not(.header),
-        #equipment .extended-value:nth-child(24n+10):not(.header),
-        #equipment .extended-weight:nth-child(24n+11):not(.header),
-        #equipment .reference:nth-child(24n+12):not(.header) {
-            background-color: rgb(var(--color-banding));
-            color: rgb(var(--color-on-banding));
-        }
+		#equipment .entry-parent:nth-child(24n+1):not(.header),
+		#equipment .equipped:nth-child(24n+2):not(.header),
+		#equipment .quantity:nth-child(24n+3):not(.header),
+		#equipment .desc:nth-child(24n+4):not(.header),
+		#equipment .uses:nth-child(24n+5):not(.header),
+		#equipment .tech-level:nth-child(24n+6):not(.header),
+		#equipment .legality-class:nth-child(24n+7):not(.header),
+		#equipment .value:nth-child(24n+8):not(.header),
+		#equipment .weight:nth-child(24n+9):not(.header),
+		#equipment .extended-value:nth-child(24n+10):not(.header),
+		#equipment .extended-weight:nth-child(24n+11):not(.header),
+		#equipment .reference:nth-child(24n+12):not(.header) {
+			background-color: rgb(var(--color-banding));
+			color: rgb(var(--color-on-banding));
+		}
 
-        #equipment .equipped:not(.header),
-        #equipment .quantity:not(.header),
-        #equipment .desc:not(.header),
-        #equipment .uses:not(.header),
-        #equipment .tech-level:not(.header),
-        #equipment .legality-class:not(.header),
-        #equipment .weight:not(.header),
-        #equipment .value:not(.header),
-        #equipment .extended-weight:not(.header),
-        #equipment .extended-value:not(.header),
-        #equipment .reference:not(.header) {
-            border-bottom: 1px solid rgb(var(--color-header));
-            border-right: 1px solid rgb(var(--color-header));
-        }
+		#equipment .equipped:not(.header),
+		#equipment .quantity:not(.header),
+		#equipment .desc:not(.header),
+		#equipment .uses:not(.header),
+		#equipment .tech-level:not(.header),
+		#equipment .legality-class:not(.header),
+		#equipment .weight:not(.header),
+		#equipment .value:not(.header),
+		#equipment .extended-weight:not(.header),
+		#equipment .extended-value:not(.header),
+		#equipment .reference:not(.header) {
+			border-bottom: 1px solid rgb(var(--color-header));
+			border-right: 1px solid rgb(var(--color-header));
+		}
 
-        #equipment :nth-last-child(-n+11) {
-            border-bottom: none !important;
-        }
+		#equipment :nth-last-child(-n+11) {
+			border-bottom: none !important;
+		}
 
-        #equipment .equipped {
-            padding: var(--padding-header);
-        }
+		#equipment .equipped {
+			padding: var(--padding-header);
+		}
 
-        #other-equipment {
-            grid-area: other_equipment;
-            grid-template-columns: min-content auto 1fr repeat(8, auto);
-        }
+		#other-equipment {
+			grid-area: other_equipment;
+			grid-template-columns: min-content auto 1fr repeat(8, auto);
+		}
 
-        #other-equipment .header {
-            grid-area: auto;
-        }
+		#other-equipment .header {
+			grid-area: auto;
+		}
 
-        #other-equipment .entry-parent:nth-child(22n+1):not(.header),
-        #other-equipment .quantity:nth-child(22n+2):not(.header),
-        #other-equipment .desc:nth-child(22n+3):not(.header),
-        #other-equipment .uses:nth-child(22n+4):not(.header),
-        #other-equipment .tech-level:nth-child(22n+5):not(.header),
-        #other-equipment .legality-class:nth-child(22n+6):not(.header),
-        #other-equipment .value:nth-child(22n+7):not(.header),
-        #other-equipment .weight:nth-child(22n+8):not(.header),
-        #other-equipment .extended-value:nth-child(22n+9):not(.header),
-        #other-equipment .extended-weight:nth-child(22n+10):not(.header),
-        #other-equipment .reference:nth-child(22n+11):not(.header) {
-            background-color: rgb(var(--color-banding));
-            color: rgb(var(--color-on-banding));
-        }
+		#other-equipment .entry-parent:nth-child(22n+1):not(.header),
+		#other-equipment .quantity:nth-child(22n+2):not(.header),
+		#other-equipment .desc:nth-child(22n+3):not(.header),
+		#other-equipment .uses:nth-child(22n+4):not(.header),
+		#other-equipment .tech-level:nth-child(22n+5):not(.header),
+		#other-equipment .legality-class:nth-child(22n+6):not(.header),
+		#other-equipment .value:nth-child(22n+7):not(.header),
+		#other-equipment .weight:nth-child(22n+8):not(.header),
+		#other-equipment .extended-value:nth-child(22n+9):not(.header),
+		#other-equipment .extended-weight:nth-child(22n+10):not(.header),
+		#other-equipment .reference:nth-child(22n+11):not(.header) {
+			background-color: rgb(var(--color-banding));
+			color: rgb(var(--color-on-banding));
+		}
 
-        #other-equipment .quantity:not(.header),
-        #other-equipment .desc:not(.header),
-        #other-equipment .uses:not(.header),
-        #other-equipment .tech-level:not(.header),
-        #other-equipment .legality-class:not(.header),
-        #other-equipment .weight:not(.header),
-        #other-equipment .value:not(.header),
-        #other-equipment .extended-weight:not(.header),
-        #other-equipment .extended-value:not(.header),
-        #other-equipment .reference:not(.header) {
-            border-bottom: 1px solid rgb(var(--color-header));
-            border-right: 1px solid rgb(var(--color-header));
-        }
+		#other-equipment .quantity:not(.header),
+		#other-equipment .desc:not(.header),
+		#other-equipment .uses:not(.header),
+		#other-equipment .tech-level:not(.header),
+		#other-equipment .legality-class:not(.header),
+		#other-equipment .weight:not(.header),
+		#other-equipment .value:not(.header),
+		#other-equipment .extended-weight:not(.header),
+		#other-equipment .extended-value:not(.header),
+		#other-equipment .reference:not(.header) {
+			border-bottom: 1px solid rgb(var(--color-header));
+			border-right: 1px solid rgb(var(--color-header));
+		}
 
-        #other-equipment :nth-last-child(-n+10) {
-            border-bottom: none !important;
-        }
+		#other-equipment :nth-last-child(-n+10) {
+			border-bottom: none !important;
+		}
 
-        #notes {
-            grid-area: notes;
-            grid-template-columns: min-content 1fr auto;
-        }
+		#notes {
+			grid-area: notes;
+			grid-template-columns: min-content 1fr auto;
+		}
 
-        #notes .header {
-            grid-area: auto;
-        }
+		#notes .header {
+			grid-area: auto;
+		}
 
-        #notes .entry-parent:nth-child(8n+1):not(.header),
-        #notes .desc:nth-child(8n+2):not(.header),
-        #notes .reference:nth-child(8n+3):not(.header) {
-            background-color: rgb(var(--color-banding));
-            color: rgb(var(--color-on-banding));
-        }
+		#notes .entry-parent:nth-child(8n+1):not(.header),
+		#notes .desc:nth-child(8n+2):not(.header),
+		#notes .reference:nth-child(8n+3):not(.header) {
+			background-color: rgb(var(--color-banding));
+			color: rgb(var(--color-on-banding));
+		}
 
-        #notes .desc:not(.header),
-        #notes .refrence:not(.header) {
-            border-bottom: 1px solid rgb(var(--color-header));
-            border-right: 1px solid rgb(var(--color-header));
-        }
+		#notes .desc:not(.header),
+		#notes .refrence:not(.header) {
+			border-bottom: 1px solid rgb(var(--color-header));
+			border-right: 1px solid rgb(var(--color-header));
+		}
 
-        #notes :nth-last-child(-n+3) {
-            border-bottom: none !important;
-        }
+		#notes :nth-last-child(-n+3) {
+			border-bottom: none !important;
+		}
 
-        #embeds>div {
-            display: grid;
-            grid-template-rows: repeat(1000, auto) 1fr;
-        }
+		#embeds>div {
+			display: grid;
+			grid-template-rows: repeat(1000, auto) 1fr;
+		}
 
-        #embeds>div>.desc .item-notes {
-            grid-area: notes;
-        }
+		#embeds>div>.desc .item-notes {
+			grid-area: notes;
+		}
 
-        #embeds>div> :not(.header):not(.entry-parent).quantity {
-            min-width: 1em;
-        }
+		#embeds>div> :not(.header):not(.entry-parent).quantity {
+			min-width: 1em;
+		}
 
-        #embeds>div> :not(.header):not(.entry-parent).drop-over {
-            border-top: 2px dashed rgb(var(--color-drop-area));
-        }
+		#embeds>div> :not(.header):not(.entry-parent).drop-over {
+			border-top: 2px dashed rgb(var(--color-drop-area));
+		}
 
-        #embeds .desc.header {
-            white-space: nowrap;
-        }
+		#embeds .desc.header {
+			white-space: nowrap;
+		}
 
-        #embeds .equipped,
-        #embeds .header.reference,
-        #embeds .header.weight,
-        #embeds .header.value,
-        #embeds .header.extended-weight,
-        #embeds .header.extended-value {
-            display: grid;
-            align-items: center;
-            grid-auto-flow: column;
-            gap: 1px;
-        }
+		#embeds .equipped,
+		#embeds .header.reference,
+		#embeds .header.weight,
+		#embeds .header.value,
+		#embeds .header.extended-weight,
+		#embeds .header.extended-value {
+			display: grid;
+			align-items: center;
+			grid-auto-flow: column;
+			gap: 1px;
+		}
 
-        #embeds .points:not(.header),
-        #embeds .level:not(.header),
-        #embeds .quantity:not(.header),
-        #embeds .uses:not(.header),
-        #embeds .tech-level:not(.header),
-        #embeds .legality-class:not(.header),
-        #embeds .weight:not(.header),
-        #embeds .value:not(.header),
-        #embeds .extended-weight:not(.header),
-        #embeds .extended-value:not(.header) {
-            text-align: right;
-        }
+		#embeds .points:not(.header),
+		#embeds .level:not(.header),
+		#embeds .quantity:not(.header),
+		#embeds .uses:not(.header),
+		#embeds .tech-level:not(.header),
+		#embeds .legality-class:not(.header),
+		#embeds .weight:not(.header),
+		#embeds .value:not(.header),
+		#embeds .extended-weight:not(.header),
+		#embeds .extended-value:not(.header) {
+			text-align: right;
+		}
 
-        #embeds>div>.header:not(.entry-parent) {
-            padding: var(--padding-header);
-        }
+		#embeds>div>.header:not(.entry-parent) {
+			padding: var(--padding-header);
+		}
 
-        #embeds>div> :not(.header):not(svg) {
-            background-color: rgb(var(--color-content));
-            color: rgb(var(--color-on-content));
-            font: var(--font-page-primary-fields);
-        }
+		#embeds>div> :not(.header):not(svg) {
+			background-color: rgb(var(--color-content));
+			color: rgb(var(--color-on-content));
+			font: var(--font-page-primary-fields);
+		}
 
-        #embeds>div> :not(.header):not(.entry-parent):not(.equipped) {
-            padding: var(--padding-standard);
-        }
+		#embeds>div> :not(.header):not(.entry-parent):not(.equipped) {
+			padding: var(--padding-standard);
+		}
 
-        #embeds .item-notes {
-            font: var(--font-page-secondary-fields);
-            background-color: transparent;
-        }
+		#embeds .item-notes {
+			font: var(--font-page-secondary-fields);
+			background-color: transparent;
+		}
 
-        div {
-            background-color: rgb(var(--color-content));
-        }
+		div {
+			background-color: rgb(var(--color-content));
+		}
 
-        #sheet>div {
-            background-color: rgb(var(--color-page));
-        }
+		#sheet>div {
+			background-color: rgb(var(--color-page));
+		}
 
-        #personal>div:not(#attributes),
-        #attributes>div,
-        #stats>div:not(#attributes),
-        #attributes>div,
-        #embeds>div:not(#attributes),
-        #attributes>div {
-            border: var(--standard-border);
-        }
+		#personal>div:not(#attributes),
+		#attributes>div,
+		#stats>div:not(#attributes),
+		#attributes>div,
+		#embeds>div:not(#attributes),
+		#attributes>div {
+			border: var(--standard-border);
+		}
 
-        #footer {
-            font: var(--font-page-secondary-footer);
-            background-color: rgb(var(--color-page));
-            color: rgb(var(--color-on-page));
-            text-align: left;
-            display: grid;
-            grid-template-columns: repeat(3, 1fr);
-        }
+		#footer {
+			font: var(--font-page-secondary-footer);
+			background-color: rgb(var(--color-page));
+			color: rgb(var(--color-on-page));
+			text-align: left;
+			display: grid;
+			grid-template-columns: repeat(3, 1fr);
+		}
 
-        #footer div {
-            background-color: inherit;
-        }
+		#footer div {
+			background-color: inherit;
+		}
 
-        #footer .centre {
-            font: var(--font-page-primary-footer);
-            text-align: center;
-        }
+		#footer .centre {
+			font: var(--font-page-primary-footer);
+			text-align: center;
+		}
 
-        #footer .right {
-            text-align: right;
-        }
+		#footer .right {
+			text-align: right;
+		}
 
-        #footer .right a {
-            color: inherit;
-            text-decoration: inherit;
-        }
-    </style>
+		#footer .right a {
+			color: inherit;
+			text-decoration: inherit;
+		}
+	</style>
 </head>
 
 <body>
-    <div id="sheet">
-        <div id="personal">
-            <div id="portrait">
-                <div class="header">Portrait</div>
-                <div class="portrait"></div>
-            </div>
-            <div id="identity">
-                <div class="header">Identity</div>
-                <div class="fieldblock">
-                    <div class="label">Name</div>
-                    <div class="field">@NAME</div>
-                    <div class="label">Title</div>
-                    <div class="field">@TITLE</div>
-                    <div class="label">Organization</div>
-                    <div class="field">@ORGANIZATION</div>
-                </div>
-            </div>
-            <div id="miscellaneous">
-                <div class="header">Miscellaneous</div>
-                <div class="fieldblock">
-                    <div class="label">Created</div>
-                    <div class="field">@CREATED_ON</div>
-                    <div class="label">Modified</div>
-                    <div class="field">@CREATED_ON</div>
-                    <div class="label">Player</div>
-                    <div class="field">@PLAYER</div>
-                </div>
-            </div>
-            <div id="description">
-                <div class="header">Description</div>
-                <div class="fieldblock">
-                    <div class="label">Gender</div>
-                    <div class="field">@GENDER</div>
-                    <div class="label">Age</div>
-                    <div class="field">@AGE</div>
-                    <div class="label">Birthday</div>
-                    <div class="field">@BIRTHDAY</div>
-                    <div class="label">Religion</div>
-                    <div class="field">@RELIGION</div>
-                </div>
-                <div class="fieldblock">
-                    <div class="label">Height</div>
-                    <div class="field">@HEIGHT</div>
-                    <div class="label">Weight</div>
-                    <div class="field">@WEIGHT</div>
-                    <div class="label">Size</div>
-                    <div class="field">@SIZE</div>
-                    <div class="label">TL</div>
-                    <div class="field">@TL</div>
-                </div>
-                <div class="fieldblock">
-                    <div class="label">Hair</div>
-                    <div class="field">@HAIR</div>
-                    <div class="label">Eyes</div>
-                    <div class="field">@EYES</div>
-                    <div class="label">Skin</div>
-                    <div class="field">@SKIN</div>
-                    <div class="label">Hand</div>
-                    <div class="field">@HAND</div>
-                </div>
-            </div>
-            <div id="points">
-                <div class="header">@TOTAL_POINTS Points</div>
-                <div class="fieldblock">
-                    <div class="field noedit">@UNSPENT_POINTS</div>
-                    <div class="label">Unspent</div>
-                    <div class="field noedit">@RACE_POINTS</div>
-                    <div class="label">Race</div>
-                    <div class="field noedit">@ATTRIBUTE_POINTS</div>
-                    <div class="label">Attributes</div>
-                    <div class="field noedit">@ADVANTAGE_POINTS</div>
-                    <div class="label">Advantages</div>
-                    <div class="field noedit">@DISADVANTAGE_POINTS</div>
-                    <div class="label">Disadvantages</div>
-                    <div class="field noedit">@QUIRK_POINTS</div>
-                    <div class="label">Quirks</div>
-                    <div class="field noedit">@SKILL_POINTS</div>
-                    <div class="label">Skills</div>
-                    <div class="field noedit">@SPELL_POINTS</div>
-                    <div class="label">Spells</div>
-                </div>
-            </div>
-        </div>
-        <div id="stats">
-            <div id="attributes">
-                <div id="primary-attributes">
-                    <div class="header">Primary Attributes</div>
-                    <div class="fieldblock3">
-                        @PRIMARY_ATTRIBUTE_LOOP_START
-                        <div class="points">[@POINTS]</div>
-                        <div class="field">@VALUE</div>
-                        <div class="label">@COMBINED_NAME</div>
-                        @PRIMARY_ATTRIBUTE_LOOP_END
-                    </div>
-                </div>
-                <div id="basic-damage">
-                    <div class="header">Basic Damage</div>
-                    <div class="fieldblock3">
-                        <div class="points">[20]</div>
-                        <div class="field noedit">@THRUST</div>
-                        <div class="label">Basic Thrust</div>
-                        <div class="points">[20]</div>
-                        <div class="field noedit">@SWING</div>
-                        <div class="label">Basic Swing</div>
-                    </div>
-                </div>
-                <div id="secondary-attributes">
-                    <div class="header">Secondary Attributes</div>
-                    <div class="fieldblock3">
-                        @SECONDARY_ATTRIBUTE_LOOP_START
-                        <div class="points">[@POINTS]</div>
-                        <div class="field">@VALUE</div>
-                        <div class="label">@COMBINED_NAME</div>
-                        @SECONDARY_ATTRIBUTE_LOOP_END
-                    </div>
-                </div>
-                <div id="pool-attributes">
-                    <div class="header">Point Pools</div>
-                    <div class="fieldblock5">
-                        @POINT_POOL_LOOP_START
-                        <div class="points">[@POINTS]</div>
-                        <div class="field">@CURRENT</div>
-                        <div class="label">of</div>
-                        <div class="field">@MAXIMUM</div>
-                        <div class="label">@COMBINED_NAME</div>
-                        @POINT_POOL_LOOP_END
-                    </div>
-                </div>
-            </div>
-            <div id="hit-locations">
-                <div class="header body-plan">Hit Locations</div>
-                <div class="header entry-parent" readonly></div>
-                <div class="header roll">Roll</div>
-                <div class="header location">Location</div>
-                <div class="header dr">DR</div>
-                @HIT_LOCATION_LOOP_START
-                <div class="entry-parent" readonly></div>
-                <div class="roll">@ROLL</div>
-                <div class="location">@WHERE</div>
-                <div class="penalty">@PENALTY</div>
-                <div class="dr">@DR</div>
-                @HIT_LOCATION_LOOP_END
-            </div>
-            <div id="encumbrance-lifting">
-                <div id="encumbrance">
-                    <div class="header title">Encumbrance, Move &amp; Dodge</div>
-                    <div class="header level">Level</div>
-                    <div class="header max-load">Max Load</div>
-                    <div class="header move">Move</div>
-                    <div class="header dodge">Dodge</div>
-                    @ENCUMBRANCE_LOOP_START
-                    <div class="encumbrance-marker @CURRENT_MARKER">
-                        <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
-                            <path></path>
-                        </svg>
-                    </div>
-                    <div class="level-number @CURRENT_MARKER enc@LEVEL_ONLY"></div>
-                    <div class="level @CURRENT_MARKER enc@LEVEL_ONLY"></div>
-                    <div class="max-load @CURRENT_MARKER">@MAX_LOAD</div>
-                    <div class="move @CURRENT_MARKER">@MOVE</div>
-                    <div class="dodge @CURRENT_MARKER">@DODGE</div>
-                    @ENCUMBRANCE_LOOP_END
-                </div>
-                <div id="lifting">
-                    <div class="header">Lifting &amp; Moving Things</div>
-                    <div class="lift">@BASIC_LIFT</div>
-                    <div class="label">Basic Lift</div>
-                    <div class="lift">@ONE_HANDED_LIFT</div>
-                    <div class="label">One-Handed Lift</div>
-                    <div class="lift">@TWO_HANDED_LIFT</div>
-                    <div class="label">Two-Handed Lift</div>
-                    <div class="lift">@SHOVE</div>
-                    <div class="label">Shove &amp; Knock Over</div>
-                    <div class="lift">@RUNNING_SHOVE</div>
-                    <div class="label">Running Shove &amp; Knock Over</div>
-                    <div class="lift">@CARRY_ON_BACK</div>
-                    <div class="label">Carry on Back</div>
-                    <div class="lift">@SHIFT_SLIGHTLY</div>
-                    <div class="label">Shift Slightly</div>
-                </div>
-            </div>
-        </div>
-        <div id="embeds">
-            <div id="reactions">
-                <div class="entry-parent header" readonly></div>
-                <div class="modifier header">&#177;</div>
-                <div class="situation header">Reaction</div>
-                @REACTION_LOOP_START
-                <div class="entry-parent" readonly></div>
-                <div class="modifier">@MODIFIER</div>
-                <div class="situation">@SITUATION</div>
-                @REACTION_LOOP_END
-            </div>
-            <div id="conditional-modifiers">
-                <div class="entry-parent header" readonly></div>
-                <div class="modifier header">&#177;</div>
-                <div class="situation header">Condition</div>
-                @CONDITIONAL_MODIFIERS_LOOP_START
-                <div class="entry-parent" readonly></div>
-                <div class="modifier">@MODIFIER</div>
-                <div class="situation">@SITUATION</div>
-                @CONDITIONAL_MODIFIERS_LOOP_END
-            </div>
-            <div id="melee">
-                <div class="header entry-parent" readonly></div>
-                <div class="header desc">Melee Weapon</div>
-                <div class="header usage">Usage</div>
-                <div class="header level">SL</div>
-                <div class="header parry">Parry</div>
-                <div class="header block">Block</div>
-                <div class="header damage">Damage</div>
-                <div class="header reach">Reach</div>
-                <div class="header st">ST</div>
-                @MELEE_LOOP_START
-                <div class="entry-parent" readonly></div>
-                <div class="desc">
-                    @DESCRIPTION_PRIMARY
-                    <div class="item-notes">
-                        @DESCRIPTION_NOTES
-                    </div>
-                </div>
-                <div class="usage">@USAGE</div>
-                <div class="level">@LEVEL</div>
-                <div class="parry">@PARRY</div>
-                <div class="block">@BLOCK</div>
-                <div class="damage">@DAMAGE</div>
-                <div class="reach">@REACH</div>
-                <div class="st">@STRENGTH</div>
-                @MELEE_LOOP_END
-            </div>
-            <div id="ranged">
-                <div class="header entry-parent" readonly></div>
-                <div class="header desc">Ranged Weapon</div>
-                <div class="header usage">Usage</div>
-                <div class="header level">SL</div>
-                <div class="header acc">Acc</div>
-                <div class="header range">Range</div>
-                <div class="header damage">Damage</div>
-                <div class="header rof">RoF</div>
-                <div class="header shots">Shots</div>
-                <div class="header bulk">Bulk</div>
-                <div class="header recoil">Recoil</div>
-                <div class="header st">ST</div>
-                @RANGED_LOOP_START
-                <div class="entry-parent" readonly></div>
-                <div class="desc">
-                    @DESCRIPTION_PRIMARY
-                    <div class="item-notes">
-                        @DESCRIPTION_NOTES
-                    </div>
-                </div>
-                <div class="usage">@USAGE</div>
-                <div class="level">@LEVEL</div>
-                <div class="acc">@ACCURACY</div>
-                <div class="range">@RANGE</div>
-                <div class="damage">@DAMAGE</div>
-                <div class="rof">@ROF</div>
-                <div class="shots">@SHOTS</div>
-                <div class="bulk">@BULK</div>
-                <div class="recoil">@RECOIL</div>
-                <div class="st">@STRENGTH</div>
-                @RANGED_LOOP_END
-            </div>
-            <div id="traits">
-                <div class="header entry-parent" readonly></div>
-                <div class="header desc">Trait</div>
-                <div class="header points">Pts</div>
-                <div class="header reference">
-                    <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
-                        <path class="shape-bookmark"></path>
-                    </svg>
-                </div>
-                @ADVANTAGES_LOOP_START
-                <div class="entry-parent" readonly></div>
-                <div class="desc" style="padding-left: calc(@DEPTHx20 * 1px + 4px)">
-                    @DESCRIPTION_PRIMARY
-                    <div class="item-notes">
-                        @DESCRIPTION_MODIFIER_NOTES
-                        @DESCRIPTION_NOTES
-                    </div>
-                </div>
-                <div class="points">@POINTS</div>
-                <div class="reference">@REF</div>
-                @ADVANTAGES_LOOP_END
-            </div>
-            <div id="skills">
-                <div class="header entry-parent" readonly></div>
-                <div class="header desc">Skill / Technique</div>
-                <div class="header level">SL</div>
-                <div class="header rsl">RSL</div>
-                <div class="header points">Pts</div>
-                <div class="header reference">
-                    <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
-                        <path class="shape-bookmark"></path>
-                    </svg>
-                </div>
-                @SKILLS_LOOP_START
-                <div class="entry-parent" readonly></div>
-                <div class="desc" style="padding-left: calc(@DEPTHx20 * 1px + 4px)">
-                    @DESCRIPTION_PRIMARY
-                    <div class="item-notes">
-                        @DESCRIPTION_MODIFIER_NOTES
-                        @DESCRIPTION_NOTES
-                    </div>
-                </div>
-                <div class="level"></div>
-                <div class="rsl"></div>
-                <div class="points"></div>
-                <div class="reference">@REF</div>
-                @SKILLS_LOOP_END
-            </div>
-            <div id="spells">
-                <div class="header entry-parent" readonly></div>
-                <div class="header desc">Spell</div>
-                <div class="header college">College</div>
-                <div class="header level">SL</div>
-                <div class="header rsl">RSL</div>
-                <div class="header points">Pts</div>
-                <div class="header reference">
-                    <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
-                        <path class="shape-bookmark"></path>
-                    </svg>
-                </div>
-                @SPELLS_LOOP_START
-                <div class="entry-parent" readonly></div>
-                <div class="desc" style="padding-left: calc(20px * @DEPTHx1 + 4px)">
-                    @DESCRIPTION_PRIMARY
-                    <div class="item-notes">
-                        @DESCRIPTION_MODIFIER_NOTES
-                        @DESCRIPTION_NOTES
-                        Class: @CLASS; Cost: @MANA_CAST; Maintain: @MANA_MAINTAIN; Time: @TIME_CAST; Duration:
-                        @DURATION;
-                    </div>
-                </div>
-                <div class="college">@COLLEGE</div>
-                <div class="level">@SL</div>
-                <div class="rsl">@RSL</div>
-                <div class="points">@POINTS</div>
-                <div class="reference">@REF</div>
-                @SPELLS_LOOP_END
-            </div>
-            <div id="equipment">
-                <div class="header entry-parent" readonly></div>
-                <div class="header equipped">
-                    <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
-                        <path class="shape-equipped-1"></path>
-                    </svg>
-                </div>
-                <div class="header quantity">#</div>
-                <div class="header desc">Carried Equipment (@CARRIED_WEIGHT; @CARRIED_VALUE)</div>
-                <div class="header uses">Uses</div>
-                <div class="header tech-level">TL</div>
-                <div class="header legality-class">LC</div>
-                <div class="header value">
-                    <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
-                        <path class="shape-coins"></path>
-                    </svg>
-                </div>
-                <div class="header weight">
-                    <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
-                        <path class="shape-weight"></path>
-                    </svg>
-                </div>
-                <div class="header extended-value">
-                    <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
-                        <path class="shape-stack"></path>
-                    </svg>
-                    <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
-                        <path class="shape-coins"></path>
-                    </svg>
-                </div>
-                <div class="header extended-weight">
-                    <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
-                        <path class="shape-stack"></path>
-                    </svg>
-                    <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
-                        <path class="shape-weight"></path>
-                    </svg>
-                </div>
-                <div class="header reference">
-                    <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
-                        <path class="shape-bookmark"></path>
-                    </svg>
-                </div>
-                @EQUIPMENT_LOOP_START
-                <div class="entry-parent" readonly></div>
-                <div class="equipped">
-                    <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
-                        <path class="shape-equipped-@EQUIPPED_NUM"></path>
-                    </svg>
-                </div>
-                <div class="quantity">@QTY</div>
-                <div class="desc" style="padding-left: calc(20px * @DEPTHx1 + 4px)">
-                    @DESCRIPTION_PRIMARY
-                    <div class="item-notes">
-                        @DESCRIPTION_MODIFIER_NOTES
-                        @DESCRIPTION_NOTES
-                    </div>
-                </div>
-                <div class="uses max@MAX_USES">@USES</div>
-                <div class="tech-level">@TL</div>
-                <div class="legality-class @LEGALITY_CLASS"></div>
-                <div class="value">@COST</div>
-                <div class="weight">@WEIGHT</div>
-                <div class="extended-value">@COST_SUMMARY</div>
-                <div class="extended-weight">@WEIGHT_SUMMARY</div>
-                <div class="reference">@REF</div>
-                @EQUIPMENT_LOOP_END
-            </div>
-            <div id="other-equipment">
-                <div class="header entry-parent" readonly></div>
-                <div class="header quantity">#</div>
-                <div class="header desc">Other Equipment (@OTHER_EQUIPMENT_VALUE)</div>
-                <div class="header uses">Uses</div>
-                <div class="header tech-level">TL</div>
-                <div class="header legality-class">LC</div>
-                <div class="header value">
-                    <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
-                        <path class="shape-coins"></path>
-                    </svg>
-                </div>
-                <div class="header weight">
-                    <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
-                        <path class="shape-weight"></path>
-                    </svg>
-                </div>
-                <div class="header extended-value">
-                    <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
-                        <path class="shape-stack"></path>
-                    </svg>
-                    <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
-                        <path class="shape-coins"></path>
-                    </svg>
-                </div>
-                <div class="header extended-weight">
-                    <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
-                        <path class="shape-stack"></path>
-                    </svg>
-                    <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
-                        <path class="shape-weight"></path>
-                    </svg>
-                </div>
-                <div class="header reference">
-                    <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
-                        <path class="shape-bookmark"></path>
-                    </svg>
-                </div>
-                @OTHER_EQUIPMENT_LOOP_START
-                <div class="entry-parent" readonly></div>
-                <div class="quantity">@QTY</div>
-                <div class="desc" style="padding-left: calc(20px * @DEPTHx1 + 4px)">
-                    @DESCRIPTION_PRIMARY
-                    <div class="item-notes">
-                        @DESCRIPTION_MODIFIER_NOTES
-                        @DESCRIPTION_NOTES
-                    </div>
-                </div>
-                <div class="uses max@MAX_USES">@USES</div>
-                <div class="tech-level">@TL</div>
-                <div class="legality-class">@LEGALITY_CLASS</div>
-                <div class="value">@COST</div>
-                <div class="weight">@WEIGHT</div>
-                <div class="extended-value">@COST_SUMMARY</div>
-                <div class="extended-weight">@WEIGHT_SUMMARY</div>
-                <div class="reference">@REF</div>
-                @OTHER_EQUIPMENT_LOOP_END
-            </div>
-            <div id="notes">
-                <div class="header entry-parent" readonly></div>
-                <div class="header desc">Note</div>
-                <div class="header reference">
-                    <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
-                        <path class="shape-bookmark"></path>
-                    </svg>
-                </div>
-                @NOTES_LOOP_START
-                <div class="entry-parent" readonly></div>
-                <div class="desc" style="padding-left: calc(20px * @DEPTHx1 + 4px)">
-                    @NOTE
-                </div>
-                <div class="reference">@REF</div>
-                @NOTES_LOOP_END
-            </div>
-        </div>
-        <div id="footer">
-            <div class="left">GCS is copyrighted &copy;1998-2022 by Richard A. Wilkes. All rights reserved</div>
-            <div class="centre">@NAME</div>
-            <div class="right"><a href="https://gurpscharactersheet.com/">gurpscharactersheet.com</a></div>
-        </div>
-    </div>
+	<div id="sheet">
+		<div id="personal">
+			<div id="portrait">
+				<div class="header">Portrait</div>
+				<div class="portrait"></div>
+			</div>
+			<div id="identity">
+				<div class="header">Identity</div>
+				<div class="fieldblock">
+					<div class="label">Name</div>
+					<div class="field">@NAME</div>
+					<div class="label">Title</div>
+					<div class="field">@TITLE</div>
+					<div class="label">Organization</div>
+					<div class="field">@ORGANIZATION</div>
+				</div>
+			</div>
+			<div id="miscellaneous">
+				<div class="header">Miscellaneous</div>
+				<div class="fieldblock">
+					<div class="label">Created</div>
+					<div class="field">@CREATED_ON</div>
+					<div class="label">Modified</div>
+					<div class="field">@CREATED_ON</div>
+					<div class="label">Player</div>
+					<div class="field">@PLAYER</div>
+				</div>
+			</div>
+			<div id="description">
+				<div class="header">Description</div>
+				<div class="fieldblock">
+					<div class="label">Gender</div>
+					<div class="field">@GENDER</div>
+					<div class="label">Age</div>
+					<div class="field">@AGE</div>
+					<div class="label">Birthday</div>
+					<div class="field">@BIRTHDAY</div>
+					<div class="label">Religion</div>
+					<div class="field">@RELIGION</div>
+				</div>
+				<div class="fieldblock">
+					<div class="label">Height</div>
+					<div class="field">@HEIGHT</div>
+					<div class="label">Weight</div>
+					<div class="field">@WEIGHT</div>
+					<div class="label">Size</div>
+					<div class="field">@SIZE</div>
+					<div class="label">TL</div>
+					<div class="field">@TL</div>
+				</div>
+				<div class="fieldblock">
+					<div class="label">Hair</div>
+					<div class="field">@HAIR</div>
+					<div class="label">Eyes</div>
+					<div class="field">@EYES</div>
+					<div class="label">Skin</div>
+					<div class="field">@SKIN</div>
+					<div class="label">Hand</div>
+					<div class="field">@HAND</div>
+				</div>
+			</div>
+			<div id="points">
+				<div class="header">@TOTAL_POINTS Points</div>
+				<div class="fieldblock">
+					<div class="field noedit">@UNSPENT_POINTS</div>
+					<div class="label">Unspent</div>
+					<div class="field noedit">@RACE_POINTS</div>
+					<div class="label">Race</div>
+					<div class="field noedit">@ATTRIBUTE_POINTS</div>
+					<div class="label">Attributes</div>
+					<div class="field noedit">@ADVANTAGE_POINTS</div>
+					<div class="label">Advantages</div>
+					<div class="field noedit">@DISADVANTAGE_POINTS</div>
+					<div class="label">Disadvantages</div>
+					<div class="field noedit">@QUIRK_POINTS</div>
+					<div class="label">Quirks</div>
+					<div class="field noedit">@SKILL_POINTS</div>
+					<div class="label">Skills</div>
+					<div class="field noedit">@SPELL_POINTS</div>
+					<div class="label">Spells</div>
+				</div>
+			</div>
+		</div>
+		<div id="stats">
+			<div id="attributes">
+				<div id="primary-attributes">
+					<div class="header">Primary Attributes</div>
+					<div class="fieldblock3">
+						@PRIMARY_ATTRIBUTE_LOOP_START
+						<div class="points">[@POINTS]</div>
+						<div class="field">@VALUE</div>
+						<div class="label">@COMBINED_NAME</div>
+						@PRIMARY_ATTRIBUTE_LOOP_END
+					</div>
+				</div>
+				<div id="basic-damage">
+					<div class="header">Basic Damage</div>
+					<div class="fieldblock3">
+						<div class="points">[20]</div>
+						<div class="field noedit">@THRUST</div>
+						<div class="label">Basic Thrust</div>
+						<div class="points">[20]</div>
+						<div class="field noedit">@SWING</div>
+						<div class="label">Basic Swing</div>
+					</div>
+				</div>
+				<div id="secondary-attributes">
+					<div class="header">Secondary Attributes</div>
+					<div class="fieldblock3">
+						@SECONDARY_ATTRIBUTE_LOOP_START
+						<div class="points">[@POINTS]</div>
+						<div class="field">@VALUE</div>
+						<div class="label">@COMBINED_NAME</div>
+						@SECONDARY_ATTRIBUTE_LOOP_END
+					</div>
+				</div>
+				<div id="pool-attributes">
+					<div class="header">Point Pools</div>
+					<div class="fieldblock5">
+						@POINT_POOL_LOOP_START
+						<div class="points">[@POINTS]</div>
+						<div class="field">@CURRENT</div>
+						<div class="label">of</div>
+						<div class="field">@MAXIMUM</div>
+						<div class="label">@COMBINED_NAME</div>
+						@POINT_POOL_LOOP_END
+					</div>
+				</div>
+			</div>
+			<div id="hit-locations">
+				<div class="header body-plan">Hit Locations</div>
+				<div class="header entry-parent" readonly></div>
+				<div class="header roll">Roll</div>
+				<div class="header location">Location</div>
+				<div class="header dr">DR</div>
+				@HIT_LOCATION_LOOP_START
+				<div class="entry-parent" readonly></div>
+				<div class="roll">@ROLL</div>
+				<div class="location">@WHERE</div>
+				<div class="penalty">@PENALTY</div>
+				<div class="dr">@DR</div>
+				@HIT_LOCATION_LOOP_END
+			</div>
+			<div id="encumbrance-lifting">
+				<div id="encumbrance">
+					<div class="header title">Encumbrance, Move &amp; Dodge</div>
+					<div class="header level">Level</div>
+					<div class="header max-load">Max Load</div>
+					<div class="header move">Move</div>
+					<div class="header dodge">Dodge</div>
+					@ENCUMBRANCE_LOOP_START
+					<div class="encumbrance-marker @CURRENT_MARKER">
+						<svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+							<path></path>
+						</svg>
+					</div>
+					<div class="level-number @CURRENT_MARKER enc@LEVEL_ONLY"></div>
+					<div class="level @CURRENT_MARKER enc@LEVEL_ONLY"></div>
+					<div class="max-load @CURRENT_MARKER">@MAX_LOAD</div>
+					<div class="move @CURRENT_MARKER">@MOVE</div>
+					<div class="dodge @CURRENT_MARKER">@DODGE</div>
+					@ENCUMBRANCE_LOOP_END
+				</div>
+				<div id="lifting">
+					<div class="header">Lifting &amp; Moving Things</div>
+					<div class="lift">@BASIC_LIFT</div>
+					<div class="label">Basic Lift</div>
+					<div class="lift">@ONE_HANDED_LIFT</div>
+					<div class="label">One-Handed Lift</div>
+					<div class="lift">@TWO_HANDED_LIFT</div>
+					<div class="label">Two-Handed Lift</div>
+					<div class="lift">@SHOVE</div>
+					<div class="label">Shove &amp; Knock Over</div>
+					<div class="lift">@RUNNING_SHOVE</div>
+					<div class="label">Running Shove &amp; Knock Over</div>
+					<div class="lift">@CARRY_ON_BACK</div>
+					<div class="label">Carry on Back</div>
+					<div class="lift">@SHIFT_SLIGHTLY</div>
+					<div class="label">Shift Slightly</div>
+				</div>
+			</div>
+		</div>
+		<div id="embeds">
+			<div id="reactions">
+				<div class="entry-parent header" readonly></div>
+				<div class="modifier header">&#177;</div>
+				<div class="situation header">Reaction</div>
+				@REACTION_LOOP_START
+				<div class="entry-parent" readonly></div>
+				<div class="modifier">@MODIFIER</div>
+				<div class="situation">@SITUATION</div>
+				@REACTION_LOOP_END
+			</div>
+			<div id="conditional-modifiers">
+				<div class="entry-parent header" readonly></div>
+				<div class="modifier header">&#177;</div>
+				<div class="situation header">Condition</div>
+				@CONDITIONAL_MODIFIERS_LOOP_START
+				<div class="entry-parent" readonly></div>
+				<div class="modifier">@MODIFIER</div>
+				<div class="situation">@SITUATION</div>
+				@CONDITIONAL_MODIFIERS_LOOP_END
+			</div>
+			<div id="melee">
+				<div class="header entry-parent" readonly></div>
+				<div class="header desc">Melee Weapon</div>
+				<div class="header usage">Usage</div>
+				<div class="header level">SL</div>
+				<div class="header parry">Parry</div>
+				<div class="header block">Block</div>
+				<div class="header damage">Damage</div>
+				<div class="header reach">Reach</div>
+				<div class="header st">ST</div>
+				@MELEE_LOOP_START
+				<div class="entry-parent" readonly></div>
+				<div class="desc">
+					@DESCRIPTION_PRIMARY
+					<div class="item-notes">
+						@DESCRIPTION_NOTES
+					</div>
+				</div>
+				<div class="usage">@USAGE</div>
+				<div class="level">@LEVEL</div>
+				<div class="parry">@PARRY</div>
+				<div class="block">@BLOCK</div>
+				<div class="damage">@DAMAGE</div>
+				<div class="reach">@REACH</div>
+				<div class="st">@STRENGTH</div>
+				@MELEE_LOOP_END
+			</div>
+			<div id="ranged">
+				<div class="header entry-parent" readonly></div>
+				<div class="header desc">Ranged Weapon</div>
+				<div class="header usage">Usage</div>
+				<div class="header level">SL</div>
+				<div class="header acc">Acc</div>
+				<div class="header range">Range</div>
+				<div class="header damage">Damage</div>
+				<div class="header rof">RoF</div>
+				<div class="header shots">Shots</div>
+				<div class="header bulk">Bulk</div>
+				<div class="header recoil">Recoil</div>
+				<div class="header st">ST</div>
+				@RANGED_LOOP_START
+				<div class="entry-parent" readonly></div>
+				<div class="desc">
+					@DESCRIPTION_PRIMARY
+					<div class="item-notes">
+						@DESCRIPTION_NOTES
+					</div>
+				</div>
+				<div class="usage">@USAGE</div>
+				<div class="level">@LEVEL</div>
+				<div class="acc">@ACCURACY</div>
+				<div class="range">@RANGE</div>
+				<div class="damage">@DAMAGE</div>
+				<div class="rof">@ROF</div>
+				<div class="shots">@SHOTS</div>
+				<div class="bulk">@BULK</div>
+				<div class="recoil">@RECOIL</div>
+				<div class="st">@STRENGTH</div>
+				@RANGED_LOOP_END
+			</div>
+			<div id="traits">
+				<div class="header entry-parent" readonly></div>
+				<div class="header desc">Trait</div>
+				<div class="header points">Pts</div>
+				<div class="header reference">
+					<svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+						<path d="M384 48v464L192 400 0 512V48C0 21.5 21.5 0 48 0h288c26.5 0 48 21.5 48 48z"></path>
+					</svg>
+				</div>
+				@ADVANTAGES_LOOP_START
+				<div class="entry-parent" readonly></div>
+				<div class="desc" style="padding-left: calc(@DEPTHx20 * 1px + 4px)">
+					@DESCRIPTION_PRIMARY
+					<div class="item-notes">
+						@DESCRIPTION_MODIFIER_NOTES
+						@DESCRIPTION_NOTES
+					</div>
+				</div>
+				<div class="points">@POINTS</div>
+				<div class="reference">@REF</div>
+				@ADVANTAGES_LOOP_END
+			</div>
+			<div id="skills">
+				<div class="header entry-parent" readonly></div>
+				<div class="header desc">Skill / Technique</div>
+				<div class="header level">SL</div>
+				<div class="header rsl">RSL</div>
+				<div class="header points">Pts</div>
+				<div class="header reference">
+					<svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+						<path d="M384 48v464L192 400 0 512V48C0 21.5 21.5 0 48 0h288c26.5 0 48 21.5 48 48z"></path>
+					</svg>
+				</div>
+				@SKILLS_LOOP_START
+				<div class="entry-parent" readonly></div>
+				<div class="desc" style="padding-left: calc(@DEPTHx20 * 1px + 4px)">
+					@DESCRIPTION_PRIMARY
+					<div class="item-notes">
+						@DESCRIPTION_MODIFIER_NOTES
+						@DESCRIPTION_NOTES
+					</div>
+				</div>
+				<div class="level"></div>
+				<div class="rsl"></div>
+				<div class="points"></div>
+				<div class="reference">@REF</div>
+				@SKILLS_LOOP_END
+			</div>
+			<div id="spells">
+				<div class="header entry-parent" readonly></div>
+				<div class="header desc">Spell</div>
+				<div class="header college">College</div>
+				<div class="header level">SL</div>
+				<div class="header rsl">RSL</div>
+				<div class="header points">Pts</div>
+				<div class="header reference">
+					<svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+						<path d="M384 48v464L192 400 0 512V48C0 21.5 21.5 0 48 0h288c26.5 0 48 21.5 48 48z"></path>
+					</svg>
+				</div>
+				@SPELLS_LOOP_START
+				<div class="entry-parent" readonly></div>
+				<div class="desc" style="padding-left: calc(20px * @DEPTHx1 + 4px)">
+					@DESCRIPTION_PRIMARY
+					<div class="item-notes">
+						@DESCRIPTION_MODIFIER_NOTES
+						@DESCRIPTION_NOTES
+						Class: @CLASS; Cost: @MANA_CAST; Maintain: @MANA_MAINTAIN; Time: @TIME_CAST; Duration:
+						@DURATION;
+					</div>
+				</div>
+				<div class="college">@COLLEGE</div>
+				<div class="level">@SL</div>
+				<div class="rsl">@RSL</div>
+				<div class="points">@POINTS</div>
+				<div class="reference">@REF</div>
+				@SPELLS_LOOP_END
+			</div>
+			<div id="equipment">
+				<div class="header entry-parent" readonly></div>
+				<div class="header equipped">
+					<svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+						<path
+							d="M 492.1883,51.561176 447.69973,21.315702 C 435.38472,12.98066 418.51958,16.176634 410.28207,28.39411 L 192.1793,350.02095 91.94873,249.79038 c -10.469445,-10.46569 -27.533399,-10.46569 -37.999091,0 L 15.849269,287.887 c -10.4656924,10.46569 -10.4656924,27.52965 0,38.09662 L 169.97628,480.10687 c 8.62763,8.62763 22.19551,15.22215 34.40924,15.22215 12.21748,0 24.52498,-7.65984 32.47365,-19.19461 L 499.36048,88.881308 c 8.33505,-12.213725 5.13907,-28.98509 -7.17594,-37.323883 z">
+						</path>
+					</svg>
+				</div>
+				<div class="header quantity">#</div>
+				<div class="header desc">Carried Equipment (@CARRIED_WEIGHT; @CARRIED_VALUE)</div>
+				<div class="header uses">Uses</div>
+				<div class="header tech-level">TL</div>
+				<div class="header legality-class">LC</div>
+				<div class="header value">
+					<svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+						<path
+							d="M512 80c0 18.01-14.3 34.6-38.4 48-29.1 16.1-72.4 27.5-122.3 30.9-3.6-1.7-7.4-3.4-11.2-5C300.6 137.4 248.2 128 192 128c-8.3 0-16.4.2-24.5.6l-1.1-.6C142.3 114.6 128 98.01 128 80c0-44.18 85.1-80 192-80 106 0 192 35.82 192 80zm-351.3 81.1c10.2-.7 20.6-1.1 31.3-1.1 62.2 0 117.4 12.3 152.5 31.4 24.8 13.5 39.5 30.3 39.5 48.6 0 3.1-.7 7.9-2.1 11.7-4.6 13.2-17.8 25.3-35 35.6-.1 0-.3.1-.4.2-.3.2-.6.3-.9.5-35 19.4-90.8 32-153.6 32-59.6 0-112.94-11.3-148.16-29.1-1.87-1-3.69-2.8-5.45-2.9C14.28 274.6 0 258 0 240c0-34.8 53.43-64.5 128-75.4 10.5-1.6 21.4-2.8 32.7-3.5zm231.2 25.5c28.3-4.4 54.2-11.4 76.2-20.5 16.3-6.8 31.4-15.2 43.9-25.5V176c0 19.3-16.5 37.1-43.8 50.9-14.7 7.4-32.4 13.6-52.4 18.4.1-1.7.2-3.5.2-5.3 0-21.9-10.6-39.9-24.1-53.4zM384 336c0 18-14.3 34.6-38.4 48-1.8.1-3.6 1.9-5.4 2.9C304.9 404.7 251.6 416 192 416c-62.8 0-118.58-12.6-153.61-32C14.28 370.6 0 354 0 336v-35.4c12.45 10.3 27.62 18.7 43.93 25.5C83.44 342.6 135.8 352 192 352c56.2 0 108.6-9.4 148.1-25.9 7.8-3.2 15.3-6.9 22.4-10.9 6.1-3.4 11.8-7.2 17.2-11.2 1.5-1.1 2.9-2.3 4.3-3.4V336zm32-57.9c18.1-5 36.5-9.5 52.1-16 16.3-6.8 31.4-15.2 43.9-25.5V272c0 10.5-5 21-14.9 30.9-16.3 16.3-45 29.7-81.3 38.4.1-1.7.2-3.5.2-5.3v-57.9zM192 448c56.2 0 108.6-9.4 148.1-25.9 16.3-6.8 31.4-15.2 43.9-25.5V432c0 44.2-86 80-192 80C85.96 512 0 476.2 0 432v-35.4c12.45 10.3 27.62 18.7 43.93 25.5C83.44 438.6 135.8 448 192 448z">
+						</path>
+					</svg>
+				</div>
+				<div class="header weight">
+					<svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+						<path class="shape-weight"></path>
+					</svg>
+				</div>
+				<div class="header extended-value">
+					<svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+						<path
+							d="M232.5 5.171a56.026 56.026 0 0 1 47 0L498.1 106.2c8.5 3.9 13.9 12.4 13.9 20.9 0 10.2-5.4 18.7-13.9 22.7l-218.6 101c-14.9 6.9-32.1 6.9-47 0l-218.57-101C5.438 145.8 0 137.3 0 127.1c0-8.5 5.437-17 13.93-20.9L232.5 5.171zM498.1 234.2c8.5 3.9 13.9 12.4 13.9 20.9 0 10.2-5.4 18.7-13.9 22.7l-218.6 101c-14.9 6.9-32.1 6.9-47 0l-218.57-101C5.438 273.8 0 265.3 0 255.1c0-8.5 5.437-17 13.93-20.9l53.2-24.6 151.97 70.2c23.4 10.9 50.4 10.9 73.8 0l152-70.2 53.2 24.6zM292.9 407.8l152-70.2 53.2 24.6c8.5 3.9 13.9 12.4 13.9 20.9 0 10.2-5.4 18.7-13.9 22.7l-218.6 101c-14.9 6.9-32.1 6.9-47 0l-218.57-101C5.438 401.8 0 393.3 0 383.1c0-8.5 5.437-17 13.93-20.9l53.2-24.6 151.97 70.2c23.4 10.9 50.4 10.9 73.8 0z">
+						</path>
+					</svg>
+					<svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+						<path
+							d="M512 80c0 18.01-14.3 34.6-38.4 48-29.1 16.1-72.4 27.5-122.3 30.9-3.6-1.7-7.4-3.4-11.2-5C300.6 137.4 248.2 128 192 128c-8.3 0-16.4.2-24.5.6l-1.1-.6C142.3 114.6 128 98.01 128 80c0-44.18 85.1-80 192-80 106 0 192 35.82 192 80zm-351.3 81.1c10.2-.7 20.6-1.1 31.3-1.1 62.2 0 117.4 12.3 152.5 31.4 24.8 13.5 39.5 30.3 39.5 48.6 0 3.1-.7 7.9-2.1 11.7-4.6 13.2-17.8 25.3-35 35.6-.1 0-.3.1-.4.2-.3.2-.6.3-.9.5-35 19.4-90.8 32-153.6 32-59.6 0-112.94-11.3-148.16-29.1-1.87-1-3.69-2.8-5.45-2.9C14.28 274.6 0 258 0 240c0-34.8 53.43-64.5 128-75.4 10.5-1.6 21.4-2.8 32.7-3.5zm231.2 25.5c28.3-4.4 54.2-11.4 76.2-20.5 16.3-6.8 31.4-15.2 43.9-25.5V176c0 19.3-16.5 37.1-43.8 50.9-14.7 7.4-32.4 13.6-52.4 18.4.1-1.7.2-3.5.2-5.3 0-21.9-10.6-39.9-24.1-53.4zM384 336c0 18-14.3 34.6-38.4 48-1.8.1-3.6 1.9-5.4 2.9C304.9 404.7 251.6 416 192 416c-62.8 0-118.58-12.6-153.61-32C14.28 370.6 0 354 0 336v-35.4c12.45 10.3 27.62 18.7 43.93 25.5C83.44 342.6 135.8 352 192 352c56.2 0 108.6-9.4 148.1-25.9 7.8-3.2 15.3-6.9 22.4-10.9 6.1-3.4 11.8-7.2 17.2-11.2 1.5-1.1 2.9-2.3 4.3-3.4V336zm32-57.9c18.1-5 36.5-9.5 52.1-16 16.3-6.8 31.4-15.2 43.9-25.5V272c0 10.5-5 21-14.9 30.9-16.3 16.3-45 29.7-81.3 38.4.1-1.7.2-3.5.2-5.3v-57.9zM192 448c56.2 0 108.6-9.4 148.1-25.9 16.3-6.8 31.4-15.2 43.9-25.5V432c0 44.2-86 80-192 80C85.96 512 0 476.2 0 432v-35.4c12.45 10.3 27.62 18.7 43.93 25.5C83.44 438.6 135.8 448 192 448z">
+						</path>
+					</svg>
+				</div>
+				<div class="header extended-weight">
+					<svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+						<path
+							d="M232.5 5.171a56.026 56.026 0 0 1 47 0L498.1 106.2c8.5 3.9 13.9 12.4 13.9 20.9 0 10.2-5.4 18.7-13.9 22.7l-218.6 101c-14.9 6.9-32.1 6.9-47 0l-218.57-101C5.438 145.8 0 137.3 0 127.1c0-8.5 5.437-17 13.93-20.9L232.5 5.171zM498.1 234.2c8.5 3.9 13.9 12.4 13.9 20.9 0 10.2-5.4 18.7-13.9 22.7l-218.6 101c-14.9 6.9-32.1 6.9-47 0l-218.57-101C5.438 273.8 0 265.3 0 255.1c0-8.5 5.437-17 13.93-20.9l53.2-24.6 151.97 70.2c23.4 10.9 50.4 10.9 73.8 0l152-70.2 53.2 24.6zM292.9 407.8l152-70.2 53.2 24.6c8.5 3.9 13.9 12.4 13.9 20.9 0 10.2-5.4 18.7-13.9 22.7l-218.6 101c-14.9 6.9-32.1 6.9-47 0l-218.57-101C5.438 401.8 0 393.3 0 383.1c0-8.5 5.437-17 13.93-20.9l53.2-24.6 151.97 70.2c23.4 10.9 50.4 10.9 73.8 0z">
+						</path>
+					</svg>
+					<svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+						<path
+							d="m510.3 445.9-73-292.1c-3.8-15.3-16.5-25.8-30.9-25.8h-60.3c3.625-9.1 5.875-20.75 5.875-32 0-53-42.1-96-96-96S159.1 43 159.1 96c0 11.25 2.25 22 5.875 32H105.6c-14.38 0-27.13 10.5-30.88 25.75L1.71 445.85C-6.641 479.1 16.36 512 47.99 512h416c31.61 0 54.61-32.9 46.31-66.1zM256 128c-17.6 0-32.9-14.4-32.9-32s15.3-32 32.9-32c17.63 0 32 14.38 32 32s-14.4 32-32 32z">
+						</path>
+					</svg>
+				</div>
+				<div class="header reference">
+					<svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+						<path d="M384 48v464L192 400 0 512V48C0 21.5 21.5 0 48 0h288c26.5 0 48 21.5 48 48z"></path>
+					</svg>
+				</div>
+				@EQUIPMENT_LOOP_START
+				<div class="entry-parent" readonly></div>
+				<div class="equipped">
+					<svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+						<path class="shape-equipped-@EQUIPPED_NUM"
+							d="M 492.1883,51.561176 447.69973,21.315702 C 435.38472,12.98066 418.51958,16.176634 410.28207,28.39411 L 192.1793,350.02095 91.94873,249.79038 c -10.469445,-10.46569 -27.533399,-10.46569 -37.999091,0 L 15.849269,287.887 c -10.4656924,10.46569 -10.4656924,27.52965 0,38.09662 L 169.97628,480.10687 c 8.62763,8.62763 22.19551,15.22215 34.40924,15.22215 12.21748,0 24.52498,-7.65984 32.47365,-19.19461 L 499.36048,88.881308 c 8.33505,-12.213725 5.13907,-28.98509 -7.17594,-37.323883 z">
+						</path>
+					</svg>
+				</div>
+				<div class="quantity">@QTY</div>
+				<div class="desc" style="padding-left: calc(20px * @DEPTHx1 + 4px)">
+					@DESCRIPTION_PRIMARY
+					<div class="item-notes">
+						@DESCRIPTION_MODIFIER_NOTES
+						@DESCRIPTION_NOTES
+					</div>
+				</div>
+				<div class="uses max@MAX_USES">@USES</div>
+				<div class="tech-level">@TL</div>
+				<div class="legality-class @LEGALITY_CLASS"></div>
+				<div class="value">@COST</div>
+				<div class="weight">@WEIGHT</div>
+				<div class="extended-value">@COST_SUMMARY</div>
+				<div class="extended-weight">@WEIGHT_SUMMARY</div>
+				<div class="reference">@REF</div>
+				@EQUIPMENT_LOOP_END
+			</div>
+			<div id="other-equipment">
+				<div class="header entry-parent" readonly></div>
+				<div class="header quantity">#</div>
+				<div class="header desc">Other Equipment (@OTHER_EQUIPMENT_VALUE)</div>
+				<div class="header uses">Uses</div>
+				<div class="header tech-level">TL</div>
+				<div class="header legality-class">LC</div>
+				<div class="header value">
+					<svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+						<path
+							d="M512 80c0 18.01-14.3 34.6-38.4 48-29.1 16.1-72.4 27.5-122.3 30.9-3.6-1.7-7.4-3.4-11.2-5C300.6 137.4 248.2 128 192 128c-8.3 0-16.4.2-24.5.6l-1.1-.6C142.3 114.6 128 98.01 128 80c0-44.18 85.1-80 192-80 106 0 192 35.82 192 80zm-351.3 81.1c10.2-.7 20.6-1.1 31.3-1.1 62.2 0 117.4 12.3 152.5 31.4 24.8 13.5 39.5 30.3 39.5 48.6 0 3.1-.7 7.9-2.1 11.7-4.6 13.2-17.8 25.3-35 35.6-.1 0-.3.1-.4.2-.3.2-.6.3-.9.5-35 19.4-90.8 32-153.6 32-59.6 0-112.94-11.3-148.16-29.1-1.87-1-3.69-2.8-5.45-2.9C14.28 274.6 0 258 0 240c0-34.8 53.43-64.5 128-75.4 10.5-1.6 21.4-2.8 32.7-3.5zm231.2 25.5c28.3-4.4 54.2-11.4 76.2-20.5 16.3-6.8 31.4-15.2 43.9-25.5V176c0 19.3-16.5 37.1-43.8 50.9-14.7 7.4-32.4 13.6-52.4 18.4.1-1.7.2-3.5.2-5.3 0-21.9-10.6-39.9-24.1-53.4zM384 336c0 18-14.3 34.6-38.4 48-1.8.1-3.6 1.9-5.4 2.9C304.9 404.7 251.6 416 192 416c-62.8 0-118.58-12.6-153.61-32C14.28 370.6 0 354 0 336v-35.4c12.45 10.3 27.62 18.7 43.93 25.5C83.44 342.6 135.8 352 192 352c56.2 0 108.6-9.4 148.1-25.9 7.8-3.2 15.3-6.9 22.4-10.9 6.1-3.4 11.8-7.2 17.2-11.2 1.5-1.1 2.9-2.3 4.3-3.4V336zm32-57.9c18.1-5 36.5-9.5 52.1-16 16.3-6.8 31.4-15.2 43.9-25.5V272c0 10.5-5 21-14.9 30.9-16.3 16.3-45 29.7-81.3 38.4.1-1.7.2-3.5.2-5.3v-57.9zM192 448c56.2 0 108.6-9.4 148.1-25.9 16.3-6.8 31.4-15.2 43.9-25.5V432c0 44.2-86 80-192 80C85.96 512 0 476.2 0 432v-35.4c12.45 10.3 27.62 18.7 43.93 25.5C83.44 438.6 135.8 448 192 448z">
+						</path>
+					</svg>
+				</div>
+				<div class="header weight">
+					<svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+						<path
+							d="m510.3 445.9-73-292.1c-3.8-15.3-16.5-25.8-30.9-25.8h-60.3c3.625-9.1 5.875-20.75 5.875-32 0-53-42.1-96-96-96S159.1 43 159.1 96c0 11.25 2.25 22 5.875 32H105.6c-14.38 0-27.13 10.5-30.88 25.75L1.71 445.85C-6.641 479.1 16.36 512 47.99 512h416c31.61 0 54.61-32.9 46.31-66.1zM256 128c-17.6 0-32.9-14.4-32.9-32s15.3-32 32.9-32c17.63 0 32 14.38 32 32s-14.4 32-32 32z">
+						</path>
+					</svg>
+				</div>
+				<div class="header extended-value">
+					<svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+						<path
+							d="M232.5 5.171a56.026 56.026 0 0 1 47 0L498.1 106.2c8.5 3.9 13.9 12.4 13.9 20.9 0 10.2-5.4 18.7-13.9 22.7l-218.6 101c-14.9 6.9-32.1 6.9-47 0l-218.57-101C5.438 145.8 0 137.3 0 127.1c0-8.5 5.437-17 13.93-20.9L232.5 5.171zM498.1 234.2c8.5 3.9 13.9 12.4 13.9 20.9 0 10.2-5.4 18.7-13.9 22.7l-218.6 101c-14.9 6.9-32.1 6.9-47 0l-218.57-101C5.438 273.8 0 265.3 0 255.1c0-8.5 5.437-17 13.93-20.9l53.2-24.6 151.97 70.2c23.4 10.9 50.4 10.9 73.8 0l152-70.2 53.2 24.6zM292.9 407.8l152-70.2 53.2 24.6c8.5 3.9 13.9 12.4 13.9 20.9 0 10.2-5.4 18.7-13.9 22.7l-218.6 101c-14.9 6.9-32.1 6.9-47 0l-218.57-101C5.438 401.8 0 393.3 0 383.1c0-8.5 5.437-17 13.93-20.9l53.2-24.6 151.97 70.2c23.4 10.9 50.4 10.9 73.8 0z">
+						</path>
+					</svg>
+					<svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+						<path
+							d="M512 80c0 18.01-14.3 34.6-38.4 48-29.1 16.1-72.4 27.5-122.3 30.9-3.6-1.7-7.4-3.4-11.2-5C300.6 137.4 248.2 128 192 128c-8.3 0-16.4.2-24.5.6l-1.1-.6C142.3 114.6 128 98.01 128 80c0-44.18 85.1-80 192-80 106 0 192 35.82 192 80zm-351.3 81.1c10.2-.7 20.6-1.1 31.3-1.1 62.2 0 117.4 12.3 152.5 31.4 24.8 13.5 39.5 30.3 39.5 48.6 0 3.1-.7 7.9-2.1 11.7-4.6 13.2-17.8 25.3-35 35.6-.1 0-.3.1-.4.2-.3.2-.6.3-.9.5-35 19.4-90.8 32-153.6 32-59.6 0-112.94-11.3-148.16-29.1-1.87-1-3.69-2.8-5.45-2.9C14.28 274.6 0 258 0 240c0-34.8 53.43-64.5 128-75.4 10.5-1.6 21.4-2.8 32.7-3.5zm231.2 25.5c28.3-4.4 54.2-11.4 76.2-20.5 16.3-6.8 31.4-15.2 43.9-25.5V176c0 19.3-16.5 37.1-43.8 50.9-14.7 7.4-32.4 13.6-52.4 18.4.1-1.7.2-3.5.2-5.3 0-21.9-10.6-39.9-24.1-53.4zM384 336c0 18-14.3 34.6-38.4 48-1.8.1-3.6 1.9-5.4 2.9C304.9 404.7 251.6 416 192 416c-62.8 0-118.58-12.6-153.61-32C14.28 370.6 0 354 0 336v-35.4c12.45 10.3 27.62 18.7 43.93 25.5C83.44 342.6 135.8 352 192 352c56.2 0 108.6-9.4 148.1-25.9 7.8-3.2 15.3-6.9 22.4-10.9 6.1-3.4 11.8-7.2 17.2-11.2 1.5-1.1 2.9-2.3 4.3-3.4V336zm32-57.9c18.1-5 36.5-9.5 52.1-16 16.3-6.8 31.4-15.2 43.9-25.5V272c0 10.5-5 21-14.9 30.9-16.3 16.3-45 29.7-81.3 38.4.1-1.7.2-3.5.2-5.3v-57.9zM192 448c56.2 0 108.6-9.4 148.1-25.9 16.3-6.8 31.4-15.2 43.9-25.5V432c0 44.2-86 80-192 80C85.96 512 0 476.2 0 432v-35.4c12.45 10.3 27.62 18.7 43.93 25.5C83.44 438.6 135.8 448 192 448z">
+						</path>
+					</svg>
+				</div>
+				<div class="header extended-weight">
+					<svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+						<path
+							d="M232.5 5.171a56.026 56.026 0 0 1 47 0L498.1 106.2c8.5 3.9 13.9 12.4 13.9 20.9 0 10.2-5.4 18.7-13.9 22.7l-218.6 101c-14.9 6.9-32.1 6.9-47 0l-218.57-101C5.438 145.8 0 137.3 0 127.1c0-8.5 5.437-17 13.93-20.9L232.5 5.171zM498.1 234.2c8.5 3.9 13.9 12.4 13.9 20.9 0 10.2-5.4 18.7-13.9 22.7l-218.6 101c-14.9 6.9-32.1 6.9-47 0l-218.57-101C5.438 273.8 0 265.3 0 255.1c0-8.5 5.437-17 13.93-20.9l53.2-24.6 151.97 70.2c23.4 10.9 50.4 10.9 73.8 0l152-70.2 53.2 24.6zM292.9 407.8l152-70.2 53.2 24.6c8.5 3.9 13.9 12.4 13.9 20.9 0 10.2-5.4 18.7-13.9 22.7l-218.6 101c-14.9 6.9-32.1 6.9-47 0l-218.57-101C5.438 401.8 0 393.3 0 383.1c0-8.5 5.437-17 13.93-20.9l53.2-24.6 151.97 70.2c23.4 10.9 50.4 10.9 73.8 0z">
+						</path>
+					</svg>
+					<svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+						<path
+							d="m510.3 445.9-73-292.1c-3.8-15.3-16.5-25.8-30.9-25.8h-60.3c3.625-9.1 5.875-20.75 5.875-32 0-53-42.1-96-96-96S159.1 43 159.1 96c0 11.25 2.25 22 5.875 32H105.6c-14.38 0-27.13 10.5-30.88 25.75L1.71 445.85C-6.641 479.1 16.36 512 47.99 512h416c31.61 0 54.61-32.9 46.31-66.1zM256 128c-17.6 0-32.9-14.4-32.9-32s15.3-32 32.9-32c17.63 0 32 14.38 32 32s-14.4 32-32 32z">
+						</path>
+					</svg>
+				</div>
+				<div class="header reference">
+					<svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+						<path d="M384 48v464L192 400 0 512V48C0 21.5 21.5 0 48 0h288c26.5 0 48 21.5 48 48z"></path>
+					</svg>
+				</div>
+				@OTHER_EQUIPMENT_LOOP_START
+				<div class="entry-parent" readonly></div>
+				<div class="quantity">@QTY</div>
+				<div class="desc" style="padding-left: calc(20px * @DEPTHx1 + 4px)">
+					@DESCRIPTION_PRIMARY
+					<div class="item-notes">
+						@DESCRIPTION_MODIFIER_NOTES
+						@DESCRIPTION_NOTES
+					</div>
+				</div>
+				<div class="uses max@MAX_USES">@USES</div>
+				<div class="tech-level">@TL</div>
+				<div class="legality-class">@LEGALITY_CLASS</div>
+				<div class="value">@COST</div>
+				<div class="weight">@WEIGHT</div>
+				<div class="extended-value">@COST_SUMMARY</div>
+				<div class="extended-weight">@WEIGHT_SUMMARY</div>
+				<div class="reference">@REF</div>
+				@OTHER_EQUIPMENT_LOOP_END
+			</div>
+			<div id="notes">
+				<div class="header entry-parent" readonly></div>
+				<div class="header desc">Note</div>
+				<div class="header reference">
+					<svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+						<path d="M384 48v464L192 400 0 512V48C0 21.5 21.5 0 48 0h288c26.5 0 48 21.5 48 48z"></path>
+					</svg>
+				</div>
+				@NOTES_LOOP_START
+				<div class="entry-parent" readonly></div>
+				<div class="desc" style="padding-left: calc(20px * @DEPTHx1 + 4px)">
+					@NOTE
+				</div>
+				<div class="reference">@REF</div>
+				@NOTES_LOOP_END
+			</div>
+		</div>
+		<div id="footer">
+			<div class="left">GCS is copyrighted &copy;1998-2022 by Richard A. Wilkes. All rights reserved</div>
+			<div class="centre">@NAME</div>
+			<div class="right"><a href="https://gurpscharactersheet.com/">gurpscharactersheet.com</a></div>
+		</div>
+	</div>
 </body>
 
 </html>

--- a/Library/Output Templates/HTML - PC.html
+++ b/Library/Output Templates/HTML - PC.html
@@ -118,6 +118,7 @@ defined by the Mozilla Public License, version 2.0.
 			flex-flow: column nowrap;
 			justify-content: start;
 			gap: var(--section-gap);
+			min-width: 840px;
 		}
 
 		.header {
@@ -219,8 +220,7 @@ defined by the Mozilla Public License, version 2.0.
 			background-position: center;
 			background-repeat: no-repeat;
 			background-size: cover;
-			width: calc(6.75rem + 1.5px);
-			height: calc(9rem + 2px);
+			width: 6.75rem;
 		}
 
 		#identity {

--- a/Library/Output Templates/HTML - PC.html
+++ b/Library/Output Templates/HTML - PC.html
@@ -16,8 +16,9 @@ defined by the Mozilla Public License, version 2.0.
 <head>
     <meta charset="ut-8" />
     <title>@NAME</title>
-    <link rel="preconnect" href="https://fonts.gstatic.com">
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500&display=swap" rel="stylesheet">
     <style>
         :root {
             --section-gap: 1px;
@@ -876,7 +877,7 @@ defined by the Mozilla Public License, version 2.0.
         #equipment :nth-last-child(-n+10) {
             border-bottom: none !important;
         }
-        
+
         #equipment .equipped {
             padding: var(--padding-header);
         }
@@ -1539,17 +1540,17 @@ defined by the Mozilla Public License, version 2.0.
                 @NOTES_LOOP_START
                 <div class="entry-parent" readonly></div>
                 <div class="desc" style="padding-left: calc(20px * @DEPTHx1 - 6px)">
-                @NOTE
+                    @NOTE
                 </div>
                 <div class="reference">@REF</div>
                 @NOTES_LOOP_END
             </div>
         </div>
-		<div id="footer">
-			<div class="left">GCS is copyrighted &copy; by Richard A. Wilkes<br>All rights reserved</div>
-			<div class="centre">@NAME</div>
-			<div class="right"><a href="https://gurpscharactersheet.com/">gurpscharactersheet.com</a></div>
-		</div>
+        <div id="footer">
+            <div class="left">GCS is copyrighted &copy; by Richard A. Wilkes<br>All rights reserved</div>
+            <div class="centre">@NAME</div>
+            <div class="right"><a href="https://gurpscharactersheet.com/">gurpscharactersheet.com</a></div>
+        </div>
     </div>
 </body>
 

--- a/Library/Output Templates/HTML - PC.html
+++ b/Library/Output Templates/HTML - PC.html
@@ -1442,7 +1442,9 @@ defined by the Mozilla Public License, version 2.0.
 				</div>
 				<div class="header weight">
 					<svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
-						<path class="shape-weight"></path>
+						<path
+							d="m510.3 445.9-73-292.1c-3.8-15.3-16.5-25.8-30.9-25.8h-60.3c3.625-9.1 5.875-20.75 5.875-32 0-53-42.1-96-96-96S159.1 43 159.1 96c0 11.25 2.25 22 5.875 32H105.6c-14.38 0-27.13 10.5-30.88 25.75L1.71 445.85C-6.641 479.1 16.36 512 47.99 512h416c31.61 0 54.61-32.9 46.31-66.1zM256 128c-17.6 0-32.9-14.4-32.9-32s15.3-32 32.9-32c17.63 0 32 14.38 32 32s-14.4 32-32 32z">
+						</path>
 					</svg>
 				</div>
 				<div class="header extended-value">

--- a/Library/Output Templates/HTML - PC.html
+++ b/Library/Output Templates/HTML - PC.html
@@ -12,705 +12,1208 @@ This Source Code Form is "Incompatible With Secondary Licenses", as
 defined by the Mozilla Public License, version 2.0.
 ***** END LICENSE BLOCK *****
 -->
+
 <head>
-    <meta charset="utf-8" />
+    <meta charset="ut-8" />
     <title>@NAME</title>
-    <script src="https://kit.fontawesome.com/b74c5174c2.js" crossorigin="anonymous"></script>
     <link rel="preconnect" href="https://fonts.gstatic.com">
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
     <style>
+        :root {
+            --section-gap: 1px;
+            --header-font-size: 80%;
+            --padding-standard: 0px 4px;
+            --padding-header: 1px 8px;
+            --standard-border: 1px solid rgb(var(--color-header));
+
+            --font-page-primary-fields: 500 var(--font-size-14) 'Roboto', sans-serif;
+            --font-page-secondary-fields: 400 var(--font-size-12) 'Roboto', sans-serif;
+            --font-page-primary-labels: 400 var(--font-size-14) 'Roboto', sans-serif;
+            --font-page-secondary-lables: 400 var(--font-size-12) 'Roboto', sans-serif;
+            --font-page-primary-footer: 500 var(--font-size-12) 'Roboto', sans-serif;
+            --font-page-secondary-footer: 400 var(--font-size-11) 'Roboto', sans-serif;
+
+            --font-size-14: 0.875rem;
+            --font-size-12: 0.75rem;
+            --font-size-11: 0.6875rem;
+
+            --color-background: 238, 238, 238;
+            --color-on-background: 0, 0, 0;
+            --color-content: 255, 255, 255;
+            --color-on-content: 0, 0, 0;
+            --color-banding: 235, 235, 220;
+            --color-on-banding: 0, 0, 0;
+            --color-header: 43, 43, 43;
+            --color-on-header: 255, 255, 255;
+            --color-focused-tab: 224, 212, 175;
+            --color-on-focused-tab: 0, 0, 0;
+            --color-current-tab: 211, 207, 197;
+            --color-on-current-tab: 0, 0, 0;
+            --color-editable: 255, 255, 255;
+            --color-on-editable: 0, 0, 160;
+            --color-editable-border: 192, 192, 192;
+            --color-focused-editable-border: 0, 0, 192;
+            --color-selection: 0, 96, 160;
+            --color-on-selection: 255, 255, 255;
+            --color-inactive-selection: 0, 64, 128;
+            --color-on-inactive-selection: 228, 228, 228;
+            --color-inactive-selection: 0, 64, 128;
+            --color-on-inactive-selection: 0, 0, 0;
+            --color-scroll: 192, 192, 192, 0.5;
+            --color-scroll-rollover: 192, 192, 192;
+            --color-scroll-edge: 128, 128, 128;
+            --color-accent: 0, 102, 102;
+            --color-control: 248, 248, 255;
+            --color-on-control: 0, 0, 0;
+            --color-pressed-control: 0, 96, 160;
+            --color-on-pressed-control: 255, 255, 255;
+            --color-control-edge: 96, 96, 96;
+            --color-divider: 192, 192, 192;
+            --color-icon-button: 96, 96, 96;
+            --color-icon-button-rollover: 0, 0, 0;
+            --color-pressed-icon-button: 0, 96, 160;
+            --color-drop-area: 204, 0, 51;
+            --color-toolip: 252, 252, 196;
+            --color-on-tooltip: 0, 0, 0;
+            --color-search-list: 224, 255, 255;
+            --color-on-search-list: 0, 0, 0;
+            --color-marker: 252, 242, 196;
+            --color-on-marker: 0, 0, 0;
+            --color-error: 192, 64, 64;
+            --color-on-error: 255, 255, 255;
+            --color-warning: 224, 128, 0;
+            --color-on-warning: 255, 255, 255;
+            --color-overloaded: 192, 64, 64;
+            --color-on-overloaded: 255, 255, 255;
+            --color-page: 255, 255, 255;
+            --color-on-page: 0, 0, 0;
+            --color-page-void: 128, 128, 128;
+            --color-hint: 128, 128, 128;
+            --color-link: 0, 255, 127;
+            --color-on-link: 0, 0, 0;
+            --color-pdf-link-highlight: 0, 255, 127;
+            --color-pdf-marker-highlight: 255, 255, 0;
+
+
+            --shape-weight: path("m510.3 445.9-73-292.1c-3.8-15.3-16.5-25.8-30.9-25.8h-60.3c3.625-9.1 5.875-20.75 5.875-32 0-53-42.1-96-96-96S159.1 43 159.1 96c0 11.25 2.25 22 5.875 32H105.6c-14.38 0-27.13 10.5-30.88 25.75L1.71 445.85C-6.641 479.1 16.36 512 47.99 512h416c31.61 0 54.61-32.9 46.31-66.1zM256 128c-17.6 0-32.9-14.4-32.9-32s15.3-32 32.9-32c17.63 0 32 14.38 32 32s-14.4 32-32 32z");
+            --shape-bookmark: path("M384 48v464L192 400 0 512V48C0 21.5 21.5 0 48 0h288c26.5 0 48 21.5 48 48z");
+            --shape-checkmark: path("M 492.1883,51.561176 447.69973,21.315702 C 435.38472,12.98066 418.51958,16.176634 410.28207,28.39411 L 192.1793,350.02095 91.94873,249.79038 c -10.469445,-10.46569 -27.533399,-10.46569 -37.999091,0 L 15.849269,287.887 c -10.4656924,10.46569 -10.4656924,27.52965 0,38.09662 L 169.97628,480.10687 c 8.62763,8.62763 22.19551,15.22215 34.40924,15.22215 12.21748,0 24.52498,-7.65984 32.47365,-19.19461 L 499.36048,88.881308 c 8.33505,-12.213725 5.13907,-28.98509 -7.17594,-37.323883 z");
+            --shape-coins: path("M512 80c0 18.01-14.3 34.6-38.4 48-29.1 16.1-72.4 27.5-122.3 30.9-3.6-1.7-7.4-3.4-11.2-5C300.6 137.4 248.2 128 192 128c-8.3 0-16.4.2-24.5.6l-1.1-.6C142.3 114.6 128 98.01 128 80c0-44.18 85.1-80 192-80 106 0 192 35.82 192 80zm-351.3 81.1c10.2-.7 20.6-1.1 31.3-1.1 62.2 0 117.4 12.3 152.5 31.4 24.8 13.5 39.5 30.3 39.5 48.6 0 3.1-.7 7.9-2.1 11.7-4.6 13.2-17.8 25.3-35 35.6-.1 0-.3.1-.4.2-.3.2-.6.3-.9.5-35 19.4-90.8 32-153.6 32-59.6 0-112.94-11.3-148.16-29.1-1.87-1-3.69-2.8-5.45-2.9C14.28 274.6 0 258 0 240c0-34.8 53.43-64.5 128-75.4 10.5-1.6 21.4-2.8 32.7-3.5zm231.2 25.5c28.3-4.4 54.2-11.4 76.2-20.5 16.3-6.8 31.4-15.2 43.9-25.5V176c0 19.3-16.5 37.1-43.8 50.9-14.7 7.4-32.4 13.6-52.4 18.4.1-1.7.2-3.5.2-5.3 0-21.9-10.6-39.9-24.1-53.4zM384 336c0 18-14.3 34.6-38.4 48-1.8.1-3.6 1.9-5.4 2.9C304.9 404.7 251.6 416 192 416c-62.8 0-118.58-12.6-153.61-32C14.28 370.6 0 354 0 336v-35.4c12.45 10.3 27.62 18.7 43.93 25.5C83.44 342.6 135.8 352 192 352c56.2 0 108.6-9.4 148.1-25.9 7.8-3.2 15.3-6.9 22.4-10.9 6.1-3.4 11.8-7.2 17.2-11.2 1.5-1.1 2.9-2.3 4.3-3.4V336zm32-57.9c18.1-5 36.5-9.5 52.1-16 16.3-6.8 31.4-15.2 43.9-25.5V272c0 10.5-5 21-14.9 30.9-16.3 16.3-45 29.7-81.3 38.4.1-1.7.2-3.5.2-5.3v-57.9zM192 448c56.2 0 108.6-9.4 148.1-25.9 16.3-6.8 31.4-15.2 43.9-25.5V432c0 44.2-86 80-192 80C85.96 512 0 476.2 0 432v-35.4c12.45 10.3 27.62 18.7 43.93 25.5C83.44 438.6 135.8 448 192 448z");
+            --shape-stack: path("M232.5 5.171a56.026 56.026 0 0 1 47 0L498.1 106.2c8.5 3.9 13.9 12.4 13.9 20.9 0 10.2-5.4 18.7-13.9 22.7l-218.6 101c-14.9 6.9-32.1 6.9-47 0l-218.57-101C5.438 145.8 0 137.3 0 127.1c0-8.5 5.437-17 13.93-20.9L232.5 5.171zM498.1 234.2c8.5 3.9 13.9 12.4 13.9 20.9 0 10.2-5.4 18.7-13.9 22.7l-218.6 101c-14.9 6.9-32.1 6.9-47 0l-218.57-101C5.438 273.8 0 265.3 0 255.1c0-8.5 5.437-17 13.93-20.9l53.2-24.6 151.97 70.2c23.4 10.9 50.4 10.9 73.8 0l152-70.2 53.2 24.6zM292.9 407.8l152-70.2 53.2 24.6c8.5 3.9 13.9 12.4 13.9 20.9 0 10.2-5.4 18.7-13.9 22.7l-218.6 101c-14.9 6.9-32.1 6.9-47 0l-218.57-101C5.438 401.8 0 393.3 0 383.1c0-8.5 5.437-17 13.93-20.9l53.2-24.6 151.97 70.2c23.4 10.9 50.4 10.9 73.8 0z");
+        }
+
+        /* @media (prefers-color-scheme: dark) { */
+        /* :root {
+            --color-background: 50, 50, 50;
+            --color-on-background: 221, 221, 221;
+            --color-content: 32, 32, 32;
+            --color-on-content: 221, 221, 221;
+            --color-banding: 42, 42, 42;
+            --color-on-banding: 221, 221, 221;
+            --color-header: 64, 64, 64;
+            --color-on-header: 192, 192, 192;
+            --color-focused-tab: 68, 102, 0;
+            --color-on-focused-tab: 221, 221, 221;
+            --color-current-tab: 41, 61, 0;
+            --color-on-current-tab: 221, 221, 221;
+            --color-editable: 24, 24, 24;
+            --color-on-editable: 100, 153, 153;
+            --color-editable-border: 96, 96, 96;
+            --color-focused-editable-border: 0, 102, 102;
+            --color-selection: 0, 96, 160;
+            --color-on-selection: 255, 255, 255;
+            --color-inactive-selection: 0, 64, 128;
+            --color-on-inactive-selection: 228, 228, 228;
+            --color-inactive-selection: 0, 64, 128;
+            --color-on-inactive-selection: 228, 228, 228;
+            --color-scroll: 128, 128, 128, 0.5;
+            --color-scroll-rollover: 128, 128, 128;
+            --color-scroll-edge: 160, 160, 160;
+            --color-accent: 100, 153, 153;
+            --color-control: 64, 64, 64;
+            --color-on-control: 221, 221, 221;
+            --color-pressed-control: 0, 96, 160;
+            --color-on-pressed-control: 255, 255, 255;
+            --color-control-edge: 96, 96, 96;
+            --color-divider: 102, 102, 102;
+            --color-icon-button: 128, 128, 128;
+            --color-icon-button-rollover: 192, 192, 192;
+            --color-pressed-icon-button: 0, 96, 160;
+            --color-drop-area: 255, 0, 0;
+            --color-toolip: 252, 252, 196;
+            --color-on-tooltip: 0, 0, 0;
+            --color-search-list: 0, 43, 43;
+            --color-on-search-list: 204, 204, 204;
+            --color-marker: 0, 51, 0;
+            --color-on-marker: 221, 221, 221;
+            --color-error: 115, 37, 37;
+            --color-on-error: 221, 221, 221;
+            --color-warning: 192, 96, 0;
+            --color-on-warning: 221, 221, 221;
+            --color-overloaded: 115, 37, 37;
+            --color-on-overloaded: 221, 221, 221;
+            --color-page: 16, 16, 16;
+            --color-on-page: 160, 160, 160;
+            --color-page-void: 0, 0, 0;
+            --color-hint: 64, 64, 64;
+            --color-link: 0, 255, 127;
+            --color-on-link: 0, 0, 0;
+            --color-pdf-link-highlight: 0, 255, 127;
+            --color-pdf-marker-highlight: 255, 255, 0;
+        } */
+
+        /* } */
+
+        svg {
+            width: 1em;
+            background-color: transparent;
+        }
+
         body {
-            font-family: Roboto, sans-serif;
-            font-size: small;
-            font-weight: normal;
-            padding: 0;
-            margin: .25in;
-            margin-bottom: calc(.25in - 1em);
+            background-color: rgb(var(--color-page));
+            color: rgb(var(--color-on-page));
+            margin: 0.25in;
+            margin-bottom: calc(0.25in - 1em);
         }
 
         #sheet {
-            display: grid;
-            grid-template:
-                "personal personal"
-                "stats stats"
-                @GRID_TEMPLATE ;
-            grid-gap: .05in;
+            background-color: rgb(var(--color-page));
+            padding: var(--padding-header);
+
+            display: flex;
+            flex-flow: column nowrap;
+            justify-content: start;
+            gap: var(--section-gap);
         }
 
-        #footer {
+        .header {
+            grid-area: header;
+            background-color: rgb(var(--color-header));
+            color: rgb(var(--color-on-header));
+            justify-content: center;
             text-align: center;
-            font-size: 80%;
+            padding-bottom: 2px;
+            font: var(--font-page-primary-labels);
         }
 
         .fieldblock {
             display: grid;
             grid-template-columns: 0fr 1fr;
             align-items: end;
-            padding-bottom: .15em;
-        }
-
-        .fieldblock hr {
-            grid-column: 1 / span 2;
-            width: 100%;
-            border: none;
-            background-color: black;
-            height: 1px;
-            margin: 0;
-            margin-top: .2em;
-            margin-bottom: .1em;
+            text-align: left;
+            white-space: nowrap;
+            align-self: stretch;
+            background-color: rgb(var(--color-content));
+            color: rgb(var(--color-on-content));
         }
 
         .fieldblock3 {
             display: grid;
-            grid-template-columns: 0fr 1fr 0fr;
-            align-items: end;
-            padding-bottom: .15em;
-        }
-
-        .fieldblock3 hr {
-            grid-column: 1 / span 3;
-            width: 100%;
-            border: none;
-            background-color: black;
-            height: 1px;
-            margin: 0;
-            margin-top: .2em;
-            margin-bottom: .1em;
+            grid-template-columns: 0fr 0fr 1fr;
+            white-space: nowrap;
+            background-color: rgb(var(--color-content));
+            color: rgb(var(--color-on-content));
         }
 
         .fieldblock5 {
             display: grid;
-            grid-template-columns: 0fr 1fr 0fr 1fr 0fr;
-            align-items: end;
-            padding-bottom: .15em;
+            grid-template-columns: repeat(5, 0fr);
+            white-space: nowrap;
+            background-color: rgb(var(--color-content));
+            color: rgb(var(--color-on-content));
+        }
+
+        .label {
+            font: var(--font-page-primary-labels);
+            padding: var(--padding-standard);
+        }
+
+        .field {
+            font: var(--font-page-primary-fields);
+            padding: 0;
+            border: none;
+            border-bottom: 1px solid rgb(var(--color-control-edge));
+            border-radius: 0;
+            color: rgb(var(--color-on-editable));
+        }
+
+        .field.noedit {
+            background-color: rgb(var(--color-content));
+            border-bottom: none;
+        }
+
+        .dropdown {
+            background-color: transparent;
+        }
+
+        #sheet {
+            background-color: rgb(var(--color-page));
+            padding: var(--padding-header);
+            display: flex;
+            flex-flow: column nowrap;
+            justify-content: start;
+            gap: var(--section-gap);
         }
 
         #personal {
             grid-area: personal;
             display: grid;
-            grid-template:
-                "portrait identity miscellaneous points"
-                "portrait description description points";
-            grid-template-columns: 0fr 1fr 1fr 0fr;
-            grid-gap: .05in;
+            grid-template: "portrait identity miscellaneous points""portrait description description points";
+            grid-template-rows: 0fr;
+            grid-template-columns: min-content auto auto 0fr;
+            gap: var(--section-gap);
         }
 
         #portrait {
             grid-area: portrait;
             display: grid;
-            grid-template:
-                "header"
-                "portrait";
+            grid-template: "header""portrait";
             grid-template-rows: 0fr auto;
-            grid-template-columns: auto;
-            border: 1px solid black;
+            border: var(--standard-border);
         }
 
         .portrait {
-            font-size: medium;
+            background-image: url(@PORTRAIT_EMBEDDED);
+            background-position: center;
+            background-repeat: no-repeat;
+            background-size: cover;
             width: 6.75em;
             height: 9em;
-            background-image: url(@PORTRAIT_EMBEDDED);
-            background-size: cover;
         }
 
         #identity {
             grid-area: identity;
+            display: grid;
+            grid-template: "header""block";
+            grid-template-rows: 0fr 1fr;
+            border: var(--standard-border);
+        }
+
+        #identity .label {
+            text-align: right;
         }
 
         #miscellaneous {
             grid-area: miscellaneous;
-        }
-
-        #points {
-            grid-area: points;
-        }
-
-        #identity, #miscellaneous, #points {
             display: grid;
+            grid-template: "header""block";
             grid-template-rows: 0fr 1fr;
-            border: 1px solid black;
+            border: var(--standard-border);
         }
 
-        #primary-attr, #secondary-attr, #pools, #lifting {
-            display: grid;
-            grid-template-rows: 0fr 0fr;
-            border: 1px solid black;
-            flex-grow: 1;
-        }
-
-        #secondary-attr, #location, #encumbrance, #lifting {
-            margin-left: 0.05in;
-        }
-
-        #pools, #lifting {
-            margin-top: 0.05in;
-        }
-
-        #attr-col, #enc-col {
-            display: flex;
-            flex-direction: column;
-            flex-grow: 1;
-        }
-
-        #attr-row {
-            display: flex;
-            flex-grow: 1;
-        }
-
-        #points .field,
-        #lifting .field,
-        #primary-attr .field,
-        #secondary-attr .field,
-        #pools .field {
+        #miscellaneous .label {
             text-align: right;
         }
 
         #description {
             grid-area: description;
             display: grid;
-            grid-template:
-                "header header header"
-                "block1 block2 block3";
+            grid-template: "header header header""block block block";
+            grid-template-columns: 1fr 1fr 1fr;
+            border: var(--standard-border);
+        }
+
+        #description .label {
+            text-align: right;
+        }
+
+        #points {
+            grid-area: points;
+            display: grid;
+            grid-template: "header""block";
             grid-template-rows: 0fr 1fr;
-            border: 1px solid black;
+            border: var(--standard-border);
         }
 
-        #description .header {
-            grid-area: header;
+        #points .field {
+            text-align: right;
         }
 
-        #description .fieldblock:nth-child(1n+3) {
-            border-left: 1px solid black;
+        #points .fieldblock .field:nth-child(4n-1),
+        #points .fieldblock .label:nth-child(4n) {
+            background-color: rgb(var(--color-banding));
+            color: rgb(var(--color-on-banding));
         }
 
         #stats {
             grid-area: stats;
-            display: flex;
+            display: grid;
+            grid-template: "attributes hit-locations encumbrance-lifting";
+            gap: var(--section-gap);
+        }
+
+        #attributes {
+            grid-area: attributes;
+            display: grid;
+            grid-template: "primary-attributes secondary-attributes""basic-damage secondary-attributes""pool-attributes pool-attributes";
+            grid-template-columns: 1fr 1fr;
+            gap: var(--section-gap);
+        }
+
+        #primary-attributes {
+            grid-area: primary-attributes;
+        }
+
+        #secondary-attributes {
+            grid-area: secondary-attributes;
+        }
+
+        #pool-attributes {
+            grid-area: pool-attributes;
+        }
+
+        #basic-damage {
+            grid-area: basic-damage;
+        }
+
+        #basic-damage .fieldblock3 .points {
+            color: transparent;
+        }
+
+        #basic-damage .fieldblock3 .label:nth-child(6n),
+        #basic-damage .fieldblock3 .field:nth-child(6n-1),
+        #basic-damage .fieldblock3 .points:nth-child(6n-2) {
+            background-color: rgb(var(--color-banding));
+        }
+
+        #attributes .points {
+            font: var(--font-page-secondary-fields);
+            color: rgba(var(--color-on-editable), 0.6);
+        }
+
+        #attributes .label {
+            font: var(--font-page-primary-labels);
+            color: rgb(var(--color-on-content));
+        }
+
+        #attributes .field {
+            text-align: right;
+        }
+
+        #hit-locations {
+            grid-area: hit-locations;
+            display: grid;
+            grid-template: "title title title title title""entry-parent roll location penalty dr";
+            grid-template-columns: min-content min-content 1fr min-content min-content;
+            grid-template-rows: 0fr;
+            white-space: nowrap;
+        }
+
+        #hit-locations .header {
+            grid-area: auto;
+        }
+
+        #hit-locations .header.body-plan {
+            grid-area: title;
+        }
+
+        #hit-locations .header.location {
+            grid-column: span 2;
+        }
+
+        #hit-locations .penalty:not(.header),
+        #hit-locations .dr:not(.header) {
+            color: rgba(var(--color-on-editable), 0.6);
+            font: var(--font-page-primary-fields);
+        }
+
+        #hit-locations .roll:not(.header),
+        #hit-locations .location:not(.header) {
+            color: rgb(var(--color-on-content));
+            font: var(--font-page-primary-labels);
+        }
+
+        #hit-locations .dr,
+        #hit-locations .roll {
+            text-align: center;
+        }
+
+        #hit-locations .roll,
+        #hit-locations .penalty {
+            border-right: 1px solid rgb(var(--color-header));
+        }
+
+        #hit-locations :not(.header):not(.entry-parent) {
+            padding: var(--padding-standard);
+        }
+
+        #hit-locations .entry-parent:nth-child(10n+1):not(.header),
+        #hit-locations .roll:nth-child(10n+2):not(.header),
+        #hit-locations .location:nth-child(10n+3):not(.header),
+        #hit-locations .penalty:nth-child(10n+4):not(.header),
+        #hit-locations .dr:nth-child(10n+5):not(.header) {
+            background-color: rgb(var(--color-banding));
+        }
+
+        #encumbrance-lifting {
+            grid-area: encumbrance-lifting;
+            display: grid;
+            grid-template: "encumbrance""lifting";
+            gap: var(--section-gap);
         }
 
         #encumbrance {
-            flex-grow: 1;
-            grid-template:
-                "header header header header header"
-                "encmarkerh ench loadh moveh dodgeh"
-                "encmarker enc load move dodge";
-            grid-template-rows: 0fr 0fr 0fr;
-            grid-auto-rows: 0fr;
-            grid-template-columns: 0fr 2fr 1fr 0.5fr 0.5fr;
+            grid-area: encumbrance;
+            display: grid;
+            grid-template: "title title title title title title""header1 header1 header1 header2 header3 header4""encumbrance-marker level-number level max-load move dodge";
+            grid-template-columns: min-content min-content 1fr min-content min-content min-content;
+            grid-template-rows: 0fr 0fr;
+            align-content: baseline;
+            white-space: nowrap;
+            font: var(--font-page-primary-fields);
+            background-color: rgb(var(--color-content));
+            color: rgba(var(--color-on-editable), 0.6);
+            text-align: right;
         }
+
+        #encumbrance .encumbrance-marker {
+            color: rgb(var(--color-on-content));
+        }
+
+        #encumbrance .level:not(.header) {
+            color: rgb(var(--color-on-content));
+            font: var(--font-page-primary-labels);
+            text-align: left;
+        }
+
+        .level-number.enc0:after {
+            content: "0";
+        }
+
+        .level-number.enc1:after {
+            content: "1";
+        }
+
+        .level-number.enc2:after {
+            content: "2";
+        }
+
+        .level-number.enc3:after {
+            content: "3";
+        }
+
+        .level-number.enc4:after {
+            content: "4";
+        }
+
+        .level.enc0:after {
+            content: "None";
+        }
+
+        .level.enc1:after {
+            content: "Light";
+        }
+
+        .level.enc2:after {
+            content: "Medium";
+        }
+
+        .level.enc3:after {
+            content: "Heavy";
+        }
+
+        .level.enc4:after {
+            content: "X-Heavy";
+        }
+
+        #encumbrance .current {
+            background-color: rgb(var(--color-marker));
+        }
+
+        #encumbrance .current svg path {
+            d: var(--shape-weight);
+        }
+
+        svg path.shape-bookmark {
+            d: var(--shape-bookmark);
+        }
+
+        svg path.shape-weight {
+            d: var(--shape-weight);
+        }
+
+        svg path.shape-coins {
+            d: var(--shape-coins);
+        }
+
+        svg path.shape-stack {
+            d: var(--shape-stack);
+        }
+
+        svg path.shape-equipped-1 {
+            d: var(--shape-checkmark);
+        }
+
+        #encumbrance .header {
+            grid-area: auto;
+            text-align: center;
+        }
+
+        #encumbrance .title {
+            grid-area: title;
+        }
+
+        #encumbrance .level.header {
+            grid-column: 1/span 3;
+        }
+
+        #encumbrance .level,
+        #encumbrance .max-load,
+        #encumbrance .move {
+            border-right: 1px solid rgb(var(--color-header));
+        }
+
+        #encumbrance> :not(.header) {
+            padding: var(--padding-standard);
+        }
+
+        #encumbrance .encumbrance-marker:nth-child(12n):not(.header),
+        #encumbrance .level-number:nth-child(12n+1):not(.header),
+        #encumbrance .level:nth-child(12n+2):not(.header),
+        #encumbrance .max-load:nth-child(12n+3):not(.header),
+        #encumbrance .move:nth-child(12n+4):not(.header),
+        #encumbrance .dodge:nth-child(12n+5):not(.header) {
+            background-color: rgb(var(--color-banding));
+        }
+
 
         #lifting {
-            flex-grow: 1;
-            grid-template:
-                "header header"
-                "desc lift";
-            grid-template-columns: 1fr 1fr;
-            grid-template-rows: 0fr 0fr;
-            grid-auto-rows: 0fr;
-        }
-
-        #lifting .header:first-child {
-            grid-area: header;
-        }
-
-        #location {
-            flex-grow: 1;
-            grid-template:
-                "header header header header"
-                "roll where penalty dr";
-            grid-template-rows: 0fr 0fr;
-            grid-auto-rows: 0fr;
-        }
-
-        #encumbrance .header:first-child,
-        #location .header:first-child {
-            grid-area: header;
-            border-bottom: 1px solid lightgray;
-        }
-
-        #encumbrance,
-        #lifting,
-        #location,
-        #reactions,
-        #conditional_modifiers,
-        #melee,
-        #ranged,
-        #advantages,
-        #skills,
-        #spells,
-        #equipment,
-        #other_equipment,
-        #notes {
+            grid-area: lifting;
             display: grid;
-            border: 1px solid black;
-            align-content: stretch;
+            grid-template: "header header""lift label";
+            grid-template-rows: 0fr;
         }
 
-        #reactions,
-        #conditional_modifiers,
-        #melee,
-        #ranged,
-        #advantages,
-        #skills,
-        #spells,
-        #equipment,
-        #other_equipment,
-        #notes {
-            grid-template-rows: repeat(1000, auto) 1fr;
+        #lifting .lift {
+            font: var(--font-page-primary-fields);
+            color: rgba(var(--color-on-editable), 0.6);
+            text-align: right;
         }
 
-        #reactions {
-            grid-template-columns: 0fr 1fr;
-            grid-area: reactions;
+        #lifting .label {
+            font: var(--font-page-primary-labels);
+            color: rgb(var(--color-on-content));
         }
 
-        #conditional_modifiers {
-            grid-template-columns: 0fr 1fr;
-            grid-area: conditional_modifiers;
+        #lifting .lift:nth-child(4n),
+        #lifting .label:nth-child(4n+1) {
+            background-color: rgb(var(--color-banding));
+        }
+
+        #embeds {
+            display: grid;
+            grid-auto-columns: 1fr 1fr;
+            gap: var(--section-gap);
+            grid-template:
+                @GRID_TEMPLATE ;
         }
 
         #melee {
-            grid-template-columns: 1fr repeat(8, auto);
             grid-area: melee;
+            grid-template-columns: min-content 1fr repeat(7, auto);
+        }
+
+        #melee .entry-parent:nth-child(18n+1):not(.header),
+        #melee .desc:nth-child(18n+2):not(.header),
+        #melee .usage:nth-child(18n+3):not(.header),
+        #melee .level:nth-child(18n+4):not(.header),
+        #melee .parry:nth-child(18n+5):not(.header),
+        #melee .block:nth-child(18n+6):not(.header),
+        #melee .damage:nth-child(18n+7):not(.header),
+        #melee .reach:nth-child(18n+8):not(.header),
+        #melee .st:nth-child(18n+9):not(.header) {
+            background-color: rgb(var(--color-banding));
+            color: rgb(var(--color-on-banding));
+        }
+
+        #melee .desc:not(.header),
+        #melee .usage:not(.header),
+        #melee .level:not(.header),
+        #melee .parry:not(.header),
+        #melee .block:not(.header),
+        #melee .damage:not(.header),
+        #melee .reach:not(.header) {
+            border-bottom: 1px solid rgb(var(--color-header));
+            border-right: 1px solid rgb(var(--color-header));
+        }
+
+        #melee .st:not(.header) {
+            border-bottom: 1px solid rgb(var(--color-header));
+        }
+
+        #melee :nth-last-child(-n+9) {
+            border-bottom: none !important;
         }
 
         #ranged {
-            grid-template-columns: 1fr repeat(10, auto);
             grid-area: ranged;
+            grid-template-columns: min-content 1fr repeat(10, auto);
         }
 
-        #advantages {
-            grid-template-columns: 1fr repeat(2, auto);
+        #ranged .entry-parent:nth-child(24n+1):not(.header),
+        #ranged .desc:nth-child(24n+2):not(.header),
+        #ranged .usage:nth-child(24n+3):not(.header),
+        #ranged .level:nth-child(24n+4):not(.header),
+        #ranged .acc:nth-child(24n+5):not(.header),
+        #ranged .range:nth-child(24n+6):not(.header),
+        #ranged .damage:nth-child(24n+7):not(.header),
+        #ranged .rof:nth-child(24n+8):not(.header),
+        #ranged .shots:nth-child(24n+9):not(.header),
+        #ranged .bulk:nth-child(24n+10):not(.header),
+        #ranged .recoil:nth-child(24n+11):not(.header),
+        #ranged .st:nth-child(24n+12):not(.header) {
+            background-color: rgb(var(--color-banding));
+            color: rgb(var(--color-on-banding));
+        }
+
+        #ranged .desc:not(.header),
+        #ranged .usage:not(.header),
+        #ranged .level:not(.header),
+        #ranged .acc:not(.header),
+        #ranged .range:not(.header),
+        #ranged .damage:not(.header),
+        #ranged .rof:not(.header),
+        #ranged .shots:not(.header),
+        #ranged .bulk:not(.header),
+        #ranged .recoil:not(.header) {
+            border-bottom: 1px solid rgb(var(--color-header));
+            border-right: 1px solid rgb(var(--color-header));
+        }
+
+        #ranged .st:not(.header) {
+            border-bottom: 1px solid rgb(var(--color-header));
+        }
+
+        #ranged :nth-last-child(-n+12) {
+            border-bottom: none !important;
+        }
+
+        #reactions {
+            grid-area: reactions;
+            grid-template-columns: min-content min-content auto;
+        }
+
+        #reactions .entry-parent:nth-child(6n+1):not(.header),
+        #reactions .modifier:nth-child(6n+2):not(.header),
+        #reactions .situation:nth-child(6n+3):not(.header) {
+            background-color: rgb(var(--color-banding));
+            color: rgb(var(--color-on-banding));
+        }
+
+        #reactions .modifier:not(.header) {
+            border-bottom: 1px solid rgb(var(--color-header));
+            border-right: 1px solid rgb(var(--color-header));
+        }
+
+        #reactions .situation:not(.header) {
+            border-bottom: 1px solid rgb(var(--color-header));
+        }
+
+        #reactions :nth-last-child(-n+3) {
+            border-bottom: none !important;
+        }
+
+        #conditional-modifiers {
+            grid-area: conditional_modifiers;
+            grid-template-columns: min-content min-content auto;
+        }
+
+        #conditional-modifiers .entry-parent:nth-child(6n+1):not(.header),
+        #conditional-modifiers .modifier:nth-child(6n+2):not(.header),
+        #conditional-modifiers .situation:nth-child(6n+3):not(.header) {
+            background-color: rgb(var(--color-banding));
+            color: rgb(var(--color-on-banding));
+        }
+
+        #conditional-modifiers .modifier:not(.header) {
+            border-bottom: 1px solid rgb(var(--color-header));
+            border-right: 1px solid rgb(var(--color-header));
+        }
+
+        #conditional-modifiers .situation:not(.header) {
+            border-bottom: 1px solid rgb(var(--color-header));
+        }
+
+        #conditional-modifiers :nth-last-child(-n+3) {
+            border-bottom: none !important;
+        }
+
+        #traits {
             grid-area: advantages;
+            grid-template-columns: min-content 1fr repeat(2, auto);
+        }
+
+        #embeds>div>.header {
+            grid-area: auto;
+        }
+
+        #traits .entry-parent:nth-child(8n+1):not(.header),
+        #traits .desc:nth-child(8n+2):not(.header),
+        #traits .points:nth-child(8n+3):not(.header),
+        #traits .reference:nth-child(8n+4):not(.header) {
+            background-color: rgb(var(--color-banding));
+            color: rgb(var(--color-on-banding));
+        }
+
+        #traits .dropdown:not(.header),
+        #traits .desc:not(.header),
+        #traits .points:not(.header),
+        #traits .reference:not(.header) {
+            border-bottom: 1px solid rgb(var(--color-header));
+            border-right: 1px solid rgb(var(--color-header));
+        }
+
+        #traits .dropdown:not(.header).reference,
+        #traits .dropdown:not(.header).dropdown,
+        #traits .desc:not(.header).reference,
+        #traits .desc:not(.header).dropdown,
+        #traits .points:not(.header).reference,
+        #traits .points:not(.header).dropdown,
+        #traits .reference:not(.header).reference,
+        #traits .reference:not(.header).dropdown {
+            border-right: none;
+        }
+
+        #traits .dropdown:not(.header):nth-last-child(-n+4),
+        #traits .desc:not(.header):nth-last-child(-n+4),
+        #traits .points:not(.header):nth-last-child(-n+4),
+        #traits .reference:not(.header):nth-last-child(-n+4) {
+            border-bottom: none;
         }
 
         #skills {
-            grid-template-columns: 1fr repeat(4, auto);
             grid-area: skills;
+            grid-template-columns: min-content 1fr repeat(4, auto);
+        }
+
+        #skills .header {
+            grid-area: auto;
+        }
+
+        #skills .entry-parent:nth-child(12n+1):not(.header),
+        #skills .desc:nth-child(12n+2):not(.header),
+        #skills .level:nth-child(12n+3):not(.header),
+        #skills .rsl:nth-child(12n+4):not(.header),
+        #skills .points:nth-child(12n+5):not(.header),
+        #skills .reference:nth-child(12n+6):not(.header) {
+            background-color: rgb(var(--color-banding));
+            color: rgb(var(--color-on-banding));
+        }
+
+        #skills .dropdown:not(.header),
+        #skills .desc:not(.header),
+        #skills .level:not(.header),
+        #skills .rsl:not(.header),
+        #skills .points:not(.header),
+        #skills .reference:not(.header) {
+            border-bottom: 1px solid rgb(var(--color-header));
+            border-right: 1px solid rgb(var(--color-header));
+        }
+
+        #skills .dropdown:not(.header).reference,
+        #skills .dropdown:not(.header).dropdown,
+        #skills .desc:not(.header).reference,
+        #skills .desc:not(.header).dropdown,
+        #skills .level:not(.header).reference,
+        #skills .level:not(.header).dropdown,
+        #skills .rsl:not(.header).reference,
+        #skills .rsl:not(.header).dropdown,
+        #skills .points:not(.header).reference,
+        #skills .points:not(.header).dropdown,
+        #skills .reference:not(.header).reference,
+        #skills .reference:not(.header).dropdown {
+            border-right: none;
+        }
+
+        #skills .dropdown:not(.header):nth-last-child(-n+6),
+        #skills .desc:not(.header):nth-last-child(-n+6),
+        #skills .level:not(.header):nth-last-child(-n+6),
+        #skills .rsl:not(.header):nth-last-child(-n+6),
+        #skills .points:not(.header):nth-last-child(-n+6),
+        #skills .reference:not(.header):nth-last-child(-n+6) {
+            border-bottom: none;
         }
 
         #spells {
-            grid-template-columns: 1fr repeat(10, auto);
             grid-area: spells;
+            grid-template-columns: min-content 1fr repeat(5, auto);
+        }
+
+        #spells .header {
+            grid-area: auto;
+        }
+
+        #spells .entry-parent:nth-child(14n+1):not(.header),
+        #spells .desc:nth-child(14n+2):not(.header),
+        #spells .college:nth-child(14n+3):not(.header),
+        #spells .level:nth-child(14n+4):not(.header),
+        #spells .rsl:nth-child(14n+5):not(.header),
+        #spells .points:nth-child(14n+6):not(.header),
+        #spells .reference:nth-child(14n+7):not(.header) {
+            background-color: rgb(var(--color-banding));
+            color: rgb(var(--color-on-banding));
+        }
+
+        #spells .dropdown:not(.header),
+        #spells .desc:not(.header),
+        #spells .college:not(.header),
+        #spells .level:not(.header),
+        #spells .rsl:not(.header),
+        #spells .points:not(.header),
+        #spells .reference:not(.header) {
+            border-bottom: 1px solid rgb(var(--color-header));
+            border-right: 1px solid rgb(var(--color-header));
+        }
+
+        #spells .dropdown:not(.header).reference,
+        #spells .dropdown:not(.header).dropdown,
+        #spells .desc:not(.header).reference,
+        #spells .desc:not(.header).dropdown,
+        #spells .college:not(.header).reference,
+        #spells .college:not(.header).dropdown,
+        #spells .level:not(.header).reference,
+        #spells .level:not(.header).dropdown,
+        #spells .rsl:not(.header).reference,
+        #spells .rsl:not(.header).dropdown,
+        #spells .points:not(.header).reference,
+        #spells .points:not(.header).dropdown,
+        #spells .reference:not(.header).reference,
+        #spells .reference:not(.header).dropdown {
+            border-right: none;
+        }
+
+        #spells .dropdown:not(.header):nth-last-child(-n+12),
+        #spells .desc:not(.header):nth-last-child(-n+12),
+        #spells .college:not(.header):nth-last-child(-n+12),
+        #spells .level:not(.header):nth-last-child(-n+12),
+        #spells .rsl:not(.header):nth-last-child(-n+12),
+        #spells .points:not(.header):nth-last-child(-n+12),
+        #spells .reference:not(.header):nth-last-child(-n+12) {
+            border-bottom: none;
         }
 
         #equipment {
-            grid-template-columns: auto auto 1fr repeat(6, auto);
             grid-area: equipment;
+            grid-template-columns: min-content auto auto 1fr repeat(8, auto);
         }
 
-        #other_equipment {
-            grid-template-columns: auto 1fr repeat(7, auto);
+        #equipment .header {
+            grid-area: auto;
+        }
+
+        #embeds #equipment>div>.equipped:not(.header) {
+            padding: var(--padding-header);
+        }
+
+        #equipment .entry-parent:nth-child(24n+1):not(.header),
+        #equipment .equipped:nth-child(24n+2):not(.header),
+        #equipment .quantity:nth-child(24n+3):not(.header),
+        #equipment .desc:nth-child(24n+4):not(.header),
+        #equipment .uses:nth-child(24n+5):not(.header),
+        #equipment .tech-level:nth-child(24n+6):not(.header),
+        #equipment .legality-class:nth-child(24n+7):not(.header),
+        #equipment .weight:nth-child(24n+8):not(.header),
+        #equipment .value:nth-child(24n+9):not(.header),
+        #equipment .extended-weight:nth-child(24n+10):not(.header),
+        #equipment .extended-value:nth-child(24n+11):not(.header),
+        #equipment .reference:nth-child(24n+12):not(.header) {
+            background-color: rgb(var(--color-banding));
+            color: rgb(var(--color-on-banding));
+        }
+
+        #equipment .equipped:not(.header),
+        #equipment .quantity:not(.header),
+        #equipment .dropdown:not(.header),
+        #equipment .desc:not(.header),
+        #equipment .uses:not(.header),
+        #equipment .tech-level:not(.header),
+        #equipment .legality-class:not(.header),
+        #equipment .weight:not(.header),
+        #equipment .value:not(.header),
+        #equipment .extended-weight:not(.header),
+        #equipment .extended-value:not(.header),
+        #equipment .reference:not(.header) {
+            border-bottom: 1px solid rgb(var(--color-header));
+            border-right: 1px solid rgb(var(--color-header));
+        }
+
+        #equipment .equipped:not(.header).reference,
+        #equipment .equipped:not(.header).dropdown,
+        #equipment .quantity:not(.header).reference,
+        #equipment .quantity:not(.header).dropdown,
+        #equipment .dropdown:not(.header).reference,
+        #equipment .dropdown:not(.header).dropdown,
+        #equipment .desc:not(.header).reference,
+        #equipment .desc:not(.header).dropdown,
+        #equipment .uses:not(.header).reference,
+        #equipment .uses:not(.header).dropdown,
+        #equipment .tech-level:not(.header).reference,
+        #equipment .tech-level:not(.header).dropdown,
+        #equipment .legality-class:not(.header).reference,
+        #equipment .legality-class:not(.header).dropdown,
+        #equipment .weight:not(.header).reference,
+        #equipment .weight:not(.header).dropdown,
+        #equipment .value:not(.header).reference,
+        #equipment .value:not(.header).dropdown,
+        #equipment .extended-weight:not(.header).reference,
+        #equipment .extended-weight:not(.header).dropdown,
+        #equipment .extended-value:not(.header).reference,
+        #equipment .extended-value:not(.header).dropdown,
+        #equipment .reference:not(.header).reference,
+        #equipment .reference:not(.header).dropdown {
+            border-right: none;
+        }
+
+        #equipment .equipped:not(.header):nth-last-child(-n+11),
+        #equipment .quantity:not(.header):nth-last-child(-n+11),
+        #equipment .dropdown:not(.header):nth-last-child(-n+11),
+        #equipment .desc:not(.header):nth-last-child(-n+11),
+        #equipment .uses:not(.header):nth-last-child(-n+11),
+        #equipment .tech-level:not(.header):nth-last-child(-n+11),
+        #equipment .legality-class:not(.header):nth-last-child(-n+11),
+        #equipment .weight:not(.header):nth-last-child(-n+11),
+        #equipment .value:not(.header):nth-last-child(-n+11),
+        #equipment .extended-weight:not(.header):nth-last-child(-n+11),
+        #equipment .extended-value:not(.header):nth-last-child(-n+11),
+        #equipment .reference:not(.header):nth-last-child(-n+11) {
+            border-bottom: none;
+        }
+
+        #equipment .equipped {
+            padding: var(--padding-header);
+        }
+
+        #other-equipment {
             grid-area: other_equipment;
+            grid-template-columns: min-content auto 1fr repeat(8, auto);
+        }
+
+        #other-equipment .header {
+            grid-area: auto;
+        }
+
+        #other-equipment .entry-parent:nth-child(22n+1):not(.header),
+        #other-equipment .quantity:nth-child(22n+2):not(.header),
+        #other-equipment .desc:nth-child(22n+3):not(.header),
+        #other-equipment .uses:nth-child(22n+4):not(.header),
+        #other-equipment .tech-level:nth-child(22n+5):not(.header),
+        #other-equipment .legality-class:nth-child(22n+6):not(.header),
+        #other-equipment .weight:nth-child(22n+7):not(.header),
+        #other-equipment .value:nth-child(22n+8):not(.header),
+        #other-equipment .extended-weight:nth-child(22n+9):not(.header),
+        #other-equipment .extended-value:nth-child(22n+10):not(.header),
+        #other-equipment .reference:nth-child(22n+11):not(.header) {
+            background-color: rgb(var(--color-banding));
+            color: rgb(var(--color-on-banding));
+        }
+
+        #other-equipment .quantity:not(.header),
+        #other-equipment .dropdown:not(.header),
+        #other-equipment .desc:not(.header),
+        #other-equipment .uses:not(.header),
+        #other-equipment .tech-level:not(.header),
+        #other-equipment .legality-class:not(.header),
+        #other-equipment .weight:not(.header),
+        #other-equipment .value:not(.header),
+        #other-equipment .extended-weight:not(.header),
+        #other-equipment .extended-value:not(.header),
+        #other-equipment .reference:not(.header) {
+            border-bottom: 1px solid rgb(var(--color-header));
+            border-right: 1px solid rgb(var(--color-header));
+        }
+
+        #other-equipment .quantity:not(.header).reference,
+        #other-equipment .quantity:not(.header).dropdown,
+        #other-equipment .dropdown:not(.header).reference,
+        #other-equipment .dropdown:not(.header).dropdown,
+        #other-equipment .desc:not(.header).reference,
+        #other-equipment .desc:not(.header).dropdown,
+        #other-equipment .uses:not(.header).reference,
+        #other-equipment .uses:not(.header).dropdown,
+        #other-equipment .tech-level:not(.header).reference,
+        #other-equipment .tech-level:not(.header).dropdown,
+        #other-equipment .legality-class:not(.header).reference,
+        #other-equipment .legality-class:not(.header).dropdown,
+        #other-equipment .weight:not(.header).reference,
+        #other-equipment .weight:not(.header).dropdown,
+        #other-equipment .value:not(.header).reference,
+        #other-equipment .value:not(.header).dropdown,
+        #other-equipment .extended-weight:not(.header).reference,
+        #other-equipment .extended-weight:not(.header).dropdown,
+        #other-equipment .extended-value:not(.header).reference,
+        #other-equipment .extended-value:not(.header).dropdown,
+        #other-equipment .reference:not(.header).reference,
+        #other-equipment .reference:not(.header).dropdown {
+            border-right: none;
+        }
+
+        #other-equipment .quantity:not(.header):nth-last-child(-n+10),
+        #other-equipment .dropdown:not(.header):nth-last-child(-n+10),
+        #other-equipment .desc:not(.header):nth-last-child(-n+10),
+        #other-equipment .uses:not(.header):nth-last-child(-n+10),
+        #other-equipment .tech-level:not(.header):nth-last-child(-n+10),
+        #other-equipment .legality-class:not(.header):nth-last-child(-n+10),
+        #other-equipment .weight:not(.header):nth-last-child(-n+10),
+        #other-equipment .value:not(.header):nth-last-child(-n+10),
+        #other-equipment .extended-weight:not(.header):nth-last-child(-n+10),
+        #other-equipment .extended-value:not(.header):nth-last-child(-n+10),
+        #other-equipment .reference:not(.header):nth-last-child(-n+10) {
+            border-bottom: none;
         }
 
         #notes {
-            grid-template-columns: 1fr auto auto;
+            grid-area: notes;
+            grid-template-columns: min-content 1fr auto;
+        }
+
+        #notes .header {
+            grid-area: auto;
+        }
+
+        #notes .entry-parent:nth-child(8n+1):not(.header),
+        #notes .desc:nth-child(8n+2):not(.header),
+        #notes .reference:nth-child(8n+3):not(.header) {
+            background-color: rgb(var(--color-banding));
+            color: rgb(var(--color-on-banding));
+        }
+
+        #notes .desc:not(.header),
+        #notes .refrence:not(.header) {
+            border-bottom: 1px solid rgb(var(--color-header));
+            border-right: 1px solid rgb(var(--color-header));
+        }
+
+        #notes .desc:not(.header).reference,
+        #notes .refrence:not(.header).reference {
+            border-right: none;
+        }
+
+        #notes .desc:not(.header):nth-last-child(-n+2),
+        #notes .refrence:not(.header):nth-last-child(-n+2) {
+            border-bottom: none;
+        }
+
+        #embeds>div {
+            display: grid;
+            grid-template-rows: repeat(1000, auto) 1fr;
+        }
+
+        #embeds>div>.desc .dropdown {
+            margin-right: 6px;
+        }
+
+        #embeds>div>.desc .item-notes {
             grid-area: notes;
         }
 
-        .points {
-            text-align: right;
-            padding-left: .2em;
-            padding-right: .2em;
-            font-size: 80%;
-            align-self: center;
+        #embeds>div> :not(.header):not(.entry-parent).quantity {
+            min-width: 1em;
         }
 
-        .label {
-            text-align: left;
-            padding-left: .2em;
-            padding-right: .2em;
-            font-size: 80%;
+        #embeds>div> :not(.header):not(.entry-parent).drop-over {
+            border-top: 2px dashed rgb(var(--color-drop-area));
+        }
+
+        #embeds .desc.header {
             white-space: nowrap;
-            align-self: center;
         }
 
-        .field {
-            margin-right: .2em;
-            font-weight: bold;
+        #embeds .equipped,
+        #embeds .header.reference,
+        #embeds .header.weight,
+        #embeds .header.value,
+        #embeds .header.extended-weight,
+        #embeds .header.extended-value {
+            display: grid;
+            align-items: center;
+            grid-auto-flow: column;
+            gap: 1px;
         }
 
-        .field,
-        .desc,
-        .cls,
-        .college,
-        .mana,
-        .mana_maintain,
-        .time,
-        .duration,
-        .sl,
-        .rsl,
-        .qty,
-        .equipped,
-        .uses,
-        .cost,
-        .sum_cost,
-        .weight,
-        .sum_weight,
-        .pts,
-        .ref,
-        .usage,
-        .level,
-        .parry,
-        .block,
-        .damage,
-        .reach,
-        .st,
-        .acc,
-        .range,
-        .rof,
-        .shots,
-        .bulk,
-        .rcl,
-        .load,
-        .loadh,
-        .move,
-        .moveh,
-        .dodge,
-        .dodgeh,
-        .roll,
-        .where,
-        .penalty,
-        .dr,
-        .liftdesc,
-        .lift,
-        .modifier,
-        .situation {
-            padding-left: .2em;
-            padding-right: .2em;
-            border-bottom: 1px solid lightgray;
-        }
-
-        .enc,
-        .ench {
-            padding-left: 0;
-            padding-right: .2em;
-            border-bottom: 1px solid lightgray;
-        }
-
-        .encmarker,
-        .encmarkerh {
-            padding-left: .2em;
-            padding-right: 0;
-            border-bottom: 1px solid lightgray;
-        }
-
-        .load, .move, .dodge, .lift, .dr, .desc, .sl, .rsl, .pts, .ref, .usage, .level, .parry,
-        .block, .damage, .reach, .st, .acc, .range, .rof, .shots, .bulk, .rcl, .cls, .college,
-        .mana, .mana_maintain, .time, .duration, .qty, .uses, .cost, .weight, .sum_cost,
-        .sum_weight {
-            font-weight: bold;
-        }
-
-        .list_note {
-            font-weight: normal;
-        }
-
-        #encumbrance .encmarker:nth-last-child(10n+5),
-        #encumbrance .enc:nth-last-child(10n+4),
-        #encumbrance .load:nth-last-child(10n+3),
-        #encumbrance .move:nth-last-child(10n+2),
-        #encumbrance .dodge:nth-last-child(10n+1),
-        #lifting .liftdesc:nth-last-child(4n+1),
-        #lifting .lift:nth-last-child(4n+2),
-        #location .roll:nth-last-child(8n+4),
-        #location .where:nth-last-child(8n+3),
-        #location .penalty:nth-last-child(8n+2),
-        #location .dr:nth-last-child(8n+1),
-        #reactions .modifier:nth-child(even),
-        #reactions .situation:nth-child(odd),
-        #conditional_modifiers .modifier:nth-child(even),
-        #conditional_modifiers .situation:nth-child(odd),
-        #melee .desc:nth-child(even),
-        #melee .usage:nth-child(odd),
-        #melee .level:nth-child(even),
-        #melee .parry:nth-child(odd),
-        #melee .block:nth-child(even),
-        #melee .damage:nth-child(odd),
-        #melee .reach:nth-child(even),
-        #melee .st:nth-child(odd),
-        #ranged .desc:nth-child(even),
-        #ranged .usage:nth-child(odd),
-        #ranged .level:nth-child(even),
-        #ranged .acc:nth-child(odd),
-        #ranged .damage:nth-child(even),
-        #ranged .range:nth-child(odd),
-        #ranged .rof:nth-child(even),
-        #ranged .shots:nth-child(odd),
-        #ranged .bulk:nth-child(even),
-        #ranged .rcl:nth-child(odd),
-        #ranged .st:nth-child(even),
-        #advantages .desc:nth-child(even),
-        #advantages .pts:nth-child(odd),
-        #advantages .ref:nth-child(even),
-        #skills .desc:nth-child(even),
-        #skills .sl:nth-child(odd),
-        #skills .rsl:nth-child(even),
-        #skills .pts:nth-child(odd),
-        #skills .ref:nth-child(even),
-        #spells .desc:nth-child(even),
-        #spells .cls:nth-child(odd),
-        #spells .college:nth-child(even),
-        #spells .mana:nth-child(odd),
-        #spells .mana_maintain:nth-child(even),
-        #spells .time:nth-child(odd),
-        #spells .duration:nth-child(even),
-        #spells .sl:nth-child(odd),
-        #spells .rsl:nth-child(even),
-        #spells .pts:nth-child(odd),
-        #spells .ref:nth-child(even),
-        #equipment .equipped:nth-child(even),
-        #equipment .qty:nth-child(odd),
-        #equipment .desc:nth-child(even),
-        #equipment .uses:nth-child(odd),
-        #equipment .cost:nth-child(even),
-        #equipment .weight:nth-child(odd),
-        #equipment .sum_cost:nth-child(even),
-        #equipment .sum_weight:nth-child(odd),
-        #equipment .ref:nth-child(even),
-        #other_equipment .qty:nth-child(even),
-        #other_equipment .desc:nth-child(odd),
-        #other_equipment .uses:nth-child(even),
-        #other_equipment .cost:nth-child(odd),
-        #other_equipment .weight:nth-child(even),
-        #other_equipment .sum_cost:nth-child(odd),
-        #other_equipment .sum_weight:nth-child(even),
-        #other_equipment .ref:nth-child(odd),
-        #notes .desc:nth-child(even),
-        #notes .ref:nth-child(odd) {
-            background-color: #e8ffe8;
-        }
-
-        #equipment .desc,
-        #other_equipment .desc,
-        .cls,
-        .college,
-        .mana,
-        .mana_maintain,
-        .time,
-        .duration,
-        .sl,
-        .rsl,
-        .qty,
-        .uses,
-        .cost,
-        .sum_cost,
-        .weight,
-        .sum_weight,
-        .pts,
-        .ref,
-        .usage,
-        .level,
-        .parry,
-        .block,
-        .damage,
-        .reach,
-        .st,
-        .acc,
-        .range,
-        .rof,
-        .shots,
-        .bulk,
-        .rcl,
-        .load,
-        .loadh,
-        .move,
-        .moveh,
-        .dodge,
-        .dodgeh,
-        .where,
-        .penalty,
-        .dr,
-        .situation {
-            border-left: 1px solid lightgray;
-        }
-
-        .sl,
-        .rsl,
-        .qty,
-        .equipped,
-        .uses,
-        .cost,
-        .sum_cost,
-        .weight,
-        .sum_weight,
-        .pts,
-        .ref,
-        .level,
-        .parry,
-        .block,
-        .reach,
-        .st,
-        .acc,
-        .rof,
-        .shots,
-        .bulk,
-        .rcl,
-        .load,
-        .move,
-        .dodge,
-        .where,
-        .penalty,
-        .dr,
-        .lift,
-        .modifier {
+        #embeds .points:not(.header),
+        #embeds .level:not(.header),
+        #embeds .quantity:not(.header),
+        #embeds .uses:not(.header),
+        #embeds .tech-level:not(.header),
+        #embeds .legality-class:not(.header),
+        #embeds .weight:not(.header),
+        #embeds .value:not(.header),
+        #embeds .extended-weight:not(.header),
+        #embeds .extended-value:not(.header) {
             text-align: right;
         }
 
-        .equipped,
-        .roll {
-            text-align: center;
+        #embeds>div>.header:not(.entry-parent) {
+            padding: var(--padding-header);
         }
 
-        .liftdesc,
-        .where {
+        #embeds>div> :not(.header):not(svg) {
+            background-color: rgb(var(--color-content));
+            color: rgb(var(--color-on-content));
+            font: var(--font-page-primary-fields);
+        }
+
+        #embeds>div> :not(.header):not(.entry-parent):not(.equipped) {
+            padding: var(--padding-standard);
+        }
+
+        #embeds .item-notes {
+            font: var(--font-page-secondary-fields);
+            background-color: transparent;
+        }
+
+        #embeds .dropdown i {
+            background-color: inherit;
+        }
+
+        #embeds .dropdown i svg {
+            background-color: inherit;
+            fill: rgb(var(--color-on-content));
+            width: 0.75em;
+        }
+
+        div {
+            background-color: rgb(var(--color-content));
+        }
+
+        #sheet>div {
+            background-color: rgb(var(--color-page));
+        }
+
+        #personal>div:not(#attributes),
+        #attributes>div,
+        #stats>div:not(#attributes),
+        #attributes>div,
+        #embeds>div:not(#attributes),
+        #attributes>div {
+            border: var(--standard-border);
+        }
+
+        #footer {
+            font: var(--font-page-secondary-footer);
+            background-color: rgb(var(--color-page));
+            color: rgb(var(--color-on-page));
             text-align: left;
+            display: grid;
+            grid-template-columns: repeat(3, 1fr);
         }
 
-        .encmarker,
-        .encmarkerh,
-        .enc,
-        .ench,
-        .load,
-        .loadh,
-        .move,
-        .moveh,
-        .dodge,
-        .dodgeh,
-        .roll,
-        .where,
-        .penalty,
-        .dr,
-        .liftdesc,
-        .lift,
-        .modifier {
-            white-space: nowrap;
+        #footer div {
+            background-color: inherit;
         }
 
-        #lifting .field,
-        .noedit {
-            white-space: nowrap;
-            border: none;
-        }
-
-        .header,
-        #reactions .header,
-        #conditional_modifiers .header,
-        #melee .header,
-        #ranged .header,
-        #equipment .header,
-        #other_equipment .header {
-            background-color: black;
-            border-bottom: 1px solid black;
-            color: white;
+        #footer .centre {
+            font: var(--font-page-primary-footer);
             text-align: center;
-            font-size: 80%;
         }
 
-        #location .header:nth-last-child(8n+4),
-        #location .header:nth-last-child(8n+3),
-        #location .header:nth-last-child(8n+2),
-        #location .header:nth-last-child(8n+1) {
-            background-color: black;
+        #footer .right {
+            text-align: right;
         }
 
-        #encumbrance > div:nth-last-child(-n+5),
-        #lifting > div:nth-last-child(-n+2),
-        #location > div:nth-last-child(-n+4) {
-            border-bottom: none;
-        }
-
-        #reactions > div:nth-last-child(-n+3),
-        #conditional_modifiers > div:nth-last-child(-n+3),
-        #melee > div:nth-last-child(-n+9),
-        #ranged > div:nth-last-child(-n+11),
-        #advantages > div:nth-last-child(-n+3),
-        #skills > div:nth-last-child(-n+5),
-        #spells > div:nth-last-child(-n+11),
-        #equipment > div:nth-last-child(-n+9),
-        #other_equipment > div:nth-last-child(-n+9),
-        #notes > div:nth-last-child(-n+3) {
-            border-bottom: none;
-            grid-row: 1001;
-        }
-
-        .indent1 {
-            padding-left: 1em;
-        }
-
-        .indent2 {
-            padding-left: 2em;
-        }
-
-        .indent3 {
-            padding-left: 3em;
-        }
-
-        .indent4 {
-            padding-left: 4em;
-        }
-
-        .indent5 {
-            padding-left: 5em;
-        }
-
-        .indent6 {
-            padding-left: 6em;
-        }
-
-        .indent7 {
-            padding-left: 7em;
-        }
-
-        .indent8 {
-            padding-left: 8em;
-        }
-
-        .indent9 {
-            padding-left: 9em;
-        }
-
-        .satisfiedN {
-            color: red;
-        }
-
-        #encumbrance .current:nth-last-child(10n+5),
-        #encumbrance .current:nth-last-child(10n+4),
-        #encumbrance .current:nth-last-child(10n+3),
-        #encumbrance .current:nth-last-child(10n+2),
-        #encumbrance .current:nth-last-child(10n+1),
-        .current {
-            background-color: lightgoldenrodyellow;
-        }
-
-        .list_note {
-            font-size: 80%;
-        }
-
-        .encmarker.current:after {
-            content: '•';
-        }
-
-        .enc0:after {
-            content: 'None (0)';
-        }
-
-        .enc1:after {
-            content: 'Light (1)';
-        }
-
-        .enc2:after {
-            content: 'Medium (2)';
-        }
-
-        .enc3:after {
-            content: 'Heavy (3)';
-        }
-
-        .enc4:after {
-            content: 'X-heavy (4)';
+        #footer .right a {
+            color: inherit;
+            text-decoration: inherit;
         }
     </style>
 </head>
@@ -725,62 +1228,62 @@ defined by the Mozilla Public License, version 2.0.
             <div id="identity">
                 <div class="header">Identity</div>
                 <div class="fieldblock">
-                    <div class="label">Name:</div>
+                    <div class="label">Name</div>
                     <div class="field">@NAME</div>
-                    <div class="label">Title:</div>
+                    <div class="label">Title</div>
                     <div class="field">@TITLE</div>
-                    <div class="label">Organization:</div>
+                    <div class="label">Organization</div>
                     <div class="field">@ORGANIZATION</div>
                 </div>
             </div>
             <div id="miscellaneous">
                 <div class="header">Miscellaneous</div>
                 <div class="fieldblock">
-                    <div class="label">Created:</div>
+                    <div class="label">Created</div>
                     <div class="field">@CREATED_ON</div>
-                    <div class="label">Modified:</div>
+                    <div class="label">Modified</div>
                     <div class="field">@CREATED_ON</div>
-                    <div class="label">Player:</div>
+                    <div class="label">Player</div>
                     <div class="field">@PLAYER</div>
                 </div>
             </div>
             <div id="description">
                 <div class="header">Description</div>
                 <div class="fieldblock">
-                    <div class="label">Gender:</div>
+                    <div class="label">Gender</div>
                     <div class="field">@GENDER</div>
-                    <div class="label">Age:</div>
+                    <div class="label">Age</div>
                     <div class="field">@AGE</div>
-                    <div class="label">Birthday:</div>
+                    <div class="label">Birthday</div>
                     <div class="field">@BIRTHDAY</div>
-                    <div class="label">Religion:</div>
+                    <div class="label">Religion</div>
                     <div class="field">@RELIGION</div>
                 </div>
                 <div class="fieldblock">
-                    <div class="label">Height:</div>
+                    <div class="label">Height</div>
                     <div class="field">@HEIGHT</div>
-                    <div class="label">Weight:</div>
+                    <div class="label">Weight</div>
                     <div class="field">@WEIGHT</div>
-                    <div class="label">Size:</div>
+                    <div class="label">Size</div>
                     <div class="field">@SIZE</div>
-                    <div class="label">TL:</div>
+                    <div class="label">TL</div>
                     <div class="field">@TL</div>
                 </div>
                 <div class="fieldblock">
-                    <div class="label">Hair:</div>
+                    <div class="label">Hair</div>
                     <div class="field">@HAIR</div>
-                    <div class="label">Eyes:</div>
+                    <div class="label">Eyes</div>
                     <div class="field">@EYES</div>
-                    <div class="label">Skin:</div>
+                    <div class="label">Skin</div>
                     <div class="field">@SKIN</div>
-                    <div class="label">Hand:</div>
+                    <div class="label">Hand</div>
                     <div class="field">@HAND</div>
                 </div>
             </div>
             <div id="points">
                 <div class="header">@TOTAL_POINTS Points</div>
                 <div class="fieldblock">
-                    <div class="field">@UNSPENT_POINTS</div>
+                    <div class="field noedit">@UNSPENT_POINTS</div>
                     <div class="label">Unspent</div>
                     <div class="field noedit">@RACE_POINTS</div>
                     <div class="label">Race</div>
@@ -800,37 +1303,39 @@ defined by the Mozilla Public License, version 2.0.
             </div>
         </div>
         <div id="stats">
-            <div id="attr-col">
-                <div id="attr-row">
-                    <div id="primary-attr">
-                        <div class="header">Primary Attributes</div>
-                        <div class="fieldblock3">
-                            @PRIMARY_ATTRIBUTE_LOOP_START
-                            <div class="points">[@POINTS]</div>
-                            <div class="field">@VALUE</div>
-                            <div class="label">@COMBINED_NAME</div>
-                            @PRIMARY_ATTRIBUTE_LOOP_END
-                            <hr>
-                            <div class="points"></div>
-                            <div class="field noedit">@THRUST</div>
-                            <div class="label">Basic Thrust</div>
-                            <div class="points"></div>
-                            <div class="field noedit">@SWING</div>
-                            <div class="label">Basic Swing</div>
-                        </div>
-                    </div>
-                    <div id="secondary-attr">
-                        <div class="header">Secondary Attributes</div>
-                        <div class="fieldblock3">
-                            @SECONDARY_ATTRIBUTE_LOOP_START
-                            <div class="points">[@POINTS]</div>
-                            <div class="field">@VALUE</div>
-                            <div class="label">@COMBINED_NAME</div>
-                            @SECONDARY_ATTRIBUTE_LOOP_END
-                        </div>
+            <div id="attributes">
+                <div id="primary-attributes">
+                    <div class="header">Primary Attributes</div>
+                    <div class="fieldblock3">
+                        @PRIMARY_ATTRIBUTE_LOOP_START
+                        <div class="points">[@POINTS]</div>
+                        <div class="field">@VALUE</div>
+                        <div class="label">@COMBINED_NAME</div>
+                        @PRIMARY_ATTRIBUTE_LOOP_END
                     </div>
                 </div>
-                <div id="pools">
+                <div id="basic-damage">
+                    <div class="header">Basic Damage</div>
+                    <div class="fieldblock3">
+                        <div class="points">[20]</div>
+                        <div class="field">@THRUST</div>
+                        <div class="label">Basic Thrust</div>
+                        <div class="points">[20]</div>
+                        <div class="field">@SWING</div>
+                        <div class="label">Basic Swing</div>
+                    </div>
+                </div>
+                <div id="secondary-attributes">
+                    <div class="header">Secondary Attributes</div>
+                    <div class="fieldblock3">
+                        @SECONDARY_ATTRIBUTE_LOOP_START
+                        <div class="points">[@POINTS]</div>
+                        <div class="field">@VALUE</div>
+                        <div class="label">@COMBINED_NAME</div>
+                        @SECONDARY_ATTRIBUTE_LOOP_END
+                    </div>
+                </div>
+                <div id="pool-attributes">
                     <div class="header">Point Pools</div>
                     <div class="fieldblock5">
                         @POINT_POOL_LOOP_START
@@ -843,31 +1348,36 @@ defined by the Mozilla Public License, version 2.0.
                     </div>
                 </div>
             </div>
-            <div id="location">
-                <div class="header">Hit Location</div>
-                <div class="roll header">Roll</div>
-                <div class="where header">Where</div>
-                <div class="penalty header">Penalty</div>
-                <div class="dr header">DR</div>
+            <div id="hit-locations">
+                <div class="header body-plan">Hit Locations</div>
+                <div class="header entry-parent" readonly></div>
+                <div class="header roll">Roll</div>
+                <div class="header location">Location</div>
+                <div class="header dr">DR</div>
                 @HIT_LOCATION_LOOP_START
+                <div class="entry-parent" readonly></div>
                 <div class="roll">@ROLL</div>
-                <div class="where">@WHERE</div>
+                <div class="location">@WHERE</div>
                 <div class="penalty">@PENALTY</div>
                 <div class="dr">@DR</div>
                 @HIT_LOCATION_LOOP_END
             </div>
-            <div id="enc-col">
+            <div id="encumbrance-lifting">
                 <div id="encumbrance">
-                    <div class="header">Encumbrance, Move &amp; Dodge</div>
-                    <div class="encmarkerh header"></div>
-                    <div class="ench header">Level</div>
-                    <div class="loadh header">Max Load</div>
-                    <div class="moveh header">Move</div>
-                    <div class="dodgeh header">Dodge</div>
+                    <div class="header title">Encumbrance, Move &amp; Dodge</div>
+                    <div class="header level">Level</div>
+                    <div class="header max-load">Max Load</div>
+                    <div class="header move">Move</div>
+                    <div class="header dodge">Dodge</div>
                     @ENCUMBRANCE_LOOP_START
-                    <div class="encmarker @CURRENT_MARKER"></div>
-                    <div class="enc @CURRENT_MARKER enc@LEVEL_ONLY"></div>
-                    <div class="load @CURRENT_MARKER">@MAX_LOAD</div>
+                    <div class="encumbrance-marker @CURRENT_MARKER">
+                        <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+                            <path></path>
+                        </svg>
+                    </div>
+                    <div class="level-number @CURRENT_MARKER enc@LEVEL_ONLY"></div>
+                    <div class="level @CURRENT_MARKER enc@LEVEL_ONLY"></div>
+                    <div class="max-load @CURRENT_MARKER">@MAX_LOAD</div>
                     <div class="move @CURRENT_MARKER">@MOVE</div>
                     <div class="dodge @CURRENT_MARKER">@DODGE</div>
                     @ENCUMBRANCE_LOOP_END
@@ -875,226 +1385,329 @@ defined by the Mozilla Public License, version 2.0.
                 <div id="lifting">
                     <div class="header">Lifting &amp; Moving Things</div>
                     <div class="lift">@BASIC_LIFT</div>
-                    <div class="liftdesc">Basic Lift</div>
+                    <div class="label">Basic Lift</div>
                     <div class="lift">@ONE_HANDED_LIFT</div>
-                    <div class="liftdesc">One-Handed Lift</div>
+                    <div class="label">One-Handed Lift</div>
                     <div class="lift">@TWO_HANDED_LIFT</div>
-                    <div class="liftdesc">Two-Handed Lift</div>
+                    <div class="label">Two-Handed Lift</div>
                     <div class="lift">@SHOVE</div>
-                    <div class="liftdesc">Shove &amp; Knock Over</div>
+                    <div class="label">Shove &amp; Knock Over</div>
                     <div class="lift">@RUNNING_SHOVE</div>
-                    <div class="liftdesc">Running Shove &amp; Knock Over</div>
+                    <div class="label">Running Shove &amp; Knock Over</div>
                     <div class="lift">@CARRY_ON_BACK</div>
-                    <div class="liftdesc">Carry on Back</div>
+                    <div class="label">Carry on Back</div>
                     <div class="lift">@SHIFT_SLIGHTLY</div>
-                    <div class="liftdesc">Shift Slightly</div>
+                    <div class="label">Shift Slightly</div>
                 </div>
             </div>
         </div>
-        <div id="reactions">
-            <div class="modifier header">Modifier</div>
-            <div class="situation header">Reaction</div>
-            <div></div>
-
-            @REACTION_LOOP_START
-            <div class="modifier">@MODIFIER</div>
-            <div class="situation">@SITUATION</div>
-            <div></div>
-            @REACTION_LOOP_END
-        </div>
-        <div id="conditional_modifiers">
-            <div class="modifier header">Modifier</div>
-            <div class="situation header">Condition</div>
-            <div></div>
-
-            @CONDITIONAL_MODIFIERS_LOOP_START
-            <div class="modifier">@MODIFIER</div>
-            <div class="situation">@SITUATION</div>
-            <div></div>
-            @CONDITIONAL_MODIFIERS_LOOP_END
-        </div>
-        <div id="melee">
-            <div class="desc header">Melee Weapons</div>
-            <div class="usage header">Usage</div>
-            <div class="level header">Lvl</div>
-            <div class="parry header">Parry</div>
-            <div class="block header">Block</div>
-            <div class="damage header">Damage</div>
-            <div class="reach header">Reach</div>
-            <div class="st header">ST</div>
-            <div></div>
-
-            @MELEE_LOOP_START
-            <div class="desc">@DESCRIPTION_PRIMARY
-                <div class="list_note">@DESCRIPTION_NOTES</div>
+        <div id="embeds">
+            <div id="reactions">
+                <div class="entry-parent header" readonly></div>
+                <div class="modifier header">&#177;</div>
+                <div class="situation header">Reaction</div>
+                @REACTION_LOOP_START
+                <div class="entry-parent" readonly></div>
+                <div class="modifier">@MODIFIER</div>
+                <div class="situation">@SITUATION</div>
+                @REACTION_LOOP_END
             </div>
-            <div class="usage">@USAGE</div>
-            <div class="level">@LEVEL</div>
-            <div class="parry">@PARRY</div>
-            <div class="block">@BLOCK</div>
-            <div class="damage">@DAMAGE</div>
-            <div class="reach">@REACH</div>
-            <div class="st">@STRENGTH</div>
-            <div></div>
-            @MELEE_LOOP_END
-        </div>
-        <div id="ranged">
-            <div class="desc header">Ranged Weapons</div>
-            <div class="usage header">Usage</div>
-            <div class="level header">Lvl</div>
-            <div class="acc header">Acc</div>
-            <div class="damage header">Damage</div>
-            <div class="range header">Range</div>
-            <div class="rof header">RoF</div>
-            <div class="shots header">Shots</div>
-            <div class="bulk header">Bulk</div>
-            <div class="rcl header">Rcl</div>
-            <div class="st header">ST</div>
-
-            @RANGED_LOOP_START
-            <div class="desc">@DESCRIPTION_PRIMARY
-                <div class="list_note">@DESCRIPTION_NOTES</div>
+            <div id="conditional-modifiers">
+                <div class="entry-parent header" readonly></div>
+                <div class="modifier header">&#177;</div>
+                <div class="situation header">Condition</div>
+                @CONDITIONAL_MODIFIERS_LOOP_START
+                <div class="entry-parent" readonly></div>
+                <div class="modifier">@MODIFIER</div>
+                <div class="situation">@SITUATION</div>
+                @CONDITIONAL_MODIFIERS_LOOP_END
             </div>
-            <div class="usage">@USAGE</div>
-            <div class="level">@LEVEL</div>
-            <div class="acc">@ACCURACY</div>
-            <div class="damage">@DAMAGE</div>
-            <div class="range">@RANGE</div>
-            <div class="rof">@ROF</div>
-            <div class="shots">@SHOTS</div>
-            <div class="bulk">@BULK</div>
-            <div class="rcl">@RECOIL</div>
-            <div class="st">@STRENGTH</div>
-            @RANGED_LOOP_END
-        </div>
-        <div id="advantages">
-            <div class="desc header">Advantages, Disadvantages, Perks &amp; Quirks</div>
-            <div class="pts header">Pts</div>
-            <div class="ref header"><i class="fas fa-bookmark"></i></div>
-
-            @ADVANTAGES_LOOP_START
-            <div class="desc indent@DEPTHx1 satisfied@SATISFIED">@DESCRIPTION_PRIMARY
-                <div class="list_note satisfied@SATISFIED">@DESCRIPTION_MODIFIER_NOTES</div>
-                <div class="list_note satisfied@SATISFIED">@DESCRIPTION_NOTES</div>
+            <div id="melee">
+                <div class="header entry-parent" readonly></div>
+                <div class="header desc">Melee Weapon</div>
+                <div class="header usage">Usage</div>
+                <div class="header level">SL</div>
+                <div class="header parry">Parry</div>
+                <div class="header block">Block</div>
+                <div class="header damage">Damage</div>
+                <div class="header reach">Reach</div>
+                <div class="header st">ST</div>
+                @MELEE_LOOP_START
+                <div class="entry-parent" readonly></div>
+                <div class="desc">
+                    @DESCRIPTION_PRIMARY
+                    <div class="item-notes">
+                        @DESCRIPTION_NOTES
+                    </div>
+                </div>
+                <div class="usage">@USAGE</div>
+                <div class="level">@LEVEL</div>
+                <div class="parry">@PARRY</div>
+                <div class="block">@BLOCK</div>
+                <div class="damage">@DAMAGE</div>
+                <div class="reach">@REACH</div>
+                <div class="st">@STRENGTH</div>
+                @MELEE_LOOP_END
             </div>
-            <div class="pts satisfied@SATISFIED">@POINTS</div>
-            <div class="ref satisfied@SATISFIED">@REF</div>
-            @ADVANTAGES_LOOP_END
-        </div>
-        <div id="skills">
-            <div class="desc header">Skills</div>
-            <div class="sl header">SL</div>
-            <div class="rsl header">RSL</div>
-            <div class="pts header">Pts</div>
-            <div class="ref header"><i class="fas fa-bookmark"></i></div>
-
-            @SKILLS_LOOP_START
-            <div class="desc indent@DEPTHx1 satisfied@SATISFIED">@DESCRIPTION_PRIMARY
-                <div class="list_note satisfied@SATISFIED">@DESCRIPTION_MODIFIER_NOTES</div>
-                <div class="list_note satisfied@SATISFIED">@DESCRIPTION_NOTES</div>
+            <div id="ranged">
+                <div class="header entry-parent" readonly></div>
+                <div class="header desc">Ranged Weapon</div>
+                <div class="header usage">Usage</div>
+                <div class="header level">SL</div>
+                <div class="header acc">Acc</div>
+                <div class="header range">range</div>
+                <div class="header damage">Damage</div>
+                <div class="header rof">RoF</div>
+                <div class="header shots">Shots</div>
+                <div class="header bulk">Bulk</div>
+                <div class="header recoil">Recoil</div>
+                <div class="header st">ST</div>
+                @RANGED_LOOP_START
+                <div class="entry-parent" readonly></div>
+                <div class="desc">
+                    @DESCRIPTION_PRIMARY
+                    <div class="item-notes">
+                        @DESCRIPTION_NOTES
+                    </div>
+                </div>
+                <div class="usage">@USAGE</div>
+                <div class="level">@LEVEL</div>
+                <div class="acc">@ACCURACY</div>
+                <div class="range">@RANGE</div>
+                <div class="damage">@DAMAGE</div>
+                <div class="rof">@ROF</div>
+                <div class="shots">@SHOTS</div>
+                <div class="bulk">@BULK</div>
+                <div class="recoil">@RECOIL</div>
+                <div class="st">@STRENGTH</div>
+                @RANGED_LOOP_END
             </div>
-            <div class="sl satisfied@SATISFIED">@SL</div>
-            <div class="rsl satisfied@SATISFIED">@RSL</div>
-            <div class="pts satisfied@SATISFIED">@POINTS</div>
-            <div class="ref satisfied@SATISFIED">@REF</div>
-            @SKILLS_LOOP_END
-        </div>
-        <div id="spells">
-            <div class="desc header">Spells</div>
-            <div class="cls header">Class</div>
-            <div class="college header">College</div>
-            <div class="mana header">Cost</div>
-            <div class="mana_maintain header">Maintain</div>
-            <div class="time header">Time</div>
-            <div class="duration header">Duration</div>
-            <div class="sl header">SL</div>
-            <div class="rsl header">RSL</div>
-            <div class="pts header">Pts</div>
-            <div class="ref header"><i class="fas fa-bookmark"></i></div>
-
-            @SPELLS_LOOP_START
-            <div class="desc indent@DEPTHx1 satisfied@SATISFIED">@DESCRIPTION_PRIMARY
-                <div class="list_note satisfied@SATISFIED">@DESCRIPTION_MODIFIER_NOTES</div>
-                <div class="list_note satisfied@SATISFIED">@DESCRIPTION_NOTES</div>
+            <div id="traits">
+                <div class="header entry-parent" readonly></div>
+                <div class="header desc">Trait</div>
+                <div class="header points">Pts</div>
+                <div class="header reference">
+                    <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+                        <path class="shape-bookmark"></path>
+                    </svg>
+                </div>
+                @ADVANTAGES_LOOP_START
+                <div class="entry-parent" readonly></div>
+                <div class="desc" style="padding-left: calc(@DEPTHx20 * 1px- 6px)">
+                    @DESCRIPTION_PRIMARY
+                    <div class="item-notes">
+                        @DESCRIPTION_MODIFIER_NOTES
+                        @DESCRIPTION_NOTES
+                    </div>
+                </div>
+                <div class="points">@POINTS</div>
+                <div class="reference">@REF</div>
+                @ADVANTAGES_LOOP_END
             </div>
-            <div class="cls satisfied@SATISFIED">@CLASS</div>
-            <div class="college satisfied@SATISFIED">@COLLEGE</div>
-            <div class="mana satisfied@SATISFIED">@MANA_CAST</div>
-            <div class="mana_maintain satisfied@SATISFIED">@MANA_MAINTAIN</div>
-            <div class="time satisfied@SATISFIED">@TIME_CAST</div>
-            <div class="duration satisfied@SATISFIED">@DURATION</div>
-            <div class="sl satisfied@SATISFIED">@SL</div>
-            <div class="rsl satisfied@SATISFIED">@RSL</div>
-            <div class="pts satisfied@SATISFIED">@POINTS</div>
-            <div class="ref satisfied@SATISFIED">@REF</div>
-            @SPELLS_LOOP_END
-        </div>
-        <div id="equipment">
-            <div class="equipped header"><i class="fas fa-check-circle"></i></div>
-            <div class="qty header"><i class="fab fa-slack-hash"></i></div>
-            <div class="desc header">Equipment (@CARRIED_WEIGHT; @CARRIED_VALUE)</div>
-            <div class="uses header">Uses</div>
-            <div class="cost header">$</div>
-            <div class="weight header"><i class="fas fa-weight-hanging"></i></div>
-            <div class="sum_cost header">∑ $</div>
-            <div class="sum_weight header">∑ <i class="fas fa-weight-hanging"></i></div>
-            <div class="ref header"><i class="fas fa-bookmark"></i></div>
-
-            @EQUIPMENT_LOOP_START
-            <div class="equipped satisfied@SATISFIED">@EQUIPPED_FA</div>
-            <div class="qty satisfied@SATISFIED">@QTY</div>
-            <div class="desc indent@DEPTHx1 satisfied@SATISFIED">@DESCRIPTION_PRIMARY
-                <div class="list_note satisfied@SATISFIED">@DESCRIPTION_MODIFIER_NOTES</div>
-                <div class="list_note satisfied@SATISFIED">@DESCRIPTION_NOTES</div>
+            <div id="skills">
+                <div class="header entry-parent" readonly></div>
+                <div class="header desc">Skill / Technique</div>
+                <div class="header level">SL</div>
+                <div class="header rsl">RSL</div>
+                <div class="header points">Pts</div>
+                <div class="header reference">
+                    <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+                        <path class="shape-bookmark"></path>
+                    </svg>
+                </div>
+                @SKILLS_LOOP_START
+                <div class="entry-parent" readonly></div>
+                <div class="desc" style="padding-left: calc(@DEPTHx20 * 1px- 6px)">
+                    @DESCRIPTION_PRIMARY
+                    <div class="item-notes">
+                        @DESCRIPTION_MODIFIER_NOTES
+                        @DESCRIPTION_NOTES
+                    </div>
+                </div>
+                <div class="level"></div>
+                <div class="rsl"></div>
+                <div class="points"></div>
+                <div class="reference">@REF</div>
+                @SKILLS_LOOP_END
             </div>
-            <div class="uses satisfied@SATISFIED">@USES</div>
-            <div class="cost satisfied@SATISFIED">@COST</div>
-            <div class="weight satisfied@SATISFIED">@WEIGHT</div>
-            <div class="sum_cost satisfied@SATISFIED">@COST_SUMMARY</div>
-            <div class="sum_weight satisfied@SATISFIED">@WEIGHT_SUMMARY</div>
-            <div class="ref satisfied@SATISFIED">@REF</div>
-            @EQUIPMENT_LOOP_END
-        </div>
-        <div id="other_equipment">
-            <div class="qty header"><i class="fab fa-slack-hash"></i></div>
-            <div class="desc header">Other Equipment (@OTHER_EQUIPMENT_VALUE)</div>
-            <div class="uses header">Uses</div>
-            <div class="cost header">$</div>
-            <div class="weight header"><i class="fas fa-weight-hanging"></i></div>
-            <div class="sum_cost header">∑ $</div>
-            <div class="sum_weight header">∑ <i class="fas fa-weight-hanging"></i></div>
-            <div class="ref header"><i class="fas fa-bookmark"></i></div>
-            <div></div>
-
-            @OTHER_EQUIPMENT_LOOP_START
-            <div class="qty satisfied@SATISFIED">@QTY</div>
-            <div class="desc indent@DEPTHx1 satisfied@SATISFIED">@DESCRIPTION_PRIMARY
-                <div class="list_note satisfied@SATISFIED">@DESCRIPTION_MODIFIER_NOTES</div>
-                <div class="list_note satisfied@SATISFIED">@DESCRIPTION_NOTES</div>
+            <div id="spells">
+                <div class="header entry-parent" readonly></div>
+                <div class="header desc">Spell</div>
+                <div class="header college">College</div>
+                <div class="header level">SL</div>
+                <div class="header rsl">RSL</div>
+                <div class="header points">Pts</div>
+                <div class="header reference">
+                    <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+                        <path class="shape-bookmark"></path>
+                    </svg>
+                </div>
+                @SPELLS_LOOP_START
+                <div class="entry-parent" readonly></div>
+                <div class="desc" style="padding-left: calc(20px * @DEPTHx1 - 6px)">
+                    @DESCRIPTION_PRIMARY
+                    <div class="item-notes">
+                        @DESCRIPTION_MODIFIER_NOTES
+                        @DESCRIPTION_NOTES
+                        Class: @CLASS; Cost: @MANA_CAST; Maintain: @MANA_MAINTAIN; Time: @TIME_CAST; Duration:
+                        @DURATION;
+                    </div>
+                </div>
+                <div class="college">@COLLEGE</div>
+                <div class="level">@SL</div>
+                <div class="rsl">@RSL</div>
+                <div class="points">@POINTS</div>
+                <div class="reference">@REF</div>
+                @SPELLS_LOOP_END
             </div>
-            <div class="uses satisfied@SATISFIED">@USES</div>
-            <div class="cost satisfied@SATISFIED">@COST</div>
-            <div class="weight satisfied@SATISFIED">@WEIGHT</div>
-            <div class="sum_cost satisfied@SATISFIED">@COST_SUMMARY</div>
-            <div class="sum_weight satisfied@SATISFIED">@WEIGHT_SUMMARY</div>
-            <div class="ref satisfied@SATISFIED">@REF</div>
-            <div></div>
-            @OTHER_EQUIPMENT_LOOP_END
+            <div id="equipment">
+                <div class="header entry-parent" readonly></div>
+                <div class="header equipped">
+                    <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+                        <path class="shape-equipped-1"></path>
+                    </svg>
+                </div>
+                <div class="header quantity">#</div>
+                <div class="header desc">Carried Equipment (@CARRIED_WEIGHT; @CARRIED_VALUE)</div>
+                <div class="header uses">Uses</div>
+                <div class="header tech-level">TL</div>
+                <div class="header legality-class">LC</div>
+                <div class="header value">
+                    <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+                        <path class="shape-coins"></path>
+                    </svg>
+                </div>
+                <div class="header weight">
+                    <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+                        <path class="shape-weight"></path>
+                    </svg>
+                </div>
+                <div class="header extended-value">
+                    <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+                        <path class="shape-stack"></path>
+                    </svg>
+                    <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+                        <path class="shape-coins"></path>
+                    </svg>
+                </div>
+                <div class="header extended-weight">
+                    <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+                        <path class="shape-stack"></path>
+                    </svg>
+                    <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+                        <path class="shape-weight"></path>
+                    </svg>
+                </div>
+                <div class="header reference">
+                    <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+                        <path class="shape-bookmark"></path>
+                    </svg>
+                </div>
+                @EQUIPMENT_LOOP_START
+                <div class="entry-parent" readonly></div>
+                <div class="equipped">
+                    <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+                        <path class="shape-equipped-@EQUIPPED_NUM"></path>
+                    </svg>
+                </div>
+                <div class="quantity">@QTY</div>
+                <div class="desc" style="padding-left: calc(20px * @DEPTHx1 - 6px)">
+                    @DESCRIPTION_PRIMARY
+                    <div class="item-notes">
+                        @DESCRIPTION_MODIFIER_NOTES
+                        @DESCRIPTION_NOTES
+                    </div>
+                </div>
+                <div class="uses">@USES</div>
+                <div class="tech-level">@TL</div>
+                <div class="legality-class">@LEGALITY_CLASS</div>
+                <div class="value">@COST</div>
+                <div class="weight">@WEIGHT</div>
+                <div class="extended-value">@COST_SUMMARY</div>
+                <div class="extended-weight">@WEIGHT_SUMMARY</div>
+                <div class="reference">@REF</div>
+                @EQUIPMENT_LOOP_END
+            </div>
+            <div id="other-equipment">
+                <div class="header entry-parent" readonly></div>
+                <div class="header quantity">#</div>
+                <div class="header desc">Other Equipment (@OTHER_EQUIPMENT_VALUE)</div>
+                <div class="header uses">Uses</div>
+                <div class="header tech-level">TL</div>
+                <div class="header legality-class">LC</div>
+                <div class="header value">
+                    <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+                        <path class="shape-coins"></path>
+                    </svg>
+                </div>
+                <div class="header weight">
+                    <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+                        <path class="shape-weight"></path>
+                    </svg>
+                </div>
+                <div class="header extended-value">
+                    <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+                        <path class="shape-stack"></path>
+                    </svg>
+                    <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+                        <path class="shape-coins"></path>
+                    </svg>
+                </div>
+                <div class="header extended-weight">
+                    <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+                        <path class="shape-stack"></path>
+                    </svg>
+                    <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+                        <path class="shape-weight"></path>
+                    </svg>
+                </div>
+                <div class="header reference">
+                    <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+                        <path class="shape-bookmark"></path>
+                    </svg>
+                </div>
+                @OTHER_EQUIPMENT_LOOP_START
+                <div class="entry-parent" readonly></div>
+                <div class="quantity">@QTY</div>
+                <div class="desc" style="padding-left: calc(20px * @DEPTHx1 - 6px)">
+                    @DESCRIPTION_PRIMARY
+                    <div class="item-notes">
+                        @DESCRIPTION_MODIFIER_NOTES
+                        @DESCRIPTION_NOTES
+                    </div>
+                </div>
+                <div class="uses">@USES</div>
+                <div class="tech-level">@TL</div>
+                <div class="legality-class">@LEGALITY_CLASS</div>
+                <div class="value">@COST</div>
+                <div class="weight">@WEIGHT</div>
+                <div class="extended-value">@COST_SUMMARY</div>
+                <div class="extended-weight">@WEIGHT_SUMMARY</div>
+                <div class="reference">@REF</div>
+                @OTHER_EQUIPMENT_LOOP_END
+            </div>
+            <div id="notes">
+                <div class="header entry-parent" readonly></div>
+                <div class="header desc">Note</div>
+                <div class="header reference">
+                    <svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+                        <path class="shape-bookmark"></path>
+                    </svg>
+                </div>
+                @NOTES_LOOP_START
+                <div class="entry-parent" readonly></div>
+                <div class="desc" style="padding-left: calc(20px * @DEPTHx1 - 6px)">
+                @NOTE
+                </div>
+                <div class="reference">@REF</div>
+                @NOTES_LOOP_END
+            </div>
         </div>
-        <div id="notes">
-            <div class="desc header">Notes</div>
-            <div class="ref header"><i class="fas fa-bookmark"></i></div>
-            <div></div>
-
-            @NOTES_LOOP_START
-            <div class="desc indent@DEPTHx1">@NOTE</div>
-            <div class="ref">@REF</div>
-            <div></div>
-            @NOTES_LOOP_END
-        </div>
-    </div>
-    <div id="footer">GCS is copyrighted ©1998-2021 by Richard A. Wilkes • All rights reserved •
-        <a href="https://gurpscharactersheet.com">gurpscharactersheet.com</a>
+		<div id="footer">
+			<div class="left">GCS is copyrighted &copy; by Richard A. Wilkes<br>All rights reserved</div>
+			<div class="centre">@NAME</div>
+			<div class="right"><a href="https://gurpscharactersheet.com/">gurpscharactersheet.com</a></div>
+		</div>
     </div>
 </body>
 

--- a/Library/Output Templates/HTML - PC.html
+++ b/Library/Output Templates/HTML - PC.html
@@ -97,67 +97,6 @@ defined by the Mozilla Public License, version 2.0.
 		}
 
 
-		/* @media (prefers-color-scheme: dark) { */
-		/* 	:root { */
-		/* 		--color-background: 50, 50, 50; */
-		/* 		--color-on-background: 221, 221, 221; */
-		/* 		--color-content: 32, 32, 32; */
-		/* 		--color-on-content: 221, 221, 221; */
-		/* 		--color-banding: 42, 42, 42; */
-		/* 		--color-on-banding: 221, 221, 221; */
-		/* 		--color-header: 64, 64, 64; */
-		/* 		--color-on-header: 192, 192, 192; */
-		/* 		--color-focused-tab: 68, 102, 0; */
-		/* 		--color-on-focused-tab: 221, 221, 221; */
-		/* 		--color-current-tab: 41, 61, 0; */
-		/* 		--color-on-current-tab: 221, 221, 221; */
-		/* 		--color-editable: 24, 24, 24; */
-		/* 		--color-on-editable: 100, 153, 153; */
-		/* 		--color-editable-border: 96, 96, 96; */
-		/* 		--color-focused-editable-border: 0, 102, 102; */
-		/* 		--color-selection: 0, 96, 160; */
-		/* 		--color-on-selection: 255, 255, 255; */
-		/* 		--color-inactive-selection: 0, 64, 128; */
-		/* 		--color-on-inactive-selection: 228, 228, 228; */
-		/* 		--color-inactive-selection: 0, 64, 128; */
-		/* 		--color-on-inactive-selection: 228, 228, 228; */
-		/* 		--color-scroll: 128, 128, 128, 0.5; */
-		/* 		--color-scroll-rollover: 128, 128, 128; */
-		/* 		--color-scroll-edge: 160, 160, 160; */
-		/* 		--color-accent: 100, 153, 153; */
-		/* 		--color-control: 64, 64, 64; */
-		/* 		--color-on-control: 221, 221, 221; */
-		/* 		--color-pressed-control: 0, 96, 160; */
-		/* 		--color-on-pressed-control: 255, 255, 255; */
-		/* 		--color-control-edge: 96, 96, 96; */
-		/* 		--color-divider: 102, 102, 102; */
-		/* 		--color-icon-button: 128, 128, 128; */
-		/* 		--color-icon-button-rollover: 192, 192, 192; */
-		/* 		--color-pressed-icon-button: 0, 96, 160; */
-		/* 		--color-drop-area: 255, 0, 0; */
-		/* 		--color-toolip: 252, 252, 196; */
-		/* 		--color-on-tooltip: 0, 0, 0; */
-		/* 		--color-search-list: 0, 43, 43; */
-		/* 		--color-on-search-list: 204, 204, 204; */
-		/* 		--color-marker: 0, 51, 0; */
-		/* 		--color-on-marker: 221, 221, 221; */
-		/* 		--color-error: 115, 37, 37; */
-		/* 		--color-on-error: 221, 221, 221; */
-		/* 		--color-warning: 192, 96, 0; */
-		/* 		--color-on-warning: 221, 221, 221; */
-		/* 		--color-overloaded: 115, 37, 37; */
-		/* 		--color-on-overloaded: 221, 221, 221; */
-		/* 		--color-page: 16, 16, 16; */
-		/* 		--color-on-page: 160, 160, 160; */
-		/* 		--color-page-void: 0, 0, 0; */
-		/* 		--color-hint: 64, 64, 64; */
-		/* 		--color-link: 0, 255, 127; */
-		/* 		--color-on-link: 0, 0, 0; */
-		/* 		--color-pdf-link-highlight: 0, 255, 127; */
-		/* 		--color-pdf-marker-highlight: 255, 255, 0; */
-		/* 	} */
-		/* } */
-
 		svg {
 			width: 1em;
 			height: 1em;
@@ -280,8 +219,8 @@ defined by the Mozilla Public License, version 2.0.
 			background-position: center;
 			background-repeat: no-repeat;
 			background-size: cover;
-			width: 111px;
-			height: 148px;
+			width: calc(6.75rem + 1.5px);
+			height: calc(9rem + 2px);
 		}
 
 		#identity {

--- a/Library/Output Templates/HTML - PC.html
+++ b/Library/Output Templates/HTML - PC.html
@@ -215,6 +215,10 @@ defined by the Mozilla Public License, version 2.0.
             color: rgb(var(--color-on-content));
         }
 
+		.fieldblock3 > * {
+			padding: var(--padding-standard);
+		}
+
         .fieldblock5 {
             display: grid;
             grid-template-columns: repeat(5, 0fr);
@@ -222,6 +226,10 @@ defined by the Mozilla Public License, version 2.0.
             background-color: rgb(var(--color-content));
             color: rgb(var(--color-on-content));
         }
+
+		.fieldblock5 > * {
+			padding: var(--padding-standard);
+		}
 
         .label {
             font: var(--font-page-primary-labels);
@@ -850,6 +858,32 @@ defined by the Mozilla Public License, version 2.0.
             padding: var(--padding-header);
         }
 
+		.legality-class.Open::after {
+			content:"4";
+		}
+		
+		.legality-class.Licensed::after {
+			content: "3";
+		}
+
+		.legality-class.Restricted::after {
+			content: "2";
+		}
+
+		.legality-class.Military::after {
+			content: "1";
+		}
+
+		.legality-class.Banned::after {
+			content: "0";
+		}
+
+		#embeds .uses.max0 {
+			text-indent: 200%;
+			white-space: nowrap;
+			overflow: hidden;
+		}
+
         #equipment .entry-parent:nth-child(24n+1):not(.header),
         #equipment .equipped:nth-child(24n+2):not(.header),
         #equipment .quantity:nth-child(24n+3):not(.header),
@@ -881,7 +915,7 @@ defined by the Mozilla Public License, version 2.0.
             border-right: 1px solid rgb(var(--color-header));
         }
 
-        #equipment :nth-last-child(-n+10) {
+        #equipment :nth-last-child(-n+11) {
             border-bottom: none !important;
         }
 
@@ -1305,7 +1339,7 @@ defined by the Mozilla Public License, version 2.0.
                 <div class="header usage">Usage</div>
                 <div class="header level">SL</div>
                 <div class="header acc">Acc</div>
-                <div class="header range">range</div>
+                <div class="header range">Range</div>
                 <div class="header damage">Damage</div>
                 <div class="header rof">RoF</div>
                 <div class="header shots">Shots</div>
@@ -1343,7 +1377,7 @@ defined by the Mozilla Public License, version 2.0.
                 </div>
                 @ADVANTAGES_LOOP_START
                 <div class="entry-parent" readonly></div>
-                <div class="desc" style="padding-left: calc(@DEPTHx20 * 1px- 6px)">
+                <div class="desc" style="padding-left: calc(@DEPTHx20 * 1px + 4px)">
                     @DESCRIPTION_PRIMARY
                     <div class="item-notes">
                         @DESCRIPTION_MODIFIER_NOTES
@@ -1367,7 +1401,7 @@ defined by the Mozilla Public License, version 2.0.
                 </div>
                 @SKILLS_LOOP_START
                 <div class="entry-parent" readonly></div>
-                <div class="desc" style="padding-left: calc(@DEPTHx20 * 1px- 6px)">
+                <div class="desc" style="padding-left: calc(@DEPTHx20 * 1px + 4px)">
                     @DESCRIPTION_PRIMARY
                     <div class="item-notes">
                         @DESCRIPTION_MODIFIER_NOTES
@@ -1394,7 +1428,7 @@ defined by the Mozilla Public License, version 2.0.
                 </div>
                 @SPELLS_LOOP_START
                 <div class="entry-parent" readonly></div>
-                <div class="desc" style="padding-left: calc(20px * @DEPTHx1 - 6px)">
+                <div class="desc" style="padding-left: calc(20px * @DEPTHx1 + 4px)">
                     @DESCRIPTION_PRIMARY
                     <div class="item-notes">
                         @DESCRIPTION_MODIFIER_NOTES
@@ -1461,16 +1495,16 @@ defined by the Mozilla Public License, version 2.0.
                     </svg>
                 </div>
                 <div class="quantity">@QTY</div>
-                <div class="desc" style="padding-left: calc(20px * @DEPTHx1 - 6px)">
+                <div class="desc" style="padding-left: calc(20px * @DEPTHx1 + 4px)">
                     @DESCRIPTION_PRIMARY
                     <div class="item-notes">
                         @DESCRIPTION_MODIFIER_NOTES
                         @DESCRIPTION_NOTES
                     </div>
                 </div>
-                <div class="uses">@USES</div>
+                <div class="uses max@MAX_USES">@USES</div>
                 <div class="tech-level">@TL</div>
-                <div class="legality-class">@LEGALITY_CLASS</div>
+                <div class="legality-class @LEGALITY_CLASS"></div>
                 <div class="value">@COST</div>
                 <div class="weight">@WEIGHT</div>
                 <div class="extended-value">@COST_SUMMARY</div>
@@ -1519,14 +1553,14 @@ defined by the Mozilla Public License, version 2.0.
                 @OTHER_EQUIPMENT_LOOP_START
                 <div class="entry-parent" readonly></div>
                 <div class="quantity">@QTY</div>
-                <div class="desc" style="padding-left: calc(20px * @DEPTHx1 - 6px)">
+                <div class="desc" style="padding-left: calc(20px * @DEPTHx1 + 4px)">
                     @DESCRIPTION_PRIMARY
                     <div class="item-notes">
                         @DESCRIPTION_MODIFIER_NOTES
                         @DESCRIPTION_NOTES
                     </div>
                 </div>
-                <div class="uses">@USES</div>
+                <div class="uses max@MAX_USES">@USES</div>
                 <div class="tech-level">@TL</div>
                 <div class="legality-class">@LEGALITY_CLASS</div>
                 <div class="value">@COST</div>
@@ -1546,7 +1580,7 @@ defined by the Mozilla Public License, version 2.0.
                 </div>
                 @NOTES_LOOP_START
                 <div class="entry-parent" readonly></div>
-                <div class="desc" style="padding-left: calc(20px * @DEPTHx1 - 6px)">
+                <div class="desc" style="padding-left: calc(20px * @DEPTHx1 + 4px)">
                     @NOTE
                 </div>
                 <div class="reference">@REF</div>
@@ -1554,7 +1588,7 @@ defined by the Mozilla Public License, version 2.0.
             </div>
         </div>
         <div id="footer">
-            <div class="left">GCS is copyrighted &copy; by Richard A. Wilkes<br>All rights reserved</div>
+            <div class="left">GCS is copyrighted &copy;1998-2022 by Richard A. Wilkes. All rights reserved</div>
             <div class="centre">@NAME</div>
             <div class="right"><a href="https://gurpscharactersheet.com/">gurpscharactersheet.com</a></div>
         </div>

--- a/Library/Output Templates/HTML - PC.html
+++ b/Library/Output Templates/HTML - PC.html
@@ -469,6 +469,14 @@ defined by the Mozilla Public License, version 2.0.
 			color: rgb(var(--color-on-content));
 		}
 
+		#encumbrance .encumbrance-marker path {
+			display: none;
+		}
+
+		#encumbrance .encumbrance-marker.current path.current {
+			display: inline;
+		}
+
 		#encumbrance .level:not(.header) {
 			color: rgb(var(--color-on-content));
 			font: var(--font-page-primary-labels);
@@ -1231,7 +1239,9 @@ defined by the Mozilla Public License, version 2.0.
 					@ENCUMBRANCE_LOOP_START
 					<div class="encumbrance-marker @CURRENT_MARKER">
 						<svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
-							<path></path>
+							<path class="@CURRENT_MARKER"
+								d="m510.3 445.9-73-292.1c-3.8-15.3-16.5-25.8-30.9-25.8h-60.3c3.625-9.1 5.875-20.75 5.875-32 0-53-42.1-96-96-96S159.1 43 159.1 96c0 11.25 2.25 22 5.875 32H105.6c-14.38 0-27.13 10.5-30.88 25.75L1.71 445.85C-6.641 479.1 16.36 512 47.99 512h416c31.61 0 54.61-32.9 46.31-66.1zM256 128c-17.6 0-32.9-14.4-32.9-32s15.3-32 32.9-32c17.63 0 32 14.38 32 32s-14.4 32-32 32z">
+							</path>
 						</svg>
 					</div>
 					<div class="level-number @CURRENT_MARKER enc@LEVEL_ONLY"></div>

--- a/Library/Output Templates/HTML - PC.html
+++ b/Library/Output Templates/HTML - PC.html
@@ -786,10 +786,13 @@ defined by the Mozilla Public License, version 2.0.
         #skills .desc:not(.header),
         #skills .level:not(.header),
         #skills .rsl:not(.header),
-        #skills .points:not(.header),
-        #skills .reference:not(.header) {
+        #skills .points:not(.header) {
             border-bottom: 1px solid rgb(var(--color-header));
             border-right: 1px solid rgb(var(--color-header));
+        }
+        
+        #skills .reference:not(.header) {
+            border-bottom: 1px solid rgb(var(--color-header));
         }
 
         #skills :nth-last-child(-n+6) {
@@ -820,11 +823,16 @@ defined by the Mozilla Public License, version 2.0.
         #spells .college:not(.header),
         #spells .level:not(.header),
         #spells .rsl:not(.header),
-        #spells .points:not(.header),
-        #spells .reference:not(.header) {
+        #spells .points:not(.header) {
             border-bottom: 1px solid rgb(var(--color-header));
             border-right: 1px solid rgb(var(--color-header));
         }
+
+
+        #spells .reference:not(.header) {
+            border-bottom: 1px solid rgb(var(--color-header));
+        }
+
 
         #spells :nth-last-child(-n+7) {
             border-bottom: none !important;


### PR DESCRIPTION
The template should now resemble the layout and styling of GCS5 as closely as I could get it.
The file contains a (commented out) option for dark mode. I can't find a way of enabling it, as it requires the `@media` keyword, which doesn't work because `@` is a reserved character. Would appreciate any help on this matter if at all possible.

Additionally, importing the Roboto font doesn't seem to work properly either. I think using `@import` *might* work, but again, doing so is not currently possible.