### PR TITLE
Cost Factors for Basic Set Equipment Modifiers

### DIFF
--- a/Library/Basic Set/Basic Set Equipment Modifiers.eqm
+++ b/Library/Basic Set/Basic Set Equipment Modifiers.eqm
@@ -221,7 +221,7 @@
 					"reference": "B275",
 					"notes": "+2 to break",
 					"cost_type": "to_base_cost",
-					"cost": "+18 CF"
+					"cost": "+19 CF"
 				},
 				{
 					"id": "c095f89e-cc51-4203-83c7-e630eb77f4d5",
@@ -230,7 +230,7 @@
 					"reference": "B275",
 					"notes": "Reduced wounding multiplier to vulnerable targets: x2 becomes x1.5, x3 becomes x2, x4 becomes x3",
 					"cost_type": "to_base_cost",
-					"cost": "+1 CF"
+					"cost": "+2 CF"
 				},
 				{
 					"id": "1ec94aaf-2041-49e5-b33c-b7741a73d8d8",
@@ -238,7 +238,7 @@
 					"name": "Silver Bullets",
 					"reference": "B275",
 					"cost_type": "to_base_cost",
-					"cost": "+48 CF"
+					"cost": "+49 CF"
 				}
 			],
 			"name": "Cost Factors"
@@ -456,7 +456,7 @@
 					"reference": "B275",
 					"notes": "+2 to break",
 					"cost_type": "to_base_cost",
-					"cost": "x19"
+					"cost": "x20"
 				},
 				{
 					"id": "d94a64f0-47ba-48e6-9cb1-285dd5d0c780",
@@ -465,7 +465,7 @@
 					"reference": "B275",
 					"notes": "Reduced wounding multiplier to vulnerable targets: x2 becomes x1.5, x3 becomes x2, x4 becomes x3",
 					"cost_type": "to_base_cost",
-					"cost": "x2"
+					"cost": "x3"
 				},
 				{
 					"id": "c49a7edd-1c86-4e0f-962b-c4e1b083060c",
@@ -473,7 +473,7 @@
 					"name": "Silver Bullets",
 					"reference": "B275",
 					"cost_type": "to_base_cost",
-					"cost": "x49"
+					"cost": "x50"
 				}
 			],
 			"name": "Multipliers"

