### PR TITLE
Updated Weak Dedicated AI Meta-Trait according to Ultra-Tech Errata

### DIFF
--- a/Library/Ultra Tech/Ultra-Tech Meta-Traits.adq
+++ b/Library/Ultra Tech/Ultra-Tech Meta-Traits.adq
@@ -719,253 +719,13 @@
 						},
 						{
 							"type": "advantage_container",
-							"id": "a21a48a3-7318-4518-928e-4bc0f0678d5a",
-							"name": "Optional Intelligence Lenses",
-							"reference": "UT28",
-							"calc": {
-								"points": 5
-							},
-							"open": false,
-							"children": [
-								{
-									"type": "advantage_container",
-									"id": "253da019-983d-4eb0-a115-a817e1eea249",
-									"name": "Expiration Date",
-									"reference": "UT28",
-									"calc": {
-										"points": 0
-									},
-									"open": false,
-									"children": [
-										{
-											"type": "advantage",
-											"id": "7cdeb0e5-facd-41e4-ac00-a7204f3f4fd9",
-											"name": "Terminally Ill",
-											"physical": true,
-											"modifiers": [
-												{
-													"type": "modifier",
-													"id": "dea153a3-c502-48ea-8687-73759cbd9758",
-													"disabled": true,
-													"name": "2 years to live",
-													"reference": "B158",
-													"cost_type": "points",
-													"cost": -50,
-													"affects": "total"
-												},
-												{
-													"type": "modifier",
-													"id": "8a05c2cf-2961-4948-9316-e4e1a688e692",
-													"disabled": true,
-													"name": "1 year to live",
-													"reference": "B158",
-													"cost_type": "points",
-													"cost": -75,
-													"affects": "total"
-												},
-												{
-													"type": "modifier",
-													"id": "3585a2b1-9aa2-4d6d-8fa8-63d5ae0dcb23",
-													"disabled": true,
-													"name": "1 month to live",
-													"reference": "B158",
-													"cost_type": "points",
-													"cost": -100,
-													"affects": "total"
-												}
-											],
-											"reference": "B158",
-											"calc": {
-												"points": 0
-											},
-											"categories": [
-												"Disadvantage"
-											]
-										}
-									]
-								},
-								{
-									"type": "advantage_container",
-									"id": "29a9db45-1c75-4c74-93d6-960d80c1265d",
-									"name": "Fast",
-									"reference": "UT28",
-									"calc": {
-										"points": 45
-									},
-									"open": false,
-									"children": [
-										{
-											"type": "advantage",
-											"id": "6d91b2eb-3a68-4cc4-986e-4ccc6d8fb696",
-											"name": "Enhanced Time Sense",
-											"mental": true,
-											"exotic": true,
-											"base_points": 45,
-											"reference": "B52",
-											"calc": {
-												"points": 45
-											},
-											"prereqs": {
-												"type": "prereq_list",
-												"all": true,
-												"prereqs": [
-													{
-														"type": "advantage_prereq",
-														"has": false,
-														"name": {
-															"compare": "is",
-															"qualifier": "Combat Reflexes"
-														}
-													}
-												]
-											},
-											"features": [
-												{
-													"type": "skill_bonus",
-													"amount": 1,
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "contains",
-														"qualifier": "fast-draw"
-													}
-												},
-												{
-													"type": "attribute_bonus",
-													"amount": 1,
-													"attribute": "dodge"
-												},
-												{
-													"type": "attribute_bonus",
-													"amount": 1,
-													"attribute": "parry"
-												},
-												{
-													"type": "attribute_bonus",
-													"amount": 1,
-													"attribute": "block"
-												},
-												{
-													"type": "attribute_bonus",
-													"amount": 2,
-													"attribute": "fright_check"
-												}
-											],
-											"notes": "You immediately act in combat before those without Enhanced Time Sense; Never freeze; +6 on all IQ rolls to wake up or to recover from surprise or mental stun; Your side gets +1 to initiative rolls (+2 if you're the leader)",
-											"categories": [
-												"Advantage"
-											]
-										}
-									]
-								},
-								{
-									"type": "advantage_container",
-									"id": "4170a042-61b1-453e-b0ae-9b9302fb4371",
-									"name": "Fragment",
-									"reference": "UT28",
-									"calc": {
-										"points": -10
-									},
-									"open": false,
-									"children": [
-										{
-											"type": "advantage",
-											"id": "50f5ec96-df42-4ec5-8333-b620bda2ae60",
-											"name": "Amnesia (Partial)",
-											"physical": true,
-											"base_points": -10,
-											"reference": "B123",
-											"calc": {
-												"points": -10
-											},
-											"categories": [
-												"Disadvantage"
-											]
-										}
-									]
-								},
-								{
-									"type": "advantage_container",
-									"id": "5dbfa1c0-01b7-4788-a2ba-f86d4c1037f0",
-									"name": "Low-Res Upload",
-									"reference": "UT28",
-									"calc": {
-										"points": -20
-									},
-									"open": false,
-									"children": [
-										{
-											"type": "advantage",
-											"id": "82742eb5-737c-4e48-8b27-8aaf29a9c9de",
-											"name": "Reduce IQ",
-											"mental": true,
-											"levels": "1",
-											"points_per_level": -20,
-											"reference": "B15",
-											"calc": {
-												"points": -20
-											},
-											"features": [
-												{
-													"type": "attribute_bonus",
-													"amount": -1,
-													"per_level": true,
-													"attribute": "iq"
-												}
-											],
-											"categories": [
-												"Attribute",
-												"Disadvantage"
-											]
-										},
-										{
-											"type": "advantage_container",
-											"id": "f49665fa-41d2-4245-abc7-143fa4449482",
-											"name": "Chose of:",
-											"calc": {
-												"points": 0
-											},
-											"open": true
-										}
-									]
-								},
-								{
-									"type": "advantage_container",
-									"id": "ca4c1de1-96d1-45c7-8b2d-12c0a6131ef4",
-									"name": "Reprogrammable",
-									"reference": "UT28",
-									"calc": {
-										"points": -10
-									},
-									"open": false,
-									"children": [
-										{
-											"type": "advantage",
-											"id": "47d979e1-9272-4f7b-88d6-50c6148b5432",
-											"name": "Reprogrammable",
-											"mental": true,
-											"exotic": true,
-											"base_points": -10,
-											"reference": "B150",
-											"calc": {
-												"points": -10
-											},
-											"categories": [
-												"Disadvantage"
-											]
-										}
-									]
-								}
-							]
-						},
-						{
-							"type": "advantage_container",
 							"id": "ef9116ac-ad86-41eb-9f07-2b4fedde7588",
-							"name": "Meta-Trait: Drone",
+							"name": "Meta-Trait: Weak Dedicated AI",
 							"reference": "UT27",
 							"calc": {
 								"points": -83
 							},
-							"notes": "This non-volitional AI is also incapable of self-improvement. It might seem to learn by storing and remembering data, but it cannot assimilate information and use that knowledge in new ways. It requires computer hardware and software with a Complexity equal to or greater than its IQ/2, rounded up.",
+							"notes": "This non-volitional AI is also incapable of self-improvement. It might seem to learn by storing and remembering data, but it cannot assimilate information and use that knowledge in new ways. It requires computer hardware and software with a Complexity equal to or greater than its IQ/2 + 1, rounded up.",
 							"open": false,
 							"children": [
 								{
@@ -1314,6 +1074,246 @@
 											"calc": {
 												"points": -10
 											}
+										}
+									]
+								}
+							]
+						},
+						{
+							"type": "advantage_container",
+							"id": "a21a48a3-7318-4518-928e-4bc0f0678d5a",
+							"name": "Optional Intelligence Lenses",
+							"reference": "UT28",
+							"calc": {
+								"points": 5
+							},
+							"open": false,
+							"children": [
+								{
+									"type": "advantage_container",
+									"id": "253da019-983d-4eb0-a115-a817e1eea249",
+									"name": "Expiration Date",
+									"reference": "UT28",
+									"calc": {
+										"points": 0
+									},
+									"open": false,
+									"children": [
+										{
+											"type": "advantage",
+											"id": "7cdeb0e5-facd-41e4-ac00-a7204f3f4fd9",
+											"name": "Terminally Ill",
+											"physical": true,
+											"modifiers": [
+												{
+													"type": "modifier",
+													"id": "dea153a3-c502-48ea-8687-73759cbd9758",
+													"disabled": true,
+													"name": "2 years to live",
+													"reference": "B158",
+													"cost_type": "points",
+													"cost": -50,
+													"affects": "total"
+												},
+												{
+													"type": "modifier",
+													"id": "8a05c2cf-2961-4948-9316-e4e1a688e692",
+													"disabled": true,
+													"name": "1 year to live",
+													"reference": "B158",
+													"cost_type": "points",
+													"cost": -75,
+													"affects": "total"
+												},
+												{
+													"type": "modifier",
+													"id": "3585a2b1-9aa2-4d6d-8fa8-63d5ae0dcb23",
+													"disabled": true,
+													"name": "1 month to live",
+													"reference": "B158",
+													"cost_type": "points",
+													"cost": -100,
+													"affects": "total"
+												}
+											],
+											"reference": "B158",
+											"calc": {
+												"points": 0
+											},
+											"categories": [
+												"Disadvantage"
+											]
+										}
+									]
+								},
+								{
+									"type": "advantage_container",
+									"id": "29a9db45-1c75-4c74-93d6-960d80c1265d",
+									"name": "Fast",
+									"reference": "UT28",
+									"calc": {
+										"points": 45
+									},
+									"open": false,
+									"children": [
+										{
+											"type": "advantage",
+											"id": "6d91b2eb-3a68-4cc4-986e-4ccc6d8fb696",
+											"name": "Enhanced Time Sense",
+											"mental": true,
+											"exotic": true,
+											"base_points": 45,
+											"reference": "B52",
+											"calc": {
+												"points": 45
+											},
+											"prereqs": {
+												"type": "prereq_list",
+												"all": true,
+												"prereqs": [
+													{
+														"type": "advantage_prereq",
+														"has": false,
+														"name": {
+															"compare": "is",
+															"qualifier": "Combat Reflexes"
+														}
+													}
+												]
+											},
+											"features": [
+												{
+													"type": "skill_bonus",
+													"amount": 1,
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "contains",
+														"qualifier": "fast-draw"
+													}
+												},
+												{
+													"type": "attribute_bonus",
+													"amount": 1,
+													"attribute": "dodge"
+												},
+												{
+													"type": "attribute_bonus",
+													"amount": 1,
+													"attribute": "parry"
+												},
+												{
+													"type": "attribute_bonus",
+													"amount": 1,
+													"attribute": "block"
+												},
+												{
+													"type": "attribute_bonus",
+													"amount": 2,
+													"attribute": "fright_check"
+												}
+											],
+											"notes": "You immediately act in combat before those without Enhanced Time Sense; Never freeze; +6 on all IQ rolls to wake up or to recover from surprise or mental stun; Your side gets +1 to initiative rolls (+2 if you're the leader)",
+											"categories": [
+												"Advantage"
+											]
+										}
+									]
+								},
+								{
+									"type": "advantage_container",
+									"id": "4170a042-61b1-453e-b0ae-9b9302fb4371",
+									"name": "Fragment",
+									"reference": "UT28",
+									"calc": {
+										"points": -10
+									},
+									"open": false,
+									"children": [
+										{
+											"type": "advantage",
+											"id": "50f5ec96-df42-4ec5-8333-b620bda2ae60",
+											"name": "Amnesia (Partial)",
+											"physical": true,
+											"base_points": -10,
+											"reference": "B123",
+											"calc": {
+												"points": -10
+											},
+											"categories": [
+												"Disadvantage"
+											]
+										}
+									]
+								},
+								{
+									"type": "advantage_container",
+									"id": "5dbfa1c0-01b7-4788-a2ba-f86d4c1037f0",
+									"name": "Low-Res Upload",
+									"reference": "UT28",
+									"calc": {
+										"points": -20
+									},
+									"open": false,
+									"children": [
+										{
+											"type": "advantage",
+											"id": "82742eb5-737c-4e48-8b27-8aaf29a9c9de",
+											"name": "Reduce IQ",
+											"mental": true,
+											"levels": "1",
+											"points_per_level": -20,
+											"reference": "B15",
+											"calc": {
+												"points": -20
+											},
+											"features": [
+												{
+													"type": "attribute_bonus",
+													"amount": -1,
+													"per_level": true,
+													"attribute": "iq"
+												}
+											],
+											"categories": [
+												"Attribute",
+												"Disadvantage"
+											]
+										},
+										{
+											"type": "advantage_container",
+											"id": "f49665fa-41d2-4245-abc7-143fa4449482",
+											"name": "Chose of:",
+											"calc": {
+												"points": 0
+											},
+											"open": true
+										}
+									]
+								},
+								{
+									"type": "advantage_container",
+									"id": "ca4c1de1-96d1-45c7-8b2d-12c0a6131ef4",
+									"name": "Reprogrammable",
+									"reference": "UT28",
+									"calc": {
+										"points": -10
+									},
+									"open": false,
+									"children": [
+										{
+											"type": "advantage",
+											"id": "47d979e1-9272-4f7b-88d6-50c6148b5432",
+											"name": "Reprogrammable",
+											"mental": true,
+											"exotic": true,
+											"base_points": -10,
+											"reference": "B150",
+											"calc": {
+												"points": -10
+											},
+											"categories": [
+												"Disadvantage"
+											]
 										}
 									]
 								}

--- a/Library/Ultra Tech/Ultra-Tech Meta-Traits.adq
+++ b/Library/Ultra Tech/Ultra-Tech Meta-Traits.adq
@@ -721,7 +721,7 @@
 							"type": "advantage_container",
 							"id": "ef9116ac-ad86-41eb-9f07-2b4fedde7588",
 							"name": "Meta-Trait: Weak Dedicated AI",
-							"reference": "UT27",
+							"reference": "UT28",
 							"calc": {
 								"points": -83
 							},


### PR DESCRIPTION
Changed name of Meta-Trait: Drone [-83] to Meta-Trait: Weak Dedicated AI and put it above Optional Intelligence Lenses container as it is done in book.
Updated Weak Dedicated AI Meta-Trait according to Ultra-Tech [Errata](https://www.sjgames.com/errata/gurps/4e/ultra-tech.html).
Also fixed reference page for it.