### PR TITLE
Fixed Harpoon skill references

### DIFF
--- a/Library/Basic Set/Basic Set Equipment.eqp
+++ b/Library/Basic Set/Basic Set Equipment.eqp
@@ -9849,6 +9849,7 @@
 						"base": "5"
 					},
 					"strength": "11",
+					"usage": "Thrown",
 					"accuracy": "2",
 					"range": "x1/x1.5",
 					"rate_of_fire": "1",
@@ -9857,7 +9858,8 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Thrown Weapon (Harpoon)"
+							"name": "Thrown Weapon",
+							"specialization": "Harpoon"
 						},
 						{
 							"type": "dx",
@@ -9865,7 +9867,8 @@
 						},
 						{
 							"type": "skill",
-							"name": "Thrown Weapon (Spear)",
+							"name": "Thrown Weapon",
+							"specialization": "Spear",
 							"modifier": -2
 						}
 					],


### PR DESCRIPTION
The harpoon in Basic Set Equipment had the wrong skill references