### PR TITLE
fixed weight and LCs errors

### DIFF
--- a/Library/Ultra Tech/Ultra Tech Equipment.eqp
+++ b/Library/Ultra Tech/Ultra Tech Equipment.eqp
@@ -49524,7 +49524,7 @@
 			"description": "Trauma Plates for Reflex Tactical Vest",
 			"reference": "UT173",
 			"tech_level": "9",
-			"legality_class": "4",
+			"legality_class": "2",
 			"tags": [
 				"Armor",
 				"Defenses"

--- a/Library/Ultra Tech/Ultra Tech Equipment.eqp
+++ b/Library/Ultra Tech/Ultra Tech Equipment.eqp
@@ -31980,7 +31980,6 @@
 			],
 			"quantity": 1,
 			"value": 30,
-			"weight": "6 lb",
 			"features": [
 				{
 					"type": "dr_bonus",
@@ -49525,7 +49524,7 @@
 			"description": "Trauma Plates for Reflex Tactical Vest",
 			"reference": "UT173",
 			"tech_level": "9",
-			"legality_class": "42",
+			"legality_class": "4",
 			"tags": [
 				"Armor",
 				"Defenses"


### PR DESCRIPTION
changed the legality class of 'Trauma Plates for Reflex Tactical Vest' from '42' to '2' [UT173]

removed weight of 'Nanoweave Gloves' to represent negligible '0lbs'  instead of '6lbs' [UT172]