### PR TITLE
Space page references

### DIFF
--- a/Library/Space/Astronaut.gct
+++ b/Library/Space/Astronaut.gct
@@ -1214,7 +1214,7 @@
 				}
 			],
 			"name": "Astronaut",
-			"reference": "Space226",
+			"reference": "S226",
 			"calc": {
 				"points": 60
 			}
@@ -2353,7 +2353,7 @@
 				}
 			],
 			"name": "Astronaut",
-			"reference": "Space226"
+			"reference": "S226"
 		},
 		{
 			"id": "e8d43f0f-d5b8-43a3-866e-43fc98c6bf2c",

--- a/Library/Space/Bounty Hunter.gct
+++ b/Library/Space/Bounty Hunter.gct
@@ -902,7 +902,7 @@
 				}
 			],
 			"name": "Bounty Hunter",
-			"reference": "Space227",
+			"reference": "S227",
 			"calc": {
 				"points": 131
 			}
@@ -1485,7 +1485,7 @@
 				}
 			],
 			"name": "Bounty Hunter",
-			"reference": "Space227"
+			"reference": "S227"
 		},
 		{
 			"id": "065e1201-26dd-49bd-a15f-ca0d7a8ae5c9",

--- a/Library/Space/Colonist.gct
+++ b/Library/Space/Colonist.gct
@@ -1422,7 +1422,7 @@
 				}
 			],
 			"name": "Colonist",
-			"reference": "Space227",
+			"reference": "S227",
 			"calc": {
 				"points": -25
 			}
@@ -1510,7 +1510,7 @@
 						}
 					],
 					"name": "Separatist or Utopian",
-					"reference": "Space228",
+					"reference": "S228",
 					"calc": {
 						"points": -45
 					}
@@ -1982,7 +1982,7 @@
 				}
 			],
 			"name": "Colonist",
-			"reference": "Space227"
+			"reference": "S227"
 		},
 		{
 			"id": "7c7a98d0-e7d3-473d-95b9-7c8739c0565e",
@@ -2080,7 +2080,7 @@
 						}
 					],
 					"name": "Separatist or Utopian",
-					"reference": "Space228"
+					"reference": "S228"
 				}
 			],
 			"name": "Colonist Lens"

--- a/Library/Space/Con Man.gct
+++ b/Library/Space/Con Man.gct
@@ -1539,7 +1539,7 @@
 				}
 			],
 			"name": "Con Man",
-			"reference": "Space228",
+			"reference": "S228",
 			"calc": {
 				"points": 40
 			}
@@ -1708,14 +1708,14 @@
 						}
 					],
 					"name": "Gambler",
-					"reference": "Space228",
+					"reference": "S228",
 					"calc": {
 						"points": 12
 					}
 				}
 			],
 			"name": "Con Man Lenses",
-			"reference": "Space228",
+			"reference": "S228",
 			"calc": {
 				"points": 12
 			}
@@ -2284,7 +2284,7 @@
 				}
 			],
 			"name": "Con Man",
-			"reference": "Space228"
+			"reference": "S228"
 		},
 		{
 			"id": "b74b673b-14ba-4204-ae64-2628fda9f84d",
@@ -2364,7 +2364,7 @@
 						}
 					],
 					"name": "Gambler",
-					"reference": "Space228"
+					"reference": "S228"
 				},
 				{
 					"id": "ad1db72c-58e5-419c-ac4d-e600f0e3a5fa",
@@ -2760,7 +2760,7 @@
 				}
 			],
 			"name": "Con Man Lenses",
-			"reference": "Space228"
+			"reference": "S228"
 		}
 	]
 }

--- a/Library/Space/Detective.gct
+++ b/Library/Space/Detective.gct
@@ -1353,7 +1353,7 @@
 				}
 			],
 			"name": "Detective",
-			"reference": "Space228",
+			"reference": "S228",
 			"calc": {
 				"points": 32
 			}
