### PR TITLE
Adding some advantage modifiers, correcting some racial templates

### DIFF
--- a/Library/Basic Set/Basic Set Advantages.adq
+++ b/Library/Basic Set/Basic Set Advantages.adq
@@ -2239,6 +2239,101 @@
 			}
 		},
 		{
+			"id": "bb686b77-de17-499e-b91f-a13b63368211",
+			"type": "trait",
+			"name": "Bad Reputation",
+			"reference": "B26,MA54",
+			"tags": [
+				"Disadvantage",
+				"Social"
+			],
+			"modifiers": [
+				{
+					"id": "4ab6e069-8e13-4a45-82bd-e07fbebf17a7",
+					"type": "modifier",
+					"name": "People Affected",
+					"reference": "B27",
+					"notes": "Almost everyone",
+					"cost": 1,
+					"cost_type": "multiplier",
+					"disabled": true
+				},
+				{
+					"id": "cd068eef-48af-4246-b1f4-c634f7c24a85",
+					"type": "modifier",
+					"name": "People Affected",
+					"reference": "B27",
+					"notes": "Almost everyone except @large class of people@",
+					"cost": 0.67,
+					"cost_type": "multiplier",
+					"disabled": true
+				},
+				{
+					"id": "d65bc4bc-7b2c-448f-bac1-09f70431fb57",
+					"type": "modifier",
+					"name": "People Affected",
+					"reference": "B27",
+					"notes": "@Large class of people@",
+					"cost": 0.5,
+					"cost_type": "multiplier",
+					"disabled": true
+				},
+				{
+					"id": "8ecfba87-4088-4469-baa7-9c83d0be8f02",
+					"type": "modifier",
+					"name": "People Affected",
+					"reference": "B27",
+					"notes": "@Small class of people@",
+					"cost": 0.33,
+					"cost_type": "multiplier",
+					"disabled": true
+				},
+				{
+					"id": "cea05dc0-0766-4fd4-a469-9a45972f922c",
+					"type": "modifier",
+					"name": "Recognized all the time",
+					"reference": "B28",
+					"cost": 1,
+					"cost_type": "multiplier",
+					"disabled": true
+				},
+				{
+					"id": "2d07e305-cee0-4c7f-90de-5977987209cf",
+					"type": "modifier",
+					"name": "Recognized sometimes",
+					"reference": "B28",
+					"notes": "10-",
+					"cost": 0.5,
+					"cost_type": "multiplier",
+					"disabled": true
+				},
+				{
+					"id": "9c247890-4512-431a-8f0e-3a033bc21284",
+					"type": "modifier",
+					"name": "Recognized occasionally",
+					"reference": "B28",
+					"notes": "7-",
+					"cost": 0.33,
+					"cost_type": "multiplier",
+					"disabled": true
+				}
+			],
+			"levels": 1,
+			"points_per_level": -5,
+			"features": [
+				{
+					"type": "reaction_bonus",
+					"situation": "from others aware of your reputation",
+					"amount": -1,
+					"per_level": true
+				}
+			],
+			"can_level": true,
+			"calc": {
+				"points": -5
+			}
+		},
+		{
 			"id": "227d7609-ce56-4314-8c6a-9d5cb8863e9b",
 			"type": "trait",
 			"name": "Bad Sight (Farsighted)",
@@ -2924,6 +3019,7 @@
 					"name": "Extended",
 					"reference": "B41",
 					"notes": "@Sense@",
+					"cost": 20,
 					"disabled": true
 				},
 				{
@@ -3524,7 +3620,7 @@
 				},
 				{
 					"type": "reaction_bonus",
-					"situation": "from others",
+					"situation": "from others for being clueless",
 					"amount": -2
 				},
 				{
@@ -3670,6 +3766,13 @@
 				"Physical"
 			],
 			"base_points": -5,
+			"features": [
+				{
+					"type": "conditional_modifier",
+					"situation": "to HT to resist the effects of temperature",
+					"amount": 2
+				}
+			],
 			"calc": {
 				"points": -5
 			}
@@ -3686,6 +3789,13 @@
 				"Physical"
 			],
 			"base_points": -10,
+			"features": [
+				{
+					"type": "conditional_modifier",
+					"situation": "to HT to resist the effects of temperature",
+					"amount": 2
+				}
+			],
 			"calc": {
 				"points": -10
 			}
@@ -5569,6 +5679,146 @@
 			}
 		},
 		{
+			"id": "2be6271c-17e9-4723-8e0d-21294ce60e3d",
+			"type": "trait",
+			"name": "Dependency (@Substance@)",
+			"reference": "B130",
+			"tags": [
+				"Disadvantage",
+				"Exotic",
+				"Physical"
+			],
+			"modifiers": [
+				{
+					"id": "4793e870-35c1-498e-8f21-2369f0e86283",
+					"type": "modifier",
+					"name": "Rarity: Rare",
+					"reference": "B130",
+					"cost": -30,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "5c4d859a-415c-4a03-a374-0ca3a45a2c9d",
+					"type": "modifier",
+					"name": "Rarity: Occasional",
+					"reference": "B130",
+					"cost": -20,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "520935c5-8877-47cd-bd7f-ab3949ba81ab",
+					"type": "modifier",
+					"name": "Rarity: Common",
+					"reference": "B130",
+					"cost": -10,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "ad3fe009-26bc-45b1-88fc-247e7e201084",
+					"type": "modifier",
+					"name": "Rarity: Very Common",
+					"reference": "B130",
+					"cost": -5,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "402098c4-6f70-42be-9136-66b7b6e15758",
+					"type": "modifier",
+					"name": "Illegal",
+					"reference": "B130",
+					"cost": -5,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "ba8f3e93-e409-478b-99c3-ecfbefa70089",
+					"type": "modifier",
+					"name": "Frequency: Constantly",
+					"reference": "B130",
+					"notes": "Lose 1 HP per minute without it",
+					"cost": 5,
+					"cost_type": "multiplier",
+					"disabled": true
+				},
+				{
+					"id": "86310a2f-c8cd-413e-88ae-da012c6edcbb",
+					"type": "modifier",
+					"name": "Frequency: Hourly",
+					"reference": "B130",
+					"notes": "Lose 1 HP per 10 minutes after missing a hourly dose",
+					"cost": 4,
+					"cost_type": "multiplier",
+					"disabled": true
+				},
+				{
+					"id": "39c664b4-4398-4b97-8aad-b0bafcfe895e",
+					"type": "modifier",
+					"name": "Frequency: Daily",
+					"reference": "B130",
+					"notes": "Lose 1 HP per hour after missing a daily dose",
+					"cost": 3,
+					"cost_type": "multiplier",
+					"disabled": true
+				},
+				{
+					"id": "ccad68c0-a7fd-4606-9dcd-6ae5b5b3872f",
+					"type": "modifier",
+					"name": "Frequency: Weekly",
+					"reference": "B130",
+					"notes": "Lose 1 HP per six hours after missing a weekly dose",
+					"cost": 2,
+					"cost_type": "multiplier",
+					"disabled": true
+				},
+				{
+					"id": "61e299a6-7dc0-43fc-8d6a-be932b848ec3",
+					"type": "modifier",
+					"name": "Frequency: Monthly",
+					"reference": "B130",
+					"notes": "Lose 1 HP per day after missing a monthly dose",
+					"cost": 1,
+					"cost_type": "multiplier",
+					"disabled": true
+				},
+				{
+					"id": "9a1ae412-539a-438b-9020-45cc3d29d8c3",
+					"type": "modifier",
+					"name": "Frequency: Seasonally",
+					"reference": "B130",
+					"notes": "Lose 1 HP per 3 days after missing a seasonal dose",
+					"cost": 0.3333,
+					"cost_type": "multiplier",
+					"disabled": true
+				},
+				{
+					"id": "746dbfd5-1295-449a-beb6-65adc25b6a88",
+					"type": "modifier",
+					"name": "Frequency: Yearly",
+					"reference": "B130",
+					"notes": "Lose 1 HP per 2 weeks after missing a yearly dose",
+					"cost": 0.1,
+					"cost_type": "multiplier",
+					"disabled": true
+				},
+				{
+					"id": "f9a60134-427e-48be-b97a-7cf8fdf83e86",
+					"type": "modifier",
+					"name": "Aging",
+					"reference": "B130",
+					"notes": "Age 2 years for each HP lost due to this dependency",
+					"cost": 30,
+					"disabled": true
+				}
+			],
+			"calc": {
+				"points": 0
+			}
+		},
+		{
 			"id": "0b04cb1b-da61-4ada-83e7-4f707512c4be",
 			"type": "trait",
 			"name": "Dependent (@Who@)",
@@ -5702,146 +5952,6 @@
 					"reference": "B131",
 					"cost": 2,
 					"cost_type": "multiplier",
-					"disabled": true
-				}
-			],
-			"calc": {
-				"points": 0
-			}
-		},
-		{
-			"id": "2be6271c-17e9-4723-8e0d-21294ce60e3d",
-			"type": "trait",
-			"name": "Dependency (@Substance@)",
-			"reference": "B130",
-			"tags": [
-				"Disadvantage",
-				"Exotic",
-				"Physical"
-			],
-			"modifiers": [
-				{
-					"id": "4793e870-35c1-498e-8f21-2369f0e86283",
-					"type": "modifier",
-					"name": "Rarity: Rare",
-					"reference": "B130",
-					"cost": -30,
-					"cost_type": "points",
-					"disabled": true
-				},
-				{
-					"id": "5c4d859a-415c-4a03-a374-0ca3a45a2c9d",
-					"type": "modifier",
-					"name": "Rarity: Occasional",
-					"reference": "B130",
-					"cost": -20,
-					"cost_type": "points",
-					"disabled": true
-				},
-				{
-					"id": "520935c5-8877-47cd-bd7f-ab3949ba81ab",
-					"type": "modifier",
-					"name": "Rarity: Common",
-					"reference": "B130",
-					"cost": -10,
-					"cost_type": "points",
-					"disabled": true
-				},
-				{
-					"id": "ad3fe009-26bc-45b1-88fc-247e7e201084",
-					"type": "modifier",
-					"name": "Rarity: Very Common",
-					"reference": "B130",
-					"cost": -5,
-					"cost_type": "points",
-					"disabled": true
-				},
-				{
-					"id": "402098c4-6f70-42be-9136-66b7b6e15758",
-					"type": "modifier",
-					"name": "Illegal",
-					"reference": "B130",
-					"cost": -5,
-					"cost_type": "points",
-					"disabled": true
-				},
-				{
-					"id": "ba8f3e93-e409-478b-99c3-ecfbefa70089",
-					"type": "modifier",
-					"name": "Frequency: Constantly",
-					"reference": "B130",
-					"notes": "Lose 1 HP per minute without it",
-					"cost": 5,
-					"cost_type": "multiplier",
-					"disabled": true
-				},
-				{
-					"id": "86310a2f-c8cd-413e-88ae-da012c6edcbb",
-					"type": "modifier",
-					"name": "Frequency: Hourly",
-					"reference": "B130",
-					"notes": "Lose 1 HP per 10 minutes after missing a hourly dose",
-					"cost": 4,
-					"cost_type": "multiplier",
-					"disabled": true
-				},
-				{
-					"id": "39c664b4-4398-4b97-8aad-b0bafcfe895e",
-					"type": "modifier",
-					"name": "Frequency: Daily",
-					"reference": "B130",
-					"notes": "Lose 1 HP per hour after missing a daily dose",
-					"cost": 3,
-					"cost_type": "multiplier",
-					"disabled": true
-				},
-				{
-					"id": "ccad68c0-a7fd-4606-9dcd-6ae5b5b3872f",
-					"type": "modifier",
-					"name": "Frequency: Weekly",
-					"reference": "B130",
-					"notes": "Lose 1 HP per six hours after missing a weekly dose",
-					"cost": 2,
-					"cost_type": "multiplier",
-					"disabled": true
-				},
-				{
-					"id": "61e299a6-7dc0-43fc-8d6a-be932b848ec3",
-					"type": "modifier",
-					"name": "Frequency: Monthly",
-					"reference": "B130",
-					"notes": "Lose 1 HP per day after missing a monthly dose",
-					"cost": 1,
-					"cost_type": "multiplier",
-					"disabled": true
-				},
-				{
-					"id": "9a1ae412-539a-438b-9020-45cc3d29d8c3",
-					"type": "modifier",
-					"name": "Frequency: Seasonally",
-					"reference": "B130",
-					"notes": "Lose 1 HP per 3 days after missing a seasonal dose",
-					"cost": 0.3333,
-					"cost_type": "multiplier",
-					"disabled": true
-				},
-				{
-					"id": "746dbfd5-1295-449a-beb6-65adc25b6a88",
-					"type": "modifier",
-					"name": "Frequency: Yearly",
-					"reference": "B130",
-					"notes": "Lose 1 HP per 2 weeks after missing a yearly dose",
-					"cost": 0.1,
-					"cost_type": "multiplier",
-					"disabled": true
-				},
-				{
-					"id": "f9a60134-427e-48be-b97a-7cf8fdf83e86",
-					"type": "modifier",
-					"name": "Aging",
-					"reference": "B130",
-					"notes": "Age 2 years for each HP lost due to this dependency",
-					"cost": 30,
 					"disabled": true
 				}
 			],
@@ -6151,6 +6261,18 @@
 				}
 			],
 			"base_points": 15,
+			"features": [
+				{
+					"type": "conditional_modifier",
+					"situation": "to Shadowing skill when following a noisy target",
+					"amount": 4
+				},
+				{
+					"type": "conditional_modifier",
+					"situation": "on any task that utilizes hearing",
+					"amount": 4
+				}
+			],
 			"calc": {
 				"points": 15
 			}
@@ -6184,6 +6306,22 @@
 				}
 			],
 			"base_points": 15,
+			"features": [
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Tracking"
+					},
+					"amount": 4
+				},
+				{
+					"type": "conditional_modifier",
+					"situation": "on any task that utilizes the sense of smell",
+					"amount": 4
+				}
+			],
 			"calc": {
 				"points": 15
 			}
@@ -6209,6 +6347,13 @@
 				}
 			],
 			"base_points": 10,
+			"features": [
+				{
+					"type": "conditional_modifier",
+					"situation": "on any task that utilizes the sense of taste",
+					"amount": 4
+				}
+			],
 			"calc": {
 				"points": 10
 			}
@@ -9039,6 +9184,102 @@
 			}
 		},
 		{
+			"id": "3c155ebc-3a17-4a33-abec-c8392e2dbe95",
+			"type": "trait",
+			"name": "Good Reputation",
+			"reference": "B26,MA54",
+			"tags": [
+				"Advantage",
+				"Social"
+			],
+			"modifiers": [
+				{
+					"id": "38aa3113-4709-485c-be35-ba35d96192fd",
+					"type": "modifier",
+					"name": "People Affected",
+					"reference": "B27",
+					"notes": "Almost everyone",
+					"cost": 1,
+					"cost_type": "multiplier",
+					"disabled": true
+				},
+				{
+					"id": "39082380-367d-4319-9daf-854976f45562",
+					"type": "modifier",
+					"name": "People Affected",
+					"reference": "B27",
+					"notes": "Almost everyone except @large class of people@",
+					"cost": 0.67,
+					"cost_type": "multiplier",
+					"disabled": true
+				},
+				{
+					"id": "b43f0211-b5bf-4271-b6cc-acd6483af8d2",
+					"type": "modifier",
+					"name": "People Affected",
+					"reference": "B27",
+					"notes": "@Large class of people@",
+					"cost": 0.5,
+					"cost_type": "multiplier",
+					"disabled": true
+				},
+				{
+					"id": "ca59a34a-2467-417f-9764-46e7617201a2",
+					"type": "modifier",
+					"name": "People Affected",
+					"reference": "B27",
+					"notes": "@Small class of people@",
+					"cost": 0.33,
+					"cost_type": "multiplier",
+					"disabled": true
+				},
+				{
+					"id": "bf87af2b-67fd-43ca-b53d-22911e628cfe",
+					"type": "modifier",
+					"name": "Recognized all the time",
+					"reference": "B28",
+					"cost": 1,
+					"cost_type": "multiplier",
+					"disabled": true
+				},
+				{
+					"id": "a0d8d318-d895-4cd6-9412-3b4839438dbe",
+					"type": "modifier",
+					"name": "Recognized sometimes",
+					"reference": "B28",
+					"notes": "10-",
+					"cost": 0.5,
+					"cost_type": "multiplier",
+					"disabled": true
+				},
+				{
+					"id": "c32da9c0-87ba-4504-b87d-7ae275bec1ce",
+					"type": "modifier",
+					"name": "Recognized occasionally",
+					"reference": "B28",
+					"notes": "7-",
+					"cost": 0.33,
+					"cost_type": "multiplier",
+					"disabled": true
+				}
+			],
+			"levels": 1,
+			"points_per_level": 5,
+			"features": [
+				{
+					"type": "reaction_bonus",
+					"situation": "from others aware of your reputation",
+					"amount": 1,
+					"per_level": true
+				}
+			],
+			"round_down": true,
+			"can_level": true,
+			"calc": {
+				"points": 5
+			}
+		},
+		{
 			"id": "b7a0c1db-f40a-471a-857f-e0c88e218d72",
 			"type": "trait",
 			"name": "Greed",
@@ -9929,6 +10170,23 @@
 			],
 			"calc": {
 				"points": 10
+			}
+		},
+		{
+			"id": "528254ea-5457-4090-979b-b06583bb2f76",
+			"type": "trait",
+			"name": "High Status",
+			"reference": "B28",
+			"notes": "@Description@",
+			"tags": [
+				"Advantage",
+				"Social"
+			],
+			"levels": 1,
+			"points_per_level": 5,
+			"can_level": true,
+			"calc": {
+				"points": 5
 			}
 		},
 		{
@@ -15747,6 +16005,23 @@
 			}
 		},
 		{
+			"id": "9bbb06dc-5928-4edf-b987-4ec0f7c2f500",
+			"type": "trait",
+			"name": "Low Status ",
+			"reference": "B28",
+			"notes": "@Description@",
+			"tags": [
+				"Disadvantage",
+				"Social"
+			],
+			"levels": 1,
+			"points_per_level": -5,
+			"can_level": true,
+			"calc": {
+				"points": -5
+			}
+		},
+		{
 			"id": "43deafab-dce4-4e71-b42c-40847484dcb8",
 			"type": "trait",
 			"name": "Low TL",
@@ -18633,6 +18908,12 @@
 			"levels": 1,
 			"points_per_level": 1,
 			"features": [
+				{
+					"type": "conditional_modifier",
+					"situation": "to all HT rolls concerned with eye damage",
+					"amount": 1,
+					"per_level": true
+				},
 				{
 					"type": "dr_bonus",
 					"location": "eye",
@@ -21730,181 +22011,6 @@
 			"base_points": -10,
 			"calc": {
 				"points": -10
-			}
-		},
-		{
-			"id": "bb686b77-de17-499e-b91f-a13b63368211",
-			"type": "trait",
-			"name": "Bad Reputation",
-			"reference": "B26,MA54",
-			"tags": [
-				"Disadvantage",
-				"Social"
-			],
-			"modifiers": [
-				{
-					"id": "4ab6e069-8e13-4a45-82bd-e07fbebf17a7",
-					"type": "modifier",
-					"name": "People Affected",
-					"reference": "B27",
-					"notes": "Almost everyone",
-					"cost": 1,
-					"cost_type": "multiplier",
-					"disabled": true
-				},
-				{
-					"id": "cd068eef-48af-4246-b1f4-c634f7c24a85",
-					"type": "modifier",
-					"name": "People Affected",
-					"reference": "B27",
-					"notes": "Almost everyone except @large class of people@",
-					"cost": 0.67,
-					"cost_type": "multiplier",
-					"disabled": true
-				},
-				{
-					"id": "d65bc4bc-7b2c-448f-bac1-09f70431fb57",
-					"type": "modifier",
-					"name": "People Affected",
-					"reference": "B27",
-					"notes": "@Large class of people@",
-					"cost": 0.5,
-					"cost_type": "multiplier",
-					"disabled": true
-				},
-				{
-					"id": "8ecfba87-4088-4469-baa7-9c83d0be8f02",
-					"type": "modifier",
-					"name": "People Affected",
-					"reference": "B27",
-					"notes": "@Small class of people@",
-					"cost": 0.33,
-					"cost_type": "multiplier",
-					"disabled": true
-				},
-				{
-					"id": "cea05dc0-0766-4fd4-a469-9a45972f922c",
-					"type": "modifier",
-					"name": "Recognized all the time",
-					"reference": "B28",
-					"cost": 1,
-					"cost_type": "multiplier",
-					"disabled": true
-				},
-				{
-					"id": "2d07e305-cee0-4c7f-90de-5977987209cf",
-					"type": "modifier",
-					"name": "Recognized sometimes",
-					"reference": "B28",
-					"notes": "10-",
-					"cost": 0.5,
-					"cost_type": "multiplier",
-					"disabled": true
-				},
-				{
-					"id": "9c247890-4512-431a-8f0e-3a033bc21284",
-					"type": "modifier",
-					"name": "Recognized occasionally",
-					"reference": "B28",
-					"notes": "7-",
-					"cost": 0.33,
-					"cost_type": "multiplier",
-					"disabled": true
-				}
-			],
-			"levels": 1,
-			"points_per_level": -5,
-			"can_level": true,
-			"calc": {
-				"points": -5
-			}
-		},
-		{
-			"id": "3c155ebc-3a17-4a33-abec-c8392e2dbe95",
-			"type": "trait",
-			"name": "Good Reputation",
-			"reference": "B26,MA54",
-			"tags": [
-				"Advantage",
-				"Social"
-			],
-			"modifiers": [
-				{
-					"id": "38aa3113-4709-485c-be35-ba35d96192fd",
-					"type": "modifier",
-					"name": "People Affected",
-					"reference": "B27",
-					"notes": "Almost everyone",
-					"cost": 1,
-					"cost_type": "multiplier",
-					"disabled": true
-				},
-				{
-					"id": "39082380-367d-4319-9daf-854976f45562",
-					"type": "modifier",
-					"name": "People Affected",
-					"reference": "B27",
-					"notes": "Almost everyone except @large class of people@",
-					"cost": 0.67,
-					"cost_type": "multiplier",
-					"disabled": true
-				},
-				{
-					"id": "b43f0211-b5bf-4271-b6cc-acd6483af8d2",
-					"type": "modifier",
-					"name": "People Affected",
-					"reference": "B27",
-					"notes": "@Large class of people@",
-					"cost": 0.5,
-					"cost_type": "multiplier",
-					"disabled": true
-				},
-				{
-					"id": "ca59a34a-2467-417f-9764-46e7617201a2",
-					"type": "modifier",
-					"name": "People Affected",
-					"reference": "B27",
-					"notes": "@Small class of people@",
-					"cost": 0.33,
-					"cost_type": "multiplier",
-					"disabled": true
-				},
-				{
-					"id": "bf87af2b-67fd-43ca-b53d-22911e628cfe",
-					"type": "modifier",
-					"name": "Recognized all the time",
-					"reference": "B28",
-					"cost": 1,
-					"cost_type": "multiplier",
-					"disabled": true
-				},
-				{
-					"id": "a0d8d318-d895-4cd6-9412-3b4839438dbe",
-					"type": "modifier",
-					"name": "Recognized sometimes",
-					"reference": "B28",
-					"notes": "10-",
-					"cost": 0.5,
-					"cost_type": "multiplier",
-					"disabled": true
-				},
-				{
-					"id": "c32da9c0-87ba-4504-b87d-7ae275bec1ce",
-					"type": "modifier",
-					"name": "Recognized occasionally",
-					"reference": "B28",
-					"notes": "7-",
-					"cost": 0.33,
-					"cost_type": "multiplier",
-					"disabled": true
-				}
-			],
-			"levels": 1,
-			"points_per_level": 5,
-			"round_down": true,
-			"can_level": true,
-			"calc": {
-				"points": 5
 			}
 		},
 		{
@@ -25082,40 +25188,6 @@
 			"base_points": 30,
 			"calc": {
 				"points": 30
-			}
-		},
-		{
-			"id": "528254ea-5457-4090-979b-b06583bb2f76",
-			"type": "trait",
-			"name": "High Status",
-			"reference": "B28",
-			"notes": "@Description@",
-			"tags": [
-				"Advantage",
-				"Social"
-			],
-			"levels": 1,
-			"points_per_level": 5,
-			"can_level": true,
-			"calc": {
-				"points": 5
-			}
-		},
-		{
-			"id": "9bbb06dc-5928-4edf-b987-4ec0f7c2f500",
-			"type": "trait",
-			"name": "Low Status ",
-			"reference": "B28",
-			"notes": "@Description@",
-			"tags": [
-				"Disadvantage",
-				"Social"
-			],
-			"levels": 1,
-			"points_per_level": -5,
-			"can_level": true,
-			"calc": {
-				"points": -5
 			}
 		},
 		{
@@ -29612,7 +29684,7 @@
 			"notes": "@Subject@",
 			"tags": [
 				"Disadvantage",
-				"Physical"
+				"Mental"
 			],
 			"modifiers": [
 				{
@@ -30440,6 +30512,13 @@
 				}
 			],
 			"base_points": -15,
+			"features": [
+				{
+					"type": "reaction_bonus",
+					"situation": "from people who realise you are a weirdness magnet (except parapsychologists, cultists, conspiracy theorists, thrill-seekers)",
+					"amount": -2
+				}
+			],
 			"calc": {
 				"points": -15
 			}

--- a/Library/Basic Set/Characters/C31R07.gcs
+++ b/Library/Basic Set/Characters/C31R07.gcs
@@ -1,0 +1,4235 @@
+{
+	"type": "character",
+	"version": 4,
+	"id": "e6a25218-065c-4bd0-ac14-b8630858b36d",
+	"total_points": 1665,
+	"points_record": [
+		{
+			"when": "2023-01-15T07:56:34Z",
+			"points": 1665,
+			"reason": "Initial points"
+		}
+	],
+	"profile": {
+		"player_name": "NPC",
+		"name": "C31R07",
+		"religion": "Buddhist",
+		"age": "3",
+		"birthday": "n/a",
+		"eyes": "n/a",
+		"hair": "n/a",
+		"skin": "Metal",
+		"handedness": "n/a",
+		"gender": "n/a",
+		"tech_level": "9",
+		"portrait": "UklGRvASAABXRUJQVlA4WAoAAAAwAAAAjwAAvwAASUNDUMgBAAAAAAHIAAAAAAQwAABtbnRyUkdCIFhZWiAAAAAAAAAAAAAAAABhY3NwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAA9tYAAQAAAADTLQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAlkZXNjAAAA8AAAACRyWFlaAAABFAAAABRnWFlaAAABKAAAABRiWFlaAAABPAAAABR3dHB0AAABUAAAABRyVFJDAAABZAAAAChnVFJDAAABZAAAAChiVFJDAAABZAAAAChjcHJ0AAABjAAAADxtbHVjAAAAAAAAAAEAAAAMZW5VUwAAAAgAAAAcAHMAUgBHAEJYWVogAAAAAAAAb6IAADj1AAADkFhZWiAAAAAAAABimQAAt4UAABjaWFlaIAAAAAAAACSgAAAPhAAAts9YWVogAAAAAAAA9tYAAQAAAADTLXBhcmEAAAAAAAQAAAACZmYAAPKnAAANWQAAE9AAAApbAAAAAAAAAABtbHVjAAAAAAAAAAEAAAAMZW5VUwAAACAAAAAcAEcAbwBvAGcAbABlACAASQBuAGMALgAgADIAMAAxADZBTFBIGAAAAAEPMP8REUJB2gbM/Juehk9E/xNy8QxCQFZQOCDiEAAAcEMAnQEqkADAAD5tMpRGpCMiISgXG8CADYllANOaU+B/YmqP7DMD4PdnH0v7eLnX/S3vLfoNdLjkObH/9P4N+OL3doJYr+srUa7Y/239r9F+9X5WahHsXeA7Z+gR7kfc+/9/0/RHxAv5f/Uv+f7Ad9P+H/43sB/0H/J/sB7KP1l6FfrH2DP2F61f7s+yT+1zU85Keclcs5A9ZiXjz7DjXWkWvE66IRO1mp/DR/8i8qy5UL9NKgTghw49yiIYzjfvnv9QlkSoDZcYV6LcVqBvkxf5bYfDfMX/qadhwe66i8aeBFeXAbvNASJQaNqCb8UIOt7bp7oCRXNDw5z6X+99ti2+44XWdSJ1H29xLbnY7RqQMWcAuFY4Ni7FJmArOM0E0z61NtZv58zAZzZGIkQy/2YzXxLT6dbkRoAOEQiYh9vAHqT2H0zRq3ePOZGkUxfq2oQiEA+4yyH+DwAD6z4twwTb+tuVsK7Hrm9sxLddy48CVSryU+Ow/2Gvg1M+PZ0wAJyNzHY8PSO4tJNoEtZVOUmeaTL+KhbC+EB5CKXVfdTuyKxygQWvpdfVVOdUqLghHBAohdK2UKV126s48OLgQEiXFLAfXsbxRCGnqyvPaTLZXVYy1J3tAQBdw39v2d6Z9OcGTwVTUsGkfghfq2OkIm669aZ0J+vCyWn31s9cIMlEgdfzvcbQ7Wg6DO3vZUexKeUKcwJXxwfbq0+9oIlvc8Da7AAA/v5HgABXEk///1aMv8UFwC9DhxIxVLu9xr89faCFlyDEpB9qJsGJ+yDugY79RkwILSdd+KOnIWSN8izoSGKEULeX/FG13ZVq1a35oRX7h6Lb8dkZ/GbxG+/yaIYCB/R+T1Qo9Fk2TGcKxUxJaaEHqlK9SfEVWmi2JoXinLXkG25EIgyBd3byv8+ninwwxq6BNsFhgiw1NkJax2WN9V2u2saGjqwcVqKgXLsX0jqnweBz4acdcSc1VE+ScDjsSYCGN22qSZTUKruX7X4c/OMi0ZuO2myp2Ui7G9EABAlM2UOFEAEMI8eS+jiiBdCwMOh1rX8oJwUiPvP3bNKY4bkAB9p44EjBrejhOKrmLugblT44mk1vTWv0GvoLQRAHzZGCra0YN0fHOzxrHNScHzZ0JClymnKPI53f7BZS5De4qrhPIowrx8vR6cBKCaHKbwVUyrlmScswcQ6nTt5Qry1X7g6Bo9ekHG5Jw/tyc+46kTqLEbgicIjNGfT/KiKlKPUHfk5N+oe1kP022UGau3EoN/z1zSbp6P1MW9qlCQmTtBWorPmg1nx+ORvyjVYCm2NcZ5uzt64n+q/YyzcUXBfmpGrokzBeCkTOEZ1Tnoyvtk92pb8xT0GFea4Q6kBhh6o19Qrz6VVMAmlCCybKY9CKWn1EBU0CaqqaXPAsdAlR8B1E1BHo41Xfu9BTmFgqNgWNTjxCEOAgeJeUpKHlgyZhS2mbc5gN5yKu+gjDKqLHN0EXDuwAQwHf176Zh0FUCJ6mCPDKpdzvtiFyqiGb5SLva4XVd+EsSnTuxSjdo5CXcdTmIGwDBNd0fr1crwME+Wbn1f8wFS6IeYOlNsxyZdv5KhTijTyIm7r65WqPP3M4tmNL+blDAJtAEto/LvEkqxHxu3ijiLA+rqlyrTLMtYvvAWivLjqz+MqjWzvr62e/viRdjeUVcxsli9uNg+0jL8i9XfiUdTcWgGib9zaRGRvZl3p28OV6PRNPpucvnm98lceoYU/OHP5cnupjHWEvo1+WEc/eamzUsgJk4DfZ0PYHzVUkdgCfDJE+7ehVkG5ojqQKMWk7U/YP+PrP2amZdvs825jxq1k5idrSuA5JJR4sjDpRnsP+IM6WuDThpQ8c48oL5nT8tvUABlV/9wk2UYqZAOPuOxNaTnBFCdHhOmG05zOOqi79gYvH0K7WdYP8M8yogkQYrCI6+pkwsQjwSE/Q+sqn8YxwQTctnEr6NbkU5Jui7bUdfvRfp81RqyvscUxplbOtGc9IGorvgTa1++0XivX4vAxQE0OJZG9AKnozQonMOCZacY+bSPnnT83sqOJvsRywnnU7owxnE/sqoRZJDN98Ycr7fNSboSd8puJwxbCepbzzAeLkfXRNVi1h8QkxraG6y7BrsBO5LHSOZkbXKkyzaDiFbpNkDSETo+8F6aQZFqvWZlGfe5Fdn/nNUA5kLsB2QuWPqkxlaua6AYQnV17K5+2MdKPDEIumsr7ukHBF9joSuzfS3e4KZz5V5gMlrRAhLkX1RxCpDr3IqFl98znRfhvOnEicB80Mgw3DWCLgwlpTPtEG/F766b0Id8ehI7aMb3uVF6zRBcU86Pg16wk5qAgwe0CKSC41N5C4OaCGiUOhy8tigVwW3KrUXrsT8iVA9ElEYSM1kT4LY1k0wuscYvdPp2oGnnS9O/nquNZfW4M/sXKy2d06hqAPCOZJz6SXyXnj9l3vsbZFa6b/CNtSQULr9dlIuuUnAo8Sg2eB4QUXpBAQEvZyrcvL/v6hnfwKdbf4LYNoIqMrHBJ2ZqKtGX/wGsEMBH2cAub6PAXRYr+rYpSeFAw54Mo5gyHLmZ8pLxawOsbRQ1b4w6YU+xpXqY+67j25xT/UkyUcS8+4Apue03A75tbCepk87fDHMAzuT21nB7h6hB/CtfgTYiQElV/0Cp+cK1RnitHm24WxLNB8jy3rLhA3e5BnBwIZ0lSc/pNk2KUcRB1hyJuLKt9V2N7W9b8Jgflj1iX/PRLaBEEAp7xCW5PnBdfQ3YH2a3TyfY5dlCg6Z8r4GwkWCj/a2Hx2MKbqFLgOLaRItvP3Bvz+wfSl2atDmr+bSuQSFuSVZ9SYEMYARHRDmHo6CdTlYCV2DFaf6Sxulu68QtJV+LpZP2NqgRHjF4GmycztYceTtWg58tS1OpCupvPv70JdP3JttfiM5hQ+C/jbqwqlSqsvzIZxoqEYReaHKIDxKOcpfNSaYs2bGChIav7N4aU+dvi75KA5czVqFi65ovgFiEHuHzVg+wLKSWmh0YVYCZH91yBzoO2Aluf+WSYlQrT6cmUi4vyh/h+g300qj0Nma3ZEHyLGBPoecnVHuBOtPavo1TNLdUqRBlCSaUhl13pjTbg/8xW8gLeRnwRkhYx9W4g0F7z1teeo5Whl2tduS5JNjJyQKztO510Fe+ujEyVrbuN9Sj98NjOOCPuF9Ba8+Tl34RhhJDGUXUsiG+nhClCgzuTxFkZypX86Pl5RaLlhOx3W/V0MQzMUu09Wk+1giOHhIbgLQz/ZL2ugCwQWky6YnEkAhc0RZJEgYAD/yEdYJ5VgnzxQ5xFKJgZJm9slxOIm659tTUVLA5GGgUy7OV5Av8IdfulCNtTQLCYSyhxiC6OITJrj/FqxgtyShfQgQMzdG+2PDFnMQSqy939YxYjQ9JE2fUNGb1SijPSk3nn02PNUdu5K5oRK0YXuUw6++uj8F6tjwDUxHq6qskgxHIcm7+/ta9TeEO/4OW1kfuiadk2/wMT73qX32bNKDO2xrxjVzy7dBqVspbBvtd1Eur/Kv8dMPp0k4Q1g9E+GT9uFZaD0ZD3pXv9JlNFrXbiNXBY1wjqihcI4EjWsiCgy6m0exgPDNuP0nb8BYQAP0XXyNZPAVBpLLXPd5H++ly6Xz9qxbN/MMjakCnnyIAqPw5zDt6zSsvhiAyit3j6wrctN6CyptK1+2+dwM79n7WQh+Hqzq6I6ObqsbXppm7LZO2mCIfM33muTDlzBxu3sP3jx0ArIBzljT6JC0v8N6Nn0IpZA1CEcMm6adGqhy20HTqbtUbIGPQZyZkckn1xgzhSkScBPUzQs1RvSCCpfYWPLiF+73GiB2y9VbtYiCKqtMabUeAeBc00nJuAtcc5c36F97gyxs+jzhCif+KXtY5cDlT0s2WDxh+RsbwFaKT5i/rbsd9Vb8XVf7I3dwnwpKZ+wVxBfgr53PbxKotQ0rjfiHcwcMPueYpzOi+WANTBkhZMh0xnEUZPReA1HoAg6Ok3pV94DvhM+5AOIErq5aw44i41sgOjwe8fLilom14BBiYmAdfOrloFhWSUbS1W1Ck1yNx0ryMGsO1r/buFycEHaNm4OTrpL/jZTfIcxD03Dvdm3PiJkhsqGShgxOqVWWNAnwx6qXGIWY57azQtL0+CrVdcFCcweD7hskkML3Ksnr3zldpKs1hqKY+lelHBdR2Oa6Hsl0SRAHQww3BfGkzrFAlfCWsqYdCh7rdYrQJFPXIVqFBck3kk996uEYPpu8/XxOwOtyoyzpkcSFMbc5U6lMWa5dbGVO/zfdUdMSd37ktw6XvytXW317dXoo0patKNEYqaWqah4fy5yI7LNuRDRiYsaVNBpUPZXNCMjZzFBQsOoOvTsjSi2iXLWgtWPQPZjlnO+VnNc2/8ntwkD7R3KeL826hOyKk6JrlssUOC2W9ukAB/QbrXCreYIdAHsGVSe/RVN5BmH4OsEGtRDOQHKA4M0nfR/KEskLBQRuH/pID3gia0I8IdWHCD6MknzEwk3qD3EJ5S1vxWYL/igC5HYzVzaGUM4PdaeLzRFFMm+2SJmuOAFgp1SxWfSMGE7j0bj1ISczs8X9mX6BilVb6hl9IcIc19sONB4c17HcbfUAp/esIFzDOpCCAF3SknwFufNkYKlWMvG/UHszNTgUSPNODO3TUpYHYL0PEi7R6YiGapmp5HI19iwvMyptHAz12BlYvXe1JSLJmCnlKQ/9dKcrNmo6zS8KTim2QQN4dVkI8YgDFp5hND7vt9/1czzV6JcAFEYh5bjDh7yFxrFe0pLX1DvKnv841009UZhQgNHiczeFg1IVUCzgR1frpb/Oc7tH7wYCbk+jTzTHHFdHvL1rUwkv1gJvK4jElg1x5cLB8REXw8YyCE8rES3vQceggB6ciggQwjSb594gx8rjRagQ7J0ck+3kpGMSODSsrrF4beaByCqx72+a3B+zLedysp9zsPuZ/Utn4bJdzUW/4j/AxvFFeYngOD0smb4o59ZGhyN2bF6X20FGfXkZYsKc/b1X9ybB220NQSCQgd1bI6QN8LY68MLWXAhLW9x7Kvfb4hMKoDde7zQiK407hODKQ5XxnjGZ20qiLYRilbZ8CzTnjoAhRR3hugDiIm0FHl6u0xoiIOLOlGSORnbBfsN/zEXx56BB5VpsgLKEdH5PiOcSvSqpyOhV6kJfjzTvR0N2vz9X5MHJzQl0L1bCEGlNOElEHSy0FsThV5mXDwwHqnZe/IA69/9E/hPnjZKnQ7i7muCMrIT55OFWsIwANitoH0op+LQvpiHOqdEtjo6UWwefh8yrLscSQizJ7luyl+/DXfWwohBPRPQMcc78B1SnNVSbs62LBp0AG5T2q9U0RU7wOSNsxIPYiY+rQSTau5OmOcZ2OJkFYI14W2+TOuX///1X5c0ne4IUD+zho2Sfe0Oi6Jd3BKMVmcw02Jpj6effRjtbvna1OfFd1tS3G4oPq0bhrKg0rAPG3R+XZLBoz/e/he2uQJjchIotfbvsCaKkslOmsyygMCxs/VuYzarQZfFHv/R7nfCGsY4jPYkhD/Vo00jUanYYR8cq/bvcRwVGpp3bw4iQaW9I3h5oi5QBG0V/WKlD88UaQSIM3hPhjLtCo5bdaFPIk1vCNpmVZSGldB/e2dprR1orRJGPR9bfJfiJ+MG2MERPza6r0jqpncus6fNTTgR8+ZTScY535bjl3X8iraRmpz9mY3ilHlciOd+aHL6cy5XxEq8C/IAs0rfAkSC9+4AAAAAAAA=",
+		"height": "7'8\"",
+		"weight": "2420 lb"
+	},
+	"settings": {
+		"page": {
+			"paper_size": "letter",
+			"orientation": "portrait",
+			"top_margin": "0.25 in",
+			"left_margin": "0.25 in",
+			"bottom_margin": "0.25 in",
+			"right_margin": "0.25 in"
+		},
+		"block_layout": [
+			"reactions conditional_modifiers",
+			"melee",
+			"ranged",
+			"traits skills",
+			"spells",
+			"equipment",
+			"other_equipment",
+			"notes"
+		],
+		"attributes": [
+			{
+				"id": "st",
+				"type": "integer",
+				"name": "ST",
+				"full_name": "Strength",
+				"attribute_base": "10",
+				"cost_per_point": 10,
+				"cost_adj_percent_per_sm": 10
+			},
+			{
+				"id": "dx",
+				"type": "integer",
+				"name": "DX",
+				"full_name": "Dexterity",
+				"attribute_base": "10",
+				"cost_per_point": 20
+			},
+			{
+				"id": "iq",
+				"type": "integer",
+				"name": "IQ",
+				"full_name": "Intelligence",
+				"attribute_base": "10",
+				"cost_per_point": 20
+			},
+			{
+				"id": "ht",
+				"type": "integer",
+				"name": "HT",
+				"full_name": "Health",
+				"attribute_base": "10",
+				"cost_per_point": 10
+			},
+			{
+				"id": "will",
+				"type": "integer",
+				"name": "Will",
+				"attribute_base": "$iq",
+				"cost_per_point": 5
+			},
+			{
+				"id": "fright_check",
+				"type": "integer",
+				"name": "Fright Check",
+				"attribute_base": "$will",
+				"cost_per_point": 2
+			},
+			{
+				"id": "senses",
+				"type": "secondary_separator",
+				"name": "Senses"
+			},
+			{
+				"id": "per",
+				"type": "integer",
+				"name": "Per",
+				"full_name": "Perception",
+				"attribute_base": "$iq",
+				"cost_per_point": 5
+			},
+			{
+				"id": "vision",
+				"type": "integer",
+				"name": "Vision",
+				"attribute_base": "$per",
+				"cost_per_point": 2
+			},
+			{
+				"id": "hearing",
+				"type": "integer",
+				"name": "Hearing",
+				"attribute_base": "$per",
+				"cost_per_point": 2
+			},
+			{
+				"id": "taste_smell",
+				"type": "integer",
+				"name": "Taste \u0026 Smell",
+				"attribute_base": "$per",
+				"cost_per_point": 2
+			},
+			{
+				"id": "touch",
+				"type": "integer",
+				"name": "Touch",
+				"attribute_base": "$per",
+				"cost_per_point": 2
+			},
+			{
+				"id": "movement",
+				"type": "secondary_separator",
+				"name": "Movement"
+			},
+			{
+				"id": "basic_speed",
+				"type": "decimal",
+				"name": "Basic Speed",
+				"attribute_base": "($dx+$ht)/4",
+				"cost_per_point": 20
+			},
+			{
+				"id": "basic_move",
+				"type": "integer",
+				"name": "Basic Move",
+				"attribute_base": "floor($basic_speed)",
+				"cost_per_point": 5
+			},
+			{
+				"id": "highjump",
+				"type": "integer_ref",
+				"name": "High Jump (in)",
+				"attribute_base": "(6 * max(max($basic_move, floor(skill_level(jumping) / 2)), $st / 4) - 10) * enc(false, true) * (2 ^ max(0, trait_level(super jump)))"
+			},
+			{
+				"id": "running_highjump",
+				"type": "integer_ref",
+				"name": "when running",
+				"attribute_base": "(6 * max(max($basic_move, floor(skill_level(jumping) / 2)), $st / 4) * (1 + max(0, trait_level(\"enhanced move (ground)\"))) - 10) * enc(false, true) * if(trait_level(\"enhanced move (ground)\")\u003c1,2,1) * (2 ^ max(0, trait_level(super jump)))"
+			},
+			{
+				"id": "broadjump",
+				"type": "integer_ref",
+				"name": "Broad Jump (ft)",
+				"attribute_base": "(2 * max(max($basic_move, floor(skill_level(jumping) / 2)), $st / 4) - 3) * enc(false, true) * (2 ^ max(0, trait_level(super jump)))"
+			},
+			{
+				"id": "running_broadjump",
+				"type": "integer_ref",
+				"name": "when running",
+				"attribute_base": "(2 * max(max($basic_move, floor(skill_level(jumping) / 2)), $st / 4) * (1 + max(0, trait_level(\"enhanced move (ground)\"))) - 3) * enc(false, true) * if(trait_level(\"enhanced move (ground)\")\u003c1,2,1) * (2 ^ max(0, trait_level(super jump)))"
+			},
+			{
+				"id": "fp",
+				"type": "pool",
+				"name": "FP",
+				"full_name": "Fatigue Points",
+				"attribute_base": "$ht",
+				"cost_per_point": 3,
+				"thresholds": [
+					{
+						"state": "Unconscious",
+						"expression": "-$fp",
+						"ops": [
+							"halve_move",
+							"halve_dodge",
+							"halve_st"
+						]
+					},
+					{
+						"state": "Collapse",
+						"expression": "0",
+						"explanation": "Roll vs. Will to do anything besides talk or rest; failure causes unconsciousness\nEach FP you lose below 0 also causes 1 HP of injury\nMove, Dodge and ST are halved (B426)",
+						"ops": [
+							"halve_move",
+							"halve_dodge",
+							"halve_st"
+						]
+					},
+					{
+						"state": "Tired",
+						"expression": "round($fp/3)",
+						"explanation": "Move, Dodge and ST are halved (B426)",
+						"ops": [
+							"halve_move",
+							"halve_dodge",
+							"halve_st"
+						]
+					},
+					{
+						"state": "Tiring",
+						"expression": "$fp-1"
+					},
+					{
+						"state": "Rested",
+						"expression": "$fp"
+					}
+				]
+			},
+			{
+				"id": "hp",
+				"type": "pool",
+				"name": "HP",
+				"full_name": "Hit Points",
+				"attribute_base": "$st",
+				"cost_per_point": 2,
+				"cost_adj_percent_per_sm": 10,
+				"thresholds": [
+					{
+						"state": "Dead",
+						"expression": "round(-$hp*5)",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Dying #4",
+						"expression": "round(-$hp*4)",
+						"explanation": "Roll vs. HT to avoid death\nRoll vs. HT-4 every second to avoid falling unconscious\nMove and Dodge are halved (B419)",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Dying #3",
+						"expression": "round(-$hp*3)",
+						"explanation": "Roll vs. HT to avoid death\nRoll vs. HT-3 every second to avoid falling unconscious\nMove and Dodge are halved (B419)",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Dying #2",
+						"expression": "round(-$hp*2)",
+						"explanation": "Roll vs. HT to avoid death\nRoll vs. HT-2 every second to avoid falling unconscious\nMove and Dodge are halved (B419)",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Dying #1",
+						"expression": "-$hp",
+						"explanation": "Roll vs. HT to avoid death\nRoll vs. HT-1 every second to avoid falling unconscious\nMove and Dodge are halved (B419)",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Collapse",
+						"expression": "0",
+						"explanation": "Roll vs. HT every second to avoid falling unconscious\nMove and Dodge are halved (B419)",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Reeling",
+						"expression": "round($hp/3)",
+						"explanation": "Move and Dodge are halved (B419)",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Wounded",
+						"expression": "$hp-1"
+					},
+					{
+						"state": "Healthy",
+						"expression": "$hp"
+					}
+				]
+			}
+		],
+		"body_type": {
+			"name": "Humanoid",
+			"roll": "3d",
+			"locations": [
+				{
+					"id": "eye",
+					"choice_name": "Eyes",
+					"table_name": "Eyes",
+					"hit_penalty": -9,
+					"description": "An attack that misses by 1 hits the torso instead. Only\nimpaling (imp), piercing (pi-, pi, pi+, pi++), and\ntight-beam burning (burn) attacks can target the eye – and\nonly from the front or sides. Injury over HP÷10 blinds the\neye. Otherwise, treat as skull, but without the extra DR!",
+					"calc": {
+						"roll_range": "-",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "skull",
+					"choice_name": "Skull",
+					"table_name": "Skull",
+					"slots": 2,
+					"hit_penalty": -7,
+					"dr_bonus": 2,
+					"description": "An attack that misses by 1 hits the torso instead. Wounding\nmodifier is x4. Knockdown rolls are at -10. Critical hits\nuse the Critical Head Blow Table (B556). Exception: These\nspecial effects do not apply to toxic (tox) damage.",
+					"calc": {
+						"roll_range": "3-4",
+						"dr": {
+							"all": 55
+						}
+					}
+				},
+				{
+					"id": "face",
+					"choice_name": "Face",
+					"table_name": "Face",
+					"slots": 1,
+					"hit_penalty": -5,
+					"description": "An attack that misses by 1 hits the torso instead. Jaw,\ncheeks, nose, ears, etc. If the target has an open-faced\nhelmet, ignore its DR. Knockdown rolls are at -5. Critical\nhits use the Critical Head Blow Table (B556). Corrosion\n(cor) damage gets a x1½ wounding modifier, and if it\ninflicts a major wound, it also blinds one eye (both eyes on\ndamage over full HP). Random attacks from behind hit the\nskull instead.",
+					"calc": {
+						"roll_range": "5",
+						"dr": {
+							"all": 53
+						}
+					}
+				},
+				{
+					"id": "leg",
+					"choice_name": "Leg",
+					"table_name": "Right Leg",
+					"slots": 2,
+					"hit_penalty": -2,
+					"description": "Reduce the wounding multiplier of large piercing (pi+), huge\npiercing (pi++), and impaling (imp) damage to x1. Any major\nwound (loss of over ½ HP from one blow) cripples the limb.\nDamage beyond that threshold is lost.",
+					"calc": {
+						"roll_range": "6-7",
+						"dr": {
+							"all": 53
+						}
+					}
+				},
+				{
+					"id": "arm",
+					"choice_name": "Arm",
+					"table_name": "Right Arm",
+					"slots": 1,
+					"hit_penalty": -2,
+					"description": "Reduce the wounding multiplier of large piercing (pi+), huge\npiercing (pi++), and impaling (imp) damage to x1. Any major\nwound (loss of over ½ HP from one blow) cripples the limb.\nDamage beyond that threshold is lost. If holding a shield,\ndouble the penalty to hit: -4 for shield arm instead of -2.",
+					"calc": {
+						"roll_range": "8",
+						"dr": {
+							"all": 53
+						}
+					}
+				},
+				{
+					"id": "torso",
+					"choice_name": "Torso",
+					"table_name": "Torso",
+					"slots": 2,
+					"calc": {
+						"roll_range": "9-10",
+						"dr": {
+							"all": 53
+						}
+					}
+				},
+				{
+					"id": "groin",
+					"choice_name": "Groin",
+					"table_name": "Groin",
+					"slots": 1,
+					"hit_penalty": -3,
+					"description": "An attack that misses by 1 hits the torso instead. Human\nmales and the males of similar species suffer double shock\nfrom crushing (cr) damage, and get -5 to knockdown rolls.\nOtherwise, treat as a torso hit.",
+					"calc": {
+						"roll_range": "11",
+						"dr": {
+							"all": 53
+						}
+					}
+				},
+				{
+					"id": "arm",
+					"choice_name": "Arm",
+					"table_name": "Left Arm",
+					"slots": 1,
+					"hit_penalty": -2,
+					"description": "Reduce the wounding multiplier of large piercing (pi+), huge\npiercing (pi++), and impaling (imp) damage to x1. Any major\nwound (loss of over ½ HP from one blow) cripples the limb.\nDamage beyond that threshold is lost. If holding a shield,\ndouble the penalty to hit: -4 for shield arm instead of -2.",
+					"calc": {
+						"roll_range": "12",
+						"dr": {
+							"all": 53
+						}
+					}
+				},
+				{
+					"id": "leg",
+					"choice_name": "Leg",
+					"table_name": "Left Leg",
+					"slots": 2,
+					"hit_penalty": -2,
+					"description": "Reduce the wounding multiplier of large piercing (pi+), huge\npiercing (pi++), and impaling (imp) damage to x1. Any major\nwound (loss of over ½ HP from one blow) cripples the limb.\nDamage beyond that threshold is lost.",
+					"calc": {
+						"roll_range": "13-14",
+						"dr": {
+							"all": 53
+						}
+					}
+				},
+				{
+					"id": "hand",
+					"choice_name": "Hand",
+					"table_name": "Hand",
+					"slots": 1,
+					"hit_penalty": -4,
+					"description": "If holding a shield, double the penalty to hit: -8 for\nshield hand instead of -4. Reduce the wounding multiplier of\nlarge piercing (pi+), huge piercing (pi++), and impaling\n(imp) damage to x1. Any major wound (loss of over ⅓ HP\nfrom one blow) cripples the extremity. Damage beyond that\nthreshold is lost.",
+					"calc": {
+						"roll_range": "15",
+						"dr": {
+							"all": 53
+						}
+					}
+				},
+				{
+					"id": "foot",
+					"choice_name": "Foot",
+					"table_name": "Foot",
+					"slots": 1,
+					"hit_penalty": -4,
+					"description": "Reduce the wounding multiplier of large piercing (pi+), huge\npiercing (pi++), and impaling (imp) damage to x1. Any major\nwound (loss of over ⅓ HP from one blow) cripples the\nextremity. Damage beyond that threshold is lost.",
+					"calc": {
+						"roll_range": "16",
+						"dr": {
+							"all": 54
+						}
+					}
+				},
+				{
+					"id": "neck",
+					"choice_name": "Neck",
+					"table_name": "Neck",
+					"slots": 2,
+					"hit_penalty": -5,
+					"description": "An attack that misses by 1 hits the torso instead. Neck and\nthroat. Increase the wounding multiplier of crushing (cr)\nand corrosion (cor) attacks to x1½, and that of cutting\n(cut) damage to x2. At the GM’s option, anyone killed by a\ncutting (cut) blow to the neck is decapitated!",
+					"calc": {
+						"roll_range": "17-18",
+						"dr": {
+							"all": 53
+						}
+					}
+				},
+				{
+					"id": "vitals",
+					"choice_name": "Vitals",
+					"table_name": "Vitals",
+					"hit_penalty": -3,
+					"description": "An attack that misses by 1 hits the torso instead. Heart,\nlungs, kidneys, etc. Increase the wounding modifier for an\nimpaling (imp) or any piercing (pi-, pi, pi+, pi++) attack\nto x3. Increase the wounding modifier for a tight-beam\nburning (burn) attack to x2. Other attacks cannot target the\nvitals.",
+					"calc": {
+						"roll_range": "-",
+						"dr": {
+							"all": 53
+						}
+					}
+				}
+			]
+		},
+		"damage_progression": "basic_set",
+		"default_length_units": "ft_in",
+		"default_weight_units": "lb",
+		"user_description_display": "tooltip",
+		"modifiers_display": "inline",
+		"notes_display": "inline",
+		"skill_level_adj_display": "tooltip",
+		"show_spell_adj": true,
+		"exclude_unspent_points_from_total": false
+	},
+	"attributes": [
+		{
+			"attr_id": "st",
+			"adj": 0,
+			"calc": {
+				"value": 28,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "dx",
+			"adj": 2,
+			"calc": {
+				"value": 15,
+				"points": 40
+			}
+		},
+		{
+			"attr_id": "iq",
+			"adj": 6,
+			"calc": {
+				"value": 16,
+				"points": 120
+			}
+		},
+		{
+			"attr_id": "ht",
+			"adj": 5,
+			"calc": {
+				"value": 15,
+				"points": 50
+			}
+		},
+		{
+			"attr_id": "will",
+			"adj": 0,
+			"calc": {
+				"value": 16,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "fright_check",
+			"adj": 0,
+			"calc": {
+				"value": 18,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "senses",
+			"adj": 0
+		},
+		{
+			"attr_id": "per",
+			"adj": 2,
+			"calc": {
+				"value": 18,
+				"points": 10
+			}
+		},
+		{
+			"attr_id": "vision",
+			"adj": 0,
+			"calc": {
+				"value": 18,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "hearing",
+			"adj": 0,
+			"calc": {
+				"value": 18,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "taste_smell",
+			"adj": 0,
+			"calc": {
+				"value": 18,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "touch",
+			"adj": 0,
+			"calc": {
+				"value": 18,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "movement",
+			"adj": 0
+		},
+		{
+			"attr_id": "basic_speed",
+			"adj": 0.5,
+			"calc": {
+				"value": 8,
+				"points": 10
+			}
+		},
+		{
+			"attr_id": "basic_move",
+			"adj": 0,
+			"calc": {
+				"value": 8,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "highjump",
+			"adj": 0,
+			"calc": {
+				"value": 38,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "running_highjump",
+			"adj": 0,
+			"calc": {
+				"value": 76,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "broadjump",
+			"adj": 0,
+			"calc": {
+				"value": 13,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "running_broadjump",
+			"adj": 0,
+			"calc": {
+				"value": 26,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "fp",
+			"adj": 0,
+			"calc": {
+				"value": 15,
+				"current": 15,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "hp",
+			"adj": 0,
+			"calc": {
+				"value": 42,
+				"current": 42,
+				"points": 0
+			}
+		}
+	],
+	"traits": [
+		{
+			"id": "52766534-3542-4c7b-b161-f4f307cef324",
+			"type": "trait",
+			"name": "Extra Hit Points",
+			"reference": "B16",
+			"notes": "Should be -10% for size to save 2 points, but hasn't been applied in the book",
+			"tags": [
+				"Advantage",
+				"Attribute",
+				"Physical"
+			],
+			"modifiers": [
+				{
+					"id": "910bfd80-869d-46d8-aa30-5c7c5bae59a4",
+					"type": "modifier",
+					"name": "Size",
+					"cost": -10,
+					"levels": 1,
+					"disabled": true
+				}
+			],
+			"levels": 14,
+			"points_per_level": 2,
+			"features": [
+				{
+					"type": "attribute_bonus",
+					"attribute": "hp",
+					"amount": 1,
+					"per_level": true
+				}
+			],
+			"can_level": true,
+			"calc": {
+				"points": 28
+			}
+		},
+		{
+			"id": "61605808-42e3-4102-be2d-e8acd1b23509",
+			"type": "trait",
+			"name": "Language: English",
+			"reference": "B24",
+			"tags": [
+				"Advantage",
+				"Language",
+				"Mental"
+			],
+			"modifiers": [
+				{
+					"id": "ff972d9a-b925-4895-a489-f3d14999074d",
+					"type": "modifier",
+					"name": "Native",
+					"reference": "B23",
+					"cost": -6,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "e9f38c71-c4bd-45ee-a5e2-b47a33029f96",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "None",
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "6cd10ab4-c4f9-4764-a47d-0e77d105d862",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Broken",
+					"cost": 1,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "3c7caa3c-055e-4422-ac8e-6a2d632b391c",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Accented",
+					"cost": 2,
+					"cost_type": "points"
+				},
+				{
+					"id": "231ba28d-11ce-44e1-8d23-074d40ca57c6",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Native",
+					"cost": 3,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "152ad20b-dc58-4abb-b256-71da14dbb89c",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "None",
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "6304a0d6-80f3-4a5f-b3cc-3ba2ae0c8063",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Broken",
+					"cost": 1,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "5818ab4a-2c4b-4c3e-a711-c4b6332daaca",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Accented",
+					"cost": 2,
+					"cost_type": "points"
+				},
+				{
+					"id": "1b77515e-5789-49a0-8238-7242900c8c2c",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Native",
+					"cost": 3,
+					"cost_type": "points",
+					"disabled": true
+				}
+			],
+			"calc": {
+				"points": 4
+			}
+		},
+		{
+			"id": "56e63326-c094-4558-b008-2d763493de9a",
+			"type": "trait",
+			"name": "Language: Koine Greek",
+			"reference": "B24",
+			"tags": [
+				"Advantage",
+				"Language",
+				"Mental"
+			],
+			"modifiers": [
+				{
+					"id": "ff972d9a-b925-4895-a489-f3d14999074d",
+					"type": "modifier",
+					"name": "Native",
+					"reference": "B23",
+					"cost": -6,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "e9f38c71-c4bd-45ee-a5e2-b47a33029f96",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "None",
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "6cd10ab4-c4f9-4764-a47d-0e77d105d862",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Broken",
+					"cost": 1,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "3c7caa3c-055e-4422-ac8e-6a2d632b391c",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Accented",
+					"cost": 2,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "231ba28d-11ce-44e1-8d23-074d40ca57c6",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Native",
+					"cost": 3,
+					"cost_type": "points"
+				},
+				{
+					"id": "152ad20b-dc58-4abb-b256-71da14dbb89c",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "None",
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "6304a0d6-80f3-4a5f-b3cc-3ba2ae0c8063",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Broken",
+					"cost": 1,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "5818ab4a-2c4b-4c3e-a711-c4b6332daaca",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Accented",
+					"cost": 2,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "1b77515e-5789-49a0-8238-7242900c8c2c",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Native",
+					"cost": 3,
+					"cost_type": "points"
+				}
+			],
+			"calc": {
+				"points": 6
+			}
+		},
+		{
+			"id": "cb42538c-f8e2-4725-b883-d83dd94fb54d",
+			"type": "trait",
+			"name": "Language: Machine Language",
+			"reference": "B24",
+			"tags": [
+				"Advantage",
+				"Language",
+				"Mental"
+			],
+			"modifiers": [
+				{
+					"id": "ff972d9a-b925-4895-a489-f3d14999074d",
+					"type": "modifier",
+					"name": "Native",
+					"reference": "B23",
+					"cost": -6,
+					"cost_type": "points"
+				},
+				{
+					"id": "e9f38c71-c4bd-45ee-a5e2-b47a33029f96",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "None",
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "6cd10ab4-c4f9-4764-a47d-0e77d105d862",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Broken",
+					"cost": 1,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "3c7caa3c-055e-4422-ac8e-6a2d632b391c",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Accented",
+					"cost": 2,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "231ba28d-11ce-44e1-8d23-074d40ca57c6",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Native",
+					"cost": 3,
+					"cost_type": "points"
+				},
+				{
+					"id": "152ad20b-dc58-4abb-b256-71da14dbb89c",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "None",
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "6304a0d6-80f3-4a5f-b3cc-3ba2ae0c8063",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Broken",
+					"cost": 1,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "5818ab4a-2c4b-4c3e-a711-c4b6332daaca",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Accented",
+					"cost": 2,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "1b77515e-5789-49a0-8238-7242900c8c2c",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Native",
+					"cost": 3,
+					"cost_type": "points"
+				}
+			],
+			"calc": {
+				"points": 0
+			}
+		},
+		{
+			"id": "c3461932-8e06-4cb5-bd50-26dc7585d6fc",
+			"type": "trait",
+			"name": "Language: Tibetan",
+			"reference": "B24",
+			"tags": [
+				"Advantage",
+				"Language",
+				"Mental"
+			],
+			"modifiers": [
+				{
+					"id": "ff972d9a-b925-4895-a489-f3d14999074d",
+					"type": "modifier",
+					"name": "Native",
+					"reference": "B23",
+					"cost": -6,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "e9f38c71-c4bd-45ee-a5e2-b47a33029f96",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "None",
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "6cd10ab4-c4f9-4764-a47d-0e77d105d862",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Broken",
+					"cost": 1,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "3c7caa3c-055e-4422-ac8e-6a2d632b391c",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Accented",
+					"cost": 2,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "231ba28d-11ce-44e1-8d23-074d40ca57c6",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Native",
+					"cost": 3,
+					"cost_type": "points"
+				},
+				{
+					"id": "152ad20b-dc58-4abb-b256-71da14dbb89c",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "None",
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "6304a0d6-80f3-4a5f-b3cc-3ba2ae0c8063",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Broken",
+					"cost": 1,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "5818ab4a-2c4b-4c3e-a711-c4b6332daaca",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Accented",
+					"cost": 2,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "1b77515e-5789-49a0-8238-7242900c8c2c",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Native",
+					"cost": 3,
+					"cost_type": "points"
+				}
+			],
+			"calc": {
+				"points": 6
+			}
+		},
+		{
+			"id": "2ea5a1c2-a357-4816-863a-b0857a562ca7",
+			"type": "trait",
+			"name": "Cultural Familiarity (Hegemony)",
+			"reference": "B23",
+			"notes": "Do not suffer the normal -3 penalty for unfamiliarity",
+			"tags": [
+				"Advantage",
+				"Mental"
+			],
+			"modifiers": [
+				{
+					"id": "ab12b725-01c8-4fc4-8e71-619a54c79496",
+					"type": "modifier",
+					"name": "Alien",
+					"cost": 1,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "f72aa995-6766-4eaf-a3ca-0f4ff76d47c5",
+					"type": "modifier",
+					"name": "Native",
+					"cost": -1,
+					"cost_type": "points"
+				}
+			],
+			"base_points": 1,
+			"calc": {
+				"points": 0
+			}
+		},
+		{
+			"id": "a94a3f81-5117-4d4e-aae0-97762dc80a2b",
+			"type": "trait",
+			"name": "Cultural Familiarity (Homeline)",
+			"reference": "B23",
+			"notes": "Do not suffer the normal -3 penalty for unfamiliarity",
+			"tags": [
+				"Advantage",
+				"Mental"
+			],
+			"modifiers": [
+				{
+					"id": "ab12b725-01c8-4fc4-8e71-619a54c79496",
+					"type": "modifier",
+					"name": "Alien",
+					"cost": 1,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "f72aa995-6766-4eaf-a3ca-0f4ff76d47c5",
+					"type": "modifier",
+					"name": "Native",
+					"cost": -1,
+					"cost_type": "points",
+					"disabled": true
+				}
+			],
+			"base_points": 1,
+			"calc": {
+				"points": 1
+			}
+		},
+		{
+			"id": "3774e382-9b9c-4f8b-ae0c-510af9209abb",
+			"type": "trait",
+			"name": "High TL",
+			"reference": "B23",
+			"tags": [
+				"Advantage",
+				"Mental"
+			],
+			"levels": 1,
+			"points_per_level": 5,
+			"can_level": true,
+			"calc": {
+				"points": 5
+			}
+		},
+		{
+			"id": "002e8af8-b799-4541-b995-9564208cfcb8",
+			"type": "trait_container",
+			"children": [
+				{
+					"id": "17caa148-16c3-4b27-ab27-ec51d2e11a9b",
+					"type": "trait",
+					"name": "Absolute Timing",
+					"reference": "B35",
+					"tags": [
+						"Advantage",
+						"Mental"
+					],
+					"modifiers": [
+						{
+							"id": "7c6198ac-c0c2-48c7-a955-3425e5dc35b0",
+							"type": "modifier",
+							"name": "Chronolocation",
+							"cost": 3,
+							"cost_type": "points",
+							"disabled": true
+						}
+					],
+					"base_points": 2,
+					"calc": {
+						"points": 2
+					}
+				},
+				{
+					"id": "ab3182f9-5e41-461b-97fc-94c7695c348e",
+					"type": "trait",
+					"name": "Digital Mind",
+					"reference": "B49",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"base_points": 5,
+					"calc": {
+						"points": 5
+					}
+				},
+				{
+					"id": "87da4ebd-5f4e-46dd-9415-5cd30014f22e",
+					"type": "trait",
+					"name": "Doesn't Sleep",
+					"reference": "B50",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"base_points": 20,
+					"calc": {
+						"points": 20
+					}
+				},
+				{
+					"id": "a0ffae83-1eb3-40f6-aba4-1c619f12a453",
+					"type": "trait",
+					"name": "Eidetic Memory",
+					"reference": "B51",
+					"tags": [
+						"Advantage",
+						"Mental"
+					],
+					"modifiers": [
+						{
+							"id": "0f54af00-8641-475f-93e7-b6fa26373acc",
+							"type": "modifier",
+							"name": "Photographic",
+							"reference": "B51",
+							"cost": 5,
+							"cost_type": "points"
+						}
+					],
+					"base_points": 5,
+					"calc": {
+						"points": 10
+					}
+				},
+				{
+					"id": "20930411-b4e0-4ceb-ab6c-8498ad562b1d",
+					"type": "trait",
+					"name": "Lightning Calculator",
+					"reference": "B66",
+					"tags": [
+						"Advantage",
+						"Mental"
+					],
+					"modifiers": [
+						{
+							"id": "f3fe3525-ea4d-4e88-841f-44be938f194c",
+							"type": "modifier",
+							"name": "Intuitive Mathematician",
+							"reference": "B66",
+							"cost": 3,
+							"cost_type": "points"
+						}
+					],
+					"base_points": 2,
+					"calc": {
+						"points": 5
+					}
+				}
+			],
+			"name": "Meta-Trait: Artificial Intelligence (not reprogrammable)",
+			"reference": "B263",
+			"container_type": "meta_trait",
+			"calc": {
+				"points": 42
+			}
+		},
+		{
+			"id": "195ed9d9-c4a0-42a1-8b63-c6d789288682",
+			"type": "trait",
+			"name": "Alternate Form",
+			"reference": "B83",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Physical"
+			],
+			"modifiers": [
+				{
+					"id": "c1c44e83-3ed1-4bc0-b82f-fda332179650",
+					"type": "modifier",
+					"name": "Cosmetic",
+					"reference": "B84",
+					"cost": -50,
+					"disabled": true
+				},
+				{
+					"id": "44695e7e-edf2-41c2-a7a7-2fbbf21eb447",
+					"type": "modifier",
+					"name": "Absorptive Change",
+					"reference": "P75",
+					"notes": "@Level of Absorptive Change. 1 None, 2, Light, 3, Medium, 4, Heavy, 5, Extra Heavy@",
+					"cost": 5,
+					"levels": 1,
+					"disabled": true
+				},
+				{
+					"id": "97308e27-18e1-4c68-8104-4098c26448a7",
+					"type": "modifier",
+					"name": "Active Change",
+					"reference": "P75",
+					"cost": 20,
+					"disabled": true
+				},
+				{
+					"id": "11645648-495b-4b39-912c-6d26f988a6fa",
+					"type": "modifier",
+					"name": "Non-Reciprocal Damage",
+					"reference": "P75",
+					"cost": 50,
+					"disabled": true
+				},
+				{
+					"id": "45ceba06-f5ae-495c-b9b2-96b7f2497751",
+					"type": "modifier",
+					"name": "Once On, Stays On",
+					"reference": "P75",
+					"cost": 50,
+					"disabled": true
+				},
+				{
+					"id": "bbea117c-d516-4e75-9e31-938be1279103",
+					"type": "modifier",
+					"name": "Reciprocal Rest",
+					"reference": "P75",
+					"cost": 30,
+					"disabled": true
+				},
+				{
+					"id": "96ab176f-cf69-4d13-b95f-25915798aa45",
+					"type": "modifier",
+					"name": "Projected Form",
+					"reference": "P75",
+					"cost": -50,
+					"disabled": true
+				},
+				{
+					"id": "9bfe7531-8c8f-4dc6-890b-5d0001a57e7a",
+					"type": "modifier",
+					"name": "Takes Extra Time",
+					"reference": "B115",
+					"cost": -10,
+					"levels": 1,
+					"disabled": true
+				}
+			],
+			"base_points": 15,
+			"calc": {
+				"points": 15
+			}
+		},
+		{
+			"id": "3a0ea3c5-d716-4461-8e38-9f1d33236a90",
+			"type": "trait_container",
+			"children": [
+				{
+					"id": "f925ec94-01c2-4e3d-9f28-3ece1c10a0d3",
+					"type": "trait",
+					"name": "Increased Strength",
+					"reference": "B14",
+					"notes": "Size -10%",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"levels": 18,
+					"points_per_level": 9,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "st",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"calc": {
+						"points": 162
+					}
+				},
+				{
+					"id": "5c9c8034-7828-47da-a7cd-6891a7db763a",
+					"type": "trait",
+					"name": "Increased Dexterity",
+					"reference": "B15",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"levels": 3,
+					"points_per_level": 20,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "dx",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"calc": {
+						"points": 60
+					}
+				},
+				{
+					"id": "33f8d9c4-2d51-484d-aa7a-8a27cdb899b7",
+					"type": "trait",
+					"name": "Size Modifier (Large)",
+					"reference": "B19",
+					"levels": 1,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "to other's intimidation skill due to your size",
+							"amount": -1,
+							"per_level": true
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to intimidation due to size",
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "sm",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "22d8b87b-56b3-4fc3-93b6-c39210f18b18",
+					"type": "trait",
+					"name": "Enhanced Move (Ground Speed)",
+					"reference": "B52,P49",
+					"notes": "Multiply normal Ground Speed Move by 1 + level",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"levels": 1,
+					"points_per_level": 20,
+					"can_level": true,
+					"calc": {
+						"points": 20
+					}
+				},
+				{
+					"id": "dbd9e193-e45a-4ea6-a076-358092042034",
+					"type": "trait",
+					"name": "Extra Legs (4 legs)",
+					"reference": "B54",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"base_points": 5,
+					"calc": {
+						"points": 5
+					}
+				}
+			],
+			"name": "Form: Centauroid Robot",
+			"ancestry": "Human",
+			"container_type": "race",
+			"calc": {
+				"points": 247
+			}
+		},
+		{
+			"id": "972bc1ff-4bbe-4a55-ac22-37f4b7a7cb03",
+			"type": "trait_container",
+			"children": [
+				{
+					"id": "c0a6590a-da6f-45d4-90a1-79c66dcf95ef",
+					"type": "trait",
+					"name": "Increased Strength",
+					"reference": "B14",
+					"notes": "No Fine Manipulators -40%",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"levels": 18,
+					"points_per_level": 6,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "st",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "f9faa014-898d-44cd-9c96-88dff2d5ef3e",
+					"type": "trait",
+					"name": "Increased Dexterity",
+					"reference": "B15",
+					"notes": "No Fine Manipulators -40%",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"levels": 3,
+					"points_per_level": 12,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "dx",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "83f9716d-cbb9-4f22-8cd0-e9e6fd840c3c",
+					"type": "trait",
+					"name": "Chameleon",
+					"reference": "B41,P43",
+					"notes": "Extended: Ladar +20%",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"levels": 3,
+					"points_per_level": 6,
+					"can_level": true,
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "9eb0e182-96af-4d84-b848-ae09ccf8eb3a",
+					"type": "trait",
+					"name": "Enhanced Move (Ground Speed)",
+					"reference": "B52,P49",
+					"notes": "Multiply normal Ground Speed Move by 1 + level",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"levels": 1.5,
+					"points_per_level": 20,
+					"can_level": true,
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "a29abee7-63f0-4bcb-91cc-4f995d66d81d",
+					"type": "trait",
+					"name": "Extra Legs (6 legs)",
+					"reference": "B54",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"base_points": 10,
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "73107e88-1901-4fe7-909e-aa98a3353604",
+					"type": "trait",
+					"name": "Horizontal",
+					"reference": "B139",
+					"tags": [
+						"Disadvantage",
+						"Exotic",
+						"Physical"
+					],
+					"base_points": -10,
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "ad395d65-36a9-4074-b4ad-1513b351e4f0",
+					"type": "trait",
+					"name": "No Fine Manipulators",
+					"reference": "B145",
+					"tags": [
+						"Disadvantage",
+						"Physical"
+					],
+					"base_points": -30,
+					"features": [
+						{
+							"type": "cost_reduction",
+							"attribute": "st",
+							"percentage": 40
+						},
+						{
+							"type": "cost_reduction",
+							"attribute": "dx",
+							"percentage": 40
+						}
+					],
+					"calc": {
+						"points": 0
+					}
+				}
+			],
+			"name": "Form: Hexapod Robot (Alternate Form)",
+			"ancestry": "Human",
+			"container_type": "race",
+			"disabled": true,
+			"calc": {
+				"points": 0
+			}
+		},
+		{
+			"id": "8823e757-eb5f-4caf-bf26-b93b96806630",
+			"type": "trait",
+			"name": "Combat Reflexes",
+			"reference": "B43",
+			"notes": "Never freeze",
+			"tags": [
+				"Advantage",
+				"Mental"
+			],
+			"base_points": 15,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Enhanced Time Sense"
+						}
+					}
+				]
+			},
+			"features": [
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "starts_with",
+						"qualifier": "fast-draw"
+					},
+					"amount": 1
+				},
+				{
+					"type": "attribute_bonus",
+					"attribute": "dodge",
+					"amount": 1
+				},
+				{
+					"type": "attribute_bonus",
+					"attribute": "parry",
+					"amount": 1
+				},
+				{
+					"type": "attribute_bonus",
+					"attribute": "block",
+					"amount": 1
+				},
+				{
+					"type": "attribute_bonus",
+					"attribute": "fright_check",
+					"amount": 2
+				},
+				{
+					"type": "conditional_modifier",
+					"situation": "on all IQ rolls to wake up or to recover from surprise or mental stun",
+					"amount": 6
+				},
+				{
+					"type": "conditional_modifier",
+					"situation": "to initiative rolls for your side (+2 if you are the leader)",
+					"amount": 1
+				}
+			],
+			"calc": {
+				"points": 15
+			}
+		},
+		{
+			"id": "ffd22eed-145a-4f69-aa21-51e20acafdad",
+			"type": "trait",
+			"name": "Damage Resistance",
+			"reference": "B47,P45,MA43,PSI14",
+			"notes": "Can't wear armour -40%; Hardened 1 +20%",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Physical"
+			],
+			"levels": 53,
+			"points_per_level": 4,
+			"features": [
+				{
+					"type": "weapon_dr_divisor_bonus",
+					"selection_type": "weapons_with_required_skill",
+					"name": {
+						"compare": "is"
+					},
+					"level": {
+						"compare": "at_least"
+					},
+					"amount": -1
+				},
+				{
+					"type": "dr_bonus",
+					"location": "skull",
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "dr_bonus",
+					"location": "face",
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "dr_bonus",
+					"location": "neck",
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "dr_bonus",
+					"location": "torso",
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "dr_bonus",
+					"location": "vitals",
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "dr_bonus",
+					"location": "groin",
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "dr_bonus",
+					"location": "arm",
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "dr_bonus",
+					"location": "hand",
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "dr_bonus",
+					"location": "leg",
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "dr_bonus",
+					"location": "foot",
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "dr_bonus",
+					"location": "tail",
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "dr_bonus",
+					"location": "wing",
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "dr_bonus",
+					"location": "fin",
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "dr_bonus",
+					"location": "brain",
+					"amount": 1,
+					"per_level": true
+				}
+			],
+			"can_level": true,
+			"calc": {
+				"points": 212
+			}
+		},
+		{
+			"id": "3befaaa2-454a-4c56-8895-016251e7e364",
+			"type": "trait",
+			"name": "Detect Electromagnetic Emissions",
+			"reference": "B48,P47,PSI14",
+			"notes": "Signal Detection +0%",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Mental",
+				"Physical"
+			],
+			"base_points": 20,
+			"calc": {
+				"points": 20
+			}
+		},
+		{
+			"id": "c88b0926-7d21-46f6-a3c4-3aa5bc2bd440",
+			"type": "trait",
+			"name": "Doesn't Breathe",
+			"reference": "B49",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Physical"
+			],
+			"base_points": 20,
+			"calc": {
+				"points": 20
+			}
+		},
+		{
+			"id": "2aa5fea6-16b1-45b9-806d-845b6c89dd67",
+			"type": "trait",
+			"name": "Enhanced Tracking",
+			"reference": "B53,P49",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Physical"
+			],
+			"levels": 1,
+			"points_per_level": 5,
+			"can_level": true,
+			"calc": {
+				"points": 5
+			}
+		},
+		{
+			"id": "599530bd-5153-4e60-946b-658a636375cc",
+			"type": "trait",
+			"name": "Extra Attack",
+			"reference": "B53,P49,MA44",
+			"tags": [
+				"Advantage",
+				"Physical"
+			],
+			"modifiers": [
+				{
+					"id": "93a98a1c-c1a9-4435-91ca-749a69332a0f",
+					"type": "modifier",
+					"name": "Multi-Strike",
+					"reference": "P49",
+					"cost": 20,
+					"disabled": true
+				},
+				{
+					"id": "0a903be4-0089-4554-9aa0-c1992ba1c7db",
+					"type": "modifier",
+					"name": "Single Skill",
+					"reference": "P49",
+					"notes": "@Skill@",
+					"cost": -20,
+					"disabled": true
+				}
+			],
+			"levels": 1,
+			"points_per_level": 25,
+			"can_level": true,
+			"calc": {
+				"points": 25
+			}
+		},
+		{
+			"id": "123a5824-cfc6-4310-ae86-1e6767362b0e",
+			"type": "trait",
+			"name": "Hooves",
+			"reference": "B42",
+			"tags": [
+				"Advantage",
+				"Physical"
+			],
+			"base_points": 3,
+			"weapons": [
+				{
+					"id": "1dd5ef16-e1a2-4722-8dd4-5a45c3c6c75b",
+					"type": "melee_weapon",
+					"damage": {
+						"type": "cr",
+						"st": "thr",
+						"modifier_per_die": 1
+					},
+					"usage": "Trample",
+					"reach": "C,1",
+					"parry": "No",
+					"block": "No",
+					"defaults": [
+						{
+							"type": "dx",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Brawling",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Karate",
+							"modifier": -2
+						}
+					],
+					"calc": {
+						"level": 13,
+						"parry": "No",
+						"block": "No",
+						"damage": "3d+2 cr"
+					}
+				}
+			],
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "foot",
+					"amount": 1
+				}
+			],
+			"calc": {
+				"points": 3
+			}
+		},
+		{
+			"id": "aeeabac1-7d2c-42ac-a083-981f72ac76c8",
+			"type": "trait",
+			"name": "Hyperspectral Vision",
+			"reference": "B60,P51",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Physical"
+			],
+			"base_points": 25,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "infravision"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "ultravision"
+						}
+					}
+				]
+			},
+			"calc": {
+				"points": 25
+			}
+		},
+		{
+			"id": "2e846c3e-f5ce-412f-82a0-63b5138f46ea",
+			"type": "trait_container",
+			"children": [
+				{
+					"id": "dd08ccf1-46c3-42ac-b553-5e101fb32ec9",
+					"type": "trait",
+					"name": "Eight-hour energy reserve, Refuel 3 times per day",
+					"reference": "B263",
+					"tags": [
+						"Physical"
+					],
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "9ffc315b-52fc-4bda-8125-d8fd9ca3c9c1",
+					"type": "trait",
+					"name": "Injury Tolerance",
+					"reference": "B60",
+					"notes": "No blood (Do not bleed, unaffected by blood-borne toxins, immune to attacks that rely on cutting off blood to part of your body).  Unliving (Altered wound modifiers: imp \u0026 pi++ are x1, pi+ is x1/2, pi is x1/3, pi- is x1/5)",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"base_points": 25,
+					"calc": {
+						"points": 25
+					}
+				},
+				{
+					"id": "30eaf0e1-c7f0-4b6a-9611-0c55090aee16",
+					"type": "trait",
+					"name": "No fatigue points, Don't spend fatigue points",
+					"reference": "B263",
+					"tags": [
+						"Physical"
+					],
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "ad41d5af-8e50-401f-a29c-801a36e44a86",
+					"type": "trait",
+					"name": "Resistant",
+					"reference": "B81",
+					"notes": "Immune to metabolic hazards",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"base_points": 30,
+					"round_down": true,
+					"calc": {
+						"points": 30
+					}
+				},
+				{
+					"id": "cbe30412-12a1-40be-8ff2-9d9d8a690ee0",
+					"type": "trait",
+					"name": "Unhealing (Total)",
+					"reference": "B160",
+					"tags": [
+						"Disadvantage",
+						"Exotic",
+						"Physical"
+					],
+					"base_points": -30,
+					"calc": {
+						"points": -30
+					}
+				},
+				{
+					"id": "731a2244-51d5-4af8-8d43-60bf9b16dcc7",
+					"type": "trait",
+					"name": "Wears out instead of aging",
+					"reference": "B263",
+					"tags": [
+						"Physical"
+					],
+					"calc": {
+						"points": 0
+					}
+				}
+			],
+			"name": "Meta-Trait: Machine",
+			"reference": "B263",
+			"container_type": "meta_trait",
+			"calc": {
+				"points": 25
+			}
+		},
+		{
+			"id": "b2f06522-e75d-44a5-80df-88ec32b6209a",
+			"type": "trait",
+			"name": "Obscure (Radar, Para-Radar)",
+			"reference": "B72,P64,PSI16",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Physical"
+			],
+			"modifiers": [
+				{
+					"id": "6bcd1d67-4bec-45c5-8e53-afcf2af34415",
+					"type": "modifier",
+					"name": "Defensive",
+					"reference": "B72",
+					"cost": 50
+				},
+				{
+					"id": "2cc1e79d-54bb-4e39-9b05-a6ec10b60b94",
+					"type": "modifier",
+					"name": "Extended",
+					"reference": "B72",
+					"notes": "Para-Radar",
+					"cost": 20
+				},
+				{
+					"id": "d1ae6617-1d6b-47e6-a392-826bd1eeea0d",
+					"type": "modifier",
+					"name": "Area effect 6",
+					"reference": "B72",
+					"cost": 300
+				}
+			],
+			"levels": 5,
+			"points_per_level": 2,
+			"can_level": true,
+			"calc": {
+				"points": 47
+			}
+		},
+		{
+			"id": "1107beec-438e-4bac-bee9-4b6da30e0857",
+			"type": "trait",
+			"name": "Scanning Sense",
+			"reference": "B81,P72,PSI17",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Physical"
+			],
+			"modifiers": [
+				{
+					"id": "c7dba5eb-8244-4eb9-aa96-6783d79bbe64",
+					"type": "modifier",
+					"name": "Imaging Radar",
+					"reference": "B81",
+					"cost": 20,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "e2dd29a9-4d6e-4b74-b537-8cfe40da3119",
+					"type": "modifier",
+					"name": "Radar",
+					"reference": "B81",
+					"cost": 20,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "2cb439b4-4dc7-492c-a25b-f10d4e393344",
+					"type": "modifier",
+					"name": "Ladar",
+					"reference": "B81",
+					"cost": 20,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "5ed6db33-a659-4ac6-b424-bb965f6a7188",
+					"type": "modifier",
+					"name": "Para-Radar",
+					"reference": "B81",
+					"cost": 40,
+					"cost_type": "points"
+				},
+				{
+					"id": "058a1327-6232-4ed7-95a8-6e62d9f7dabb",
+					"type": "modifier",
+					"name": "Sonar",
+					"reference": "B81",
+					"cost": 20,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "dda9d4fd-592b-4892-bcf0-ea489ea86c2a",
+					"type": "modifier",
+					"name": "Extended Arc",
+					"reference": "B82",
+					"notes": "240°",
+					"cost": 75,
+					"disabled": true
+				},
+				{
+					"id": "838bb94a-27dc-4389-a8e3-158552e67017",
+					"type": "modifier",
+					"name": "Extended Arc",
+					"reference": "B82",
+					"notes": "360°",
+					"cost": 125
+				},
+				{
+					"id": "6a5b14bb-73a6-4e2e-b4b8-a6bccec0c45c",
+					"type": "modifier",
+					"name": "Low-Probability Intercept",
+					"reference": "B82",
+					"cost": 10,
+					"disabled": true
+				},
+				{
+					"id": "5fbf1d78-3879-472b-a545-17e0ade3d2e5",
+					"type": "modifier",
+					"name": "Multi-Mode",
+					"reference": "B82",
+					"cost": 50,
+					"disabled": true
+				},
+				{
+					"id": "4f8579bd-0ab1-44c4-80ab-a2d5cc4d9580",
+					"type": "modifier",
+					"name": "Penetrating",
+					"reference": "B82",
+					"cost": 50
+				},
+				{
+					"id": "2329cb1e-0795-4323-9203-2c168a41fbbd",
+					"type": "modifier",
+					"name": "Targeting",
+					"reference": "B82",
+					"cost": 20
+				},
+				{
+					"id": "809869d1-7eed-4e7a-8ef8-ca61905a0230",
+					"type": "modifier",
+					"name": "Targeting Only",
+					"reference": "B82",
+					"cost": -40,
+					"disabled": true
+				},
+				{
+					"id": "c78e13f9-4693-4332-a2c3-b3c1fc807f8a",
+					"type": "modifier",
+					"name": "Active IR",
+					"reference": "P72",
+					"cost": 20,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "1bd50a99-a493-40ad-aef2-3f543756a618",
+					"type": "modifier",
+					"name": "T-Ray Vision",
+					"reference": "P72",
+					"cost": 25,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "301f86f9-f08f-4db4-898f-e33ee1857676",
+					"type": "modifier",
+					"name": "Bio-Scan",
+					"reference": "P72",
+					"cost": 50,
+					"disabled": true
+				},
+				{
+					"id": "e998e9d8-938f-4032-8721-7640eef7f9a5",
+					"type": "modifier",
+					"name": "No Intercept",
+					"reference": "P72",
+					"cost": 50,
+					"disabled": true
+				},
+				{
+					"id": "e3a94283-9719-44a9-9976-e8903211a304",
+					"type": "modifier",
+					"name": "Scanner",
+					"reference": "P72",
+					"cost": 50,
+					"disabled": true
+				},
+				{
+					"id": "94fb7267-fd38-4d4f-9ee9-219a5b079d80",
+					"type": "modifier",
+					"name": "Field Sense",
+					"reference": "SU27",
+					"cost": 10,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "4a19b241-43e4-4855-8dd0-893666259f41",
+					"type": "modifier",
+					"name": "Extra-Sensory Awareness",
+					"reference": "PSI17",
+					"cost": 20,
+					"cost_type": "points",
+					"disabled": true
+				}
+			],
+			"calc": {
+				"points": 118
+			}
+		},
+		{
+			"id": "8b391e4f-e615-41c1-a7c0-6f477960b6bb",
+			"type": "trait",
+			"name": "Payload",
+			"reference": "B74",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Physical"
+			],
+			"modifiers": [
+				{
+					"id": "334523f8-f59a-45fb-8c40-3cfab2763f0d",
+					"type": "modifier",
+					"name": "Exposed",
+					"reference": "B74",
+					"cost": -50
+				}
+			],
+			"levels": 14,
+			"points_per_level": 1,
+			"can_level": true,
+			"calc": {
+				"points": 7
+			}
+		},
+		{
+			"id": "5b900c9a-dc7e-4252-97d0-323ac558a692",
+			"type": "trait",
+			"name": "Payload",
+			"reference": "B74",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Physical"
+			],
+			"modifiers": [
+				{
+					"id": "334523f8-f59a-45fb-8c40-3cfab2763f0d",
+					"type": "modifier",
+					"name": "Exposed",
+					"reference": "B74",
+					"cost": -50,
+					"disabled": true
+				}
+			],
+			"levels": 5,
+			"points_per_level": 1,
+			"can_level": true,
+			"calc": {
+				"points": 5
+			}
+		},
+		{
+			"id": "9a1171a6-23d0-410c-a2ee-a2822663f260",
+			"type": "trait",
+			"name": "Pressure Support",
+			"reference": "B77",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Physical"
+			],
+			"levels": 2,
+			"points_per_level": 5,
+			"can_level": true,
+			"calc": {
+				"points": 10
+			}
+		},
+		{
+			"id": "fa578321-173c-49b3-b946-dae594e69ead",
+			"type": "trait",
+			"name": "Protected Sense (Para-Radar)",
+			"reference": "B78,P69",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Physical"
+			],
+			"base_points": 5,
+			"calc": {
+				"points": 5
+			}
+		},
+		{
+			"id": "abae22e0-41bd-496f-94c9-71b0f94e1a8a",
+			"type": "trait",
+			"name": "Protected Sense (Vision)",
+			"reference": "B78,P69",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Physical"
+			],
+			"base_points": 5,
+			"calc": {
+				"points": 5
+			}
+		},
+		{
+			"id": "d9721956-62f3-4af6-9bc4-977eb3cbcacc",
+			"type": "trait",
+			"name": "Telecommunication",
+			"reference": "B91,P81,PSI17",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Mental",
+				"Physical"
+			],
+			"modifiers": [
+				{
+					"id": "907a171c-0524-4b66-a528-ea3de53ebc77",
+					"type": "modifier",
+					"name": "Infrared Communication",
+					"reference": "B91",
+					"cost": 10,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "fe87b471-a595-407d-861d-9cedf839d5ba",
+					"type": "modifier",
+					"name": "Laser Communication",
+					"reference": "B91",
+					"cost": 15,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "1ce7cf23-966a-4233-908d-9998fb1723ec",
+					"type": "modifier",
+					"name": "Radio",
+					"reference": "B91",
+					"cost": 10,
+					"cost_type": "points"
+				},
+				{
+					"id": "3bb4f552-2f5f-4d04-a382-aefd6e0d0d8d",
+					"type": "modifier",
+					"name": "Telesend",
+					"reference": "B91",
+					"cost": 30,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "8dfb3cc3-5eaf-44d1-af2d-82c681b6cc6c",
+					"type": "modifier",
+					"name": "Broadcast",
+					"reference": "B91",
+					"cost": 50,
+					"disabled": true
+				},
+				{
+					"id": "8bd06112-302f-40b9-9c81-cf05367f8427",
+					"type": "modifier",
+					"name": "Short Wave",
+					"reference": "B91",
+					"cost": 50
+				},
+				{
+					"id": "31dc35a5-b5be-4ea3-a1f6-9d3614d3291c",
+					"type": "modifier",
+					"name": "Universal",
+					"reference": "B91",
+					"cost": 50,
+					"disabled": true
+				},
+				{
+					"id": "89ba8d02-bab8-4e80-9c5e-e8528d296414",
+					"type": "modifier",
+					"name": "Video",
+					"reference": "B91",
+					"cost": 40
+				},
+				{
+					"id": "215e5a1a-ac21-4676-9e7e-66bf441ce8c8",
+					"type": "modifier",
+					"name": "Racial",
+					"reference": "B91",
+					"cost": -20,
+					"disabled": true
+				},
+				{
+					"id": "d7f2bdef-fbb0-4adc-b9b7-4fd7fcd9d0f6",
+					"type": "modifier",
+					"name": "Receive Only",
+					"reference": "B91",
+					"cost": -50,
+					"disabled": true
+				},
+				{
+					"id": "8f6884d2-48e7-477c-a1c4-9671a3f35de1",
+					"type": "modifier",
+					"name": "Send Only",
+					"reference": "B91",
+					"cost": -50,
+					"disabled": true
+				},
+				{
+					"id": "4a422848-3ff6-4cbd-b9cc-dbf461c698c6",
+					"type": "modifier",
+					"name": "Vague",
+					"reference": "B91",
+					"cost": -50,
+					"disabled": true
+				},
+				{
+					"id": "0be44163-089b-4f6c-8ccc-fc346aeb0a09",
+					"type": "modifier",
+					"name": "Directional Sound",
+					"reference": "P81",
+					"cost": 5,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "a4b519a7-f3b6-4548-ab36-84f4fa6323ee",
+					"type": "modifier",
+					"name": "Gravity Ripple",
+					"reference": "P81",
+					"cost": 20,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "f62ac5a6-3ed4-4f87-99da-726ffb8a0aca",
+					"type": "modifier",
+					"name": "Neutrino",
+					"reference": "P81",
+					"cost": 25,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "c9e96f67-4858-4f1d-8e2e-f7e1e788aacd",
+					"type": "modifier",
+					"name": "Sonar",
+					"reference": "P81",
+					"cost": 10,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "c1e662c3-c012-45ce-9ed6-7ce4687f7fa2",
+					"type": "modifier",
+					"name": "Burst",
+					"reference": "P81",
+					"cost": 30,
+					"levels": 1,
+					"disabled": true
+				},
+				{
+					"id": "bb038cbb-b180-4f34-8302-188b5bd0821d",
+					"type": "modifier",
+					"name": "FTL",
+					"reference": "P82",
+					"cost": 120,
+					"disabled": true
+				},
+				{
+					"id": "a0c1ec34-080a-42d8-8112-05a963182009",
+					"type": "modifier",
+					"name": "Secure",
+					"reference": "P82",
+					"cost": 20,
+					"disabled": true
+				},
+				{
+					"id": "d5d966e0-13f5-479c-a140-838583741247",
+					"type": "modifier",
+					"name": "Sensie",
+					"reference": "P82",
+					"cost": 80,
+					"disabled": true
+				},
+				{
+					"id": "afbf6331-6597-4b69-ae8d-a5581b34bfc2",
+					"type": "modifier",
+					"name": "Cable Jack",
+					"reference": "UT31",
+					"cost": 5,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "59a27a6f-8680-4ecb-9f94-cfc47aa63b6d",
+					"type": "modifier",
+					"name": "Full Communion",
+					"reference": "PSI17",
+					"cost": 20,
+					"disabled": true
+				}
+			],
+			"calc": {
+				"points": 19
+			}
+		},
+		{
+			"id": "0d69fd2b-9952-49b6-bb2f-44ee1400c178",
+			"type": "trait",
+			"name": "Sealed",
+			"reference": "B82",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Physical"
+			],
+			"base_points": 15,
+			"calc": {
+				"points": 15
+			}
+		},
+		{
+			"id": "f18d337f-357b-47aa-9d1b-f58d2d197175",
+			"type": "trait",
+			"name": "Talons",
+			"reference": "B43",
+			"tags": [
+				"Advantage",
+				"Physical"
+			],
+			"base_points": 8,
+			"weapons": [
+				{
+					"id": "4ef3e921-504d-4564-b793-dd4cdf4fcb51",
+					"type": "melee_weapon",
+					"damage": {
+						"type": "cut",
+						"st": "thr",
+						"base": "-1"
+					},
+					"usage": "Slash",
+					"reach": "C",
+					"parry": "0",
+					"block": "No",
+					"defaults": [
+						{
+							"type": "dx"
+						},
+						{
+							"type": "skill",
+							"name": "Brawling"
+						},
+						{
+							"type": "skill",
+							"name": "Boxing"
+						},
+						{
+							"type": "skill",
+							"name": "Karate"
+						}
+					],
+					"calc": {
+						"level": 15,
+						"parry": "11",
+						"block": "No",
+						"damage": "3d-2 cut"
+					}
+				},
+				{
+					"id": "f7ecdc36-9959-4bb3-bb66-0176dc15c9c6",
+					"type": "melee_weapon",
+					"damage": {
+						"type": "imp",
+						"st": "thr",
+						"base": "-1"
+					},
+					"usage": "Stab",
+					"reach": "C",
+					"parry": "0",
+					"block": "No",
+					"defaults": [
+						{
+							"type": "dx"
+						},
+						{
+							"type": "skill",
+							"name": "Brawling"
+						},
+						{
+							"type": "skill",
+							"name": "Boxing"
+						},
+						{
+							"type": "skill",
+							"name": "Karate"
+						}
+					],
+					"calc": {
+						"level": 15,
+						"parry": "11",
+						"block": "No",
+						"damage": "3d-2 imp"
+					}
+				}
+			],
+			"calc": {
+				"points": 8
+			}
+		},
+		{
+			"id": "29717dd4-6dde-4a16-b46c-00c7b93eaf4e",
+			"type": "trait",
+			"name": "True Faith",
+			"reference": "B94,P84",
+			"tags": [
+				"Advantage",
+				"Mental",
+				"Supernatural"
+			],
+			"modifiers": [
+				{
+					"id": "ca3afde0-4e16-4370-96b4-06f654841cb6",
+					"type": "modifier",
+					"name": "Chosen",
+					"reference": "P84",
+					"notes": "@Deity@",
+					"disabled": true
+				},
+				{
+					"id": "32701344-c513-4fdb-9337-c3261e231622",
+					"type": "modifier",
+					"name": "Turning",
+					"reference": "P84",
+					"cost": 65,
+					"disabled": true
+				}
+			],
+			"base_points": 15,
+			"calc": {
+				"points": 15
+			}
+		},
+		{
+			"id": "9d1fa864-391e-41f4-8621-89caa0ba0d38",
+			"type": "trait_container",
+			"children": [
+				{
+					"id": "08b4b3cf-9709-49a6-b578-08c208f9a5b3",
+					"type": "trait_container",
+					"open": true,
+					"children": [
+						{
+							"id": "22e428f4-eb6f-4a36-b9e7-a8fe0a6d573a",
+							"type": "trait",
+							"name": "Innate Attack (Chain Gun)",
+							"reference": "B62,P53,MA45",
+							"tags": [
+								"Advantage",
+								"Exotic",
+								"Physical"
+							],
+							"modifiers": [
+								{
+									"id": "0741edc9-0e5a-4a46-840c-611fb2b29060",
+									"type": "modifier",
+									"name": "Accurate 6",
+									"reference": "B102",
+									"cost": 30
+								},
+								{
+									"id": "3fd094ba-37bc-42d1-a69b-56fce9f046cf",
+									"type": "modifier",
+									"name": "Armor Divisor",
+									"reference": "B102",
+									"notes": "2",
+									"cost": 50
+								},
+								{
+									"id": "95c114b3-4a8c-409a-a301-a58d9b31022d",
+									"type": "modifier",
+									"name": "Extra Recoil 3",
+									"reference": "B112",
+									"cost": -30
+								},
+								{
+									"id": "3160f2ce-1cfa-47b3-92df-10d50dee9f76",
+									"type": "modifier",
+									"name": "Increased Range 20",
+									"reference": "B106",
+									"cost": 40
+								},
+								{
+									"id": "c3218ec9-e895-485a-921e-e7a1b9ce9803",
+									"type": "modifier",
+									"name": "Rapid Fire 15",
+									"reference": "B108",
+									"cost": 100
+								}
+							],
+							"levels": 15,
+							"points_per_level": 6,
+							"weapons": [
+								{
+									"id": "db3e25aa-0051-4143-b14f-ecc8e64d65ba",
+									"type": "ranged_weapon",
+									"damage": {
+										"type": "pi+",
+										"base": "1d"
+									},
+									"accuracy": "3",
+									"range": "10/100",
+									"rate_of_fire": "1",
+									"recoil": "1",
+									"defaults": [
+										{
+											"type": "skill",
+											"name": "Innate Attack",
+											"specialization": "Chain Gun"
+										},
+										{
+											"type": "skill",
+											"name": "Innate Attack",
+											"modifier": -2
+										},
+										{
+											"type": "dx",
+											"modifier": -4
+										}
+									],
+									"calc": {
+										"level": 13,
+										"range": "10/100",
+										"damage": "15d pi+"
+									}
+								}
+							],
+							"can_level": true,
+							"calc": {
+								"points": 261
+							}
+						},
+						{
+							"id": "a293050f-a960-4eb1-b1db-551549a26d90",
+							"type": "trait",
+							"name": "Innate Attack (Plasma Cannon)",
+							"reference": "B61,P53,MA45",
+							"tags": [
+								"Advantage",
+								"Exotic",
+								"Physical"
+							],
+							"modifiers": [
+								{
+									"id": "c152c232-3215-4b3f-8b18-eb7517254903",
+									"type": "modifier",
+									"name": "Cone, 4 yards",
+									"reference": "B103",
+									"cost": 90
+								},
+								{
+									"id": "802740fa-7684-4566-82d3-d45d639e940f",
+									"type": "modifier",
+									"name": "Cyclic (1 second, 5 cycles)",
+									"cost": 400
+								}
+							],
+							"levels": 6,
+							"points_per_level": 5,
+							"weapons": [
+								{
+									"id": "e0cd7330-a694-442e-9bca-e7ead83585aa",
+									"type": "ranged_weapon",
+									"damage": {
+										"type": "burn",
+										"base": "1d"
+									},
+									"accuracy": "3",
+									"range": "10/100",
+									"rate_of_fire": "1",
+									"recoil": "1",
+									"defaults": [
+										{
+											"type": "skill",
+											"name": "Innate Attack",
+											"specialization": "Plasma Cannon"
+										},
+										{
+											"type": "skill",
+											"name": "Innate Attack",
+											"modifier": -2
+										},
+										{
+											"type": "dx",
+											"modifier": -4
+										}
+									],
+									"calc": {
+										"level": 13,
+										"range": "10/100",
+										"damage": "6d burn"
+									}
+								}
+							],
+							"can_level": true,
+							"calc": {
+								"points": 177
+							}
+						}
+					],
+					"name": "Alternative Attacks",
+					"container_type": "alternative_abilities",
+					"calc": {
+						"points": 297
+					}
+				}
+			],
+			"name": "Weapon Pod",
+			"container_type": "meta_trait",
+			"calc": {
+				"points": 297
+			}
+		},
+		{
+			"id": "60c2bfea-c3ed-488b-bb99-708ce0a68fdc",
+			"type": "trait_container",
+			"children": [
+				{
+					"id": "e39e0df3-a7ff-4f15-9630-fe495bf84ad5",
+					"type": "trait_container",
+					"open": true,
+					"children": [
+						{
+							"id": "e427e808-3134-4671-9bb0-55c7631da811",
+							"type": "trait",
+							"name": "Innate Attack (Chain Gun)",
+							"reference": "B62,P53,MA45",
+							"tags": [
+								"Advantage",
+								"Exotic",
+								"Physical"
+							],
+							"modifiers": [
+								{
+									"id": "0741edc9-0e5a-4a46-840c-611fb2b29060",
+									"type": "modifier",
+									"name": "Accurate 6",
+									"reference": "B102",
+									"cost": 30
+								},
+								{
+									"id": "3fd094ba-37bc-42d1-a69b-56fce9f046cf",
+									"type": "modifier",
+									"name": "Armor Divisor",
+									"reference": "B102",
+									"notes": "2",
+									"cost": 50
+								},
+								{
+									"id": "95c114b3-4a8c-409a-a301-a58d9b31022d",
+									"type": "modifier",
+									"name": "Extra Recoil 3",
+									"reference": "B112",
+									"cost": -30
+								},
+								{
+									"id": "3160f2ce-1cfa-47b3-92df-10d50dee9f76",
+									"type": "modifier",
+									"name": "Increased Range 20",
+									"reference": "B106",
+									"cost": 40
+								},
+								{
+									"id": "c3218ec9-e895-485a-921e-e7a1b9ce9803",
+									"type": "modifier",
+									"name": "Rapid Fire 15",
+									"reference": "B108",
+									"cost": 100
+								}
+							],
+							"levels": 15,
+							"points_per_level": 6,
+							"weapons": [
+								{
+									"id": "db3e25aa-0051-4143-b14f-ecc8e64d65ba",
+									"type": "ranged_weapon",
+									"damage": {
+										"type": "pi+",
+										"base": "1d"
+									},
+									"accuracy": "3",
+									"range": "10/100",
+									"rate_of_fire": "1",
+									"recoil": "1",
+									"defaults": [
+										{
+											"type": "skill",
+											"name": "Innate Attack",
+											"specialization": "Chain Gun"
+										},
+										{
+											"type": "skill",
+											"name": "Innate Attack",
+											"modifier": -2
+										},
+										{
+											"type": "dx",
+											"modifier": -4
+										}
+									],
+									"calc": {
+										"level": 13,
+										"range": "10/100",
+										"damage": "15d pi+"
+									}
+								}
+							],
+							"can_level": true,
+							"calc": {
+								"points": 261
+							}
+						},
+						{
+							"id": "de2e9b49-f771-4a2c-9b98-57e8de9f50df",
+							"type": "trait",
+							"name": "Innate Attack (Plasma Cannon)",
+							"reference": "B61,P53,MA45",
+							"tags": [
+								"Advantage",
+								"Exotic",
+								"Physical"
+							],
+							"modifiers": [
+								{
+									"id": "c152c232-3215-4b3f-8b18-eb7517254903",
+									"type": "modifier",
+									"name": "Cone, 4 yards",
+									"reference": "B103",
+									"cost": 90
+								},
+								{
+									"id": "802740fa-7684-4566-82d3-d45d639e940f",
+									"type": "modifier",
+									"name": "Cyclic (1 second, 5 cycles)",
+									"cost": 400
+								}
+							],
+							"levels": 6,
+							"points_per_level": 5,
+							"weapons": [
+								{
+									"id": "e0cd7330-a694-442e-9bca-e7ead83585aa",
+									"type": "ranged_weapon",
+									"damage": {
+										"type": "burn",
+										"base": "1d"
+									},
+									"accuracy": "3",
+									"range": "10/100",
+									"rate_of_fire": "1",
+									"recoil": "1",
+									"defaults": [
+										{
+											"type": "skill",
+											"name": "Innate Attack",
+											"specialization": "Plasma Cannon"
+										},
+										{
+											"type": "skill",
+											"name": "Innate Attack",
+											"modifier": -2
+										},
+										{
+											"type": "dx",
+											"modifier": -4
+										}
+									],
+									"calc": {
+										"level": 13,
+										"range": "10/100",
+										"damage": "6d burn"
+									}
+								}
+							],
+							"can_level": true,
+							"calc": {
+								"points": 177
+							}
+						}
+					],
+					"name": "Alternative Attacks",
+					"container_type": "alternative_abilities",
+					"calc": {
+						"points": 297
+					}
+				}
+			],
+			"name": "Weapon Pod",
+			"container_type": "meta_trait",
+			"calc": {
+				"points": 297
+			}
+		},
+		{
+			"id": "93ff3ead-bdf5-40a1-9394-0c6a8bb9434b",
+			"type": "trait",
+			"name": "Clueless",
+			"reference": "B126",
+			"tags": [
+				"Disadvantage",
+				"Mental"
+			],
+			"base_points": -10,
+			"features": [
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "starts_with",
+						"qualifier": "savoir-faire"
+					},
+					"amount": -4
+				},
+				{
+					"type": "reaction_bonus",
+					"situation": "from others for being clueless",
+					"amount": -2
+				},
+				{
+					"type": "conditional_modifier",
+					"situation": "to resist Sex Appeal",
+					"amount": 4
+				}
+			],
+			"calc": {
+				"points": -10
+			}
+		},
+		{
+			"id": "49a7b0e4-21ea-4f6a-987f-c3d3d8793e8c",
+			"type": "trait",
+			"name": "Disciplines of Faith (Asceticism)",
+			"reference": "B132",
+			"tags": [
+				"Disadvantage",
+				"Mental"
+			],
+			"base_points": -15,
+			"calc": {
+				"points": -15
+			}
+		},
+		{
+			"id": "da33a08e-8ee4-4158-8a82-308c285405db",
+			"type": "trait",
+			"name": "Electrical",
+			"reference": "B134",
+			"tags": [
+				"Disadvantage",
+				"Exotic",
+				"Physical"
+			],
+			"base_points": -20,
+			"calc": {
+				"points": -20
+			}
+		},
+		{
+			"id": "23f46771-b7b0-466e-86f3-34bc17ce3af7",
+			"type": "trait",
+			"name": "Fragile (Explosive)",
+			"reference": "B137",
+			"tags": [
+				"Disadvantage",
+				"Exotic",
+				"Physical"
+			],
+			"base_points": -15,
+			"calc": {
+				"points": -15
+			}
+		},
+		{
+			"id": "6035b5f8-310a-48c5-937d-a44009de3324",
+			"type": "trait",
+			"name": "Low Empathy",
+			"reference": "B142",
+			"tags": [
+				"Disadvantage",
+				"Mental"
+			],
+			"base_points": -20,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "oblivious"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "callous"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "empathy"
+						}
+					}
+				]
+			},
+			"features": [
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "acting"
+					},
+					"amount": -3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "carousing"
+					},
+					"amount": -3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "criminology"
+					},
+					"amount": -3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "detect lies"
+					},
+					"amount": -3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "diplomacy"
+					},
+					"amount": -3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "enthrallment"
+					},
+					"amount": -3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "fast-talk"
+					},
+					"amount": -3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "interrogation"
+					},
+					"amount": -3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "leadership"
+					},
+					"amount": -3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "merchant"
+					},
+					"amount": -3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "politics"
+					},
+					"amount": -3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "contains",
+						"qualifier": "psychology"
+					},
+					"amount": -3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "contains",
+						"qualifier": "savoir-faire"
+					},
+					"amount": -3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "sex appeal"
+					},
+					"amount": -3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "sociology"
+					},
+					"amount": -3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "streetwise"
+					},
+					"amount": -3
+				}
+			],
+			"calc": {
+				"points": -20
+			}
+		},
+		{
+			"id": "9d1a7530-687e-450c-86e7-f4f301c269ab",
+			"type": "trait",
+			"name": "Numb",
+			"reference": "B146",
+			"tags": [
+				"Disadvantage",
+				"Physical"
+			],
+			"base_points": -20,
+			"calc": {
+				"points": -20
+			}
+		},
+		{
+			"id": "862ca597-2a5f-45ba-b2b9-fd39bfd1652c",
+			"type": "trait",
+			"name": "Pacifism: Cannot Harm Innocents",
+			"reference": "B148",
+			"notes": "You may fight – you may even start fights – but you may only use deadly force on a foe that is attempting to do you serious harm. Capture is not “serious harm” unless you are already under penalty of death or have a Code of Honor that would require suicide if captured. You never intentionally do anything that causes, or even threatens to cause, injury to the uninvolved – particularly if they are “ordinary folks.”",
+			"tags": [
+				"Disadvantage",
+				"Mental"
+			],
+			"modifiers": [
+				{
+					"id": "74354ea8-96ba-4eee-9027-9f746e9bd941",
+					"type": "modifier",
+					"name": "Species-Specific",
+					"reference": "UT32",
+					"cost": -80,
+					"disabled": true
+				}
+			],
+			"base_points": -10,
+			"calc": {
+				"points": -10
+			}
+		},
+		{
+			"id": "74a7af26-226b-44b3-ad59-931a3767a215",
+			"type": "trait",
+			"name": "Restricted Diet (Fissionables)",
+			"reference": "B151",
+			"tags": [
+				"Disadvantage",
+				"Physical"
+			],
+			"modifiers": [
+				{
+					"id": "0dae0fad-abcc-4e90-a149-326bea6573a8",
+					"type": "modifier",
+					"name": "Substitution",
+					"reference": "B151",
+					"cost": -50,
+					"disabled": true
+				},
+				{
+					"id": "1cc9a927-6c9b-402c-bd43-9fe3454103aa",
+					"type": "modifier",
+					"name": "Very Common",
+					"reference": "B151",
+					"cost": -10,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "7ee9ad59-a4f4-4310-ad24-cbd4d90047c7",
+					"type": "modifier",
+					"name": "Common",
+					"reference": "B151",
+					"cost": -20,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "0d16b1d2-ff4b-40d7-a015-5b3a71fbbd1a",
+					"type": "modifier",
+					"name": "Occasional",
+					"reference": "B151",
+					"cost": -30,
+					"cost_type": "points"
+				},
+				{
+					"id": "2b764a44-21bf-4285-83d6-a2443b93fe36",
+					"type": "modifier",
+					"name": "Rare",
+					"reference": "B151",
+					"cost": -40,
+					"cost_type": "points",
+					"disabled": true
+				}
+			],
+			"calc": {
+				"points": -30
+			}
+		},
+		{
+			"id": "8df7dc14-b650-4863-ac41-62b656319443",
+			"type": "trait",
+			"name": "Truthfulness",
+			"reference": "B159",
+			"notes": "Make a self-control roll whenever you must keep silent about an uncomfortable truth (lying by omission). Roll at -5 if you actually have to tell a falsehood! If you fail, you blurt out the truth, or stumble so much that your lie is obvious.",
+			"tags": [
+				"Disadvantage",
+				"Mental"
+			],
+			"base_points": -5,
+			"features": [
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "fast talk"
+					},
+					"amount": -5
+				}
+			],
+			"cr": 6,
+			"calc": {
+				"points": -10
+			}
+		},
+		{
+			"id": "606c41f1-23bb-47a8-9b52-1fe16046331e",
+			"type": "trait",
+			"name": "Dead Broke",
+			"reference": "B25",
+			"notes": "Starting wealth is 0",
+			"tags": [
+				"Disadvantage",
+				"Social",
+				"Wealth"
+			],
+			"base_points": -25,
+			"calc": {
+				"points": -25
+			}
+		},
+		{
+			"id": "2f50848a-bc1e-4c42-b9fe-04b3266aaf61",
+			"type": "trait",
+			"name": "Quirk: Always takes time to search out new sutras",
+			"reference": "B162",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "3308b77d-8288-4afc-b68a-0484f07ae51a",
+			"type": "trait",
+			"name": "Quirk: Broad-Minded",
+			"reference": "B163",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "251425e1-a077-4b7f-8641-a53fa8edf9d8",
+			"type": "trait",
+			"name": "Quirk: Cannot Float",
+			"reference": "B165",
+			"tags": [
+				"Physical",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "e2d85f90-ab45-4f49-88bd-7562231d40f1",
+			"type": "trait",
+			"name": "Quirk: Constantly looking for challenges",
+			"reference": "B162",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "9f95ba00-f6d7-4e87-9db7-73224102dede",
+			"type": "trait",
+			"name": "Quirk: Humble",
+			"reference": "B164",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		}
+	],
+	"skills": [
+		{
+			"id": "23581915-efd1-4ce6-960e-a377bc40a5fe",
+			"type": "skill",
+			"name": "Armoury",
+			"reference": "B178",
+			"tags": [
+				"Maintenance",
+				"Military",
+				"Repair"
+			],
+			"specialization": "Heavy Weapons",
+			"tech_level": "9",
+			"difficulty": "iq/a",
+			"points": 2,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -5,
+				"level": 11,
+				"adjusted_level": 11,
+				"points": -11
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Engineer",
+					"specialization": "Heavy Weapons",
+					"modifier": -4
+				}
+			],
+			"calc": {
+				"level": 16,
+				"rsl": "IQ+0"
+			}
+		},
+		{
+			"id": "f3e0b234-3486-47d9-93b7-4a5131e1a34d",
+			"type": "skill",
+			"name": "Brawling",
+			"reference": "B182,MA55",
+			"tags": [
+				"Combat",
+				"Melee Combat",
+				"Weapon"
+			],
+			"difficulty": "dx/e",
+			"points": 1,
+			"features": [
+				{
+					"type": "weapon_bonus",
+					"selection_type": "weapons_with_required_skill",
+					"name": {
+						"compare": "is",
+						"qualifier": "Brawling"
+					},
+					"level": {
+						"compare": "at_least",
+						"qualifier": 2
+					},
+					"amount": 1,
+					"per_level": true
+				}
+			],
+			"calc": {
+				"level": 15,
+				"rsl": "DX+0"
+			}
+		},
+		{
+			"id": "2af4bffc-db7d-44d7-9a2a-f0ae11bd0c53",
+			"type": "skill",
+			"name": "Computer Operation",
+			"reference": "B184",
+			"tags": [
+				"Everyman",
+				"Scholarly",
+				"Technical"
+			],
+			"tech_level": "9",
+			"difficulty": "iq/e",
+			"points": 1,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -4,
+				"level": 12,
+				"adjusted_level": 12,
+				"points": -12
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -4
+				}
+			],
+			"calc": {
+				"level": 16,
+				"rsl": "IQ+0"
+			}
+		},
+		{
+			"id": "374438c9-613c-4e37-8573-6e86406fe436",
+			"type": "skill",
+			"name": "Electronics Repair",
+			"reference": "B190",
+			"tags": [
+				"Maintenance",
+				"Repair"
+			],
+			"specialization": "Computer",
+			"tech_level": "9",
+			"difficulty": "iq/a",
+			"points": 8,
+			"defaulted_from": {
+				"type": "skill",
+				"name": "Computer Operation",
+				"modifier": -3,
+				"level": 13,
+				"adjusted_level": 13,
+				"points": -13
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Computer Operation",
+					"modifier": -3
+				},
+				{
+					"type": "skill",
+					"name": "Engineer",
+					"specialization": "Electronics",
+					"modifier": -3
+				},
+				{
+					"type": "skill",
+					"name": "Electronics Repair",
+					"modifier": -4
+				}
+			],
+			"calc": {
+				"level": 18,
+				"rsl": "IQ+2"
+			}
+		},
+		{
+			"id": "38892a8a-401c-4c08-9030-d568b6cf9587",
+			"type": "skill",
+			"name": "Expert Skill",
+			"reference": "B193,MA56",
+			"tags": [
+				"Knowledge",
+				"Military",
+				"Scholarly"
+			],
+			"specialization": "Military Science",
+			"difficulty": "iq/h",
+			"points": 2,
+			"calc": {
+				"level": 15,
+				"rsl": "IQ-1"
+			}
+		},
+		{
+			"id": "44dc3c28-b14a-443c-a876-98afc87cf783",
+			"type": "skill",
+			"name": "Forward Observer",
+			"reference": "B196",
+			"tags": [
+				"Military"
+			],
+			"tech_level": "9",
+			"difficulty": "iq/a",
+			"points": 1,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -5,
+				"level": 11,
+				"adjusted_level": 11,
+				"points": -11
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Artillery",
+					"modifier": -5
+				}
+			],
+			"calc": {
+				"level": 15,
+				"rsl": "IQ-1"
+			}
+		},
+		{
+			"id": "6a887e40-f6f5-47c8-a42a-cc6e4d88eeef",
+			"type": "skill",
+			"name": "Innate Attack",
+			"reference": "B201",
+			"tags": [
+				"Combat",
+				"Ranged Combat",
+				"Weapon"
+			],
+			"specialization": "Beam",
+			"difficulty": "dx/e",
+			"points": 1,
+			"defaulted_from": {
+				"type": "skill",
+				"name": "Innate Attack",
+				"specialization": "Projectile",
+				"modifier": -2,
+				"level": 13,
+				"adjusted_level": 13,
+				"points": -13
+			},
+			"defaults": [
+				{
+					"type": "dx",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Innate Attack",
+					"modifier": -2
+				}
+			],
+			"calc": {
+				"level": 15,
+				"rsl": "DX+0"
+			}
+		},
+		{
+			"id": "9d8745ee-90ec-47b0-a895-fa5539e677bb",
+			"type": "skill",
+			"name": "Innate Attack",
+			"reference": "B201",
+			"tags": [
+				"Combat",
+				"Ranged Combat",
+				"Weapon"
+			],
+			"specialization": "Projectile",
+			"difficulty": "dx/e",
+			"points": 1,
+			"defaulted_from": {
+				"type": "dx",
+				"modifier": -4,
+				"level": 11,
+				"adjusted_level": 11,
+				"points": -11
+			},
+			"defaults": [
+				{
+					"type": "dx",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Innate Attack",
+					"modifier": -2
+				}
+			],
+			"calc": {
+				"level": 15,
+				"rsl": "DX+0"
+			}
+		},
+		{
+			"id": "745c7bdb-db59-4da9-bc2e-e2d18badbb03",
+			"type": "skill",
+			"name": "Mechanic",
+			"reference": "B207",
+			"tags": [
+				"Maintenance",
+				"Repair"
+			],
+			"specialization": "Robotics",
+			"tech_level": "9",
+			"difficulty": "iq/a",
+			"points": 8,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -5,
+				"level": 11,
+				"adjusted_level": 11,
+				"points": -11
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Engineer",
+					"specialization": "Robotics",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Machinist",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Mechanic",
+					"modifier": -4
+				}
+			],
+			"calc": {
+				"level": 18,
+				"rsl": "IQ+2"
+			}
+		},
+		{
+			"id": "09dfc55f-eb51-4dfd-9ecd-7a8e553d9fa3",
+			"type": "skill",
+			"name": "Meditation",
+			"reference": "B207",
+			"tags": [
+				"Esoteric"
+			],
+			"difficulty": "will/h",
+			"points": 1,
+			"defaulted_from": {
+				"type": "will",
+				"modifier": -6,
+				"level": 10,
+				"adjusted_level": 10,
+				"points": -10
+			},
+			"defaults": [
+				{
+					"type": "will",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Autohypnosis",
+					"modifier": -4
+				}
+			],
+			"calc": {
+				"level": 14,
+				"rsl": "Will-2"
+			}
+		},
+		{
+			"id": "d0517b45-4837-4347-a696-7f68f22b1729",
+			"type": "skill",
+			"name": "Mount",
+			"reference": "B210",
+			"tags": [
+				"Animal",
+				"Athletic"
+			],
+			"difficulty": "dx/a",
+			"points": 2,
+			"defaulted_from": {
+				"type": "dx",
+				"modifier": -5,
+				"level": 10,
+				"adjusted_level": 10,
+				"points": -10
+			},
+			"defaults": [
+				{
+					"type": "dx",
+					"modifier": -5
+				}
+			],
+			"calc": {
+				"level": 15,
+				"rsl": "DX+0"
+			}
+		},
+		{
+			"id": "8cc9d5bb-4ea9-4a2a-9530-973959eecb1b",
+			"type": "skill",
+			"name": "Navigation",
+			"reference": "B211",
+			"tags": [
+				"Exploration",
+				"Outdoor",
+				"Technical",
+				"Vehicle"
+			],
+			"specialization": "Land",
+			"tech_level": "9",
+			"difficulty": "iq/a",
+			"points": 1,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -5,
+				"level": 11,
+				"adjusted_level": 11,
+				"points": -11
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Cartography",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Mathematics",
+					"specialization": "Surveying",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Navigation",
+					"specialization": "Air",
+					"modifier": -2
+				},
+				{
+					"type": "skill",
+					"name": "Navigation",
+					"specialization": "Sea",
+					"modifier": -2
+				}
+			],
+			"calc": {
+				"level": 15,
+				"rsl": "IQ-1"
+			}
+		},
+		{
+			"id": "999ba280-dec3-43e6-ab3b-632ba0927d58",
+			"type": "skill",
+			"name": "Parachuting",
+			"reference": "B212",
+			"tags": [
+				"Athletic",
+				"Military",
+				"Technical"
+			],
+			"tech_level": "9",
+			"difficulty": "dx/e",
+			"points": 1,
+			"defaulted_from": {
+				"type": "dx",
+				"modifier": -4,
+				"level": 11,
+				"adjusted_level": 11,
+				"points": -11
+			},
+			"defaults": [
+				{
+					"type": "dx",
+					"modifier": -4
+				}
+			],
+			"calc": {
+				"level": 15,
+				"rsl": "DX+0"
+			}
+		},
+		{
+			"id": "adf50208-6f88-4cc4-adf6-0fa4cbc55fce",
+			"type": "skill",
+			"name": "Tactics",
+			"reference": "B224,MA60",
+			"tags": [
+				"Military",
+				"Police"
+			],
+			"difficulty": "iq/h",
+			"points": 20,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -6,
+				"level": 10,
+				"adjusted_level": 10,
+				"points": -10
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Strategy",
+					"modifier": -6
+				}
+			],
+			"calc": {
+				"level": 20,
+				"rsl": "IQ+4"
+			}
+		},
+		{
+			"id": "45edc1fe-6e8d-4c30-b3b3-c4be78e84061",
+			"type": "skill",
+			"name": "Strategy",
+			"reference": "B222",
+			"tags": [
+				"Military"
+			],
+			"specialization": "Land",
+			"difficulty": "iq/h",
+			"points": 11,
+			"defaulted_from": {
+				"type": "skill",
+				"name": "Tactics",
+				"modifier": -6,
+				"level": 14,
+				"adjusted_level": 14,
+				"points": 1
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Intelligence Analysis",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Tactics",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Strategy",
+					"modifier": -4
+				}
+			],
+			"calc": {
+				"level": 18,
+				"rsl": "IQ+2"
+			}
+		},
+		{
+			"id": "12af05c8-f252-4b20-b555-7fda69bbb27f",
+			"type": "skill",
+			"name": "Theology",
+			"reference": "B226",
+			"tags": [
+				"Humanities",
+				"Social Sciences"
+			],
+			"specialization": "Buddhist",
+			"difficulty": "iq/h",
+			"points": 2,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -6,
+				"level": 10,
+				"adjusted_level": 10,
+				"points": -10
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Religious Ritual",
+					"specialization": "Buddhist",
+					"modifier": -4
+				}
+			],
+			"calc": {
+				"level": 15,
+				"rsl": "IQ-1"
+			}
+		}
+	],
+	"created_date": "2023-01-15T07:56:34Z",
+	"modified_date": "2023-01-15T21:22:39Z",
+	"calc": {
+		"swing": "5d+1",
+		"thrust": "3d-1",
+		"basic_lift": "157 lb",
+		"dodge_bonus": 1,
+		"parry_bonus": 1,
+		"block_bonus": 1,
+		"move": [
+			8,
+			6,
+			4,
+			3,
+			1
+		],
+		"dodge": [
+			12,
+			11,
+			10,
+			9,
+			8
+		]
+	}
+}

--- a/Library/Basic Set/Characters/Janos Telkozep.gcs
+++ b/Library/Basic Set/Characters/Janos Telkozep.gcs
@@ -1,0 +1,4894 @@
+{
+	"type": "character",
+	"version": 4,
+	"id": "0e933430-c5e6-4701-aaa1-d7aea888e227",
+	"total_points": 535,
+	"points_record": [
+		{
+			"when": "2023-01-15T22:20:24Z",
+			"points": 535,
+			"reason": "Initial points"
+		}
+	],
+	"profile": {
+		"player_name": "NPC",
+		"name": "Janos Telkozep",
+		"title": "Baron",
+		"age": "421",
+		"gender": "Male",
+		"tech_level": "8",
+		"height": "5'8\"",
+		"weight": "197 lb"
+	},
+	"settings": {
+		"page": {
+			"paper_size": "letter",
+			"orientation": "portrait",
+			"top_margin": "0.25 in",
+			"left_margin": "0.25 in",
+			"bottom_margin": "0.25 in",
+			"right_margin": "0.25 in"
+		},
+		"block_layout": [
+			"reactions conditional_modifiers",
+			"melee",
+			"ranged",
+			"traits skills",
+			"spells",
+			"equipment",
+			"other_equipment",
+			"notes"
+		],
+		"attributes": [
+			{
+				"id": "st",
+				"type": "integer",
+				"name": "ST",
+				"full_name": "Strength",
+				"attribute_base": "10",
+				"cost_per_point": 10,
+				"cost_adj_percent_per_sm": 10
+			},
+			{
+				"id": "dx",
+				"type": "integer",
+				"name": "DX",
+				"full_name": "Dexterity",
+				"attribute_base": "10",
+				"cost_per_point": 20
+			},
+			{
+				"id": "iq",
+				"type": "integer",
+				"name": "IQ",
+				"full_name": "Intelligence",
+				"attribute_base": "10",
+				"cost_per_point": 20
+			},
+			{
+				"id": "ht",
+				"type": "integer",
+				"name": "HT",
+				"full_name": "Health",
+				"attribute_base": "10",
+				"cost_per_point": 10
+			},
+			{
+				"id": "will",
+				"type": "integer",
+				"name": "Will",
+				"attribute_base": "$iq",
+				"cost_per_point": 5
+			},
+			{
+				"id": "fright_check",
+				"type": "integer",
+				"name": "Fright Check",
+				"attribute_base": "$will",
+				"cost_per_point": 2
+			},
+			{
+				"id": "senses",
+				"type": "secondary_separator",
+				"name": "Senses"
+			},
+			{
+				"id": "per",
+				"type": "integer",
+				"name": "Per",
+				"full_name": "Perception",
+				"attribute_base": "$iq",
+				"cost_per_point": 5
+			},
+			{
+				"id": "vision",
+				"type": "integer",
+				"name": "Vision",
+				"attribute_base": "$per",
+				"cost_per_point": 2
+			},
+			{
+				"id": "hearing",
+				"type": "integer",
+				"name": "Hearing",
+				"attribute_base": "$per",
+				"cost_per_point": 2
+			},
+			{
+				"id": "taste_smell",
+				"type": "integer",
+				"name": "Taste \u0026 Smell",
+				"attribute_base": "$per",
+				"cost_per_point": 2
+			},
+			{
+				"id": "touch",
+				"type": "integer",
+				"name": "Touch",
+				"attribute_base": "$per",
+				"cost_per_point": 2
+			},
+			{
+				"id": "movement",
+				"type": "secondary_separator",
+				"name": "Movement"
+			},
+			{
+				"id": "basic_speed",
+				"type": "decimal",
+				"name": "Basic Speed",
+				"attribute_base": "($dx+$ht)/4",
+				"cost_per_point": 20
+			},
+			{
+				"id": "basic_move",
+				"type": "integer",
+				"name": "Basic Move",
+				"attribute_base": "floor($basic_speed)",
+				"cost_per_point": 5
+			},
+			{
+				"id": "highjump",
+				"type": "integer_ref",
+				"name": "High Jump (in)",
+				"attribute_base": "(6 * max(max($basic_move, floor(skill_level(jumping) / 2)), $st / 4) - 10) * enc(false, true) * (2 ^ max(0, trait_level(super jump)))"
+			},
+			{
+				"id": "running_highjump",
+				"type": "integer_ref",
+				"name": "when running",
+				"attribute_base": "(6 * max(max($basic_move, floor(skill_level(jumping) / 2)), $st / 4) * (1 + max(0, trait_level(\"enhanced move (ground)\"))) - 10) * enc(false, true) * if(trait_level(\"enhanced move (ground)\")\u003c1,2,1) * (2 ^ max(0, trait_level(super jump)))"
+			},
+			{
+				"id": "broadjump",
+				"type": "integer_ref",
+				"name": "Broad Jump (ft)",
+				"attribute_base": "(2 * max(max($basic_move, floor(skill_level(jumping) / 2)), $st / 4) - 3) * enc(false, true) * (2 ^ max(0, trait_level(super jump)))"
+			},
+			{
+				"id": "running_broadjump",
+				"type": "integer_ref",
+				"name": "when running",
+				"attribute_base": "(2 * max(max($basic_move, floor(skill_level(jumping) / 2)), $st / 4) * (1 + max(0, trait_level(\"enhanced move (ground)\"))) - 3) * enc(false, true) * if(trait_level(\"enhanced move (ground)\")\u003c1,2,1) * (2 ^ max(0, trait_level(super jump)))"
+			},
+			{
+				"id": "fp",
+				"type": "pool",
+				"name": "FP",
+				"full_name": "Fatigue Points",
+				"attribute_base": "$ht",
+				"cost_per_point": 3,
+				"thresholds": [
+					{
+						"state": "Unconscious",
+						"expression": "-$fp",
+						"ops": [
+							"halve_move",
+							"halve_dodge",
+							"halve_st"
+						]
+					},
+					{
+						"state": "Collapse",
+						"expression": "0",
+						"explanation": "Roll vs. Will to do anything besides talk or rest; failure causes unconsciousness\nEach FP you lose below 0 also causes 1 HP of injury\nMove, Dodge and ST are halved (B426)",
+						"ops": [
+							"halve_move",
+							"halve_dodge",
+							"halve_st"
+						]
+					},
+					{
+						"state": "Tired",
+						"expression": "round($fp/3)",
+						"explanation": "Move, Dodge and ST are halved (B426)",
+						"ops": [
+							"halve_move",
+							"halve_dodge",
+							"halve_st"
+						]
+					},
+					{
+						"state": "Tiring",
+						"expression": "$fp-1"
+					},
+					{
+						"state": "Rested",
+						"expression": "$fp"
+					}
+				]
+			},
+			{
+				"id": "hp",
+				"type": "pool",
+				"name": "HP",
+				"full_name": "Hit Points",
+				"attribute_base": "$st",
+				"cost_per_point": 2,
+				"cost_adj_percent_per_sm": 10,
+				"thresholds": [
+					{
+						"state": "Dead",
+						"expression": "round(-$hp*5)",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Dying #4",
+						"expression": "round(-$hp*4)",
+						"explanation": "Roll vs. HT to avoid death\nRoll vs. HT-4 every second to avoid falling unconscious\nMove and Dodge are halved (B419)",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Dying #3",
+						"expression": "round(-$hp*3)",
+						"explanation": "Roll vs. HT to avoid death\nRoll vs. HT-3 every second to avoid falling unconscious\nMove and Dodge are halved (B419)",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Dying #2",
+						"expression": "round(-$hp*2)",
+						"explanation": "Roll vs. HT to avoid death\nRoll vs. HT-2 every second to avoid falling unconscious\nMove and Dodge are halved (B419)",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Dying #1",
+						"expression": "-$hp",
+						"explanation": "Roll vs. HT to avoid death\nRoll vs. HT-1 every second to avoid falling unconscious\nMove and Dodge are halved (B419)",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Collapse",
+						"expression": "0",
+						"explanation": "Roll vs. HT every second to avoid falling unconscious\nMove and Dodge are halved (B419)",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Reeling",
+						"expression": "round($hp/3)",
+						"explanation": "Move and Dodge are halved (B419)",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Wounded",
+						"expression": "$hp-1"
+					},
+					{
+						"state": "Healthy",
+						"expression": "$hp"
+					}
+				]
+			}
+		],
+		"body_type": {
+			"name": "Humanoid",
+			"roll": "3d",
+			"locations": [
+				{
+					"id": "eye",
+					"choice_name": "Eyes",
+					"table_name": "Eyes",
+					"hit_penalty": -9,
+					"description": "An attack that misses by 1 hits the torso instead. Only\nimpaling (imp), piercing (pi-, pi, pi+, pi++), and\ntight-beam burning (burn) attacks can target the eye – and\nonly from the front or sides. Injury over HP÷10 blinds the\neye. Otherwise, treat as skull, but without the extra DR!",
+					"calc": {
+						"roll_range": "-",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "skull",
+					"choice_name": "Skull",
+					"table_name": "Skull",
+					"slots": 2,
+					"hit_penalty": -7,
+					"dr_bonus": 2,
+					"description": "An attack that misses by 1 hits the torso instead. Wounding\nmodifier is x4. Knockdown rolls are at -10. Critical hits\nuse the Critical Head Blow Table (B556). Exception: These\nspecial effects do not apply to toxic (tox) damage.",
+					"calc": {
+						"roll_range": "3-4",
+						"dr": {
+							"all": 2
+						}
+					}
+				},
+				{
+					"id": "face",
+					"choice_name": "Face",
+					"table_name": "Face",
+					"slots": 1,
+					"hit_penalty": -5,
+					"description": "An attack that misses by 1 hits the torso instead. Jaw,\ncheeks, nose, ears, etc. If the target has an open-faced\nhelmet, ignore its DR. Knockdown rolls are at -5. Critical\nhits use the Critical Head Blow Table (B556). Corrosion\n(cor) damage gets a x1½ wounding modifier, and if it\ninflicts a major wound, it also blinds one eye (both eyes on\ndamage over full HP). Random attacks from behind hit the\nskull instead.",
+					"calc": {
+						"roll_range": "5",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "leg",
+					"choice_name": "Leg",
+					"table_name": "Right Leg",
+					"slots": 2,
+					"hit_penalty": -2,
+					"description": "Reduce the wounding multiplier of large piercing (pi+), huge\npiercing (pi++), and impaling (imp) damage to x1. Any major\nwound (loss of over ½ HP from one blow) cripples the limb.\nDamage beyond that threshold is lost.",
+					"calc": {
+						"roll_range": "6-7",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "arm",
+					"choice_name": "Arm",
+					"table_name": "Right Arm",
+					"slots": 1,
+					"hit_penalty": -2,
+					"description": "Reduce the wounding multiplier of large piercing (pi+), huge\npiercing (pi++), and impaling (imp) damage to x1. Any major\nwound (loss of over ½ HP from one blow) cripples the limb.\nDamage beyond that threshold is lost. If holding a shield,\ndouble the penalty to hit: -4 for shield arm instead of -2.",
+					"calc": {
+						"roll_range": "8",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "torso",
+					"choice_name": "Torso",
+					"table_name": "Torso",
+					"slots": 2,
+					"calc": {
+						"roll_range": "9-10",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "groin",
+					"choice_name": "Groin",
+					"table_name": "Groin",
+					"slots": 1,
+					"hit_penalty": -3,
+					"description": "An attack that misses by 1 hits the torso instead. Human\nmales and the males of similar species suffer double shock\nfrom crushing (cr) damage, and get -5 to knockdown rolls.\nOtherwise, treat as a torso hit.",
+					"calc": {
+						"roll_range": "11",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "arm",
+					"choice_name": "Arm",
+					"table_name": "Left Arm",
+					"slots": 1,
+					"hit_penalty": -2,
+					"description": "Reduce the wounding multiplier of large piercing (pi+), huge\npiercing (pi++), and impaling (imp) damage to x1. Any major\nwound (loss of over ½ HP from one blow) cripples the limb.\nDamage beyond that threshold is lost. If holding a shield,\ndouble the penalty to hit: -4 for shield arm instead of -2.",
+					"calc": {
+						"roll_range": "12",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "leg",
+					"choice_name": "Leg",
+					"table_name": "Left Leg",
+					"slots": 2,
+					"hit_penalty": -2,
+					"description": "Reduce the wounding multiplier of large piercing (pi+), huge\npiercing (pi++), and impaling (imp) damage to x1. Any major\nwound (loss of over ½ HP from one blow) cripples the limb.\nDamage beyond that threshold is lost.",
+					"calc": {
+						"roll_range": "13-14",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "hand",
+					"choice_name": "Hand",
+					"table_name": "Hand",
+					"slots": 1,
+					"hit_penalty": -4,
+					"description": "If holding a shield, double the penalty to hit: -8 for\nshield hand instead of -4. Reduce the wounding multiplier of\nlarge piercing (pi+), huge piercing (pi++), and impaling\n(imp) damage to x1. Any major wound (loss of over ⅓ HP\nfrom one blow) cripples the extremity. Damage beyond that\nthreshold is lost.",
+					"calc": {
+						"roll_range": "15",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "foot",
+					"choice_name": "Foot",
+					"table_name": "Foot",
+					"slots": 1,
+					"hit_penalty": -4,
+					"description": "Reduce the wounding multiplier of large piercing (pi+), huge\npiercing (pi++), and impaling (imp) damage to x1. Any major\nwound (loss of over ⅓ HP from one blow) cripples the\nextremity. Damage beyond that threshold is lost.",
+					"calc": {
+						"roll_range": "16",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "neck",
+					"choice_name": "Neck",
+					"table_name": "Neck",
+					"slots": 2,
+					"hit_penalty": -5,
+					"description": "An attack that misses by 1 hits the torso instead. Neck and\nthroat. Increase the wounding multiplier of crushing (cr)\nand corrosion (cor) attacks to x1½, and that of cutting\n(cut) damage to x2. At the GM’s option, anyone killed by a\ncutting (cut) blow to the neck is decapitated!",
+					"calc": {
+						"roll_range": "17-18",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "vitals",
+					"choice_name": "Vitals",
+					"table_name": "Vitals",
+					"hit_penalty": -3,
+					"description": "An attack that misses by 1 hits the torso instead. Heart,\nlungs, kidneys, etc. Increase the wounding modifier for an\nimpaling (imp) or any piercing (pi-, pi, pi+, pi++) attack\nto x3. Increase the wounding modifier for a tight-beam\nburning (burn) attack to x2. Other attacks cannot target the\nvitals.",
+					"calc": {
+						"roll_range": "-",
+						"dr": {
+							"all": 0
+						}
+					}
+				}
+			]
+		},
+		"damage_progression": "basic_set",
+		"default_length_units": "ft_in",
+		"default_weight_units": "lb",
+		"user_description_display": "tooltip",
+		"modifiers_display": "inline",
+		"notes_display": "inline",
+		"skill_level_adj_display": "tooltip",
+		"show_spell_adj": true,
+		"exclude_unspent_points_from_total": false
+	},
+	"attributes": [
+		{
+			"attr_id": "st",
+			"adj": 4,
+			"calc": {
+				"value": 20,
+				"points": 40
+			}
+		},
+		{
+			"attr_id": "dx",
+			"adj": 1,
+			"calc": {
+				"value": 11,
+				"points": 20
+			}
+		},
+		{
+			"attr_id": "iq",
+			"adj": 5,
+			"calc": {
+				"value": 15,
+				"points": 100
+			}
+		},
+		{
+			"attr_id": "ht",
+			"adj": 0,
+			"calc": {
+				"value": 10,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "will",
+			"adj": 1,
+			"calc": {
+				"value": 16,
+				"points": 5
+			}
+		},
+		{
+			"attr_id": "fright_check",
+			"adj": 0,
+			"calc": {
+				"value": 16,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "senses",
+			"adj": 0
+		},
+		{
+			"attr_id": "per",
+			"adj": 0,
+			"calc": {
+				"value": 18,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "vision",
+			"adj": 0,
+			"calc": {
+				"value": 18,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "hearing",
+			"adj": 0,
+			"calc": {
+				"value": 18,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "taste_smell",
+			"adj": 0,
+			"calc": {
+				"value": 18,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "touch",
+			"adj": 0,
+			"calc": {
+				"value": 18,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "movement",
+			"adj": 0
+		},
+		{
+			"attr_id": "basic_speed",
+			"adj": 2.75,
+			"calc": {
+				"value": 8,
+				"points": 55
+			}
+		},
+		{
+			"attr_id": "basic_move",
+			"adj": 0,
+			"calc": {
+				"value": 8,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "highjump",
+			"adj": 0,
+			"calc": {
+				"value": 38,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "running_highjump",
+			"adj": 0,
+			"calc": {
+				"value": 76,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "broadjump",
+			"adj": 0,
+			"calc": {
+				"value": 13,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "running_broadjump",
+			"adj": 0,
+			"calc": {
+				"value": 26,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "fp",
+			"adj": 0,
+			"calc": {
+				"value": 10,
+				"current": 10,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "hp",
+			"adj": 0,
+			"calc": {
+				"value": 24,
+				"current": 24,
+				"points": 0
+			}
+		}
+	],
+	"traits": [
+		{
+			"id": "60e3a237-7825-47a7-9fc3-334d7504f9e0",
+			"type": "trait",
+			"name": "Natural Attacks",
+			"reference": "B271",
+			"weapons": [
+				{
+					"id": "b33d54c1-fb2c-4077-b3dd-b21843705212",
+					"type": "melee_weapon",
+					"damage": {
+						"type": "cr",
+						"st": "thr",
+						"base": "-1"
+					},
+					"usage": "Bite",
+					"reach": "C",
+					"parry": "No",
+					"block": "No",
+					"defaults": [
+						{
+							"type": "dx"
+						},
+						{
+							"type": "skill",
+							"name": "Brawling"
+						}
+					],
+					"calc": {
+						"level": 12,
+						"parry": "No",
+						"block": "No",
+						"damage": "2d+1 cr"
+					}
+				},
+				{
+					"id": "acb28cbe-1f66-46fd-b547-5be1b783ccc6",
+					"type": "melee_weapon",
+					"damage": {
+						"type": "cr",
+						"st": "thr",
+						"base": "-1"
+					},
+					"usage": "Punch",
+					"reach": "C",
+					"parry": "0",
+					"defaults": [
+						{
+							"type": "dx"
+						},
+						{
+							"type": "skill",
+							"name": "Boxing"
+						},
+						{
+							"type": "skill",
+							"name": "Brawling"
+						},
+						{
+							"type": "skill",
+							"name": "Karate"
+						}
+					],
+					"calc": {
+						"level": 12,
+						"parry": "9",
+						"damage": "2d+1 cr"
+					}
+				},
+				{
+					"id": "0ecf71dd-97b8-405e-968c-ed0ca77effb1",
+					"type": "melee_weapon",
+					"damage": {
+						"type": "cr",
+						"st": "thr"
+					},
+					"usage": "Kick",
+					"reach": "C,1",
+					"parry": "No",
+					"defaults": [
+						{
+							"type": "dx",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Brawling",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Kicking"
+						},
+						{
+							"type": "skill",
+							"name": "Karate",
+							"modifier": -2
+						}
+					],
+					"calc": {
+						"level": 10,
+						"parry": "No",
+						"damage": "2d+2 cr"
+					}
+				}
+			],
+			"calc": {
+				"points": 0
+			}
+		},
+		{
+			"id": "4a5ca714-89b8-4a80-bef1-f1d7ecec8467",
+			"type": "trait",
+			"name": "Language: English",
+			"reference": "B24",
+			"tags": [
+				"Advantage",
+				"Language",
+				"Mental"
+			],
+			"modifiers": [
+				{
+					"id": "ff972d9a-b925-4895-a489-f3d14999074d",
+					"type": "modifier",
+					"name": "Native",
+					"reference": "B23",
+					"cost": -6,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "e9f38c71-c4bd-45ee-a5e2-b47a33029f96",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "None",
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "6cd10ab4-c4f9-4764-a47d-0e77d105d862",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Broken",
+					"cost": 1,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "3c7caa3c-055e-4422-ac8e-6a2d632b391c",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Accented",
+					"cost": 2,
+					"cost_type": "points"
+				},
+				{
+					"id": "231ba28d-11ce-44e1-8d23-074d40ca57c6",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Native",
+					"cost": 3,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "152ad20b-dc58-4abb-b256-71da14dbb89c",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "None",
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "6304a0d6-80f3-4a5f-b3cc-3ba2ae0c8063",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Broken",
+					"cost": 1,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "5818ab4a-2c4b-4c3e-a711-c4b6332daaca",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Accented",
+					"cost": 2,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "1b77515e-5789-49a0-8238-7242900c8c2c",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Native",
+					"cost": 3,
+					"cost_type": "points"
+				}
+			],
+			"calc": {
+				"points": 5
+			}
+		},
+		{
+			"id": "9aee6dba-5a09-43bf-a3d2-ea15c39a4fd1",
+			"type": "trait",
+			"name": "Language: French",
+			"reference": "B24",
+			"tags": [
+				"Advantage",
+				"Language",
+				"Mental"
+			],
+			"modifiers": [
+				{
+					"id": "ff972d9a-b925-4895-a489-f3d14999074d",
+					"type": "modifier",
+					"name": "Native",
+					"reference": "B23",
+					"cost": -6,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "e9f38c71-c4bd-45ee-a5e2-b47a33029f96",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "None",
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "6cd10ab4-c4f9-4764-a47d-0e77d105d862",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Broken",
+					"cost": 1,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "3c7caa3c-055e-4422-ac8e-6a2d632b391c",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Accented",
+					"cost": 2,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "231ba28d-11ce-44e1-8d23-074d40ca57c6",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Native",
+					"cost": 3,
+					"cost_type": "points"
+				},
+				{
+					"id": "152ad20b-dc58-4abb-b256-71da14dbb89c",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "None",
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "6304a0d6-80f3-4a5f-b3cc-3ba2ae0c8063",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Broken",
+					"cost": 1,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "5818ab4a-2c4b-4c3e-a711-c4b6332daaca",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Accented",
+					"cost": 2,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "1b77515e-5789-49a0-8238-7242900c8c2c",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Native",
+					"cost": 3,
+					"cost_type": "points"
+				}
+			],
+			"calc": {
+				"points": 6
+			}
+		},
+		{
+			"id": "6f2118b6-0d23-49a4-b61d-a02abd7d6605",
+			"type": "trait",
+			"name": "Language: Hungarian",
+			"reference": "B24",
+			"tags": [
+				"Advantage",
+				"Language",
+				"Mental"
+			],
+			"modifiers": [
+				{
+					"id": "ff972d9a-b925-4895-a489-f3d14999074d",
+					"type": "modifier",
+					"name": "Native",
+					"reference": "B23",
+					"cost": -6,
+					"cost_type": "points"
+				},
+				{
+					"id": "e9f38c71-c4bd-45ee-a5e2-b47a33029f96",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "None",
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "6cd10ab4-c4f9-4764-a47d-0e77d105d862",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Broken",
+					"cost": 1,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "3c7caa3c-055e-4422-ac8e-6a2d632b391c",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Accented",
+					"cost": 2,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "231ba28d-11ce-44e1-8d23-074d40ca57c6",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Native",
+					"cost": 3,
+					"cost_type": "points"
+				},
+				{
+					"id": "152ad20b-dc58-4abb-b256-71da14dbb89c",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "None",
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "6304a0d6-80f3-4a5f-b3cc-3ba2ae0c8063",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Broken",
+					"cost": 1,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "5818ab4a-2c4b-4c3e-a711-c4b6332daaca",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Accented",
+					"cost": 2,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "1b77515e-5789-49a0-8238-7242900c8c2c",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Native",
+					"cost": 3,
+					"cost_type": "points"
+				}
+			],
+			"calc": {
+				"points": 0
+			}
+		},
+		{
+			"id": "9dd0e02e-8938-4144-9e50-8fe18eb35493",
+			"type": "trait",
+			"name": "Language: Latin",
+			"reference": "B24",
+			"tags": [
+				"Advantage",
+				"Language",
+				"Mental"
+			],
+			"modifiers": [
+				{
+					"id": "ff972d9a-b925-4895-a489-f3d14999074d",
+					"type": "modifier",
+					"name": "Native",
+					"reference": "B23",
+					"cost": -6,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "e9f38c71-c4bd-45ee-a5e2-b47a33029f96",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "None",
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "6cd10ab4-c4f9-4764-a47d-0e77d105d862",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Broken",
+					"cost": 1,
+					"cost_type": "points"
+				},
+				{
+					"id": "3c7caa3c-055e-4422-ac8e-6a2d632b391c",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Accented",
+					"cost": 2,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "231ba28d-11ce-44e1-8d23-074d40ca57c6",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Native",
+					"cost": 3,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "152ad20b-dc58-4abb-b256-71da14dbb89c",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "None",
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "6304a0d6-80f3-4a5f-b3cc-3ba2ae0c8063",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Broken",
+					"cost": 1,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "5818ab4a-2c4b-4c3e-a711-c4b6332daaca",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Accented",
+					"cost": 2,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "1b77515e-5789-49a0-8238-7242900c8c2c",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Native",
+					"cost": 3,
+					"cost_type": "points"
+				}
+			],
+			"calc": {
+				"points": 4
+			}
+		},
+		{
+			"id": "1b2165ef-3aaa-441f-b19f-6d021de4e69a",
+			"type": "trait",
+			"name": "Language: Russian",
+			"reference": "B24",
+			"tags": [
+				"Advantage",
+				"Language",
+				"Mental"
+			],
+			"modifiers": [
+				{
+					"id": "ff972d9a-b925-4895-a489-f3d14999074d",
+					"type": "modifier",
+					"name": "Native",
+					"reference": "B23",
+					"cost": -6,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "e9f38c71-c4bd-45ee-a5e2-b47a33029f96",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "None",
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "6cd10ab4-c4f9-4764-a47d-0e77d105d862",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Broken",
+					"cost": 1,
+					"cost_type": "points"
+				},
+				{
+					"id": "3c7caa3c-055e-4422-ac8e-6a2d632b391c",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Accented",
+					"cost": 2,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "231ba28d-11ce-44e1-8d23-074d40ca57c6",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Native",
+					"cost": 3,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "152ad20b-dc58-4abb-b256-71da14dbb89c",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "None",
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "6304a0d6-80f3-4a5f-b3cc-3ba2ae0c8063",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Broken",
+					"cost": 1,
+					"cost_type": "points"
+				},
+				{
+					"id": "5818ab4a-2c4b-4c3e-a711-c4b6332daaca",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Accented",
+					"cost": 2,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "1b77515e-5789-49a0-8238-7242900c8c2c",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Native",
+					"cost": 3,
+					"cost_type": "points",
+					"disabled": true
+				}
+			],
+			"calc": {
+				"points": 2
+			}
+		},
+		{
+			"id": "85411b7c-4539-44b8-84a0-b0b0773022e9",
+			"type": "trait",
+			"name": "Cultural Familiarity (18th-Century Europe)",
+			"reference": "B23",
+			"notes": "Do not suffer the normal -3 penalty for unfamiliarity",
+			"tags": [
+				"Advantage",
+				"Mental"
+			],
+			"modifiers": [
+				{
+					"id": "ab12b725-01c8-4fc4-8e71-619a54c79496",
+					"type": "modifier",
+					"name": "Alien",
+					"cost": 1,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "f72aa995-6766-4eaf-a3ca-0f4ff76d47c5",
+					"type": "modifier",
+					"name": "Native",
+					"cost": -1,
+					"cost_type": "points"
+				}
+			],
+			"base_points": 1,
+			"calc": {
+				"points": 0
+			}
+		},
+		{
+			"id": "813a1bcc-1d19-49a8-a602-fca826175274",
+			"type": "trait",
+			"name": "Cultural Familiarity (Homeline)",
+			"reference": "B23",
+			"notes": "Do not suffer the normal -3 penalty for unfamiliarity",
+			"tags": [
+				"Advantage",
+				"Mental"
+			],
+			"modifiers": [
+				{
+					"id": "ab12b725-01c8-4fc4-8e71-619a54c79496",
+					"type": "modifier",
+					"name": "Alien",
+					"cost": 1,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "f72aa995-6766-4eaf-a3ca-0f4ff76d47c5",
+					"type": "modifier",
+					"name": "Native",
+					"cost": -1,
+					"cost_type": "points",
+					"disabled": true
+				}
+			],
+			"base_points": 1,
+			"calc": {
+				"points": 1
+			}
+		},
+		{
+			"id": "a27a2c7c-df35-4f0f-ac4c-cfaf6948c796",
+			"type": "trait",
+			"name": "Charisma",
+			"reference": "B41",
+			"tags": [
+				"Advantage",
+				"Mental"
+			],
+			"levels": 3,
+			"points_per_level": 5,
+			"features": [
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "fortune-telling"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "leadership"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "panhandling"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "public speaking"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "reaction_bonus",
+					"situation": "from sapient being with whom you actively interact (converse, lecture, etc.)",
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "reaction_bonus",
+					"situation": "to Influence rolls",
+					"amount": 1,
+					"per_level": true
+				}
+			],
+			"can_level": true,
+			"calc": {
+				"points": 15
+			}
+		},
+		{
+			"id": "9fc0e3c0-aba3-4d5b-bd98-be5531c0e346",
+			"type": "trait",
+			"name": "Independent Income",
+			"reference": "B26",
+			"tags": [
+				"Advantage",
+				"Social"
+			],
+			"levels": 10,
+			"points_per_level": 1,
+			"can_level": true,
+			"calc": {
+				"points": 10
+			}
+		},
+		{
+			"id": "1bb13cd0-8264-4e6b-a397-ed8504a23445",
+			"type": "trait",
+			"name": "Legal Enforcement Powers",
+			"reference": "B65",
+			"tags": [
+				"Advantage",
+				"Social"
+			],
+			"levels": 3,
+			"points_per_level": 5,
+			"can_level": true,
+			"calc": {
+				"points": 15
+			}
+		},
+		{
+			"id": "9a56d381-f327-4fe0-aa30-98790f322240",
+			"type": "trait",
+			"name": "Mind Control",
+			"reference": "B68,P61,PSI15",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Mental"
+			],
+			"modifiers": [
+				{
+					"id": "42962b87-a3da-43c4-9fc0-39275ab8916c",
+					"type": "modifier",
+					"name": "Conditioning",
+					"reference": "B69",
+					"cost": 50,
+					"disabled": true
+				},
+				{
+					"id": "94fc2ca5-8936-44f4-a6cc-ecbb2c9f112b",
+					"type": "modifier",
+					"name": "No Memory",
+					"reference": "B69",
+					"cost": 10,
+					"disabled": true
+				},
+				{
+					"id": "62e4e382-c445-4b83-94eb-5b9b1e304902",
+					"type": "modifier",
+					"name": "Conditioning Only",
+					"reference": "B69",
+					"cost": -50,
+					"disabled": true
+				},
+				{
+					"id": "7cba0279-e699-4ef8-b006-4865e2a44e88",
+					"type": "modifier",
+					"name": "Puppet",
+					"reference": "B69",
+					"cost": -40,
+					"disabled": true
+				},
+				{
+					"id": "8188d7f8-0005-4e64-af28-b1585182864f",
+					"type": "modifier",
+					"name": "Independent",
+					"reference": "P61",
+					"cost": 70,
+					"disabled": true
+				},
+				{
+					"id": "2f103a1c-ec3b-4a23-910c-15f374eea24f",
+					"type": "modifier",
+					"name": "Emotion Control",
+					"reference": "P61",
+					"cost": -50,
+					"disabled": true
+				},
+				{
+					"id": "91b1efac-5d7a-47b3-ba9e-fb9c93ad52a6",
+					"type": "modifier",
+					"name": "One Emotion Only",
+					"reference": "H17",
+					"cost": -80,
+					"disabled": true
+				},
+				{
+					"id": "d0c7e4af-b025-4c43-b780-cb733ea468f9",
+					"type": "modifier",
+					"name": "Suggestion",
+					"reference": "P61",
+					"cost": -40,
+					"disabled": true
+				},
+				{
+					"id": "e531a4f0-a091-4c7e-9c42-6ec89de317aa",
+					"type": "modifier",
+					"name": "Rationalization",
+					"reference": "PSI15",
+					"cost": 20,
+					"disabled": true
+				},
+				{
+					"id": "60f687b0-79bd-4217-97b7-0e618ace7dec",
+					"type": "modifier",
+					"name": "Slow and Sure",
+					"reference": "PSI15",
+					"notes": "1 hour",
+					"cost": 80,
+					"disabled": true
+				},
+				{
+					"id": "30167781-f206-45ae-a138-d06d9bfdac35",
+					"type": "modifier",
+					"name": "Slow and Sure Only",
+					"reference": "PSI15",
+					"notes": "1 hour",
+					"cost": 40,
+					"disabled": true
+				},
+				{
+					"id": "9d9d9bd5-7bb8-4d67-ae52-e992dedd2e7f",
+					"type": "modifier",
+					"name": "Slow and Sure",
+					"reference": "PSI15",
+					"notes": "10 minutes",
+					"cost": 110,
+					"disabled": true
+				},
+				{
+					"id": "5cd58b61-4176-49e3-a2af-d7305651adad",
+					"type": "modifier",
+					"name": "Slow and Sure Only",
+					"reference": "PSI15",
+					"notes": "10 minutes",
+					"cost": 70,
+					"disabled": true
+				},
+				{
+					"id": "483d7784-edd7-46dc-8782-e88f326fcccb",
+					"type": "modifier",
+					"name": "Slow and Sure",
+					"reference": "PSI15",
+					"notes": "10 seconds",
+					"cost": 155,
+					"disabled": true
+				},
+				{
+					"id": "688f28d3-ce7b-4db2-99d8-b301b1e25c99",
+					"type": "modifier",
+					"name": "Slow and Sure Only",
+					"reference": "PSI15",
+					"notes": "10 seconds",
+					"cost": 115,
+					"disabled": true
+				},
+				{
+					"id": "3efbb25f-6854-4fcb-926c-0b5ec0b09d60",
+					"type": "modifier",
+					"name": "Mind Tricks",
+					"reference": "PSI15",
+					"cost": -30,
+					"disabled": true
+				}
+			],
+			"base_points": 50,
+			"calc": {
+				"points": 50
+			}
+		},
+		{
+			"id": "a9814025-7a38-486e-b601-178cafc8183b",
+			"type": "trait",
+			"name": "Striking ST",
+			"reference": "B88,P78",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Physical"
+			],
+			"modifiers": [
+				{
+					"id": "9b8e80e8-e2b2-459f-ab27-d96a9aa1e1ca",
+					"type": "modifier",
+					"name": "No Fine Manipulators",
+					"cost": -40,
+					"disabled": true
+				},
+				{
+					"id": "32892d90-82df-401d-bddc-d39a12d0f8b7",
+					"type": "modifier",
+					"name": "Size",
+					"cost": -10,
+					"levels": 1,
+					"disabled": true
+				},
+				{
+					"id": "eaabe509-f453-401a-89c1-4830111d0544",
+					"type": "modifier",
+					"name": "Super Effort",
+					"reference": "SU24",
+					"cost": 400,
+					"disabled": true
+				},
+				{
+					"id": "f35b516b-28d2-4935-8caa-e9f85f5310e0",
+					"type": "modifier",
+					"name": "One Attack Only",
+					"reference": "P79",
+					"notes": "@Attack@",
+					"cost": -60,
+					"disabled": true
+				},
+				{
+					"id": "4c469f7d-a2fc-45fa-9b19-a51985d575cd",
+					"type": "modifier",
+					"name": "Know Your Own Strength Pricing Variant",
+					"reference": "PY83:18",
+					"cost": -4,
+					"affects": "levels_only",
+					"cost_type": "points",
+					"disabled": true
+				}
+			],
+			"levels": 5,
+			"points_per_level": 5,
+			"features": [
+				{
+					"type": "attribute_bonus",
+					"limitation": "striking_only",
+					"attribute": "st",
+					"amount": 1,
+					"per_level": true
+				}
+			],
+			"can_level": true,
+			"calc": {
+				"points": 25
+			}
+		},
+		{
+			"id": "9d6cc089-e1f0-467e-ac7a-be5a17c5e693",
+			"type": "trait",
+			"name": "Talent (Business Acumen)",
+			"reference": "B90",
+			"tags": [
+				"Advantage",
+				"Mental",
+				"Talent"
+			],
+			"levels": 3,
+			"points_per_level": 10,
+			"features": [
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Accounting"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Administration"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Economics"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Finance"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Gambling"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Market Analysis"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Merchant"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Propaganda"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "reaction_bonus",
+					"situation": "from business partners",
+					"amount": 1,
+					"per_level": true
+				}
+			],
+			"can_level": true,
+			"calc": {
+				"points": 30
+			}
+		},
+		{
+			"id": "b6084452-cebe-4408-b177-2b243e44676c",
+			"type": "trait",
+			"name": "Temperature Control",
+			"reference": "B92,P83",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Mental",
+				"Physical"
+			],
+			"modifiers": [
+				{
+					"id": "4041ffa7-2ed5-4152-a73e-153b8037d8a4",
+					"type": "modifier",
+					"name": "Cold",
+					"reference": "B92",
+					"cost": -50
+				},
+				{
+					"id": "cfe3d1b5-3c69-4a53-9c2a-703ecc2c7e53",
+					"type": "modifier",
+					"name": "Heat",
+					"reference": "B92",
+					"cost": -50,
+					"disabled": true
+				},
+				{
+					"id": "b6881a65-af36-4c95-b76a-45686b2cfd40",
+					"type": "modifier",
+					"name": "Uncontrollable",
+					"reference": "B116",
+					"cost": -10
+				}
+			],
+			"levels": 3,
+			"points_per_level": 5,
+			"can_level": true,
+			"calc": {
+				"points": 6
+			}
+		},
+		{
+			"id": "32d7f716-2ec6-4fe7-980f-cb787528bf3f",
+			"type": "trait_container",
+			"children": [
+				{
+					"id": "c884eb6f-685b-4206-8674-31053051c1de",
+					"type": "trait",
+					"name": "Alternate Forms",
+					"reference": "B83",
+					"notes": "Wolf, Bat",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "9ca7163d-a487-4a59-a03c-0ebded18b262",
+							"type": "modifier",
+							"name": "Cosmetic",
+							"reference": "B84",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "7d8a91c9-6f26-4b57-ab66-594945ba5ece",
+							"type": "modifier",
+							"name": "Absorptive Change",
+							"reference": "P75",
+							"notes": "@Level of Absorptive Change. 1 None, 2, Light, 3, Medium, 4, Heavy, 5, Extra Heavy@",
+							"cost": 5,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "0c698881-6d69-4c72-a1f7-10f23c4bb130",
+							"type": "modifier",
+							"name": "Active Change",
+							"reference": "P75",
+							"cost": 20,
+							"disabled": true
+						},
+						{
+							"id": "1377328a-5da4-4ccf-b96b-7bfc5630d701",
+							"type": "modifier",
+							"name": "Non-Reciprocal Damage",
+							"reference": "P75",
+							"cost": 50,
+							"disabled": true
+						},
+						{
+							"id": "92008597-6bd1-4dd0-9a0c-55379e3fbde5",
+							"type": "modifier",
+							"name": "Once On, Stays On",
+							"reference": "P75",
+							"cost": 50,
+							"disabled": true
+						},
+						{
+							"id": "14a58541-d4a8-465a-84a4-58705f52577d",
+							"type": "modifier",
+							"name": "Reciprocal Rest",
+							"reference": "P75",
+							"cost": 30,
+							"disabled": true
+						},
+						{
+							"id": "f1749ef3-d85e-4812-80f0-2e2c5babd79c",
+							"type": "modifier",
+							"name": "Projected Form",
+							"reference": "P75",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "2215b6a9-06a5-4c2c-ba47-52153769611b",
+							"type": "modifier",
+							"name": "Takes Extra Time",
+							"reference": "B115",
+							"cost": -10,
+							"levels": 1,
+							"disabled": true
+						}
+					],
+					"base_points": 30,
+					"calc": {
+						"points": 30
+					}
+				},
+				{
+					"id": "7a3201ee-216c-4e3a-96d1-387ba0fb21af",
+					"type": "trait",
+					"name": "Attribute Modifiers",
+					"reference": "B14",
+					"tags": [
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "65817a68-8c6d-4a99-a45c-a38c0be0a9d0",
+							"type": "modifier",
+							"name": "ST +6",
+							"reference": "B14",
+							"cost": 60,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "attribute_bonus",
+									"attribute": "st",
+									"amount": 6
+								}
+							]
+						},
+						{
+							"id": "1bd5726b-1ccb-452e-a6f4-230360c9ebf5",
+							"type": "modifier",
+							"name": "HP +4",
+							"reference": "B16",
+							"cost": 8,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "attribute_bonus",
+									"attribute": "hp",
+									"amount": 4
+								}
+							]
+						},
+						{
+							"id": "a7c88cd3-68fc-444b-a738-44c2ef365374",
+							"type": "modifier",
+							"name": "Per +3",
+							"reference": "B16",
+							"cost": 15,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "attribute_bonus",
+									"attribute": "per",
+									"amount": 3
+								}
+							]
+						}
+					],
+					"calc": {
+						"points": 83
+					}
+				},
+				{
+					"id": "5ef10d49-28cf-465d-b962-adf9611c573f",
+					"type": "trait",
+					"name": "Dependency (Coffin with soil of homeland)",
+					"reference": "B130",
+					"tags": [
+						"Disadvantage",
+						"Exotic",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "c8d7f1ba-3064-446d-b51f-a3ac2a0f9b1d",
+							"type": "modifier",
+							"name": "Rarity: Rare",
+							"reference": "B130",
+							"cost": -30,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "c6ab907f-8130-4c58-83dc-220449dec577",
+							"type": "modifier",
+							"name": "Rarity: Occasional",
+							"reference": "B130",
+							"cost": -20,
+							"cost_type": "points"
+						},
+						{
+							"id": "eb214bc3-80e2-43df-9191-6b2ca96fd3f6",
+							"type": "modifier",
+							"name": "Rarity: Common",
+							"reference": "B130",
+							"cost": -10,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "f178b257-c606-4a9b-a40d-8d1495d17f85",
+							"type": "modifier",
+							"name": "Rarity: Very Common",
+							"reference": "B130",
+							"cost": -5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "70fdbce1-9d02-4f14-baae-c6e3a526db45",
+							"type": "modifier",
+							"name": "Illegal",
+							"reference": "B130",
+							"cost": -5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "d2260ad2-6d4a-49bf-916f-03844a541a44",
+							"type": "modifier",
+							"name": "Frequency: Constantly",
+							"reference": "B130",
+							"notes": "Lose 1 HP per minute without it",
+							"cost": 5,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "b48af4d1-b0a9-4ed1-8efb-5e078f74b231",
+							"type": "modifier",
+							"name": "Frequency: Hourly",
+							"reference": "B130",
+							"notes": "Lose 1 HP per 10 minutes after missing a hourly dose",
+							"cost": 4,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "97bf8eac-166d-4d16-93da-70b05433e741",
+							"type": "modifier",
+							"name": "Frequency: Daily",
+							"reference": "B130",
+							"notes": "Lose 1 HP per hour after missing a daily dose",
+							"cost": 3,
+							"cost_type": "multiplier"
+						},
+						{
+							"id": "e188fb2a-4a85-4401-a20d-3edcdf09c0b5",
+							"type": "modifier",
+							"name": "Frequency: Weekly",
+							"reference": "B130",
+							"notes": "Lose 1 HP per six hours after missing a weekly dose",
+							"cost": 2,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "b1577faa-f5c5-4c2f-8d91-2a20fac34bac",
+							"type": "modifier",
+							"name": "Frequency: Monthly",
+							"reference": "B130",
+							"notes": "Lose 1 HP per day after missing a monthly dose",
+							"cost": 1,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "e3bdc04f-e1f4-4499-95a0-af6f35ba85f0",
+							"type": "modifier",
+							"name": "Frequency: Seasonally",
+							"reference": "B130",
+							"notes": "Lose 1 HP per 3 days after missing a seasonal dose",
+							"cost": 0.3333,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "37a6d4a5-53e4-4ba6-8f8e-55b7c43d0686",
+							"type": "modifier",
+							"name": "Frequency: Yearly",
+							"reference": "B130",
+							"notes": "Lose 1 HP per 2 weeks after missing a yearly dose",
+							"cost": 0.1,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "b2b10b7f-2ec2-49cd-9edb-0907c1ad3850",
+							"type": "modifier",
+							"name": "Aging",
+							"reference": "B130",
+							"notes": "Age 2 years for each HP lost due to this dependency",
+							"cost": 30,
+							"disabled": true
+						}
+					],
+					"calc": {
+						"points": -60
+					}
+				},
+				{
+					"id": "ab55533a-aed4-44c5-9d61-1768120ffe78",
+					"type": "trait",
+					"name": "Divine Curse",
+					"reference": "B132",
+					"tags": [
+						"Disadvantage",
+						"Mental",
+						"Supernatural"
+					],
+					"modifiers": [
+						{
+							"id": "eb43185c-0904-4295-b99c-dcf9fa6ac63a",
+							"type": "modifier",
+							"name": "Minor",
+							"notes": "@Curse@",
+							"cost": -5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "73f1f226-3d53-4494-90ec-0d7132a69219",
+							"type": "modifier",
+							"name": "Major",
+							"notes": "Cannot enter dwelling for the first time unless invited",
+							"cost": -10,
+							"cost_type": "points"
+						},
+						{
+							"id": "066741da-7049-43f7-b193-35bb8ae918b2",
+							"type": "modifier",
+							"name": "Severe",
+							"notes": "@Curse@",
+							"cost": -15,
+							"cost_type": "points",
+							"disabled": true
+						}
+					],
+					"calc": {
+						"points": -10
+					}
+				},
+				{
+					"id": "55386642-0f7f-4ac6-af52-0b619b81c3f0",
+					"type": "trait",
+					"name": "Doesn't Breathe",
+					"reference": "B49",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "4496885c-7d2c-49a4-aa83-aebee897c2a6",
+							"type": "modifier",
+							"name": "Gills",
+							"reference": "B49",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "6ddb49b9-25e7-49cb-be64-0086a20bfd51",
+							"type": "modifier",
+							"name": "Gills",
+							"reference": "B49",
+							"notes": "Suffocates in air",
+							"cost": -20,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "c1ece579-33ac-4781-89c9-9c30a2dc0141",
+							"type": "modifier",
+							"name": "Oxygen Absorption",
+							"reference": "B49",
+							"cost": -25,
+							"disabled": true
+						},
+						{
+							"id": "3a75e94c-68fb-4eec-a419-ef7cd94e19a5",
+							"type": "modifier",
+							"name": "Oxygen Storage",
+							"reference": "B49",
+							"notes": "Can hold breath 25 times as long as normal",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "fa2ee12e-bb41-4606-bd0c-d1b100f4c479",
+							"type": "modifier",
+							"name": "Oxygen Storage",
+							"reference": "B49",
+							"notes": "Can hold breath 50 times as long as normal",
+							"cost": -40,
+							"disabled": true
+						},
+						{
+							"id": "7170d0bb-b30f-420e-af47-e2d8f231ce38",
+							"type": "modifier",
+							"name": "Oxygen Storage",
+							"reference": "B49",
+							"notes": "Can hold breath 100 times as long as normal",
+							"cost": -30,
+							"disabled": true
+						},
+						{
+							"id": "938b3957-01e6-4f97-9f66-afac8c75066b",
+							"type": "modifier",
+							"name": "Oxygen Storage",
+							"reference": "B49",
+							"notes": "Can hold breath 200 times as long as normal",
+							"cost": -20,
+							"disabled": true
+						},
+						{
+							"id": "a49d9d75-a0c4-4bee-afcb-99325ec389a6",
+							"type": "modifier",
+							"name": "Oxygen Storage",
+							"reference": "B49",
+							"notes": "Can hold breath 300 times as long as normal",
+							"cost": -10,
+							"disabled": true
+						},
+						{
+							"id": "b86ffe31-5046-42be-8a46-591a772f2a3e",
+							"type": "modifier",
+							"name": "Oxygen Combustion",
+							"reference": "B49",
+							"cost": -50,
+							"disabled": true
+						}
+					],
+					"base_points": 20,
+					"calc": {
+						"points": 20
+					}
+				},
+				{
+					"id": "b62528d8-f03d-4844-b271-ce5fd9037a83",
+					"type": "trait",
+					"name": "Dominance",
+					"reference": "B50",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Mental"
+					],
+					"base_points": 20,
+					"calc": {
+						"points": 20
+					}
+				},
+				{
+					"id": "6334e195-c927-4d35-8038-7393e9762d56",
+					"type": "trait",
+					"name": "Draining",
+					"reference": "B132",
+					"tags": [
+						"Disadvantage",
+						"Physical",
+						"Supernatural"
+					],
+					"modifiers": [
+						{
+							"id": "5c7054b2-11fb-46f5-9a7f-7a62e098953b",
+							"type": "modifier",
+							"name": "Common",
+							"notes": "Human blood",
+							"cost": -5,
+							"cost_type": "points"
+						},
+						{
+							"id": "3d78ec1a-5731-4cf4-812c-4eebb632e55b",
+							"type": "modifier",
+							"name": "Occasional",
+							"notes": "@Substance@",
+							"cost": -10,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "518aa34b-1e1e-4937-8d2b-7232fd4bf61a",
+							"type": "modifier",
+							"name": "Rare",
+							"notes": "@Substance@",
+							"cost": -15,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "526ce199-c1c3-4ccf-b2af-77413f2f65cc",
+							"type": "modifier",
+							"name": "Illegal",
+							"cost": -5,
+							"cost_type": "points"
+						}
+					],
+					"calc": {
+						"points": -10
+					}
+				},
+				{
+					"id": "4c62fb6e-172e-41fa-9a36-5e50dba0652c",
+					"type": "trait",
+					"name": "Dread",
+					"reference": "B132",
+					"notes": "May not come within level yards of Running water",
+					"tags": [
+						"Disadvantage",
+						"Mental",
+						"Supernatural"
+					],
+					"modifiers": [
+						{
+							"id": "d552a1c4-00ad-4bc0-a98b-b7d7310c2f91",
+							"type": "modifier",
+							"name": "Very Common",
+							"reference": "B161",
+							"notes": "@What@",
+							"cost": 3,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "b2563a2f-854c-4038-a641-6c7dccd5c04e",
+							"type": "modifier",
+							"name": "Common",
+							"reference": "B161",
+							"notes": "Running water",
+							"cost": 2,
+							"cost_type": "multiplier"
+						},
+						{
+							"id": "a0dce49b-80ab-4783-8264-377ece61e62e",
+							"type": "modifier",
+							"name": "Occasional",
+							"reference": "B161",
+							"notes": "@What@",
+							"cost": 1,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "824150af-4c10-49b5-8e35-03634c874551",
+							"type": "modifier",
+							"name": "Rare",
+							"reference": "B161",
+							"notes": "@What@",
+							"cost": 0.5,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "f50cff29-1e19-4a1d-a794-a0fe0f4b7f14",
+							"type": "modifier",
+							"name": "Cannot be trapped",
+							"reference": "B133",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "50f61143-4121-494f-8455-4ede54abb555",
+							"type": "modifier",
+							"name": "Insensitive",
+							"reference": "H25",
+							"cost": -50,
+							"disabled": true
+						}
+					],
+					"base_points": -9,
+					"levels": 1,
+					"points_per_level": -1,
+					"can_level": true,
+					"calc": {
+						"points": -20
+					}
+				},
+				{
+					"id": "e5321710-01ba-4046-a444-bbff37237a01",
+					"type": "trait",
+					"name": "Dread",
+					"reference": "B132",
+					"notes": "May not come within level yards of Garlic",
+					"tags": [
+						"Disadvantage",
+						"Mental",
+						"Supernatural"
+					],
+					"modifiers": [
+						{
+							"id": "e4fc2812-38f9-4b8d-8684-41cc73a0bfec",
+							"type": "modifier",
+							"name": "Very Common",
+							"reference": "B161",
+							"notes": "@What@",
+							"cost": 3,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "c772baa1-8304-4d95-9f20-cda09f0561b4",
+							"type": "modifier",
+							"name": "Common",
+							"reference": "B161",
+							"notes": "@What@",
+							"cost": 2,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "74431d25-2ca8-4966-84b5-4f9fe22cfcde",
+							"type": "modifier",
+							"name": "Occasional",
+							"reference": "B161",
+							"notes": "Garlic",
+							"cost": 1,
+							"cost_type": "multiplier"
+						},
+						{
+							"id": "54fe5256-926f-481f-acae-afee8e055c06",
+							"type": "modifier",
+							"name": "Rare",
+							"reference": "B161",
+							"notes": "@What@",
+							"cost": 0.5,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "e9c805dc-76a0-40b7-8162-e0e81f6fcdaa",
+							"type": "modifier",
+							"name": "Cannot be trapped",
+							"reference": "B133",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "c7fcb394-a05d-4fad-8efa-a1b5159a9ba9",
+							"type": "modifier",
+							"name": "Insensitive",
+							"reference": "H25",
+							"cost": -50,
+							"disabled": true
+						}
+					],
+					"base_points": -9,
+					"levels": 1,
+					"points_per_level": -1,
+					"can_level": true,
+					"calc": {
+						"points": -10
+					}
+				},
+				{
+					"id": "6c1bde9c-75cc-48b3-bc5b-cfab7a894b00",
+					"type": "trait",
+					"name": "Dread",
+					"reference": "B132",
+					"notes": "May not come within level yards of Religious Symbols",
+					"tags": [
+						"Disadvantage",
+						"Mental",
+						"Supernatural"
+					],
+					"modifiers": [
+						{
+							"id": "df21b22b-2c32-41e3-92c5-f6b62014fd24",
+							"type": "modifier",
+							"name": "Very Common",
+							"reference": "B161",
+							"notes": "@What@",
+							"cost": 3,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "6fc7f3dd-f530-48ac-b4a8-0991ed7f3544",
+							"type": "modifier",
+							"name": "Common",
+							"reference": "B161",
+							"notes": "@What@",
+							"cost": 2,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "1366eb7a-af9a-43a9-b878-1e06b4b8b762",
+							"type": "modifier",
+							"name": "Occasional",
+							"reference": "B161",
+							"notes": "Religious Symbols",
+							"cost": 1,
+							"cost_type": "multiplier"
+						},
+						{
+							"id": "2b9f561f-9c95-497e-9637-2a8cc94e1b71",
+							"type": "modifier",
+							"name": "Rare",
+							"reference": "B161",
+							"notes": "@What@",
+							"cost": 0.5,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "0eb1c9db-e482-44fd-b1c2-5b62cab5b522",
+							"type": "modifier",
+							"name": "Cannot be trapped",
+							"reference": "B133",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "90bfdf5b-1c64-4004-a0b6-b70fec261fbe",
+							"type": "modifier",
+							"name": "Insensitive",
+							"reference": "H25",
+							"cost": -50,
+							"disabled": true
+						}
+					],
+					"base_points": -9,
+					"levels": 5,
+					"points_per_level": -1,
+					"can_level": true,
+					"calc": {
+						"points": -14
+					}
+				},
+				{
+					"id": "8fe5d879-9003-4a4f-9dc3-e55ef86322eb",
+					"type": "trait",
+					"name": "Injury Tolerance",
+					"reference": "B60",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "137a1582-ec11-4c4e-ac39-d67048df73b9",
+							"type": "modifier",
+							"name": "Diffuse",
+							"reference": "B60",
+							"notes": "Immune to crippling injuries. Brain, Vitals and Groin cannot be targeted. Most foes cannot slam or grapple you (GM's decision). Do not bleed. Unaffected by blood-borne toxins. Immune to attacks that rely on cutting off blood to part of your body. Impaling and piercing attacks of any size never do more than 1 HP of injury, regardless of penetrating damage. Other attacks never do more than 2 HP of injury. Exception: Area-effect, cone, and explosion attacks cause normal injury",
+							"cost": 100,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "7b062c40-2334-44a5-97dd-64d653b82b0e",
+							"type": "modifier",
+							"name": "Homogenous",
+							"reference": "B60",
+							"notes": "Altered wound modifiers: imp \u0026 pi++ are x1/2, pi+ is x1/3, pi is x1/5, pi- is x1/10",
+							"cost": 40,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "58b587de-cc89-48a0-b727-c532bfc764fa",
+							"type": "modifier",
+							"name": "No Blood",
+							"reference": "B61",
+							"notes": "Do not bleed, unaffected by blood-borne toxins, immune to attacks that rely on cutting off blood to part of your body",
+							"cost": 5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "91e33216-0b32-4e5e-980a-d5c2b66306da",
+							"type": "modifier",
+							"name": "No Brain",
+							"reference": "B61",
+							"notes": "Brain cannot be targeted. Blows to the skull or eye are treated like blows to the face, except that eye injury can still cripple the eye",
+							"cost": 5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "35e78448-a22c-4724-a361-a224b3bf1b78",
+							"type": "modifier",
+							"name": "No Eyes",
+							"reference": "B61",
+							"notes": "Eyes may not be targeted. Immune to blinding attacks",
+							"cost": 5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "b10fa6f7-4d66-4fc9-b8ad-e54a843b2079",
+							"type": "modifier",
+							"name": "No Head",
+							"reference": "B61",
+							"notes": "Skull, Brain and Face cannot be targeted",
+							"cost": 7,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "7b5c8b11-c869-4abf-8e69-c5b9ca0cf319",
+							"type": "modifier",
+							"name": "No Neck",
+							"reference": "B61",
+							"notes": "Neck may not be targeted and cannot be decapitated, choked or strangled",
+							"cost": 5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "320c9db3-1704-4f9d-8550-13bfc6e4472f",
+							"type": "modifier",
+							"name": "No Vitals",
+							"reference": "B61",
+							"notes": "Attacks to the Vitals or Groin are treated as attacks to the Torso",
+							"cost": 5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "f9a1b9d0-7c58-4d15-b467-def7cfeac6d2",
+							"type": "modifier",
+							"name": "Unliving",
+							"reference": "B61",
+							"notes": "Altered wound modifiers: imp \u0026 pi++ are x1, pi+ is x1/2, pi is x1/3, pi- is x1/5",
+							"cost": 20,
+							"cost_type": "points"
+						}
+					],
+					"calc": {
+						"points": 20
+					}
+				},
+				{
+					"id": "85b4ac63-d36d-44bc-ba68-c8f7b120745d",
+					"type": "trait",
+					"name": "Insubstantiality",
+					"reference": "B62",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Mental",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "66109c84-fc35-43cb-965a-46604dd12286",
+							"type": "modifier",
+							"name": "Affect Substantial",
+							"reference": "B63",
+							"cost": 100,
+							"disabled": true
+						},
+						{
+							"id": "1d2aed7a-9430-4f9b-a386-36244358debd",
+							"type": "modifier",
+							"name": "Can Carry Objects",
+							"reference": "B63",
+							"notes": "Up to No Encumbrance",
+							"cost": 10,
+							"disabled": true
+						},
+						{
+							"id": "4eb8dc38-efb2-4e7d-bcf1-dbf33acd2ed7",
+							"type": "modifier",
+							"name": "Can Carry Objects",
+							"reference": "B63",
+							"notes": "Up to Light Encumbrance",
+							"cost": 20,
+							"disabled": true
+						},
+						{
+							"id": "51be0831-afdb-4e8c-b7e9-0525d15cac48",
+							"type": "modifier",
+							"name": "Can Carry Objects",
+							"reference": "B63",
+							"notes": "Up to Medium Encumbrance",
+							"cost": 50,
+							"disabled": true
+						},
+						{
+							"id": "13c4ae83-6dcd-4241-915b-a503153ca43b",
+							"type": "modifier",
+							"name": "Can Carry Objects",
+							"reference": "B63",
+							"notes": "Up to Heavy Encumbrance",
+							"cost": 100,
+							"disabled": true
+						},
+						{
+							"id": "fab00185-94d2-4bf0-a110-d09eae81bb9a",
+							"type": "modifier",
+							"name": "Partial Change",
+							"reference": "B63",
+							"cost": 20,
+							"disabled": true
+						},
+						{
+							"id": "4f87de31-d376-49f7-8406-7ab4c289c8c7",
+							"type": "modifier",
+							"name": "Partial Change",
+							"reference": "B63",
+							"notes": "Can turn an item you are carrying substantial without dropping it",
+							"cost": 100,
+							"disabled": true
+						},
+						{
+							"id": "f06e4e3c-f7e3-4e30-839c-87507512dc09",
+							"type": "modifier",
+							"name": "Always On",
+							"reference": "B63",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "f3447f81-2d6e-4792-8b49-f6e0d4e6e333",
+							"type": "modifier",
+							"name": "Usually On",
+							"reference": "B63",
+							"notes": "Materialization costs 1 FP per second",
+							"cost": -40,
+							"disabled": true
+						},
+						{
+							"id": "1f0623eb-2c46-46ef-8939-e1f0903653ee",
+							"type": "modifier",
+							"name": "No Vertical Move",
+							"reference": "P56",
+							"cost": -10,
+							"disabled": true
+						},
+						{
+							"id": "7593b90c-d4dc-4d62-96c1-35fc1f7d21a0",
+							"type": "modifier",
+							"name": "Noisy",
+							"reference": "P56",
+							"cost": -5,
+							"disabled": true
+						},
+						{
+							"id": "7ee41470-fd82-4d86-b326-876a6d146d58",
+							"type": "modifier",
+							"name": "Projection",
+							"reference": "P56",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "b5e7e83a-511a-46c2-9ad8-bc4cf7926477",
+							"type": "modifier",
+							"name": "Reversion",
+							"reference": "H16",
+							"cost": 60,
+							"disabled": true
+						},
+						{
+							"id": "900192f0-8441-47e3-a9ce-a48fbc4a87eb",
+							"type": "modifier",
+							"name": "Touch",
+							"reference": "H16",
+							"notes": "Always On",
+							"disabled": true
+						},
+						{
+							"id": "5a468660-9a90-4327-94ce-b5d4e8fe1f04",
+							"type": "modifier",
+							"name": "Touch",
+							"reference": "H16",
+							"notes": "Switchable",
+							"cost": 5,
+							"disabled": true
+						},
+						{
+							"id": "e3ee6db7-d55d-484a-ba5e-86e960da4d60",
+							"type": "modifier",
+							"name": "Difficult Materialization",
+							"reference": "H16",
+							"notes": "Mutually exclusive with Usually On.",
+							"cost": -20,
+							"disabled": true
+						},
+						{
+							"id": "6c60112f-b2e8-49a7-8ea5-a6eb9003845f",
+							"type": "modifier",
+							"name": "Ectoplasmic Materialization",
+							"reference": "H16",
+							"cost": -35,
+							"disabled": true
+						},
+						{
+							"id": "c6632067-f063-4ec8-8ebd-6e7617a23fd8",
+							"type": "modifier",
+							"name": "Ghost Air",
+							"reference": "PSI14",
+							"cost": 10,
+							"disabled": true
+						},
+						{
+							"id": "0285e576-53ff-4f6c-915b-f8e1527aa065",
+							"type": "modifier",
+							"name": "Substantial Communication",
+							"reference": "PSI14",
+							"cost": 40,
+							"disabled": true
+						},
+						{
+							"id": "b09a14b5-67de-4c13-8d6b-b23a454083f7",
+							"type": "modifier",
+							"name": "Costs Fatigue",
+							"reference": "B111",
+							"cost": -5,
+							"levels": 2
+						}
+					],
+					"base_points": 80,
+					"calc": {
+						"points": 72
+					}
+				},
+				{
+					"id": "b9fc2c45-f7b6-46a7-baf0-8cb250444548",
+					"type": "trait",
+					"name": "Night Vision",
+					"reference": "B71",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"levels": 5,
+					"points_per_level": 1,
+					"can_level": true,
+					"calc": {
+						"points": 5
+					}
+				},
+				{
+					"id": "c67fc0c1-fbf1-4630-bb94-f6ce39a68d61",
+					"type": "trait",
+					"name": "Resistant",
+					"reference": "B81",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "5126a56f-bdf2-4057-84d2-4de062d58b52",
+							"type": "modifier",
+							"name": "Metabolic Hazards",
+							"reference": "B80",
+							"cost": 30,
+							"cost_type": "points"
+						},
+						{
+							"id": "5272faad-ef2f-447a-81bb-0ca3b2a7ac4c",
+							"type": "modifier",
+							"name": "@Common: Poison, Sickness, etc.@",
+							"reference": "B81",
+							"cost": 15,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "aa2163bb-3115-4936-a7dc-8bffdd8f9056",
+							"type": "modifier",
+							"name": "@Occasional: Disease, Ingested Poison, etc.@",
+							"reference": "B81",
+							"cost": 10,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "344d96a3-3b54-4825-aefb-a7191d6c202d",
+							"type": "modifier",
+							"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+							"reference": "B81",
+							"cost": 5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "eb63e6eb-858d-421d-8c54-8760e139f33f",
+							"type": "modifier",
+							"name": "Immunity",
+							"reference": "B81",
+							"cost": 1,
+							"cost_type": "multiplier"
+						},
+						{
+							"id": "25f47393-3b79-4bcd-aaa4-7ff342d9a6a1",
+							"type": "modifier",
+							"name": "+8 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.5,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "b525f581-a940-451c-a89b-c05a88a7b96b",
+							"type": "modifier",
+							"name": "+3 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.33,
+							"cost_type": "multiplier",
+							"disabled": true
+						}
+					],
+					"round_down": true,
+					"calc": {
+						"points": 30
+					}
+				},
+				{
+					"id": "9a02233b-a0d6-4782-b40a-eebc339bb80c",
+					"type": "trait",
+					"name": "Speak With Animals",
+					"reference": "B87",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Mental"
+					],
+					"modifiers": [
+						{
+							"id": "f470bd1e-5d31-4ab9-aa25-b41b0bf2a119",
+							"type": "modifier",
+							"name": "Specialized",
+							"reference": "B87",
+							"notes": "All aquatic animals",
+							"cost": -40,
+							"disabled": true
+						},
+						{
+							"id": "e39f7fe9-65ef-4404-be92-e6fa950858fc",
+							"type": "modifier",
+							"name": "Specialized",
+							"reference": "B87",
+							"notes": "All land animals",
+							"cost": -40,
+							"disabled": true
+						},
+						{
+							"id": "98fb4bda-2729-4fdd-ac00-9f68b6a01311",
+							"type": "modifier",
+							"name": "Specialized",
+							"reference": "B87",
+							"notes": "@One class: Mammals, Birds, etc.@",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "80777412-143e-445e-b6fa-38482f062856",
+							"type": "modifier",
+							"name": "Specialized",
+							"reference": "B87",
+							"notes": "Wolves \u0026 Bats",
+							"cost": -60
+						},
+						{
+							"id": "f47c0215-d6a3-4cb0-b9d5-e549828b0faf",
+							"type": "modifier",
+							"name": "Specialized",
+							"reference": "B87",
+							"notes": "@One species: House Cats, Macaws, etc.@",
+							"cost": -80,
+							"disabled": true
+						},
+						{
+							"id": "092a8443-03bb-45f5-ade8-7091abe09e79",
+							"type": "modifier",
+							"name": "Sapience",
+							"reference": "P77",
+							"cost": 40,
+							"disabled": true
+						},
+						{
+							"id": "4c896bdd-3471-4c46-896f-e00adca6735a",
+							"type": "modifier",
+							"name": "Universal",
+							"reference": "P77",
+							"cost": 20,
+							"disabled": true
+						}
+					],
+					"base_points": 25,
+					"calc": {
+						"points": 10
+					}
+				},
+				{
+					"id": "19a7c2fd-affa-46b8-bfb6-21fed9b196da",
+					"type": "trait",
+					"name": "Sterile",
+					"tags": [
+						"Physical"
+					],
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "fa03523f-ee2e-48c6-aa53-0b71b93784b5",
+					"type": "trait",
+					"name": "Supernatural Features",
+					"reference": "B157",
+					"tags": [
+						"Disadvantage",
+						"Physical",
+						"Supernatural"
+					],
+					"modifiers": [
+						{
+							"id": "23ef80b7-a0f1-4403-9e20-67e04278d128",
+							"type": "modifier",
+							"name": "No Body Heat",
+							"reference": "B157",
+							"notes": "Gives +1 on all rolls to deduce your secret",
+							"cost": -5,
+							"cost_type": "points",
+							"disabled": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those who touch you, shake your hand, kiss you, etc.",
+									"amount": -1
+								}
+							]
+						},
+						{
+							"id": "52e38216-4550-45b0-bc86-00e56c594971",
+							"type": "modifier",
+							"name": "No Body Heat",
+							"reference": "B157",
+							"notes": "Can gain warmth temporarily, such as after feeding for a vampire. Gives +1 on all rolls to deduce your secret",
+							"cost": -1,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those who touch you, shake your hand, kiss you, etc.",
+									"amount": -1
+								}
+							]
+						},
+						{
+							"id": "78997788-f6ea-48be-8f22-53110c23fd55",
+							"type": "modifier",
+							"name": "No Reflection",
+							"reference": "B157",
+							"notes": "Gives +2 on all rolls to deduce your secret",
+							"cost": -10,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others who notice you have no reflection",
+									"amount": -2
+								}
+							]
+						},
+						{
+							"id": "2e3e17dc-3198-4c16-a960-1a0788fcf727",
+							"type": "modifier",
+							"name": "No Shadow",
+							"reference": "B157",
+							"notes": "Gives +2 on all rolls to deduce your secret",
+							"cost": -10,
+							"cost_type": "points",
+							"disabled": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others that notice you have no shadow",
+									"amount": -2
+								}
+							]
+						},
+						{
+							"id": "85cc6e48-0e22-40c4-aec9-f416a611afb1",
+							"type": "modifier",
+							"name": "Pallor",
+							"reference": "B157",
+							"notes": "Gives +2 on all rolls to deduce your secret",
+							"cost": -10,
+							"cost_type": "points",
+							"disabled": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others who can see you without makeup in good light",
+									"amount": -2
+								}
+							]
+						},
+						{
+							"id": "ef2e1d6a-9cc7-4963-8206-e4b8964792d2",
+							"type": "modifier",
+							"name": "Pallor",
+							"reference": "B157",
+							"notes": "Can gain the flush of life temporarily, such as after feeding for a vampire. Gives +2 on all rolls to deduce your secret",
+							"cost": -5,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others who can see you without makeup in good light",
+									"amount": -2
+								}
+							]
+						}
+					],
+					"calc": {
+						"points": -16
+					}
+				},
+				{
+					"id": "547867a0-a151-45db-a8e3-74aacaf4ea71",
+					"type": "trait",
+					"name": "Teeth, Sharp",
+					"reference": "B91",
+					"tags": [
+						"Exotic",
+						"Perk",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "fe3c80ea-63ea-4aa5-a75a-d47368af2a6a",
+							"type": "modifier",
+							"name": "Provided by Vampiric Bite",
+							"reference": "B96",
+							"cost": -1,
+							"cost_type": "points"
+						}
+					],
+					"base_points": 1,
+					"weapons": [
+						{
+							"id": "f4760ec1-1996-47c4-afc5-91d8b216dc02",
+							"type": "melee_weapon",
+							"damage": {
+								"type": "cut",
+								"st": "thr",
+								"base": "-1"
+							},
+							"usage": "Bite",
+							"reach": "C",
+							"parry": "No",
+							"block": "No",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Brawling"
+								},
+								{
+									"type": "dx"
+								}
+							],
+							"calc": {
+								"level": 12,
+								"parry": "No",
+								"block": "No",
+								"damage": "2d+1 cut"
+							}
+						}
+					],
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "6181f6b9-fcbb-4aaf-bac0-6a3b97335e4b",
+					"type": "trait",
+					"name": "Unaging",
+					"reference": "B95",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "991310ae-54a9-4980-aea3-530481881204",
+							"type": "modifier",
+							"name": "Age Control",
+							"reference": "B95",
+							"cost": 20,
+							"disabled": true
+						},
+						{
+							"id": "bf175d45-ac78-47ce-8e3a-bf850e8da65b",
+							"type": "modifier",
+							"name": "IQ Only",
+							"reference": "RSWL24",
+							"cost": -75,
+							"disabled": true
+						},
+						{
+							"id": "62823d5c-7e8e-447a-94ec-1f0fd5fcae2a",
+							"type": "modifier",
+							"name": "Halt Aging, Weekly",
+							"reference": "PSI18",
+							"cost": 80,
+							"disabled": true
+						},
+						{
+							"id": "928caf87-e369-4a49-b39b-b65dd390be14",
+							"type": "modifier",
+							"name": "Halt Aging, Monthly",
+							"reference": "PSI18",
+							"cost": 100,
+							"disabled": true
+						},
+						{
+							"id": "6f7fa532-26f5-44b5-b80a-39e57496f6f1",
+							"type": "modifier",
+							"name": "Halt Aging, Yearly",
+							"reference": "PSI18",
+							"cost": 130,
+							"disabled": true
+						},
+						{
+							"id": "84ff77b8-6d5a-42d1-a9cb-37b5346d6483",
+							"type": "modifier",
+							"name": "Life Extension",
+							"reference": "PSI18",
+							"cost": -30,
+							"disabled": true
+						}
+					],
+					"base_points": 15,
+					"calc": {
+						"points": 15
+					}
+				},
+				{
+					"id": "5013ee97-1de3-43cb-995f-944356866bd7",
+					"type": "trait",
+					"name": "Uncontrollable Appetite (Blood)",
+					"reference": "B159",
+					"tags": [
+						"Disadvantage",
+						"Mental",
+						"Supernatural"
+					],
+					"base_points": -15,
+					"cr": 12,
+					"calc": {
+						"points": -15
+					}
+				},
+				{
+					"id": "f1b63e62-e6b0-440c-b2a3-ecdbe99a3adb",
+					"type": "trait",
+					"name": "Unhealing (Partial)",
+					"reference": "B160",
+					"tags": [
+						"Disadvantage",
+						"Exotic",
+						"Physical"
+					],
+					"base_points": -20,
+					"calc": {
+						"points": -20
+					}
+				},
+				{
+					"id": "3a5f7f15-85e5-42bd-979d-03a6b3dd2b86",
+					"type": "trait",
+					"name": "Unkillable",
+					"reference": "B95",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "2f72f7e1-c19d-4620-a249-b6f8a4bcbc39",
+							"type": "modifier",
+							"name": "Achilles' Heal",
+							"reference": "B95",
+							"notes": "@Rare Achilles' Heal@",
+							"cost": -10,
+							"disabled": true
+						},
+						{
+							"id": "3610658c-8020-497b-9905-658fb60b823b",
+							"type": "modifier",
+							"name": "Achilles' Heal",
+							"reference": "B95",
+							"notes": "@Occasional Achilles' Heal@",
+							"cost": -30,
+							"disabled": true
+						},
+						{
+							"id": "3a8815c8-087d-4975-90a5-ac9cd727ee57",
+							"type": "modifier",
+							"name": "Achilles' Heal",
+							"reference": "B95",
+							"notes": "Wood",
+							"cost": -50
+						},
+						{
+							"id": "ef6433b0-0d9c-4825-8c9e-81d8d051a178",
+							"type": "modifier",
+							"name": "Hindrance",
+							"reference": "B95",
+							"notes": "@Rare Hindrance@",
+							"cost": -5,
+							"disabled": true
+						},
+						{
+							"id": "2021cca7-6e92-49f5-b184-fe5a0f0c1bf8",
+							"type": "modifier",
+							"name": "Hindrance",
+							"reference": "B95",
+							"notes": "@Occasional Hindrance@",
+							"cost": -15,
+							"disabled": true
+						},
+						{
+							"id": "998e2349-fe82-4ac8-aa16-a81180a9c127",
+							"type": "modifier",
+							"name": "Hindrance",
+							"reference": "B95",
+							"notes": "@Common Hindrance@",
+							"cost": -25,
+							"disabled": true
+						},
+						{
+							"id": "70060344-a1a3-4731-9a02-ca26105413c9",
+							"type": "modifier",
+							"name": "Reincarnation",
+							"reference": "B95",
+							"cost": -20,
+							"disabled": true
+						},
+						{
+							"id": "390c4374-2977-4825-a8af-8c2429576346",
+							"type": "modifier",
+							"name": "Trigger",
+							"reference": "B95",
+							"notes": "@Rare Trigger@",
+							"cost": -25,
+							"disabled": true
+						},
+						{
+							"id": "f6721180-5390-49d5-88e9-b1fecc67f6e9",
+							"type": "modifier",
+							"name": "Trigger",
+							"reference": "B95",
+							"notes": "@Occasional Trigger@",
+							"cost": -15,
+							"disabled": true
+						},
+						{
+							"id": "8c64b959-1bf6-459d-a949-695bbec5c2b7",
+							"type": "modifier",
+							"name": "Trigger",
+							"reference": "B95",
+							"notes": "@Common Trigger@",
+							"cost": -5,
+							"disabled": true
+						}
+					],
+					"levels": 2,
+					"points_per_level": 50,
+					"can_level": true,
+					"calc": {
+						"points": 50
+					}
+				},
+				{
+					"id": "df9c7344-0604-4bdc-9bee-51985f37ceb9",
+					"type": "trait",
+					"name": "Vampiric Bite",
+					"reference": "B96",
+					"notes": "Drains 1 HP + 1/level per second. For every 3 HP stolen, you heal 1 HP or 1 FP (your choice). Also lets you bite in combat without feeding. Add Teeth (Sharp Teeth) or Teeth (Sharp Beak) – your choice for free.",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"base_points": 30,
+					"points_per_level": 5,
+					"can_level": true,
+					"calc": {
+						"points": 30
+					}
+				},
+				{
+					"id": "3c141945-8bd8-419e-9bd2-5b61c146b676",
+					"type": "trait",
+					"name": "Weakness",
+					"reference": "B161",
+					"tags": [
+						"Disadvantage",
+						"Exotic",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "f5de54e5-01e2-42b1-8499-2cf528fa4cd4",
+							"type": "modifier",
+							"name": "1d damage per minute",
+							"reference": "B161",
+							"cost": -20,
+							"cost_type": "points"
+						},
+						{
+							"id": "0f027326-b4be-4d82-bd24-a1d627eeb281",
+							"type": "modifier",
+							"name": "1d damage per 5 minutes",
+							"reference": "B161",
+							"cost": -10,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "b8a0bd50-b059-4cb0-87eb-b6a9ecd81e4c",
+							"type": "modifier",
+							"name": "1d damage per 30 minutes",
+							"reference": "B161",
+							"cost": -5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "be692982-69a6-4510-bda0-a7c7a35c08ac",
+							"type": "modifier",
+							"name": "@Rare Substance@",
+							"reference": "B161",
+							"cost": 0.5,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "76c114f6-3225-4415-9547-a8efe82e3dfc",
+							"type": "modifier",
+							"name": "@Occasional Substance@",
+							"reference": "B161",
+							"cost": 1,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "2ae3df7f-a1f4-40da-a175-24712fdc52d6",
+							"type": "modifier",
+							"name": "@Common Substance@",
+							"reference": "B161",
+							"cost": 2,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "74aa7fb6-ef62-43d9-882d-278ac5ba24cd",
+							"type": "modifier",
+							"name": "Sunlight",
+							"reference": "B161",
+							"cost": 3,
+							"cost_type": "multiplier"
+						},
+						{
+							"id": "0dbfc654-de6b-46a2-8e1d-b03148e81c01",
+							"type": "modifier",
+							"name": "Fatigue Only",
+							"reference": "B161",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "e8f6ae84-1b91-4380-b0fb-153fac21b037",
+							"type": "modifier",
+							"name": "Variable",
+							"reference": "B161",
+							"cost": -40,
+							"disabled": true
+						}
+					],
+					"calc": {
+						"points": -60
+					}
+				},
+				{
+					"id": "a82390cc-9200-4c86-a0e7-c1ba60ec6556",
+					"type": "trait",
+					"name": "Feature: Sterile",
+					"calc": {
+						"points": 0
+					}
+				}
+			],
+			"name": "Vampire",
+			"reference": "B262",
+			"ancestry": "Human",
+			"container_type": "race",
+			"calc": {
+				"points": 150
+			}
+		},
+		{
+			"id": "fe77986f-8bd4-4946-b417-8c621f1b3517",
+			"type": "trait",
+			"name": "Filthy Rich",
+			"reference": "B25",
+			"notes": "Starting wealth is 100x normal",
+			"tags": [
+				"Advantage",
+				"Social",
+				"Wealth"
+			],
+			"base_points": 50,
+			"calc": {
+				"points": 50
+			}
+		},
+		{
+			"id": "99d53a5f-30d9-4e8b-bf49-b1343c0fd5ae",
+			"type": "trait",
+			"name": "Berserk",
+			"reference": "B124",
+			"notes": "Make a self-control roll any time you suffer damage over 1/4 your HP in the space of one second, and whenever you witness equivalent harm to a loved one",
+			"tags": [
+				"Disadvantage",
+				"Mental"
+			],
+			"modifiers": [
+				{
+					"id": "1760bea2-00ee-41fa-af42-452dbb538251",
+					"type": "modifier",
+					"name": "Battle Rage",
+					"cost": 50,
+					"disabled": true
+				}
+			],
+			"base_points": -10,
+			"cr": 9,
+			"calc": {
+				"points": -15
+			}
+		},
+		{
+			"id": "6897fbb1-11b1-4c4f-8c38-e9eee182da5a",
+			"type": "trait",
+			"name": "Bloodlust",
+			"reference": "B125",
+			"notes": "You must make a self-control roll whenever you need to accept a surrender, evade a sentry, take a prisoner, etc.",
+			"tags": [
+				"Disadvantage",
+				"Mental"
+			],
+			"base_points": -10,
+			"cr": 9,
+			"calc": {
+				"points": -15
+			}
+		},
+		{
+			"id": "af9f6b4b-6b57-429f-b633-3cd700531fc1",
+			"type": "trait",
+			"name": "Callous",
+			"reference": "B125",
+			"tags": [
+				"Disadvantage",
+				"Mental"
+			],
+			"base_points": -5,
+			"features": [
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "psychology"
+					},
+					"amount": -3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "teaching"
+					},
+					"amount": -3
+				},
+				{
+					"type": "reaction_bonus",
+					"situation": "from past victims and anyone with Empathy",
+					"amount": -1
+				},
+				{
+					"type": "conditional_modifier",
+					"situation": "to Interrogation and Intimidation rolls when you use threats or torture",
+					"amount": 1
+				}
+			],
+			"calc": {
+				"points": -5
+			}
+		},
+		{
+			"id": "e5640f0a-40ba-47ac-9b64-5f04962d2ed5",
+			"type": "trait",
+			"name": "Duty (To ISWAT)",
+			"reference": "B133",
+			"tags": [
+				"Disadvantage",
+				"Social"
+			],
+			"modifiers": [
+				{
+					"id": "fb0c80a4-4c65-4521-9e18-7378dda34a46",
+					"type": "modifier",
+					"name": "FR: 6",
+					"cost": -2,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "92ade39a-a64c-4ff4-a84b-89ab92a6e217",
+					"type": "modifier",
+					"name": "FR: 9",
+					"cost": -5,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "80577150-cbdb-4c26-bde4-1ad85a7deec2",
+					"type": "modifier",
+					"name": "FR: 12",
+					"cost": -10,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "d6406b89-6289-4b8c-b7c7-4d25add3c352",
+					"type": "modifier",
+					"name": "FR: 15",
+					"cost": -15,
+					"cost_type": "points"
+				},
+				{
+					"id": "f4458d02-9b67-42f8-8f31-5837064fb751",
+					"type": "modifier",
+					"name": "Extremely Hazardous",
+					"cost": -5,
+					"cost_type": "points"
+				},
+				{
+					"id": "814f2484-cac1-4eca-af21-f9eaca8c0d0a",
+					"type": "modifier",
+					"name": "Involuntary",
+					"cost": -5,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "5d87b90f-fc68-4d78-8547-7c2ef58ae7bd",
+					"type": "modifier",
+					"name": "Nonhazardous",
+					"cost": 5,
+					"cost_type": "points",
+					"disabled": true
+				}
+			],
+			"calc": {
+				"points": -20
+			}
+		},
+		{
+			"id": "8011ecc3-7989-42da-a3fe-ba9a87b7a367",
+			"type": "trait",
+			"name": "Enemy (The Cabal)",
+			"reference": "B135",
+			"tags": [
+				"Disadvantage",
+				"Social"
+			],
+			"modifiers": [
+				{
+					"id": "de332956-d4a1-4af6-9339-34f1fa617363",
+					"type": "modifier",
+					"name": "Weak Individual",
+					"reference": "B135",
+					"notes": "50% of your starting points",
+					"cost": -5,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "73913cf5-78dc-4fa9-93e8-9182656fb07e",
+					"type": "modifier",
+					"name": "Equal Individual",
+					"reference": "B135",
+					"notes": "100% of your starting points",
+					"cost": -10,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "81b5a233-41ef-48a3-8d98-450dab7c74a2",
+					"type": "modifier",
+					"name": "Powerful Individual",
+					"reference": "B135",
+					"notes": "\u003e150% of your starting points",
+					"cost": -20,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "4ad57666-9f27-4986-9191-16d65214969b",
+					"type": "modifier",
+					"name": "Weak Group",
+					"reference": "B135",
+					"cost": -10,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "8427a345-55ea-4e91-a797-cef5991899d4",
+					"type": "modifier",
+					"name": "Medium Group",
+					"reference": "B135",
+					"cost": -20,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "4de4b388-72a9-4143-b57b-c3ea069c1600",
+					"type": "modifier",
+					"name": "Appears almost all the time",
+					"reference": "B36",
+					"notes": "15-",
+					"cost": 3,
+					"cost_type": "multiplier",
+					"disabled": true
+				},
+				{
+					"id": "98bee615-b142-4c48-be3d-ce6e87cec21b",
+					"type": "modifier",
+					"name": "Appears quite often",
+					"reference": "B36",
+					"notes": "12-",
+					"cost": 2,
+					"cost_type": "multiplier",
+					"disabled": true
+				},
+				{
+					"id": "8e56e038-28dd-41ed-b516-969294228bca",
+					"type": "modifier",
+					"name": "Appears fairly often",
+					"reference": "B36",
+					"notes": "9-",
+					"cost": 1,
+					"cost_type": "multiplier",
+					"disabled": true
+				},
+				{
+					"id": "04e80fd4-8cc7-423e-8af5-3906657f8cb2",
+					"type": "modifier",
+					"name": "Appears quite rarely",
+					"reference": "B36",
+					"notes": "6-",
+					"cost": 0.5,
+					"cost_type": "multiplier"
+				},
+				{
+					"id": "08aa132f-60f2-4bed-b3a3-ef4321d2f09f",
+					"type": "modifier",
+					"name": "Large/Powerful Group",
+					"reference": "B135",
+					"cost": -30,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "19ea1f4b-fc64-4c1d-8217-1c7f5cd09190",
+					"type": "modifier",
+					"name": "Utterly Formidable Group",
+					"reference": "B135",
+					"cost": -40,
+					"cost_type": "points"
+				},
+				{
+					"id": "1f9b2afd-1cb9-460a-ba7d-8315a7698ba8",
+					"type": "modifier",
+					"name": "Unknown",
+					"reference": "B135",
+					"cost": -5,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "f6364f57-15e6-4d03-bc3f-ebf2c4718dac",
+					"type": "modifier",
+					"name": "Evil Twin",
+					"reference": "B135",
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "4560fba2-c960-4c2d-9201-f69dc83ed26f",
+					"type": "modifier",
+					"name": "Evil Twin",
+					"reference": "B135",
+					"notes": "More skilled or extra abilities",
+					"cost": -5,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "f948ad5e-0ca0-4e8f-84c1-d65105981603",
+					"type": "modifier",
+					"name": "Evil Twin",
+					"reference": "B135",
+					"notes": "More skilled and extra abilities",
+					"cost": -10,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "43075921-7dd0-468f-9609-296e9f7ebf0b",
+					"type": "modifier",
+					"name": "Watcher",
+					"reference": "B135",
+					"cost": 0.25,
+					"cost_type": "multiplier",
+					"disabled": true
+				},
+				{
+					"id": "85d6d113-01ac-4074-a7ce-21572db84555",
+					"type": "modifier",
+					"name": "Rival",
+					"reference": "B135",
+					"cost": 0.5,
+					"cost_type": "multiplier",
+					"disabled": true
+				},
+				{
+					"id": "1b7c0201-7ba5-46e9-9c3d-2398527a3712",
+					"type": "modifier",
+					"name": "Hunter",
+					"reference": "B135",
+					"cost": 1,
+					"cost_type": "multiplier"
+				}
+			],
+			"calc": {
+				"points": -20
+			}
+		},
+		{
+			"id": "bf4f18ae-1e2f-4bfd-9273-0b4a04911e07",
+			"type": "trait",
+			"name": "Frightens Animals",
+			"reference": "B137",
+			"tags": [
+				"Disadvantage",
+				"Mental",
+				"Supernatural"
+			],
+			"base_points": -10,
+			"calc": {
+				"points": -10
+			}
+		},
+		{
+			"id": "9b601843-1bc0-4c86-b60a-a987879dcf0f",
+			"type": "trait",
+			"name": "Greed",
+			"reference": "B137",
+			"notes": "Make a self-control roll any time riches are offered – as payment for fair work, gains from adventure, spoils of crime, or just bait. If you fail, you do whatever it takes to get the payoff.",
+			"tags": [
+				"Disadvantage",
+				"Mental"
+			],
+			"base_points": -15,
+			"cr": 6,
+			"calc": {
+				"points": -30
+			}
+		},
+		{
+			"id": "47342bce-aca2-42b4-845b-32a64b702fc6",
+			"type": "trait",
+			"name": "Quirk: Code of Honour - Aristocratic manners",
+			"reference": "B162",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "5ed1a0fe-30c3-4e8f-a475-4cef46b88b53",
+			"type": "trait",
+			"name": "Quirk: Dislikes mirrors",
+			"reference": "B162",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "824a70d7-ee3f-43a5-913f-babf03b8e4d3",
+			"type": "trait",
+			"name": "Quirk: Old-fashioned language and idioms",
+			"reference": "B162",
+			"notes": "-1 to some uses of Fast-Talk, Propaganda, etc; GM's option",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "bf21702f-ab63-4216-873b-6e378b219495",
+			"type": "trait",
+			"name": "Quirk: Patriot - Hungary, minor fanaticism",
+			"reference": "B162",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"features": [
+				{
+					"type": "reaction_bonus",
+					"situation": "from patriotic Turks and Romanians",
+					"amount": -1
+				}
+			],
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "8a75b877-f494-4f46-9285-80f11772201e",
+			"type": "trait",
+			"name": "Quirk: Vow - never let vampiric appetites corrupt my judgement",
+			"reference": "B162",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		}
+	],
+	"skills": [
+		{
+			"id": "5e45e414-b4b5-4b84-8f38-7a5875441d61",
+			"type": "skill",
+			"name": "Administration",
+			"reference": "B174",
+			"tags": [
+				"Business",
+				"Social"
+			],
+			"difficulty": "iq/a",
+			"points": 1,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -5,
+				"level": 10,
+				"adjusted_level": 10,
+				"points": -10
+			},
+			"defaults": [
+				{
+					"type": "skill",
+					"name": "Merchant",
+					"modifier": -3
+				},
+				{
+					"type": "iq",
+					"modifier": -5
+				}
+			],
+			"calc": {
+				"level": 17,
+				"rsl": "IQ+2"
+			}
+		},
+		{
+			"id": "33096b01-38b0-4dc5-97ea-6bf4b5c6d409",
+			"type": "skill",
+			"name": "Area Knowledge",
+			"reference": "B176",
+			"notes": "General nature of its settlements and towns, political allegiances, leaders, and most citizens of Status 5+",
+			"tags": [
+				"Everyman",
+				"Knowledge"
+			],
+			"specialization": "Hungary; Lived there",
+			"difficulty": "iq/e",
+			"points": 1,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -4,
+				"level": 11,
+				"adjusted_level": 11,
+				"points": -11
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Geography",
+					"modifier": -3
+				}
+			],
+			"calc": {
+				"level": 15,
+				"rsl": "IQ+0"
+			}
+		},
+		{
+			"id": "6ff1ebf9-b49c-4798-9ece-72f3f7c14af9",
+			"type": "skill",
+			"name": "Body Language",
+			"reference": "B181",
+			"tags": [
+				"Police",
+				"Social",
+				"Spy"
+			],
+			"difficulty": "per/a",
+			"points": 1,
+			"defaulted_from": {
+				"type": "skill",
+				"name": "Detect Lies",
+				"modifier": -4,
+				"level": 13,
+				"adjusted_level": 13,
+				"points": -13
+			},
+			"defaults": [
+				{
+					"type": "skill",
+					"name": "Detect Lies",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Psychology",
+					"modifier": -4
+				}
+			],
+			"calc": {
+				"level": 17,
+				"rsl": "Per-1"
+			}
+		},
+		{
+			"id": "00b6b933-d53b-45cc-a67e-e7f91654b161",
+			"type": "skill",
+			"name": "Brawling",
+			"reference": "B182,MA55",
+			"tags": [
+				"Combat",
+				"Melee Combat",
+				"Weapon"
+			],
+			"difficulty": "dx/e",
+			"points": 2,
+			"features": [
+				{
+					"type": "weapon_bonus",
+					"selection_type": "weapons_with_required_skill",
+					"name": {
+						"compare": "is",
+						"qualifier": "Brawling"
+					},
+					"level": {
+						"compare": "at_least",
+						"qualifier": 2
+					},
+					"amount": 1,
+					"per_level": true
+				}
+			],
+			"calc": {
+				"level": 12,
+				"rsl": "DX+1"
+			}
+		},
+		{
+			"id": "3f3bd0dd-f341-4fe3-a07a-c2119c288cbc",
+			"type": "skill",
+			"name": "Connoisseur",
+			"reference": "B185,MA56",
+			"tags": [
+				"Arts",
+				"Entertainment",
+				"Knowledge",
+				"Social"
+			],
+			"specialization": "Visual Arts",
+			"difficulty": "iq/a",
+			"points": 2,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -5,
+				"level": 10,
+				"adjusted_level": 10,
+				"points": -10
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -5
+				}
+			],
+			"calc": {
+				"level": 15,
+				"rsl": "IQ+0"
+			}
+		},
+		{
+			"id": "f0be0659-8a95-484a-ab48-ae39c48077dd",
+			"type": "skill",
+			"name": "Current Affairs",
+			"reference": "B186",
+			"tags": [
+				"Business",
+				"Everyman",
+				"Knowledge",
+				"Social"
+			],
+			"specialization": "Business",
+			"tech_level": "8",
+			"difficulty": "iq/e",
+			"points": 2,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -4,
+				"level": 11,
+				"adjusted_level": 11,
+				"points": -11
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Research",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Current Affairs",
+					"modifier": -4
+				}
+			],
+			"calc": {
+				"level": 16,
+				"rsl": "IQ+1"
+			}
+		},
+		{
+			"id": "468bb7e2-ed5d-44c0-97e6-2be31b994800",
+			"type": "skill",
+			"name": "Detect Lies",
+			"reference": "B187",
+			"tags": [
+				"Police",
+				"Social",
+				"Spy"
+			],
+			"difficulty": "per/h",
+			"points": 2,
+			"defaulted_from": {
+				"type": "per",
+				"modifier": -6,
+				"level": 12,
+				"adjusted_level": 12,
+				"points": -12
+			},
+			"defaults": [
+				{
+					"type": "per",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Body Language",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Psychology",
+					"modifier": -4
+				}
+			],
+			"calc": {
+				"level": 17,
+				"rsl": "Per-1"
+			}
+		},
+		{
+			"id": "577de2fb-a060-49ae-bbea-46cd70136e39",
+			"type": "skill",
+			"name": "Diplomacy",
+			"reference": "B187",
+			"tags": [
+				"Business",
+				"Police",
+				"Social"
+			],
+			"difficulty": "iq/h",
+			"points": 2,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -6,
+				"level": 9,
+				"adjusted_level": 9,
+				"points": -9
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Politics",
+					"modifier": -6
+				}
+			],
+			"calc": {
+				"level": 14,
+				"rsl": "IQ-1"
+			}
+		},
+		{
+			"id": "ad01f88a-2b14-43b2-b4d4-f68376bc0f5b",
+			"type": "skill",
+			"name": "Economics",
+			"reference": "B189",
+			"tags": [
+				"Business",
+				"Humanities",
+				"Social Sciences"
+			],
+			"difficulty": "iq/h",
+			"points": 1,
+			"defaulted_from": {
+				"type": "skill",
+				"name": "Finance",
+				"modifier": -3,
+				"level": 10,
+				"adjusted_level": 10,
+				"points": -10
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Finance",
+					"modifier": -3
+				},
+				{
+					"type": "skill",
+					"name": "Market Analysis",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Merchant",
+					"modifier": -6
+				}
+			],
+			"calc": {
+				"level": 16,
+				"rsl": "IQ+1"
+			}
+		},
+		{
+			"id": "0268da27-4f0d-4d0f-a6da-e39fabe68719",
+			"type": "skill",
+			"name": "Finance",
+			"reference": "B195",
+			"tags": [
+				"Business"
+			],
+			"difficulty": "iq/h",
+			"points": 1,
+			"defaults": [
+				{
+					"type": "skill",
+					"name": "Accounting",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Economics",
+					"modifier": -3
+				},
+				{
+					"type": "skill",
+					"name": "Merchant",
+					"modifier": -6
+				}
+			],
+			"calc": {
+				"level": 16,
+				"rsl": "IQ+1"
+			}
+		},
+		{
+			"id": "9b1d5837-7d3f-409e-9204-c3b42b7f7d9a",
+			"type": "skill",
+			"name": "Guns",
+			"reference": "B198",
+			"tags": [
+				"Combat",
+				"Ranged Combat",
+				"Weapon"
+			],
+			"specialization": "Pistol",
+			"tech_level": "5",
+			"difficulty": "dx/e",
+			"points": 2,
+			"defaulted_from": {
+				"type": "dx",
+				"modifier": -4,
+				"level": 7,
+				"adjusted_level": 7,
+				"points": -7
+			},
+			"defaults": [
+				{
+					"type": "dx",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Guns",
+					"specialization": "Grenade Launcher",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Guns",
+					"specialization": "Gyroc",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Guns",
+					"specialization": "Light Anti-Armor Weapon",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Guns",
+					"specialization": "Light Machine Gun",
+					"modifier": -2
+				},
+				{
+					"type": "skill",
+					"name": "Guns",
+					"specialization": "Musket",
+					"modifier": -2
+				},
+				{
+					"type": "skill",
+					"name": "Beam Weapons",
+					"specialization": "Pistol",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Guns",
+					"specialization": "Rifle",
+					"modifier": -2
+				},
+				{
+					"type": "skill",
+					"name": "Guns",
+					"specialization": "Shotgun",
+					"modifier": -2
+				},
+				{
+					"type": "skill",
+					"name": "Guns",
+					"specialization": "Submachine Gun",
+					"modifier": -2
+				}
+			],
+			"calc": {
+				"level": 12,
+				"rsl": "DX+1"
+			}
+		},
+		{
+			"id": "44072ed1-28d9-4d61-830c-a4a4a85a24c7",
+			"type": "skill",
+			"name": "History",
+			"reference": "B200",
+			"tags": [
+				"Humanities",
+				"Social Sciences"
+			],
+			"specialization": "Hungary",
+			"difficulty": "iq/h",
+			"points": 4,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -6,
+				"level": 9,
+				"adjusted_level": 9,
+				"points": -9
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -6
+				}
+			],
+			"calc": {
+				"level": 15,
+				"rsl": "IQ+0"
+			}
+		},
+		{
+			"id": "4931e4e4-26b5-4fe9-b13e-4eafeb126c20",
+			"type": "skill",
+			"name": "Intimidation",
+			"reference": "B202",
+			"tags": [
+				"Criminal",
+				"Police",
+				"Social",
+				"Street"
+			],
+			"difficulty": "will/a",
+			"points": 16,
+			"defaulted_from": {
+				"type": "will",
+				"modifier": -5,
+				"level": 11,
+				"adjusted_level": 11,
+				"points": -11
+			},
+			"defaults": [
+				{
+					"type": "will",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Acting",
+					"modifier": -3
+				}
+			],
+			"calc": {
+				"level": 20,
+				"rsl": "Will+4"
+			}
+		},
+		{
+			"id": "86ae09a2-8d76-44b0-838c-42c509595749",
+			"type": "skill",
+			"name": "Market Analysis",
+			"reference": "B207",
+			"tags": [
+				"Business"
+			],
+			"difficulty": "iq/h",
+			"points": 2,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -6,
+				"level": 9,
+				"adjusted_level": 9,
+				"points": -9
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Economics",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Merchant",
+					"modifier": -4
+				}
+			],
+			"calc": {
+				"level": 17,
+				"rsl": "IQ+2"
+			}
+		},
+		{
+			"id": "1b7b25ec-7f44-4fa3-8103-dfb27abfa4a9",
+			"type": "skill",
+			"name": "Merchant",
+			"reference": "B209",
+			"tags": [
+				"Business",
+				"Social"
+			],
+			"difficulty": "iq/a",
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -5,
+				"level": 10,
+				"adjusted_level": 10,
+				"points": -10
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Finance",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Market Analysis",
+					"modifier": -4
+				}
+			],
+			"calc": {
+				"level": 13,
+				"rsl": "IQ-2"
+			}
+		},
+		{
+			"id": "fdb6be39-b2f7-49ac-bce3-f09b5da52747",
+			"type": "skill",
+			"name": "Mimicry",
+			"reference": "B210",
+			"tags": [
+				"Animal",
+				"Arts",
+				"Entertainment",
+				"Exploration",
+				"Outdoor"
+			],
+			"specialization": "Animal Sounds",
+			"difficulty": "iq/h",
+			"points": 2,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -6,
+				"level": 9,
+				"adjusted_level": 9,
+				"points": -9
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Naturalist",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Mimicry",
+					"specialization": "Bird Calls",
+					"modifier": -6
+				}
+			],
+			"calc": {
+				"level": 14,
+				"rsl": "IQ-1"
+			}
+		},
+		{
+			"id": "9cdacf40-6e47-41df-804b-62c5e31810d1",
+			"type": "skill",
+			"name": "Occultism",
+			"reference": "B212",
+			"tags": [
+				"Magical",
+				"Occult"
+			],
+			"specialization": "Vampirology",
+			"difficulty": "iq/a",
+			"points": 12,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -5,
+				"level": 10,
+				"adjusted_level": 10,
+				"points": -10
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -5
+				}
+			],
+			"calc": {
+				"level": 18,
+				"rsl": "IQ+3"
+			}
+		},
+		{
+			"id": "2a6c860b-1347-4d65-98d3-ea720307615a",
+			"type": "skill",
+			"name": "Propaganda",
+			"reference": "B216",
+			"tags": [
+				"Business",
+				"Military",
+				"Social",
+				"Spy"
+			],
+			"tech_level": "8",
+			"difficulty": "iq/a",
+			"points": 1,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -5,
+				"level": 10,
+				"adjusted_level": 10,
+				"points": -10
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Merchant",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Psychology",
+					"modifier": -4
+				}
+			],
+			"calc": {
+				"level": 17,
+				"rsl": "IQ+2"
+			}
+		},
+		{
+			"id": "ca0778df-3043-4fc7-97b6-1db9aa9be471",
+			"type": "skill",
+			"name": "Saber",
+			"reference": "B208",
+			"tags": [
+				"Combat",
+				"Melee Combat",
+				"Weapon"
+			],
+			"difficulty": "dx/a",
+			"points": 4,
+			"defaulted_from": {
+				"type": "dx",
+				"modifier": -5,
+				"level": 6,
+				"adjusted_level": 6,
+				"points": -6
+			},
+			"defaults": [
+				{
+					"type": "dx",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Broadsword",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Shortsword",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Main-Gauche",
+					"modifier": -3
+				},
+				{
+					"type": "skill",
+					"name": "Rapier",
+					"modifier": -3
+				},
+				{
+					"type": "skill",
+					"name": "Smallsword",
+					"modifier": -3
+				}
+			],
+			"calc": {
+				"level": 12,
+				"rsl": "DX+1"
+			}
+		},
+		{
+			"id": "6e537718-9d23-427a-a055-688ae69e3453",
+			"type": "skill",
+			"name": "Savoir-Faire",
+			"reference": "B218,MA59",
+			"tags": [
+				"Business",
+				"Knowledge",
+				"Social"
+			],
+			"specialization": "High Society",
+			"difficulty": "iq/e",
+			"points": 1,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -4,
+				"level": 11,
+				"adjusted_level": 11,
+				"points": -11
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Savoir-Faire",
+					"specialization": "Servant",
+					"modifier": -2
+				}
+			],
+			"calc": {
+				"level": 15,
+				"rsl": "IQ+0"
+			}
+		},
+		{
+			"id": "2597cadf-7184-45b0-9ba2-0b3ed6effce0",
+			"type": "skill",
+			"name": "Sex Appeal",
+			"reference": "B219",
+			"tags": [
+				"Social"
+			],
+			"difficulty": "ht/a",
+			"points": 4,
+			"defaulted_from": {
+				"type": "ht",
+				"modifier": -3,
+				"level": 7,
+				"adjusted_level": 7,
+				"points": -7
+			},
+			"defaults": [
+				{
+					"type": "ht",
+					"modifier": -3
+				}
+			],
+			"calc": {
+				"level": 11,
+				"rsl": "HT+1"
+			}
+		},
+		{
+			"id": "d44bbe81-db0b-45ee-8863-bdf3c7ed7d8e",
+			"type": "skill",
+			"name": "Teamster",
+			"reference": "B225",
+			"tags": [
+				"Animal",
+				"Vehicle"
+			],
+			"specialization": "Equines",
+			"difficulty": "iq/a",
+			"points": 1,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -5,
+				"level": 10,
+				"adjusted_level": 10,
+				"points": -10
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Animal Handling",
+					"specialization": "Equines",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Riding",
+					"specialization": "Equines",
+					"modifier": -2
+				}
+			],
+			"calc": {
+				"level": 14,
+				"rsl": "IQ-1"
+			}
+		},
+		{
+			"id": "613c71ca-42e9-493e-8fbc-a53acbfc966f",
+			"type": "skill",
+			"name": "Tracking",
+			"reference": "B226",
+			"tags": [
+				"Exploration",
+				"Outdoor"
+			],
+			"difficulty": "per/a",
+			"points": 2,
+			"defaulted_from": {
+				"type": "per",
+				"modifier": -5,
+				"level": 13,
+				"adjusted_level": 13,
+				"points": -13
+			},
+			"defaults": [
+				{
+					"type": "per",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Naturalist",
+					"modifier": -5
+				}
+			],
+			"calc": {
+				"level": 18,
+				"rsl": "Per+0"
+			}
+		}
+	],
+	"created_date": "2023-01-15T22:20:24Z",
+	"modified_date": "2023-01-15T22:50:25Z",
+	"calc": {
+		"swing": "5d-1",
+		"thrust": "2d+2",
+		"basic_lift": "80 lb",
+		"striking_st_bonus": 5,
+		"move": [
+			8,
+			6,
+			4,
+			3,
+			1
+		],
+		"dodge": [
+			11,
+			10,
+			9,
+			8,
+			7
+		]
+	}
+}

--- a/Library/Basic Set/Characters/Sora.gcs
+++ b/Library/Basic Set/Characters/Sora.gcs
@@ -1,0 +1,3401 @@
+{
+	"type": "character",
+	"version": 4,
+	"id": "54027c80-6be4-46fe-b591-1ca5ebdbf0a4",
+	"total_points": 335,
+	"points_record": [
+		{
+			"when": "2023-01-15T21:53:59Z",
+			"points": 335,
+			"reason": "Initial points"
+		}
+	],
+	"profile": {
+		"player_name": "Donald Taylor",
+		"name": "Sora",
+		"religion": "Roman Catholic",
+		"age": "23",
+		"birthday": "?",
+		"gender": "Female",
+		"tech_level": "8",
+		"height": "5'2\"",
+		"weight": "130 lb"
+	},
+	"settings": {
+		"page": {
+			"paper_size": "letter",
+			"orientation": "portrait",
+			"top_margin": "0.25 in",
+			"left_margin": "0.25 in",
+			"bottom_margin": "0.25 in",
+			"right_margin": "0.25 in"
+		},
+		"block_layout": [
+			"reactions conditional_modifiers",
+			"melee",
+			"ranged",
+			"traits skills",
+			"spells",
+			"equipment",
+			"other_equipment",
+			"notes"
+		],
+		"attributes": [
+			{
+				"id": "st",
+				"type": "integer",
+				"name": "ST",
+				"full_name": "Strength",
+				"attribute_base": "10",
+				"cost_per_point": 10,
+				"cost_adj_percent_per_sm": 10
+			},
+			{
+				"id": "dx",
+				"type": "integer",
+				"name": "DX",
+				"full_name": "Dexterity",
+				"attribute_base": "10",
+				"cost_per_point": 20
+			},
+			{
+				"id": "iq",
+				"type": "integer",
+				"name": "IQ",
+				"full_name": "Intelligence",
+				"attribute_base": "10",
+				"cost_per_point": 20
+			},
+			{
+				"id": "ht",
+				"type": "integer",
+				"name": "HT",
+				"full_name": "Health",
+				"attribute_base": "10",
+				"cost_per_point": 10
+			},
+			{
+				"id": "will",
+				"type": "integer",
+				"name": "Will",
+				"attribute_base": "$iq",
+				"cost_per_point": 5
+			},
+			{
+				"id": "fright_check",
+				"type": "integer",
+				"name": "Fright Check",
+				"attribute_base": "$will",
+				"cost_per_point": 2
+			},
+			{
+				"id": "senses",
+				"type": "secondary_separator",
+				"name": "Senses"
+			},
+			{
+				"id": "per",
+				"type": "integer",
+				"name": "Per",
+				"full_name": "Perception",
+				"attribute_base": "$iq",
+				"cost_per_point": 5
+			},
+			{
+				"id": "vision",
+				"type": "integer",
+				"name": "Vision",
+				"attribute_base": "$per",
+				"cost_per_point": 2
+			},
+			{
+				"id": "hearing",
+				"type": "integer",
+				"name": "Hearing",
+				"attribute_base": "$per",
+				"cost_per_point": 2
+			},
+			{
+				"id": "taste_smell",
+				"type": "integer",
+				"name": "Taste \u0026 Smell",
+				"attribute_base": "$per",
+				"cost_per_point": 2
+			},
+			{
+				"id": "touch",
+				"type": "integer",
+				"name": "Touch",
+				"attribute_base": "$per",
+				"cost_per_point": 2
+			},
+			{
+				"id": "movement",
+				"type": "secondary_separator",
+				"name": "Movement"
+			},
+			{
+				"id": "basic_speed",
+				"type": "decimal",
+				"name": "Basic Speed",
+				"attribute_base": "($dx+$ht)/4",
+				"cost_per_point": 20
+			},
+			{
+				"id": "basic_move",
+				"type": "integer",
+				"name": "Basic Move",
+				"attribute_base": "floor($basic_speed)",
+				"cost_per_point": 5
+			},
+			{
+				"id": "highjump",
+				"type": "integer_ref",
+				"name": "High Jump (in)",
+				"attribute_base": "(6 * max(max($basic_move, floor(skill_level(jumping) / 2)), $st / 4) - 10) * enc(false, true) * (2 ^ max(0, trait_level(super jump)))"
+			},
+			{
+				"id": "running_highjump",
+				"type": "integer_ref",
+				"name": "when running",
+				"attribute_base": "(6 * max(max($basic_move, floor(skill_level(jumping) / 2)), $st / 4) * (1 + max(0, trait_level(\"enhanced move (ground)\"))) - 10) * enc(false, true) * if(trait_level(\"enhanced move (ground)\")\u003c1,2,1) * (2 ^ max(0, trait_level(super jump)))"
+			},
+			{
+				"id": "broadjump",
+				"type": "integer_ref",
+				"name": "Broad Jump (ft)",
+				"attribute_base": "(2 * max(max($basic_move, floor(skill_level(jumping) / 2)), $st / 4) - 3) * enc(false, true) * (2 ^ max(0, trait_level(super jump)))"
+			},
+			{
+				"id": "running_broadjump",
+				"type": "integer_ref",
+				"name": "when running",
+				"attribute_base": "(2 * max(max($basic_move, floor(skill_level(jumping) / 2)), $st / 4) * (1 + max(0, trait_level(\"enhanced move (ground)\"))) - 3) * enc(false, true) * if(trait_level(\"enhanced move (ground)\")\u003c1,2,1) * (2 ^ max(0, trait_level(super jump)))"
+			},
+			{
+				"id": "fp",
+				"type": "pool",
+				"name": "FP",
+				"full_name": "Fatigue Points",
+				"attribute_base": "$ht",
+				"cost_per_point": 3,
+				"thresholds": [
+					{
+						"state": "Unconscious",
+						"expression": "-$fp",
+						"ops": [
+							"halve_move",
+							"halve_dodge",
+							"halve_st"
+						]
+					},
+					{
+						"state": "Collapse",
+						"expression": "0",
+						"explanation": "Roll vs. Will to do anything besides talk or rest; failure causes unconsciousness\nEach FP you lose below 0 also causes 1 HP of injury\nMove, Dodge and ST are halved (B426)",
+						"ops": [
+							"halve_move",
+							"halve_dodge",
+							"halve_st"
+						]
+					},
+					{
+						"state": "Tired",
+						"expression": "round($fp/3)",
+						"explanation": "Move, Dodge and ST are halved (B426)",
+						"ops": [
+							"halve_move",
+							"halve_dodge",
+							"halve_st"
+						]
+					},
+					{
+						"state": "Tiring",
+						"expression": "$fp-1"
+					},
+					{
+						"state": "Rested",
+						"expression": "$fp"
+					}
+				]
+			},
+			{
+				"id": "hp",
+				"type": "pool",
+				"name": "HP",
+				"full_name": "Hit Points",
+				"attribute_base": "$st",
+				"cost_per_point": 2,
+				"cost_adj_percent_per_sm": 10,
+				"thresholds": [
+					{
+						"state": "Dead",
+						"expression": "round(-$hp*5)",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Dying #4",
+						"expression": "round(-$hp*4)",
+						"explanation": "Roll vs. HT to avoid death\nRoll vs. HT-4 every second to avoid falling unconscious\nMove and Dodge are halved (B419)",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Dying #3",
+						"expression": "round(-$hp*3)",
+						"explanation": "Roll vs. HT to avoid death\nRoll vs. HT-3 every second to avoid falling unconscious\nMove and Dodge are halved (B419)",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Dying #2",
+						"expression": "round(-$hp*2)",
+						"explanation": "Roll vs. HT to avoid death\nRoll vs. HT-2 every second to avoid falling unconscious\nMove and Dodge are halved (B419)",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Dying #1",
+						"expression": "-$hp",
+						"explanation": "Roll vs. HT to avoid death\nRoll vs. HT-1 every second to avoid falling unconscious\nMove and Dodge are halved (B419)",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Collapse",
+						"expression": "0",
+						"explanation": "Roll vs. HT every second to avoid falling unconscious\nMove and Dodge are halved (B419)",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Reeling",
+						"expression": "round($hp/3)",
+						"explanation": "Move and Dodge are halved (B419)",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Wounded",
+						"expression": "$hp-1"
+					},
+					{
+						"state": "Healthy",
+						"expression": "$hp"
+					}
+				]
+			}
+		],
+		"body_type": {
+			"name": "Humanoid",
+			"roll": "3d",
+			"locations": [
+				{
+					"id": "eye",
+					"choice_name": "Eyes",
+					"table_name": "Eyes",
+					"hit_penalty": -9,
+					"description": "An attack that misses by 1 hits the torso instead. Only\nimpaling (imp), piercing (pi-, pi, pi+, pi++), and\ntight-beam burning (burn) attacks can target the eye – and\nonly from the front or sides. Injury over HP÷10 blinds the\neye. Otherwise, treat as skull, but without the extra DR!",
+					"calc": {
+						"roll_range": "-",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "skull",
+					"choice_name": "Skull",
+					"table_name": "Skull",
+					"slots": 2,
+					"hit_penalty": -7,
+					"dr_bonus": 2,
+					"description": "An attack that misses by 1 hits the torso instead. Wounding\nmodifier is x4. Knockdown rolls are at -10. Critical hits\nuse the Critical Head Blow Table (B556). Exception: These\nspecial effects do not apply to toxic (tox) damage.",
+					"calc": {
+						"roll_range": "3-4",
+						"dr": {
+							"all": 2
+						}
+					}
+				},
+				{
+					"id": "face",
+					"choice_name": "Face",
+					"table_name": "Face",
+					"slots": 1,
+					"hit_penalty": -5,
+					"description": "An attack that misses by 1 hits the torso instead. Jaw,\ncheeks, nose, ears, etc. If the target has an open-faced\nhelmet, ignore its DR. Knockdown rolls are at -5. Critical\nhits use the Critical Head Blow Table (B556). Corrosion\n(cor) damage gets a x1½ wounding modifier, and if it\ninflicts a major wound, it also blinds one eye (both eyes on\ndamage over full HP). Random attacks from behind hit the\nskull instead.",
+					"calc": {
+						"roll_range": "5",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "leg",
+					"choice_name": "Leg",
+					"table_name": "Right Leg",
+					"slots": 2,
+					"hit_penalty": -2,
+					"description": "Reduce the wounding multiplier of large piercing (pi+), huge\npiercing (pi++), and impaling (imp) damage to x1. Any major\nwound (loss of over ½ HP from one blow) cripples the limb.\nDamage beyond that threshold is lost.",
+					"calc": {
+						"roll_range": "6-7",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "arm",
+					"choice_name": "Arm",
+					"table_name": "Right Arm",
+					"slots": 1,
+					"hit_penalty": -2,
+					"description": "Reduce the wounding multiplier of large piercing (pi+), huge\npiercing (pi++), and impaling (imp) damage to x1. Any major\nwound (loss of over ½ HP from one blow) cripples the limb.\nDamage beyond that threshold is lost. If holding a shield,\ndouble the penalty to hit: -4 for shield arm instead of -2.",
+					"calc": {
+						"roll_range": "8",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "torso",
+					"choice_name": "Torso",
+					"table_name": "Torso",
+					"slots": 2,
+					"calc": {
+						"roll_range": "9-10",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "groin",
+					"choice_name": "Groin",
+					"table_name": "Groin",
+					"slots": 1,
+					"hit_penalty": -3,
+					"description": "An attack that misses by 1 hits the torso instead. Human\nmales and the males of similar species suffer double shock\nfrom crushing (cr) damage, and get -5 to knockdown rolls.\nOtherwise, treat as a torso hit.",
+					"calc": {
+						"roll_range": "11",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "arm",
+					"choice_name": "Arm",
+					"table_name": "Left Arm",
+					"slots": 1,
+					"hit_penalty": -2,
+					"description": "Reduce the wounding multiplier of large piercing (pi+), huge\npiercing (pi++), and impaling (imp) damage to x1. Any major\nwound (loss of over ½ HP from one blow) cripples the limb.\nDamage beyond that threshold is lost. If holding a shield,\ndouble the penalty to hit: -4 for shield arm instead of -2.",
+					"calc": {
+						"roll_range": "12",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "leg",
+					"choice_name": "Leg",
+					"table_name": "Left Leg",
+					"slots": 2,
+					"hit_penalty": -2,
+					"description": "Reduce the wounding multiplier of large piercing (pi+), huge\npiercing (pi++), and impaling (imp) damage to x1. Any major\nwound (loss of over ½ HP from one blow) cripples the limb.\nDamage beyond that threshold is lost.",
+					"calc": {
+						"roll_range": "13-14",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "hand",
+					"choice_name": "Hand",
+					"table_name": "Hand",
+					"slots": 1,
+					"hit_penalty": -4,
+					"description": "If holding a shield, double the penalty to hit: -8 for\nshield hand instead of -4. Reduce the wounding multiplier of\nlarge piercing (pi+), huge piercing (pi++), and impaling\n(imp) damage to x1. Any major wound (loss of over ⅓ HP\nfrom one blow) cripples the extremity. Damage beyond that\nthreshold is lost.",
+					"calc": {
+						"roll_range": "15",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "foot",
+					"choice_name": "Foot",
+					"table_name": "Foot",
+					"slots": 1,
+					"hit_penalty": -4,
+					"description": "Reduce the wounding multiplier of large piercing (pi+), huge\npiercing (pi++), and impaling (imp) damage to x1. Any major\nwound (loss of over ⅓ HP from one blow) cripples the\nextremity. Damage beyond that threshold is lost.",
+					"calc": {
+						"roll_range": "16",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "neck",
+					"choice_name": "Neck",
+					"table_name": "Neck",
+					"slots": 2,
+					"hit_penalty": -5,
+					"description": "An attack that misses by 1 hits the torso instead. Neck and\nthroat. Increase the wounding multiplier of crushing (cr)\nand corrosion (cor) attacks to x1½, and that of cutting\n(cut) damage to x2. At the GM’s option, anyone killed by a\ncutting (cut) blow to the neck is decapitated!",
+					"calc": {
+						"roll_range": "17-18",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "vitals",
+					"choice_name": "Vitals",
+					"table_name": "Vitals",
+					"hit_penalty": -3,
+					"description": "An attack that misses by 1 hits the torso instead. Heart,\nlungs, kidneys, etc. Increase the wounding modifier for an\nimpaling (imp) or any piercing (pi-, pi, pi+, pi++) attack\nto x3. Increase the wounding modifier for a tight-beam\nburning (burn) attack to x2. Other attacks cannot target the\nvitals.",
+					"calc": {
+						"roll_range": "-",
+						"dr": {
+							"all": 0
+						}
+					}
+				}
+			]
+		},
+		"damage_progression": "basic_set",
+		"default_length_units": "ft_in",
+		"default_weight_units": "lb",
+		"user_description_display": "tooltip",
+		"modifiers_display": "inline",
+		"notes_display": "inline",
+		"skill_level_adj_display": "tooltip",
+		"show_spell_adj": true,
+		"exclude_unspent_points_from_total": false
+	},
+	"attributes": [
+		{
+			"attr_id": "st",
+			"adj": 2,
+			"calc": {
+				"value": 12,
+				"points": 20
+			}
+		},
+		{
+			"attr_id": "dx",
+			"adj": 6,
+			"calc": {
+				"value": 16,
+				"points": 120
+			}
+		},
+		{
+			"attr_id": "iq",
+			"adj": 3,
+			"calc": {
+				"value": 13,
+				"points": 60
+			}
+		},
+		{
+			"attr_id": "ht",
+			"adj": 1,
+			"calc": {
+				"value": 11,
+				"points": 10
+			}
+		},
+		{
+			"attr_id": "will",
+			"adj": 0,
+			"calc": {
+				"value": 13,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "fright_check",
+			"adj": 0,
+			"calc": {
+				"value": 15,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "senses",
+			"adj": 0
+		},
+		{
+			"attr_id": "per",
+			"adj": -1,
+			"calc": {
+				"value": 12,
+				"points": -5
+			}
+		},
+		{
+			"attr_id": "vision",
+			"adj": 0,
+			"calc": {
+				"value": 12,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "hearing",
+			"adj": 0,
+			"calc": {
+				"value": 12,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "taste_smell",
+			"adj": 0,
+			"calc": {
+				"value": 12,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "touch",
+			"adj": 0,
+			"calc": {
+				"value": 12,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "movement",
+			"adj": 0
+		},
+		{
+			"attr_id": "basic_speed",
+			"adj": 0.25,
+			"calc": {
+				"value": 7,
+				"points": 5
+			}
+		},
+		{
+			"attr_id": "basic_move",
+			"adj": 1,
+			"calc": {
+				"value": 8,
+				"points": 5
+			}
+		},
+		{
+			"attr_id": "highjump",
+			"adj": 0,
+			"calc": {
+				"value": 38,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "running_highjump",
+			"adj": 0,
+			"calc": {
+				"value": 76,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "broadjump",
+			"adj": 0,
+			"calc": {
+				"value": 13,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "running_broadjump",
+			"adj": 0,
+			"calc": {
+				"value": 26,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "fp",
+			"adj": 0,
+			"calc": {
+				"value": 11,
+				"current": 11,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "hp",
+			"adj": 0,
+			"calc": {
+				"value": 12,
+				"current": 12,
+				"points": 0
+			}
+		}
+	],
+	"traits": [
+		{
+			"id": "deb5dba7-b2ff-4dbb-bff7-e78ebeacb4d5",
+			"type": "trait",
+			"name": "Natural Attacks",
+			"reference": "B271",
+			"weapons": [
+				{
+					"id": "6b53d307-f80d-4e9d-a4d0-c82f6e0d1270",
+					"type": "melee_weapon",
+					"damage": {
+						"type": "cr",
+						"st": "thr",
+						"base": "-1"
+					},
+					"usage": "Bite",
+					"reach": "C",
+					"parry": "No",
+					"block": "No",
+					"defaults": [
+						{
+							"type": "dx"
+						},
+						{
+							"type": "skill",
+							"name": "Brawling"
+						}
+					],
+					"calc": {
+						"level": 16,
+						"parry": "No",
+						"block": "No",
+						"damage": "1d-2 cr"
+					}
+				},
+				{
+					"id": "00943fd4-1f85-48b5-80c4-850999c493c4",
+					"type": "melee_weapon",
+					"damage": {
+						"type": "cr",
+						"st": "thr",
+						"base": "-1"
+					},
+					"usage": "Punch",
+					"reach": "C",
+					"parry": "0",
+					"defaults": [
+						{
+							"type": "dx"
+						},
+						{
+							"type": "skill",
+							"name": "Boxing"
+						},
+						{
+							"type": "skill",
+							"name": "Brawling"
+						},
+						{
+							"type": "skill",
+							"name": "Karate"
+						}
+					],
+					"calc": {
+						"level": 16,
+						"parry": "12",
+						"damage": "1d-1 cr"
+					}
+				},
+				{
+					"id": "300f863b-1677-47f1-a0e6-0a44ee4e1fd2",
+					"type": "melee_weapon",
+					"damage": {
+						"type": "cr",
+						"st": "thr"
+					},
+					"usage": "Kick",
+					"reach": "C,1",
+					"parry": "No",
+					"defaults": [
+						{
+							"type": "dx",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Brawling",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Kicking"
+						},
+						{
+							"type": "skill",
+							"name": "Karate",
+							"modifier": -2
+						}
+					],
+					"calc": {
+						"level": 14,
+						"parry": "No",
+						"damage": "1d cr"
+					}
+				}
+			],
+			"calc": {
+				"points": 0
+			}
+		},
+		{
+			"id": "c2122dfe-5df0-486f-aca9-b7f339c2d611",
+			"type": "trait",
+			"name": "Language: Chinese",
+			"reference": "B24",
+			"tags": [
+				"Advantage",
+				"Language",
+				"Mental"
+			],
+			"modifiers": [
+				{
+					"id": "ff972d9a-b925-4895-a489-f3d14999074d",
+					"type": "modifier",
+					"name": "Native",
+					"reference": "B23",
+					"cost": -6,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "e9f38c71-c4bd-45ee-a5e2-b47a33029f96",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "None",
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "6cd10ab4-c4f9-4764-a47d-0e77d105d862",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Broken",
+					"cost": 1,
+					"cost_type": "points"
+				},
+				{
+					"id": "3c7caa3c-055e-4422-ac8e-6a2d632b391c",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Accented",
+					"cost": 2,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "231ba28d-11ce-44e1-8d23-074d40ca57c6",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Native",
+					"cost": 3,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "152ad20b-dc58-4abb-b256-71da14dbb89c",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "None",
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "6304a0d6-80f3-4a5f-b3cc-3ba2ae0c8063",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Broken",
+					"cost": 1,
+					"cost_type": "points"
+				},
+				{
+					"id": "5818ab4a-2c4b-4c3e-a711-c4b6332daaca",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Accented",
+					"cost": 2,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "1b77515e-5789-49a0-8238-7242900c8c2c",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Native",
+					"cost": 3,
+					"cost_type": "points",
+					"disabled": true
+				}
+			],
+			"calc": {
+				"points": 2
+			}
+		},
+		{
+			"id": "d2f692de-a636-4eef-a63a-a7542e37b7d0",
+			"type": "trait",
+			"name": "Language: English",
+			"reference": "B24",
+			"tags": [
+				"Advantage",
+				"Language",
+				"Mental"
+			],
+			"modifiers": [
+				{
+					"id": "ff972d9a-b925-4895-a489-f3d14999074d",
+					"type": "modifier",
+					"name": "Native",
+					"reference": "B23",
+					"cost": -6,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "e9f38c71-c4bd-45ee-a5e2-b47a33029f96",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "None",
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "6cd10ab4-c4f9-4764-a47d-0e77d105d862",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Broken",
+					"cost": 1,
+					"cost_type": "points"
+				},
+				{
+					"id": "3c7caa3c-055e-4422-ac8e-6a2d632b391c",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Accented",
+					"cost": 2,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "231ba28d-11ce-44e1-8d23-074d40ca57c6",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Native",
+					"cost": 3,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "152ad20b-dc58-4abb-b256-71da14dbb89c",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "None",
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "6304a0d6-80f3-4a5f-b3cc-3ba2ae0c8063",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Broken",
+					"cost": 1,
+					"cost_type": "points"
+				},
+				{
+					"id": "5818ab4a-2c4b-4c3e-a711-c4b6332daaca",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Accented",
+					"cost": 2,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "1b77515e-5789-49a0-8238-7242900c8c2c",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Native",
+					"cost": 3,
+					"cost_type": "points",
+					"disabled": true
+				}
+			],
+			"calc": {
+				"points": 2
+			}
+		},
+		{
+			"id": "743c85ca-aeb0-4b02-beb2-bfb5c503de6e",
+			"type": "trait",
+			"name": "Language: Japanese",
+			"reference": "B24",
+			"tags": [
+				"Advantage",
+				"Language",
+				"Mental"
+			],
+			"modifiers": [
+				{
+					"id": "ff972d9a-b925-4895-a489-f3d14999074d",
+					"type": "modifier",
+					"name": "Native",
+					"reference": "B23",
+					"cost": -6,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "e9f38c71-c4bd-45ee-a5e2-b47a33029f96",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "None",
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "6cd10ab4-c4f9-4764-a47d-0e77d105d862",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Broken",
+					"cost": 1,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "3c7caa3c-055e-4422-ac8e-6a2d632b391c",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Accented",
+					"cost": 2,
+					"cost_type": "points"
+				},
+				{
+					"id": "231ba28d-11ce-44e1-8d23-074d40ca57c6",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Native",
+					"cost": 3,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "152ad20b-dc58-4abb-b256-71da14dbb89c",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "None",
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "6304a0d6-80f3-4a5f-b3cc-3ba2ae0c8063",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Broken",
+					"cost": 1,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "5818ab4a-2c4b-4c3e-a711-c4b6332daaca",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Accented",
+					"cost": 2,
+					"cost_type": "points"
+				},
+				{
+					"id": "1b77515e-5789-49a0-8238-7242900c8c2c",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Native",
+					"cost": 3,
+					"cost_type": "points",
+					"disabled": true
+				}
+			],
+			"calc": {
+				"points": 4
+			}
+		},
+		{
+			"id": "19a2af45-6b3d-4704-a1c3-5e85b562deaa",
+			"type": "trait",
+			"name": "Language: Tagalog",
+			"reference": "B24",
+			"tags": [
+				"Advantage",
+				"Language",
+				"Mental"
+			],
+			"modifiers": [
+				{
+					"id": "ff972d9a-b925-4895-a489-f3d14999074d",
+					"type": "modifier",
+					"name": "Native",
+					"reference": "B23",
+					"cost": -6,
+					"cost_type": "points"
+				},
+				{
+					"id": "e9f38c71-c4bd-45ee-a5e2-b47a33029f96",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "None",
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "6cd10ab4-c4f9-4764-a47d-0e77d105d862",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Broken",
+					"cost": 1,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "3c7caa3c-055e-4422-ac8e-6a2d632b391c",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Accented",
+					"cost": 2,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "231ba28d-11ce-44e1-8d23-074d40ca57c6",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Native",
+					"cost": 3,
+					"cost_type": "points"
+				},
+				{
+					"id": "152ad20b-dc58-4abb-b256-71da14dbb89c",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "None",
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "6304a0d6-80f3-4a5f-b3cc-3ba2ae0c8063",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Broken",
+					"cost": 1,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "5818ab4a-2c4b-4c3e-a711-c4b6332daaca",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Accented",
+					"cost": 2,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "1b77515e-5789-49a0-8238-7242900c8c2c",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Native",
+					"cost": 3,
+					"cost_type": "points"
+				}
+			],
+			"calc": {
+				"points": 0
+			}
+		},
+		{
+			"id": "b068c821-925a-452b-8d3d-9b7f3662a6a5",
+			"type": "trait",
+			"name": "Cultural Familiarity (East Asian)",
+			"reference": "B23",
+			"notes": "Do not suffer the normal -3 penalty for unfamiliarity",
+			"tags": [
+				"Advantage",
+				"Mental"
+			],
+			"modifiers": [
+				{
+					"id": "ab12b725-01c8-4fc4-8e71-619a54c79496",
+					"type": "modifier",
+					"name": "Alien",
+					"cost": 1,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "f72aa995-6766-4eaf-a3ca-0f4ff76d47c5",
+					"type": "modifier",
+					"name": "Native",
+					"cost": -1,
+					"cost_type": "points"
+				}
+			],
+			"base_points": 1,
+			"calc": {
+				"points": 0
+			}
+		},
+		{
+			"id": "8b4045e9-59c7-4b91-b369-3c000d2ab956",
+			"type": "trait",
+			"name": "Cultural Familiarity (Homeline)",
+			"reference": "B23",
+			"notes": "Do not suffer the normal -3 penalty for unfamiliarity",
+			"tags": [
+				"Advantage",
+				"Mental"
+			],
+			"modifiers": [
+				{
+					"id": "ab12b725-01c8-4fc4-8e71-619a54c79496",
+					"type": "modifier",
+					"name": "Alien",
+					"cost": 1,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "f72aa995-6766-4eaf-a3ca-0f4ff76d47c5",
+					"type": "modifier",
+					"name": "Native",
+					"cost": -1,
+					"cost_type": "points",
+					"disabled": true
+				}
+			],
+			"base_points": 1,
+			"calc": {
+				"points": 1
+			}
+		},
+		{
+			"id": "fc51b1fb-9f93-4375-ae7b-8a32b473de5e",
+			"type": "trait",
+			"name": "Catfall",
+			"reference": "B41,P43",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Physical"
+			],
+			"modifiers": [
+				{
+					"id": "4f09c6de-6a88-4593-9e01-2441530cb0e6",
+					"type": "modifier",
+					"name": "Feather Fall",
+					"reference": "P43",
+					"cost": 20,
+					"disabled": true
+				},
+				{
+					"id": "d05208e4-b857-4e41-b7fa-3b7fa594ac68",
+					"type": "modifier",
+					"name": "Parachute",
+					"reference": "P43",
+					"cost": -30,
+					"disabled": true
+				}
+			],
+			"base_points": 10,
+			"calc": {
+				"points": 10
+			}
+		},
+		{
+			"id": "ff1f63a8-26c7-4732-a3e4-7e6d44b0cbd6",
+			"type": "trait",
+			"name": "Combat Reflexes",
+			"reference": "B43",
+			"notes": "Never freeze",
+			"tags": [
+				"Advantage",
+				"Mental"
+			],
+			"base_points": 15,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Enhanced Time Sense"
+						}
+					}
+				]
+			},
+			"features": [
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "starts_with",
+						"qualifier": "fast-draw"
+					},
+					"amount": 1
+				},
+				{
+					"type": "attribute_bonus",
+					"attribute": "dodge",
+					"amount": 1
+				},
+				{
+					"type": "attribute_bonus",
+					"attribute": "parry",
+					"amount": 1
+				},
+				{
+					"type": "attribute_bonus",
+					"attribute": "block",
+					"amount": 1
+				},
+				{
+					"type": "attribute_bonus",
+					"attribute": "fright_check",
+					"amount": 2
+				},
+				{
+					"type": "conditional_modifier",
+					"situation": "on all IQ rolls to wake up or to recover from surprise or mental stun",
+					"amount": 6
+				},
+				{
+					"type": "conditional_modifier",
+					"situation": "to initiative rolls for your side (+2 if you are the leader)",
+					"amount": 1
+				}
+			],
+			"calc": {
+				"points": 15
+			}
+		},
+		{
+			"id": "d966713e-4954-4b45-8863-1711190c2066",
+			"type": "trait",
+			"name": "Fit",
+			"reference": "B55",
+			"notes": "Recover FP at twice the normal rate (but not FP spent for spells or psi powers)",
+			"tags": [
+				"Advantage",
+				"Physical"
+			],
+			"base_points": 5,
+			"features": [
+				{
+					"type": "conditional_modifier",
+					"situation": "to all HT rolls to stay conscious, avoid death, resist disease, or resist poison",
+					"amount": 1
+				}
+			],
+			"calc": {
+				"points": 5
+			}
+		},
+		{
+			"id": "a74f4403-8f6d-4ed4-80b8-e8b66689c509",
+			"type": "trait",
+			"name": "Legal Enforcement Powers",
+			"reference": "B65",
+			"tags": [
+				"Advantage",
+				"Social"
+			],
+			"levels": 3,
+			"points_per_level": 5,
+			"can_level": true,
+			"calc": {
+				"points": 15
+			}
+		},
+		{
+			"id": "80ed9687-8d79-4c2c-8ab8-c7236784130a",
+			"type": "trait",
+			"name": "Perfect Balance",
+			"reference": "B74",
+			"tags": [
+				"Advantage",
+				"Physical"
+			],
+			"base_points": 15,
+			"features": [
+				{
+					"type": "conditional_modifier",
+					"situation": "on DX and DX-based skill rolls to keep your feet or avoid being knocked down in combat",
+					"amount": 4
+				},
+				{
+					"type": "conditional_modifier",
+					"situation": "on all rolls to keep your feet if the surface is wet, slippery or unstable",
+					"amount": 6
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "starts_with",
+						"qualifier": "piloting"
+					},
+					"amount": 1
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "acrobatics"
+					},
+					"amount": 1
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "climbing"
+					},
+					"amount": 1
+				}
+			],
+			"calc": {
+				"points": 15
+			}
+		},
+		{
+			"id": "ec089560-facc-4e5a-b6b9-63370f3dc1ea",
+			"type": "trait",
+			"name": "Trained by a Master",
+			"reference": "B93,MA48",
+			"tags": [
+				"Advantage",
+				"Mental"
+			],
+			"modifiers": [
+				{
+					"id": "73e69b8e-41f1-4ccf-b67f-8434034dfdb9",
+					"type": "modifier",
+					"name": "Unarmed only",
+					"cost": -40,
+					"disabled": true
+				}
+			],
+			"base_points": 30,
+			"calc": {
+				"points": 30
+			}
+		},
+		{
+			"id": "7093cd9e-40e6-47b3-81de-c0d5765869a5",
+			"type": "trait",
+			"name": "Code of Honor (Professional)",
+			"reference": "B127",
+			"notes": "Adhere to the ethics of your profession; always do your job to the best of your ability; support your guild, union, or professional association.",
+			"tags": [
+				"Disadvantage",
+				"Mental"
+			],
+			"base_points": -5,
+			"calc": {
+				"points": -5
+			}
+		},
+		{
+			"id": "d005f41a-adfe-4007-aed9-31e3ca5c995d",
+			"type": "trait",
+			"name": "Delusion (My mother is an angel in heaven watching over me)",
+			"reference": "B130",
+			"tags": [
+				"Disadvantage",
+				"Mental"
+			],
+			"modifiers": [
+				{
+					"id": "ac2f3661-107e-4425-a132-9d90df099e7c",
+					"type": "modifier",
+					"name": "Minor",
+					"reference": "B130",
+					"cost": -5,
+					"cost_type": "points"
+				},
+				{
+					"id": "aecc1c19-74f1-4379-b1e9-baed32ec4088",
+					"type": "modifier",
+					"name": "Major",
+					"reference": "B130",
+					"cost": -10,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "dbb776b3-9d95-4203-8e0c-9d500dae7615",
+					"type": "modifier",
+					"name": "Severe",
+					"reference": "B130",
+					"cost": -15,
+					"cost_type": "points",
+					"disabled": true
+				}
+			],
+			"calc": {
+				"points": -5
+			}
+		},
+		{
+			"id": "267898e4-b354-4a32-b40e-727e0a504a8b",
+			"type": "trait",
+			"name": "Duty (To ISWAT)",
+			"reference": "B133",
+			"tags": [
+				"Disadvantage",
+				"Social"
+			],
+			"modifiers": [
+				{
+					"id": "fb0c80a4-4c65-4521-9e18-7378dda34a46",
+					"type": "modifier",
+					"name": "FR: 6",
+					"cost": -2,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "92ade39a-a64c-4ff4-a84b-89ab92a6e217",
+					"type": "modifier",
+					"name": "FR: 9",
+					"cost": -5,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "80577150-cbdb-4c26-bde4-1ad85a7deec2",
+					"type": "modifier",
+					"name": "FR: 12",
+					"cost": -10,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "d6406b89-6289-4b8c-b7c7-4d25add3c352",
+					"type": "modifier",
+					"name": "FR: 15",
+					"cost": -15,
+					"cost_type": "points"
+				},
+				{
+					"id": "f4458d02-9b67-42f8-8f31-5837064fb751",
+					"type": "modifier",
+					"name": "Extremely Hazardous",
+					"cost": -5,
+					"cost_type": "points"
+				},
+				{
+					"id": "814f2484-cac1-4eca-af21-f9eaca8c0d0a",
+					"type": "modifier",
+					"name": "Involuntary",
+					"cost": -5,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "5d87b90f-fc68-4d78-8547-7c2ef58ae7bd",
+					"type": "modifier",
+					"name": "Nonhazardous",
+					"cost": 5,
+					"cost_type": "points",
+					"disabled": true
+				}
+			],
+			"calc": {
+				"points": -20
+			}
+		},
+		{
+			"id": "e395953f-f5e1-4e81-a50c-74caeb4d0bb4",
+			"type": "trait",
+			"name": "Enemy (Manila Triads)",
+			"reference": "B135",
+			"tags": [
+				"Disadvantage",
+				"Social"
+			],
+			"modifiers": [
+				{
+					"id": "de332956-d4a1-4af6-9339-34f1fa617363",
+					"type": "modifier",
+					"name": "Weak Individual",
+					"reference": "B135",
+					"notes": "50% of your starting points",
+					"cost": -5,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "73913cf5-78dc-4fa9-93e8-9182656fb07e",
+					"type": "modifier",
+					"name": "Equal Individual",
+					"reference": "B135",
+					"notes": "100% of your starting points",
+					"cost": -10,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "81b5a233-41ef-48a3-8d98-450dab7c74a2",
+					"type": "modifier",
+					"name": "Powerful Individual",
+					"reference": "B135",
+					"notes": "\u003e150% of your starting points",
+					"cost": -20,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "4ad57666-9f27-4986-9191-16d65214969b",
+					"type": "modifier",
+					"name": "Weak Group",
+					"reference": "B135",
+					"cost": -10,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "8427a345-55ea-4e91-a797-cef5991899d4",
+					"type": "modifier",
+					"name": "Medium Group",
+					"reference": "B135",
+					"cost": -20,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "4de4b388-72a9-4143-b57b-c3ea069c1600",
+					"type": "modifier",
+					"name": "Appears almost all the time",
+					"reference": "B36",
+					"notes": "15-",
+					"cost": 3,
+					"cost_type": "multiplier",
+					"disabled": true
+				},
+				{
+					"id": "98bee615-b142-4c48-be3d-ce6e87cec21b",
+					"type": "modifier",
+					"name": "Appears quite often",
+					"reference": "B36",
+					"notes": "12-",
+					"cost": 2,
+					"cost_type": "multiplier",
+					"disabled": true
+				},
+				{
+					"id": "8e56e038-28dd-41ed-b516-969294228bca",
+					"type": "modifier",
+					"name": "Appears fairly often",
+					"reference": "B36",
+					"notes": "9-",
+					"cost": 1,
+					"cost_type": "multiplier",
+					"disabled": true
+				},
+				{
+					"id": "04e80fd4-8cc7-423e-8af5-3906657f8cb2",
+					"type": "modifier",
+					"name": "Appears quite rarely",
+					"reference": "B36",
+					"notes": "6-",
+					"cost": 0.5,
+					"cost_type": "multiplier"
+				},
+				{
+					"id": "08aa132f-60f2-4bed-b3a3-ef4321d2f09f",
+					"type": "modifier",
+					"name": "Large/Powerful Group",
+					"reference": "B135",
+					"cost": -30,
+					"cost_type": "points"
+				},
+				{
+					"id": "19ea1f4b-fc64-4c1d-8217-1c7f5cd09190",
+					"type": "modifier",
+					"name": "Utterly Formidable Group",
+					"reference": "B135",
+					"cost": -40,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "1f9b2afd-1cb9-460a-ba7d-8315a7698ba8",
+					"type": "modifier",
+					"name": "Unknown",
+					"reference": "B135",
+					"cost": -5,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "f6364f57-15e6-4d03-bc3f-ebf2c4718dac",
+					"type": "modifier",
+					"name": "Evil Twin",
+					"reference": "B135",
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "4560fba2-c960-4c2d-9201-f69dc83ed26f",
+					"type": "modifier",
+					"name": "Evil Twin",
+					"reference": "B135",
+					"notes": "More skilled or extra abilities",
+					"cost": -5,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "f948ad5e-0ca0-4e8f-84c1-d65105981603",
+					"type": "modifier",
+					"name": "Evil Twin",
+					"reference": "B135",
+					"notes": "More skilled and extra abilities",
+					"cost": -10,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "43075921-7dd0-468f-9609-296e9f7ebf0b",
+					"type": "modifier",
+					"name": "Watcher",
+					"reference": "B135",
+					"cost": 0.25,
+					"cost_type": "multiplier",
+					"disabled": true
+				},
+				{
+					"id": "85d6d113-01ac-4074-a7ce-21572db84555",
+					"type": "modifier",
+					"name": "Rival",
+					"reference": "B135",
+					"cost": 0.5,
+					"cost_type": "multiplier",
+					"disabled": true
+				},
+				{
+					"id": "1b7c0201-7ba5-46e9-9c3d-2398527a3712",
+					"type": "modifier",
+					"name": "Hunter",
+					"reference": "B135",
+					"cost": 1,
+					"cost_type": "multiplier"
+				}
+			],
+			"calc": {
+				"points": -15
+			}
+		},
+		{
+			"id": "ebeb018f-cc6f-4d34-9ed1-928669abedbd",
+			"type": "trait",
+			"name": "Light Sleeper",
+			"reference": "B142",
+			"notes": "Whenever you must sleep in an uncomfortable place, or whenever there is more than the slightest noise, you must make a HT roll in order to fall asleep. On a failure, you can try again after one hour, but you will suffer all the usual effects of one hour of missed sleep.",
+			"tags": [
+				"Disadvantage",
+				"Physical"
+			],
+			"base_points": -5,
+			"calc": {
+				"points": -5
+			}
+		},
+		{
+			"id": "27622c5f-b310-4ae3-b072-0dad6a417c0a",
+			"type": "trait",
+			"name": "Pacifism: Cannot Harm Innocents",
+			"reference": "B148",
+			"notes": "You may fight – you may even start fights – but you may only use deadly force on a foe that is attempting to do you serious harm. Capture is not “serious harm” unless you are already under penalty of death or have a Code of Honor that would require suicide if captured. You never intentionally do anything that causes, or even threatens to cause, injury to the uninvolved – particularly if they are “ordinary folks.”",
+			"tags": [
+				"Disadvantage",
+				"Mental"
+			],
+			"modifiers": [
+				{
+					"id": "74354ea8-96ba-4eee-9027-9f746e9bd941",
+					"type": "modifier",
+					"name": "Species-Specific",
+					"reference": "UT32",
+					"cost": -80,
+					"disabled": true
+				}
+			],
+			"base_points": -10,
+			"calc": {
+				"points": -10
+			}
+		},
+		{
+			"id": "dc1c81e4-1eab-4f0d-bb24-42566b6b1ae2",
+			"type": "trait",
+			"name": "Quirk: Careful",
+			"reference": "B163",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "e7db2e9c-8ec2-4cb0-b324-edbb31063b0a",
+			"type": "trait",
+			"name": "Quirk: Devout Roman Catholic",
+			"reference": "B162",
+			"notes": "Reacts at +1 to Catholic clergy, tithes, attends church regularly",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "5f6a9b99-6d3f-47a4-9c2a-700a97244150",
+			"type": "trait",
+			"name": "Quirk: Dislikes wide open spaces",
+			"reference": "B162",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "062c8641-b64f-4e86-b61c-4d2feea21272",
+			"type": "trait",
+			"name": "Quirk: Uncongenial",
+			"reference": "B164",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "b7849cd2-7548-490e-ab44-5fd61ecc6ff6",
+			"type": "trait",
+			"name": "Quirk: Vow never to refuse a challenge to single combat ",
+			"reference": "B165",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		}
+	],
+	"skills": [
+		{
+			"id": "added82e-15a6-45ba-a073-6ca999f7db64",
+			"type": "skill_container",
+			"open": true,
+			"children": [
+				{
+					"id": "852f3fa3-dbbf-4e26-9661-51afc69a36e6",
+					"type": "skill",
+					"name": "Acrobatics",
+					"reference": "B174,MA54",
+					"tags": [
+						"Athletic"
+					],
+					"difficulty": "dx/h",
+					"points": 4,
+					"defaulted_from": {
+						"type": "dx",
+						"modifier": -6,
+						"level": 10,
+						"adjusted_level": 10,
+						"points": -10
+					},
+					"defaults": [
+						{
+							"type": "dx",
+							"modifier": -6
+						},
+						{
+							"type": "skill",
+							"name": "Aerobatics",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Aquabatics",
+							"modifier": -4
+						}
+					],
+					"calc": {
+						"level": 17,
+						"rsl": "DX+1"
+					}
+				},
+				{
+					"id": "8878e7ff-78fc-4fe0-bd6c-531a13d83682",
+					"type": "skill",
+					"name": "Area Knowledge",
+					"reference": "B176",
+					"notes": "All important businesses, streets, citizens, leaders, etc.",
+					"tags": [
+						"Everyman",
+						"Knowledge"
+					],
+					"specialization": "Manila; Lived there",
+					"difficulty": "iq/e",
+					"points": 2,
+					"defaulted_from": {
+						"type": "iq",
+						"modifier": -4,
+						"level": 9,
+						"adjusted_level": 9,
+						"points": -9
+					},
+					"defaults": [
+						{
+							"type": "iq",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Geography",
+							"modifier": -3
+						}
+					],
+					"calc": {
+						"level": 14,
+						"rsl": "IQ+1"
+					}
+				},
+				{
+					"id": "e294f03f-e0b3-4248-8afa-7b5e59d15120",
+					"type": "skill",
+					"name": "Broadsword",
+					"reference": "B208",
+					"tags": [
+						"Combat",
+						"Melee Combat",
+						"Weapon"
+					],
+					"difficulty": "dx/a",
+					"points": 1,
+					"defaulted_from": {
+						"type": "dx",
+						"modifier": -5,
+						"level": 11,
+						"adjusted_level": 11,
+						"points": -11
+					},
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Force Sword",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Rapier",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Saber",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Shortsword",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Two-Handed Sword",
+							"modifier": -4
+						},
+						{
+							"type": "dx",
+							"modifier": -5
+						}
+					],
+					"calc": {
+						"level": 15,
+						"rsl": "DX-1"
+					}
+				},
+				{
+					"id": "eeb86176-7e42-454b-ab17-fe41255cf0fb",
+					"type": "skill",
+					"name": "Climbing",
+					"reference": "B183",
+					"tags": [
+						"Athletic",
+						"Criminal",
+						"Exploration",
+						"Outdoor",
+						"Street"
+					],
+					"difficulty": "dx/a",
+					"points": 2,
+					"encumbrance_penalty_multiplier": 1,
+					"defaulted_from": {
+						"type": "dx",
+						"modifier": -5,
+						"level": 11,
+						"adjusted_level": 11,
+						"points": -11
+					},
+					"defaults": [
+						{
+							"type": "dx",
+							"modifier": -5
+						}
+					],
+					"calc": {
+						"level": 17,
+						"rsl": "DX+1"
+					}
+				},
+				{
+					"id": "b01f9064-ce5b-41b8-ae6b-6031ae57b0d5",
+					"type": "skill",
+					"name": "Computer Hacking",
+					"reference": "B184",
+					"tags": [
+						"Criminal",
+						"Spy",
+						"Street"
+					],
+					"tech_level": "8",
+					"difficulty": "iq/vh",
+					"points": 2,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "skill_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "computer programming"
+								}
+							}
+						]
+					},
+					"calc": {
+						"level": 11,
+						"rsl": "IQ-2"
+					}
+				},
+				{
+					"id": "1980214e-d4d1-4697-ad53-511a8e50f35f",
+					"type": "skill",
+					"name": "Computer Programming",
+					"reference": "B184",
+					"tags": [
+						"Design",
+						"Invention"
+					],
+					"tech_level": "8",
+					"difficulty": "iq/h",
+					"points": 1,
+					"calc": {
+						"level": 11,
+						"rsl": "IQ-2"
+					}
+				},
+				{
+					"id": "bba9a692-c4b9-4e80-9a33-ab318045829e",
+					"type": "skill",
+					"name": "Fast-Draw",
+					"reference": "B194,MA56",
+					"tags": [
+						"Combat",
+						"Melee Combat",
+						"Weapon"
+					],
+					"specialization": "Knife",
+					"difficulty": "dx/e",
+					"points": 1,
+					"calc": {
+						"level": 17,
+						"rsl": "DX+1"
+					}
+				},
+				{
+					"id": "63b1b709-26c4-481d-952e-9e5dc4c69993",
+					"type": "skill",
+					"name": "Fast-Draw",
+					"reference": "B194,MA56",
+					"tags": [
+						"Combat",
+						"Ranged Combat",
+						"Weapon"
+					],
+					"specialization": "Small Thrown Weapon",
+					"difficulty": "dx/e",
+					"points": 1,
+					"calc": {
+						"level": 17,
+						"rsl": "DX+1"
+					}
+				},
+				{
+					"id": "4d57e6e4-aca9-4d6e-a098-ecf267910124",
+					"type": "skill",
+					"name": "Fast-Draw",
+					"reference": "B194,MA56",
+					"tags": [
+						"Combat",
+						"Melee Combat",
+						"Weapon"
+					],
+					"specialization": "Tonfa",
+					"difficulty": "dx/e",
+					"points": 1,
+					"calc": {
+						"level": 17,
+						"rsl": "DX+1"
+					}
+				},
+				{
+					"id": "9231a34a-a67f-4dca-9aaa-4579db48caf5",
+					"type": "skill",
+					"name": "Fast-Talk",
+					"reference": "B195",
+					"tags": [
+						"Criminal",
+						"Social",
+						"Spy",
+						"Street"
+					],
+					"difficulty": "iq/a",
+					"points": 2,
+					"defaulted_from": {
+						"type": "iq",
+						"modifier": -5,
+						"level": 8,
+						"adjusted_level": 8,
+						"points": -8
+					},
+					"defaults": [
+						{
+							"type": "iq",
+							"modifier": -5
+						},
+						{
+							"type": "skill",
+							"name": "Acting",
+							"modifier": -5
+						}
+					],
+					"calc": {
+						"level": 13,
+						"rsl": "IQ+0"
+					}
+				},
+				{
+					"id": "e8ae48cc-8a40-40a6-83c0-e1129e4fd3d1",
+					"type": "skill",
+					"name": "Filch",
+					"reference": "B195",
+					"tags": [
+						"Criminal",
+						"Spy",
+						"Street"
+					],
+					"difficulty": "dx/a",
+					"points": 1,
+					"defaulted_from": {
+						"type": "dx",
+						"modifier": -5,
+						"level": 11,
+						"adjusted_level": 11,
+						"points": -11
+					},
+					"defaults": [
+						{
+							"type": "dx",
+							"modifier": -5
+						},
+						{
+							"type": "skill",
+							"name": "Pickpocket",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Sleight of Hand",
+							"modifier": -4
+						}
+					],
+					"calc": {
+						"level": 15,
+						"rsl": "DX-1"
+					}
+				},
+				{
+					"id": "d2fd83d0-a601-4cd9-ad9d-e7aef63938aa",
+					"type": "skill",
+					"name": "Garrote",
+					"reference": "B197",
+					"tags": [
+						"Combat",
+						"Melee Combat",
+						"Weapon"
+					],
+					"difficulty": "dx/e",
+					"points": 1,
+					"defaulted_from": {
+						"type": "dx",
+						"modifier": -4,
+						"level": 12,
+						"adjusted_level": 12,
+						"points": -12
+					},
+					"defaults": [
+						{
+							"type": "dx",
+							"modifier": -4
+						}
+					],
+					"calc": {
+						"level": 16,
+						"rsl": "DX+0"
+					}
+				},
+				{
+					"id": "9111f777-c384-4599-825e-911bdbc2adca",
+					"type": "skill",
+					"name": "Holdout",
+					"reference": "B200",
+					"tags": [
+						"Criminal",
+						"Spy",
+						"Street"
+					],
+					"difficulty": "iq/a",
+					"points": 1,
+					"defaulted_from": {
+						"type": "iq",
+						"modifier": -5,
+						"level": 8,
+						"adjusted_level": 8,
+						"points": -8
+					},
+					"defaults": [
+						{
+							"type": "iq",
+							"modifier": -5
+						},
+						{
+							"type": "skill",
+							"name": "Sleight of Hand",
+							"modifier": -3
+						}
+					],
+					"calc": {
+						"level": 12,
+						"rsl": "IQ-1"
+					}
+				},
+				{
+					"id": "76efcc9e-d542-40a5-9496-7f82250e3598",
+					"type": "skill",
+					"name": "Judo",
+					"reference": "B203,MA57",
+					"notes": "Allows parrying two different attacks per turn, one with each hand.",
+					"tags": [
+						"Combat",
+						"Melee Combat",
+						"Weapon"
+					],
+					"difficulty": "dx/h",
+					"points": 4,
+					"encumbrance_penalty_multiplier": 1,
+					"calc": {
+						"level": 16,
+						"rsl": "DX+0"
+					}
+				},
+				{
+					"id": "c75a1924-81c0-4b57-9af5-165662b14295",
+					"type": "skill",
+					"name": "Jumping",
+					"reference": "B203,MA57",
+					"tags": [
+						"Athletic"
+					],
+					"difficulty": "dx/e",
+					"points": 1,
+					"calc": {
+						"level": 16,
+						"rsl": "DX+0"
+					}
+				},
+				{
+					"id": "b1d58778-8738-4437-9619-03ce0db0028c",
+					"type": "skill",
+					"name": "Karate",
+					"reference": "B203,MA57",
+					"tags": [
+						"Combat",
+						"Melee Combat",
+						"Weapon"
+					],
+					"difficulty": "dx/h",
+					"points": 4,
+					"encumbrance_penalty_multiplier": 1,
+					"features": [
+						{
+							"type": "weapon_bonus",
+							"selection_type": "weapons_with_required_skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Karate"
+							},
+							"level": {
+								"compare": "at_least"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "weapon_bonus",
+							"selection_type": "weapons_with_required_skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Karate"
+							},
+							"level": {
+								"compare": "at_least",
+								"qualifier": 1
+							},
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"calc": {
+						"level": 16,
+						"rsl": "DX+0"
+					}
+				},
+				{
+					"id": "2402a251-3fc2-4a0f-8560-6fa80b3f1628",
+					"type": "skill",
+					"name": "Knife",
+					"reference": "B208",
+					"tags": [
+						"Combat",
+						"Melee Combat",
+						"Weapon"
+					],
+					"difficulty": "dx/e",
+					"points": 1,
+					"defaulted_from": {
+						"type": "skill",
+						"name": "Main-Gauche",
+						"modifier": -3,
+						"level": 13,
+						"adjusted_level": 13,
+						"points": -13
+					},
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Force Sword",
+							"modifier": -3
+						},
+						{
+							"type": "skill",
+							"name": "Main-Gauche",
+							"modifier": -3
+						},
+						{
+							"type": "skill",
+							"name": "Shortsword",
+							"modifier": -3
+						},
+						{
+							"type": "dx",
+							"modifier": -4
+						}
+					],
+					"calc": {
+						"level": 16,
+						"rsl": "DX+0"
+					}
+				},
+				{
+					"id": "cab8c24d-10c6-48c7-9d3f-3f64eb82cb9e",
+					"type": "skill",
+					"name": "Lockpicking",
+					"reference": "B206",
+					"tags": [
+						"Criminal",
+						"Police",
+						"Spy",
+						"Street",
+						"Technical"
+					],
+					"tech_level": "8",
+					"difficulty": "iq/a",
+					"points": 8,
+					"defaulted_from": {
+						"type": "iq",
+						"modifier": -5,
+						"level": 8,
+						"adjusted_level": 8,
+						"points": -8
+					},
+					"defaults": [
+						{
+							"type": "iq",
+							"modifier": -5
+						}
+					],
+					"calc": {
+						"level": 15,
+						"rsl": "IQ+2"
+					}
+				},
+				{
+					"id": "0f19c82f-083e-4f9d-bdfa-5e63319f3347",
+					"type": "skill",
+					"name": "Makeup",
+					"reference": "B206",
+					"tags": [
+						"Arts",
+						"Entertainment"
+					],
+					"tech_level": "8",
+					"difficulty": "iq/e",
+					"points": 1,
+					"defaulted_from": {
+						"type": "iq",
+						"modifier": -4,
+						"level": 9,
+						"adjusted_level": 9,
+						"points": -9
+					},
+					"defaults": [
+						{
+							"type": "iq",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Disguise",
+							"modifier": -2
+						}
+					],
+					"calc": {
+						"level": 13,
+						"rsl": "IQ+0"
+					}
+				},
+				{
+					"id": "a24177f1-9a55-48fc-b679-799d071a75bf",
+					"type": "skill",
+					"name": "Main-Gauche",
+					"reference": "B208,MA58",
+					"tags": [
+						"Combat",
+						"Melee Combat",
+						"Weapon"
+					],
+					"difficulty": "dx/a",
+					"points": 2,
+					"defaulted_from": {
+						"type": "skill",
+						"name": "Smallsword",
+						"modifier": -3,
+						"level": 14,
+						"adjusted_level": 14,
+						"points": -14
+					},
+					"defaults": [
+						{
+							"type": "dx",
+							"modifier": -5
+						},
+						{
+							"type": "skill",
+							"name": "Jitte/Sai",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Knife",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Rapier",
+							"modifier": -3
+						},
+						{
+							"type": "skill",
+							"name": "Saber",
+							"modifier": -3
+						},
+						{
+							"type": "skill",
+							"name": "Smallsword",
+							"modifier": -3
+						}
+					],
+					"calc": {
+						"level": 16,
+						"rsl": "DX+0"
+					}
+				},
+				{
+					"id": "b05a4358-73f2-4921-84b9-8a8d0285d856",
+					"type": "skill",
+					"name": "Observation",
+					"reference": "B211",
+					"tags": [
+						"Criminal",
+						"Military",
+						"Police",
+						"Spy",
+						"Street"
+					],
+					"difficulty": "per/a",
+					"points": 1,
+					"defaulted_from": {
+						"type": "skill",
+						"name": "Shadowing",
+						"modifier": -5,
+						"level": 8,
+						"adjusted_level": 8,
+						"points": -8
+					},
+					"defaults": [
+						{
+							"type": "per",
+							"modifier": -5
+						},
+						{
+							"type": "skill",
+							"name": "Shadowing",
+							"modifier": -5
+						}
+					],
+					"calc": {
+						"level": 11,
+						"rsl": "Per-1"
+					}
+				},
+				{
+					"id": "7c4c1040-a6ef-463e-bb58-809f63bcbdd5",
+					"type": "skill",
+					"name": "Performance",
+					"reference": "B212",
+					"tags": [
+						"Arts",
+						"Entertainment"
+					],
+					"difficulty": "iq/a",
+					"points": 1,
+					"defaulted_from": {
+						"type": "iq",
+						"modifier": -5,
+						"level": 8,
+						"adjusted_level": 8,
+						"points": -8
+					},
+					"defaults": [
+						{
+							"type": "iq",
+							"modifier": -5
+						},
+						{
+							"type": "skill",
+							"name": "Acting",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Public Speaking",
+							"modifier": -2
+						}
+					],
+					"calc": {
+						"level": 12,
+						"rsl": "IQ-1"
+					}
+				},
+				{
+					"id": "c8189367-e822-4a6c-8a18-6dacaae2f940",
+					"type": "skill",
+					"name": "Photography",
+					"reference": "B213",
+					"tags": [
+						"Arts",
+						"Entertainment",
+						"Spy",
+						"Technical"
+					],
+					"tech_level": "8",
+					"difficulty": "iq/a",
+					"points": 1,
+					"defaulted_from": {
+						"type": "iq",
+						"modifier": -5,
+						"level": 8,
+						"adjusted_level": 8,
+						"points": -8
+					},
+					"defaults": [
+						{
+							"type": "iq",
+							"modifier": -5
+						},
+						{
+							"type": "skill",
+							"name": "Electronics Operation",
+							"specialization": "Media",
+							"modifier": -5
+						}
+					],
+					"calc": {
+						"level": 12,
+						"rsl": "IQ-1"
+					}
+				},
+				{
+					"id": "f25cc22c-fb2e-470a-84bb-fe214f4b8232",
+					"type": "skill",
+					"name": "Pickpocket",
+					"reference": "B213",
+					"tags": [
+						"Criminal",
+						"Street"
+					],
+					"difficulty": "dx/h",
+					"points": 1,
+					"defaulted_from": {
+						"type": "dx",
+						"modifier": -6,
+						"level": 10,
+						"adjusted_level": 10,
+						"points": -10
+					},
+					"defaults": [
+						{
+							"type": "dx",
+							"modifier": -6
+						},
+						{
+							"type": "skill",
+							"name": "Filch",
+							"modifier": -5
+						},
+						{
+							"type": "skill",
+							"name": "Sleight of Hand",
+							"modifier": -4
+						}
+					],
+					"calc": {
+						"level": 14,
+						"rsl": "DX-2"
+					}
+				},
+				{
+					"id": "9f66d47f-7604-4f08-82c1-cf53a8fe353c",
+					"type": "skill",
+					"name": "Search",
+					"reference": "B219",
+					"tags": [
+						"Police",
+						"Spy"
+					],
+					"difficulty": "per/a",
+					"points": 1,
+					"defaulted_from": {
+						"type": "per",
+						"modifier": -5,
+						"level": 7,
+						"adjusted_level": 7,
+						"points": -7
+					},
+					"defaults": [
+						{
+							"type": "per",
+							"modifier": -5
+						},
+						{
+							"type": "skill",
+							"name": "Criminology",
+							"modifier": -5
+						}
+					],
+					"calc": {
+						"level": 11,
+						"rsl": "Per-1"
+					}
+				},
+				{
+					"id": "bd6bfef5-b07d-4809-a8e0-e8effbdf7fa7",
+					"type": "skill",
+					"name": "Shadowing",
+					"reference": "B219",
+					"tags": [
+						"Criminal",
+						"Police",
+						"Spy",
+						"Street"
+					],
+					"difficulty": "iq/a",
+					"points": 2,
+					"defaulted_from": {
+						"type": "skill",
+						"name": "Stealth",
+						"modifier": -4,
+						"level": 11,
+						"adjusted_level": 11,
+						"points": -11
+					},
+					"defaults": [
+						{
+							"type": "iq",
+							"modifier": -5
+						},
+						{
+							"type": "skill",
+							"name": "Observation",
+							"modifier": -5
+						},
+						{
+							"type": "skill",
+							"name": "Stealth",
+							"modifier": -4
+						}
+					],
+					"calc": {
+						"level": 13,
+						"rsl": "IQ+0"
+					}
+				},
+				{
+					"id": "c180ed8a-fb79-4d68-a0e0-4981e6bb3130",
+					"type": "skill",
+					"name": "Smallsword",
+					"reference": "B208",
+					"tags": [
+						"Combat",
+						"Melee Combat",
+						"Weapon"
+					],
+					"difficulty": "dx/a",
+					"points": 4,
+					"defaulted_from": {
+						"type": "dx",
+						"modifier": -5,
+						"level": 11,
+						"adjusted_level": 11,
+						"points": -11
+					},
+					"defaults": [
+						{
+							"type": "dx",
+							"modifier": -5
+						},
+						{
+							"type": "skill",
+							"name": "Shortsword",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Main-Gauche",
+							"modifier": -3
+						},
+						{
+							"type": "skill",
+							"name": "Rapier",
+							"modifier": -3
+						},
+						{
+							"type": "skill",
+							"name": "Saber",
+							"modifier": -3
+						}
+					],
+					"calc": {
+						"level": 17,
+						"rsl": "DX+1"
+					}
+				},
+				{
+					"id": "25e30549-f14d-42b3-906c-648298121bae",
+					"type": "skill",
+					"name": "Stealth",
+					"reference": "B222",
+					"tags": [
+						"Criminal",
+						"Police",
+						"Spy",
+						"Street"
+					],
+					"difficulty": "dx/a",
+					"points": 1,
+					"encumbrance_penalty_multiplier": 1,
+					"defaulted_from": {
+						"type": "dx",
+						"modifier": -5,
+						"level": 11,
+						"adjusted_level": 11,
+						"points": -11
+					},
+					"defaults": [
+						{
+							"type": "iq",
+							"modifier": -5
+						},
+						{
+							"type": "dx",
+							"modifier": -5
+						}
+					],
+					"calc": {
+						"level": 15,
+						"rsl": "DX-1"
+					}
+				},
+				{
+					"id": "9e183416-ed32-4e45-976e-b5080468a26b",
+					"type": "skill",
+					"name": "Streetwise",
+					"reference": "B223",
+					"tags": [
+						"Criminal",
+						"Police",
+						"Social",
+						"Street"
+					],
+					"difficulty": "iq/a",
+					"points": 2,
+					"defaulted_from": {
+						"type": "iq",
+						"modifier": -5,
+						"level": 8,
+						"adjusted_level": 8,
+						"points": -8
+					},
+					"defaults": [
+						{
+							"type": "iq",
+							"modifier": -5
+						}
+					],
+					"calc": {
+						"level": 13,
+						"rsl": "IQ+0"
+					}
+				},
+				{
+					"id": "2e8c1a03-1d1d-4153-bb60-f0dc885709eb",
+					"type": "skill",
+					"name": "Throwing Art",
+					"reference": "B226,MA60",
+					"tags": [
+						"Esoteric"
+					],
+					"difficulty": "dx/h",
+					"points": 2,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": true,
+								"name": {
+									"compare": "starts_with",
+									"qualifier": "weapon master"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "trained by a master"
+								}
+							}
+						]
+					},
+					"calc": {
+						"level": 15,
+						"rsl": "DX-1"
+					}
+				},
+				{
+					"id": "6c9207be-88a0-4a70-bb8a-ba708dd62fe0",
+					"type": "skill",
+					"name": "Tonfa",
+					"reference": "B209,MA61",
+					"tags": [
+						"Combat",
+						"Melee Combat",
+						"Weapon"
+					],
+					"difficulty": "dx/a",
+					"points": 1,
+					"defaulted_from": {
+						"type": "dx",
+						"modifier": -5,
+						"level": 11,
+						"adjusted_level": 11,
+						"points": -11
+					},
+					"defaults": [
+						{
+							"type": "dx",
+							"modifier": -5
+						},
+						{
+							"type": "skill",
+							"name": "Shortsword",
+							"modifier": -3
+						}
+					],
+					"calc": {
+						"level": 15,
+						"rsl": "DX-1"
+					}
+				},
+				{
+					"id": "8fff7160-cae2-4a13-9957-6526c7e11d68",
+					"type": "skill",
+					"name": "Traps",
+					"reference": "B226",
+					"tags": [
+						"Criminal",
+						"Military",
+						"Street"
+					],
+					"tech_level": "8",
+					"difficulty": "iq/a",
+					"points": 1,
+					"defaulted_from": {
+						"type": "skill",
+						"name": "Lockpicking",
+						"modifier": -3,
+						"level": 12,
+						"adjusted_level": 12,
+						"points": 1
+					},
+					"defaults": [
+						{
+							"type": "iq",
+							"modifier": -5
+						},
+						{
+							"type": "skill",
+							"name": "Lockpicking",
+							"modifier": -3
+						}
+					],
+					"calc": {
+						"level": 13,
+						"rsl": "IQ+0"
+					}
+				},
+				{
+					"id": "6e9e641f-676e-4487-9c02-ff73207e86d1",
+					"type": "skill",
+					"name": "Urban Survival",
+					"reference": "B228",
+					"tags": [
+						"Criminal",
+						"Police",
+						"Street"
+					],
+					"difficulty": "per/a",
+					"points": 1,
+					"defaulted_from": {
+						"type": "per",
+						"modifier": -5,
+						"level": 7,
+						"adjusted_level": 7,
+						"points": -7
+					},
+					"defaults": [
+						{
+							"type": "per",
+							"modifier": -5
+						}
+					],
+					"calc": {
+						"level": 11,
+						"rsl": "Per-1"
+					}
+				}
+			],
+			"name": "Skills"
+		},
+		{
+			"id": "af631221-9a18-4fc9-9cd0-2123c8ede93d",
+			"type": "skill_container",
+			"open": true,
+			"children": [
+				{
+					"id": "387be0e3-b994-472e-bc3e-f2d2b3e49d61",
+					"type": "technique",
+					"name": "Arm Lock",
+					"reference": "B230,MA65",
+					"tags": [
+						"Combat",
+						"Melee Combat",
+						"Technique",
+						"Weapon"
+					],
+					"difficulty": "a",
+					"points": 1,
+					"default": {
+						"type": "skill",
+						"name": "Judo"
+					},
+					"limit": 4,
+					"calc": {
+						"level": 17,
+						"rsl": "+1"
+					}
+				},
+				{
+					"id": "b02068fa-964a-4b68-bbfc-874327a1f402",
+					"type": "technique",
+					"name": "Back Kick",
+					"reference": "B230,MA67",
+					"tags": [
+						"Combat",
+						"Melee Combat",
+						"Technique",
+						"Weapon"
+					],
+					"difficulty": "h",
+					"points": 2,
+					"default": {
+						"type": "skill",
+						"name": "Karate",
+						"modifier": -4
+					},
+					"limit": 0,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "skill_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Karate"
+								}
+							}
+						]
+					},
+					"calc": {
+						"level": 13,
+						"rsl": "-3"
+					}
+				},
+				{
+					"id": "069e8598-75b3-44c3-bb20-d9df3007d8ca",
+					"type": "technique",
+					"name": "Choke Hold",
+					"reference": "B230,MA69",
+					"tags": [
+						"Combat",
+						"Melee Combat",
+						"Technique",
+						"Weapon"
+					],
+					"difficulty": "h",
+					"points": 2,
+					"default": {
+						"type": "skill",
+						"name": "Judo",
+						"modifier": -2
+					},
+					"limit": 0,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "skill_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Judo"
+								}
+							}
+						]
+					},
+					"calc": {
+						"level": 15,
+						"rsl": "-1"
+					}
+				},
+				{
+					"id": "d221d5e6-b7a2-48f8-a673-ec740a2b802a",
+					"type": "technique",
+					"name": "Disarming",
+					"reference": "B230,MA70",
+					"tags": [
+						"Combat",
+						"Melee Combat",
+						"Technique",
+						"Weapon"
+					],
+					"difficulty": "h",
+					"points": 2,
+					"default": {
+						"type": "skill",
+						"name": "Smallsword"
+					},
+					"limit": 5,
+					"calc": {
+						"level": 18,
+						"rsl": "+1"
+					}
+				},
+				{
+					"id": "93a89071-f560-494f-8a97-a2a58f0b5ce5",
+					"type": "technique",
+					"name": "Dual-Weapon Attack",
+					"reference": "B230,MA83",
+					"tags": [
+						"Cinematic Techniques",
+						"Combat",
+						"Melee Combat",
+						"Weapon"
+					],
+					"difficulty": "h",
+					"points": 3,
+					"default": {
+						"type": "skill",
+						"name": "Smallsword",
+						"modifier": -4
+					},
+					"limit": 0,
+					"calc": {
+						"level": 15,
+						"rsl": "-2"
+					}
+				},
+				{
+					"id": "12da4636-bf9b-4ef9-836d-ffe4ee56394a",
+					"type": "technique",
+					"name": "Elbow Strike",
+					"reference": "B230,MA71",
+					"tags": [
+						"Combat",
+						"Melee Combat",
+						"Technique",
+						"Weapon"
+					],
+					"difficulty": "a",
+					"points": 1,
+					"default": {
+						"type": "skill",
+						"name": "Karate",
+						"modifier": -2
+					},
+					"limit": 0,
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "skill_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Karate"
+								}
+							}
+						]
+					},
+					"calc": {
+						"level": 15,
+						"rsl": "-1"
+					}
+				},
+				{
+					"id": "bfbebb66-eea7-45b8-801e-e946a5814e77",
+					"type": "technique",
+					"name": "Jump Kick",
+					"reference": "B231,MA75",
+					"tags": [
+						"Combat",
+						"Melee Combat",
+						"Technique",
+						"Weapon"
+					],
+					"difficulty": "h",
+					"points": 3,
+					"default": {
+						"type": "skill",
+						"name": "Karate",
+						"modifier": -4
+					},
+					"limit": 0,
+					"calc": {
+						"level": 14,
+						"rsl": "-2"
+					}
+				},
+				{
+					"id": "4c1c10a4-0cd6-432b-bae2-9977b286c514",
+					"type": "technique",
+					"name": "Knee Strike",
+					"reference": "B232,MA76",
+					"tags": [
+						"Combat",
+						"Melee Combat",
+						"Technique",
+						"Weapon"
+					],
+					"difficulty": "a",
+					"points": 1,
+					"default": {
+						"type": "skill",
+						"name": "Karate",
+						"modifier": -1
+					},
+					"limit": 0,
+					"calc": {
+						"level": 16,
+						"rsl": "+0"
+					}
+				},
+				{
+					"id": "aca60fac-2f1e-4dff-a0a9-576c3130a456",
+					"type": "technique",
+					"name": "Off-Hand Weapon Training",
+					"reference": "B232",
+					"tags": [
+						"Combat",
+						"Melee Combat",
+						"Technique",
+						"Weapon"
+					],
+					"difficulty": "h",
+					"points": 4,
+					"default": {
+						"type": "skill",
+						"name": "Smallsword",
+						"modifier": -4
+					},
+					"limit": 0,
+					"calc": {
+						"level": 16,
+						"rsl": "-1"
+					}
+				},
+				{
+					"id": "59ba02ea-639f-4fb8-ac7c-c57bc5cef7fc",
+					"type": "technique",
+					"name": "Rope Up",
+					"reference": "B233",
+					"tags": [
+						"Athletic",
+						"Criminal",
+						"Exploration",
+						"Outdoor",
+						"Street",
+						"Technique"
+					],
+					"difficulty": "a",
+					"points": 2,
+					"default": {
+						"type": "skill",
+						"name": "Climbing",
+						"modifier": -2
+					},
+					"limit": 0,
+					"calc": {
+						"level": 17,
+						"rsl": "+0"
+					}
+				},
+				{
+					"id": "efc75f32-cd0a-4601-90af-6e262cdff2bd",
+					"type": "technique",
+					"name": "Scaling",
+					"reference": "B233",
+					"tags": [
+						"Athletic",
+						"Criminal",
+						"Exploration",
+						"Outdoor",
+						"Street",
+						"Technique"
+					],
+					"difficulty": "h",
+					"points": 2,
+					"default": {
+						"type": "skill",
+						"name": "Climbing",
+						"modifier": -3
+					},
+					"limit": 0,
+					"calc": {
+						"level": 15,
+						"rsl": "-2"
+					}
+				},
+				{
+					"id": "0a860890-6114-4ff0-aa05-c60312c134bc",
+					"type": "technique",
+					"name": "Sweeping Kick",
+					"reference": "B232,MA81",
+					"tags": [
+						"Combat",
+						"Melee Combat",
+						"Technique",
+						"Weapon"
+					],
+					"difficulty": "h",
+					"points": 3,
+					"default": {
+						"type": "skill",
+						"name": "Judo",
+						"modifier": -3
+					},
+					"limit": 0,
+					"calc": {
+						"level": 15,
+						"rsl": "-1"
+					}
+				}
+			],
+			"name": "Techniques"
+		}
+	],
+	"notes": [
+		{
+			"id": "852d90d6-7233-46b4-9f8a-c8fa3a55e973",
+			"type": "note",
+			"text": "The 1 point in traps, with default from lockpicking, raises the skill to IQ+0.  The book seems to miss the default, and shows the skill at IQ-1."
+		}
+	],
+	"created_date": "2023-01-15T21:53:59Z",
+	"modified_date": "2023-01-15T22:18:30Z",
+	"calc": {
+		"swing": "1d+2",
+		"thrust": "1d-1",
+		"basic_lift": "29 lb",
+		"dodge_bonus": 1,
+		"parry_bonus": 1,
+		"block_bonus": 1,
+		"move": [
+			8,
+			6,
+			4,
+			3,
+			1
+		],
+		"dodge": [
+			11,
+			10,
+			9,
+			8,
+			7
+		]
+	}
+}

--- a/Library/Basic Set/Characters/William Headley.gcs
+++ b/Library/Basic Set/Characters/William Headley.gcs
@@ -1,0 +1,3198 @@
+{
+	"type": "character",
+	"version": 4,
+	"id": "c2d3f690-b171-400f-998e-eacab75f30a1",
+	"total_points": 200,
+	"points_record": [
+		{
+			"when": "2023-01-14T22:39:22Z",
+			"points": 200,
+			"reason": "Initial points"
+		}
+	],
+	"profile": {
+		"player_name": "NPC",
+		"name": "William Headley",
+		"title": "Professor",
+		"religion": "?",
+		"age": "43",
+		"birthday": "?",
+		"eyes": "Brown",
+		"hair": "Light brown",
+		"skin": "Pale",
+		"handedness": "Right",
+		"gender": "Male",
+		"tech_level": "7",
+		"portrait": "UklGRnARAABXRUJQVlA4WAoAAAAwAAAAjwAAvwAASUNDUMgBAAAAAAHIAAAAAAQwAABtbnRyUkdCIFhZWiAAAAAAAAAAAAAAAABhY3NwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAA9tYAAQAAAADTLQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAlkZXNjAAAA8AAAACRyWFlaAAABFAAAABRnWFlaAAABKAAAABRiWFlaAAABPAAAABR3dHB0AAABUAAAABRyVFJDAAABZAAAAChnVFJDAAABZAAAAChiVFJDAAABZAAAAChjcHJ0AAABjAAAADxtbHVjAAAAAAAAAAEAAAAMZW5VUwAAAAgAAAAcAHMAUgBHAEJYWVogAAAAAAAAb6IAADj1AAADkFhZWiAAAAAAAABimQAAt4UAABjaWFlaIAAAAAAAACSgAAAPhAAAts9YWVogAAAAAAAA9tYAAQAAAADTLXBhcmEAAAAAAAQAAAACZmYAAPKnAAANWQAAE9AAAApbAAAAAAAAAABtbHVjAAAAAAAAAAEAAAAMZW5VUwAAACAAAAAcAEcAbwBvAGcAbABlACAASQBuAGMALgAgADIAMAAxADZBTFBIGQAAAAEPMP8REYJI20bK/DscG7yER/R/AmzmbQEAVlA4IGAPAADwQgCdASqQAMAAPm0wlEckIqIhJzasYIANiWcA1K3oO4J9n71/0/hD5NvhmgrkztH/l/4W/l+evfr8wdQvxh4pe5ctb6CPfzv6/8b0p+yf/R9wL9U/TX/keIF5d7Af9D/w37Dey7oJetPYM/nH9/61n7pezweoq3gAh3WQbfdVjhHwK4D0yt01YLLFmZ/R59lhtqj9fUFAtF9PBd63CI1jO+cmzpc/kkal27y4INHZ/RyH8NSR7dbyzhWdC4wcyuo5yXyjYfgFlVXSeXU1eU3/xQ1rA2BQneu7HVRAVbjT5QW4lTnejQAUzz4rHAI8/Gpyoek5m0mAzETyPQIpmDfhB0p85QnFLKNcsBrfgk4mjwaCKpBY1/CLVVaL/2qiKCQyuvc5la2MmQ+xEEKZJEvjg8kFOuZtATrXTUvNUXSv7Qc9X3lYjsp7+jL3cQ0+nMYTcTbpHScdZy+WbnoubP/ao+zDM9voWUxWvYmyXn0SfG9Zcg0c3KBrwIQmAVVbBCw0q9l0NoPSE21nTkb+9IPQtutgQ3fliGkcT7fbqnEKZMALpDYcO6ZuizWurM0DssiZ2GLMZ2jeaiiOzefjbSjvdVAce+SX30vj3qeGbsyXYxm5uLV1PdESl2ryl7trLWveOL+ltyUf0E0DDZYbVM6QYM5KmdT3JZSsutVREOrBkaMXEN0rzRnuu/GejTJs5SW2e+I7HLYuc4+pd6I3WDcAAP78qAJEezcOe362AFT9or8R+luE3LgYgk+5Y8mtd2XLNMzq900fpGBJROCk999HMfHD9UbaulHLWR/MdrNZivqOljF9e3ML9Ap/KJG97m+wrXvvmyXl0ZQmitX4h7NZwd3YVuI9Y+QGb9W+JD8MKMnum6l2yoPywoArsX2XHdFXycmIZLRGDH47I6644MO154tSdXADwhBIUeLZqHd1/G3b6aCRf4UIgdFl6FdzJPCCIei4Bvu6Sw8VFlUqmRrI6kg3wrfxigiPjjCjLsl+HuC0eLKRaoRY+CS7mJChp9t3QSywOfqtgPiqc5SLFFYgv2kfajaiGAll8/V2RXz/SM4YyMdB4D7Nppu/rfZMS5Cbn1RwUaZCr1xKrXcvM3u8datMecn2wPtkTP+Z2D98FGLXVC6RQjiz5gUPrYdyJpi06gtoG/S41VXcK9I6DRvQ2STzpne2nhnVki1YOqPP9tnhdKNWAw9hb92yc0BWEJSxcfYFhKkdcWJMjYO+DadpRLB1xfBg1c8eyMSYTC7qx5TURc1p5pzAGq/iyg8m525Nuk4rtoQP4BqEJ+8mRmcQjwYFGHbhm7bydp8eOQ487nneMmoQnCDF4RS2ECo4XDA4r32wUiWwnKY8t44p/sCBuuFisG/ejXOW3aBKm/TyDknxaHo9JP68ZSD+g4QwGACPxbyjeJj8jsH0bhs1HNB7AzM/VY6D6eC1sMqQmAazw7d1V8+Om6Y+HxEVPRNlRzC1pP8BvivFAECjrZSzqNjghEZCg2eX3izFc1oOivy12CmQdXKD8K/J8NF9LRkXJRdcnAD+3ZDTo+SaZyqI/TNI3HfZlnbSeKh/kS7aw38s+cPn+dSp5RwsIdRUYRJnlwifAv5keQ0ZLho1fhjrNPFreTqth6LU13uqOT0YsTLTSIMw2Qw0Ea2Q3WpVd/Y2mWhjgtZ0b/LetjtQ6Y1budDq8s6dGz5HXJiYy89Zc6QTaBKmSot2zLyY+MtbkuOlha9SPWlu3bOR+mZiyNVpmA9EbIE6AiPhBegcxfODBTpQ/A/KLcHOz55AVjfnJzmjONXXXdhy2fFU6yv6kvKrc0PVnmmRRIADzR1Y5Tl1Qsom2smqJSoOc1IZXupJ5WEZ4iTKvHT/0C+wUehmXms4Z7+RNUJrgKlTlyfCVn68N+AWG+ypvBLbFJjYECwTtEcSFrkiv0SVyX7vWln2u465ji86P3PG2rD5wk4T6/c/CxZaohQELFMHt/8TeunGDUeBjCdrgD0oGza4NUJFgmfE0RdIe63sA8bOMBa6Aea6D8HtDQObKIfuCU66FxrvyfxqL1/4QaL7/FbnKlT9aYPIqT/RVEa+cw3e3vjroX1lNIqGIB9t/CwAEzTBu2oaJseS2HLIYr/4MM+0/ccfuH8Lq47ex0J21dh9l48zDuHbEOW1HMsdt7ape38uG6Oi1SdW2LwHCObRolvs2XRULkht+q4dmLp/CRZAfbULzt6twRpw/PaNJslRo9KRjBOu9Mw/ctv1mnBO1Mt74LEvJ6ZI+n022seYGOn7Wi1AtxGpDKrbR97x2SqCmcsyz3PejZTloBq4nlJoKnvWfTf/8Cau+xbJJC9frbrkN8Gx/UdqPI6B7oFeDkVQvaBj+wUQkcy9I5lphnIRnVevqbzSw61tbyN/7a9BpdE3nkH7HutGk8kYAaylGoJB31ZAblRyUr+uIWzyKa3NoObhdxaJEGTfQ33zmE+qBZqPo6J8Im13byvh8O0JFeYgjunKGSloBuwyENRjgJXl9aycf6IS6ta0yqSc3LqXOHyqEE/zU2u5zRipeOkFbVzcjvmjEzg55jOc9Ri7uJTRa3FDoLy+ad7VgsHi0vt3/D24LdTfdzR7q/eD4cBbRWwAAWrxYsZ47fRskcTZo0e/12Q1dH0ho/8wjX9mm82gnrJ8SPp3CRN5+VSFv0zTmTUPOClT6C+pt2eyKGJelkX63shk4AWLkQ4kq8OfTbapJtmszsGjtp5he5VKTSNDDaFHvx6bX6QKrANh1jUqUeoEl47bg2Os+aBbRELkfldt6YrDfVLLXNy1wdxj4XRwe6nshRU5dCFeB1Ecc8EnP+x0FrTamIkEd46NE6UHCHdQeSejOwRynWxe/klC6Hf9J0npZWznUXshnvc0qlScDBuO1ng1nvUj7UBJ17toMkT8+mI0QYgesCQYoP47g1slG5MW67OWuAHoYe7KYoLbn4TX5NE7V9qKGXHFo37CvvdAvSK+VRGn4xahiqu+/pcXTdrg5R9X0pWUp0fe0lmSi6dFMGqQQ6/+kcG6Jn16MGJFqgjRyPUJLMvTQu6bz7LiN1ZFG1dTx7MncSAlixZ4EJm72W/3dzXJ7/tU5zg/zYQkh4BjIEf92RI8cpeJR6nbnqLVh/5rhN+aZPDcZmiPgDcp+ycQw189CMf4EdAK5m4gus/3PoO3EuryrOd6c80Um7IQAG5r/IFD2TjSfh/eIf9mPnKLcfjEltvSt0I2aIj7swtucjxP+JGANK61P7iI4iZ6Pfa75C0LYi/bx5Bj6tbfCC1Z53PS7PqzBX3whscRMAnvhGOKF8OLcWzlISbj7BqpxySZFkUOBDKtPN6RA2c9duWABHUlvafsUFPK7Drj70dSDp3LOKKZ0h8gbHip0GGQ48fpphiEvStzslWgPs31kEaBHF/W349p2RQ+bLk4ocHYdhJvcz/aonztcOWV1MUkCQqxSNodszMO6F9e2Q09jv6i0T/jwAn1q5ByX0JPRVauH+xzvl1DLCgxHFPsmdPGFwKDHbHDcB9vWyqY9LoNlnssRnowlXKp9pvhxcuE6a6jw9N7y3n2Kq61MpvjHSJXFEo+mUK3PQ/RGH5nwHWC0dJISFD1WpLueiuozEWDQ4sn7azWIWQ3FlIivi6VqhLg3NCJVqfkk/eNhhevzzXeKbq5gculGvv53f4k0WBUsecUX8eKR3VuoW7gC7SRES/ei76gKHlPkcl93NO2rB0gGB35ov1SFtGiYDz9EBhsTriyIsbO1QnafXU7UlinjaMYeEIJ9E2YtllmZQZdQoqVLEwVeqY3neXNahfJnxW0tMvp8CuZiUCKF8Ft7WTYHoAjwMvBDFugEW9HKyVs6kJs01wXrj1rcvrtt7ob+TF5uy2fcaiaxYA+K2YrRU2lMAt2H9S/UzvMuVs4AwUw6fW19Uv2WanKS+xMuXb7/7hhxERaKjpAisr0fI/an4N5NwKVLnRX59cVB9Lhsv8Zz2aM5XJXNnr1K3tMWRC5Lw5WmQXmr51ecZFzbTsEPpk71GN+ix7q4yZJYEeUncg0Bd6xnILG8kgdIailytF/C6CaCMwY4Md9UUmcnpw12txVQRGdGm2VWgL7jBqJoOarhaSLmJuI2lL2PXUezwFzNf3MbLvihaOsY9qy/FNMuwmAi8fww3oTFgxB6QajBSiaZJwcn0SpWp3C+kfKj9sDkKoX4HyFonL9c6vHF3C85XZMEf62yoxzTii62xoiN/rImXV326R5fdNSA98sD9pSJjFE5mn4G01rU3qeCKqXZwK4EaN2qnrtrRnsHMZBVibp4cIp0cUfP4fcCkJ52US1kMWtwLzV20CYcD0UNI4fHdfWFHlTqa7EzL8aAP25OvW6q2nTcRFgc25Un2rvd1kHBJrvh7nuwayTS62boZ/GNZhJpXhBdIdq1ixAjwcqKfwHt2O5xltl1hC9AmOVp3k5VPCvQxNIJc3GjPFqPJeHlhHdsLGshkBQraWh3TSwmtt3T1peCLeuYYMh/Ve0ccVj60ijVTaTQeCdcShO+iGfSjtFCfLr1U5tuTY3xsQiVsG4IlafS2ViuAAHABt3QZq5CbNGKukeHD0mU33uFh05IxNfjmtuxQcEJkzKll12e+E2l3LW1ha6aOF32QdFvqG8kZ0HCyMe+It/hgcatV0SlNfGaQDXtUDS7Ysuz7UG9ARGP2pwMsDCvwK4Y1PRr00JTQ4oVxYnAiP+QVAdb+D6bSbrv1qkiLNVqpena5N6lSKRVqe+DSwJk0+W2J2vYuT8QHL1e4e8eiSgQJZanbrb5JP2ICMxhMf9iSvHqUi/76xtRYaIxeiGm/tQQ9FSs5AXwYr1TFIAi7Hy10qG6DwVy+gdPwUwjkx9CWFRt1tW3x3WUfDObrrlm1J+s9I0FNrzmLnsb8CV+OGnr5X4pEo/eBgdB/7C6UOTeeH4p4/SuUxWjOrS0QZHdMjelBVUGzLunriuh87dYcC1a1/fWBaQ8xxVodPd6LWypNtMR9MbUvY5Bj58zLEb2jCMeZ0rWc74hTnacJwSdYWslSIk0NAG0EffbcsiNLFOa7eLVlvY3Nh2LLBekXGqK8EMHfXuNE0UEl6ayMfVQ/ohd87QnnKw4j4zY/NZ9IYHpzgyJlqb5NEhhiC+jqcApx6nvgJLewBB/+TrWr2naV7OKvsagIB83UlVsbZcf+FnjDNBAs5Jucp64oeDlqBIBUS1SHiCBRb3ONmZlHhglXZrAuYvwQQj/eMWNJOmWVZr+IH8okWAAAA=",
+		"height": "5'8\"",
+		"weight": "165 lb"
+	},
+	"settings": {
+		"page": {
+			"paper_size": "letter",
+			"orientation": "portrait",
+			"top_margin": "0.25 in",
+			"left_margin": "0.25 in",
+			"bottom_margin": "0.25 in",
+			"right_margin": "0.25 in"
+		},
+		"block_layout": [
+			"reactions conditional_modifiers",
+			"melee",
+			"ranged",
+			"traits skills",
+			"spells",
+			"equipment",
+			"other_equipment",
+			"notes"
+		],
+		"attributes": [
+			{
+				"id": "st",
+				"type": "integer",
+				"name": "ST",
+				"full_name": "Strength",
+				"attribute_base": "10",
+				"cost_per_point": 10,
+				"cost_adj_percent_per_sm": 10
+			},
+			{
+				"id": "dx",
+				"type": "integer",
+				"name": "DX",
+				"full_name": "Dexterity",
+				"attribute_base": "10",
+				"cost_per_point": 20
+			},
+			{
+				"id": "iq",
+				"type": "integer",
+				"name": "IQ",
+				"full_name": "Intelligence",
+				"attribute_base": "10",
+				"cost_per_point": 20
+			},
+			{
+				"id": "ht",
+				"type": "integer",
+				"name": "HT",
+				"full_name": "Health",
+				"attribute_base": "10",
+				"cost_per_point": 10
+			},
+			{
+				"id": "will",
+				"type": "integer",
+				"name": "Will",
+				"attribute_base": "$iq",
+				"cost_per_point": 5
+			},
+			{
+				"id": "fright_check",
+				"type": "integer",
+				"name": "Fright Check",
+				"attribute_base": "$will",
+				"cost_per_point": 2
+			},
+			{
+				"id": "senses",
+				"type": "secondary_separator",
+				"name": "Senses"
+			},
+			{
+				"id": "per",
+				"type": "integer",
+				"name": "Per",
+				"full_name": "Perception",
+				"attribute_base": "$iq",
+				"cost_per_point": 5
+			},
+			{
+				"id": "vision",
+				"type": "integer",
+				"name": "Vision",
+				"attribute_base": "$per",
+				"cost_per_point": 2
+			},
+			{
+				"id": "hearing",
+				"type": "integer",
+				"name": "Hearing",
+				"attribute_base": "$per",
+				"cost_per_point": 2
+			},
+			{
+				"id": "taste_smell",
+				"type": "integer",
+				"name": "Taste \u0026 Smell",
+				"attribute_base": "$per",
+				"cost_per_point": 2
+			},
+			{
+				"id": "touch",
+				"type": "integer",
+				"name": "Touch",
+				"attribute_base": "$per",
+				"cost_per_point": 2
+			},
+			{
+				"id": "movement",
+				"type": "secondary_separator",
+				"name": "Movement"
+			},
+			{
+				"id": "basic_speed",
+				"type": "decimal",
+				"name": "Basic Speed",
+				"attribute_base": "($dx+$ht)/4",
+				"cost_per_point": 20
+			},
+			{
+				"id": "basic_move",
+				"type": "integer",
+				"name": "Basic Move",
+				"attribute_base": "floor($basic_speed)",
+				"cost_per_point": 5
+			},
+			{
+				"id": "highjump",
+				"type": "integer_ref",
+				"name": "High Jump (in)",
+				"attribute_base": "(6 * max(max($basic_move, floor(skill_level(jumping) / 2)), $st / 4) - 10) * enc(false, true) * (2 ^ max(0, trait_level(super jump)))"
+			},
+			{
+				"id": "running_highjump",
+				"type": "integer_ref",
+				"name": "when running",
+				"attribute_base": "(6 * max(max($basic_move, floor(skill_level(jumping) / 2)), $st / 4) * (1 + max(0, trait_level(\"enhanced move (ground)\"))) - 10) * enc(false, true) * if(trait_level(\"enhanced move (ground)\")\u003c1,2,1) * (2 ^ max(0, trait_level(super jump)))"
+			},
+			{
+				"id": "broadjump",
+				"type": "integer_ref",
+				"name": "Broad Jump (ft)",
+				"attribute_base": "(2 * max(max($basic_move, floor(skill_level(jumping) / 2)), $st / 4) - 3) * enc(false, true) * (2 ^ max(0, trait_level(super jump)))"
+			},
+			{
+				"id": "running_broadjump",
+				"type": "integer_ref",
+				"name": "when running",
+				"attribute_base": "(2 * max(max($basic_move, floor(skill_level(jumping) / 2)), $st / 4) * (1 + max(0, trait_level(\"enhanced move (ground)\"))) - 3) * enc(false, true) * if(trait_level(\"enhanced move (ground)\")\u003c1,2,1) * (2 ^ max(0, trait_level(super jump)))"
+			},
+			{
+				"id": "fp",
+				"type": "pool",
+				"name": "FP",
+				"full_name": "Fatigue Points",
+				"attribute_base": "$ht",
+				"cost_per_point": 3,
+				"thresholds": [
+					{
+						"state": "Unconscious",
+						"expression": "-$fp",
+						"ops": [
+							"halve_move",
+							"halve_dodge",
+							"halve_st"
+						]
+					},
+					{
+						"state": "Collapse",
+						"expression": "0",
+						"explanation": "Roll vs. Will to do anything besides talk or rest; failure causes unconsciousness\nEach FP you lose below 0 also causes 1 HP of injury\nMove, Dodge and ST are halved (B426)",
+						"ops": [
+							"halve_move",
+							"halve_dodge",
+							"halve_st"
+						]
+					},
+					{
+						"state": "Tired",
+						"expression": "round($fp/3)",
+						"explanation": "Move, Dodge and ST are halved (B426)",
+						"ops": [
+							"halve_move",
+							"halve_dodge",
+							"halve_st"
+						]
+					},
+					{
+						"state": "Tiring",
+						"expression": "$fp-1"
+					},
+					{
+						"state": "Rested",
+						"expression": "$fp"
+					}
+				]
+			},
+			{
+				"id": "hp",
+				"type": "pool",
+				"name": "HP",
+				"full_name": "Hit Points",
+				"attribute_base": "$st",
+				"cost_per_point": 2,
+				"cost_adj_percent_per_sm": 10,
+				"thresholds": [
+					{
+						"state": "Dead",
+						"expression": "round(-$hp*5)",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Dying #4",
+						"expression": "round(-$hp*4)",
+						"explanation": "Roll vs. HT to avoid death\nRoll vs. HT-4 every second to avoid falling unconscious\nMove and Dodge are halved (B419)",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Dying #3",
+						"expression": "round(-$hp*3)",
+						"explanation": "Roll vs. HT to avoid death\nRoll vs. HT-3 every second to avoid falling unconscious\nMove and Dodge are halved (B419)",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Dying #2",
+						"expression": "round(-$hp*2)",
+						"explanation": "Roll vs. HT to avoid death\nRoll vs. HT-2 every second to avoid falling unconscious\nMove and Dodge are halved (B419)",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Dying #1",
+						"expression": "-$hp",
+						"explanation": "Roll vs. HT to avoid death\nRoll vs. HT-1 every second to avoid falling unconscious\nMove and Dodge are halved (B419)",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Collapse",
+						"expression": "0",
+						"explanation": "Roll vs. HT every second to avoid falling unconscious\nMove and Dodge are halved (B419)",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Reeling",
+						"expression": "round($hp/3)",
+						"explanation": "Move and Dodge are halved (B419)",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Wounded",
+						"expression": "$hp-1"
+					},
+					{
+						"state": "Healthy",
+						"expression": "$hp"
+					}
+				]
+			}
+		],
+		"body_type": {
+			"name": "Humanoid",
+			"roll": "3d",
+			"locations": [
+				{
+					"id": "eye",
+					"choice_name": "Eyes",
+					"table_name": "Eyes",
+					"hit_penalty": -9,
+					"description": "An attack that misses by 1 hits the torso instead. Only\nimpaling (imp), piercing (pi-, pi, pi+, pi++), and\ntight-beam burning (burn) attacks can target the eye – and\nonly from the front or sides. Injury over HP÷10 blinds the\neye. Otherwise, treat as skull, but without the extra DR!",
+					"calc": {
+						"roll_range": "-",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "skull",
+					"choice_name": "Skull",
+					"table_name": "Skull",
+					"slots": 2,
+					"hit_penalty": -7,
+					"dr_bonus": 2,
+					"description": "An attack that misses by 1 hits the torso instead. Wounding\nmodifier is x4. Knockdown rolls are at -10. Critical hits\nuse the Critical Head Blow Table (B556). Exception: These\nspecial effects do not apply to toxic (tox) damage.",
+					"calc": {
+						"roll_range": "3-4",
+						"dr": {
+							"all": 2
+						}
+					}
+				},
+				{
+					"id": "face",
+					"choice_name": "Face",
+					"table_name": "Face",
+					"slots": 1,
+					"hit_penalty": -5,
+					"description": "An attack that misses by 1 hits the torso instead. Jaw,\ncheeks, nose, ears, etc. If the target has an open-faced\nhelmet, ignore its DR. Knockdown rolls are at -5. Critical\nhits use the Critical Head Blow Table (B556). Corrosion\n(cor) damage gets a x1½ wounding modifier, and if it\ninflicts a major wound, it also blinds one eye (both eyes on\ndamage over full HP). Random attacks from behind hit the\nskull instead.",
+					"calc": {
+						"roll_range": "5",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "leg",
+					"choice_name": "Leg",
+					"table_name": "Right Leg",
+					"slots": 2,
+					"hit_penalty": -2,
+					"description": "Reduce the wounding multiplier of large piercing (pi+), huge\npiercing (pi++), and impaling (imp) damage to x1. Any major\nwound (loss of over ½ HP from one blow) cripples the limb.\nDamage beyond that threshold is lost.",
+					"calc": {
+						"roll_range": "6-7",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "arm",
+					"choice_name": "Arm",
+					"table_name": "Right Arm",
+					"slots": 1,
+					"hit_penalty": -2,
+					"description": "Reduce the wounding multiplier of large piercing (pi+), huge\npiercing (pi++), and impaling (imp) damage to x1. Any major\nwound (loss of over ½ HP from one blow) cripples the limb.\nDamage beyond that threshold is lost. If holding a shield,\ndouble the penalty to hit: -4 for shield arm instead of -2.",
+					"calc": {
+						"roll_range": "8",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "torso",
+					"choice_name": "Torso",
+					"table_name": "Torso",
+					"slots": 2,
+					"calc": {
+						"roll_range": "9-10",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "groin",
+					"choice_name": "Groin",
+					"table_name": "Groin",
+					"slots": 1,
+					"hit_penalty": -3,
+					"description": "An attack that misses by 1 hits the torso instead. Human\nmales and the males of similar species suffer double shock\nfrom crushing (cr) damage, and get -5 to knockdown rolls.\nOtherwise, treat as a torso hit.",
+					"calc": {
+						"roll_range": "11",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "arm",
+					"choice_name": "Arm",
+					"table_name": "Left Arm",
+					"slots": 1,
+					"hit_penalty": -2,
+					"description": "Reduce the wounding multiplier of large piercing (pi+), huge\npiercing (pi++), and impaling (imp) damage to x1. Any major\nwound (loss of over ½ HP from one blow) cripples the limb.\nDamage beyond that threshold is lost. If holding a shield,\ndouble the penalty to hit: -4 for shield arm instead of -2.",
+					"calc": {
+						"roll_range": "12",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "leg",
+					"choice_name": "Leg",
+					"table_name": "Left Leg",
+					"slots": 2,
+					"hit_penalty": -2,
+					"description": "Reduce the wounding multiplier of large piercing (pi+), huge\npiercing (pi++), and impaling (imp) damage to x1. Any major\nwound (loss of over ½ HP from one blow) cripples the limb.\nDamage beyond that threshold is lost.",
+					"calc": {
+						"roll_range": "13-14",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "hand",
+					"choice_name": "Hand",
+					"table_name": "Hand",
+					"slots": 1,
+					"hit_penalty": -4,
+					"description": "If holding a shield, double the penalty to hit: -8 for\nshield hand instead of -4. Reduce the wounding multiplier of\nlarge piercing (pi+), huge piercing (pi++), and impaling\n(imp) damage to x1. Any major wound (loss of over ⅓ HP\nfrom one blow) cripples the extremity. Damage beyond that\nthreshold is lost.",
+					"calc": {
+						"roll_range": "15",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "foot",
+					"choice_name": "Foot",
+					"table_name": "Foot",
+					"slots": 1,
+					"hit_penalty": -4,
+					"description": "Reduce the wounding multiplier of large piercing (pi+), huge\npiercing (pi++), and impaling (imp) damage to x1. Any major\nwound (loss of over ⅓ HP from one blow) cripples the\nextremity. Damage beyond that threshold is lost.",
+					"calc": {
+						"roll_range": "16",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "neck",
+					"choice_name": "Neck",
+					"table_name": "Neck",
+					"slots": 2,
+					"hit_penalty": -5,
+					"description": "An attack that misses by 1 hits the torso instead. Neck and\nthroat. Increase the wounding multiplier of crushing (cr)\nand corrosion (cor) attacks to x1½, and that of cutting\n(cut) damage to x2. At the GM’s option, anyone killed by a\ncutting (cut) blow to the neck is decapitated!",
+					"calc": {
+						"roll_range": "17-18",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "vitals",
+					"choice_name": "Vitals",
+					"table_name": "Vitals",
+					"hit_penalty": -3,
+					"description": "An attack that misses by 1 hits the torso instead. Heart,\nlungs, kidneys, etc. Increase the wounding modifier for an\nimpaling (imp) or any piercing (pi-, pi, pi+, pi++) attack\nto x3. Increase the wounding modifier for a tight-beam\nburning (burn) attack to x2. Other attacks cannot target the\nvitals.",
+					"calc": {
+						"roll_range": "-",
+						"dr": {
+							"all": 0
+						}
+					}
+				}
+			]
+		},
+		"damage_progression": "basic_set",
+		"default_length_units": "ft_in",
+		"default_weight_units": "lb",
+		"user_description_display": "tooltip",
+		"modifiers_display": "inline",
+		"notes_display": "inline",
+		"skill_level_adj_display": "tooltip",
+		"show_spell_adj": true,
+		"exclude_unspent_points_from_total": false
+	},
+	"attributes": [
+		{
+			"attr_id": "st",
+			"adj": -1,
+			"calc": {
+				"value": 9,
+				"points": -10
+			}
+		},
+		{
+			"attr_id": "dx",
+			"adj": 0,
+			"calc": {
+				"value": 10,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "iq",
+			"adj": 6,
+			"calc": {
+				"value": 16,
+				"points": 120
+			}
+		},
+		{
+			"attr_id": "ht",
+			"adj": 1,
+			"calc": {
+				"value": 11,
+				"points": 10
+			}
+		},
+		{
+			"attr_id": "will",
+			"adj": 1,
+			"calc": {
+				"value": 17,
+				"points": 5
+			}
+		},
+		{
+			"attr_id": "fright_check",
+			"adj": 0,
+			"calc": {
+				"value": 17,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "senses",
+			"adj": 0
+		},
+		{
+			"attr_id": "per",
+			"adj": -1,
+			"calc": {
+				"value": 15,
+				"points": -5
+			}
+		},
+		{
+			"attr_id": "vision",
+			"adj": 0,
+			"calc": {
+				"value": 15,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "hearing",
+			"adj": 0,
+			"calc": {
+				"value": 15,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "taste_smell",
+			"adj": 0,
+			"calc": {
+				"value": 15,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "touch",
+			"adj": 0,
+			"calc": {
+				"value": 15,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "movement",
+			"adj": 0
+		},
+		{
+			"attr_id": "basic_speed",
+			"adj": -0.25,
+			"calc": {
+				"value": 5,
+				"points": -5
+			}
+		},
+		{
+			"attr_id": "basic_move",
+			"adj": 0,
+			"calc": {
+				"value": 5,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "highjump",
+			"adj": 0,
+			"calc": {
+				"value": 20,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "running_highjump",
+			"adj": 0,
+			"calc": {
+				"value": 40,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "broadjump",
+			"adj": 0,
+			"calc": {
+				"value": 7,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "running_broadjump",
+			"adj": 0,
+			"calc": {
+				"value": 14,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "fp",
+			"adj": 3,
+			"calc": {
+				"value": 14,
+				"current": 14,
+				"points": 9
+			}
+		},
+		{
+			"attr_id": "hp",
+			"adj": 0,
+			"calc": {
+				"value": 9,
+				"current": 9,
+				"points": 0
+			}
+		}
+	],
+	"traits": [
+		{
+			"id": "7b54261b-6e96-45f3-ab8e-9288c1f7d8c7",
+			"type": "trait",
+			"name": "Natural Attacks",
+			"reference": "B271",
+			"weapons": [
+				{
+					"id": "8c5d469e-1b1d-4ad5-a8b7-6a3eff19df46",
+					"type": "melee_weapon",
+					"damage": {
+						"type": "cr",
+						"st": "thr",
+						"base": "-1"
+					},
+					"usage": "Bite",
+					"reach": "C",
+					"parry": "No",
+					"block": "No",
+					"defaults": [
+						{
+							"type": "dx"
+						},
+						{
+							"type": "skill",
+							"name": "Brawling"
+						}
+					],
+					"calc": {
+						"level": 10,
+						"parry": "No",
+						"block": "No",
+						"damage": "1d-3 cr"
+					}
+				},
+				{
+					"id": "582a8cbb-0051-4f35-b634-ce1039c0adad",
+					"type": "melee_weapon",
+					"damage": {
+						"type": "cr",
+						"st": "thr",
+						"base": "-1"
+					},
+					"usage": "Punch",
+					"reach": "C",
+					"parry": "0",
+					"defaults": [
+						{
+							"type": "dx"
+						},
+						{
+							"type": "skill",
+							"name": "Boxing"
+						},
+						{
+							"type": "skill",
+							"name": "Brawling"
+						},
+						{
+							"type": "skill",
+							"name": "Karate"
+						}
+					],
+					"calc": {
+						"level": 10,
+						"parry": "8",
+						"damage": "1d-3 cr"
+					}
+				},
+				{
+					"id": "7af56a61-264d-4cfb-919b-0f4fb2591870",
+					"type": "melee_weapon",
+					"damage": {
+						"type": "cr",
+						"st": "thr"
+					},
+					"usage": "Kick",
+					"reach": "C,1",
+					"parry": "No",
+					"defaults": [
+						{
+							"type": "dx",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Brawling",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Kicking"
+						},
+						{
+							"type": "skill",
+							"name": "Karate",
+							"modifier": -2
+						}
+					],
+					"calc": {
+						"level": 8,
+						"parry": "No",
+						"damage": "1d-2 cr"
+					}
+				}
+			],
+			"calc": {
+				"points": 0
+			}
+		},
+		{
+			"id": "173102c6-eaa0-49c0-8e57-cdd7aa45d85a",
+			"type": "trait",
+			"name": "Comfortable Wealth",
+			"reference": "B25",
+			"notes": "Starting wealth is twice normal",
+			"tags": [
+				"Advantage",
+				"Social",
+				"Wealth"
+			],
+			"base_points": 10,
+			"calc": {
+				"points": 10
+			}
+		},
+		{
+			"id": "3f0eb717-f915-417a-bed8-4fe1a825458a",
+			"type": "trait",
+			"name": "Legal Enforcement Powers",
+			"reference": "B65",
+			"tags": [
+				"Advantage",
+				"Social"
+			],
+			"levels": 3,
+			"points_per_level": 5,
+			"can_level": true,
+			"calc": {
+				"points": 15
+			}
+		},
+		{
+			"id": "70f3589b-bc58-4c3c-a167-bb2e2bc067e7",
+			"type": "trait",
+			"name": "Ritual Magery",
+			"reference": "B66",
+			"tags": [
+				"Advantage",
+				"Mental",
+				"Supernatural"
+			],
+			"modifiers": [
+				{
+					"id": "c68415a9-45d1-46fb-8f0f-6edb11c77ff6",
+					"type": "modifier",
+					"name": "Dance",
+					"cost": -40,
+					"affects": "levels_only",
+					"disabled": true
+				},
+				{
+					"id": "f151ee39-e427-4d37-810e-d4f332b69405",
+					"type": "modifier",
+					"name": "Dark-Aspected",
+					"cost": -50,
+					"affects": "levels_only",
+					"disabled": true
+				},
+				{
+					"id": "b391ce81-ecb1-4bb5-8a76-17654ea96a3a",
+					"type": "modifier",
+					"name": "Day-Aspected",
+					"cost": -40,
+					"affects": "levels_only",
+					"disabled": true
+				},
+				{
+					"id": "b65098b9-542f-4074-a84c-cb91b491c685",
+					"type": "modifier",
+					"name": "Musical",
+					"cost": -50,
+					"affects": "levels_only",
+					"disabled": true
+				},
+				{
+					"id": "8e0c6667-35ec-443d-ab58-2744547934a2",
+					"type": "modifier",
+					"name": "Night-Aspected",
+					"cost": -40,
+					"affects": "levels_only",
+					"disabled": true
+				},
+				{
+					"id": "33aee417-5f27-43ed-9e74-96f6f2ddb2fc",
+					"type": "modifier",
+					"name": "One College",
+					"notes": "@College@",
+					"cost": -40,
+					"affects": "levels_only",
+					"disabled": true
+				},
+				{
+					"id": "ab51bbd4-d383-4f72-a9c0-2ad5064a177b",
+					"type": "modifier",
+					"name": "Solitary",
+					"cost": -40,
+					"affects": "levels_only",
+					"disabled": true
+				},
+				{
+					"id": "edf1d838-59d8-4946-b094-0a471d9e8318",
+					"type": "modifier",
+					"name": "Song",
+					"cost": -40,
+					"affects": "levels_only",
+					"disabled": true
+				}
+			],
+			"base_points": 5,
+			"levels": 1,
+			"points_per_level": 10,
+			"features": [
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "thaumatology"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "ritual magic"
+					},
+					"amount": 1,
+					"per_level": true
+				}
+			],
+			"can_level": true,
+			"calc": {
+				"points": 15
+			}
+		},
+		{
+			"id": "e0106225-48d7-4de3-8c93-2c8f7098bcf6",
+			"type": "trait",
+			"name": "Signature Gear (Magic Staff)",
+			"reference": "B85",
+			"notes": "For equipment normally bought with money, each point gives goods worth up to 50% of the average campaign starting wealth (but never cash).",
+			"tags": [
+				"Advantage",
+				"Social"
+			],
+			"levels": 1,
+			"points_per_level": 1,
+			"can_level": true,
+			"calc": {
+				"points": 1
+			}
+		},
+		{
+			"id": "620933d3-ce02-4f2a-8c63-f4709e41163b",
+			"type": "trait",
+			"name": "Talent (Healer)",
+			"reference": "B90,PU3:11",
+			"notes": "Modern",
+			"tags": [
+				"Advantage",
+				"Mental",
+				"Talent"
+			],
+			"modifiers": [
+				{
+					"id": "8a7f420e-72c4-4cbc-b6a1-e9672b7202c8",
+					"type": "modifier",
+					"name": "Alternate Benefit",
+					"notes": "Bonus to HT rolls for a specific patient and condition if treated full time.",
+					"disabled": true
+				},
+				{
+					"id": "660cd855-3088-4e77-bee9-15654cf1e514",
+					"type": "modifier",
+					"name": "Alternative Cost",
+					"cost": 1,
+					"affects": "levels_only",
+					"cost_type": "points",
+					"disabled": true
+				}
+			],
+			"levels": 1,
+			"points_per_level": 10,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Talent (Healer)"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 1
+						},
+						"notes": {
+							"compare": "does_not_contain",
+							"qualifier": "Modern"
+						}
+					}
+				]
+			},
+			"features": [
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Diagnosis"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Esoteric Medicine"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "First Aid"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Pharmacy"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Physician"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Physiology"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Psychology"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Surgery"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Veterinary"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Operation"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Medical"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Expert Skill"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Epidemiology"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "reaction_bonus",
+					"situation": "from patients",
+					"amount": 1,
+					"per_level": true
+				}
+			],
+			"can_level": true,
+			"calc": {
+				"points": 10
+			}
+		},
+		{
+			"id": "22b68bb5-28d3-471d-b150-878a525e39e9",
+			"type": "trait",
+			"name": "Unfazeable",
+			"reference": "B95",
+			"notes": "Exempt from fright checks. Reaction modifiers do not affect you.",
+			"tags": [
+				"Advantage",
+				"Mental"
+			],
+			"modifiers": [
+				{
+					"id": "afc741f6-01f8-48bc-936d-37d51b5cdd0e",
+					"type": "modifier",
+					"name": "Familiar Horrors",
+					"reference": "H20",
+					"cost": -50,
+					"disabled": true
+				}
+			],
+			"base_points": 15,
+			"calc": {
+				"points": 15
+			}
+		},
+		{
+			"id": "45b0507f-1774-436e-b359-934d5927be34",
+			"type": "trait",
+			"name": "Low TL",
+			"reference": "B22",
+			"tags": [
+				"Disadvantage",
+				"Social"
+			],
+			"levels": 1,
+			"points_per_level": -5,
+			"can_level": true,
+			"calc": {
+				"points": -5
+			}
+		},
+		{
+			"id": "43ea62af-ad5d-4a51-b35c-6dc17e55269e",
+			"type": "trait",
+			"name": "Language Talent",
+			"reference": "B65",
+			"tags": [
+				"Advantage",
+				"Mental"
+			],
+			"base_points": 10,
+			"calc": {
+				"points": 10
+			}
+		},
+		{
+			"id": "415efb0a-471f-4e92-958a-48ec847d044a",
+			"type": "trait",
+			"name": "Language: English",
+			"reference": "B24",
+			"notes": "With Language Talent",
+			"tags": [
+				"Advantage",
+				"Language",
+				"Mental"
+			],
+			"modifiers": [
+				{
+					"id": "6e350dac-03e7-454b-aae0-910e3480d549",
+					"type": "modifier",
+					"name": "Native",
+					"reference": "B23",
+					"cost": -4,
+					"cost_type": "points"
+				},
+				{
+					"id": "8b45dbdd-df61-46c2-ac1d-a4512c1b6f87",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Accented",
+					"cost": 1,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "f1b65fd7-b774-4c35-89c8-4bcae8e38203",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Native",
+					"cost": 2,
+					"cost_type": "points"
+				},
+				{
+					"id": "4e5950f0-3680-4091-9cbb-ad9a6bdf6e58",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Accented",
+					"cost": 1,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "5a815059-e937-4dce-b933-c8b9b83c9a3e",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Native",
+					"cost": 2,
+					"cost_type": "points"
+				}
+			],
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Language Talent"
+						}
+					}
+				]
+			},
+			"calc": {
+				"points": 0
+			}
+		},
+		{
+			"id": "6e8319a9-599c-453b-91a3-00cff04dc3ec",
+			"type": "trait",
+			"name": "Language: German",
+			"reference": "B24",
+			"notes": "With Language Talent",
+			"tags": [
+				"Advantage",
+				"Language",
+				"Mental"
+			],
+			"modifiers": [
+				{
+					"id": "6e350dac-03e7-454b-aae0-910e3480d549",
+					"type": "modifier",
+					"name": "Native",
+					"reference": "B23",
+					"cost": -4,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "8b45dbdd-df61-46c2-ac1d-a4512c1b6f87",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Accented",
+					"cost": 1,
+					"cost_type": "points"
+				},
+				{
+					"id": "f1b65fd7-b774-4c35-89c8-4bcae8e38203",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Native",
+					"cost": 2,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "4e5950f0-3680-4091-9cbb-ad9a6bdf6e58",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Accented",
+					"cost": 1,
+					"cost_type": "points"
+				},
+				{
+					"id": "5a815059-e937-4dce-b933-c8b9b83c9a3e",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Native",
+					"cost": 2,
+					"cost_type": "points",
+					"disabled": true
+				}
+			],
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Language Talent"
+						}
+					}
+				]
+			},
+			"calc": {
+				"points": 2
+			}
+		},
+		{
+			"id": "15bbb691-6ed1-472d-98ce-5b36a0b7999c",
+			"type": "trait",
+			"name": "Language: Arabic",
+			"reference": "B24",
+			"notes": "With Language Talent",
+			"tags": [
+				"Advantage",
+				"Language",
+				"Mental"
+			],
+			"modifiers": [
+				{
+					"id": "6e350dac-03e7-454b-aae0-910e3480d549",
+					"type": "modifier",
+					"name": "Native",
+					"reference": "B23",
+					"cost": -4,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "8b45dbdd-df61-46c2-ac1d-a4512c1b6f87",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Accented",
+					"cost": 1,
+					"cost_type": "points"
+				},
+				{
+					"id": "f1b65fd7-b774-4c35-89c8-4bcae8e38203",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Native",
+					"cost": 2,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "4e5950f0-3680-4091-9cbb-ad9a6bdf6e58",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Accented",
+					"cost": 1,
+					"cost_type": "points"
+				},
+				{
+					"id": "5a815059-e937-4dce-b933-c8b9b83c9a3e",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Native",
+					"cost": 2,
+					"cost_type": "points",
+					"disabled": true
+				}
+			],
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Language Talent"
+						}
+					}
+				]
+			},
+			"calc": {
+				"points": 2
+			}
+		},
+		{
+			"id": "a9c91b86-363c-4d64-a1b3-c1a0139ff3dc",
+			"type": "trait",
+			"name": "Language: Ancient Egyptian",
+			"reference": "B24",
+			"notes": "With Language Talent",
+			"tags": [
+				"Advantage",
+				"Language",
+				"Mental"
+			],
+			"modifiers": [
+				{
+					"id": "6e350dac-03e7-454b-aae0-910e3480d549",
+					"type": "modifier",
+					"name": "Native",
+					"reference": "B23",
+					"cost": -4,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "8b45dbdd-df61-46c2-ac1d-a4512c1b6f87",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Accented",
+					"cost": 1,
+					"cost_type": "points"
+				},
+				{
+					"id": "f1b65fd7-b774-4c35-89c8-4bcae8e38203",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Native",
+					"cost": 2,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "4e5950f0-3680-4091-9cbb-ad9a6bdf6e58",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Accented",
+					"cost": 1,
+					"cost_type": "points"
+				},
+				{
+					"id": "5a815059-e937-4dce-b933-c8b9b83c9a3e",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Native",
+					"cost": 2,
+					"cost_type": "points",
+					"disabled": true
+				}
+			],
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Language Talent"
+						}
+					}
+				]
+			},
+			"calc": {
+				"points": 2
+			}
+		},
+		{
+			"id": "8e50aad7-4566-49af-acc5-ff6af4f8a60d",
+			"type": "trait",
+			"name": "Language: Latin",
+			"reference": "B24",
+			"notes": "With Language Talent",
+			"tags": [
+				"Advantage",
+				"Language",
+				"Mental"
+			],
+			"modifiers": [
+				{
+					"id": "6e350dac-03e7-454b-aae0-910e3480d549",
+					"type": "modifier",
+					"name": "Native",
+					"reference": "B23",
+					"cost": -4,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "8b45dbdd-df61-46c2-ac1d-a4512c1b6f87",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Accented",
+					"cost": 1,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "f1b65fd7-b774-4c35-89c8-4bcae8e38203",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Native",
+					"cost": 2,
+					"cost_type": "points"
+				},
+				{
+					"id": "4e5950f0-3680-4091-9cbb-ad9a6bdf6e58",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Accented",
+					"cost": 1,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "5a815059-e937-4dce-b933-c8b9b83c9a3e",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Native",
+					"cost": 2,
+					"cost_type": "points"
+				}
+			],
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Language Talent"
+						}
+					}
+				]
+			},
+			"calc": {
+				"points": 4
+			}
+		},
+		{
+			"id": "fe25db77-8f08-44d8-8983-280cdc6c6033",
+			"type": "trait",
+			"name": "Cultural Familiarity (Western)",
+			"reference": "B23",
+			"notes": "Do not suffer the normal -3 penalty for unfamiliarity",
+			"tags": [
+				"Advantage",
+				"Mental"
+			],
+			"modifiers": [
+				{
+					"id": "ab12b725-01c8-4fc4-8e71-619a54c79496",
+					"type": "modifier",
+					"name": "Alien",
+					"cost": 1,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "f72aa995-6766-4eaf-a3ca-0f4ff76d47c5",
+					"type": "modifier",
+					"name": "Native",
+					"cost": -1,
+					"cost_type": "points"
+				}
+			],
+			"base_points": 1,
+			"calc": {
+				"points": 0
+			}
+		},
+		{
+			"id": "ebd4db2d-8f5f-4e93-abb3-b5bb012b1012",
+			"type": "trait",
+			"name": "Cultural Familiarity (Homeline)",
+			"reference": "B23",
+			"notes": "Do not suffer the normal -3 penalty for unfamiliarity",
+			"tags": [
+				"Advantage",
+				"Mental"
+			],
+			"modifiers": [
+				{
+					"id": "ab12b725-01c8-4fc4-8e71-619a54c79496",
+					"type": "modifier",
+					"name": "Alien",
+					"cost": 1,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "f72aa995-6766-4eaf-a3ca-0f4ff76d47c5",
+					"type": "modifier",
+					"name": "Native",
+					"cost": -1,
+					"cost_type": "points",
+					"disabled": true
+				}
+			],
+			"base_points": 1,
+			"calc": {
+				"points": 1
+			}
+		},
+		{
+			"id": "0cf2601a-41db-4b00-8941-dbbf84c338e4",
+			"type": "trait",
+			"name": "Duty (to ISWAT)",
+			"reference": "B133",
+			"tags": [
+				"Disadvantage",
+				"Social"
+			],
+			"modifiers": [
+				{
+					"id": "fb0c80a4-4c65-4521-9e18-7378dda34a46",
+					"type": "modifier",
+					"name": "FR: 6",
+					"cost": -2,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "92ade39a-a64c-4ff4-a84b-89ab92a6e217",
+					"type": "modifier",
+					"name": "FR: 9",
+					"cost": -5,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "80577150-cbdb-4c26-bde4-1ad85a7deec2",
+					"type": "modifier",
+					"name": "FR: 12",
+					"cost": -10,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "d6406b89-6289-4b8c-b7c7-4d25add3c352",
+					"type": "modifier",
+					"name": "FR: 15",
+					"cost": -15,
+					"cost_type": "points"
+				},
+				{
+					"id": "f4458d02-9b67-42f8-8f31-5837064fb751",
+					"type": "modifier",
+					"name": "Extremely Hazardous",
+					"cost": -5,
+					"cost_type": "points"
+				},
+				{
+					"id": "814f2484-cac1-4eca-af21-f9eaca8c0d0a",
+					"type": "modifier",
+					"name": "Involuntary",
+					"cost": -5,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "5d87b90f-fc68-4d78-8547-7c2ef58ae7bd",
+					"type": "modifier",
+					"name": "Nonhazardous",
+					"cost": 5,
+					"cost_type": "points",
+					"disabled": true
+				}
+			],
+			"calc": {
+				"points": -20
+			}
+		},
+		{
+			"id": "053cc9a5-9f99-4317-934d-1871ee4a342b",
+			"type": "trait",
+			"name": "Fanaticism (Destroy all things man was not meant to know)",
+			"reference": "B136",
+			"tags": [
+				"Disadvantage",
+				"Mental"
+			],
+			"modifiers": [
+				{
+					"id": "478df057-c461-425c-8d04-17a240d0e6e4",
+					"type": "modifier",
+					"name": "Extreme",
+					"reference": "B136"
+				}
+			],
+			"base_points": -15,
+			"calc": {
+				"points": -15
+			}
+		},
+		{
+			"id": "180b8465-86eb-47ca-b158-c891b8f28778",
+			"type": "trait",
+			"name": "Insomniac",
+			"reference": "B140",
+			"tags": [
+				"Disadvantage",
+				"Physical"
+			],
+			"modifiers": [
+				{
+					"id": "e47e9c6f-e931-4653-b330-dca69460b277",
+					"type": "modifier",
+					"name": "Mild",
+					"reference": "B140",
+					"notes": "GM secretly rolls 3d for the number of days between episodes",
+					"cost": -10,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "160153c2-a7b8-49f7-b638-940d2a427f25",
+					"type": "modifier",
+					"name": "Severe",
+					"reference": "B140",
+					"notes": "GM secretly rolls 2d-1 for the number of days between episodes",
+					"cost": -15,
+					"cost_type": "points"
+				}
+			],
+			"calc": {
+				"points": -15
+			}
+		},
+		{
+			"id": "0aace46f-4e2c-4a27-b370-83fe61e7ac1a",
+			"type": "trait",
+			"name": "Weirdness Magnet",
+			"reference": "B161",
+			"tags": [
+				"Disadvantage",
+				"Mental",
+				"Supernatural"
+			],
+			"modifiers": [
+				{
+					"id": "966289db-d5f0-4670-9498-27d9cbd2872e",
+					"type": "modifier",
+					"name": "Origins Magnet",
+					"reference": "SU32",
+					"disabled": true
+				}
+			],
+			"base_points": -15,
+			"features": [
+				{
+					"type": "reaction_bonus",
+					"situation": "from people who realise you are a weirdness magnet (except parapsychologists, cultists, conspiracy theorists, thrill-seekers)",
+					"amount": -2
+				}
+			],
+			"calc": {
+				"points": -15
+			}
+		},
+		{
+			"id": "b100e8e1-155e-41dd-9185-e70bdb2b1090",
+			"type": "trait",
+			"name": "Bad Sight (Nearsighted)",
+			"reference": "B123",
+			"notes": "Double actual distance to the target when calculating the range modifier for ranged attacks",
+			"tags": [
+				"Disadvantage",
+				"Physical"
+			],
+			"modifiers": [
+				{
+					"id": "bcf5ee4d-8f70-41e5-81ee-9f4a2956f9c3",
+					"type": "modifier",
+					"name": "Mitigator",
+					"notes": "Glasses",
+					"cost": -60
+				}
+			],
+			"base_points": -25,
+			"features": [
+				{
+					"type": "conditional_modifier",
+					"situation": "to Vision rolls to spot items more than 1 yd away",
+					"amount": -6
+				},
+				{
+					"type": "conditional_modifier",
+					"situation": "to all melee attacks",
+					"amount": -2
+				}
+			],
+			"calc": {
+				"points": -10
+			}
+		},
+		{
+			"id": "ff5344c3-a94b-4c7b-9555-8eeddecef417",
+			"type": "trait",
+			"name": "Guilt Complex",
+			"reference": "B137",
+			"tags": [
+				"Disadvantage",
+				"Mental"
+			],
+			"base_points": -5,
+			"calc": {
+				"points": -5
+			}
+		},
+		{
+			"id": "cd12cc27-a138-4454-891e-e1b40f7cf753",
+			"type": "trait",
+			"name": "Nightmares",
+			"reference": "B144",
+			"notes": "Make a self-control roll each morning upon awakening. If you fail, you suffered nightmares; this costs you 1 FP that you can only recover through sleep. On a roll of 17 or 18, you are left shaking, and are at -1 to all skill and Perception rolls for the entire day.",
+			"tags": [
+				"Disadvantage",
+				"Mental"
+			],
+			"base_points": -5,
+			"cr": 12,
+			"calc": {
+				"points": -5
+			}
+		},
+		{
+			"id": "290c1649-c572-4bb3-95fa-706f2ee1054f",
+			"type": "trait",
+			"name": "Quirk: Makes decisions by consulting the tarot (Compulsion)",
+			"reference": "B162",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "b916ae7d-8bee-4c24-8bd6-aff32f76d291",
+			"type": "trait",
+			"name": "Quirk: Bad knee",
+			"reference": "B164",
+			"tags": [
+				"Physical",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "6e2d21d7-dc89-481e-ab9d-6b8c593edb9b",
+			"type": "trait",
+			"name": "Quirk: Bibliophile",
+			"reference": "B162",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "acddb901-e655-4f47-b89f-e385e97b925c",
+			"type": "trait",
+			"name": "Quirk: Distrusts Germans",
+			"reference": "B162",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"features": [
+				{
+					"type": "reaction_bonus",
+					"situation": "from especially touchy Germans",
+					"amount": -1
+				}
+			],
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "9b5ff38d-294b-4f84-a7c9-ea8f1485e2f1",
+			"type": "trait",
+			"name": "Quirk: Pipe smoker (0-point addiction to tobacco)",
+			"reference": "B164",
+			"tags": [
+				"Physical",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		}
+	],
+	"skills": [
+		{
+			"id": "9c740ab1-809f-474c-aef7-acb1023710dc",
+			"type": "skill",
+			"name": "Anthropology",
+			"reference": "B175",
+			"tags": [
+				"Humanities",
+				"Social Sciences"
+			],
+			"difficulty": "iq/h",
+			"points": 1,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -6,
+				"level": 10,
+				"adjusted_level": 10,
+				"points": -10
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Paleontology",
+					"specialization": "Paleoanthropology",
+					"modifier": -2
+				},
+				{
+					"type": "skill",
+					"name": "Sociology",
+					"modifier": -3
+				}
+			],
+			"calc": {
+				"level": 14,
+				"rsl": "IQ-2"
+			}
+		},
+		{
+			"id": "a4a3b06c-b051-48aa-92df-6cd1dcff409f",
+			"type": "skill",
+			"name": "Biology",
+			"reference": "B180",
+			"tags": [
+				"Natural Science",
+				"Plant"
+			],
+			"specialization": "Earthlike",
+			"tech_level": "7",
+			"difficulty": "iq/vh",
+			"points": 1,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -6,
+				"level": 10,
+				"adjusted_level": 10,
+				"points": -10
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Naturalist",
+					"modifier": -6
+				}
+			],
+			"calc": {
+				"level": 13,
+				"rsl": "IQ-3"
+			}
+		},
+		{
+			"id": "7dc5d4a7-cf66-4b2a-b50b-684462903baa",
+			"type": "skill",
+			"name": "Criminology",
+			"reference": "B186",
+			"tags": [
+				"Humanities",
+				"Police",
+				"Social Sciences"
+			],
+			"tech_level": "7",
+			"difficulty": "iq/a",
+			"points": 2,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -5,
+				"level": 11,
+				"adjusted_level": 11,
+				"points": -11
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Psychology",
+					"modifier": -4
+				}
+			],
+			"calc": {
+				"level": 16,
+				"rsl": "IQ+0"
+			}
+		},
+		{
+			"id": "9103a8f6-fc32-47ee-b224-68b223a1699f",
+			"type": "skill",
+			"name": "Detect Lies",
+			"reference": "B187",
+			"tags": [
+				"Police",
+				"Social",
+				"Spy"
+			],
+			"difficulty": "per/h",
+			"points": 2,
+			"defaulted_from": {
+				"type": "skill",
+				"name": "Psychology",
+				"modifier": -4,
+				"level": 10,
+				"adjusted_level": 10,
+				"points": -10
+			},
+			"defaults": [
+				{
+					"type": "per",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Body Language",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Psychology",
+					"modifier": -4
+				}
+			],
+			"calc": {
+				"level": 14,
+				"rsl": "Per-1"
+			}
+		},
+		{
+			"id": "7dfa478a-7efc-4c68-84c4-6d1f57c0d73e",
+			"type": "skill",
+			"name": "Diagnosis",
+			"reference": "B187",
+			"tags": [
+				"Medical"
+			],
+			"tech_level": "7",
+			"difficulty": "iq/h",
+			"points": 1,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -6,
+				"level": 10,
+				"adjusted_level": 10,
+				"points": -10
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "First Aid",
+					"modifier": -8
+				},
+				{
+					"type": "skill",
+					"name": "Physician",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Veterinary",
+					"modifier": -5
+				}
+			],
+			"calc": {
+				"level": 15,
+				"rsl": "IQ-1"
+			}
+		},
+		{
+			"id": "b2a1fc2b-64ce-40a1-9069-ecfefd3bb87a",
+			"type": "skill",
+			"name": "Dreaming",
+			"reference": "B188",
+			"tags": [
+				"Esoteric"
+			],
+			"difficulty": "will/h",
+			"points": 4,
+			"defaulted_from": {
+				"type": "will",
+				"modifier": -6,
+				"level": 11,
+				"adjusted_level": 11,
+				"points": -11
+			},
+			"defaults": [
+				{
+					"type": "will",
+					"modifier": -6
+				}
+			],
+			"calc": {
+				"level": 17,
+				"rsl": "Will+0"
+			}
+		},
+		{
+			"id": "c0378462-e4cd-46b8-9da5-b5850f7e2a42",
+			"type": "skill",
+			"name": "Exorcism",
+			"reference": "B193",
+			"tags": [
+				"Magical",
+				"Occult"
+			],
+			"difficulty": "will/h",
+			"points": 1,
+			"defaulted_from": {
+				"type": "skill",
+				"name": "Ritual Magic",
+				"specialization": "Hermetic",
+				"modifier": -3,
+				"level": 13,
+				"adjusted_level": 13,
+				"points": -13
+			},
+			"defaults": [
+				{
+					"type": "will",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Religious Ritual",
+					"modifier": -3
+				},
+				{
+					"type": "skill",
+					"name": "Ritual Magic",
+					"modifier": -3
+				},
+				{
+					"type": "skill",
+					"name": "Theology",
+					"modifier": -3
+				}
+			],
+			"calc": {
+				"level": 15,
+				"rsl": "Will-2"
+			}
+		},
+		{
+			"id": "53629c00-96fe-4ec2-ba1a-4f5a657c3dfb",
+			"type": "skill",
+			"name": "Expert Skill",
+			"reference": "B193,MA56",
+			"tags": [
+				"Knowledge",
+				"Magical",
+				"Occult",
+				"Scholarly"
+			],
+			"specialization": "Psionics",
+			"difficulty": "iq/h",
+			"points": 1,
+			"calc": {
+				"level": 14,
+				"rsl": "IQ-2"
+			}
+		},
+		{
+			"id": "a94ee472-0174-4653-b0fa-19d714d4ff71",
+			"type": "skill",
+			"name": "First Aid",
+			"reference": "B195",
+			"tags": [
+				"Everyman",
+				"Medical"
+			],
+			"tech_level": "7",
+			"difficulty": "iq/e",
+			"defaulted_from": {
+				"type": "skill",
+				"name": "Physician",
+				"level": 14,
+				"adjusted_level": 14,
+				"points": -14
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Esoteric Medicine"
+				},
+				{
+					"type": "skill",
+					"name": "Physician"
+				},
+				{
+					"type": "skill",
+					"name": "Veterinary",
+					"modifier": -4
+				}
+			],
+			"calc": {
+				"level": 15,
+				"rsl": "IQ-1"
+			}
+		},
+		{
+			"id": "5dc2d829-5794-4807-b2a0-3053323743bc",
+			"type": "skill",
+			"name": "Forensics",
+			"reference": "B196",
+			"tags": [
+				"Police"
+			],
+			"tech_level": "7",
+			"difficulty": "iq/h",
+			"points": 1,
+			"defaulted_from": {
+				"type": "skill",
+				"name": "Criminology",
+				"modifier": -4,
+				"level": 12,
+				"adjusted_level": 12,
+				"points": -12
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Criminology",
+					"modifier": -4
+				}
+			],
+			"calc": {
+				"level": 14,
+				"rsl": "IQ-2"
+			}
+		},
+		{
+			"id": "0b12e6a9-7f01-45ad-85cf-1f6ee647fa38",
+			"type": "skill",
+			"name": "Guns",
+			"reference": "B198",
+			"tags": [
+				"Combat",
+				"Ranged Combat",
+				"Weapon"
+			],
+			"specialization": "Pistol",
+			"tech_level": "7",
+			"difficulty": "dx/e",
+			"points": 4,
+			"defaulted_from": {
+				"type": "dx",
+				"modifier": -4,
+				"level": 6,
+				"adjusted_level": 6,
+				"points": -6
+			},
+			"defaults": [
+				{
+					"type": "dx",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Guns",
+					"specialization": "Grenade Launcher",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Guns",
+					"specialization": "Gyroc",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Guns",
+					"specialization": "Light Anti-Armor Weapon",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Guns",
+					"specialization": "Light Machine Gun",
+					"modifier": -2
+				},
+				{
+					"type": "skill",
+					"name": "Guns",
+					"specialization": "Musket",
+					"modifier": -2
+				},
+				{
+					"type": "skill",
+					"name": "Beam Weapons",
+					"specialization": "Pistol",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Guns",
+					"specialization": "Rifle",
+					"modifier": -2
+				},
+				{
+					"type": "skill",
+					"name": "Guns",
+					"specialization": "Shotgun",
+					"modifier": -2
+				},
+				{
+					"type": "skill",
+					"name": "Guns",
+					"specialization": "Submachine Gun",
+					"modifier": -2
+				}
+			],
+			"calc": {
+				"level": 12,
+				"rsl": "DX+2"
+			}
+		},
+		{
+			"id": "512c8cb3-a381-43f4-8842-d44f677b59e1",
+			"type": "skill",
+			"name": "Hidden Lore",
+			"reference": "B199,MA57",
+			"tags": [
+				"Knowledge"
+			],
+			"specialization": "Things Man Was Not Meant To Know",
+			"difficulty": "iq/a",
+			"points": 1,
+			"calc": {
+				"level": 15,
+				"rsl": "IQ-1"
+			}
+		},
+		{
+			"id": "d560c581-b2ae-4154-9ed2-236810be7b1d",
+			"type": "skill",
+			"name": "Hypnotism",
+			"reference": "B201",
+			"tags": [
+				"Medical"
+			],
+			"difficulty": "iq/h",
+			"points": 1,
+			"calc": {
+				"level": 14,
+				"rsl": "IQ-2"
+			}
+		},
+		{
+			"id": "11715e9a-6d25-4931-8507-fb1911c89132",
+			"type": "skill",
+			"name": "Literature",
+			"reference": "B205",
+			"tags": [
+				"Humanities",
+				"Scholarly",
+				"Social Sciences"
+			],
+			"difficulty": "iq/h",
+			"points": 1,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -6,
+				"level": 10,
+				"adjusted_level": 10,
+				"points": -10
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -6
+				}
+			],
+			"calc": {
+				"level": 14,
+				"rsl": "IQ-2"
+			}
+		},
+		{
+			"id": "a7126dfc-66a5-49ae-8834-603011a8aae8",
+			"type": "skill",
+			"name": "Mental Strength",
+			"reference": "B209",
+			"tags": [
+				"Esoteric"
+			],
+			"difficulty": "will/e",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": false,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "starts_with",
+							"qualifier": "weapon master"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "trained by a master"
+						}
+					}
+				]
+			},
+			"calc": {
+				"level": 17,
+				"rsl": "Will+0"
+			}
+		},
+		{
+			"id": "8f75eb9c-af0c-45ab-87c9-36a37c21aa1a",
+			"type": "skill",
+			"name": "Occultism",
+			"reference": "B212",
+			"tags": [
+				"Magical",
+				"Occult"
+			],
+			"difficulty": "iq/a",
+			"points": 4,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -5,
+				"level": 11,
+				"adjusted_level": 11,
+				"points": -11
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -5
+				}
+			],
+			"calc": {
+				"level": 17,
+				"rsl": "IQ+1"
+			}
+		},
+		{
+			"id": "c18912a0-1c45-4db8-be6f-f90b04f7868c",
+			"type": "skill",
+			"name": "Pharmacy",
+			"reference": "B213",
+			"tags": [
+				"Design",
+				"Invention",
+				"Medical"
+			],
+			"specialization": "Synthetic",
+			"tech_level": "7",
+			"difficulty": "iq/h",
+			"points": 1,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -6,
+				"level": 10,
+				"adjusted_level": 10,
+				"points": -10
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Chemistry",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Physician",
+					"modifier": -5
+				}
+			],
+			"calc": {
+				"level": 15,
+				"rsl": "IQ-1"
+			}
+		},
+		{
+			"id": "64bbbc89-cd07-43e4-91a3-9404afaf02a7",
+			"type": "skill",
+			"name": "Physician",
+			"reference": "B213",
+			"tags": [
+				"Medical"
+			],
+			"tech_level": "7",
+			"difficulty": "iq/h",
+			"points": 1,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -7,
+				"level": 9,
+				"adjusted_level": 9,
+				"points": -9
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -7
+				},
+				{
+					"type": "skill",
+					"name": "First Aid",
+					"modifier": -11
+				},
+				{
+					"type": "skill",
+					"name": "Veterinary",
+					"modifier": -5
+				}
+			],
+			"calc": {
+				"level": 15,
+				"rsl": "IQ-1"
+			}
+		},
+		{
+			"id": "3e8d4663-be2b-46c2-8696-b43dfd4e059a",
+			"type": "skill",
+			"name": "Psychology",
+			"reference": "B216",
+			"tags": [
+				"Humanities",
+				"Social Sciences"
+			],
+			"difficulty": "iq/h",
+			"points": 1,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -6,
+				"level": 10,
+				"adjusted_level": 10,
+				"points": -10
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Sociology",
+					"modifier": -4
+				}
+			],
+			"calc": {
+				"level": 15,
+				"rsl": "IQ-1"
+			}
+		},
+		{
+			"id": "e6cac54f-fb56-4892-b18e-21245e1a338f",
+			"type": "skill",
+			"name": "Public Speaking",
+			"reference": "B216",
+			"tags": [
+				"Business",
+				"Scholarly",
+				"Social"
+			],
+			"difficulty": "iq/a",
+			"points": 1,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -5,
+				"level": 11,
+				"adjusted_level": 11,
+				"points": -11
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Acting",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Performance",
+					"modifier": -2
+				},
+				{
+					"type": "skill",
+					"name": "Politics",
+					"modifier": -5
+				}
+			],
+			"calc": {
+				"level": 15,
+				"rsl": "IQ-1"
+			}
+		},
+		{
+			"id": "4568a6a2-276c-455d-ad9c-8f8c8bf41321",
+			"type": "skill",
+			"name": "Research",
+			"reference": "B217",
+			"tags": [
+				"Scholarly",
+				"Spy"
+			],
+			"tech_level": "7",
+			"difficulty": "iq/a",
+			"points": 4,
+			"defaulted_from": {
+				"type": "skill",
+				"name": "Writing",
+				"modifier": -3,
+				"level": 12,
+				"adjusted_level": 12,
+				"points": -12
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Writing",
+					"modifier": -3
+				}
+			],
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "prereq_list",
+						"all": true,
+						"when_tl": {
+							"compare": "at_least",
+							"qualifier": 8
+						},
+						"prereqs": [
+							{
+								"type": "skill_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Computer Operation"
+								}
+							}
+						]
+					},
+					{
+						"type": "prereq_list",
+						"all": false,
+						"when_tl": {
+							"compare": "at_most",
+							"qualifier": 4
+						},
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": true,
+								"name": {
+									"compare": "starts_with",
+									"qualifier": "Language"
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "Written (Native"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": true,
+								"name": {
+									"compare": "starts_with",
+									"qualifier": "Language"
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "Written (Accented)"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": true,
+								"name": {
+									"compare": "starts_with",
+									"qualifier": "Language"
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "Written (Broken)"
+								}
+							}
+						]
+					}
+				]
+			},
+			"calc": {
+				"level": 17,
+				"rsl": "IQ+1"
+			}
+		},
+		{
+			"id": "9c382f00-42fd-4dba-862a-467f2f1fdcfe",
+			"type": "skill",
+			"name": "Ritual Magic",
+			"reference": "B218",
+			"tags": [
+				"Magical",
+				"Occult"
+			],
+			"specialization": "Hermetic",
+			"difficulty": "iq/vh",
+			"points": 8,
+			"defaults": [
+				{
+					"type": "skill",
+					"name": "Ritual Magic",
+					"modifier": -6
+				}
+			],
+			"calc": {
+				"level": 17,
+				"rsl": "IQ+1"
+			}
+		},
+		{
+			"id": "632eeb2a-6891-45d7-8ec4-848ca83a82c2",
+			"type": "skill",
+			"name": "Savoir-Faire",
+			"reference": "B218,MA59",
+			"tags": [
+				"Knowledge",
+				"Police",
+				"Social"
+			],
+			"specialization": "Police",
+			"difficulty": "iq/e",
+			"points": 1,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -4,
+				"level": 12,
+				"adjusted_level": 12,
+				"points": -12
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -4
+				}
+			],
+			"calc": {
+				"level": 16,
+				"rsl": "IQ+0"
+			}
+		},
+		{
+			"id": "152a76fc-6046-4929-8da5-88ed695fa329",
+			"type": "skill",
+			"name": "Symbol Drawing",
+			"reference": "B224",
+			"tags": [
+				"Magical",
+				"Occult"
+			],
+			"specialization": "Hermetic Sigils",
+			"difficulty": "iq/h",
+			"points": 1,
+			"calc": {
+				"level": 14,
+				"rsl": "IQ-2"
+			}
+		},
+		{
+			"id": "f2cf54db-a294-4a59-baef-017d1c6ccf27",
+			"type": "skill",
+			"name": "Teaching",
+			"reference": "B224",
+			"tags": [
+				"Scholarly",
+				"Social"
+			],
+			"difficulty": "iq/a",
+			"points": 1,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -5,
+				"level": 11,
+				"adjusted_level": 11,
+				"points": -11
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -5
+				}
+			],
+			"calc": {
+				"level": 15,
+				"rsl": "IQ-1"
+			}
+		},
+		{
+			"id": "a95e71fa-0c7b-4b3e-a607-1e510714a2bf",
+			"type": "skill",
+			"name": "Thaumatology",
+			"reference": "B225",
+			"tags": [
+				"Magical",
+				"Occult"
+			],
+			"difficulty": "iq/vh",
+			"points": 1,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -7,
+				"level": 9,
+				"adjusted_level": 9,
+				"points": -9
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -7
+				}
+			],
+			"calc": {
+				"level": 14,
+				"rsl": "IQ-2"
+			}
+		},
+		{
+			"id": "c64e8d9a-b047-4a02-9aa2-5298df6fa3c1",
+			"type": "skill",
+			"name": "Theology",
+			"reference": "B226",
+			"tags": [
+				"Humanities",
+				"Social Sciences"
+			],
+			"specialization": "Satanism",
+			"difficulty": "iq/h",
+			"points": 1,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -6,
+				"level": 10,
+				"adjusted_level": 10,
+				"points": -10
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Religious Ritual",
+					"specialization": "Satanism",
+					"modifier": -4
+				}
+			],
+			"calc": {
+				"level": 14,
+				"rsl": "IQ-2"
+			}
+		},
+		{
+			"id": "cb323dfe-0ed7-43b6-b431-d98ec5ac44b3",
+			"type": "skill",
+			"name": "Writing",
+			"reference": "B228",
+			"tags": [
+				"Arts",
+				"Entertainment",
+				"Scholarly"
+			],
+			"difficulty": "iq/a",
+			"points": 1,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -5,
+				"level": 11,
+				"adjusted_level": 11,
+				"points": -11
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -5
+				}
+			],
+			"calc": {
+				"level": 15,
+				"rsl": "IQ-1"
+			}
+		},
+		{
+			"id": "49bd2dc8-65b9-4b67-ac07-db7aa4af60e9",
+			"type": "skill_container",
+			"open": true,
+			"children": [
+				{
+					"id": "76f644be-09e0-4306-a56d-a77e784689bd",
+					"type": "skill",
+					"name": "Path of Communication and Empathy",
+					"difficulty": "iq/vh",
+					"points": 4,
+					"calc": {
+						"level": 15,
+						"rsl": "IQ-1"
+					}
+				},
+				{
+					"id": "0f49c56b-43d5-4f32-9db5-309b84f35b82",
+					"type": "skill",
+					"name": "Path of Gate",
+					"difficulty": "iq/vh",
+					"points": 8,
+					"calc": {
+						"level": 16,
+						"rsl": "IQ+0"
+					}
+				},
+				{
+					"id": "6b1efd30-88c0-47c0-8ffe-6034f95773c8",
+					"type": "skill",
+					"name": "Path of Necromancy",
+					"difficulty": "iq/vh",
+					"points": 1,
+					"calc": {
+						"level": 13,
+						"rsl": "IQ-3"
+					}
+				}
+			],
+			"name": "Ritual Paths"
+		}
+	],
+	"spells": [
+		{
+			"id": "7ceac805-4a3c-4784-bb2b-9efd23a9ee07",
+			"type": "ritual_magic_spell",
+			"name": "Banish",
+			"reference": "M156",
+			"tags": [
+				"Necromancy",
+				"Ritual Magic"
+			],
+			"difficulty": "h",
+			"college": [
+				"Necromancy"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Special",
+			"casting_cost": "1 per 10 CP",
+			"maintenance_cost": "-",
+			"casting_time": "5 sec",
+			"duration": "Permanent",
+			"base_skill": "Ritual Magic",
+			"prereq_count": 11,
+			"points": 6,
+			"calc": {
+				"level": 5,
+				"rsl": "-12"
+			}
+		},
+		{
+			"id": "881fa5df-9f19-4353-8772-c9a2bf1c0e7d",
+			"type": "ritual_magic_spell",
+			"name": "Planar Summons (@Plane@)",
+			"reference": "M82",
+			"tags": [
+				"Gate",
+				"Ritual Magic"
+			],
+			"difficulty": "h",
+			"college": [
+				"Gate"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Special",
+			"casting_cost": "20#",
+			"maintenance_cost": "-",
+			"casting_time": "5 min",
+			"duration": "1 hr",
+			"base_skill": "Ritual Magic",
+			"prereq_count": 11,
+			"points": 5,
+			"calc": {
+				"level": 4,
+				"rsl": "-13"
+			}
+		},
+		{
+			"id": "998a0d4c-dff2-4792-8e78-0da13cdbb99a",
+			"type": "ritual_magic_spell",
+			"name": "Plane Shift (@Plane@)",
+			"reference": "M83",
+			"tags": [
+				"Gate",
+				"Ritual Magic"
+			],
+			"difficulty": "h",
+			"college": [
+				"Gate"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Special",
+			"casting_cost": "20",
+			"maintenance_cost": "-",
+			"casting_time": "5 sec",
+			"duration": "Instant",
+			"base_skill": "Ritual Magic",
+			"prereq_count": 12,
+			"points": 6,
+			"calc": {
+				"level": 4,
+				"rsl": "-13"
+			}
+		},
+		{
+			"id": "6307d69f-be0c-4c3b-9f97-f4a22e80d64e",
+			"type": "ritual_magic_spell",
+			"name": "Sense Emotion",
+			"reference": "M45",
+			"tags": [
+				"Communication \u0026 Empathy",
+				"Ritual Magic"
+			],
+			"difficulty": "h",
+			"college": [
+				"Communication \u0026 Empathy"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Regular",
+			"casting_cost": "2",
+			"maintenance_cost": "-",
+			"casting_time": "1 sec",
+			"duration": "Instant",
+			"base_skill": "Ritual Magic",
+			"prereq_count": 1,
+			"points": 2,
+			"calc": {
+				"level": 11,
+				"rsl": "-6"
+			}
+		},
+		{
+			"id": "ba03cc51-b48c-4fbf-9fa6-873fd2d85776",
+			"type": "ritual_magic_spell",
+			"name": "Sense Spirit",
+			"reference": "M149",
+			"tags": [
+				"Necromancy",
+				"Ritual Magic"
+			],
+			"difficulty": "h",
+			"college": [
+				"Necromancy"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Info/Area",
+			"casting_cost": "1/2 (min 1)",
+			"maintenance_cost": "-",
+			"casting_time": "1 sec",
+			"duration": "Instant",
+			"base_skill": "Ritual Magic",
+			"prereq_count": 2,
+			"points": 2,
+			"calc": {
+				"level": 10,
+				"rsl": "-7"
+			}
+		},
+		{
+			"id": "27381111-a9bd-4594-a884-5943f2c98793",
+			"type": "ritual_magic_spell",
+			"name": "Truthsayer",
+			"reference": "M45",
+			"tags": [
+				"Communication \u0026 Empathy",
+				"Ritual Magic"
+			],
+			"difficulty": "h",
+			"college": [
+				"Communication \u0026 Empathy"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Info",
+			"casting_cost": "2",
+			"maintenance_cost": "-",
+			"casting_time": "1 sec",
+			"duration": "Instant",
+			"base_skill": "Ritual Magic",
+			"prereq_count": 2,
+			"points": 2,
+			"calc": {
+				"level": 10,
+				"rsl": "-7"
+			}
+		}
+	],
+	"created_date": "2023-01-14T22:39:22Z",
+	"modified_date": "2023-01-15T21:21:50Z",
+	"calc": {
+		"swing": "1d-1",
+		"thrust": "1d-2",
+		"basic_lift": "16 lb",
+		"move": [
+			5,
+			4,
+			3,
+			2,
+			1
+		],
+		"dodge": [
+			8,
+			7,
+			6,
+			5,
+			4
+		]
+	}
+}

--- a/Library/Basic Set/Characters/Xing La.gcs
+++ b/Library/Basic Set/Characters/Xing La.gcs
@@ -1,0 +1,3460 @@
+{
+	"type": "character",
+	"version": 4,
+	"id": "25554a29-e43a-4ef0-b457-b6484cfd9581",
+	"total_points": 225,
+	"points_record": [
+		{
+			"when": "2023-01-16T06:52:39Z",
+			"points": 225,
+			"reason": "Initial points"
+		}
+	],
+	"profile": {
+		"player_name": "NPC",
+		"name": "Xing La",
+		"age": "27",
+		"gender": "Female",
+		"tech_level": "8",
+		"height": "5'9\"",
+		"weight": "163 lb"
+	},
+	"settings": {
+		"page": {
+			"paper_size": "letter",
+			"orientation": "portrait",
+			"top_margin": "0.25 in",
+			"left_margin": "0.25 in",
+			"bottom_margin": "0.25 in",
+			"right_margin": "0.25 in"
+		},
+		"block_layout": [
+			"reactions conditional_modifiers",
+			"melee",
+			"ranged",
+			"traits skills",
+			"spells",
+			"equipment",
+			"other_equipment",
+			"notes"
+		],
+		"attributes": [
+			{
+				"id": "st",
+				"type": "integer",
+				"name": "ST",
+				"full_name": "Strength",
+				"attribute_base": "10",
+				"cost_per_point": 10,
+				"cost_adj_percent_per_sm": 10
+			},
+			{
+				"id": "dx",
+				"type": "integer",
+				"name": "DX",
+				"full_name": "Dexterity",
+				"attribute_base": "10",
+				"cost_per_point": 20
+			},
+			{
+				"id": "iq",
+				"type": "integer",
+				"name": "IQ",
+				"full_name": "Intelligence",
+				"attribute_base": "10",
+				"cost_per_point": 20
+			},
+			{
+				"id": "ht",
+				"type": "integer",
+				"name": "HT",
+				"full_name": "Health",
+				"attribute_base": "10",
+				"cost_per_point": 10
+			},
+			{
+				"id": "will",
+				"type": "integer",
+				"name": "Will",
+				"attribute_base": "$iq",
+				"cost_per_point": 5
+			},
+			{
+				"id": "fright_check",
+				"type": "integer",
+				"name": "Fright Check",
+				"attribute_base": "$will",
+				"cost_per_point": 2
+			},
+			{
+				"id": "senses",
+				"type": "secondary_separator",
+				"name": "Senses"
+			},
+			{
+				"id": "per",
+				"type": "integer",
+				"name": "Per",
+				"full_name": "Perception",
+				"attribute_base": "$iq",
+				"cost_per_point": 5
+			},
+			{
+				"id": "vision",
+				"type": "integer",
+				"name": "Vision",
+				"attribute_base": "$per",
+				"cost_per_point": 2
+			},
+			{
+				"id": "hearing",
+				"type": "integer",
+				"name": "Hearing",
+				"attribute_base": "$per",
+				"cost_per_point": 2
+			},
+			{
+				"id": "taste_smell",
+				"type": "integer",
+				"name": "Taste \u0026 Smell",
+				"attribute_base": "$per",
+				"cost_per_point": 2
+			},
+			{
+				"id": "touch",
+				"type": "integer",
+				"name": "Touch",
+				"attribute_base": "$per",
+				"cost_per_point": 2
+			},
+			{
+				"id": "movement",
+				"type": "secondary_separator",
+				"name": "Movement"
+			},
+			{
+				"id": "basic_speed",
+				"type": "decimal",
+				"name": "Basic Speed",
+				"attribute_base": "($dx+$ht)/4",
+				"cost_per_point": 20
+			},
+			{
+				"id": "basic_move",
+				"type": "integer",
+				"name": "Basic Move",
+				"attribute_base": "floor($basic_speed)",
+				"cost_per_point": 5
+			},
+			{
+				"id": "highjump",
+				"type": "integer_ref",
+				"name": "High Jump (in)",
+				"attribute_base": "(6 * max(max($basic_move, floor(skill_level(jumping) / 2)), $st / 4) - 10) * enc(false, true) * (2 ^ max(0, trait_level(super jump)))"
+			},
+			{
+				"id": "running_highjump",
+				"type": "integer_ref",
+				"name": "when running",
+				"attribute_base": "(6 * max(max($basic_move, floor(skill_level(jumping) / 2)), $st / 4) * (1 + max(0, trait_level(\"enhanced move (ground)\"))) - 10) * enc(false, true) * if(trait_level(\"enhanced move (ground)\")\u003c1,2,1) * (2 ^ max(0, trait_level(super jump)))"
+			},
+			{
+				"id": "broadjump",
+				"type": "integer_ref",
+				"name": "Broad Jump (ft)",
+				"attribute_base": "(2 * max(max($basic_move, floor(skill_level(jumping) / 2)), $st / 4) - 3) * enc(false, true) * (2 ^ max(0, trait_level(super jump)))"
+			},
+			{
+				"id": "running_broadjump",
+				"type": "integer_ref",
+				"name": "when running",
+				"attribute_base": "(2 * max(max($basic_move, floor(skill_level(jumping) / 2)), $st / 4) * (1 + max(0, trait_level(\"enhanced move (ground)\"))) - 3) * enc(false, true) * if(trait_level(\"enhanced move (ground)\")\u003c1,2,1) * (2 ^ max(0, trait_level(super jump)))"
+			},
+			{
+				"id": "fp",
+				"type": "pool",
+				"name": "FP",
+				"full_name": "Fatigue Points",
+				"attribute_base": "$ht",
+				"cost_per_point": 3,
+				"thresholds": [
+					{
+						"state": "Unconscious",
+						"expression": "-$fp",
+						"ops": [
+							"halve_move",
+							"halve_dodge",
+							"halve_st"
+						]
+					},
+					{
+						"state": "Collapse",
+						"expression": "0",
+						"explanation": "Roll vs. Will to do anything besides talk or rest; failure causes unconsciousness\nEach FP you lose below 0 also causes 1 HP of injury\nMove, Dodge and ST are halved (B426)",
+						"ops": [
+							"halve_move",
+							"halve_dodge",
+							"halve_st"
+						]
+					},
+					{
+						"state": "Tired",
+						"expression": "round($fp/3)",
+						"explanation": "Move, Dodge and ST are halved (B426)",
+						"ops": [
+							"halve_move",
+							"halve_dodge",
+							"halve_st"
+						]
+					},
+					{
+						"state": "Tiring",
+						"expression": "$fp-1"
+					},
+					{
+						"state": "Rested",
+						"expression": "$fp"
+					}
+				]
+			},
+			{
+				"id": "hp",
+				"type": "pool",
+				"name": "HP",
+				"full_name": "Hit Points",
+				"attribute_base": "$st",
+				"cost_per_point": 2,
+				"cost_adj_percent_per_sm": 10,
+				"thresholds": [
+					{
+						"state": "Dead",
+						"expression": "round(-$hp*5)",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Dying #4",
+						"expression": "round(-$hp*4)",
+						"explanation": "Roll vs. HT to avoid death\nRoll vs. HT-4 every second to avoid falling unconscious\nMove and Dodge are halved (B419)",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Dying #3",
+						"expression": "round(-$hp*3)",
+						"explanation": "Roll vs. HT to avoid death\nRoll vs. HT-3 every second to avoid falling unconscious\nMove and Dodge are halved (B419)",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Dying #2",
+						"expression": "round(-$hp*2)",
+						"explanation": "Roll vs. HT to avoid death\nRoll vs. HT-2 every second to avoid falling unconscious\nMove and Dodge are halved (B419)",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Dying #1",
+						"expression": "-$hp",
+						"explanation": "Roll vs. HT to avoid death\nRoll vs. HT-1 every second to avoid falling unconscious\nMove and Dodge are halved (B419)",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Collapse",
+						"expression": "0",
+						"explanation": "Roll vs. HT every second to avoid falling unconscious\nMove and Dodge are halved (B419)",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Reeling",
+						"expression": "round($hp/3)",
+						"explanation": "Move and Dodge are halved (B419)",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Wounded",
+						"expression": "$hp-1"
+					},
+					{
+						"state": "Healthy",
+						"expression": "$hp"
+					}
+				]
+			}
+		],
+		"body_type": {
+			"name": "Humanoid",
+			"roll": "3d",
+			"locations": [
+				{
+					"id": "eye",
+					"choice_name": "Eyes",
+					"table_name": "Eyes",
+					"hit_penalty": -9,
+					"description": "An attack that misses by 1 hits the torso instead. Only\nimpaling (imp), piercing (pi-, pi, pi+, pi++), and\ntight-beam burning (burn) attacks can target the eye – and\nonly from the front or sides. Injury over HP÷10 blinds the\neye. Otherwise, treat as skull, but without the extra DR!",
+					"calc": {
+						"roll_range": "-",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "skull",
+					"choice_name": "Skull",
+					"table_name": "Skull",
+					"slots": 2,
+					"hit_penalty": -7,
+					"dr_bonus": 2,
+					"description": "An attack that misses by 1 hits the torso instead. Wounding\nmodifier is x4. Knockdown rolls are at -10. Critical hits\nuse the Critical Head Blow Table (B556). Exception: These\nspecial effects do not apply to toxic (tox) damage.",
+					"calc": {
+						"roll_range": "3-4",
+						"dr": {
+							"all": 2
+						}
+					}
+				},
+				{
+					"id": "face",
+					"choice_name": "Face",
+					"table_name": "Face",
+					"slots": 1,
+					"hit_penalty": -5,
+					"description": "An attack that misses by 1 hits the torso instead. Jaw,\ncheeks, nose, ears, etc. If the target has an open-faced\nhelmet, ignore its DR. Knockdown rolls are at -5. Critical\nhits use the Critical Head Blow Table (B556). Corrosion\n(cor) damage gets a x1½ wounding modifier, and if it\ninflicts a major wound, it also blinds one eye (both eyes on\ndamage over full HP). Random attacks from behind hit the\nskull instead.",
+					"calc": {
+						"roll_range": "5",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "leg",
+					"choice_name": "Leg",
+					"table_name": "Right Leg",
+					"slots": 2,
+					"hit_penalty": -2,
+					"description": "Reduce the wounding multiplier of large piercing (pi+), huge\npiercing (pi++), and impaling (imp) damage to x1. Any major\nwound (loss of over ½ HP from one blow) cripples the limb.\nDamage beyond that threshold is lost.",
+					"calc": {
+						"roll_range": "6-7",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "arm",
+					"choice_name": "Arm",
+					"table_name": "Right Arm",
+					"slots": 1,
+					"hit_penalty": -2,
+					"description": "Reduce the wounding multiplier of large piercing (pi+), huge\npiercing (pi++), and impaling (imp) damage to x1. Any major\nwound (loss of over ½ HP from one blow) cripples the limb.\nDamage beyond that threshold is lost. If holding a shield,\ndouble the penalty to hit: -4 for shield arm instead of -2.",
+					"calc": {
+						"roll_range": "8",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "torso",
+					"choice_name": "Torso",
+					"table_name": "Torso",
+					"slots": 2,
+					"calc": {
+						"roll_range": "9-10",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "groin",
+					"choice_name": "Groin",
+					"table_name": "Groin",
+					"slots": 1,
+					"hit_penalty": -3,
+					"description": "An attack that misses by 1 hits the torso instead. Human\nmales and the males of similar species suffer double shock\nfrom crushing (cr) damage, and get -5 to knockdown rolls.\nOtherwise, treat as a torso hit.",
+					"calc": {
+						"roll_range": "11",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "arm",
+					"choice_name": "Arm",
+					"table_name": "Left Arm",
+					"slots": 1,
+					"hit_penalty": -2,
+					"description": "Reduce the wounding multiplier of large piercing (pi+), huge\npiercing (pi++), and impaling (imp) damage to x1. Any major\nwound (loss of over ½ HP from one blow) cripples the limb.\nDamage beyond that threshold is lost. If holding a shield,\ndouble the penalty to hit: -4 for shield arm instead of -2.",
+					"calc": {
+						"roll_range": "12",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "leg",
+					"choice_name": "Leg",
+					"table_name": "Left Leg",
+					"slots": 2,
+					"hit_penalty": -2,
+					"description": "Reduce the wounding multiplier of large piercing (pi+), huge\npiercing (pi++), and impaling (imp) damage to x1. Any major\nwound (loss of over ½ HP from one blow) cripples the limb.\nDamage beyond that threshold is lost.",
+					"calc": {
+						"roll_range": "13-14",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "hand",
+					"choice_name": "Hand",
+					"table_name": "Hand",
+					"slots": 1,
+					"hit_penalty": -4,
+					"description": "If holding a shield, double the penalty to hit: -8 for\nshield hand instead of -4. Reduce the wounding multiplier of\nlarge piercing (pi+), huge piercing (pi++), and impaling\n(imp) damage to x1. Any major wound (loss of over ⅓ HP\nfrom one blow) cripples the extremity. Damage beyond that\nthreshold is lost.",
+					"calc": {
+						"roll_range": "15",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "foot",
+					"choice_name": "Foot",
+					"table_name": "Foot",
+					"slots": 1,
+					"hit_penalty": -4,
+					"description": "Reduce the wounding multiplier of large piercing (pi+), huge\npiercing (pi++), and impaling (imp) damage to x1. Any major\nwound (loss of over ⅓ HP from one blow) cripples the\nextremity. Damage beyond that threshold is lost.",
+					"calc": {
+						"roll_range": "16",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "neck",
+					"choice_name": "Neck",
+					"table_name": "Neck",
+					"slots": 2,
+					"hit_penalty": -5,
+					"description": "An attack that misses by 1 hits the torso instead. Neck and\nthroat. Increase the wounding multiplier of crushing (cr)\nand corrosion (cor) attacks to x1½, and that of cutting\n(cut) damage to x2. At the GM’s option, anyone killed by a\ncutting (cut) blow to the neck is decapitated!",
+					"calc": {
+						"roll_range": "17-18",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "vitals",
+					"choice_name": "Vitals",
+					"table_name": "Vitals",
+					"hit_penalty": -3,
+					"description": "An attack that misses by 1 hits the torso instead. Heart,\nlungs, kidneys, etc. Increase the wounding modifier for an\nimpaling (imp) or any piercing (pi-, pi, pi+, pi++) attack\nto x3. Increase the wounding modifier for a tight-beam\nburning (burn) attack to x2. Other attacks cannot target the\nvitals.",
+					"calc": {
+						"roll_range": "-",
+						"dr": {
+							"all": 0
+						}
+					}
+				}
+			]
+		},
+		"damage_progression": "basic_set",
+		"default_length_units": "ft_in",
+		"default_weight_units": "lb",
+		"user_description_display": "tooltip",
+		"modifiers_display": "inline",
+		"notes_display": "inline",
+		"skill_level_adj_display": "tooltip",
+		"show_spell_adj": true,
+		"exclude_unspent_points_from_total": false
+	},
+	"attributes": [
+		{
+			"attr_id": "st",
+			"adj": 0,
+			"calc": {
+				"value": 10,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "dx",
+			"adj": 2,
+			"calc": {
+				"value": 12,
+				"points": 40
+			}
+		},
+		{
+			"attr_id": "iq",
+			"adj": 2,
+			"calc": {
+				"value": 12,
+				"points": 40
+			}
+		},
+		{
+			"attr_id": "ht",
+			"adj": 3,
+			"calc": {
+				"value": 13,
+				"points": 30
+			}
+		},
+		{
+			"attr_id": "will",
+			"adj": 0,
+			"calc": {
+				"value": 12,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "fright_check",
+			"adj": 0,
+			"calc": {
+				"value": 12,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "senses",
+			"adj": 0
+		},
+		{
+			"attr_id": "per",
+			"adj": 0,
+			"calc": {
+				"value": 12,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "vision",
+			"adj": 0,
+			"calc": {
+				"value": 12,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "hearing",
+			"adj": 0,
+			"calc": {
+				"value": 8,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "taste_smell",
+			"adj": 0,
+			"calc": {
+				"value": 12,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "touch",
+			"adj": 0,
+			"calc": {
+				"value": 12,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "movement",
+			"adj": 0
+		},
+		{
+			"attr_id": "basic_speed",
+			"adj": 0,
+			"calc": {
+				"value": 6.25,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "basic_move",
+			"adj": 0,
+			"calc": {
+				"value": 6,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "highjump",
+			"adj": 0,
+			"calc": {
+				"value": 26,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "running_highjump",
+			"adj": 0,
+			"calc": {
+				"value": 52,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "broadjump",
+			"adj": 0,
+			"calc": {
+				"value": 9,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "running_broadjump",
+			"adj": 0,
+			"calc": {
+				"value": 18,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "fp",
+			"adj": -3,
+			"calc": {
+				"value": 10,
+				"current": 10,
+				"points": -9
+			}
+		},
+		{
+			"attr_id": "hp",
+			"adj": 0,
+			"calc": {
+				"value": 10,
+				"current": 10,
+				"points": 0
+			}
+		}
+	],
+	"traits": [
+		{
+			"id": "5b81b462-8aee-4ac3-8ba2-bda23837f176",
+			"type": "trait",
+			"name": "Natural Attacks",
+			"reference": "B271",
+			"weapons": [
+				{
+					"id": "0e9c5587-d1c5-4945-946c-3d3041ec0b4d",
+					"type": "melee_weapon",
+					"damage": {
+						"type": "cr",
+						"st": "thr",
+						"base": "-1"
+					},
+					"usage": "Bite",
+					"reach": "C",
+					"parry": "No",
+					"block": "No",
+					"defaults": [
+						{
+							"type": "dx"
+						},
+						{
+							"type": "skill",
+							"name": "Brawling"
+						}
+					],
+					"calc": {
+						"level": 12,
+						"parry": "No",
+						"block": "No",
+						"damage": "2d-2 cr"
+					}
+				},
+				{
+					"id": "335065e2-f912-4a96-b9d0-daf74b359715",
+					"type": "melee_weapon",
+					"damage": {
+						"type": "cr",
+						"st": "thr",
+						"base": "-1"
+					},
+					"usage": "Punch",
+					"reach": "C",
+					"parry": "0",
+					"defaults": [
+						{
+							"type": "dx"
+						},
+						{
+							"type": "skill",
+							"name": "Boxing"
+						},
+						{
+							"type": "skill",
+							"name": "Brawling"
+						},
+						{
+							"type": "skill",
+							"name": "Karate"
+						}
+					],
+					"calc": {
+						"level": 12,
+						"parry": "9",
+						"damage": "2d-2 cr"
+					}
+				},
+				{
+					"id": "dc2cd116-d70d-4e58-b99c-e54e34fe3143",
+					"type": "melee_weapon",
+					"damage": {
+						"type": "cr",
+						"st": "thr"
+					},
+					"usage": "Kick",
+					"reach": "C,1",
+					"parry": "No",
+					"defaults": [
+						{
+							"type": "dx",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Brawling",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Kicking"
+						},
+						{
+							"type": "skill",
+							"name": "Karate",
+							"modifier": -2
+						}
+					],
+					"calc": {
+						"level": 10,
+						"parry": "No",
+						"damage": "2d-1 cr"
+					}
+				}
+			],
+			"calc": {
+				"points": 0
+			}
+		},
+		{
+			"id": "7acf9451-bf67-4649-9ce9-6d947fbef2d6",
+			"type": "trait",
+			"name": "Language: Cantonese",
+			"reference": "B24",
+			"tags": [
+				"Advantage",
+				"Language",
+				"Mental"
+			],
+			"modifiers": [
+				{
+					"id": "ff972d9a-b925-4895-a489-f3d14999074d",
+					"type": "modifier",
+					"name": "Native",
+					"reference": "B23",
+					"cost": -6,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "e9f38c71-c4bd-45ee-a5e2-b47a33029f96",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "None",
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "6cd10ab4-c4f9-4764-a47d-0e77d105d862",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Broken",
+					"cost": 1,
+					"cost_type": "points"
+				},
+				{
+					"id": "3c7caa3c-055e-4422-ac8e-6a2d632b391c",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Accented",
+					"cost": 2,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "231ba28d-11ce-44e1-8d23-074d40ca57c6",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Native",
+					"cost": 3,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "152ad20b-dc58-4abb-b256-71da14dbb89c",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "None",
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "6304a0d6-80f3-4a5f-b3cc-3ba2ae0c8063",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Broken",
+					"cost": 1,
+					"cost_type": "points"
+				},
+				{
+					"id": "5818ab4a-2c4b-4c3e-a711-c4b6332daaca",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Accented",
+					"cost": 2,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "1b77515e-5789-49a0-8238-7242900c8c2c",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Native",
+					"cost": 3,
+					"cost_type": "points",
+					"disabled": true
+				}
+			],
+			"calc": {
+				"points": 2
+			}
+		},
+		{
+			"id": "60b480a4-347f-48ce-a11a-7f02e32adc7c",
+			"type": "trait",
+			"name": "Language: English",
+			"reference": "B24",
+			"tags": [
+				"Advantage",
+				"Language",
+				"Mental"
+			],
+			"modifiers": [
+				{
+					"id": "ff972d9a-b925-4895-a489-f3d14999074d",
+					"type": "modifier",
+					"name": "Native",
+					"reference": "B23",
+					"cost": -6,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "e9f38c71-c4bd-45ee-a5e2-b47a33029f96",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "None",
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "6cd10ab4-c4f9-4764-a47d-0e77d105d862",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Broken",
+					"cost": 1,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "3c7caa3c-055e-4422-ac8e-6a2d632b391c",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Accented",
+					"cost": 2,
+					"cost_type": "points"
+				},
+				{
+					"id": "231ba28d-11ce-44e1-8d23-074d40ca57c6",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Native",
+					"cost": 3,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "152ad20b-dc58-4abb-b256-71da14dbb89c",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "None",
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "6304a0d6-80f3-4a5f-b3cc-3ba2ae0c8063",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Broken",
+					"cost": 1,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "5818ab4a-2c4b-4c3e-a711-c4b6332daaca",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Accented",
+					"cost": 2,
+					"cost_type": "points"
+				},
+				{
+					"id": "1b77515e-5789-49a0-8238-7242900c8c2c",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Native",
+					"cost": 3,
+					"cost_type": "points",
+					"disabled": true
+				}
+			],
+			"calc": {
+				"points": 4
+			}
+		},
+		{
+			"id": "fb240f68-b74f-41bc-99a7-b05990c70148",
+			"type": "trait",
+			"name": "Language: Mandarin",
+			"reference": "B24",
+			"tags": [
+				"Advantage",
+				"Language",
+				"Mental"
+			],
+			"modifiers": [
+				{
+					"id": "ff972d9a-b925-4895-a489-f3d14999074d",
+					"type": "modifier",
+					"name": "Native",
+					"reference": "B23",
+					"cost": -6,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "e9f38c71-c4bd-45ee-a5e2-b47a33029f96",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "None",
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "6cd10ab4-c4f9-4764-a47d-0e77d105d862",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Broken",
+					"cost": 1,
+					"cost_type": "points"
+				},
+				{
+					"id": "3c7caa3c-055e-4422-ac8e-6a2d632b391c",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Accented",
+					"cost": 2,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "231ba28d-11ce-44e1-8d23-074d40ca57c6",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Native",
+					"cost": 3,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "152ad20b-dc58-4abb-b256-71da14dbb89c",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "None",
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "6304a0d6-80f3-4a5f-b3cc-3ba2ae0c8063",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Broken",
+					"cost": 1,
+					"cost_type": "points"
+				},
+				{
+					"id": "5818ab4a-2c4b-4c3e-a711-c4b6332daaca",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Accented",
+					"cost": 2,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "1b77515e-5789-49a0-8238-7242900c8c2c",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Native",
+					"cost": 3,
+					"cost_type": "points",
+					"disabled": true
+				}
+			],
+			"calc": {
+				"points": 2
+			}
+		},
+		{
+			"id": "2be0f6d2-2653-48fb-a500-00c7ae203f7b",
+			"type": "trait",
+			"name": "Language: Shanghainese",
+			"reference": "B24",
+			"tags": [
+				"Advantage",
+				"Language",
+				"Mental"
+			],
+			"modifiers": [
+				{
+					"id": "ff972d9a-b925-4895-a489-f3d14999074d",
+					"type": "modifier",
+					"name": "Native",
+					"reference": "B23",
+					"cost": -6,
+					"cost_type": "points"
+				},
+				{
+					"id": "e9f38c71-c4bd-45ee-a5e2-b47a33029f96",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "None",
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "6cd10ab4-c4f9-4764-a47d-0e77d105d862",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Broken",
+					"cost": 1,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "3c7caa3c-055e-4422-ac8e-6a2d632b391c",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Accented",
+					"cost": 2,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "231ba28d-11ce-44e1-8d23-074d40ca57c6",
+					"type": "modifier",
+					"name": "Spoken",
+					"reference": "B24",
+					"notes": "Native",
+					"cost": 3,
+					"cost_type": "points"
+				},
+				{
+					"id": "152ad20b-dc58-4abb-b256-71da14dbb89c",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "None",
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "6304a0d6-80f3-4a5f-b3cc-3ba2ae0c8063",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Broken",
+					"cost": 1,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "5818ab4a-2c4b-4c3e-a711-c4b6332daaca",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Accented",
+					"cost": 2,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "1b77515e-5789-49a0-8238-7242900c8c2c",
+					"type": "modifier",
+					"name": "Written",
+					"reference": "B24",
+					"notes": "Native",
+					"cost": 3,
+					"cost_type": "points"
+				}
+			],
+			"calc": {
+				"points": 0
+			}
+		},
+		{
+			"id": "2443991c-d128-46d8-9f1f-b93c19ba9a47",
+			"type": "trait",
+			"name": "Cultural Familiarity (East Asian)",
+			"reference": "B23",
+			"notes": "Do not suffer the normal -3 penalty for unfamiliarity",
+			"tags": [
+				"Advantage",
+				"Mental"
+			],
+			"modifiers": [
+				{
+					"id": "ab12b725-01c8-4fc4-8e71-619a54c79496",
+					"type": "modifier",
+					"name": "Alien",
+					"cost": 1,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "f72aa995-6766-4eaf-a3ca-0f4ff76d47c5",
+					"type": "modifier",
+					"name": "Native",
+					"cost": -1,
+					"cost_type": "points"
+				}
+			],
+			"base_points": 1,
+			"calc": {
+				"points": 0
+			}
+		},
+		{
+			"id": "4456ef75-ecd5-4adc-b1e9-43cbcc398593",
+			"type": "trait",
+			"name": "Cultural Familiarity (Homeline)",
+			"reference": "B23",
+			"notes": "Do not suffer the normal -3 penalty for unfamiliarity",
+			"tags": [
+				"Advantage",
+				"Mental"
+			],
+			"modifiers": [
+				{
+					"id": "ab12b725-01c8-4fc4-8e71-619a54c79496",
+					"type": "modifier",
+					"name": "Alien",
+					"cost": 1,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "f72aa995-6766-4eaf-a3ca-0f4ff76d47c5",
+					"type": "modifier",
+					"name": "Native",
+					"cost": -1,
+					"cost_type": "points",
+					"disabled": true
+				}
+			],
+			"base_points": 1,
+			"calc": {
+				"points": 1
+			}
+		},
+		{
+			"id": "bd8b7ebe-f42c-49a5-a611-a0d706b0d840",
+			"type": "trait",
+			"name": "Absolute Direction",
+			"reference": "B34",
+			"tags": [
+				"Advantage",
+				"Mental",
+				"Physical"
+			],
+			"modifiers": [
+				{
+					"id": "940c9da3-6966-4ea6-9974-517614d0606b",
+					"type": "modifier",
+					"name": "Requires signal",
+					"reference": "B34",
+					"cost": -20,
+					"disabled": true
+				},
+				{
+					"id": "12730389-6652-4df8-8b34-ad078b76e408",
+					"type": "modifier",
+					"name": "3D Spatial Sense",
+					"reference": "B34",
+					"cost": 5,
+					"cost_type": "points",
+					"disabled": true,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "starts_with",
+								"qualifier": "piloting"
+							},
+							"amount": 1
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "aerobatics"
+							},
+							"amount": 2
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "free fall"
+							},
+							"amount": 2
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "navigation"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "hyperspace"
+							},
+							"amount": 2
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "navigation"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "space"
+							},
+							"amount": 2
+						}
+					]
+				}
+			],
+			"base_points": 5,
+			"features": [
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "body sense"
+					},
+					"amount": 3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "navigation"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "air"
+					},
+					"amount": 3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "navigation"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "land"
+					},
+					"amount": 3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "navigation"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "sea"
+					},
+					"amount": 3
+				}
+			],
+			"calc": {
+				"points": 5
+			}
+		},
+		{
+			"id": "be65d3b3-2755-4f23-af0d-e84d7c0c56f4",
+			"type": "trait",
+			"name": "Breath-Holding",
+			"reference": "B41",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Physical"
+			],
+			"levels": 3,
+			"points_per_level": 2,
+			"can_level": true,
+			"calc": {
+				"points": 6
+			}
+		},
+		{
+			"id": "07d8c704-c2f3-45ca-9ea1-f8826314adb2",
+			"type": "trait",
+			"name": "Discriminatory Smell",
+			"reference": "B49,P47",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Physical"
+			],
+			"modifiers": [
+				{
+					"id": "17ab7dd3-7774-4c6f-b4b8-f4e209866f47",
+					"type": "modifier",
+					"name": "Emotion Sense",
+					"reference": "B49",
+					"cost": 50,
+					"disabled": true
+				},
+				{
+					"id": "5b99c3b7-6e6e-44a5-b0e5-e7738f4a1ede",
+					"type": "modifier",
+					"name": "Profiling",
+					"reference": "P47",
+					"cost": 50,
+					"disabled": true
+				}
+			],
+			"base_points": 15,
+			"calc": {
+				"points": 15
+			}
+		},
+		{
+			"id": "1219b048-9b30-4d4e-bf86-640695d67482",
+			"type": "trait",
+			"name": "Infravision",
+			"reference": "B60,P87",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Physical"
+			],
+			"modifiers": [
+				{
+					"id": "3e2a555d-c6fe-44a5-ad72-d83e881f28fc",
+					"type": "modifier",
+					"name": "No normal vision",
+					"reference": "B60",
+					"cost": -10,
+					"cost_type": "points",
+					"disabled": true
+				}
+			],
+			"base_points": 10,
+			"calc": {
+				"points": 10
+			}
+		},
+		{
+			"id": "a59977bc-9107-4d0e-b6d3-98524b884ebb",
+			"type": "trait",
+			"name": "Legal Enforcement Powers",
+			"reference": "B65",
+			"tags": [
+				"Advantage",
+				"Social"
+			],
+			"levels": 3,
+			"points_per_level": 5,
+			"can_level": true,
+			"calc": {
+				"points": 15
+			}
+		},
+		{
+			"id": "a4dcda9c-5866-44fc-aedc-849e023632a2",
+			"type": "trait",
+			"name": "Pressure Support",
+			"reference": "B77",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Physical"
+			],
+			"levels": 1,
+			"points_per_level": 5,
+			"can_level": true,
+			"calc": {
+				"points": 5
+			}
+		},
+		{
+			"id": "d2a5160e-d0ad-4639-92e2-f6aa91e90d74",
+			"type": "trait",
+			"name": "Sanitized Metabolism",
+			"reference": "B101",
+			"tags": [
+				"Perk",
+				"Physical"
+			],
+			"base_points": 1,
+			"features": [
+				{
+					"type": "reaction_bonus",
+					"situation": "from others in close confines",
+					"amount": 1
+				},
+				{
+					"type": "conditional_modifier",
+					"situation": "to attempts to track you by scent",
+					"amount": -1
+				}
+			],
+			"calc": {
+				"points": 1
+			}
+		},
+		{
+			"id": "0c4c407d-b732-47e0-bc97-b345a980cd7a",
+			"type": "trait",
+			"name": "Striking ST",
+			"reference": "B88,P78",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Physical"
+			],
+			"modifiers": [
+				{
+					"id": "9b8e80e8-e2b2-459f-ab27-d96a9aa1e1ca",
+					"type": "modifier",
+					"name": "No Fine Manipulators",
+					"cost": -40,
+					"disabled": true
+				},
+				{
+					"id": "32892d90-82df-401d-bddc-d39a12d0f8b7",
+					"type": "modifier",
+					"name": "Size",
+					"cost": -10,
+					"levels": 1,
+					"disabled": true
+				},
+				{
+					"id": "eaabe509-f453-401a-89c1-4830111d0544",
+					"type": "modifier",
+					"name": "Super Effort",
+					"reference": "SU24",
+					"cost": 400,
+					"disabled": true
+				},
+				{
+					"id": "f35b516b-28d2-4935-8caa-e9f85f5310e0",
+					"type": "modifier",
+					"name": "One Attack Only",
+					"reference": "P79",
+					"notes": "Bite",
+					"cost": -60
+				},
+				{
+					"id": "4c469f7d-a2fc-45fa-9b19-a51985d575cd",
+					"type": "modifier",
+					"name": "Know Your Own Strength Pricing Variant",
+					"reference": "PY83:18",
+					"cost": -4,
+					"affects": "levels_only",
+					"cost_type": "points",
+					"disabled": true
+				}
+			],
+			"levels": 10,
+			"points_per_level": 5,
+			"features": [
+				{
+					"type": "attribute_bonus",
+					"limitation": "striking_only",
+					"attribute": "st",
+					"amount": 1,
+					"per_level": true
+				}
+			],
+			"can_level": true,
+			"calc": {
+				"points": 20
+			}
+		},
+		{
+			"id": "04f0c67b-126e-460c-af61-880d58c4543e",
+			"type": "trait",
+			"name": "Talent (Artificer)",
+			"reference": "B90",
+			"tags": [
+				"Advantage",
+				"Mental",
+				"Talent"
+			],
+			"levels": 2,
+			"points_per_level": 10,
+			"features": [
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "armoury"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Carpentry"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electrician"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Repair"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Masonry"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Smith"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "reaction_bonus",
+					"situation": "from any employer",
+					"amount": 1,
+					"per_level": true
+				}
+			],
+			"can_level": true,
+			"calc": {
+				"points": 20
+			}
+		},
+		{
+			"id": "1ba455af-634b-4893-9dd0-ada172377088",
+			"type": "trait",
+			"name": "Clueless",
+			"reference": "B126",
+			"tags": [
+				"Disadvantage",
+				"Mental"
+			],
+			"base_points": -10,
+			"features": [
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "starts_with",
+						"qualifier": "savoir-faire"
+					},
+					"amount": -4
+				},
+				{
+					"type": "reaction_bonus",
+					"situation": "from others for being clueless",
+					"amount": -2
+				},
+				{
+					"type": "conditional_modifier",
+					"situation": "to resist Sex Appeal",
+					"amount": 4
+				}
+			],
+			"calc": {
+				"points": -10
+			}
+		},
+		{
+			"id": "aa6f517d-37b8-4dc8-bfea-60a487c664e2",
+			"type": "trait",
+			"name": "Disturbing Voice",
+			"reference": "B132",
+			"tags": [
+				"Disadvantage",
+				"Physical"
+			],
+			"base_points": -10,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "voice"
+						}
+					}
+				]
+			},
+			"features": [
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "diplomacy"
+					},
+					"amount": -2
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "fast-talk"
+					},
+					"amount": -2
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "performance"
+					},
+					"amount": -2
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "public speaking"
+					},
+					"amount": -2
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "sex appeal"
+					},
+					"amount": -2
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "singing"
+					},
+					"amount": -2
+				}
+			],
+			"calc": {
+				"points": -10
+			}
+		},
+		{
+			"id": "0bbc057b-c688-489c-a718-f8533bdc6f8e",
+			"type": "trait",
+			"name": "Duty (To ISWAT)",
+			"reference": "B133",
+			"tags": [
+				"Disadvantage",
+				"Social"
+			],
+			"modifiers": [
+				{
+					"id": "fb0c80a4-4c65-4521-9e18-7378dda34a46",
+					"type": "modifier",
+					"name": "FR: 6",
+					"cost": -2,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "92ade39a-a64c-4ff4-a84b-89ab92a6e217",
+					"type": "modifier",
+					"name": "FR: 9",
+					"cost": -5,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "80577150-cbdb-4c26-bde4-1ad85a7deec2",
+					"type": "modifier",
+					"name": "FR: 12",
+					"cost": -10,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "d6406b89-6289-4b8c-b7c7-4d25add3c352",
+					"type": "modifier",
+					"name": "FR: 15",
+					"cost": -15,
+					"cost_type": "points"
+				},
+				{
+					"id": "f4458d02-9b67-42f8-8f31-5837064fb751",
+					"type": "modifier",
+					"name": "Extremely Hazardous",
+					"cost": -5,
+					"cost_type": "points"
+				},
+				{
+					"id": "814f2484-cac1-4eca-af21-f9eaca8c0d0a",
+					"type": "modifier",
+					"name": "Involuntary",
+					"cost": -5,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "5d87b90f-fc68-4d78-8547-7c2ef58ae7bd",
+					"type": "modifier",
+					"name": "Nonhazardous",
+					"cost": 5,
+					"cost_type": "points",
+					"disabled": true
+				}
+			],
+			"calc": {
+				"points": -20
+			}
+		},
+		{
+			"id": "5d427e6f-f3a2-4b44-80e3-8749f0999885",
+			"type": "trait",
+			"name": "Gluttony",
+			"reference": "B137",
+			"notes": "Make a self-control roll when presented with a tempting morsel or good wine that, for some reason, you should resist. If you fail, you partake – regardless of the consequences.",
+			"tags": [
+				"Disadvantage",
+				"Mental"
+			],
+			"base_points": -5,
+			"cr": 15,
+			"calc": {
+				"points": -2
+			}
+		},
+		{
+			"id": "2594051c-4e67-4813-9a89-cc2ac017db99",
+			"type": "trait",
+			"name": "Hard of Hearing",
+			"reference": "B138",
+			"tags": [
+				"Disadvantage",
+				"Physical"
+			],
+			"base_points": -10,
+			"features": [
+				{
+					"type": "attribute_bonus",
+					"attribute": "hearing",
+					"amount": -4
+				},
+				{
+					"type": "conditional_modifier",
+					"situation": "to any skill roll where it is important that you understand someone speaking",
+					"amount": -4
+				}
+			],
+			"calc": {
+				"points": -10
+			}
+		},
+		{
+			"id": "d7839991-a63e-446d-b114-d96b0f116cbd",
+			"type": "trait",
+			"name": "Low Empathy",
+			"reference": "B142",
+			"tags": [
+				"Disadvantage",
+				"Mental"
+			],
+			"base_points": -20,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "oblivious"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "callous"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "empathy"
+						}
+					}
+				]
+			},
+			"features": [
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "acting"
+					},
+					"amount": -3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "carousing"
+					},
+					"amount": -3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "criminology"
+					},
+					"amount": -3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "detect lies"
+					},
+					"amount": -3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "diplomacy"
+					},
+					"amount": -3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "enthrallment"
+					},
+					"amount": -3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "fast-talk"
+					},
+					"amount": -3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "interrogation"
+					},
+					"amount": -3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "leadership"
+					},
+					"amount": -3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "merchant"
+					},
+					"amount": -3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "politics"
+					},
+					"amount": -3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "contains",
+						"qualifier": "psychology"
+					},
+					"amount": -3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "contains",
+						"qualifier": "savoir-faire"
+					},
+					"amount": -3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "sex appeal"
+					},
+					"amount": -3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "sociology"
+					},
+					"amount": -3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "streetwise"
+					},
+					"amount": -3
+				}
+			],
+			"calc": {
+				"points": -20
+			}
+		},
+		{
+			"id": "9a210006-bd07-43e3-973b-23d5d13614ed",
+			"type": "trait",
+			"name": "Severe Shyness",
+			"reference": "B154",
+			"notes": "You are very uncomfortable around strangers, and tend to be quiet even among friends.",
+			"tags": [
+				"Disadvantage",
+				"Mental"
+			],
+			"base_points": -10,
+			"features": [
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Acting"
+					},
+					"amount": -2
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Carousing"
+					},
+					"amount": -2
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Diplomacy"
+					},
+					"amount": -2
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Fast-Talk"
+					},
+					"amount": -2
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Intimidation"
+					},
+					"amount": -2
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Leadership"
+					},
+					"amount": -2
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Merchant"
+					},
+					"amount": -2
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Panhandling"
+					},
+					"amount": -2
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Performance"
+					},
+					"amount": -2
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Politics"
+					},
+					"amount": -2
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Public Speaking"
+					},
+					"amount": -2
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Savoir-Faire"
+					},
+					"amount": -2
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Sex Appeal"
+					},
+					"amount": -2
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Streetwise"
+					},
+					"amount": -2
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Teaching"
+					},
+					"amount": -2
+				}
+			],
+			"calc": {
+				"points": -10
+			}
+		},
+		{
+			"id": "925d4f71-853f-4a17-94af-1149d4a62412",
+			"type": "trait",
+			"name": "Skinny",
+			"reference": "B18",
+			"tags": [
+				"Disadvantage",
+				"Physical"
+			],
+			"base_points": -5,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "attribute_prereq",
+						"has": true,
+						"qualifier": {
+							"compare": "at_most",
+							"qualifier": 14
+						},
+						"which": "ht"
+					}
+				]
+			},
+			"features": [
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "disguise"
+					},
+					"amount": -2
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "shadowing"
+					},
+					"amount": -2
+				},
+				{
+					"type": "conditional_modifier",
+					"situation": "to ST vs. knockback",
+					"amount": -2
+				}
+			],
+			"calc": {
+				"points": -5
+			}
+		},
+		{
+			"id": "d6dc9931-f0cf-4533-9fed-ef5bc84f2667",
+			"type": "trait",
+			"name": "Unnatural Features (Lambent eyes and bony teeth)",
+			"reference": "B22",
+			"tags": [
+				"Disadvantage",
+				"Physical"
+			],
+			"levels": 2,
+			"points_per_level": -1,
+			"features": [
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "disguise"
+					},
+					"amount": -1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "shadowing"
+					},
+					"amount": -1,
+					"per_level": true
+				}
+			],
+			"can_level": true,
+			"calc": {
+				"points": -2
+			}
+		},
+		{
+			"id": "94ef811c-d389-425f-8317-1a39537ff73d",
+			"type": "trait",
+			"name": "Unusual Biochemistry",
+			"reference": "B160",
+			"tags": [
+				"Disadvantage",
+				"Physical"
+			],
+			"base_points": -5,
+			"calc": {
+				"points": -5
+			}
+		},
+		{
+			"id": "84af5aa1-ff9c-4db8-9087-46a73ba3e091",
+			"type": "trait",
+			"name": "Struggling",
+			"reference": "B25",
+			"notes": "Starting wealth is ½ normal",
+			"tags": [
+				"Disadvantage",
+				"Social",
+				"Wealth"
+			],
+			"base_points": -10,
+			"calc": {
+				"points": -10
+			}
+		},
+		{
+			"id": "fe753f7a-2646-4b9a-b961-336e5a7d2445",
+			"type": "trait",
+			"name": "Quirk: Attentive",
+			"reference": "B163",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"features": [
+				{
+					"type": "conditional_modifier",
+					"situation": "to skill rolls when working on lengthy tasks, but -3 to notice any important interruption",
+					"amount": 1
+				}
+			],
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "c539abdb-d9b8-4abb-872a-d39057eda6d1",
+			"type": "trait",
+			"name": "Quirk: Bad posture",
+			"reference": "B164",
+			"notes": "-1 to Dancing and Sex Appeal",
+			"tags": [
+				"Physical",
+				"Quirk"
+			],
+			"base_points": -1,
+			"features": [
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Sex Appeal"
+					},
+					"amount": -1
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Dancing"
+					},
+					"amount": -1
+				}
+			],
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "493a9c66-0517-45cc-abb9-887550516290",
+			"type": "trait",
+			"name": "Quirk: Code of Honor - Stay bought and finish the job",
+			"reference": "B162",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "22e376a6-4865-47ba-97f5-6eeb299bbca4",
+			"type": "trait",
+			"name": "Quirk: Incompetence (Finance)",
+			"reference": "B164",
+			"notes": "May only know Finance at default (i.e. no points spent)",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"features": [
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Finance"
+					},
+					"amount": -4
+				}
+			],
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "488dec3e-58b7-4b52-bb6b-3aaf89310c78",
+			"type": "trait",
+			"name": "Quirk: Likes processed food (especially fast food)",
+			"reference": "B162",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		}
+	],
+	"skills": [
+		{
+			"id": "7b24df6e-f588-4028-a579-b13cd9ad07c8",
+			"type": "skill",
+			"name": "Airshipman",
+			"reference": "B185",
+			"tags": [
+				"Vehicle"
+			],
+			"tech_level": "7",
+			"difficulty": "iq/e",
+			"points": 2,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -4,
+				"level": 8,
+				"adjusted_level": 8,
+				"points": -8
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -4
+				}
+			],
+			"calc": {
+				"level": 13,
+				"rsl": "IQ+1"
+			}
+		},
+		{
+			"id": "ae026507-d205-4fb5-b492-fdbdb8a99a17",
+			"type": "skill",
+			"name": "Armoury",
+			"reference": "B178",
+			"tags": [
+				"Maintenance",
+				"Military",
+				"Repair"
+			],
+			"specialization": "Heavy Weapons",
+			"tech_level": "7",
+			"difficulty": "iq/a",
+			"points": 1,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -5,
+				"level": 7,
+				"adjusted_level": 7,
+				"points": -7
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Engineer",
+					"specialization": "Heavy Weapons",
+					"modifier": -4
+				}
+			],
+			"calc": {
+				"level": 13,
+				"rsl": "IQ+1"
+			}
+		},
+		{
+			"id": "d7c661d6-882b-47f8-a5cd-a1e6b6663231",
+			"type": "skill",
+			"name": "Axe/Mace",
+			"reference": "B208",
+			"tags": [
+				"Combat",
+				"Melee Combat",
+				"Weapon"
+			],
+			"difficulty": "dx/a",
+			"points": 2,
+			"defaulted_from": {
+				"type": "dx",
+				"modifier": -5,
+				"level": 7,
+				"adjusted_level": 7,
+				"points": -7
+			},
+			"defaults": [
+				{
+					"type": "dx",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Two-Handed Axe/Mace",
+					"modifier": -3
+				},
+				{
+					"type": "skill",
+					"name": "Flail",
+					"modifier": -4
+				}
+			],
+			"calc": {
+				"level": 12,
+				"rsl": "DX+0"
+			}
+		},
+		{
+			"id": "85fc04b2-6627-48e5-bd0c-661595479a56",
+			"type": "skill",
+			"name": "Breath Control",
+			"reference": "B182",
+			"tags": [
+				"Athletic"
+			],
+			"difficulty": "ht/h",
+			"points": 8,
+			"calc": {
+				"level": 14,
+				"rsl": "HT+1"
+			}
+		},
+		{
+			"id": "c09730ae-cdca-4cc1-ba2f-3bc89d21f76b",
+			"type": "skill",
+			"name": "Drive!",
+			"reference": "B175",
+			"difficulty": "dx/w",
+			"points": 72,
+			"calc": {
+				"level": 16,
+				"rsl": "DX+4"
+			}
+		},
+		{
+			"id": "da4df35d-521a-421f-a742-ba12d692ad48",
+			"type": "skill",
+			"name": "Electrician",
+			"reference": "B189",
+			"tags": [
+				"Maintenance",
+				"Repair"
+			],
+			"tech_level": "7",
+			"difficulty": "iq/a",
+			"points": 1,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -5,
+				"level": 7,
+				"adjusted_level": 7,
+				"points": -7
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Engineer",
+					"specialization": "Electrical",
+					"modifier": -3
+				}
+			],
+			"calc": {
+				"level": 13,
+				"rsl": "IQ+1"
+			}
+		},
+		{
+			"id": "60923589-854a-4e68-a21e-f84efbd947d0",
+			"type": "skill",
+			"name": "Electronics Repair",
+			"reference": "B190",
+			"tags": [
+				"Maintenance",
+				"Repair"
+			],
+			"specialization": "Sensors",
+			"tech_level": "7",
+			"difficulty": "iq/a",
+			"points": 4,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -5,
+				"level": 7,
+				"adjusted_level": 7,
+				"points": -7
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Electronics Operation",
+					"specialization": "Sensors",
+					"modifier": -3
+				},
+				{
+					"type": "skill",
+					"name": "Engineer",
+					"specialization": "Electronics",
+					"modifier": -3
+				},
+				{
+					"type": "skill",
+					"name": "Electronics Repair",
+					"modifier": -4
+				}
+			],
+			"calc": {
+				"level": 15,
+				"rsl": "IQ+3"
+			}
+		},
+		{
+			"id": "2f6e4233-e81b-440a-9823-d2fabceae981",
+			"type": "skill",
+			"name": "Electronics Repair",
+			"reference": "B190",
+			"tags": [
+				"Maintenance",
+				"Repair"
+			],
+			"specialization": "Sonar",
+			"tech_level": "7",
+			"difficulty": "iq/a",
+			"points": 2,
+			"defaulted_from": {
+				"type": "skill",
+				"name": "Electronics Repair",
+				"specialization": "Sensors",
+				"modifier": -4,
+				"level": 9,
+				"adjusted_level": 9,
+				"points": -9
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Electronics Operation",
+					"specialization": "Sonar",
+					"modifier": -3
+				},
+				{
+					"type": "skill",
+					"name": "Engineer",
+					"specialization": "Electronics",
+					"modifier": -3
+				},
+				{
+					"type": "skill",
+					"name": "Electronics Repair",
+					"modifier": -4
+				}
+			],
+			"calc": {
+				"level": 14,
+				"rsl": "IQ+2"
+			}
+		},
+		{
+			"id": "2f8c9d59-6450-4638-a7e0-b64b2d8db76f",
+			"type": "skill",
+			"name": "Fishing",
+			"reference": "B195",
+			"tags": [
+				"Exploration",
+				"Outdoor"
+			],
+			"difficulty": "per/e",
+			"points": 1,
+			"defaulted_from": {
+				"type": "per",
+				"modifier": -4,
+				"level": 8,
+				"adjusted_level": 8,
+				"points": -8
+			},
+			"defaults": [
+				{
+					"type": "per",
+					"modifier": -4
+				}
+			],
+			"calc": {
+				"level": 12,
+				"rsl": "Per+0"
+			}
+		},
+		{
+			"id": "31dd276a-a3b7-4707-98ba-bf0b28feb14b",
+			"type": "skill",
+			"name": "Gunner",
+			"reference": "B198",
+			"tags": [
+				"Combat",
+				"Ranged Combat",
+				"Weapon"
+			],
+			"specialization": "Rockets",
+			"tech_level": "7",
+			"difficulty": "dx/e",
+			"points": 4,
+			"defaulted_from": {
+				"type": "dx",
+				"modifier": -4,
+				"level": 8,
+				"adjusted_level": 8,
+				"points": -8
+			},
+			"defaults": [
+				{
+					"type": "dx",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Gunner",
+					"modifier": -4
+				}
+			],
+			"calc": {
+				"level": 14,
+				"rsl": "DX+2"
+			}
+		},
+		{
+			"id": "a4aaa242-8fe5-4403-a66f-abd4ff8087b8",
+			"type": "skill",
+			"name": "Knot-Tying",
+			"reference": "B203,MA58",
+			"tags": [
+				"Everyman"
+			],
+			"difficulty": "dx/e",
+			"points": 2,
+			"defaulted_from": {
+				"type": "skill",
+				"name": "Seamanship",
+				"modifier": -4,
+				"level": 9,
+				"adjusted_level": 9,
+				"points": -9
+			},
+			"defaults": [
+				{
+					"type": "dx",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Climbing",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Seamanship",
+					"modifier": -4
+				}
+			],
+			"calc": {
+				"level": 13,
+				"rsl": "DX+1"
+			}
+		},
+		{
+			"id": "9a729c13-ccff-4731-9604-087f2fbe89e6",
+			"type": "skill",
+			"name": "Machinist",
+			"reference": "B206",
+			"tags": [
+				"Maintenance",
+				"Repair"
+			],
+			"tech_level": "7",
+			"difficulty": "iq/a",
+			"points": 1,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -5,
+				"level": 7,
+				"adjusted_level": 7,
+				"points": -7
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Mechanic",
+					"modifier": -5
+				}
+			],
+			"calc": {
+				"level": 13,
+				"rsl": "IQ+1"
+			}
+		},
+		{
+			"id": "a2adc24d-0da1-4e40-bace-767a78c507e8",
+			"type": "skill",
+			"name": "Mechanic",
+			"reference": "B207",
+			"tags": [
+				"Maintenance",
+				"Repair"
+			],
+			"specialization": "Gasoline Engine",
+			"tech_level": "7",
+			"difficulty": "iq/a",
+			"points": 2,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -5,
+				"level": 7,
+				"adjusted_level": 7,
+				"points": -7
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Engineer",
+					"specialization": "Gasoline Engine",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Machinist",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Mechanic",
+					"modifier": -4
+				}
+			],
+			"calc": {
+				"level": 14,
+				"rsl": "IQ+2"
+			}
+		},
+		{
+			"id": "767af9d0-751f-4fc9-a445-80e63222b04b",
+			"type": "skill",
+			"name": "Navigation",
+			"reference": "B211",
+			"tags": [
+				"Exploration",
+				"Outdoor",
+				"Technical",
+				"Vehicle"
+			],
+			"specialization": "Sea",
+			"tech_level": "2",
+			"difficulty": "iq/a",
+			"points": 2,
+			"defaulted_from": {
+				"type": "skill",
+				"name": "Seamanship",
+				"modifier": -5,
+				"level": 8,
+				"adjusted_level": 8,
+				"points": -8
+			},
+			"defaults": [
+				{
+					"type": "skill",
+					"name": "Astronomy",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Seamanship",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Navigation",
+					"specialization": "Air",
+					"modifier": -2
+				},
+				{
+					"type": "skill",
+					"name": "Navigation",
+					"specialization": "Land",
+					"modifier": -2
+				}
+			],
+			"calc": {
+				"level": 15,
+				"rsl": "IQ+3"
+			}
+		},
+		{
+			"id": "29344587-b6b1-4721-99b8-107d9c34686c",
+			"type": "skill",
+			"name": "Navigation",
+			"reference": "B211",
+			"tags": [
+				"Exploration",
+				"Outdoor",
+				"Technical",
+				"Vehicle"
+			],
+			"specialization": "Sea",
+			"tech_level": "7",
+			"difficulty": "iq/a",
+			"points": 1,
+			"defaulted_from": {
+				"type": "skill",
+				"name": "Seamanship",
+				"modifier": -5,
+				"level": 8,
+				"adjusted_level": 8,
+				"points": -8
+			},
+			"defaults": [
+				{
+					"type": "skill",
+					"name": "Astronomy",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Seamanship",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Navigation",
+					"specialization": "Air",
+					"modifier": -2
+				},
+				{
+					"type": "skill",
+					"name": "Navigation",
+					"specialization": "Land",
+					"modifier": -2
+				}
+			],
+			"calc": {
+				"level": 14,
+				"rsl": "IQ+2"
+			}
+		},
+		{
+			"id": "0c4b546a-9f57-41ee-a7ac-c59243a14e8b",
+			"type": "skill",
+			"name": "Scrounging",
+			"reference": "B218",
+			"tags": [
+				"Criminal",
+				"Street"
+			],
+			"difficulty": "per/e",
+			"points": 8,
+			"defaulted_from": {
+				"type": "per",
+				"modifier": -4,
+				"level": 8,
+				"adjusted_level": 8,
+				"points": -8
+			},
+			"defaults": [
+				{
+					"type": "per",
+					"modifier": -4
+				}
+			],
+			"calc": {
+				"level": 15,
+				"rsl": "Per+3"
+			}
+		},
+		{
+			"id": "fa31d38d-e419-46f4-b19e-16a0ad4ab2f6",
+			"type": "skill",
+			"name": "Scuba",
+			"reference": "B219",
+			"tags": [
+				"Athletic",
+				"Exploration",
+				"Military",
+				"Outdoor",
+				"Technical"
+			],
+			"tech_level": "8",
+			"difficulty": "iq/a",
+			"points": 1,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -5,
+				"level": 7,
+				"adjusted_level": 7,
+				"points": -7
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Diving Suit",
+					"modifier": -2
+				}
+			],
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "swimming"
+						}
+					}
+				]
+			},
+			"calc": {
+				"level": 11,
+				"rsl": "IQ-1"
+			}
+		},
+		{
+			"id": "8269fbff-1e40-41a0-96d3-6b6eb7a11a80",
+			"type": "skill",
+			"name": "Seamanship",
+			"reference": "B185",
+			"tags": [
+				"Vehicle"
+			],
+			"tech_level": "7",
+			"difficulty": "iq/e",
+			"points": 2,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -4,
+				"level": 8,
+				"adjusted_level": 8,
+				"points": -8
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -4
+				}
+			],
+			"calc": {
+				"level": 13,
+				"rsl": "IQ+1"
+			}
+		},
+		{
+			"id": "8d79fb34-5404-4a29-af7a-2885d06605d6",
+			"type": "skill",
+			"name": "Smuggling",
+			"reference": "B221",
+			"tags": [
+				"Criminal",
+				"Spy",
+				"Street"
+			],
+			"difficulty": "iq/a",
+			"points": 1,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -5,
+				"level": 7,
+				"adjusted_level": 7,
+				"points": -7
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -5
+				}
+			],
+			"calc": {
+				"level": 11,
+				"rsl": "IQ-1"
+			}
+		},
+		{
+			"id": "1d4e6c71-da4d-4cd6-9ab9-a1c5759f5622",
+			"type": "skill",
+			"name": "Spear Thrower",
+			"reference": "B222",
+			"tags": [
+				"Combat",
+				"Ranged Combat",
+				"Weapon"
+			],
+			"difficulty": "dx/a",
+			"points": 4,
+			"defaulted_from": {
+				"type": "dx",
+				"modifier": -5,
+				"level": 7,
+				"adjusted_level": 7,
+				"points": -7
+			},
+			"defaults": [
+				{
+					"type": "dx",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Thrown Weapon",
+					"specialization": "Spear",
+					"modifier": -4
+				}
+			],
+			"calc": {
+				"level": 13,
+				"rsl": "DX+1"
+			}
+		},
+		{
+			"id": "c722c178-19df-4f70-8811-763baafe5705",
+			"type": "skill",
+			"name": "Survival",
+			"reference": "B223",
+			"tags": [
+				"Exploration",
+				"Outdoor"
+			],
+			"specialization": "Island/Beach",
+			"difficulty": "per/a",
+			"points": 1,
+			"defaulted_from": {
+				"type": "skill",
+				"name": "Survival",
+				"specialization": "Swampland",
+				"modifier": -3,
+				"level": 8,
+				"adjusted_level": 8,
+				"points": -8
+			},
+			"defaults": [
+				{
+					"type": "per",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Naturalist",
+					"modifier": -3
+				},
+				{
+					"type": "skill",
+					"name": "Survival",
+					"specialization": "Tropical Lagoon",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Survival",
+					"specialization": "Arctic",
+					"modifier": -3
+				},
+				{
+					"type": "skill",
+					"name": "Survival",
+					"specialization": "Desert",
+					"modifier": -3
+				},
+				{
+					"type": "skill",
+					"name": "Survival",
+					"specialization": "Jungle",
+					"modifier": -3
+				},
+				{
+					"type": "skill",
+					"name": "Survival",
+					"specialization": "Mountain",
+					"modifier": -3
+				},
+				{
+					"type": "skill",
+					"name": "Survival",
+					"specialization": "Plains",
+					"modifier": -3
+				},
+				{
+					"type": "skill",
+					"name": "Survival",
+					"specialization": "Swampland",
+					"modifier": -3
+				},
+				{
+					"type": "skill",
+					"name": "Survival",
+					"specialization": "Woodlands",
+					"modifier": -3
+				}
+			],
+			"calc": {
+				"level": 11,
+				"rsl": "Per-1"
+			}
+		},
+		{
+			"id": "748f44a9-9e14-4d6e-a520-598847c0beaa",
+			"type": "skill",
+			"name": "Survival",
+			"reference": "B223",
+			"tags": [
+				"Exploration",
+				"Outdoor"
+			],
+			"specialization": "Swampland",
+			"difficulty": "per/a",
+			"points": 1,
+			"defaulted_from": {
+				"type": "per",
+				"modifier": -6,
+				"level": 6,
+				"adjusted_level": 6,
+				"points": -6
+			},
+			"defaults": [
+				{
+					"type": "per",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Naturalist",
+					"modifier": -3
+				},
+				{
+					"type": "skill",
+					"name": "Survival",
+					"specialization": "River/Stream",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Survival",
+					"specialization": "Arctic",
+					"modifier": -3
+				},
+				{
+					"type": "skill",
+					"name": "Survival",
+					"specialization": "Desert",
+					"modifier": -3
+				},
+				{
+					"type": "skill",
+					"name": "Survival",
+					"specialization": "Jungle",
+					"modifier": -3
+				},
+				{
+					"type": "skill",
+					"name": "Survival",
+					"specialization": "Mountain",
+					"modifier": -3
+				},
+				{
+					"type": "skill",
+					"name": "Survival",
+					"specialization": "Plains",
+					"modifier": -3
+				},
+				{
+					"type": "skill",
+					"name": "Survival",
+					"specialization": "Island/Beach",
+					"modifier": -3
+				},
+				{
+					"type": "skill",
+					"name": "Survival",
+					"specialization": "Woodlands",
+					"modifier": -3
+				}
+			],
+			"calc": {
+				"level": 11,
+				"rsl": "Per-1"
+			}
+		},
+		{
+			"id": "ca45c788-54f7-4fd4-a379-c53bba92c717",
+			"type": "skill",
+			"name": "Swimming",
+			"reference": "B224",
+			"tags": [
+				"Athletic",
+				"Exploration",
+				"Outdoor"
+			],
+			"difficulty": "ht/e",
+			"points": 4,
+			"encumbrance_penalty_multiplier": 2,
+			"defaulted_from": {
+				"type": "ht",
+				"modifier": -4,
+				"level": 9,
+				"adjusted_level": 9,
+				"points": -9
+			},
+			"defaults": [
+				{
+					"type": "ht",
+					"modifier": -4
+				}
+			],
+			"calc": {
+				"level": 15,
+				"rsl": "HT+2"
+			}
+		}
+	],
+	"created_date": "2023-01-16T06:52:39Z",
+	"modified_date": "2023-01-16T07:31:59Z",
+	"calc": {
+		"swing": "3d+2",
+		"thrust": "2d-1",
+		"basic_lift": "20 lb",
+		"striking_st_bonus": 10,
+		"move": [
+			6,
+			4,
+			3,
+			2,
+			1
+		],
+		"dodge": [
+			9,
+			8,
+			7,
+			6,
+			5
+		]
+	}
+}

--- a/Library/Basic Set/Races/Vampire.gct
+++ b/Library/Basic Set/Races/Vampire.gct
@@ -429,6 +429,21 @@
 					}
 				},
 				{
+					"id": "4234277b-bace-4b29-83b5-b6f9b960273b",
+					"type": "trait",
+					"name": "Dominance",
+					"reference": "B50",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Mental"
+					],
+					"base_points": 20,
+					"calc": {
+						"points": 20
+					}
+				},
+				{
 					"id": "f100ae38-738c-4d8f-8097-d93393058fdb",
 					"type": "trait",
 					"name": "Draining",
@@ -1625,19 +1640,19 @@
 						{
 							"id": "2ae3df7f-a1f4-40da-a175-24712fdc52d6",
 							"type": "modifier",
-							"name": "Sunlight",
+							"name": "@Common Substance@",
 							"reference": "B161",
 							"cost": 2,
-							"cost_type": "multiplier"
+							"cost_type": "multiplier",
+							"disabled": true
 						},
 						{
 							"id": "74aa7fb6-ef62-43d9-882d-278ac5ba24cd",
 							"type": "modifier",
-							"name": "@Very Common Substance@",
+							"name": "Sunlight",
 							"reference": "B161",
 							"cost": 3,
-							"cost_type": "multiplier",
-							"disabled": true
+							"cost_type": "multiplier"
 						},
 						{
 							"id": "0dbfc654-de6b-46a2-8e1d-b03148e81c01",
@@ -1657,7 +1672,15 @@
 						}
 					],
 					"calc": {
-						"points": -40
+						"points": -60
+					}
+				},
+				{
+					"id": "c478e36f-0eaa-4bce-9bf4-289e17d84f7e",
+					"type": "trait",
+					"name": "Feature: Sterile",
+					"calc": {
+						"points": 0
 					}
 				}
 			],

--- a/Library/Fantasy Folk/Ghoul.gct
+++ b/Library/Fantasy Folk/Ghoul.gct
@@ -149,16 +149,6 @@
 						"Exotic",
 						"Physical"
 					],
-					"modifiers": [
-						{
-							"id": "11a92b4d-003f-4dd9-97e3-9af9e0f75206",
-							"type": "modifier",
-							"name": "Dynamic",
-							"reference": "P76",
-							"cost": 40,
-							"disabled": true
-						}
-					],
 					"levels": 1,
 					"points_per_level": 5,
 					"features": [
@@ -298,7 +288,13 @@
 							}
 						}
 					],
-					"name": "Delete if not living among orcs",
+					"name": "Select degenerate if living among orcs",
+					"template_picker": {
+						"type": "count",
+						"qualifier": {
+							"qualifier": 1
+						}
+					},
 					"calc": {
 						"points": -40
 					}

--- a/Library/Fantasy Folk/Giant.gct
+++ b/Library/Fantasy Folk/Giant.gct
@@ -261,9 +261,8 @@
 								}
 							],
 							"name": "Normal Giant",
-							"container_type": "alternative_abilities",
 							"calc": {
-								"points": 63
+								"points": 99
 							}
 						},
 						{
@@ -779,9 +778,8 @@
 							"qualifier": 1
 						}
 					},
-					"container_type": "alternative_abilities",
 					"calc": {
-						"points": 239
+						"points": 433
 					}
 				},
 				{
@@ -1221,7 +1219,6 @@
 							"qualifier": 1
 						}
 					},
-					"container_type": "alternative_abilities",
 					"calc": {
 						"points": 20
 					}
@@ -1232,7 +1229,7 @@
 			"ancestry": "Human",
 			"container_type": "race",
 			"calc": {
-				"points": 250
+				"points": 444
 			}
 		}
 	],

--- a/Library/Fantasy Folk/Onocentaur.gct
+++ b/Library/Fantasy Folk/Onocentaur.gct
@@ -352,39 +352,41 @@
 			"id": "5291d62a-540f-4a56-bf90-39e27f80932c",
 			"type": "skill_container",
 			"open": true,
+			"children": [
+				{
+					"id": "f4e4037e-5677-4ea9-bdc9-ca7338055ad4",
+					"type": "skill",
+					"name": "Teamster",
+					"reference": "B225",
+					"tags": [
+						"Animal",
+						"Vehicle"
+					],
+					"specialization": "Equines",
+					"difficulty": "iq/a",
+					"points": 2,
+					"defaults": [
+						{
+							"type": "iq",
+							"modifier": -5
+						},
+						{
+							"type": "skill",
+							"name": "Animal Handling",
+							"specialization": "Equines",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Riding",
+							"specialization": "Equines",
+							"modifier": -2
+						}
+					]
+				}
+			],
 			"name": "Race: Onocentaur",
 			"reference": "FF46"
-		},
-		{
-			"id": "f4e4037e-5677-4ea9-bdc9-ca7338055ad4",
-			"type": "skill",
-			"name": "Teamster",
-			"reference": "B225",
-			"tags": [
-				"Animal",
-				"Vehicle"
-			],
-			"specialization": "Equines",
-			"difficulty": "iq/a",
-			"points": 2,
-			"defaults": [
-				{
-					"type": "iq",
-					"modifier": -5
-				},
-				{
-					"type": "skill",
-					"name": "Animal Handling",
-					"specialization": "Equines",
-					"modifier": -4
-				},
-				{
-					"type": "skill",
-					"name": "Riding",
-					"specialization": "Equines",
-					"modifier": -2
-				}
-			]
 		}
 	],
 	"notes": [

--- a/Library/Fantasy Folk/Orc.gct
+++ b/Library/Fantasy Folk/Orc.gct
@@ -469,9 +469,8 @@
 							"qualifier": 1
 						}
 					},
-					"container_type": "alternative_abilities",
 					"calc": {
-						"points": 19
+						"points": 23
 					}
 				}
 			],
@@ -480,7 +479,7 @@
 			"ancestry": "Human",
 			"container_type": "race",
 			"calc": {
-				"points": -26
+				"points": -22
 			}
 		}
 	],


### PR DESCRIPTION
Advantages:
- good/bad reputation: reaction modifiers
- chameleon: extended enhancement has cost of +20%
- clueless: clarified condition for reaction penalty
- cold blooded: HT modifiers for temperature effects
- dependency / dependent correction I think
- discriminatory hearing / smell / taste: added conditional bonuses
- nictating membrane: HT modifier to eye damage
- vow: change tag to mental
- weirdness magnet: added reaction penalty

Race templates (from the Fantasy Folk unless noted):
- vampire (basic set): Added dominance and tweaked weakness for the right points
- ghoul: tweaked how the degenerate if living among orcs was dealt with
- onocentaur: moved its racial skill into the container
- giant, orc: changed container from alternative ability to group