### PR TITLE
Adjust Alter Voice Prerequisites

### DIFF
--- a/Library/Magic/Magic Spells.spl
+++ b/Library/Magic/Magic Spells.spl
@@ -1141,11 +1141,11 @@
 				"prereqs": [
 					{
 						"type": "spell_prereq",
-						"sub_type": "name",
+						"sub_type": "college",
 						"has": true,
 						"qualifier": {
 							"compare": "contains",
-							"qualifier": "body"
+							"qualifier": "Body Control"
 						},
 						"quantity": {
 							"compare": "at_least",


### PR DESCRIPTION
Very few Body Control spells contain "body" in the name.

This adjusts the Body Control prerequisites for Alter Voice to depend on the college name instead.