@@ -1367,7 +1367,7 @@
 					"id": "8a563a1c-0158-43bb-ba1d-fd71e1b8a991",
 					"type": "trait_container",
 					"name": "Private Detective",
-					"reference": "Space229",
+					"reference": "S229",
 					"notes": "Delete Legal Enforcement Powers, Police Rank, and Duty",
 					"calc": {
 						"points": 0
@@ -1404,7 +1404,7 @@
 						}
 					],
 					"name": "Psionic Detective",
-					"reference": "Space229",
+					"reference": "S229",
 					"notes": "Add Psi powers as appropriate for campaign",
 					"calc": {
 						"points": 5
@@ -1522,7 +1522,7 @@
 						}
 					],
 					"name": "Secret Police Inspector",
-					"reference": "Space229",
+					"reference": "S229",
 					"calc": {
 						"points": 5
 					}
@@ -2338,7 +2338,7 @@
 				}
 			],
 			"name": "Detective",
-			"reference": "Space228"
+			"reference": "S228"
 		},
 		{
 			"id": "10fbc33e-9702-4375-9d21-0732cdb5fc89",
@@ -2424,7 +2424,7 @@
 						}
 					],
 					"name": "Psionic Detective",
-					"reference": "Space229"
+					"reference": "S229"
 				},
 				{
 					"id": "06b8fe8a-3e61-4083-ae6d-cfd7a9ef3048",
@@ -2457,7 +2457,7 @@
 						}
 					],
 					"name": "Secret Police Inspector",
-					"reference": "Space229"
+					"reference": "S229"
 				}
 			],
 			"name": "Detective Lenses"

--- a/Library/Space/Doctor.gct
+++ b/Library/Space/Doctor.gct
@@ -774,7 +774,7 @@
 				}
 			],
 			"name": "Doctor",
-			"reference": "Space229",
+			"reference": "S229",
 			"calc": {
 				"points": 35
 			}
@@ -1309,7 +1309,7 @@
 				}
 			],
 			"name": "Doctor",
-			"reference": "Space229"
+			"reference": "S229"
 		},
 		{
 			"id": "265d89e9-b4e8-4c30-976b-ba7f3d2238cd",
@@ -1499,7 +1499,7 @@
 						}
 					],
 					"name": "Field Medic",
-					"reference": "Space229",
+					"reference": "S229",
 					"notes": "Choose any other templaet and add the following skills"
 				},
 				{
@@ -1646,7 +1646,7 @@
 						}
 					],
 					"name": "Xenomedical Specialist",
-					"reference": "Space230"
+					"reference": "S230"
 				}
 			],
 			"name": "Doctor Lenses"

--- a/Library/Space/Explorer.gct
+++ b/Library/Space/Explorer.gct
@@ -1285,7 +1285,7 @@
 				}
 			],
 			"name": "Explorer",
-			"reference": "Space230",
+			"reference": "S230",
 			"calc": {
 				"points": 173
 			}
@@ -2312,7 +2312,7 @@
 				}
 			],
 			"name": "Explorer",
-			"reference": "Space230"
+			"reference": "S230"
 		},
 		{
 			"id": "a467756b-dccc-4101-9223-747a470c0034",
@@ -2376,7 +2376,7 @@
 						}
 					],
 					"name": "Contact Specialist",
-					"reference": "Space230",
+					"reference": "S230",
 					"notes": "Delete Cartography, Geography, and Survival skills [-8]."
 				}
 			],

--- a/Library/Space/Merchant.gct
+++ b/Library/Space/Merchant.gct
@@ -1185,7 +1185,7 @@
 				}
 			],
 			"name": "Merchant",
-			"reference": "Space230",
+			"reference": "S230",
 			"calc": {
 				"points": 85
 			}
@@ -1930,7 +1930,7 @@
 				}
 			],
 			"name": "Merchant",
-			"reference": "Space230"
+			"reference": "S230"
 		},
 		{
 			"id": "a23a0509-0839-4e22-8a1d-e02ea784265e",
@@ -2041,7 +2041,7 @@
 						}
 					],
 					"name": "Antiquities Dealer",