--- a/Library/Basic Set/Basic Set Equipment Modifiers.eqm
+++ b/Library/Basic Set/Basic Set Equipment Modifiers.eqm
@@ -3,231 +3,480 @@
 	"version": 4,
 	"rows": [
 		{
-			"id": "04f61624-9ebc-4ce9-ac6f-b381e359f3ac",
+			"id": "0968b2b8-694c-44ef-b46c-a1ab16df6761",
+			"type": "eqp_modifier_container",
+			"name": "Note",
+			"notes": "Both Cost Factor and Multiplicative Modifiers for equipment are provided here. Kromm recommends using Cost Factor which was introduced in Low-Tech, rather than the multiplicative cost modifiers. But some GMs may wish to use multiplicative."
+		},
+		{
+			"id": "728f1581-50a0-4c51-8951-7025e041c9c4",
 			"type": "eqp_modifier_container",
 			"open": true,
 			"children": [
 				{
-					"id": "deeb1400-a8b7-4e33-8f8c-5e747507c63d",
+					"id": "7366c26f-19ec-40d5-a453-f06b0d8d499b",
 					"type": "eqp_modifier_container",
 					"open": true,
 					"children": [
 						{
-							"id": "a82d5d92-78d3-418d-a4d3-9f4e4100ffb0",
-							"type": "eqp_modifier",
-							"name": "Fine Quality",
-							"reference": "B277",
-							"notes": "Increase 1/2D and Max range by 20%",
-							"cost_type": "to_base_cost",
-							"cost": "x4"
-						}
-					],
-					"name": "Blowpipe, Bow \u0026 Crossbow Weapon Quality",
-					"reference": "B277"
-				},
-				{
-					"id": "4966e73f-b195-483b-a04c-978ac9138624",
-					"type": "eqp_modifier_container",
-					"open": true,
-					"children": [
-						{
-							"id": "6ed41037-feef-407e-a166-d97d0a32d684",
-							"type": "eqp_modifier",
-							"name": "Fine Quality",
-							"reference": "B280",
-							"notes": "+1 to Acc; +1 to Malf",
-							"cost_type": "to_base_cost",
-							"cost": "x2"
-						},
-						{
-							"id": "98591a98-c689-44a7-b1c8-e4d002acb453",
-							"type": "eqp_modifier",
-							"name": "Very Fine Quality",
-							"reference": "B280",
-							"notes": "+2 to Acc; +1 to Malf",
-							"cost_type": "to_base_cost",
-							"cost": "x5"
-						}
-					],
-					"name": "Firearm Weapon Quality",
-					"reference": "B280"
-				},
-				{
-					"id": "f373d17e-1f6b-4312-88a0-d3a4a18bcd76",
-					"type": "eqp_modifier_container",
-					"open": true,
-					"children": [
-						{
-							"id": "8efb201a-db64-47bd-8ac3-d0ea85f55740",
+							"id": "992c2e44-b657-4d6a-88ef-4c33fe3c6104",
 							"type": "eqp_modifier_container",
 							"open": true,
 							"children": [
 								{
-									"id": "e1f0980b-eec4-4e27-9e56-9c0a797417cd",
-									"type": "eqp_modifier",
-									"name": "Cheap Quality",
-									"reference": "B274",
-									"notes": "+2 to break, -1 Acc if thrown",
-									"cost_type": "to_base_cost",
-									"cost": "x0.4"
-								},
-								{
-									"id": "41229252-0fe2-4b85-97b8-bfcc440808d6",
+									"id": "2c4b47c1-eb0c-4037-9d78-0ee436af5fc0",
 									"type": "eqp_modifier",
 									"name": "Fine Quality",
-									"reference": "B274",
-									"notes": "-1 to break; blades only",
+									"reference": "B277",
+									"notes": "Increase 1/2D and Max range by 20%",
 									"cost_type": "to_base_cost",
-									"cost": "x4",
-									"features": [
-										{
-											"type": "weapon_bonus",
-											"selection_type": "this_weapon",
-											"amount": 1
-										}
-									]
-								},
-								{
-									"id": "58c7080b-005b-4677-804f-3d31df72ce66",
-									"type": "eqp_modifier",
-									"name": "Fine Quality",
-									"reference": "B274",
-									"notes": "-1 to break; for non-blades that do only crushing or impaling damage",
-									"cost_type": "to_base_cost",
-									"cost": "x3"
-								},
-								{
-									"id": "5ab0e073-5309-4caa-a2c0-e62488d5d25e",
-									"type": "eqp_modifier",
-									"name": "Fine Quality",
-									"reference": "B274",
-									"notes": "-1 to break; for non-blades that do cutting damage",
-									"cost_type": "to_base_cost",
-									"cost": "x10",
-									"features": [
-										{
-											"type": "weapon_bonus",
-											"selection_type": "this_weapon",
-											"amount": 1
-										}
-									]
-								},
-								{
-									"id": "431dc28d-d5cd-45e8-ba48-591362d71614",
-									"type": "eqp_modifier",
-									"name": "Very Fine Quality",
-									"reference": "B274",
-									"notes": "-2 to break; for fencing weapons and swords only",
-									"cost_type": "to_base_cost",
-									"cost": "x20",
-									"features": [
-										{
-											"type": "weapon_bonus",
-											"selection_type": "this_weapon",
-											"amount": 2
-										}
-									]
+									"cost": "+3 CF"
 								}
 							],
-							"name": "TL6 or less",
-							"reference": "B274"
+							"name": "Blowpipe, Bow \u0026 Crossbow Weapon Quality",
+							"reference": "B277"
 						},
 						{
-							"id": "5b0fe0f0-124d-4410-acea-25e2a687d934",
+							"id": "d13a81d1-c138-470d-b219-3117785c25ed",
 							"type": "eqp_modifier_container",
 							"open": true,
 							"children": [
 								{
-									"id": "e225f88d-21c7-4d77-a0df-13d9acc48d24",
-									"type": "eqp_modifier",
-									"name": "Cheap Quality",
-									"reference": "B274",
-									"notes": "+2 to break, -1 Acc if thrown",
-									"cost_type": "to_base_cost",
-									"cost": "x0.2"
-								},
-								{
-									"id": "5121cc2f-efd9-4ad5-b4b4-882fb5d86630",
-									"type": "eqp_modifier",
-									"name": "Good Quality",
-									"reference": "B274",
-									"cost_type": "to_base_cost",
-									"cost": "x0.4"
-								},
-								{
-									"id": "6328780f-a1e3-41b4-8661-2b306b86b960",
+									"id": "6f3a344b-b5d1-47e0-9141-891639273287",
 									"type": "eqp_modifier",
 									"name": "Fine Quality",
-									"reference": "B274",
-									"notes": "-1 to break; for blades that do cutting and impaling damage",
-									"features": [
-										{
-											"type": "weapon_bonus",
-											"selection_type": "this_weapon",
-											"amount": 1
-										}
-									]
+									"reference": "B280",
+									"notes": "+1 to Acc; +1 to Malf",
+									"cost_type": "to_base_cost",
+									"cost": "+1 CF"
 								},
 								{
-									"id": "41b1736e-bf77-4dd6-83f3-8923bb4d5309",
+									"id": "cf4c9959-e2c8-44d5-8c8f-e0afaa571945",
 									"type": "eqp_modifier",
 									"name": "Very Fine Quality",
-									"reference": "B274",
-									"notes": "-2 to break; +2 to cutting and impaling damage; for fencing weapons and swords only",
+									"reference": "B280",
+									"notes": "+2 to Acc; +1 to Malf",
 									"cost_type": "to_base_cost",
-									"cost": "x4",
-									"features": [
-										{
-											"type": "weapon_bonus",
-											"selection_type": "this_weapon",
-											"amount": 2
-										}
-									]
-								},
-								{
-									"id": "02151d9e-7f86-4be4-bd12-eae88f8f0c12",
-									"type": "eqp_modifier",
-									"name": "Fine Quality",
-									"reference": "B274",
-									"notes": "-1 to break; for other weapons"
+									"cost": "+4 CF"
 								}
 							],
-							"name": "TL7 or greater",
-							"reference": "B274"
+							"name": "Firearm Weapon Quality",
+							"reference": "B280"
+						},
+						{
+							"id": "228879f3-1333-4ca7-8504-30d213b098f6",
+							"type": "eqp_modifier_container",
+							"open": true,
+							"children": [
+								{
+									"id": "9595ab33-8e00-4911-a81a-75e233f0f08e",
+									"type": "eqp_modifier_container",
+									"open": true,
+									"children": [
+										{
+											"id": "91bd8dcf-f599-495e-a15a-9434a79e2ded",
+											"type": "eqp_modifier",
+											"name": "Cheap Quality",
+											"reference": "B274",
+											"notes": "+2 to break, -1 Acc if thrown",
+											"cost_type": "to_base_cost",
+											"cost": "-0.6 CF"
+										},
+										{
+											"id": "f50e8161-72f6-4f64-a502-1af7d97b0ee1",
+											"type": "eqp_modifier",
+											"name": "Fine Quality",
+											"reference": "B274",
+											"notes": "-1 to break; blades only",
+											"cost_type": "to_base_cost",
+											"cost": "+3 CF",
+											"features": [
+												{
+													"type": "weapon_bonus",
+													"selection_type": "this_weapon",
+													"amount": 1
+												}
+											]
+										},
+										{
+											"id": "834ab918-4677-415a-b44a-d84dde7a5bf5",
+											"type": "eqp_modifier",
+											"name": "Fine Quality",
+											"reference": "B274",
+											"notes": "-1 to break; for non-blades that do only crushing or impaling damage",
+											"cost_type": "to_base_cost",
+											"cost": "+2 CF"
+										},
+										{
+											"id": "6a661d47-ee7d-45d6-bc22-98c6254ccf97",
+											"type": "eqp_modifier",
+											"name": "Fine Quality",
+											"reference": "B274",
+											"notes": "-1 to break; for non-blades that do cutting damage",
+											"cost_type": "to_base_cost",
+											"cost": "+9 CF",
+											"features": [
+												{
+													"type": "weapon_bonus",
+													"selection_type": "this_weapon",
+													"amount": 1
+												}
+											]
+										},
+										{
+											"id": "fc58222d-d7f8-478d-8432-5d1907864ff4",
+											"type": "eqp_modifier",
+											"name": "Very Fine Quality",
+											"reference": "B274",
+											"notes": "-2 to break; for fencing weapons and swords only",
+											"cost_type": "to_base_cost",
+											"cost": "+19 CF",
+											"features": [
+												{
+													"type": "weapon_bonus",
+													"selection_type": "this_weapon",
+													"amount": 2
+												}
+											]
+										}
+									],
+									"name": "TL6 or less",
+									"reference": "B274"
+								},
+								{
+									"id": "9795c491-0877-4266-9a43-539b771c4126",
+									"type": "eqp_modifier_container",
+									"open": true,
+									"children": [
+										{
+											"id": "22258cb1-d0c0-4695-9785-2297ad032260",
+											"type": "eqp_modifier",
+											"name": "Cheap Quality",
+											"reference": "B274",
+											"notes": "+2 to break, -1 Acc if thrown",
+											"cost_type": "to_base_cost",
+											"cost": "-0.8 CF"
+										},
+										{
+											"id": "70c2076e-7f24-4639-8f66-d9c30f09ced3",
+											"type": "eqp_modifier",
+											"name": "Good Quality",
+											"reference": "B274",
+											"cost_type": "to_base_cost",
+											"cost": "-0.6 CF"
+										},
+										{
+											"id": "27bb5066-8eca-401c-8289-da93d5a6ab0b",
+											"type": "eqp_modifier",
+											"name": "Fine Quality",
+											"reference": "B274",
+											"notes": "-1 to break; for blades that do cutting and impaling damage",
+											"features": [
+												{
+													"type": "weapon_bonus",
+													"selection_type": "this_weapon",
+													"amount": 1
+												}
+											]
+										},
+										{
+											"id": "fa394b70-0097-48be-9879-eb7d113f5c8b",
+											"type": "eqp_modifier",
+											"name": "Very Fine Quality",
+											"reference": "B274",
+											"notes": "-2 to break; +2 to cutting and impaling damage; for fencing weapons and swords only",
+											"cost_type": "to_base_cost",
+											"cost": "+3 CF",
+											"features": [
+												{
+													"type": "weapon_bonus",
+													"selection_type": "this_weapon",
+													"amount": 2
+												}
+											]
+										},
+										{
+											"id": "6746bcad-8d62-48ae-b19d-d2fe778c8cc0",
+											"type": "eqp_modifier",
+											"name": "Fine Quality",
+											"reference": "B274",
+											"notes": "-1 to break; for other weapons"
+										}
+									],
+									"name": "TL7 or greater",
+									"reference": "B274"
+								}
+							],
+							"name": "Melee, Thrown, Arrow \u0026 Bolt Weapon Quality",
+							"reference": "B274",
+							"notes": "Weapon damage is included in the modifiers"
 						}
 					],
-					"name": "Melee, Thrown, Arrow \u0026 Bolt Weapon Quality",
-					"reference": "B274",
-					"notes": "Weapon damage is included in the modifiers"
+					"name": "Weapon Quality"
+				},
+				{
+					"id": "0bbd759b-51c1-4431-a410-46cb09b5b9f7",
+					"type": "eqp_modifier",
+					"name": "Silver",
+					"reference": "B275",
+					"notes": "+2 to break",
+					"cost_type": "to_base_cost",
+					"cost": "+18 CF"
+				},
+				{
+					"id": "c095f89e-cc51-4203-83c7-e630eb77f4d5",
+					"type": "eqp_modifier",
+					"name": "Silver-coated",
+					"reference": "B275",
+					"notes": "Reduced wounding multiplier to vulnerable targets: x2 becomes x1.5, x3 becomes x2, x4 becomes x3",
+					"cost_type": "to_base_cost",
+					"cost": "+1 CF"
+				},
+				{
+					"id": "1ec94aaf-2041-49e5-b33c-b7741a73d8d8",
+					"type": "eqp_modifier",
+					"name": "Silver Bullets",
+					"reference": "B275",
+					"cost_type": "to_base_cost",
+					"cost": "+48 CF"
 				}
 			],
-			"name": "Weapon Quality"
+			"name": "Cost Factors"
 		},
 		{
-			"id": "14b76b22-60e4-42ff-94c2-d3ae2d0fb1b9",
-			"type": "eqp_modifier",
-			"name": "Silver",
-			"reference": "B275",
-			"notes": "+2 to break",
-			"cost_type": "to_base_cost",
-			"cost": "x19"
-		},
-		{
-			"id": "d94a64f0-47ba-48e6-9cb1-285dd5d0c780",
-			"type": "eqp_modifier",
-			"name": "Silver-coated",
-			"reference": "B275",
-			"notes": "Reduced wounding multiplier to vulnerable targets: x2 becomes x1.5, x3 becomes x2, x4 becomes x3",
-			"cost_type": "to_base_cost",
-			"cost": "x2"
-		},
-		{
-			"id": "c49a7edd-1c86-4e0f-962b-c4e1b083060c",
-			"type": "eqp_modifier",
-			"name": "Silver Bullets",
-			"reference": "B275",
-			"cost_type": "to_base_cost",
-			"cost": "x49"
+			"id": "6ca65492-6776-4e98-900e-f103c52dec58",
+			"type": "eqp_modifier_container",
+			"open": true,
+			"children": [
+				{
+					"id": "04f61624-9ebc-4ce9-ac6f-b381e359f3ac",
+					"type": "eqp_modifier_container",
+					"open": true,
+					"children": [
+						{
+							"id": "deeb1400-a8b7-4e33-8f8c-5e747507c63d",
+							"type": "eqp_modifier_container",
+							"open": true,
+							"children": [
+								{
+									"id": "a82d5d92-78d3-418d-a4d3-9f4e4100ffb0",
+									"type": "eqp_modifier",
+									"name": "Fine Quality",
+									"reference": "B277",
+									"notes": "Increase 1/2D and Max range by 20%",
+									"cost_type": "to_base_cost",
+									"cost": "x4"
+								}
+							],
+							"name": "Blowpipe, Bow \u0026 Crossbow Weapon Quality",
+							"reference": "B277"
+						},
+						{
+							"id": "4966e73f-b195-483b-a04c-978ac9138624",
+							"type": "eqp_modifier_container",
+							"open": true,
+							"children": [
+								{
+									"id": "6ed41037-feef-407e-a166-d97d0a32d684",
+									"type": "eqp_modifier",
+									"name": "Fine Quality",
+									"reference": "B280",
+									"notes": "+1 to Acc; +1 to Malf",
+									"cost_type": "to_base_cost",
+									"cost": "x2"
+								},
+								{
+									"id": "98591a98-c689-44a7-b1c8-e4d002acb453",
+									"type": "eqp_modifier",
+									"name": "Very Fine Quality",
+									"reference": "B280",
+									"notes": "+2 to Acc; +1 to Malf",
+									"cost_type": "to_base_cost",
+									"cost": "x5"
+								}
+							],
+							"name": "Firearm Weapon Quality",
+							"reference": "B280"
+						},
+						{
+							"id": "f373d17e-1f6b-4312-88a0-d3a4a18bcd76",
+							"type": "eqp_modifier_container",
+							"open": true,
+							"children": [
+								{
+									"id": "8efb201a-db64-47bd-8ac3-d0ea85f55740",
+									"type": "eqp_modifier_container",
+									"open": true,
+									"children": [
+										{
+											"id": "e1f0980b-eec4-4e27-9e56-9c0a797417cd",
+											"type": "eqp_modifier",
+											"name": "Cheap Quality",
+											"reference": "B274",
+											"notes": "+2 to break, -1 Acc if thrown",
+											"cost_type": "to_base_cost",
+											"cost": "x0.4"
+										},
+										{
+											"id": "41229252-0fe2-4b85-97b8-bfcc440808d6",
+											"type": "eqp_modifier",
+											"name": "Fine Quality",
+											"reference": "B274",
+											"notes": "-1 to break; blades only",
+											"cost_type": "to_base_cost",
+											"cost": "x4",
+											"features": [
+												{
+													"type": "weapon_bonus",
+													"selection_type": "this_weapon",
+													"amount": 1
+												}
+											]
+										},
+										{
+											"id": "58c7080b-005b-4677-804f-3d31df72ce66",
+											"type": "eqp_modifier",
+											"name": "Fine Quality",
+											"reference": "B274",
+											"notes": "-1 to break; for non-blades that do only crushing or impaling damage",
+											"cost_type": "to_base_cost",
+											"cost": "x3"
+										},
+										{
+											"id": "5ab0e073-5309-4caa-a2c0-e62488d5d25e",
+											"type": "eqp_modifier",
+											"name": "Fine Quality",
+											"reference": "B274",
+											"notes": "-1 to break; for non-blades that do cutting damage",
+											"cost_type": "to_base_cost",
+											"cost": "x10",
+											"features": [
+												{
+													"type": "weapon_bonus",
+													"selection_type": "this_weapon",
+													"amount": 1
+												}
+											]
+										},
+										{
+											"id": "431dc28d-d5cd-45e8-ba48-591362d71614",
+											"type": "eqp_modifier",
+											"name": "Very Fine Quality",
+											"reference": "B274",
+											"notes": "-2 to break; for fencing weapons and swords only",
+											"cost_type": "to_base_cost",
+											"cost": "x20",
+											"features": [
+												{
+													"type": "weapon_bonus",
+													"selection_type": "this_weapon",
+													"amount": 2
+												}
+											]
+										}
+									],
+									"name": "TL6 or less",
+									"reference": "B274"
+								},
+								{
+									"id": "5b0fe0f0-124d-4410-acea-25e2a687d934",
+									"type": "eqp_modifier_container",
+									"open": true,
+									"children": [
+										{
+											"id": "e225f88d-21c7-4d77-a0df-13d9acc48d24",
+											"type": "eqp_modifier",
+											"name": "Cheap Quality",
+											"reference": "B274",
+											"notes": "+2 to break, -1 Acc if thrown",
+											"cost_type": "to_base_cost",
+											"cost": "x0.2"
+										},
+										{
+											"id": "5121cc2f-efd9-4ad5-b4b4-882fb5d86630",
+											"type": "eqp_modifier",
+											"name": "Good Quality",
+											"reference": "B274",
+											"cost_type": "to_base_cost",
+											"cost": "x0.4"
+										},
+										{
+											"id": "6328780f-a1e3-41b4-8661-2b306b86b960",
+											"type": "eqp_modifier",
+											"name": "Fine Quality",
+											"reference": "B274",
+											"notes": "-1 to break; for blades that do cutting and impaling damage",
+											"features": [
+												{
+													"type": "weapon_bonus",
+													"selection_type": "this_weapon",
+													"amount": 1
+												}
+											]
+										},
+										{
+											"id": "41b1736e-bf77-4dd6-83f3-8923bb4d5309",
+											"type": "eqp_modifier",
+											"name": "Very Fine Quality",
+											"reference": "B274",
+											"notes": "-2 to break; +2 to cutting and impaling damage; for fencing weapons and swords only",
+											"cost_type": "to_base_cost",
+											"cost": "x4",
+											"features": [
+												{
+													"type": "weapon_bonus",
+													"selection_type": "this_weapon",
+													"amount": 2
+												}
+											]
+										},
+										{
+											"id": "02151d9e-7f86-4be4-bd12-eae88f8f0c12",
+											"type": "eqp_modifier",
+											"name": "Fine Quality",
+											"reference": "B274",
+											"notes": "-1 to break; for other weapons"
+										}
+									],
+									"name": "TL7 or greater",
+									"reference": "B274"
+								}
+							],
+							"name": "Melee, Thrown, Arrow \u0026 Bolt Weapon Quality",
+							"reference": "B274",
+							"notes": "Weapon damage is included in the modifiers"
+						}
+					],
+					"name": "Weapon Quality"
+				},
+				{
+					"id": "14b76b22-60e4-42ff-94c2-d3ae2d0fb1b9",
+					"type": "eqp_modifier",
+					"name": "Silver",
+					"reference": "B275",
+					"notes": "+2 to break",
+					"cost_type": "to_base_cost",
+					"cost": "x19"
+				},
+				{
+					"id": "d94a64f0-47ba-48e6-9cb1-285dd5d0c780",
+					"type": "eqp_modifier",
+					"name": "Silver-coated",
+					"reference": "B275",
+					"notes": "Reduced wounding multiplier to vulnerable targets: x2 becomes x1.5, x3 becomes x2, x4 becomes x3",
+					"cost_type": "to_base_cost",
+					"cost": "x2"
+				},
+				{
+					"id": "c49a7edd-1c86-4e0f-962b-c4e1b083060c",
+					"type": "eqp_modifier",
+					"name": "Silver Bullets",
+					"reference": "B275",
+					"cost_type": "to_base_cost",
+					"cost": "x49"
+				}
+			],
+			"name": "Multipliers"
 		}
 	]
 }


### PR DESCRIPTION
Added versions of the Basic Set Equipment modifiers that use the Cost Factor system introduced in Low-Tech. I copied over the Note from High-Tech Equipment Modifiers because it's a very good explanation of why to use Cost Factor versions.