### PR TITLE
Added modifiers for Basic: Perfect Balance, and corrected page refere…

### DIFF
--- a/Library/Basic Set/Basic Set Advantages.adq
+++ b/Library/Basic Set/Basic Set Advantages.adq
@@ -20115,6 +20115,16 @@
 			"base_points": 15,
 			"features": [
 				{
+					"type": "conditional_modifier",
+					"situation": "on DX and DX-based skill rolls to keep your feet or avoid being knocked down in combat",
+					"amount": 4
+				},
+				{
+					"type": "conditional_modifier",
+					"situation": "on all rolls to keep your feet if the surface is wet, slippery or unstable",
+					"amount": 6
+				},
+				{
 					"type": "skill_bonus",
 					"selection_type": "skills_with_name",
 					"name": {

--- a/Library/Basic Set/Races/Elf.gct
+++ b/Library/Basic Set/Races/Elf.gct
@@ -795,7 +795,7 @@
 				}
 			],
 			"name": "Elf",
-			"reference": "BX316",
+			"reference": "B316",
 			"ancestry": "Human",
 			"container_type": "race",
 			"calc": {


### PR DESCRIPTION
Perfect Balance:
Added the conditional modifiers for keeping your feet shown in the Basic Set book.

Elf Template:
This is in Basic: Characters rather than Basic: Compaigns, so changed the reference from BX316 to B316