-					"reference": "Space231"
+					"reference": "S231"
 				},
 				{
 					"id": "fe5dd569-a739-443e-b5a1-c3547c905507",
@@ -2146,7 +2146,7 @@
 						}
 					],
 					"name": "Executive",
-					"reference": "Space231",
+					"reference": "S231",
 					"notes": "Delete all secondary skills except Propaganda [-6]. Remove all combat background skills and First-Aid [-2]."
 				}
 			],

--- a/Library/Space/Scientist.gct
+++ b/Library/Space/Scientist.gct
@@ -2100,7 +2100,7 @@
 				}
 			],
 			"name": "Scientist",
-			"reference": "Space231",
+			"reference": "S231",
 			"calc": {
 				"points": -30
 			}
@@ -2164,7 +2164,7 @@
 						}
 					],
 					"name": "Cinematic Scientist",
-					"reference": "Space231",
+					"reference": "S231",
 					"calc": {
 						"points": 13
 					}
@@ -2247,7 +2247,7 @@
 						}
 					],
 					"name": "Science Officer",
-					"reference": "Space231",
+					"reference": "S231",
 					"notes": "Add Duty [-5 to -15] to disadvantage options.",
 					"calc": {
 						"points": 35
@@ -3602,7 +3602,7 @@
 				}
 			],
 			"name": "Scientist",
-			"reference": "Space231"
+			"reference": "S231"
 		},
 		{
 			"id": "c3ec6ee2-10ec-458f-89c3-fa302d9bfb9a",
@@ -3785,7 +3785,7 @@
 						}
 					],
 					"name": "Science Officer",
-					"reference": "Space231"
+					"reference": "S231"
 				}
 			],
 			"name": "Scientist Lenses"

--- a/Library/Space/Secret Agent.gct
+++ b/Library/Space/Secret Agent.gct
@@ -1363,7 +1363,7 @@
 				}
 			],
 			"name": "Secret Agent",
-			"reference": "Space231",
+			"reference": "S231",
 			"calc": {
 				"points": 107
 			}
@@ -1879,7 +1879,7 @@
 						}
 					],
 					"name": "Superspy",
-					"reference": "Space232",
+					"reference": "S232",
 					"calc": {
 						"points": 57
 					}
@@ -2183,7 +2183,7 @@
 						}
 					],
 					"name": "Covert Military Advisor",
-					"reference": "Space232",
+					"reference": "S232",
 					"calc": {
 						"points": 35
 					}
@@ -3313,7 +3313,7 @@
 				}
 			],
 			"name": "Secret Agent",
-			"reference": "Space231"
+			"reference": "S231"
 		},
 		{
 			"id": "6534ce3a-d215-4137-8af1-3c11def32dcd",
@@ -3433,7 +3433,7 @@
 						}
 					],
 					"name": "Superspy",
-					"reference": "Space232"
+					"reference": "S232"
 				},
 				{
 					"id": "f516e60e-8108-4624-aa91-62fdd430c427",
@@ -3780,7 +3780,7 @@
 						}
 					],
 					"name": "Covert Military Advisor",
-					"reference": "Space232"
+					"reference": "S232"
 				}
 			],
 			"name": "Secret Agent Lenses"

--- a/Library/Space/Security Officer.gct
+++ b/Library/Space/Security Officer.gct
@@ -1431,7 +1431,7 @@
 				}
 			],
 			"name": "Security Officer",
-			"reference": "Space232",
+			"reference": "S232",
 			"calc": {
 				"points": 14
 			}
@@ -1472,7 +1472,7 @@
 						}
 					],
 					"name": "Frontier Marshal",
-					"reference": "Space233",
+					"reference": "S233",
 					"calc": {
 						"points": 20
 					}
@@ -1508,7 +1508,7 @@
 						}
 					],
 					"name": "Rescue Squad",
-					"reference": "Space233",
+					"reference": "S233",
 					"calc": {
 						"points": 20
 					}
