### PR TITLE
Fix technique limits for A New Take on Grappling

### DIFF
--- a/Library/Pyramid Magazine/Pyramid 34/Pyramid 34 Skills.skl
+++ b/Library/Pyramid Magazine/Pyramid 34/Pyramid 34 Skills.skl
@@ -168,7 +168,7 @@
 				"name": "Judo",
 				"modifier": -3
 			},
-			"limit": 2
+			"limit": -1
 		},
 		{
 			"id": "7df71335-9c12-42b9-8cae-18c19dd9c9ef",
@@ -185,7 +185,7 @@
 				"name": "Sumo Wrestling",
 				"modifier": -3
 			},
-			"limit": 2
+			"limit": -1
 		},
 		{
 			"id": "23a1042a-dc4a-422e-aa8b-d4ebc16d0fff",
@@ -202,7 +202,7 @@
 				"name": "Wrestling",
 				"modifier": -3
 			},
-			"limit": 2
+			"limit": -1
 		},
 		{
 			"id": "2bec256b-9485-4cff-9c20-b66f77df6a88",
@@ -251,7 +251,7 @@
 				"name": "Wrestling",
 				"modifier": -2
 			},
-			"limit": 2
+			"limit": 0
 		},
 		{
 			"id": "36a398aa-78dc-44e1-bab0-d65a5449a588",
@@ -483,7 +483,7 @@
 				"name": "Judo",
 				"modifier": -3
 			},
-			"limit": 3
+			"limit": 0
 		},
 		{
 			"id": "c453f06e-9483-4b4b-8c51-ae409d46b11c",
@@ -500,7 +500,7 @@
 				"name": "Sumo Wrestling",
 				"modifier": -5
 			},
-			"limit": 3
+			"limit": -2
 		},
 		{
 			"id": "7b78ae7b-c597-4f54-87ec-47fc45c680a1",
@@ -517,7 +517,7 @@
 				"name": "Wrestling",
 				"modifier": -3
 			},
-			"limit": 3
+			"limit": 0
 		},
 		{
 			"id": "02ab9d93-c07b-4745-a1bb-1aac56e70bac",
@@ -534,7 +534,7 @@
 				"name": "Judo",
 				"modifier": -4
 			},
-			"limit": 4
+			"limit": 0
 		},
 		{
 			"id": "2db53ac4-0f0b-406a-b7fa-e4762a97bdf3",
@@ -551,7 +551,7 @@
 				"name": "Sumo Wrestling",
 				"modifier": -6
 			},
-			"limit": 4
+			"limit": -2
 		},
 		{
 			"id": "517a605d-e7a9-4e9b-95bd-bfc6a8f8c376",
@@ -568,7 +568,7 @@
 				"name": "Wrestling",
 				"modifier": -4
 			},
-			"limit": 4
+			"limit": 0
 		},
 		{
 			"id": "e1bd02c1-4883-4fe3-8773-b0f207f03085",
@@ -585,7 +585,7 @@
 				"name": "Judo",
 				"modifier": -4
 			},
-			"limit": 4
+			"limit": 0
 		},
 		{
 			"id": "67f7318b-86ad-40af-9f83-ae7a6911a43e",
@@ -602,7 +602,7 @@
 				"name": "Sumo Wrestling",
 				"modifier": -6
 			},
-			"limit": 4
+			"limit": -2
 		},
 		{
 			"id": "4222fa74-e071-46a5-a352-711d365be1f6",
@@ -619,7 +619,7 @@
 				"name": "Wrestling",
 				"modifier": -4
 			},
-			"limit": 4
+			"limit": 0
 		},
 		{
 			"id": "e4f6cd05-420a-4c75-9910-0ecb21fd7fd0",
@@ -636,7 +636,7 @@
 				"name": "Judo",
 				"modifier": -4
 			},
-			"limit": 4
+			"limit": 0
 		},
 		{
 			"id": "d647c0e1-eab5-49dd-ab9e-610d8a5b3ef2",
@@ -653,7 +653,7 @@
 				"name": "Sumo Wrestling",
 				"modifier": -6
 			},
-			"limit": 4
+			"limit": -2
 		},
 		{
 			"id": "3c2a47c6-4994-462b-981c-1fc5f74717b1",
@@ -670,7 +670,7 @@
 				"name": "Wrestling",
 				"modifier": -4
 			},
