### PR TITLE
Fix Cost Adjustment for APHC Ammo in High-Tech

### DIFF
--- a/Library/High Tech/High Tech Equipment Modifiers.eqm
+++ b/Library/High Tech/High Tech Equipment Modifiers.eqm
@@ -321,7 +321,7 @@
 					"name": "Armor-Piercing Hardcore",
 					"reference": "HT167",
 					"cost_type": "to_base_cost",
-					"cost": "+0.5 CF"
+					"cost": "+1 CF"
 				},
 				{
 					"id": "b2e50996-a50e-4ed6-8d43-2af408a96451",
@@ -849,7 +849,7 @@
 					"name": "Armor-Piercing Hardcore",
 					"reference": "HT167",
 					"cost_type": "to_final_base_cost",
-					"cost": "x1.5"
+					"cost": "x2"
 				},
 				{
 					"id": "84373e5b-a632-4aca-aefc-30119a8ba9dd",


### PR DESCRIPTION
Armor-Piercing Hardcore multiplies CPS by 2, rather than 1.5.