@@ -1535,7 +1535,7 @@
 						}
 					],
 					"name": "Starship Security",
-					"reference": "Space233",
+					"reference": "S233",
 					"calc": {
 						"points": 5
 					}
@@ -2130,7 +2130,7 @@
 				}
 			],
 			"name": "Security Officer",
-			"reference": "Space232"
+			"reference": "S232"
 		},
 		{
 			"id": "2b5ad160-196d-450a-9dc7-6ea7ec29917e",
@@ -2323,7 +2323,7 @@
 						}
 					],
 					"name": "Frontier Marshal",
-					"reference": "Space233",
+					"reference": "S233",
 					"notes": "Delete Savoir-Faire [-4]."
 				},
 				{
@@ -2495,7 +2495,7 @@
 						}
 					],
 					"name": "Rescue Squad",
-					"reference": "Space233"
+					"reference": "S233"
 				},
 				{
 					"id": "f70e8455-a7f8-4c46-9636-0a44f2c21d4f",
@@ -2575,7 +2575,7 @@
 						}
 					],
 					"name": "Starship Security",
-					"reference": "Space233"
+					"reference": "S233"
 				}
 			],
 			"name": "Security Officer Lenses"

--- a/Library/Space/Soldier.gct
+++ b/Library/Space/Soldier.gct
@@ -1039,7 +1039,7 @@
 				}
 			],
 			"name": "Soldier",
-			"reference": "Space233",
+			"reference": "S233",
 			"calc": {
 				"points": -18
 			}
@@ -1080,7 +1080,7 @@
 						}
 					],
 					"name": "Engineer",
-					"reference": "Space233",
+					"reference": "S233",
 					"calc": {
 						"points": 20
 					}
@@ -1116,7 +1116,7 @@
 						}
 					],
 					"name": "Ranger",
-					"reference": "Space234",
+					"reference": "S234",
 					"calc": {
 						"points": 20
 					}
@@ -1288,7 +1288,7 @@
 						}
 					],
 					"name": "Space Marine",
-					"reference": "Space234",
+					"reference": "S234",
 					"calc": {
 						"points": 15
 					}
@@ -1435,7 +1435,7 @@
 						}
 					],
 					"name": "Elite Trooper",
-					"reference": "Space234",
+					"reference": "S234",
 					"calc": {
 						"points": 55
 					}
@@ -1509,7 +1509,7 @@
 						}
 					],
 					"name": "Officer",
-					"reference": "Space234",
+					"reference": "S234",
 					"calc": {
 						"points": 35
 					}
@@ -1633,7 +1633,7 @@
 						}
 					],
 					"name": "Veteran",
-					"reference": "Space234",
+					"reference": "S234",
 					"calc": {
 						"points": 50
 					}
@@ -1974,7 +1974,7 @@
 				}
 			],
 			"name": "Soldier",
-			"reference": "Space233"
+			"reference": "S233"
 		},
 		{
 			"id": "d3835614-1f94-4283-98ec-6d4a22aa3943",
@@ -2216,7 +2216,7 @@
 						}
 					],
 					"name": "Armored",
-					"reference": "Space233"
+					"reference": "S233"
 				},
 				{
 					"id": "896b21e9-129e-4169-afe2-6da25b6c77bd",
@@ -2473,7 +2473,7 @@
 						}
 					],
 					"name": "Battlesuit Trooper",
-					"reference": "Space233"
+					"reference": "S233"
 				},
 				{
 					"id": "63c91bb5-c933-4a6f-9551-865296f95cc7",
@@ -2686,7 +2686,7 @@
 						}
 					],
 					"name": "Engineer",
-					"reference": "Space233"
+					"reference": "S233"
 				},
 				{
 					"id": "3e62ba50-28da-476b-974c-fb0e6211c0c2",
@@ -2959,7 +2959,7 @@
 						}
 					],
 					"name": "Infantry",
