### PR TITLE
Fix Forest Guardian skills list for Wood Elf race

### DIFF
--- a/Library/Dungeon Fantasy/Races/Elves/Wood Elf.gct
+++ b/Library/Dungeon Fantasy/Races/Elves/Wood Elf.gct
@@ -458,8 +458,8 @@
 							"per_level": true,
 							"selection_type": "skills_with_name",
 							"name": {
-								"compare": "contains",
-								"qualifier": "biology"
+								"compare": "is",
+								"qualifier": "bow"
 							}
 						},
 						{
@@ -469,7 +469,21 @@
 							"selection_type": "skills_with_name",
 							"name": {
 								"compare": "is",
-								"qualifier": "farming"
+								"qualifier": "camouflage"
+							}
+						},
+						{
+							"type": "skill_bonus",
+							"amount": 1,
+							"per_level": true,
+							"selection_type": "skills_with_name",
+							"specialization": {
+								"compare": "is",
+								"qualifier": "arrow"
+							},
+							"name": {
+								"compare": "is",
+								"qualifier": "fast-draw"
 							}
 						},
 						{
@@ -479,7 +493,7 @@
 							"selection_type": "skills_with_name",
 							"name": {
 								"compare": "is",
-								"qualifier": "gardening"
+								"qualifier": "stealth"
 							}
 						},
 						{
@@ -487,19 +501,13 @@
 							"amount": 1,
 							"per_level": true,
 							"selection_type": "skills_with_name",
+							"specialization": {
+								"compare": "is",
+								"qualifier": "woodlands"
+							},
 							"name": {
 								"compare": "is",
-								"qualifier": "herb lore"
-							}
-						},
-						{
-							"type": "skill_bonus",
-							"amount": 1,
-							"per_level": true,
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "naturalist"
+								"qualifier": "survival"
 							}
 						}
 					],


### PR DESCRIPTION
It looks like the skills that were associated with the Forest Guardian talent from the DF Wood Elf race were actually the skills for the Green Thumb talent.