-			"limit": 4
+			"limit": 0
 		},
 		{
 			"id": "677e3030-69e5-4b9f-8602-eb6dc6d16b3e",
@@ -687,7 +687,7 @@
 				"name": "Judo",
 				"modifier": -3
 			},
-			"limit": 3
+			"limit": 0
 		},
 		{
 			"id": "ebddde97-62a1-4118-a2e4-5c893a3fdc79",
@@ -704,7 +704,7 @@
 				"name": "Sumo Wrestling",
 				"modifier": -5
 			},
-			"limit": 3
+			"limit": -2
 		},
 		{
 			"id": "75fbd6c5-82a9-452a-a977-18e3c8066a56",
@@ -721,7 +721,7 @@
 				"name": "Wrestling",
 				"modifier": -3
 			},
-			"limit": 3
+			"limit": 0
 		},
 		{
 			"id": "e5daaadb-bd8b-4be0-8d50-dc21d3370395",
@@ -738,7 +738,7 @@
 				"name": "Judo",
 				"modifier": -5
 			},
-			"limit": 3
+			"limit": -2
 		},
 		{
 			"id": "9d9afd1e-f0cf-4172-bb8a-233c2f6fa760",
@@ -755,7 +755,7 @@
 				"name": "Sumo Wrestling",
 				"modifier": -7
 			},
-			"limit": 3
+			"limit": -4
 		},
 		{
 			"id": "ac468ec1-7f65-4b1b-bffb-fcbf744f04b3",
@@ -772,7 +772,7 @@
 				"name": "Wrestling",
 				"modifier": -5
 			},
-			"limit": 3
+			"limit": -2
 		},
 		{
 			"id": "251c02da-3834-4c40-aca1-09c2cf276ba6",
@@ -789,7 +789,7 @@
 				"name": "Judo",
 				"modifier": -4
 			},
-			"limit": 1
+			"limit": -3
 		},
 		{
 			"id": "34e16008-3547-4a32-a49c-c2b85a474149",
@@ -806,7 +806,7 @@
 				"name": "Sumo Wrestling",
 				"modifier": -6
 			},
-			"limit": 1
+			"limit": -5
 		},
 		{
 			"id": "e4e9f8fa-159c-49a8-a89f-794f09489f1b",
@@ -823,7 +823,7 @@
 				"name": "Wrestling",
 				"modifier": -4
 			},
-			"limit": 1
+			"limit": -3
 		},
 		{
 			"id": "2ff8f168-496d-477a-a83a-c37075a73b1d",
@@ -840,7 +840,7 @@
 				"name": "Judo",
 				"modifier": -2
 			},
-			"limit": 2
+			"limit": 0
 		},
 		{
 			"id": "02865c6e-8cd9-408a-a688-82e5c3f9d34e",
@@ -857,7 +857,7 @@
 				"name": "Sumo Wrestling",
 				"modifier": -4
 			},
-			"limit": 2
+			"limit": -2
 		},
 		{
 			"id": "83b0f5fd-5c6a-4208-bb3c-b729a0a9c25d",
@@ -874,7 +874,7 @@
 				"name": "Wrestling",
 				"modifier": -2
 			},
-			"limit": 2
+			"limit": 0
 		},
 		{
 			"id": "09137925-cb02-45ca-bbca-cbc80b23c674",
@@ -891,7 +891,7 @@
 				"name": "Judo",
 				"modifier": -4
 			},
-			"limit": 1
+			"limit": -3
 		},
 		{
 			"id": "d60c3356-b465-40f9-8cae-83f03d6dfcd6",
@@ -908,7 +908,7 @@
 				"name": "Sumo Wrestling",
 				"modifier": -6
 			},
-			"limit": 1
+			"limit": -5
 		},
 		{
 			"id": "7fa8797a-abad-4c90-9c6a-9a2b25b2be0d",
@@ -925,7 +925,7 @@
 				"name": "Wrestling",
 				"modifier": -4
 			},
-			"limit": 1
+			"limit": -3
 		},
 		{
 			"id": "829ca818-52a0-4536-8c13-ad5f6a0a2b38",


### PR DESCRIPTION
Many of the limits for techniques found in A New Take on Grappling are incorrect.
The current limits are inputted as if the techniques said "cannot exceed prerequisite skill+x" as is usual for most techniques. The techniques in question however, say "cannot exceed default+x".