-					"reference": "Space233"
+					"reference": "S233"
 				},
 				{
 					"id": "e4e8a0c1-c026-4183-9728-2752da30fa83",
@@ -3253,7 +3253,7 @@
 						}
 					],
 					"name": "Ranger",
-					"reference": "Space234"
+					"reference": "S234"
 				},
 				{
 					"id": "538a3775-263d-4302-9005-53d35a1a39d4",
@@ -3333,7 +3333,7 @@
 						}
 					],
 					"name": "Space Marine",
-					"reference": "Space234"
+					"reference": "S234"
 				},
 				{
 					"id": "80ff4919-af16-4354-82c6-f2b49831121f",
@@ -3380,7 +3380,7 @@
 						}
 					],
 					"name": "Elite Trooper",
-					"reference": "Space234"
+					"reference": "S234"
 				},
 				{
 					"id": "b1b0d1f0-fa96-4ab5-88f5-6704d5c73d09",
@@ -3493,7 +3493,7 @@
 						}
 					],
 					"name": "Officer",
-					"reference": "Space234"
+					"reference": "S234"
 				},
 				{
 					"id": "ed2c85b0-1ed4-44af-8202-37c0790f8db9",
@@ -3539,7 +3539,7 @@
 						}
 					],
 					"name": "Veteran",
-					"reference": "Space234"
+					"reference": "S234"
 				}
 			],
 			"name": "Soldier Lenses"

--- a/Library/Space/Space Knight.gct
+++ b/Library/Space/Space Knight.gct
@@ -1237,7 +1237,7 @@
 				}
 			],
 			"name": "Space Knight",
-			"reference": "Space234",
+			"reference": "S234",
 			"calc": {
 				"points": 137
 			}
@@ -1894,7 +1894,7 @@
 				}
 			],
 			"name": "Space Knight",
-			"reference": "Space234"
+			"reference": "S234"
 		}
 	]
 }

--- a/Library/Space/Space Worker.gct
+++ b/Library/Space/Space Worker.gct
@@ -1291,7 +1291,7 @@
 				}
 			],
 			"name": "Space Worker",
-			"reference": "Space234",
+			"reference": "S234",
 			"calc": {
 				"points": 16
 			}
@@ -1725,7 +1725,7 @@
 				}
 			],
 			"name": "Space Worker",
-			"reference": "Space234"
+			"reference": "S234"
 		}
 	]
 }

--- a/Library/Space/Technician.gct
+++ b/Library/Space/Technician.gct
@@ -2078,7 +2078,7 @@
 				}
 			],
 			"name": "Technician",
-			"reference": "Space235",
+			"reference": "S235",
 			"calc": {
 				"points": -53
 			}
@@ -2144,7 +2144,7 @@
 						}
 					],
 					"name": "Inventor",
-					"reference": "Space235",
+					"reference": "S235",
 					"calc": {
 						"points": 45
 					}
@@ -2618,7 +2618,7 @@
 				}
 			],
 			"name": "Technician",
-			"reference": "Space235"
+			"reference": "S235"
 		}
 	]
 }

--- a/Library/Space/Thief.gct
+++ b/Library/Space/Thief.gct
@@ -1317,7 +1317,7 @@
 				}
 			],
 			"name": "Thief",
-			"reference": "Space235",
+			"reference": "S235",
 			"calc": {
 				"points": 0
 			}
@@ -1903,7 +1903,7 @@
 				}
 			],
 			"name": "Thief",
-			"reference": "Space235"
+			"reference": "S235"
 		},
 		{
 			"id": "ceee230b-7092-4aad-bf60-a679d7feea10",
@@ -1957,7 +1957,7 @@
 						}
 					],
 					"name": "Cyberspace Thief",
-					"reference": "Space235",
+					"reference": "S235",
 					"notes": "Change Primary Skills to"
 				}
 			],


### PR DESCRIPTION
The page references had been entered as "SpaceXXX" however the website lists the code for GURPS Space as "S".  Changed the references in the Space files to have the correct book code.