### PR TITLE
fixed weight and class errors

### DIFF
--- a/Library/Ultra Tech/Ultra Tech Equipment.eqp
+++ b/Library/Ultra Tech/Ultra Tech Equipment.eqp
@@ -31980,7 +31980,7 @@
 			],
 			"quantity": 1,
 			"value": 30,
-			"weight": "6 lb",
+			"weight": "0 lb",
 			"features": [
 				{
 					"type": "dr_bonus",
@@ -49525,7 +49525,7 @@
 			"description": "Trauma Plates for Reflex Tactical Vest",
 			"reference": "UT173",
 			"tech_level": "9",
-			"legality_class": "42",
+			"legality_class": "2",
 			"tags": [
 				"Armor",
 				"Defenses"


### PR DESCRIPTION
changed legality class of Trauma Plates for Reflex Tactical Vest from '42' to 2 [UT173]

and wight of Nanoweave Gloves from '6lbs' to negligible '0lbs' [UT172]