### PR TITLE
Add licenses and certificates from GURPS Traveller Far Trader.

### DIFF
--- a/Library/Traveller/Traveller Standard Licenses and Certificates.adq
+++ b/Library/Traveller/Traveller Standard Licenses and Certificates.adq
@@ -1,0 +1,690 @@
+{
+	"type": "advantage_list",
+	"version": 2,
+	"id": "5c442304-8fb6-498f-b96c-7b0bb989048c",
+	"rows": [
+		{
+			"type": "advantage",
+			"id": "f218d1ef-62ba-4e37-8744-89e7a4908bac",
+			"name": "Certified Medical Technician",
+			"mental": true,
+			"reference": "GTFT84",
+			"calc": {
+				"points": 0
+			},
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Electronics Operation"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 12
+						},
+						"specialization": {
+							"compare": "is",
+							"qualifier": "Medical"
+						}
+					},
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "First Aid"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 12
+						}
+					},
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Diagnosis"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 12
+						}
+					}
+				]
+			}
+		},
+		{
+			"type": "advantage",
+			"id": "d87c927c-1d85-43b6-b9ec-1b4ead1b7a3f",
+			"name": "Medical Doctor",
+			"mental": true,
+			"reference": "GTFT85",
+			"calc": {
+				"points": 0
+			},
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Physician"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 15
+						}
+					},
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Electronics Operation"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 15
+						},
+						"specialization": {
+							"compare": "is",
+							"qualifier": "Medical"
+						}
+					},
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Diagnosis"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 15
+						}
+					}
+				]
+			},
+			"notes": "Requires attending an accredited medical school, regardless of skill, and may require residency or internship."
+		},
+		{
+			"type": "advantage",
+			"id": "e164f246-653b-46ea-8293-33a41bd964cf",
+			"name": "Surgeon's License",
+			"mental": true,
+			"reference": "GTFT85",
+			"calc": {
+				"points": 0
+			},
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "advantage_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Medical Doctor"
+						}
+					},
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Surgery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 15
+						}
+					}
+				]
+			}
+		},
+		{
+			"type": "advantage",
+			"id": "7a5de6f0-df9e-4111-8de4-aa2a84aafdc9",
+			"name": "Communication Operator's Certificate",
+			"mental": true,
+			"reference": "GTFT83",
+			"calc": {
+				"points": 0
+			},
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Electronics Operation"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 12
+						},
+						"specialization": {
+							"compare": "is",
+							"qualifier": "Communications"
+						}
+					}
+				]
+			}
+		},
+		{
+			"type": "advantage",
+			"id": "55ff5a49-5c91-412d-8867-f7ef8558f4ad",
+			"name": "Sensor Operator's Certificate",
+			"mental": true,
+			"reference": "GTFT83",
+			"calc": {
+				"points": 0
+			},
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Electronics Operation"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 12
+						},
+						"specialization": {
+							"compare": "is",
+							"qualifier": "Sensors"
+						}
+					}
+				]
+			}
+		},
+		{
+			"type": "advantage",
+			"id": "e91c2005-5fdd-41cb-9e74-eab682b471bc",
+			"name": "Assistant Engineer's License",
+			"mental": true,
+			"reference": "GTFT84",
+			"calc": {
+				"points": 0
+			},
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Mechanic"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 12
+						},
+						"specialization": {
+							"compare": "is",
+							"qualifier": "Power Plant"
+						}
+					},
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Mechanic"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 12
+						},
+						"specialization": {
+							"compare": "is",
+							"qualifier": "Maneuver Drive"
+						}
+					},
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Mechanic"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 12
+						},
+						"specialization": {
+							"compare": "is",
+							"qualifier": "Jump Drive"
+						}
+					},
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Mechanic"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 12
+						},
+						"specialization": {
+							"compare": "is",
+							"qualifier": "Starship"
+						}
+					},
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Engineer"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 10
+						},
+						"specialization": {
+							"compare": "is",
+							"qualifier": "Starship"
+						}
+					}
+				]
+			},
+			"notes": "Requires any two of the Mechanic specializations"
+		},
+		{
+			"type": "advantage",
+			"id": "35f0df32-b932-46c6-9d21-3e7a195d5560",
+			"name": "Chief Engineer's License",
+			"mental": true,
+			"reference": "GTFT84",
+			"calc": {
+				"points": 0
+			},
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "advantage_prereq",
+						"has": true,
+						"name": {
+							"compare": "is"
+						}
+					},
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Engineer"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 12
+						},
+						"specialization": {
+							"compare": "is",
+							"qualifier": "Starship"
+						}
+					}
+				]
+			},
+			"notes": "8 points in Mechanic (Jump Drive, Maneuver Drive, Power Plant, Starship) and Engineer (Starship)"
+		},
+		{
+			"type": "advantage",
+			"id": "1f15a707-2581-4514-9960-0b3c1ac6b197",
+			"name": "Mate's License",
+			"mental": true,
+			"reference": "GTFT83",
+			"calc": {
+				"points": 0
+			},
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Spacer"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 12
+						}
+					},
+					{
+						"type": "advantage_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Sensor Operator's Certificate"
+						}
+					},
+					{
+						"type": "advantage_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Communication Operator's Certificate"
+						}
+					},
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Engineer"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 10
+						}
+					},
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Shiphandling"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 12
+						}
+					},
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Piloting"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 12
+						},
+						"specialization": {
+							"compare": "is",
+							"qualifier": "High-Performance Spacecraft"
+						}
+					},
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Freight Handling"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 12
+						}
+					},
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Navigation"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 12
+						},
+						"specialization": {
+							"compare": "is",
+							"qualifier": "Hyperspace"
+						}
+					}
+				]
+			}
+		},
+		{
+			"type": "advantage",
+			"id": "ec2e769d-ce50-45d5-a76d-8d7f7677f65e",
+			"name": "Master's License",
+			"mental": true,
+			"reference": "GTFT85",
+			"calc": {
+				"points": 0
+			},
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Tactics"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 12
+						}
+					},
+					{
+						"type": "advantage_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Mate's License"
+						}
+					},
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Leadership"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 12
+						}
+					}
+				]
+			},
+			"notes": "Must not have a non-Secret debilitating psychological disadvantage.  8 points in Administration, Navigation (Hyperspace), Law, Piloting (High-Performance Spaceship), Spacer, Shiphandling (Starship)"
+		},
+		{
+			"type": "advantage",
+			"id": "ad9365bc-c94f-4eca-9ecf-ff3e21283b83",
+			"name": "Cargomaster's Certificate",
+			"mental": true,
+			"reference": "GTFT85",
+			"calc": {
+				"points": 0
+			},
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Savoir-Faire"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 12
+						}
+					},
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Merchant"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 12
+						}
+					},
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Freight Handling"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 12
+						}
+					}
+				]
+			}
+		},
+		{
+			"type": "advantage",
+			"id": "0240b3a9-3caf-47bb-9556-c710ed2fb122",
+			"name": "Basic Hazardous Material Handler's Certificate",
+			"mental": true,
+			"reference": "GTFT85",
+			"calc": {
+				"points": 0
+			},
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Environment Suit"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 12
+						}
+					},
+					{
+						"type": "advantage_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Cargomaster's Certificate"
+						}
+					},
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Hazardous Materials"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 12
+						}
+					}
+				]
+			}
+		},
+		{
+			"type": "advantage",
+			"id": "cfcd81ad-7c3b-44a0-a5de-702afa7186e6",
+			"name": "Advanced Hazardous Material Handler's Certificate",
+			"mental": true,
+			"reference": "GTFT85",
+			"calc": {
+				"points": 0
+			},
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is"
+						}
+					},
+					{
+						"type": "advantage_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Basic Hazardous Material Handler's Certificate"
+						}
+					}
+				]
+			}
+		},
+		{
+			"type": "advantage",
+			"id": "34129f08-ee71-426e-9675-f6c69f03af11",
+			"name": "Broker's License",
+			"mental": true,
+			"reference": "GTFT85",
+			"calc": {
+				"points": 0
+			},
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Merchant"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 12
+						}
+					},
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Law"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 10
+						}
+					}
+				]
+			},
+			"notes": "Specific to one world."
+		}
+	]
+}


### PR DESCRIPTION
These should be identical to the ones on GURPS Traveller Far Trader
pages 83-85, with some small changes to remove references to skills in
GURPS 3E that are no longer found in 4E.  Shipbuilding has been merged
into Engineer (Starships).  Shipmaster is now Shiphandling (Starship).
This removes the distinction between Limited and Unlimited Master's and
Mate's Licenses, so now there is just one type of Master's License and
one type of Mate's License.

Note that a few of the licenses require a certain number of points
spread across multiple skills, or multiple specializations of a skill,
of skills, which are not supported by the current GCS prerequisite
system, so for those licenses that part of the requirement is just
written in the notes rather than actually enforced.  Players and GMs
should manually check that characters actually fulfill any requirements
listed in the notes.