### PR TITLE
Reformatted Star Wars library files

### DIFF
--- a/Library/Settings/Attributes/Star Wars - with Energy Reserve (Force).attr
+++ b/Library/Settings/Attributes/Star Wars - with Energy Reserve (Force).attr
@@ -1,0 +1,252 @@
+{
+	"type": "attribute_settings",
+	"version": 4,
+	"rows": [
+		{
+			"id": "st",
+			"type": "integer",
+			"name": "ST",
+			"full_name": "Strength",
+			"attribute_base": "10",
+			"cost_per_point": 10,
+			"cost_adj_percent_per_sm": 10
+		},
+		{
+			"id": "dx",
+			"type": "integer",
+			"name": "DX",
+			"full_name": "Dexterity",
+			"attribute_base": "10",
+			"cost_per_point": 20
+		},
+		{
+			"id": "iq",
+			"type": "integer",
+			"name": "IQ",
+			"full_name": "Intelligence",
+			"attribute_base": "10",
+			"cost_per_point": 20
+		},
+		{
+			"id": "ht",
+			"type": "integer",
+			"name": "HT",
+			"full_name": "Health",
+			"attribute_base": "10",
+			"cost_per_point": 10
+		},
+		{
+			"id": "will",
+			"type": "integer",
+			"name": "Will",
+			"attribute_base": "$iq",
+			"cost_per_point": 5
+		},
+		{
+			"id": "fright_check",
+			"type": "integer",
+			"name": "Fright Check",
+			"attribute_base": "$will",
+			"cost_per_point": 2
+		},
+		{
+			"id": "per",
+			"type": "integer",
+			"name": "Per",
+			"full_name": "Perception",
+			"attribute_base": "$iq",
+			"cost_per_point": 5
+		},
+		{
+			"id": "vision",
+			"type": "integer",
+			"name": "Vision",
+			"attribute_base": "$per",
+			"cost_per_point": 2
+		},
+		{
+			"id": "hearing",
+			"type": "integer",
+			"name": "Hearing",
+			"attribute_base": "$per",
+			"cost_per_point": 2
+		},
+		{
+			"id": "taste_smell",
+			"type": "integer",
+			"name": "Taste & Smell",
+			"attribute_base": "$per",
+			"cost_per_point": 2
+		},
+		{
+			"id": "touch",
+			"type": "integer",
+			"name": "Touch",
+			"attribute_base": "$per",
+			"cost_per_point": 2
+		},
+		{
+			"id": "forcesight",
+			"type": "integer",
+			"name": "Force Sight",
+			"attribute_base": "$per",
+			"cost_per_point": 2
+		},
+		{
+			"id": "basic_speed",
+			"type": "decimal",
+			"name": "Basic Speed",
+			"attribute_base": "($dx+$ht)/4",
+			"cost_per_point": 20
+		},
+		{
+			"id": "basic_move",
+			"type": "integer",
+			"name": "Basic Move",
+			"attribute_base": "floor($basic_speed)",
+			"cost_per_point": 5
+		},
+		{
+			"id": "fp",
+			"type": "pool",
+			"name": "FP",
+			"full_name": "Fatigue Points",
+			"attribute_base": "$ht",
+			"cost_per_point": 3,
+			"thresholds": [
+				{
+					"state": "Unconscious",
+					"expression": "-$fp",
+					"ops": [
+						"halve_move",
+						"halve_dodge",
+						"halve_st"
+					]
+				},
+				{
+					"state": "Collapse",
+					"expression": "0",
+					"explanation": "Roll vs. Will to do anything besides talk or rest; failure causes unconsciousness\nEach FP you lose below 0 also causes 1 HP of injury\nMove, Dodge and ST are halved (B426)",
+					"ops": [
+						"halve_move",
+						"halve_dodge",
+						"halve_st"
+					]
+				},
+				{
+					"state": "Tired",
+					"expression": "round($fp/3)",
+					"explanation": "Move, Dodge and ST are halved (B426)",
+					"ops": [
+						"halve_move",
+						"halve_dodge",
+						"halve_st"
+					]
+				},
+				{
+					"state": "Tiring",
+					"expression": "$fp-1"
+				},
+				{
+					"state": "Rested",
+					"expression": "$fp"
+				}
+			]
+		},
+		{
+			"id": "hp",
+			"type": "pool",
+			"name": "HP",
+			"full_name": "Hit Points",
+			"attribute_base": "$st",
+			"cost_per_point": 2,
+			"cost_adj_percent_per_sm": 10,
+			"thresholds": [
+				{
+					"state": "Dead",
+					"expression": "round(-$hp*5)",
+					"ops": [
+						"halve_move",
+						"halve_dodge"
+					]
+				},
+				{
+					"state": "Dying #4",
+					"expression": "round(-$hp*4)",
+					"explanation": "Roll vs. HT to avoid death\nRoll vs. HT-4 every second to avoid falling unconscious\nMove and Dodge are halved (B419)",
+					"ops": [
+						"halve_move",
+						"halve_dodge"
+					]
+				},
+				{
+					"state": "Dying #3",
+					"expression": "round(-$hp*3)",
+					"explanation": "Roll vs. HT to avoid death\nRoll vs. HT-3 every second to avoid falling unconscious\nMove and Dodge are halved (B419)",
+					"ops": [
+						"halve_move",
+						"halve_dodge"
+					]
+				},
+				{
+					"state": "Dying #2",
+					"expression": "round(-$hp*2)",
+					"explanation": "Roll vs. HT to avoid death\nRoll vs. HT-2 every second to avoid falling unconscious\nMove and Dodge are halved (B419)",
+					"ops": [
+						"halve_move",
+						"halve_dodge"
+					]
+				},
+				{
+					"state": "Dying #1",
+					"expression": "-$hp",
+					"explanation": "Roll vs. HT to avoid death\nRoll vs. HT-1 every second to avoid falling unconscious\nMove and Dodge are halved (B419)",
+					"ops": [
+						"halve_move",
+						"halve_dodge"
+					]
+				},
+				{
+					"state": "Collapse",
+					"expression": "0",
+					"explanation": "Roll vs. HT every second to avoid falling unconscious\nMove and Dodge are halved (B419)",
+					"ops": [
+						"halve_move",
+						"halve_dodge"
+					]
+				},
+				{
+					"state": "Reeling",
+					"expression": "round($hp/3)",
+					"explanation": "Move and Dodge are halved (B419)",
+					"ops": [
+						"halve_move",
+						"halve_dodge"
+					]
+				},
+				{
+					"state": "Wounded",
+					"expression": "$hp-1"
+				},
+				{
+					"state": "Healthy",
+					"expression": "$hp"
+				}
+			]
+		},
+		{
+			"id": "er",
+			"type": "pool",
+			"name": "ER",
+			"full_name": "Energy Reserver (Force)",
+			"attribute_base": "0",
+			"cost_per_point": 2,
+			"thresholds": [
+				{
+					"state": "",
+					"expression": ""
+				}
+			]
+		}
+	]
+}

--- a/Library/Settings/Attributes/Star Wars.attr
+++ b/Library/Settings/Attributes/Star Wars.attr
@@ -1,0 +1,238 @@
+{
+	"type": "attribute_settings",
+	"version": 4,
+	"rows": [
+		{
+			"id": "st",
+			"type": "integer",
+			"name": "ST",
+			"full_name": "Strength",
+			"attribute_base": "10",
+			"cost_per_point": 10,
+			"cost_adj_percent_per_sm": 10
+		},
+		{
+			"id": "dx",
+			"type": "integer",
+			"name": "DX",
+			"full_name": "Dexterity",
+			"attribute_base": "10",
+			"cost_per_point": 20
+		},
+		{
+			"id": "iq",
+			"type": "integer",
+			"name": "IQ",
+			"full_name": "Intelligence",
+			"attribute_base": "10",
+			"cost_per_point": 20
+		},
+		{
+			"id": "ht",
+			"type": "integer",
+			"name": "HT",
+			"full_name": "Health",
+			"attribute_base": "10",
+			"cost_per_point": 10
+		},
+		{
+			"id": "will",
+			"type": "integer",
+			"name": "Will",
+			"attribute_base": "$iq",
+			"cost_per_point": 5
+		},
+		{
+			"id": "fright_check",
+			"type": "integer",
+			"name": "Fright Check",
+			"attribute_base": "$will",
+			"cost_per_point": 2
+		},
+		{
+			"id": "per",
+			"type": "integer",
+			"name": "Per",
+			"full_name": "Perception",
+			"attribute_base": "$iq",
+			"cost_per_point": 5
+		},
+		{
+			"id": "vision",
+			"type": "integer",
+			"name": "Vision",
+			"attribute_base": "$per",
+			"cost_per_point": 2
+		},
+		{
+			"id": "hearing",
+			"type": "integer",
+			"name": "Hearing",
+			"attribute_base": "$per",
+			"cost_per_point": 2
+		},
+		{
+			"id": "taste_smell",
+			"type": "integer",
+			"name": "Taste & Smell",
+			"attribute_base": "$per",
+			"cost_per_point": 2
+		},
+		{
+			"id": "touch",
+			"type": "integer",
+			"name": "Touch",
+			"attribute_base": "$per",
+			"cost_per_point": 2
+		},
+		{
+			"id": "forcesight",
+			"type": "integer",
+			"name": "Force Sight",
+			"attribute_base": "$per",
+			"cost_per_point": 2
+		},
+		{
+			"id": "basic_speed",
+			"type": "decimal",
+			"name": "Basic Speed",
+			"attribute_base": "($dx+$ht)/4",
+			"cost_per_point": 20
+		},
+		{
+			"id": "basic_move",
+			"type": "integer",
+			"name": "Basic Move",
+			"attribute_base": "floor($basic_speed)",
+			"cost_per_point": 5
+		},
+		{
+			"id": "fp",
+			"type": "pool",
+			"name": "FP",
+			"full_name": "Fatigue Points",
+			"attribute_base": "$ht",
+			"cost_per_point": 3,
+			"thresholds": [
+				{
+					"state": "Unconscious",
+					"expression": "-$fp",
+					"ops": [
+						"halve_move",
+						"halve_dodge",
+						"halve_st"
+					]
+				},
+				{
+					"state": "Collapse",
+					"expression": "0",
+					"explanation": "Roll vs. Will to do anything besides talk or rest; failure causes unconsciousness\nEach FP you lose below 0 also causes 1 HP of injury\nMove, Dodge and ST are halved (B426)",
+					"ops": [
+						"halve_move",
+						"halve_dodge",
+						"halve_st"
+					]
+				},
+				{
+					"state": "Tired",
+					"expression": "round($fp/3)",
+					"explanation": "Move, Dodge and ST are halved (B426)",
+					"ops": [
+						"halve_move",
+						"halve_dodge",
+						"halve_st"
+					]
+				},
+				{
+					"state": "Tiring",
+					"expression": "$fp-1"
+				},
+				{
+					"state": "Rested",
+					"expression": "$fp"
+				}
+			]
+		},
+		{
+			"id": "hp",
+			"type": "pool",
+			"name": "HP",
+			"full_name": "Hit Points",
+			"attribute_base": "$st",
+			"cost_per_point": 2,
+			"cost_adj_percent_per_sm": 10,
+			"thresholds": [
+				{
+					"state": "Dead",
+					"expression": "round(-$hp*5)",
+					"ops": [
+						"halve_move",
+						"halve_dodge"
+					]
+				},
+				{
+					"state": "Dying #4",
+					"expression": "round(-$hp*4)",
+					"explanation": "Roll vs. HT to avoid death\nRoll vs. HT-4 every second to avoid falling unconscious\nMove and Dodge are halved (B419)",
+					"ops": [
+						"halve_move",
+						"halve_dodge"
+					]
+				},
+				{
+					"state": "Dying #3",
+					"expression": "round(-$hp*3)",
+					"explanation": "Roll vs. HT to avoid death\nRoll vs. HT-3 every second to avoid falling unconscious\nMove and Dodge are halved (B419)",
+					"ops": [
+						"halve_move",
+						"halve_dodge"
+					]
+				},
+				{
+					"state": "Dying #2",
+					"expression": "round(-$hp*2)",
+					"explanation": "Roll vs. HT to avoid death\nRoll vs. HT-2 every second to avoid falling unconscious\nMove and Dodge are halved (B419)",
+					"ops": [
+						"halve_move",
+						"halve_dodge"
+					]
+				},
+				{
+					"state": "Dying #1",
+					"expression": "-$hp",
+					"explanation": "Roll vs. HT to avoid death\nRoll vs. HT-1 every second to avoid falling unconscious\nMove and Dodge are halved (B419)",
+					"ops": [
+						"halve_move",
+						"halve_dodge"
+					]
+				},
+				{
+					"state": "Collapse",
+					"expression": "0",
+					"explanation": "Roll vs. HT every second to avoid falling unconscious\nMove and Dodge are halved (B419)",
+					"ops": [
+						"halve_move",
+						"halve_dodge"
+					]
+				},
+				{
+					"state": "Reeling",
+					"expression": "round($hp/3)",
+					"explanation": "Move and Dodge are halved (B419)",
+					"ops": [
+						"halve_move",
+						"halve_dodge"
+					]
+				},
+				{
+					"state": "Wounded",
+					"expression": "$hp-1"
+				},
+				{
+					"state": "Healthy",
+					"expression": "$hp"
+				}
+			]
+		}
+	]
+}

--- a/Library/Star Wars/Star Wars Force Abilities.spl
+++ b/Library/Star Wars/Star Wars Force Abilities.spl
@@ -3,23 +3,25 @@
 	"version": 4,
 	"rows": [
 		{
-			"id": "1336bdbd-d3e7-4cd5-9aa6-1c49ad447300",
+			"id": "621c412c-1730-4852-bd01-0dc594b8ca92",
 			"type": "spell",
-			"name": "Analyze Force",
-			"notes": "Cannot exceed: Sense Force -1",
+			"name": "Steal Vitality",
+			"reference": "SWF13",
+			"notes": "Cannot Exceed: Heal Self",
 			"tags": [
-				"Neutral",
-				"Sense"
+				"Alter",
+				"Dark"
 			],
 			"difficulty": "will/vh",
 			"college": [
-				"Neutral"
+				"Alter",
+				"Dark"
 			],
 			"power_source": "Force",
-			"spell_class": "Information",
-			"casting_cost": "8+ Power level of item",
-			"casting_time": "1 hour",
-			"duration": "1 sec",
+			"spell_class": "Regular",
+			"casting_cost": "0",
+			"casting_time": "1 minute for every 3 HP drained",
+			"duration": "Permanent",
 			"points": 1,
 			"prereqs": {
 				"type": "prereq_list",
@@ -31,7 +33,20 @@
 						"has": true,
 						"qualifier": {
 							"compare": "is",
-							"qualifier": "Sense Force"
+							"qualifier": "Heal Self"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Steal Energy"
 						},
 						"quantity": {
 							"compare": "at_least",
@@ -43,7 +58,7 @@
 						"has": true,
 						"name": {
 							"compare": "is",
-							"qualifier": "Sense Talent"
+							"qualifier": "Alter Talent"
 						},
 						"level": {
 							"compare": "at_least",
@@ -62,23 +77,24 @@
 			}
 		},
 		{
-			"id": "d0c23e86-f060-4698-a2a5-ce8a81023406",
+			"id": "28e4e26f-3c2c-43ae-8cb7-400895c8fb7b",
 			"type": "spell",
-			"name": "Aura of Insignificance",
+			"name": "Steal Energy",
+			"reference": "SWF13",
 			"tags": [
 				"Alter",
 				"Dark"
 			],
-			"difficulty": "will/vh",
+			"difficulty": "will/a",
 			"college": [
+				"Alter",
 				"Dark"
 			],
 			"power_source": "Force",
 			"spell_class": "Regular",
-			"casting_cost": "4",
-			"maintenance_cost": "4",
-			"casting_time": "10 sec",
-			"duration": "1 hour",
+			"casting_cost": "0",
+			"casting_time": "1 minute for every 3 FP drained",
+			"duration": "Permanent",
 			"points": 1,
 			"prereqs": {
 				"type": "prereq_list",
@@ -93,30 +109,40 @@
 						},
 						"level": {
 							"compare": "at_least",
-							"qualifier": 1
+							"qualifier": 2
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Force Sensitivity"
 						}
 					}
 				]
 			}
 		},
 		{
-			"id": "6cc35015-517e-427c-9c49-8b6d653c8fb3",
+			"id": "56323fc1-d72e-4c9f-af36-c7131f386963",
 			"type": "spell",
-			"name": "Aura of Presence",
+			"name": "Sound",
+			"reference": "SWF13",
 			"tags": [
 				"Alter",
-				"Dark"
+				"Neutral"
 			],
-			"difficulty": "will/vh",
+			"difficulty": "will/a",
 			"college": [
-				"Dark"
+				"Alter",
+				"Neutral"
 			],
 			"power_source": "Force",
 			"spell_class": "Regular",
-			"casting_cost": "4",
-			"maintenance_cost": "4",
+			"casting_cost": "1",
+			"maintenance_cost": "1 per 5 sec",
 			"casting_time": "10 sec",
-			"duration": "1 hour",
+			"duration": "5 sec",
 			"points": 1,
 			"prereqs": {
 				"type": "prereq_list",
@@ -127,7 +153,7 @@
 						"has": true,
 						"name": {
 							"compare": "is",
-							"qualifier": "Alter Talent"
+							"qualifier": "Force Sensitivity"
 						},
 						"level": {
 							"compare": "at_least",
@@ -138,24 +164,74 @@
 			}
 		},
 		{
-			"id": "a3dbcb03-00bc-477f-a4d6-9c48a96088a8",
+			"id": "564a5309-0c12-4fb0-bda4-ef58e2e30bfc",
 			"type": "spell",
-			"name": "Battle Meditation",
-			"notes": "cannot exceed Meditation-1",
+			"name": "Slow",
+			"reference": "SWF15",
 			"tags": [
 				"Control",
+				"Dark"
+			],
+			"difficulty": "will/a",
+			"college": [
+				"Control",
+				"Dark"
+			],
+			"power_source": "Force",
+			"spell_class": "Regular",
+			"resist": "HT+SM",
+			"casting_cost": "1",
+			"casting_time": "1 sec",
+			"duration": "varies",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Control Talent"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Force Sensitivity"
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "2e9ebb13-9fbf-4866-9849-2207eb889317",
+			"type": "spell",
+			"name": "Sever Force",
+			"reference": "SWF12",
+			"notes": "Cannot Exceed: Meditation - 1",
+			"tags": [
+				"Alter",
 				"Neutral"
 			],
 			"difficulty": "will/vh",
 			"college": [
+				"Alter",
 				"Neutral"
 			],
 			"power_source": "Force",
-			"spell_class": "Area, Unique",
-			"casting_cost": "1+1 per bonus granted",
-			"maintenance_cost": "1",
-			"casting_time": "1 sec",
-			"duration": "1 min",
+			"spell_class": "Regular",
+			"resist": "Will",
+			"casting_cost": "10 + Power level target",
+			"casting_time": "10 sec",
+			"duration": "Permanent",
 			"points": 1,
 			"prereqs": {
 				"type": "prereq_list",
@@ -174,7 +250,66 @@
 						"has": true,
 						"name": {
 							"compare": "is",
-							"qualifier": "Control Talent"
+							"qualifier": "Alter Talent"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Force Sensitivity"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "c4ac60f0-1027-4b58-b345-fba889f30a15",
+			"type": "spell",
+			"name": "Sense Shatterpoint",
+			"reference": "SWF17",
+			"tags": [
+				"Neutral",
+				"Sense"
+			],
+			"difficulty": "will/vh",
+			"college": [
+				"Neutral",
+				"Sense"
+			],
+			"power_source": "Force",
+			"spell_class": "Information, Unique",
+			"casting_cost": "10 + Power Level Target",
+			"casting_time": "1 sec",
+			"duration": "Instant",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Precognition"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Sense Talent"
 						},
 						"level": {
 							"compare": "at_least",
@@ -190,28 +325,132 @@
 						},
 						"level": {
 							"compare": "at_least",
-							"qualifier": 4
+							"qualifier": 1
 						}
 					}
 				]
 			}
 		},
 		{
-			"id": "aee2088f-48e6-45b7-83e2-8e1335e3aacd",
+			"id": "679595e2-8ba0-426c-8504-29d8b7ab47c6",
 			"type": "spell",
-			"name": "Battle Sense",
+			"name": "Sense Life",
+			"reference": "SWF17",
+			"tags": [
+				"Neutral",
+				"Sense"
+			],
+			"difficulty": "will/a",
+			"college": [
+				"Neutral",
+				"Sense"
+			],
+			"power_source": "Force",
+			"spell_class": "Information,Area",
+			"casting_cost": "1",
+			"casting_time": "1 sec",
+			"duration": "Instant",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Sense Talent"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Force Sensitivity"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "be2affbf-0ae9-4502-9658-7bf10821aa9e",
+			"type": "spell",
+			"name": "Sense Force",
+			"reference": "SWF17",
 			"tags": [
 				"Neutral",
 				"Sense"
 			],
 			"difficulty": "will/vh",
 			"college": [
-				"Neutral"
+				"Neutral",
+				"Sense"
 			],
 			"power_source": "Force",
-			"spell_class": "Information",
+			"spell_class": "Information, Area",
+			"casting_cost": "1",
+			"casting_time": "1 sec",
+			"duration": "Instant",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Sense Talent"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Force Sensitivity"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "b37e90c9-2a4e-412b-99de-743191fc04b2",
+			"type": "spell",
+			"name": "Sense Emotion",
+			"reference": "SWF16",
+			"tags": [
+				"Neutral",
+				"Sense"
+			],
+			"difficulty": "will/a",
+			"college": [
+				"Neutral",
+				"Sense"
+			],
+			"power_source": "Force",
+			"spell_class": "Information, Regular",
 			"resist": "Will",
-			"casting_cost": "1 perfoe",
+			"casting_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "Instant",
 			"points": 1,
@@ -243,23 +482,24 @@
 			}
 		},
 		{
-			"id": "0d6492fa-1584-49aa-a607-92ed4399e2aa",
+			"id": "829994f5-8c34-4bbd-9e79-1b7301876204",
 			"type": "spell",
-			"name": "Body-Reading",
-			"notes": "Cannot Exceed: Sense Life-1",
+			"name": "Sense Disease",
+			"reference": "SWF16",
+			"notes": "Cannot Exceed: Sense Life - 1",
 			"tags": [
 				"Neutral",
 				"Sense"
 			],
 			"difficulty": "will/vh",
 			"college": [
-				"Neutral"
+				"Neutral",
+				"Sense"
 			],
 			"power_source": "Force",
-			"spell_class": "Information",
-			"resist": "Will",
-			"casting_cost": "2",
-			"casting_time": "30 sec",
+			"spell_class": "Information, Regular",
+			"casting_cost": "1",
+			"casting_time": "10 sec",
 			"duration": "Instant",
 			"points": 1,
 			"prereqs": {
@@ -278,7 +518,35 @@
 							"compare": "at_least",
 							"qualifier": 1
 						}
-					},
+					}
+				]
+			}
+		},
+		{
+			"id": "5164dc54-e5d3-4c4f-b45f-2d1d30334dc3",
+			"type": "spell",
+			"name": "Receptive Telepathy",
+			"reference": "SWF16",
+			"tags": [
+				"Neutral",
+				"Sense"
+			],
+			"difficulty": "will/a",
+			"college": [
+				"Neutral",
+				"Sense"
+			],
+			"power_source": "Force",
+			"spell_class": "Regular",
+			"casting_cost": "1",
+			"maintenance_cost": "1",
+			"casting_time": "1 sec",
+			"duration": "1 sec",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
 					{
 						"type": "trait_prereq",
 						"has": true,
@@ -288,7 +556,7 @@
 						},
 						"level": {
 							"compare": "at_least",
-							"qualifier": 2
+							"qualifier": 1
 						}
 					},
 					{
@@ -303,39 +571,40 @@
 			}
 		},
 		{
-			"id": "09844a8d-7ab6-4f87-a30c-f1c5e91f983d",
+			"id": "c467f99f-bd93-431b-9e40-f7185f942e6c",
 			"type": "spell",
-			"name": "Choke",
-			"notes": "Force Grip-1",
+			"name": "Psychometric Sense",
+			"reference": "SWF16",
+			"notes": "Dark if it involves emotional stress",
 			"tags": [
-				"Control",
+				"Neutral",
+				"Sense",
 				"Dark"
 			],
 			"difficulty": "will/vh",
 			"college": [
+				"Neutral",
+				"Sense",
 				"Dark"
 			],
 			"power_source": "Force",
-			"spell_class": "Regular",
-			"resist": "HT",
-			"casting_cost": "4",
-			"maintenance_cost": "1",
-			"casting_time": "Instant",
-			"duration": "1 min",
+			"spell_class": "Information",
+			"casting_cost": "varies",
+			"casting_time": "1 sec per EP",
+			"duration": "Event tied",
 			"points": 1,
 			"prereqs": {
 				"type": "prereq_list",
 				"all": true,
 				"prereqs": [
 					{
-						"type": "spell_prereq",
-						"sub_type": "name",
+						"type": "trait_prereq",
 						"has": true,
-						"qualifier": {
+						"name": {
 							"compare": "is",
-							"qualifier": "Force Grip"
+							"qualifier": "Sense Talent"
 						},
-						"quantity": {
+						"level": {
 							"compare": "at_least",
 							"qualifier": 1
 						}
@@ -345,11 +614,143 @@
 						"has": true,
 						"name": {
 							"compare": "is",
+							"qualifier": "Force Sensitivity"
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "6b83e68e-bf7d-49ba-8ec7-cd0d65d6b445",
+			"type": "spell",
+			"name": "Projective Telepathy",
+			"reference": "SWF15",
+			"tags": [
+				"Control",
+				"Neutral"
+			],
+			"difficulty": "will/a",
+			"college": [
+				"Control",
+				"Neutral"
+			],
+			"power_source": "Force",
+			"spell_class": "Regular",
+			"resist": "Will",
+			"casting_cost": "4",
+			"casting_time": "1 sec",
+			"duration": "1 sec",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
 							"qualifier": "Control Talent"
 						},
 						"level": {
 							"compare": "at_least",
-							"qualifier": 4
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Force Sensitivity"
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "f42f250e-947f-4ceb-953c-64014c13c03c",
+			"type": "spell",
+			"name": "Pain",
+			"reference": "SWF15",
+			"tags": [
+				"Control",
+				"Dark"
+			],
+			"difficulty": "will/a",
+			"college": [
+				"Control",
+				"Dark"
+			],
+			"power_source": "Force",
+			"spell_class": "Regular",
+			"resist": "HT",
+			"casting_cost": "2",
+			"casting_time": "1 sec",
+			"duration": "1 sec",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Control Talent"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Force Sensitivity"
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "10d79352-ce29-4c33-b287-00a2ddfc807c",
+			"type": "spell",
+			"name": "Neutralize Poison",
+			"reference": "SWF12",
+			"notes": "Cannot Exceed: Meditation - 1",
+			"tags": [
+				"Alter",
+				"Neutral"
+			],
+			"difficulty": "will/a",
+			"college": [
+				"Alter",
+				"Neutral"
+			],
+			"power_source": "Force",
+			"spell_class": "Regular",
+			"casting_cost": "5",
+			"casting_time": "30 sec",
+			"duration": "Permanent",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Alter Talent"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 2
 						}
 					},
 					{
@@ -368,269 +769,114 @@
 			}
 		},
 		{
-			"id": "9053494c-c4ee-4292-8238-c467db12ea5e",
+			"id": "0abf81da-6f38-4c84-a951-bd14bb276895",
 			"type": "spell",
-			"name": "Cure Another",
+			"name": "Move Object",
+			"reference": "SWF15",
 			"tags": [
-				"Alter",
-				"Light"
-			],
-			"difficulty": "will/vh",
-			"college": [
-				"Light"
-			],
-			"power_source": "Force",
-			"spell_class": "Regular",
-			"casting_cost": "4 for SM 0, 2xdimension in meter",
-			"casting_time": "10 minutes",
-			"duration": "Permanent",
-			"points": 1,
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Force Sensitivity"
-						}
-					}
-				]
-			}
-		},
-		{
-			"id": "82e37c42-c072-4043-b663-80c360129b85",
-			"type": "spell",
-			"name": "Cure Self",
-			"tags": [
-				"Alter",
+				"Control",
 				"Neutral"
 			],
-			"difficulty": "will/vh",
+			"difficulty": "will/a",
 			"college": [
+				"Control",
 				"Neutral"
-			],
-			"power_source": "Force",
-			"spell_class": "Regular",
-			"casting_cost": "4 for SM 0, 2xdimension in meter",
-			"casting_time": "10 minutes",
-			"duration": "Permanent",
-			"points": 1,
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Force Sensitivity"
-						}
-					}
-				]
-			}
-		},
-		{
-			"id": "41dc73ba-5966-4732-8417-0116bdb89656",
-			"type": "spell",
-			"name": "Detect Poison",
-			"tags": [
-				"Neutral",
-				"Sense"
-			],
-			"difficulty": "will/vh",
-			"college": [
-				"Neutral"
-			],
-			"power_source": "Force",
-			"spell_class": "Information,Regular",
-			"casting_cost": "2",
-			"casting_time": "10 sec",
-			"duration": "Instant",
-			"points": 1,
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Sense Talent"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 2
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Force Sensitivity"
-						}
-					}
-				]
-			}
-		},
-		{
-			"id": "34551f2c-1e4d-41bc-a50d-32cfe6203ab4",
-			"type": "spell",
-			"name": "Drain Energy",
-			"tags": [
-				"Alter",
-				"Dark"
-			],
-			"difficulty": "will/vh",
-			"college": [
-				"Dark"
-			],
-			"power_source": "Force",
-			"spell_class": "Regular",
-			"casting_cost": "varies",
-			"casting_time": "1 sec",
-			"duration": "Instant",
-			"points": 1,
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Alter Talent"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Force Sensitivity"
-						}
-					}
-				]
-			}
-		},
-		{
-			"id": "279fb397-4932-4891-b869-481dfc9f0fda",
-			"type": "spell",
-			"name": "Enhance Senses",
-			"tags": [
-				"Alter",
-				"Neutral"
-			],
-			"difficulty": "will/vh",
-			"college": [
-				"Neutral"
-			],
-			"power_source": "Force",
-			"spell_class": "Regular",
-			"casting_cost": "2 for every point of PER increase",
-			"maintenance_cost": "Same as cost",
-			"casting_time": "1 sec",
-			"duration": "1 minutes",
-			"points": 1,
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Alter Talent"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Force Sensitivity"
-						}
-					}
-				]
-			}
-		},
-		{
-			"id": "eeb41d6a-dfd9-4964-a797-8c287d5750e2",
-			"type": "spell",
-			"name": "Enhance Strength",
-			"tags": [
-				"Alter",
-				"Neutral"
-			],
-			"difficulty": "will/vh",
-			"college": [
-				"Neutral"
-			],
-			"power_source": "Force",
-			"spell_class": "Regular",
-			"casting_cost": "2 for every point of ST increase",
-			"maintenance_cost": "Same as cost",
-			"casting_time": "1 sec",
-			"duration": "1 minutes",
-			"points": 1,
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Alter Talent"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Force Sensitivity"
-						}
-					}
-				]
-			}
-		},
-		{
-			"id": "5f75c991-fab7-4f07-8d26-944f14cc414e",
-			"type": "spell",
-			"name": "Fear",
-			"tags": [
-				"Alter",
-				"Dark"
-			],
-			"difficulty": "will/vh",
-			"college": [
-				"Dark"
 			],
 			"power_source": "Force",
 			"spell_class": "Regular",
 			"resist": "Will",
-			"casting_cost": "1",
+			"casting_cost": "varies",
+			"casting_time": "1 sec",
+			"duration": "1 minute",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Innate Attack"
+						},
+						"specialization": {
+							"compare": "is",
+							"qualifier": "Force"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Force Sensitivity"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "a334edcc-73c8-4e57-a4a8-32e02eb4eb1c",
+			"type": "spell",
+			"name": "Mind Trick",
+			"reference": "SWF12",
+			"notes": "Cannot Exceed: Meditation - 1",
+			"tags": [
+				"Alter",
+				"Neutral"
+			],
+			"difficulty": "will/a",
+			"college": [
+				"Alter",
+				"Neutral"
+			],
+			"power_source": "Force",
+			"spell_class": "Regular",
+			"resist": "Will",
+			"casting_cost": "4",
+			"maintenance_cost": "3",
+			"casting_time": "10 sec",
+			"duration": "2 sec",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Force Sensitivity"
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "a17b491d-5147-484f-a3b6-0fead702aabc",
+			"type": "spell",
+			"name": "Hide Thoughts",
+			"reference": "SWF14",
+			"notes": "Cannot Exceed: Hide Emotions - 1",
+			"tags": [
+				"Control",
+				"Neutral"
+			],
+			"difficulty": "will/vh",
+			"college": [
+				"Control",
+				"Neutral"
+			],
+			"power_source": "Force",
+			"spell_class": "Regular",
+			"casting_cost": "3",
+			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "10 minutes",
 			"points": 1,
@@ -639,6 +885,31 @@
 				"all": true,
 				"prereqs": [
 					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Hide Emotion"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Control Talent"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
 						"type": "trait_prereq",
 						"has": true,
 						"name": {
@@ -650,22 +921,330 @@
 			}
 		},
 		{
-			"id": "91227f2b-0bef-4d29-b3ca-2816cfb4cbf9",
+			"id": "43bc26f9-0882-41f5-84d0-14180fb14c96",
 			"type": "spell",
-			"name": "Force Blast",
-			"notes": "Cannot Exceed: Move Object-1",
+			"name": "Hide Emotion",
+			"reference": "SWF14",
+			"tags": [
+				"Control",
+				"Neutral"
+			],
+			"difficulty": "will/a",
+			"college": [
+				"Control",
+				"Neutral"
+			],
+			"power_source": "Force",
+			"spell_class": "Regular",
+			"casting_cost": "2",
+			"maintenance_cost": "2",
+			"casting_time": "1 sec",
+			"duration": "1 hour",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Force Sensitivity"
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "d8fc63e2-e8b8-4d58-b344-a96a33715fb9",
+			"type": "spell",
+			"name": "Heal Self",
+			"reference": "SWF12",
+			"notes": "Cannot Exceed: Meditation - 1",
+			"tags": [
+				"Alter",
+				"Neutral"
+			],
+			"difficulty": "will/a",
+			"college": [
+				"Alter",
+				"Neutral"
+			],
+			"power_source": "Force",
+			"spell_class": "Regular",
+			"casting_cost": "6 (12 to half recovery time)",
+			"casting_time": "10 sec",
+			"duration": "Max 8 hours (max 8hp per day)",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Meditation"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Force Sensitivity"
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "1d1412b2-98b2-44e3-a480-15de69a53f4c",
+			"type": "spell",
+			"name": "Heal Another",
+			"reference": "SWF12",
+			"tags": [
+				"Alter",
+				"Light"
+			],
+			"difficulty": "will/vh",
+			"college": [
+				"Light"
+			],
+			"power_source": "Force",
+			"spell_class": "Regular",
+			"casting_cost": "1 to stop bleeding on a normal wound; 10 to stabilize a mortal wound",
+			"casting_time": "10 sec",
+			"duration": "Permanent",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Force Sensitivity"
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "2520eda9-1e47-46ac-8971-052382a2eb41",
+			"type": "spell",
+			"name": "Fury",
+			"reference": "SWF17",
+			"tags": [
+				"Dark",
+				"Miscellaneous"
+			],
+			"difficulty": "will/a",
+			"college": [
+				"Dark"
+			],
+			"power_source": "Force",
+			"spell_class": "Regular",
+			"casting_cost": "1 HP per foe",
+			"casting_time": "1 sec",
+			"duration": "Instant",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Berserk"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Dark Aspect of The Force"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Force Sensitivity"
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "5033c9fb-7bab-4569-8d80-d7dc1c234042",
+			"type": "spell",
+			"name": "Force Stealth",
+			"reference": "SWF12",
+			"tags": [
+				"Alter",
+				"Neutral"
+			],
+			"difficulty": "will/a",
+			"college": [
+				"Alter",
+				"Neutral"
+			],
+			"power_source": "Force",
+			"spell_class": "Regular",
+			"casting_cost": "1 per -1 to detect (up to 10)",
+			"maintenance_cost": "same as cost",
+			"casting_time": "10 sec",
+			"duration": "1 day",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Force Sensitivity"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "579c410e-d331-4f8f-95a0-f308e463c3ae",
+			"type": "spell",
+			"name": "Force Speed",
+			"reference": "SWF14",
+			"tags": [
+				"Control",
+				"Neutral"
+			],
+			"difficulty": "will/a",
+			"college": [
+				"Control",
+				"Neutral"
+			],
+			"power_source": "Force",
+			"spell_class": "Regular",
+			"casting_cost": "1",
+			"maintenance_cost": "1 per MV point",
+			"casting_time": "Instant",
+			"duration": "1 minute",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Control Talent"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Force Sensitivity"
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "c9e71f68-f017-4d13-92e4-5bfe67751e79",
+			"type": "spell",
+			"name": "Force Shield",
+			"reference": "SWF11",
+			"tags": [
+				"Alter",
+				"Neutral"
+			],
+			"difficulty": "will/a",
+			"college": [
+				"Alter",
+				"Neutral"
+			],
+			"power_source": "Force",
+			"spell_class": "Regular",
+			"casting_cost": "2 per DB",
+			"casting_time": "1 sec",
+			"duration": "1 minutes",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Alter Talent"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 3
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Force Sensitivity"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "0fbaecf1-bc09-4bdf-9908-4b14a68b4bb4",
+			"type": "spell",
+			"name": "Force Push",
+			"reference": "SWF14",
+			"notes": "Cannot Exceed: Move Object - 1",
 			"tags": [
 				"Control",
 				"Neutral"
 			],
 			"difficulty": "will/vh",
 			"college": [
+				"Control",
 				"Neutral"
 			],
 			"power_source": "Force",
-			"spell_class": "Missile",
-			"casting_cost": "1 to 3",
-			"maintenance_cost": "1",
+			"spell_class": "Regular",
+			"casting_cost": "1 per +2 ST",
 			"casting_time": "Instant",
 			"duration": "1 sec",
 			"points": 1,
@@ -707,37 +1286,75 @@
 						}
 					}
 				]
-			},
-			"weapons": [
-				{
-					"id": "cf354ea3-e07f-4148-9f51-a25df555cc67",
-					"type": "ranged_weapon",
-					"damage": {
-						"type": "kb",
-						"base": "2d"
-					},
-					"usage": "Force Blast",
-					"defaults": [
-						{
-							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "Force"
-						},
-						{
-							"type": "dx",
-							"modifier": -4
-						}
-					],
-					"calc": {
-						"damage": "2d kb"
-					}
-				}
-			]
+			}
 		},
 		{
-			"id": "21327009-2f5e-44b5-a443-dcf40b6c924d",
+			"id": "b7800457-c0a5-43ab-b61d-2f01749a9dee",
 			"type": "spell",
-			"name": "Force Deflection",
+			"name": "Force Pull",
+			"reference": "SWF14",
+			"notes": "Cannot Exceed: Move Object - 1",
+			"tags": [
+				"Control",
+				"Neutral"
+			],
+			"difficulty": "will/vh",
+			"college": [
+				"Control",
+				"Neutral"
+			],
+			"power_source": "Force",
+			"spell_class": "Regular",
+			"casting_cost": "1 per +2 ST",
+			"casting_time": "Instant",
+			"duration": "1 sec",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Move Object"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Control Talent"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Force Sensitivity"
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "a53abd91-60ba-4e74-89b0-61f6e84eba2f",
+			"type": "spell",
+			"name": "Force Protection",
+			"reference": "SWF11",
+			"notes": "Cannot Exceed: Force Shield - 1",
 			"tags": [
 				"Alter",
 				"Neutral"
@@ -747,15 +1364,28 @@
 				"Neutral"
 			],
 			"power_source": "Force",
-			"spell_class": "Block",
-			"casting_cost": "1+variable",
+			"spell_class": "Regular",
+			"casting_cost": "2 per DR",
 			"casting_time": "1 sec",
-			"duration": "Instant",
+			"duration": "1 minute",
 			"points": 1,
 			"prereqs": {
 				"type": "prereq_list",
 				"all": true,
 				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Force Shield"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
 					{
 						"type": "trait_prereq",
 						"has": true,
@@ -774,54 +1404,6 @@
 						"name": {
 							"compare": "is",
 							"qualifier": "Force Sensitivity"
-						}
-					}
-				]
-			}
-		},
-		{
-			"id": "2bf155c2-1ff1-4a9a-a673-ef9c41eaadda",
-			"type": "spell",
-			"name": "Force Grip",
-			"notes": "Neutral, unless used on a living creature. Then it becomes a Dark side Force ability.",
-			"tags": [
-				"Control",
-				"Dark",
-				"Neutral"
-			],
-			"difficulty": "will/vh",
-			"college": [
-				"Dark",
-				"Neutral"
-			],
-			"power_source": "Force",
-			"spell_class": "Regular",
-			"casting_cost": "1 for every ST",
-			"casting_time": "Instant",
-			"duration": "1 sec",
-			"points": 1,
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Control Talent"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 2
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Force Sensitivity"
 						},
 						"level": {
 							"compare": "at_least",
@@ -829,160 +1411,20 @@
 						}
 					}
 				]
-			},
-			"weapons": [
-				{
-					"id": "4b1400df-5fac-4d37-af58-6efc86345b69",
-					"type": "ranged_weapon",
-					"damage": {
-						"type": "cr",
-						"base": "1d"
-					},
-					"usage": "Force Grip",
-					"defaults": [
-						{
-							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "Force"
-						},
-						{
-							"type": "dx",
-							"modifier": -4
-						}
-					],
-					"calc": {
-						"damage": "1d cr"
-					}
-				}
-			]
-		},
-		{
-			"id": "b799513b-3cec-444b-88e8-d5d7bce3cfe8",
-			"type": "spell",
-			"name": "Force Jump",
-			"tags": [
-				"Control",
-				"Neutral"
-			],
-			"difficulty": "will/vh",
-			"college": [
-				"Neutral"
-			],
-			"power_source": "Force",
-			"spell_class": "Regular",
-			"casting_cost": "1 per +2 to Move",
-			"casting_time": "Instant",
-			"duration": "1 jump",
-			"points": 1,
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Control Talent"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Force Sensitivity"
-						}
-					}
-				]
 			}
 		},
 		{
-			"id": "b68c16c8-cac8-4f92-809d-552d6ede3d8d",
-			"type": "spell",
-			"name": "Force Light",
-			"difficulty": "will/h",
-			"college": [
-				"Light"
-			],
-			"power_source": "Force",
-			"spell_class": "Regular",
-			"resist": "Will",
-			"casting_cost": "2+1 per d-1 (aff) samage",
-			"casting_time": "1 sec",
-			"duration": "Instant",
-			"points": 1,
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Light Aspect of The Force"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Alter Talent"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Force Sensitivity"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 4
-						}
-					}
-				]
-			},
-			"weapons": [
-				{
-					"id": "7a7f5be3-5e38-412a-810a-dac35f702402",
-					"type": "ranged_weapon",
-					"damage": {
-						"type": ""
-					},
-					"usage": "Force Light",
-					"defaults": [
-						{
-							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "Force"
-						}
-					],
-					"calc": {}
-				}
-			]
-		},
-		{
-			"id": "a3a63f5b-cf2f-4518-9ae6-39482c5d2211",
+			"id": "587b93d7-5d91-48e3-92e6-65428c669a73",
 			"type": "spell",
 			"name": "Force Lightning",
+			"reference": "SWF14",
 			"tags": [
 				"Control",
 				"Dark"
 			],
-			"difficulty": "will/vh",
+			"difficulty": "will/a",
 			"college": [
+				"Control",
 				"Dark"
 			],
 			"power_source": "Force",
@@ -1066,40 +1508,233 @@
 			]
 		},
 		{
-			"id": "d352c4c6-3dff-4d77-a6c1-943d0f605767",
+			"id": "b82a5c6e-d5b6-4f58-8059-c9c6d1d5c35d",
 			"type": "spell",
-			"name": "Force Protection",
+			"name": "Force Light",
+			"reference": "SWF11",
 			"tags": [
 				"Alter",
-				"Neutral"
+				"Light"
 			],
 			"difficulty": "will/vh",
 			"college": [
-				"Neutral"
+				"Alter",
+				"Light"
 			],
 			"power_source": "Force",
 			"spell_class": "Regular",
-			"casting_cost": "2 per DR",
+			"resist": "Will",
+			"casting_cost": "2+1 per d-1 (aff) samage",
 			"casting_time": "1 sec",
-			"duration": "1 minute",
+			"duration": "Instant",
 			"points": 1,
 			"prereqs": {
 				"type": "prereq_list",
 				"all": true,
 				"prereqs": [
 					{
-						"type": "spell_prereq",
-						"sub_type": "name",
+						"type": "trait_prereq",
 						"has": true,
-						"qualifier": {
+						"name": {
 							"compare": "is",
-							"qualifier": "Force Shield"
+							"qualifier": "Light Aspect of The Force"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Alter Talent"
 						},
-						"quantity": {
+						"level": {
 							"compare": "at_least",
 							"qualifier": 1
 						}
 					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Force Sensitivity"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 4
+						}
+					}
+				]
+			},
+			"weapons": [
+				{
+					"id": "7a7f5be3-5e38-412a-810a-dac35f702402",
+					"type": "ranged_weapon",
+					"damage": {
+						"type": ""
+					},
+					"usage": "Force Light",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Innate Attack",
+							"specialization": "Force"
+						}
+					],
+					"calc": {}
+				}
+			]
+		},
+		{
+			"id": "e169f0a6-c3d0-45b4-b457-baaadfdc5776",
+			"type": "spell",
+			"name": "Force Jump",
+			"reference": "SWF14",
+			"tags": [
+				"Control",
+				"Neutral"
+			],
+			"difficulty": "will/a",
+			"college": [
+				"Control",
+				"Neutral"
+			],
+			"power_source": "Force",
+			"spell_class": "Regular",
+			"casting_cost": "1 per +2 to Move",
+			"casting_time": "Instant",
+			"duration": "1 jump",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Control Talent"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Force Sensitivity"
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "39574846-b3ac-4291-8e5e-7dcc9021110f",
+			"type": "spell",
+			"name": "Force Grip",
+			"reference": "SWF14",
+			"notes": "Neutral, unless used on a living creature. Then it becomes a Dark side Force ability.",
+			"tags": [
+				"Control",
+				"Neutral",
+				"Dark"
+			],
+			"difficulty": "will/a",
+			"college": [
+				"Control",
+				"Neutral",
+				"Dark"
+			],
+			"power_source": "Force",
+			"spell_class": "Regular",
+			"casting_cost": "1 for every ST",
+			"casting_time": "Instant",
+			"duration": "1 sec",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Control Talent"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 2
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Force Sensitivity"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 2
+						}
+					}
+				]
+			},
+			"weapons": [
+				{
+					"id": "4b1400df-5fac-4d37-af58-6efc86345b69",
+					"type": "ranged_weapon",
+					"damage": {
+						"type": "cr",
+						"base": "1d"
+					},
+					"usage": "Force Grip",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Innate Attack",
+							"specialization": "Force"
+						},
+						{
+							"type": "dx",
+							"modifier": -4
+						}
+					],
+					"calc": {
+						"damage": "1d cr"
+					}
+				}
+			]
+		},
+		{
+			"id": "afc9caab-d2dd-471b-b1a4-568f9ce80fd5",
+			"type": "spell",
+			"name": "Force Deflection",
+			"reference": "SWF11",
+			"tags": [
+				"Alter",
+				"Neutral"
+			],
+			"difficulty": "will/vh",
+			"college": [
+				"Alter",
+				"Neutral"
+			],
+			"power_source": "Force",
+			"spell_class": "Block",
+			"casting_cost": "1+variable",
+			"casting_time": "1 sec",
+			"duration": "Instant",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
 					{
 						"type": "trait_prereq",
 						"has": true,
@@ -1118,31 +1753,30 @@
 						"name": {
 							"compare": "is",
 							"qualifier": "Force Sensitivity"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 2
 						}
 					}
 				]
 			}
 		},
 		{
-			"id": "209ab882-f4cf-473a-af14-5b3fb3fe24bb",
+			"id": "2619bae9-33f1-4ae3-8bcb-ee3bf70b8111",
 			"type": "spell",
-			"name": "Force Pull",
-			"notes": "Cannot Exceed: Move Object-1",
+			"name": "Force Blast",
+			"reference": "SWF13",
+			"notes": "Cannot Exceed: Move Object - 1",
 			"tags": [
 				"Control",
 				"Neutral"
 			],
 			"difficulty": "will/vh",
 			"college": [
+				"Control",
 				"Neutral"
 			],
 			"power_source": "Force",
-			"spell_class": "Regular",
-			"casting_cost": "1 per +2 ST",
+			"spell_class": "Missile",
+			"casting_cost": "1 to 3",
+			"maintenance_cost": "1",
 			"casting_time": "Instant",
 			"duration": "1 sec",
 			"points": 1,
@@ -1184,56 +1818,58 @@
 						}
 					}
 				]
-			}
+			},
+			"weapons": [
+				{
+					"id": "cf354ea3-e07f-4148-9f51-a25df555cc67",
+					"type": "ranged_weapon",
+					"damage": {
+						"type": "kb",
+						"base": "2d"
+					},
+					"usage": "Force Blast",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Innate Attack",
+							"specialization": "Force"
+						},
+						{
+							"type": "dx",
+							"modifier": -4
+						}
+					],
+					"calc": {
+						"damage": "2d kb"
+					}
+				}
+			]
 		},
 		{
-			"id": "ab87a1f2-2ea3-43a7-b1b2-c3e22409fafc",
+			"id": "03423db5-6192-44a3-b298-f98c73f93d48",
 			"type": "spell",
-			"name": "Force Push",
-			"notes": "Cannot Exceed: Move Object-1",
+			"name": "Fear",
+			"reference": "SWF11",
 			"tags": [
-				"Control",
-				"Neutral"
+				"Alter",
+				"Dark"
 			],
-			"difficulty": "will/vh",
+			"difficulty": "will/a",
 			"college": [
-				"Neutral"
+				"Alter",
+				"Dark"
 			],
 			"power_source": "Force",
 			"spell_class": "Regular",
-			"casting_cost": "1 per +2 ST",
-			"casting_time": "Instant",
-			"duration": "1 sec",
+			"resist": "Will",
+			"casting_cost": "1",
+			"casting_time": "1 sec",
+			"duration": "10 minutes",
 			"points": 1,
 			"prereqs": {
 				"type": "prereq_list",
 				"all": true,
 				"prereqs": [
-					{
-						"type": "spell_prereq",
-						"sub_type": "name",
-						"has": true,
-						"qualifier": {
-							"compare": "is",
-							"qualifier": "Move Object"
-						},
-						"quantity": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Control Talent"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
-					},
 					{
 						"type": "trait_prereq",
 						"has": true,
@@ -1246,20 +1882,23 @@
 			}
 		},
 		{
-			"id": "03059fc0-34bc-438e-a08b-32212837a790",
+			"id": "f589a66b-9618-4796-a4fe-6a925ed65a82",
 			"type": "spell",
-			"name": "Force Shield",
+			"name": "Enhance Strength",
+			"reference": "SWF11",
 			"tags": [
 				"Alter",
 				"Neutral"
 			],
-			"difficulty": "will/vh",
+			"difficulty": "will/a",
 			"college": [
+				"Alter",
 				"Neutral"
 			],
 			"power_source": "Force",
 			"spell_class": "Regular",
-			"casting_cost": "2 per DB",
+			"casting_cost": "2 for every point of ST increase",
+			"maintenance_cost": "Same as cost",
 			"casting_time": "1 sec",
 			"duration": "1 minutes",
 			"points": 1,
@@ -1276,56 +1915,6 @@
 						},
 						"level": {
 							"compare": "at_least",
-							"qualifier": 3
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Force Sensitivity"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
-					}
-				]
-			}
-		},
-		{
-			"id": "5b9e4edf-0265-4e67-a575-5e277d3fb4a7",
-			"type": "spell",
-			"name": "Force Speed",
-			"tags": [
-				"Control",
-				"Neutral"
-			],
-			"difficulty": "will/vh",
-			"college": [
-				"Neutral"
-			],
-			"power_source": "Force",
-			"spell_class": "Regular",
-			"casting_cost": "1",
-			"maintenance_cost": "1 per MV point",
-			"casting_time": "Instant",
-			"duration": "1 minute",
-			"points": 1,
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Control Talent"
-						},
-						"level": {
-							"compare": "at_least",
 							"qualifier": 1
 						}
 					},
@@ -1341,23 +1930,25 @@
 			}
 		},
 		{
-			"id": "4fad84e9-199f-4082-8d9f-06c876f9a188",
+			"id": "df82c275-d711-4b66-b276-ea15ea752978",
 			"type": "spell",
-			"name": "Force Stealth",
+			"name": "Enhance Senses",
+			"reference": "SWF11",
 			"tags": [
 				"Alter",
 				"Neutral"
 			],
-			"difficulty": "will/vh",
+			"difficulty": "will/a",
 			"college": [
+				"Alter",
 				"Neutral"
 			],
 			"power_source": "Force",
 			"spell_class": "Regular",
-			"casting_cost": "1 per -1 to detect (up to 10)",
-			"maintenance_cost": "same as cost",
-			"casting_time": "10 sec",
-			"duration": "1 day",
+			"casting_cost": "2 for every point of PER increase",
+			"maintenance_cost": "Same as cost",
+			"casting_time": "1 sec",
+			"duration": "1 minutes",
 			"points": 1,
 			"prereqs": {
 				"type": "prereq_list",
@@ -1368,30 +1959,41 @@
 						"has": true,
 						"name": {
 							"compare": "is",
-							"qualifier": "Force Sensitivity"
+							"qualifier": "Alter Talent"
 						},
 						"level": {
 							"compare": "at_least",
 							"qualifier": 1
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Force Sensitivity"
 						}
 					}
 				]
 			}
 		},
 		{
-			"id": "9518b70c-00c3-4a0d-a309-a3dece97debe",
+			"id": "74ffab18-959a-4287-a7d2-9850cbec6f2e",
 			"type": "spell",
-			"name": "Fury",
+			"name": "Drain Energy",
+			"reference": "SWF10",
 			"tags": [
+				"Alter",
 				"Dark"
 			],
 			"difficulty": "will/vh",
 			"college": [
+				"Alter",
 				"Dark"
 			],
 			"power_source": "Force",
 			"spell_class": "Regular",
-			"casting_cost": "1 HP per foe",
+			"casting_cost": "varies",
 			"casting_time": "1 sec",
 			"duration": "Instant",
 			"points": 1,
@@ -1404,15 +2006,11 @@
 						"has": true,
 						"name": {
 							"compare": "is",
-							"qualifier": "Berserk"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Dark Aspect of The Force"
+							"qualifier": "Alter Talent"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 1
 						}
 					},
 					{
@@ -1427,21 +2025,70 @@
 			}
 		},
 		{
-			"id": "0644c87d-fea4-495d-890e-907e467379ea",
+			"id": "2268ade0-2ee9-4607-bf38-32eeabb6bda2",
 			"type": "spell",
-			"name": "Heal Another",
+			"name": "Detect Poison",
+			"reference": "SWF16",
+			"tags": [
+				"Neutral",
+				"Sense"
+			],
+			"difficulty": "will/a",
+			"college": [
+				"Neutral",
+				"Sense"
+			],
+			"power_source": "Force",
+			"spell_class": "Information, Regular",
+			"casting_cost": "2",
+			"casting_time": "10 sec",
+			"duration": "Instant",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Sense Talent"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 2
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Force Sensitivity"
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "0c55d44e-be23-47a9-bdb1-08c8ba42de82",
+			"type": "spell",
+			"name": "Cure Self",
+			"reference": "SWF10",
 			"tags": [
 				"Alter",
-				"Light"
+				"Neutral"
 			],
-			"difficulty": "will/vh",
+			"difficulty": "will/a",
 			"college": [
-				"Light"
+				"Alter",
+				"Neutral"
 			],
 			"power_source": "Force",
 			"spell_class": "Regular",
-			"casting_cost": "1 to stop bleeding on a normal wound;10 to stabilize a mortal wound",
-			"casting_time": "10 sec",
+			"casting_cost": "4 for SM 0, 2xdimension in meter",
+			"casting_time": "10 minutes",
 			"duration": "Permanent",
 			"points": 1,
 			"prereqs": {
@@ -1460,40 +2107,29 @@
 			}
 		},
 		{
-			"id": "6cde6573-7836-424e-9037-407e8e8f02ba",
+			"id": "9066ea85-d158-4a1e-a365-ed108938dbd4",
 			"type": "spell",
-			"name": "Heal Self",
-			"notes": "cannot exceed Meditation-1",
+			"name": "Cure Another",
+			"reference": "SWF10",
 			"tags": [
 				"Alter",
-				"Neutral"
+				"Light"
 			],
 			"difficulty": "will/vh",
 			"college": [
-				"Neutral"
+				"Alter",
+				"Light"
 			],
 			"power_source": "Force",
 			"spell_class": "Regular",
-			"casting_cost": "6 (12 to half recovery time)",
-			"casting_time": "10 sec",
-			"duration": "Max 8 hours (max 8hp per day)",
+			"casting_cost": "4 for SM 0, 2x dimension in meters",
+			"casting_time": "10 minutes",
+			"duration": "Permanent",
 			"points": 1,
 			"prereqs": {
 				"type": "prereq_list",
 				"all": true,
 				"prereqs": [
-					{
-						"type": "skill_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Meditation"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
-					},
 					{
 						"type": "trait_prereq",
 						"has": true,
@@ -1506,70 +2142,27 @@
 			}
 		},
 		{
-			"id": "b8138f4b-58cd-49e4-afc7-3aa47faee4f7",
+			"id": "66d01166-ce97-4b76-85b0-999f8ff2a1cb",
 			"type": "spell",
-			"name": "Hide Emotion",
+			"name": "Choke",
+			"reference": "SWF13",
+			"notes": "Cannot Exceed: Force Grip - 1",
 			"tags": [
 				"Control",
-				"Neutral"
+				"Dark"
 			],
 			"difficulty": "will/vh",
 			"college": [
-				"Neutral"
-			],
-			"power_source": "Force",
-			"spell_class": "Regular",
-			"casting_cost": "2",
-			"maintenance_cost": "2",
-			"casting_time": "1 sec",
-			"duration": "1 hour",
-			"points": 1,
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Control Talent"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Force Sensitivity"
-						}
-					}
-				]
-			}
-		},
-		{
-			"id": "070815df-b964-4fe9-8506-04e28b903082",
-			"type": "spell",
-			"name": "Hide Thoughts",
-			"notes": "Cannot Exceed: Hide Emotions-1",
-			"tags": [
 				"Control",
-				"Neutral"
-			],
-			"difficulty": "will/vh",
-			"college": [
-				"Neutral"
+				"Dark"
 			],
 			"power_source": "Force",
 			"spell_class": "Regular",
-			"casting_cost": "3",
+			"resist": "HT",
+			"casting_cost": "4",
 			"maintenance_cost": "1",
-			"casting_time": "1 sec",
-			"duration": "10 minutes",
+			"casting_time": "Instant",
+			"duration": "1 min",
 			"points": 1,
 			"prereqs": {
 				"type": "prereq_list",
@@ -1581,7 +2174,7 @@
 						"has": true,
 						"qualifier": {
 							"compare": "is",
-							"qualifier": "Hide Emotion"
+							"qualifier": "Force Grip"
 						},
 						"quantity": {
 							"compare": "at_least",
@@ -1597,147 +2190,7 @@
 						},
 						"level": {
 							"compare": "at_least",
-							"qualifier": 1
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Force Sensitivity"
-						}
-					}
-				]
-			}
-		},
-		{
-			"id": "a9a4364e-1bda-45d8-a705-0abbcbe450eb",
-			"type": "spell",
-			"name": "Mind Trick",
-			"notes": "cannot exceed Meditation-1",
-			"tags": [
-				"Alter",
-				"Neutral"
-			],
-			"difficulty": "will/vh",
-			"college": [
-				"Neutral"
-			],
-			"power_source": "Force",
-			"spell_class": "Regular",
-			"resist": "Will",
-			"casting_cost": "4",
-			"maintenance_cost": "3",
-			"casting_time": "10 sec",
-			"duration": "2 sec",
-			"points": 1,
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Force Sensitivity"
-						}
-					}
-				]
-			}
-		},
-		{
-			"id": "7fb565ab-50c9-4289-a63c-3f7f27d4e9d8",
-			"type": "spell",
-			"name": "Move Object",
-			"tags": [
-				"Control",
-				"Neutral"
-			],
-			"difficulty": "will/vh",
-			"college": [
-				"Neutral"
-			],
-			"power_source": "Force",
-			"spell_class": "Regular",
-			"resist": "Will",
-			"casting_cost": "varies",
-			"casting_time": "1 sec",
-			"duration": "1 minute",
-			"points": 1,
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "skill_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Innate Attack"
-						},
-						"specialization": {
-							"compare": "is",
-							"qualifier": "Force"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Control Talent"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Force Sensitivity"
-						}
-					}
-				]
-			}
-		},
-		{
-			"id": "66c317ea-d945-4936-962f-f3354f24b706",
-			"type": "spell",
-			"name": "Neutralize Poison",
-			"notes": "cannot exceed Meditation-1",
-			"tags": [
-				"Alter",
-				"Neutral"
-			],
-			"difficulty": "will/vh",
-			"college": [
-				"Neutral"
-			],
-			"power_source": "Force",
-			"spell_class": "Regular",
-			"casting_cost": "5",
-			"casting_time": "30 sec",
-			"duration": "Permanent",
-			"points": 1,
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Alter Talent"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 2
+							"qualifier": 4
 						}
 					},
 					{
@@ -1756,195 +2209,10 @@
 			}
 		},
 		{
-			"id": "8a0a1440-35cd-45a3-95f5-985907e8c46f",
+			"id": "24a55979-f609-4480-8e8c-a31738525780",
 			"type": "spell",
-			"name": "Pain",
-			"tags": [
-				"Control",
-				"Dark"
-			],
-			"difficulty": "will/vh",
-			"college": [
-				"Dark"
-			],
-			"power_source": "Force",
-			"spell_class": "Regular",
-			"resist": "HT",
-			"casting_cost": "2",
-			"casting_time": "1 sec",
-			"duration": "1 sec",
-			"points": 1,
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Control Talent"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Force Sensitivity"
-						}
-					}
-				]
-			}
-		},
-		{
-			"id": "7e4fd439-ddd6-4685-8122-0149d11f6ee8",
-			"type": "spell",
-			"name": "Projective Telepathy",
-			"tags": [
-				"Control",
-				"Neutral"
-			],
-			"difficulty": "will/vh",
-			"college": [
-				"Neutral"
-			],
-			"power_source": "Force",
-			"spell_class": "Regular",
-			"resist": "Will",
-			"casting_cost": "4",
-			"casting_time": "1 sec",
-			"duration": "1 sec",
-			"points": 1,
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Control Talent"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Force Sensitivity"
-						}
-					}
-				]
-			}
-		},
-		{
-			"id": "b1be1838-4134-4f3d-a75c-1c4ac57e03bf",
-			"type": "spell",
-			"name": "Psychometric Sense",
-			"notes": "Dark if it involves emotional stress",
-			"tags": [
-				"Dark",
-				"Neutral",
-				"Sense"
-			],
-			"difficulty": "will/vh",
-			"college": [
-				"Dark",
-				"Neutral"
-			],
-			"power_source": "Force",
-			"spell_class": "Information",
-			"casting_cost": "varies",
-			"casting_time": "1 sec per EP",
-			"duration": "Event tied",
-			"points": 1,
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Sense Talent"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Force Sensitivity"
-						}
-					}
-				]
-			}
-		},
-		{
-			"id": "43e91187-8a14-42f2-9fb2-5cfafafd8076",
-			"type": "spell",
-			"name": "Receptive Telepathy",
-			"tags": [
-				"Neutral",
-				"Sense"
-			],
-			"difficulty": "will/vh",
-			"college": [
-				"Neutral"
-			],
-			"power_source": "Force",
-			"spell_class": "Regular",
-			"casting_cost": "1",
-			"maintenance_cost": "1",
-			"casting_time": "1 sec",
-			"duration": "1 sec",
-			"points": 1,
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Sense Talent"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Force Sensitivity"
-						}
-					}
-				]
-			}
-		},
-		{
-			"id": "ecef12de-b21d-42f3-812d-4a939f265a85",
-			"type": "spell",
-			"name": "Sense Disease",
+			"name": "Body-Reading",
+			"reference": "SWF16",
 			"notes": "Cannot Exceed: Sense Life-1",
 			"tags": [
 				"Neutral",
@@ -1952,12 +2220,14 @@
 			],
 			"difficulty": "will/vh",
 			"college": [
-				"Neutral"
+				"Neutral",
+				"Sense"
 			],
 			"power_source": "Force",
-			"spell_class": "Information,Regular",
-			"casting_cost": "1",
-			"casting_time": "10 sec",
+			"spell_class": "Information",
+			"resist": "Will",
+			"casting_cost": "2",
+			"casting_time": "30 sec",
 			"duration": "Instant",
 			"points": 1,
 			"prereqs": {
@@ -1976,26 +2246,52 @@
 							"compare": "at_least",
 							"qualifier": 1
 						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Sense Talent"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 2
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Force Sensitivity"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 2
+						}
 					}
 				]
 			}
 		},
 		{
-			"id": "b77be85d-cd2a-45f1-a72c-32250e7455bf",
+			"id": "93ec5ece-f5b9-45d7-b7b1-8dee9f23d6b7",
 			"type": "spell",
-			"name": "Sense Emotion",
+			"name": "Battle Sense",
+			"reference": "SWF15",
 			"tags": [
 				"Neutral",
 				"Sense"
 			],
-			"difficulty": "will/vh",
+			"difficulty": "will/a",
 			"college": [
-				"Neutral"
+				"Neutral",
+				"Sense"
 			],
 			"power_source": "Force",
-			"spell_class": "Information,Regular",
+			"spell_class": "Information",
 			"resist": "Will",
-			"casting_cost": "2",
+			"casting_cost": "1 per foe",
 			"casting_time": "1 sec",
 			"duration": "Instant",
 			"points": 1,
@@ -2027,179 +2323,26 @@
 			}
 		},
 		{
-			"id": "b234c1aa-971c-43ff-8836-7120d0aa0d53",
+			"id": "9d8b6f23-6667-4e5a-946b-25311013b245",
 			"type": "spell",
-			"name": "Sense Force",
+			"name": "Battle Meditation",
+			"reference": "SWF13",
+			"notes": "Cannot Exceed: Meditation - 1",
 			"tags": [
-				"Neutral",
-				"Sense"
+				"Control",
+				"Neutral"
 			],
 			"difficulty": "will/vh",
 			"college": [
+				"Control",
 				"Neutral"
 			],
 			"power_source": "Force",
-			"spell_class": "Information,Area",
-			"casting_cost": "1",
+			"spell_class": "Area, Unique",
+			"casting_cost": "1+1 per bonus granted",
+			"maintenance_cost": "1",
 			"casting_time": "1 sec",
-			"duration": "Instant",
-			"points": 1,
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Sense Talent"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Force Sensitivity"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
-					}
-				]
-			}
-		},
-		{
-			"id": "153b2ef5-5424-4831-999a-91ae91e598d1",
-			"type": "spell",
-			"name": "Sense Life",
-			"tags": [
-				"Neutral",
-				"Sense"
-			],
-			"difficulty": "will/vh",
-			"college": [
-				"Neutral"
-			],
-			"power_source": "Force",
-			"spell_class": "Information,Area",
-			"casting_cost": "1",
-			"casting_time": "1 sec",
-			"duration": "Instant",
-			"points": 1,
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Sense Talent"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Force Sensitivity"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
-					}
-				]
-			}
-		},
-		{
-			"id": "cfdcee6b-bd93-483f-81c0-00caa13a6cdc",
-			"type": "spell",
-			"name": "Sense Shatterpoint",
-			"tags": [
-				"Neutral",
-				"Sense"
-			],
-			"difficulty": "will/vh",
-			"college": [
-				"Neutral"
-			],
-			"power_source": "Force",
-			"spell_class": "Information, Unique",
-			"casting_cost": "10 + Power Level Target",
-			"casting_time": "1 sec",
-			"duration": "Instant",
-			"points": 1,
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Precognition"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Sense Talent"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 4
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Force Sensitivity"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
-					}
-				]
-			}
-		},
-		{
-			"id": "8704a395-7d7a-41b3-afff-31f5fb9c9cd7",
-			"type": "spell",
-			"name": "Sever Force",
-			"notes": "cannot exceed Meditation-1",
-			"tags": [
-				"Alter",
-				"Neutral"
-			],
-			"difficulty": "will/vh",
-			"college": [
-				"Neutral"
-			],
-			"power_source": "Force",
-			"spell_class": "Regular",
-			"resist": "Will",
-			"casting_cost": "10 + Power level target",
-			"casting_time": "10 sec",
-			"duration": "Permanent",
+			"duration": "1 min",
 			"points": 1,
 			"prereqs": {
 				"type": "prereq_list",
@@ -2218,61 +2361,11 @@
 						"has": true,
 						"name": {
 							"compare": "is",
-							"qualifier": "Alter Talent"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Force Sensitivity"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
-					}
-				]
-			}
-		},
-		{
-			"id": "8ccc22a9-6976-4d00-b923-df90b2cc6029",
-			"type": "spell",
-			"name": "Slow",
-			"tags": [
-				"Control",
-				"Dark"
-			],
-			"difficulty": "will/vh",
-			"college": [
-				"Dark"
-			],
-			"power_source": "Force",
-			"spell_class": "Regular",
-			"resist": "HT+SM",
-			"casting_cost": "1",
-			"casting_time": "1 sec",
-			"duration": "varies",
-			"points": 1,
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
 							"qualifier": "Control Talent"
 						},
 						"level": {
 							"compare": "at_least",
-							"qualifier": 1
+							"qualifier": 4
 						}
 					},
 					{
@@ -2281,29 +2374,35 @@
 						"name": {
 							"compare": "is",
 							"qualifier": "Force Sensitivity"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 4
 						}
 					}
 				]
 			}
 		},
 		{
-			"id": "819d9c5f-a068-49d4-bb5e-6bc8e838303b",
+			"id": "ba5842de-9f3a-4f4a-ad54-da3e56e5477f",
 			"type": "spell",
-			"name": "Sound",
+			"name": "Aura of Presence",
+			"reference": "SWF10",
 			"tags": [
 				"Alter",
-				"Neutral"
+				"Dark"
 			],
-			"difficulty": "will/vh",
+			"difficulty": "will/a",
 			"college": [
-				"Neutral"
+				"Alter",
+				"Dark"
 			],
 			"power_source": "Force",
 			"spell_class": "Regular",
-			"casting_cost": "1",
-			"maintenance_cost": "1 per 5 sec",
+			"casting_cost": "4",
+			"maintenance_cost": "4",
 			"casting_time": "10 sec",
-			"duration": "5 sec",
+			"duration": "1 hour",
 			"points": 1,
 			"prereqs": {
 				"type": "prereq_list",
@@ -2314,7 +2413,7 @@
 						"has": true,
 						"name": {
 							"compare": "is",
-							"qualifier": "Force Sensitivity"
+							"qualifier": "Alter Talent"
 						},
 						"level": {
 							"compare": "at_least",
@@ -2325,23 +2424,25 @@
 			}
 		},
 		{
-			"id": "b4f31f17-b89c-466e-beb5-61abb1f1cbfc",
+			"id": "496c4bee-0fbe-47e8-a7db-da779d575221",
 			"type": "spell",
-			"name": "Steal Energy",
-			"notes": "willing target or unconscious",
+			"name": "Aura of Insignificance",
+			"reference": "SWF10",
 			"tags": [
 				"Alter",
 				"Dark"
 			],
-			"difficulty": "will/vh",
+			"difficulty": "will/a",
 			"college": [
-				"Dark"
+				"Dark",
+				"Alter"
 			],
 			"power_source": "Force",
 			"spell_class": "Regular",
-			"casting_cost": "0",
-			"casting_time": "1 minute for every 3 FP drained",
-			"duration": "Permanent",
+			"casting_cost": "4",
+			"maintenance_cost": "4",
+			"casting_time": "10 sec",
+			"duration": "1 hour",
 			"points": 1,
 			"prereqs": {
 				"type": "prereq_list",
@@ -2353,37 +2454,35 @@
 						"name": {
 							"compare": "is",
 							"qualifier": "Alter Talent"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Force Sensitivity"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 1
 						}
 					}
 				]
 			}
 		},
 		{
-			"id": "74fc0be5-8fac-466b-95eb-0f109ed092d9",
+			"id": "de54b130-bd12-4604-9207-0f881ee17e43",
 			"type": "spell",
-			"name": "Steal Vitality",
-			"notes": "willing target or unconscious,Cannot Exceed: Heal Self",
+			"name": "Analyze Force",
+			"reference": "SWF15",
+			"notes": "Cannot Exceed: Sense Force -1",
 			"tags": [
-				"Alter",
-				"Dark"
+				"Neutral",
+				"Sense"
 			],
 			"difficulty": "will/vh",
 			"college": [
-				"Dark"
+				"Neutral",
+				"Sense"
 			],
 			"power_source": "Force",
-			"spell_class": "Regular",
-			"casting_cost": "0",
-			"casting_time": "1 minute for every 3 HP drained",
-			"duration": "Permanent",
+			"spell_class": "Information",
+			"casting_cost": "8+ Power level of item",
+			"casting_time": "1 hour",
+			"duration": "1 sec",
 			"points": 1,
 			"prereqs": {
 				"type": "prereq_list",
@@ -2395,20 +2494,7 @@
 						"has": true,
 						"qualifier": {
 							"compare": "is",
-							"qualifier": "Heal Self"
-						},
-						"quantity": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
-					},
-					{
-						"type": "spell_prereq",
-						"sub_type": "name",
-						"has": true,
-						"qualifier": {
-							"compare": "is",
-							"qualifier": "Steal Energy"
+							"qualifier": "Sense Force"
 						},
 						"quantity": {
 							"compare": "at_least",
@@ -2420,7 +2506,7 @@
 						"has": true,
 						"name": {
 							"compare": "is",
-							"qualifier": "Alter Talent"
+							"qualifier": "Sense Talent"
 						},
 						"level": {
 							"compare": "at_least",

--- a/Library/Star Wars/Star Wars Skills.skl
+++ b/Library/Star Wars/Star Wars Skills.skl
@@ -3,9 +3,10 @@
 	"version": 4,
 	"rows": [
 		{
-			"id": "32c0d213-eecc-42bc-9dd3-e16b9d03a3b7",
+			"id": "9eb03795-ec90-49b5-be0b-6cbadfb4d032",
 			"type": "skill",
 			"name": "Armoury",
+			"reference": "SWF28",
 			"tags": [
 				"Force",
 				"Maintenance",
@@ -26,12 +27,167 @@
 					"specialization": "Force",
 					"modifier": -4
 				}
-			]
+			],
+			"calc": {}
 		},
 		{
-			"id": "443a447f-9df8-4e5c-a5dc-b368f31587eb",
+			"id": "2dd4da02-5974-4730-80dd-5ac138bf4b64",
+			"type": "technique",
+			"name": "Back Strike",
+			"reference": "MA67",
+			"tags": [
+				"Combat",
+				"Melee Combat",
+				"Technique",
+				"Weapon"
+			],
+			"difficulty": "h",
+			"points": 2,
+			"default": {
+				"type": "skill",
+				"name": "Lightsaber",
+				"specialization": "Two-Handed",
+				"modifier": -2
+			},
+			"limit": 0,
+			"calc": {}
+		},
+		{
+			"id": "59bc9495-54ba-4619-99de-e0f924e458c1",
+			"type": "technique",
+			"name": "Back Strike",
+			"reference": "MA67",
+			"tags": [
+				"Combat",
+				"Melee Combat",
+				"Technique",
+				"Weapon"
+			],
+			"difficulty": "h",
+			"points": 2,
+			"default": {
+				"type": "skill",
+				"name": "Lightsaber",
+				"modifier": -2
+			},
+			"limit": 0,
+			"calc": {}
+		},
+		{
+			"id": "74bf9ef6-eecc-441d-a397-9f57f643e410",
+			"type": "technique",
+			"name": "Disarming",
+			"reference": "MA70",
+			"tags": [
+				"Combat",
+				"Melee Combat",
+				"Technique",
+				"Weapon"
+			],
+			"difficulty": "h",
+			"points": 2,
+			"default": {
+				"type": "skill",
+				"name": "Lightsaber"
+			},
+			"limit": 5,
+			"calc": {}
+		},
+		{
+			"id": "310f61b8-7744-4e88-8dd3-2e281a4536a5",
+			"type": "technique",
+			"name": "Disarming",
+			"reference": "MA70",
+			"tags": [
+				"Combat",
+				"Melee Combat",
+				"Technique",
+				"Weapon"
+			],
+			"difficulty": "h",
+			"points": 2,
+			"default": {
+				"type": "skill",
+				"name": "Lightsaber",
+				"specialization": "Fencing"
+			},
+			"limit": 5,
+			"calc": {}
+		},
+		{
+			"id": "2911626a-6a64-4d2e-a152-f80afbe77b53",
+			"type": "technique",
+			"name": "Disarming",
+			"reference": "MA70",
+			"tags": [
+				"Combat",
+				"Melee Combat",
+				"Technique",
+				"Weapon"
+			],
+			"difficulty": "h",
+			"points": 2,
+			"default": {
+				"type": "skill",
+				"name": "Lightsaber",
+				"specialization": "Two-Handed"
+			},
+			"limit": 5,
+			"calc": {}
+		},
+		{
+			"id": "f4adbca0-5b0c-463c-9cfa-7ba94517ec68",
+			"type": "skill",
+			"name": "Dun Möch",
+			"reference": "SWF28",
+			"notes": "You are adept in the ancient skill of Dun Möch to temp others into using the Dark side of The Force.",
+			"tags": [
+				"Dark Side",
+				"Force"
+			],
+			"difficulty": "will/a",
+			"points": 1,
+			"defaults": [
+				{
+					"type": "skill",
+					"name": "Intimidation",
+					"modifier": -2
+				},
+				{
+					"type": "skill",
+					"name": "Fast-Talk",
+					"modifier": -2
+				},
+				{
+					"type": "skill",
+					"name": "Acting",
+					"modifier": -2
+				}
+			],
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Dark Aspect of The Force"
+						},
+						"level": {
+							"compare": "at_least"
+						}
+					}
+				]
+			},
+			"calc": {}
+		},
+		{
+			"id": "9b4433cf-f261-45cc-bb69-7e8beb07f874",
 			"type": "skill",
 			"name": "Electronics Repair",
+			"reference": "SWF28",
 			"tags": [
 				"Force",
 				"Maintenance",
@@ -57,12 +213,14 @@
 					"specialization": "Electronics",
 					"modifier": -3
 				}
-			]
+			],
+			"calc": {}
 		},
 		{
-			"id": "da9e281f-7278-42c5-940c-116ff46d8612",
+			"id": "a5e5160f-14bc-40b7-a3d4-295b4cccdfd7",
 			"type": "skill",
 			"name": "Engineer",
+			"reference": "SWF28",
 			"tags": [
 				"Design",
 				"Engineer",
@@ -97,56 +255,281 @@
 						}
 					}
 				]
-			}
+			},
+			"calc": {}
 		},
 		{
-			"id": "6ac36f84-aa8c-4651-b6a3-7c7edd5a14a9",
+			"id": "560abc5d-2022-4950-8121-42418b90897d",
 			"type": "skill",
 			"name": "Fast-Draw",
+			"reference": "B194,MA56,SWF28",
+			"tags": [
+				"Combat",
+				"Melee Combat",
+				"Weapon"
+			],
 			"specialization": "Lightsaber",
 			"difficulty": "dx/e",
-			"points": 1
+			"points": 1,
+			"calc": {}
 		},
 		{
-			"id": "38a1e48b-66c9-45df-8c15-e827cbace1d8",
+			"id": "a36fabcb-eb02-43f6-9088-6c7a90f1f288",
+			"type": "technique",
+			"name": "Feint",
+			"reference": "B231,MA73",
+			"tags": [
+				"Combat",
+				"Melee Combat",
+				"Technique",
+				"Weapon"
+			],
+			"difficulty": "h",
+			"points": 2,
+			"default": {
+				"type": "skill",
+				"name": "Lightsaber",
+				"specialization": "Double"
+			},
+			"limit": 4,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Lightsaber"
+						},
+						"level": {
+							"compare": "at_least"
+						},
+						"specialization": {
+							"compare": "is",
+							"qualifier": "Double"
+						}
+					}
+				]
+			},
+			"calc": {}
+		},
+		{
+			"id": "c6d4a0e6-010b-4f12-846e-b4b4554d6462",
+			"type": "technique",
+			"name": "Feint",
+			"reference": "B231,MA73",
+			"tags": [
+				"Combat",
+				"Melee Combat",
+				"Technique",
+				"Weapon"
+			],
+			"difficulty": "h",
+			"points": 2,
+			"default": {
+				"type": "skill",
+				"name": "Lightsaber",
+				"specialization": "Double-Headed"
+			},
+			"limit": 4,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Lightsaber"
+						},
+						"level": {
+							"compare": "at_least"
+						},
+						"specialization": {
+							"compare": "is",
+							"qualifier": "Double-Headed"
+						}
+					}
+				]
+			},
+			"calc": {}
+		},
+		{
+			"id": "2da668f7-bc06-4679-9aa0-3aac84f97da9",
+			"type": "technique",
+			"name": "Feint",
+			"reference": "B231,MA73",
+			"tags": [
+				"Combat",
+				"Melee Combat",
+				"Technique",
+				"Weapon"
+			],
+			"difficulty": "h",
+			"points": 2,
+			"default": {
+				"type": "skill",
+				"name": "Lightsaber",
+				"specialization": "Fencing"
+			},
+			"limit": 4,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Lightsaber"
+						},
+						"level": {
+							"compare": "at_least"
+						},
+						"specialization": {
+							"compare": "is",
+							"qualifier": "Fencing"
+						}
+					}
+				]
+			},
+			"calc": {}
+		},
+		{
+			"id": "7569e35e-305f-44a4-b9f3-ca15dfa8c5dd",
+			"type": "technique",
+			"name": "Feint",
+			"reference": "B231,MA73",
+			"tags": [
+				"Combat",
+				"Melee Combat",
+				"Technique",
+				"Weapon"
+			],
+			"difficulty": "h",
+			"points": 2,
+			"default": {
+				"type": "skill",
+				"name": "Lightsaber",
+				"specialization": "Short"
+			},
+			"limit": 4,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Lightsaber"
+						},
+						"level": {
+							"compare": "at_least"
+						},
+						"specialization": {
+							"compare": "is",
+							"qualifier": "Short"
+						}
+					}
+				]
+			},
+			"calc": {}
+		},
+		{
+			"id": "ef0b6b13-6bc2-4c31-b67d-0950a99cd6e3",
+			"type": "technique",
+			"name": "Feint",
+			"reference": "B231,MA73",
+			"tags": [
+				"Combat",
+				"Melee Combat",
+				"Technique",
+				"Weapon"
+			],
+			"difficulty": "h",
+			"points": 2,
+			"default": {
+				"type": "skill",
+				"name": "Lightsaber",
+				"specialization": "Two-Handed"
+			},
+			"limit": 4,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Lightsaber"
+						},
+						"level": {
+							"compare": "at_least"
+						},
+						"specialization": {
+							"compare": "is",
+							"qualifier": "Two-Handed"
+						}
+					}
+				]
+			},
+			"calc": {}
+		},
+		{
+			"id": "0a22d1c9-d52c-432c-b7f6-97f25aa4abd1",
 			"type": "skill",
 			"name": "Hidden Lore",
+			"reference": "SWF28",
 			"tags": [
 				"Force",
 				"Knowledge"
 			],
 			"specialization": "Dark Jedi",
 			"difficulty": "iq/a",
-			"points": 1
+			"points": 1,
+			"calc": {}
 		},
 		{
-			"id": "d16102d0-b9d3-43eb-a6f5-ea4995b73f17",
+			"id": "1346fdda-8211-4fd3-b44d-ecbf5dd45576",
 			"type": "skill",
 			"name": "Hidden Lore",
+			"reference": "SWF28",
 			"tags": [
 				"Force",
 				"Knowledge"
 			],
 			"specialization": "Jedi Lore",
 			"difficulty": "iq/a",
-			"points": 1
+			"points": 1,
+			"calc": {}
 		},
 		{
-			"id": "a24458a3-7df7-4dc0-8ddc-8df8bffde1fb",
+			"id": "0ace2270-5b58-4419-88fb-1096cd02ac43",
 			"type": "skill",
 			"name": "Hidden Lore",
+			"reference": "SWF28",
 			"tags": [
 				"Force",
 				"Knowledge"
 			],
 			"specialization": "Sith Lore",
 			"difficulty": "iq/a",
-			"points": 1
+			"points": 1,
+			"calc": {}
 		},
 		{
-			"id": "37fe673e-8702-4d53-9624-a01a153ac9cd",
+			"id": "dbbf067e-81ad-4fd3-9594-5ae82c53f3d3",
 			"type": "skill",
 			"name": "Innate Attack",
+			"reference": "B201, SWF28",
 			"tags": [
 				"Combat",
 				"Force",
@@ -161,48 +544,14 @@
 					"type": "dx",
 					"modifier": -4
 				}
-			]
-		},
-		{
-			"id": "7f4d706e-15d7-4ce7-b602-e23ed12889d5",
-			"type": "skill",
-			"name": "Lightsaber",
-			"tags": [
-				"Combat",
-				"Melee Combat",
-				"Weapon"
 			],
-			"specialization": "Fencing",
-			"difficulty": "dx/a",
-			"points": 1,
-			"defaults": [
-				{
-					"type": "skill",
-					"name": "Broadsword",
-					"modifier": -6
-				},
-				{
-					"type": "skill",
-					"name": "Saber",
-					"modifier": -6
-				},
-				{
-					"type": "skill",
-					"name": "Smallsword",
-					"modifier": -4
-				},
-				{
-					"type": "skill",
-					"name": "Lightsaber",
-					"specialization": "Short",
-					"modifier": -6
-				}
-			]
+			"calc": {}
 		},
 		{
-			"id": "d43aafa5-d5e0-4eb4-b0db-c9d56eee20c7",
+			"id": "823bf818-c6a1-44cb-8b20-4e408ae921fe",
 			"type": "skill",
 			"name": "Lighsaber",
+			"reference": "SWF29",
 			"tags": [
 				"Combat",
 				"Melee Combat",
@@ -212,6 +561,10 @@
 			"difficulty": "dx/a",
 			"points": 1,
 			"defaults": [
+				{
+					"type": "dx",
+					"modifier": -5
+				},
 				{
 					"type": "skill",
 					"name": "Lightsaber",
@@ -228,12 +581,14 @@
 					"name": "Double-Headed",
 					"modifier": -4
 				}
-			]
+			],
+			"calc": {}
 		},
 		{
-			"id": "db59848d-8b6e-4f9b-8357-c4ba7e0c66d3",
+			"id": "096b9b19-0c38-485c-8ad8-c73f53ad177d",
 			"type": "skill",
 			"name": "Lightsaber",
+			"reference": "SWF29",
 			"tags": [
 				"Combat",
 				"Melee Combat",
@@ -242,6 +597,10 @@
 			"difficulty": "dx/a",
 			"points": 1,
 			"defaults": [
+				{
+					"type": "dx",
+					"modifier": -5
+				},
 				{
 					"type": "skill",
 					"name": "Lightsaber",
@@ -285,12 +644,57 @@
 					"specialization": "Fencing",
 					"modifier": -4
 				}
-			]
+			],
+			"calc": {}
 		},
 		{
-			"id": "249dfcf4-e87a-4ea7-bd37-79c075f5ca09",
+			"id": "6f41b35c-5a7c-4b73-bcf1-60fee8347565",
 			"type": "skill",
 			"name": "Lightsaber",
+			"reference": "SWF29",
+			"tags": [
+				"Combat",
+				"Melee Combat",
+				"Weapon"
+			],
+			"specialization": "Fencing",
+			"difficulty": "dx/a",
+			"points": 1,
+			"encumbrance_penalty_multiplier": 1,
+			"defaults": [
+				{
+					"type": "dx",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Broadsword",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Saber",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Smallsword",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Lightsaber",
+					"specialization": "Short",
+					"modifier": -6
+				}
+			],
+			"calc": {}
+		},
+		{
+			"id": "ec3125c6-c5ef-4669-8b23-d321932e6543",
+			"type": "skill",
+			"name": "Lightsaber",
+			"reference": "SWF29",
 			"tags": [
 				"Combat",
 				"Melee Combat",
@@ -300,6 +704,10 @@
 			"difficulty": "dx/a",
 			"points": 1,
 			"defaults": [
+				{
+					"type": "dx",
+					"modifier": -5
+				},
 				{
 					"type": "skill",
 					"name": "Broadsword",
@@ -336,12 +744,14 @@
 					"specialization": "Fencing",
 					"modifier": -6
 				}
-			]
+			],
+			"calc": {}
 		},
 		{
-			"id": "8734c056-549a-497b-a227-d677b13f0b3e",
+			"id": "a3dee101-bd35-41d2-8aa0-7b51868cae35",
 			"type": "skill",
 			"name": "Lightsaber",
+			"reference": "SWF29",
 			"tags": [
 				"Combat",
 				"Melee Combat",
@@ -352,8 +762,12 @@
 			"points": 1,
 			"defaults": [
 				{
+					"type": "dx",
+					"modifier": -5
+				},
+				{
 					"type": "skill",
-					"name": "Two-Handed\nSword",
+					"name": "Two-Handed Sword",
 					"modifier": -2
 				},
 				{
@@ -366,25 +780,19 @@
 					"name": "Lightsaber",
 					"modifier": -2
 				}
-			]
-		},
-		{
-			"id": "70c7efca-4fe9-4423-a583-e5f54dddd0c7",
-			"type": "skill",
-			"name": "Lightsaber",
-			"tags": [
-				"Combat",
-				"Melee Combat",
-				"Weapon"
 			],
-			"specialization": "Double-Headed",
-			"difficulty": "dx/a",
-			"points": 1
+			"calc": {}
 		},
 		{
-			"id": "248ee2c0-2fed-4a8f-aa67-09bca3c78815",
+			"id": "01ae8328-3782-45e8-9e54-51b9b389c615",
 			"type": "skill",
 			"name": "Meditation",
+			"reference": "B207",
+			"tags": [
+				"Force",
+				"Mental",
+				"Esoteric"
+			],
 			"difficulty": "will/h",
 			"points": 1,
 			"defaults": [
@@ -394,28 +802,118 @@
 				},
 				{
 					"type": "skill",
-					"name": "Autohypnosys",
+					"name": "Autohypnosis",
 					"modifier": -4
 				}
-			]
+			],
+			"calc": {}
 		},
 		{
-			"id": "b146c483-be16-48c6-8c05-72504ded073e",
-			"type": "skill",
-			"name": "Parry Beam Weapons",
+			"id": "5f3d4ea4-7967-41ba-a971-19cf44ac15dd",
+			"type": "technique",
+			"name": "Off-Hand Weapon Training",
+			"reference": "B232",
 			"tags": [
 				"Combat",
-				"Force",
+				"Melee Combat",
+				"Technique",
+				"Weapon"
+			],
+			"difficulty": "h",
+			"points": 2,
+			"default": {
+				"type": "skill",
+				"name": "Lightsaber",
+				"specialization": "Double",
+				"modifier": -4
+			},
+			"limit": 0,
+			"calc": {}
+		},
+		{
+			"id": "cb5f8037-28eb-40bc-8091-da596dda6be7",
+			"type": "technique",
+			"name": "Off-Hand Weapon Training",
+			"reference": "B232",
+			"tags": [
+				"Combat",
+				"Melee Combat",
+				"Technique",
+				"Weapon"
+			],
+			"difficulty": "h",
+			"points": 2,
+			"default": {
+				"type": "skill",
+				"name": "Lightsaber",
+				"specialization": "Fencing",
+				"modifier": -4
+			},
+			"limit": 0,
+			"calc": {}
+		},
+		{
+			"id": "11c03cdc-6bcd-43b3-99cd-43cf86c919d9",
+			"type": "technique",
+			"name": "Off-Hand Weapon Training",
+			"reference": "B232",
+			"tags": [
+				"Combat",
+				"Melee Combat",
+				"Technique",
+				"Weapon"
+			],
+			"difficulty": "h",
+			"points": 2,
+			"default": {
+				"type": "skill",
+				"name": "Lightsaber",
+				"specialization": "Short",
+				"modifier": -4
+			},
+			"limit": 0,
+			"calc": {}
+		},
+		{
+			"id": "fc2b6696-93ae-4606-aedb-933eecba4381",
+			"type": "technique",
+			"name": "Off-Hand Weapon Training",
+			"reference": "B232",
+			"tags": [
+				"Combat",
+				"Melee Combat",
+				"Technique",
+				"Weapon"
+			],
+			"difficulty": "h",
+			"points": 2,
+			"default": {
+				"type": "skill",
+				"name": "Lightsaber",
+				"modifier": -4
+			},
+			"limit": 0,
+			"calc": {}
+		},
+		{
+			"id": "750fc465-4aed-42f2-aa80-f4bdc86b0de1",
+			"type": "skill",
+			"name": "Parry Beam Weapons",
+			"reference": "SWF29",
+			"tags": [
+				"Combat",
 				"Melee Combat",
 				"Weapon"
 			],
 			"difficulty": "dx/vh",
-			"points": 1
+			"points": 1,
+			"calc": {}
 		},
 		{
-			"id": "621bce00-d851-47fc-9bb7-5401025bec9d",
+			"id": "603af705-f56a-4331-b7e9-76dc12f3570c",
 			"type": "skill",
 			"name": "Parry Missile Weapons",
+			"reference": "B212,SWF29",
 			"tags": [
 				"Combat",
 				"Melee Combat",
@@ -423,27 +921,37 @@
 			],
 			"difficulty": "dx/h",
 			"points": 1,
-			"features": [
+			"defaults": [
 				{
-					"type": "skill_bonus",
-					"selection_type": "skills_with_name",
-					"name": {
-						"compare": "is"
-					},
-					"amount": 1
+					"type": "skill",
+					"name": "Parry Beam Weapons",
+					"modifier": -2
 				}
-			]
+			],
+			"calc": {}
 		},
 		{
-			"id": "5d4b8ce2-b3fa-4e91-84ec-fef835d00ede",
+			"id": "4af94435-41cb-41aa-bf5f-928932bc325b",
 			"type": "skill",
 			"name": "Power Blow",
-			"difficulty": "dx/a",
+			"reference": "B215,MA58,SWF29",
+			"tags": [
+				"Esoteric"
+			],
+			"difficulty": "will/h",
 			"points": 1,
 			"prereqs": {
 				"type": "prereq_list",
 				"all": false,
 				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Trained By A Jedi Battlemaster"
+						}
+					},
 					{
 						"type": "trait_prereq",
 						"has": true,
@@ -461,13 +969,20 @@
 						}
 					}
 				]
-			}
+			},
+			"calc": {}
 		},
 		{
-			"id": "035658ef-ab95-449c-b559-1b5a9801e5df",
+			"id": "9e9e7aa9-2058-4514-bb0c-dffb70618660",
 			"type": "skill",
 			"name": "Precognitive Parry",
-			"difficulty": "dx/a",
+			"reference": "MA62,SWF29",
+			"tags": [
+				"Force",
+				"Combat",
+				"Melee Combat"
+			],
+			"difficulty": "will/h",
 			"points": 1,
 			"prereqs": {
 				"type": "prereq_list",
@@ -510,204 +1025,29 @@
 						]
 					}
 				]
-			}
-		},
-		{
-			"id": "1e035dea-b185-4208-a2a3-b20948341b30",
-			"type": "technique",
-			"name": "Off-Hand Weapon Training",
-			"notes": "Lightsaber",
-			"tags": [
-				"Combat",
-				"Melee Combat",
-				"Technique",
-				"Weapon"
-			],
-			"difficulty": "h",
-			"points": 2,
-			"default": {
-				"type": "skill",
-				"name": "Lightsaber",
-				"modifier": -4
 			},
-			"limit": 0
+			"calc": {}
 		},
 		{
-			"id": "16f24165-ece9-4d0e-b3ab-9410367a1a25",
-			"type": "technique",
-			"name": "Disarming",
-			"notes": "Lightsaber",
-			"tags": [
-				"Combat",
-				"Melee Combat",
-				"Technique",
-				"Weapon"
-			],
-			"difficulty": "h",
-			"points": 2,
-			"default": {
-				"type": "skill",
-				"name": "Lightsaber"
-			},
-			"limit": 5
-		},
-		{
-			"id": "fdacaa50-45bd-43ae-ab8f-e8ac4c754a3a",
-			"type": "technique",
-			"name": "Disarming",
-			"notes": "Lightsaber (Two-Handed)",
-			"tags": [
-				"Combat",
-				"Melee Combat",
-				"Technique",
-				"Weapon"
-			],
-			"difficulty": "h",
-			"points": 2,
-			"default": {
-				"type": "skill",
-				"name": "Lightsaber",
-				"specialization": "Two-Handed"
-			},
-			"limit": 5
-		},
-		{
-			"id": "e5699fc8-c2ce-40e6-8e16-e1610ca97cfe",
-			"type": "technique",
-			"name": "Back Strike",
-			"notes": "Lightsaber",
-			"tags": [
-				"Combat",
-				"Melee Combat",
-				"Technique",
-				"Weapon"
-			],
-			"difficulty": "h",
-			"points": 2,
-			"default": {
-				"type": "skill",
-				"name": "Lightsaber",
-				"modifier": -2
-			},
-			"limit": 0
-		},
-		{
-			"id": "970c2902-a054-45c6-b6f2-cc024074470d",
-			"type": "technique",
-			"name": "Back Strike",
-			"notes": "Lightsaber (Two-Handed)",
-			"tags": [
-				"Combat",
-				"Melee Combat",
-				"Technique",
-				"Weapon"
-			],
-			"difficulty": "h",
-			"points": 2,
-			"default": {
-				"type": "skill",
-				"name": "Lightsaber",
-				"specialization": "Two-Handed",
-				"modifier": -2
-			},
-			"limit": 0
-		},
-		{
-			"id": "663bce98-7a0d-4bae-b4c3-0758ae956a7b",
-			"type": "technique",
-			"name": "Disarming",
-			"notes": "Lightsaber (Fencing)",
-			"tags": [
-				"Combat",
-				"Melee Combat",
-				"Technique",
-				"Weapon"
-			],
-			"difficulty": "h",
-			"points": 2,
-			"default": {
-				"type": "skill",
-				"name": "Lightsaber",
-				"specialization": "Fencing"
-			},
-			"limit": 5
-		},
-		{
-			"id": "3c0418e5-38cd-400a-89b0-4a862df60d43",
-			"type": "technique",
-			"name": "Off-Hand Weapon Training",
-			"notes": "Lighsaber (Fencing)",
-			"tags": [
-				"Combat",
-				"Melee Combat",
-				"Technique",
-				"Weapon"
-			],
-			"difficulty": "h",
-			"points": 2,
-			"default": {
-				"type": "skill",
-				"name": "Lightsaber",
-				"specialization": "Fencing",
-				"modifier": -4
-			},
-			"limit": 0
-		},
-		{
-			"id": "c81da96e-9ce9-4fe8-ab09-f97c314357e1",
-			"type": "technique",
-			"name": "Off-Hand Weapon Training",
-			"notes": "Lighsaber (Short)",
-			"tags": [
-				"Combat",
-				"Melee Combat",
-				"Technique",
-				"Weapon"
-			],
-			"difficulty": "h",
-			"points": 2,
-			"default": {
-				"type": "skill",
-				"name": "Lightsaber",
-				"specialization": "Short",
-				"modifier": -4
-			},
-			"limit": 0
-		},
-		{
-			"id": "9b923c1d-afc8-4e0c-9c6a-8fe2febc1466",
-			"type": "technique",
-			"name": "Off-Hand Weapon Training",
-			"notes": "Lightsaber (Double)",
-			"tags": [
-				"Combat",
-				"Melee Combat",
-				"Technique",
-				"Weapon"
-			],
-			"difficulty": "h",
-			"points": 2,
-			"default": {
-				"type": "skill",
-				"name": "Lightsaber",
-				"specialization": "Double",
-				"modifier": -4
-			},
-			"limit": 0
-		},
-		{
-			"id": "e5d73e4e-abe3-489b-ad23-5b75a3961c66",
+			"id": "318c8001-71a9-4132-91d9-05c84bb2a230",
 			"type": "skill",
 			"name": "Thrown Weapon",
+			"reference": "B226,SWF29",
+			"tags": [
+				"Combat",
+				"Ranged Combat",
+				"Weapon"
+			],
 			"specialization": "Lightsaber",
 			"difficulty": "dx/a",
 			"points": 1,
 			"defaults": [
 				{
 					"type": "dx",
-					"modifier": -5
+					"modifier": -4
 				}
-			]
+			],
+			"calc": {}
 		}
 	]
 }

--- a/Library/Star Wars/Star Wars Trait Modifiers.adm
+++ b/Library/Star Wars/Star Wars Trait Modifiers.adm
@@ -1,0 +1,57 @@
+{
+	"type": "modifier_list",
+	"version": 4,
+	"rows": [
+		{
+			"id": "b04bb6ab-f607-44a1-a0a4-e346fdedf2ba",
+			"type": "modifier",
+			"name": "Force",
+			"reference": "SWF25",
+			"tags": [
+				"Force"
+			],
+			"cost": -10
+		},
+		{
+			"id": "0cc23f19-3749-40bb-84f9-6315e9874569",
+			"type": "modifier",
+			"name": "Accessibility",
+			"reference": "SWF25",
+			"notes": "Only when subject to negative emotions",
+			"cost": -10
+		},
+		{
+			"id": "197b813c-cd34-448b-b1ca-8e835f8adf0c",
+			"type": "modifier",
+			"name": "Accessibility",
+			"reference": "SWF25",
+			"notes": "Only when subject to anger",
+			"tags": [
+				"Force"
+			],
+			"cost": -40
+		},
+		{
+			"id": "627b2678-d748-4fa3-9989-2af157a7f259",
+			"type": "modifier",
+			"name": "Accessibility",
+			"reference": "SWF25",
+			"notes": "Only when subject to fear",
+			"tags": [
+				"Force"
+			],
+			"cost": -40
+		},
+		{
+			"id": "751b1d69-4c1c-47df-ac1e-3f6e57e6327a",
+			"type": "modifier",
+			"name": "Accessibility",
+			"reference": "SWF25",
+			"notes": "Only when subject to hate",
+			"tags": [
+				"Force"
+			],
+			"cost": -40
+		}
+	]
+}

--- a/Library/Star Wars/Star Wars Traits.adq
+++ b/Library/Star Wars/Star Wars Traits.adq
@@ -3,242 +3,105 @@
 	"version": 4,
 	"rows": [
 		{
-			"id": "85561a7f-cd97-4e6b-af59-95719c0c22fc",
+			"id": "29fc3c87-ab3a-446d-a73a-dd399806245f",
 			"type": "trait",
-			"name": "Alter Talent",
+			"name": "Acute Force Sight",
+			"reference": "SWF21",
+			"reference_highlight": "Acute Senses",
 			"tags": [
 				"Advantage",
-				"Force",
-				"Mental",
-				"Supernatural"
-			],
-			"levels": 1,
-			"points_per_level": 10,
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Force Sensitivity"
-						}
-					}
-				]
-			},
-			"can_level": true,
-			"calc": {
-				"points": 10
-			}
-		},
-		{
-			"id": "e0f76e28-cb70-470d-9b83-188f6d93e765",
-			"type": "trait",
-			"name": "Control Talent",
-			"tags": [
-				"Advantage",
-				"Force",
-				"Mental",
-				"Supernatural"
-			],
-			"levels": 1,
-			"points_per_level": 10,
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Force Sensitivity"
-						}
-					}
-				]
-			},
-			"can_level": true,
-			"calc": {
-				"points": 10
-			}
-		},
-		{
-			"id": "1713acd2-d503-4bd9-966b-c8d59ec19181",
-			"type": "trait",
-			"name": "Dark Rage",
-			"tags": [
 				"Physical"
 			],
-			"base_points": 5,
+			"levels": 1,
+			"points_per_level": 2,
+			"features": [
+				{
+					"type": "attribute_bonus",
+					"attribute": "forcesight",
+					"amount": 1,
+					"per_level": true
+				}
+			],
+			"can_level": true,
 			"calc": {
-				"points": 5
+				"points": 2
 			}
 		},
 		{
-			"id": "9c30043f-fd00-4ebc-b19d-f2cf1b93ef49",
+			"id": "6baf160c-5f87-434a-915d-0f876a40dcbe",
 			"type": "trait",
-			"name": "Force Sensitivity",
+			"name": "Alter Talent",
+			"reference": "SWF21",
 			"tags": [
 				"Advantage",
-				"Force",
-				"Mental",
-				"Supernatural"
+				"Force"
 			],
-			"modifiers": [
-				{
-					"id": "44658d72-bcac-4243-9eb3-4c71a3af1da9",
-					"type": "modifier",
-					"name": "Dark Aspect",
-					"cost": -40,
-					"disabled": true
-				},
-				{
-					"id": "f1b13b68-c101-454a-9e98-e9f89554a89e",
-					"type": "modifier",
-					"name": "Light Aspect",
-					"cost": -40,
-					"disabled": true
-				},
-				{
-					"id": "3fed15a2-6798-406d-a8b0-f8fae006ff05",
-					"type": "modifier",
-					"name": "Neutral Aspect",
-					"cost": -40,
-					"disabled": true
-				}
-			],
-			"base_points": 5,
 			"levels": 1,
 			"points_per_level": 10,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Force Sensitivity"
+						}
+					}
+				]
+			},
 			"features": [
 				{
 					"type": "skill_bonus",
 					"selection_type": "skills_with_name",
 					"name": {
-						"compare": "is"
-					},
-					"amount": 1
-				}
-			],
-			"can_level": true,
-			"calc": {
-				"points": 15
-			}
-		},
-		{
-			"id": "bd35d5b9-c3b7-463f-b454-a4a41bf7ac97",
-			"type": "trait",
-			"name": "Weapon Bond (Lightsaber)",
-			"tags": [
-				"Mental",
-				"Supernatural"
-			],
-			"levels": 1,
-			"points_per_level": 5,
-			"can_level": true,
-			"calc": {
-				"points": 5
-			}
-		},
-		{
-			"id": "0fa0c61a-9851-4a4c-9bc9-b2608852d3e5",
-			"type": "trait",
-			"name": "Trained By A Jedi Battlemaster",
-			"notes": "You have half the usual penalty to make a Rapid Strike, or to parry more than once per turn. These\nbenefits apply to all your unarmed combat skills (Punching, Striking, etc.) and all Lightsaber Weapon skills.",
-			"tags": [
-				"Advantage",
-				"Force",
-				"Supernatural"
-			],
-			"base_points": 30,
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Force Sensitivity"
-						}
-					}
-				]
-			},
-			"calc": {
-				"points": 30
-			}
-		},
-		{
-			"id": "54c4c131-93f6-481f-ae15-bec222ba18ca",
-			"type": "trait",
-			"name": "Dark Aspect of The Force",
-			"notes": "Tempted",
-			"tags": [
-				"Disadvantage",
-				"Force",
-				"Supernatural"
-			],
-			"base_points": -2,
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Force Sensitivity"
-						}
-					}
-				]
-			},
-			"features": [
-				{
-					"type": "spell_bonus",
-					"match": "college_name",
-					"name": {
 						"compare": "is",
-						"qualifier": "Dark"
+						"qualifier": "Engineer"
 					},
-					"amount": 1
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Force"
+					},
+					"amount": 1,
+					"per_level": true
 				},
 				{
 					"type": "spell_bonus",
 					"match": "college_name",
 					"name": {
 						"compare": "is",
-						"qualifier": "Light"
+						"qualifier": "Alter"
 					},
-					"amount": -1
+					"amount": 1,
+					"per_level": true
 				},
 				{
-					"type": "conditional_modifier",
-					"situation": "Reaction from Jedi",
-					"amount": -1
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Reaction from Dark Jedi \u0026 Sith",
-					"amount": 1
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Dun Möch"
+					},
+					"amount": -1,
+					"per_level": true
 				}
 			],
+			"can_level": true,
 			"calc": {
-				"points": -2
+				"points": 10
 			}
 		},
 		{
-			"id": "7652dd51-b221-40ff-913d-3921cd6a3eae",
+			"id": "ecdcab4c-673e-4db9-ba85-d69e99511271",
 			"type": "trait",
-			"name": "Code of Honor",
-			"notes": "Crystal Code",
+			"name": "Code of Honor (Crystal Code)",
+			"reference": "SWF26",
+			"notes": "The crystal is the heart of the blade.\nThe heart is the crystal of the Jedi.\nThe Jedi is the crystal of the Force.\nThe Force is the blade of the heart.\nAll are intertwined,\nthe crystal, the blade, the Jedi.\nYou are one.",
 			"tags": [
 				"Disadvantage",
-				"Force",
-				"Physical"
+				"Mental"
 			],
 			"base_points": -5,
 			"calc": {
@@ -246,14 +109,14 @@
 			}
 		},
 		{
-			"id": "5eaf309b-eb46-450a-9313-db5b84cdc25e",
+			"id": "fbbea39b-e17e-43d9-bb6c-a69008d6fd16",
 			"type": "trait",
-			"name": "Code of Honor",
-			"notes": "Dark Jedi’s",
+			"name": "Code of Honor (Dark Jedi’s)",
+			"reference": "SWF26",
+			"notes": "There is no peace, there is anger.\nThere is no fear, there is power.\nThere is no death, there is immortality.\nThere is no weakness, there is the Dark Side.\nI am the Heart of Darkness.\nI know no fear, but rather I instill it in my enemies.\nI am the destroyer of worlds.\nI know the power of the Dark Side.\nI am the fire of hate.\nAll the universe bows before me.\nI pledge myself to the Darkness.\nFor I have found true life, in death of the light.",
 			"tags": [
 				"Disadvantage",
-				"Force",
-				"Physical"
+				"Mental"
 			],
 			"base_points": -10,
 			"calc": {
@@ -261,14 +124,14 @@
 			}
 		},
 		{
-			"id": "db41f9fe-3caf-4771-a39e-a947f88ee9e2",
+			"id": "2a1968a4-10f4-45c8-9393-f36162f16735",
 			"type": "trait",
-			"name": "Code of Honor",
-			"notes": "Jedi Code of Udan-Urr",
+			"name": "Code of Honor (Jedi Code of Luke Skywalker)",
+			"reference": "SWF26",
+			"notes": "Jedi are the guardians of peace in the galaxy.\nJedi use their powers to defend and to protect.\nJedi respect all life, in any form.\nJedi serve others rather than ruling over them, for the good of the galaxy.\nJedi seek to improve themselves through knowledge and training.",
 			"tags": [
 				"Disadvantage",
-				"Force",
-				"Physical"
+				"Mental"
 			],
 			"base_points": -10,
 			"calc": {
@@ -276,14 +139,14 @@
 			}
 		},
 		{
-			"id": "8bed45c5-2f28-403f-8105-901714848dd0",
+			"id": "b4135526-3855-4d54-a75f-e26113889829",
 			"type": "trait",
-			"name": "Code of Honor",
-			"notes": "Jedi Code of Luke Skywalker",
+			"name": "Code of Honor (Jedi Code of Udan-Urr)",
+			"reference": "SWF26",
+			"notes": "There is no emotion, there is peace.\nThere is no ignorance, there is knowledge.\nThere is no passion, there is serenity.\nThere is no chaos, there is harmony.\nThere is no death, there is the Force.",
 			"tags": [
 				"Disadvantage",
-				"Force",
-				"Physical"
+				"Mental"
 			],
 			"base_points": -10,
 			"calc": {
@@ -291,14 +154,14 @@
 			}
 		},
 		{
-			"id": "aac6adbb-2ff2-4253-a299-76bf46da62c0",
+			"id": "31ac6784-b34c-4f5e-bc77-207723b49268",
 			"type": "trait",
-			"name": "Code of Honor",
-			"notes": "Sith Rule of Two. A Sith apprentice can only take on a new apprentice after he has killed his Master",
+			"name": "Code of Honor (Sith Rule of Two)",
+			"reference": "SWF26",
+			"notes": "A Sith apprentice can only take on a new apprentice after he has killed his Master",
 			"tags": [
 				"Disadvantage",
-				"Force",
-				"Physical"
+				"Mental"
 			],
 			"base_points": -10,
 			"calc": {
@@ -306,424 +169,38 @@
 			}
 		},
 		{
-			"id": "aed7d1a5-d2ce-443c-88a4-74ba9fdb2d9e",
+			"id": "3500faf5-c85f-4e83-ad5d-d69c40973739",
 			"type": "trait",
-			"name": "Code of Honor",
-			"notes": "Sith’s",
-			"tags": [
-				"Disadvantage",
-				"Force",
-				"Physical"
-			],
-			"base_points": -10,
-			"calc": {
-				"points": -10
-			}
-		},
-		{
-			"id": "103612f6-a2f3-48d1-8037-3f2ae7fd26f1",
-			"type": "trait",
-			"name": "Dark Aspect of The Force",
-			"notes": "Tainted",
-			"tags": [
-				"Disadvantage",
-				"Force",
-				"Supernatural"
-			],
-			"base_points": -4,
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Force Sensitivity"
-						}
-					}
-				]
-			},
-			"features": [
-				{
-					"type": "spell_bonus",
-					"match": "college_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "Dark"
-					},
-					"amount": 2
-				},
-				{
-					"type": "spell_bonus",
-					"match": "college_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "Light"
-					},
-					"amount": -2
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Reaction from Jedi",
-					"amount": -2
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Reaction from Dark Jedi \u0026 Sith",
-					"amount": 2
-				}
-			],
-			"calc": {
-				"points": -4
-			}
-		},
-		{
-			"id": "ac33f64a-01cc-4a70-8c39-b145b468a4c3",
-			"type": "trait",
-			"name": "Dark Aspect of The Force",
-			"notes": "Devoted",
-			"tags": [
-				"Disadvantage",
-				"Force",
-				"Supernatural"
-			],
-			"base_points": -8,
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Force Sensitivity"
-						}
-					}
-				]
-			},
-			"features": [
-				{
-					"type": "spell_bonus",
-					"match": "college_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "Dark"
-					},
-					"amount": 3
-				},
-				{
-					"type": "spell_bonus",
-					"match": "college_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "Light"
-					},
-					"amount": -4
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Reaction from Jedi",
-					"amount": -3
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Reaction from Dark Jedi \u0026 Sith",
-					"amount": 2
-				}
-			],
-			"calc": {
-				"points": -8
-			}
-		},
-		{
-			"id": "1f680ef3-8baf-4107-92e6-0a6e34e20af2",
-			"type": "trait",
-			"name": "Dark Aspect of The Force",
-			"notes": "Dark Sider",
-			"tags": [
-				"Disadvantage",
-				"Force",
-				"Supernatural"
-			],
-			"base_points": -12,
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Force Sensitivity"
-						}
-					}
-				]
-			},
-			"features": [
-				{
-					"type": "spell_bonus",
-					"match": "college_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "Dark"
-					},
-					"amount": 4
-				},
-				{
-					"type": "spell_bonus",
-					"match": "college_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "Light"
-					},
-					"amount": -8
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Reaction from Jedi",
-					"amount": -4
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Reaction from Dark Jedi \u0026 Sith",
-					"amount": 2
-				}
-			],
-			"calc": {
-				"points": -12
-			}
-		},
-		{
-			"id": "3698c353-0d50-408b-abcd-f0cbaa2c6268",
-			"type": "trait",
-			"name": "Light Aspect of The Force",
-			"notes": "Journeyman",
-			"tags": [
-				"Disadvantage",
-				"Force",
-				"Supernatural"
-			],
-			"base_points": -2,
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Force Sensitivity"
-						}
-					}
-				]
-			},
-			"features": [
-				{
-					"type": "spell_bonus",
-					"match": "college_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "Light"
-					},
-					"amount": 1
-				},
-				{
-					"type": "spell_bonus",
-					"match": "college_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "Dark"
-					},
-					"amount": -1
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Reaction from Jedi",
-					"amount": 1
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Reaction from Dark Jedi \u0026 Sith",
-					"amount": -1
-				}
-			],
-			"calc": {
-				"points": -2
-			}
-		},
-		{
-			"id": "bb88f88f-bb13-442b-919c-ebc7409cdfa3",
-			"type": "trait",
-			"name": "Talent (Hot pilot)",
-			"reference": "SWC61",
+			"name": "Control Talent",
+			"reference": "SWF21",
 			"tags": [
 				"Advantage",
-				"Mental",
-				"Talent"
+				"Force"
 			],
-			"levels": 1,
-			"points_per_level": 5,
-			"features": [
-				{
-					"type": "reaction_bonus",
-					"situation": "from other pilots",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "skill_bonus",
-					"selection_type": "skills_with_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "Piloting"
-					},
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "skill_bonus",
-					"selection_type": "skills_with_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "Navigation"
-					},
-					"specialization": {
-						"compare": "is",
-						"qualifier": "Air"
-					},
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "skill_bonus",
-					"selection_type": "skills_with_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "Navigation"
-					},
-					"specialization": {
-						"compare": "is",
-						"qualifier": "Space"
-					},
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "skill_bonus",
-					"selection_type": "skills_with_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "Gunner"
-					},
-					"amount": 1,
-					"per_level": true
-				}
-			],
-			"can_level": true,
-			"calc": {
-				"points": 5
-			}
-		},
-		{
-			"id": "44a9984f-cf35-408f-a0f3-9c229424307e",
-			"type": "trait",
-			"name": "Talent (Alien Friend)",
-			"reference": "SWC61",
-			"levels": 1,
-			"points_per_level": 5,
-			"features": [
-				{
-					"type": "reaction_bonus",
-					"situation": "from aliens",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "skill_bonus",
-					"selection_type": "skills_with_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "History"
-					},
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "skill_bonus",
-					"selection_type": "skills_with_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "Psychology"
-					},
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "skill_bonus",
-					"selection_type": "skills_with_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "Expert Skill"
-					},
-					"specialization": {
-						"compare": "is",
-						"qualifier": "Xenology"
-					},
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "skill_bonus",
-					"selection_type": "skills_with_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "Diplomacy"
-					},
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "skill_bonus",
-					"selection_type": "skills_with_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "Anthropology"
-					},
-					"amount": 1,
-					"per_level": true
-				}
-			],
-			"can_level": true,
-			"calc": {
-				"points": 5
-			}
-		},
-		{
-			"id": "0d943e80-d27d-427b-b3da-b30b73475f65",
-			"type": "trait",
-			"name": "Talent (Born Tactician)",
-			"reference": "SWC61",
 			"levels": 1,
 			"points_per_level": 10,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Force Sensitivity"
+						}
+					}
+				]
+			},
 			"features": [
 				{
 					"type": "skill_bonus",
 					"selection_type": "skills_with_name",
 					"name": {
 						"compare": "is",
-						"qualifier": "Tactics"
+						"qualifier": "Meditation"
 					},
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "from anyone you serve with (or command) in the army",
 					"amount": 1,
 					"per_level": true
 				},
@@ -732,11 +209,11 @@
 					"selection_type": "skills_with_name",
 					"name": {
 						"compare": "is",
-						"qualifier": "History"
+						"qualifier": "Innate Attack"
 					},
 					"specialization": {
 						"compare": "is",
-						"qualifier": "Military"
+						"qualifier": "Force"
 					},
 					"amount": 1,
 					"per_level": true
@@ -746,67 +223,14 @@
 					"selection_type": "skills_with_name",
 					"name": {
 						"compare": "is",
-						"qualifier": "Intelligence Analysis"
-					},
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "skill_bonus",
-					"selection_type": "skills_with_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "Expert Skill"
+						"qualifier": "Fast Draw"
 					},
 					"specialization": {
 						"compare": "is",
-						"qualifier": "Military Science"
+						"qualifier": "Lightsaber"
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "skill_bonus",
-					"selection_type": "skills_with_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "Soldier"
-					},
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "skill_bonus",
-					"selection_type": "skills_with_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "Strategy"
-					},
-					"specialization": {
-						"compare": "is",
-						"qualifier": "Land"
-					},
-					"amount": 1,
-					"per_level": true
-				}
-			],
-			"can_level": true,
-			"calc": {
-				"points": 10
-			}
-		},
-		{
-			"id": "c5fbfcf8-ee20-47e1-a2e7-3ec554f91e40",
-			"type": "trait",
-			"name": "Talent (Cyberneticist)",
-			"reference": "SWC61",
-			"levels": 1,
-			"points_per_level": 5,
-			"features": [
-				{
-					"type": "reaction_bonus",
-					"situation": "from computer professionals, AI systems, and droids",
-					"amount": 1
 				},
 				{
 					"type": "skill_bonus",
@@ -817,7 +241,7 @@
 					},
 					"specialization": {
 						"compare": "is",
-						"qualifier": "Computers"
+						"qualifier": "Force"
 					},
 					"amount": 1,
 					"per_level": true
@@ -827,20 +251,11 @@
 					"selection_type": "skills_with_name",
 					"name": {
 						"compare": "is",
-						"qualifier": "Computer Programming"
+						"qualifier": "Electronics Operation"
 					},
 					"specialization": {
 						"compare": "is",
-						"qualifier": "AI"
-					},
-					"amount": 1
-				},
-				{
-					"type": "skill_bonus",
-					"selection_type": "skills_with_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "Computer Programming"
+						"qualifier": "Force"
 					},
 					"amount": 1,
 					"per_level": true
@@ -850,51 +265,21 @@
 					"selection_type": "skills_with_name",
 					"name": {
 						"compare": "is",
-						"qualifier": "Computer Operation"
-					},
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "skill_bonus",
-					"selection_type": "skills_with_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "Computer Hacking"
-					},
-					"amount": 1,
-					"per_level": true
-				}
-			],
-			"can_level": true,
-			"calc": {
-				"points": 5
-			}
-		},
-		{
-			"id": "6461d2e1-7652-4a05-979a-866cddc95ca3",
-			"type": "trait",
-			"name": "Talent (Intuitive Admiral)",
-			"reference": "SWC62",
-			"levels": 1,
-			"points_per_level": 10,
-			"features": [
-				{
-					"type": "reaction_bonus",
-					"situation": "from anyone you serve with (or command) in the space navy",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "skill_bonus",
-					"selection_type": "skills_with_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "Strategy"
+						"qualifier": "Armoury"
 					},
 					"specialization": {
 						"compare": "is",
-						"qualifier": "Space"
+						"qualifier": "Lightsabers"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "spell_bonus",
+					"match": "college_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Control"
 					},
 					"amount": 1,
 					"per_level": true
@@ -904,103 +289,9 @@
 					"selection_type": "skills_with_name",
 					"name": {
 						"compare": "is",
-						"qualifier": "Shiphandling"
+						"qualifier": "Dun Möch"
 					},
-					"specialization": {
-						"compare": "is",
-						"qualifier": "Starship"
-					},
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "skill_bonus",
-					"selection_type": "skills_with_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "Shiphandling"
-					},
-					"specialization": {
-						"compare": "is",
-						"qualifier": "Spaceship"
-					},
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "skill_bonus",
-					"selection_type": "skills_with_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "Savoir-Faire"
-					},
-					"specialization": {
-						"compare": "is",
-						"qualifier": "Military"
-					},
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "skill_bonus",
-					"selection_type": "skills_with_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "Leadership"
-					},
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "skill_bonus",
-					"selection_type": "skills_with_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "Intelligence Analysis"
-					},
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "skill_bonus",
-					"selection_type": "skills_with_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "History"
-					},
-					"specialization": {
-						"compare": "is",
-						"qualifier": "Military"
-					},
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "skill_bonus",
-					"selection_type": "skills_with_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "Expert Skill"
-					},
-					"specialization": {
-						"compare": "is",
-						"qualifier": "Military Science"
-					},
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "skill_bonus",
-					"selection_type": "skills_with_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "Crewman"
-					},
-					"specialization": {
-						"compare": "is",
-						"qualifier": "Spacer"
-					},
-					"amount": 1,
+					"amount": -1,
 					"per_level": true
 				}
 			],
@@ -1010,193 +301,985 @@
 			}
 		},
 		{
-			"id": "055812ce-0684-422d-97dc-c5a9413dc946",
+			"id": "cb5b6009-9496-436a-aed4-61de75ab5a68",
 			"type": "trait",
-			"name": "Talent (Martial Prowess)",
-			"reference": "SWC62",
-			"levels": 1,
-			"points_per_level": 15,
-			"features": [
+			"name": "Dark Aspect of the Force",
+			"reference": "SWF26",
+			"tags": [
+				"Disadvantage",
+				"Force"
+			],
+			"modifiers": [
 				{
-					"type": "skill_bonus",
-					"selection_type": "skills_with_name",
-					"tags": {
-						"compare": "is",
-						"qualifier": "Melee Combat"
-					},
-					"amount": 1,
-					"per_level": true
+					"id": "2828e007-5ceb-4748-b055-232730bfb8b6",
+					"type": "modifier",
+					"name": "Tempted",
+					"reference": "SWF26",
+					"cost": -2,
+					"cost_type": "points",
+					"disabled": true,
+					"features": [
+						{
+							"type": "reaction_bonus",
+							"situation": "from Dark Jedi and Sith who sense your aspect",
+							"amount": 1
+						},
+						{
+							"type": "reaction_bonus",
+							"situation": "from Jedi who sense your aspect",
+							"amount": -1
+						},
+						{
+							"type": "spell_bonus",
+							"match": "college_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Light"
+							},
+							"amount": -1
+						},
+						{
+							"type": "spell_bonus",
+							"match": "college_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Dark"
+							},
+							"amount": 1
+						}
+					]
+				},
+				{
+					"id": "350e9e4e-4f4b-4bbc-a422-c3c3f11ccc79",
+					"type": "modifier",
+					"name": "Tainted",
+					"reference": "SWF26",
+					"cost": -4,
+					"cost_type": "points",
+					"disabled": true,
+					"features": [
+						{
+							"type": "reaction_bonus",
+							"situation": "from Dark Jedi and Sith who sense your aspect",
+							"amount": 2
+						},
+						{
+							"type": "reaction_bonus",
+							"situation": "from Jedi who sense your aspect",
+							"amount": -2
+						},
+						{
+							"type": "spell_bonus",
+							"match": "college_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Light"
+							},
+							"amount": -2
+						},
+						{
+							"type": "spell_bonus",
+							"match": "college_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Dark"
+							},
+							"amount": 2
+						}
+					]
+				},
+				{
+					"id": "dafb33e3-2b6a-485f-9b69-f29197877f74",
+					"type": "modifier",
+					"name": "Devoted",
+					"reference": "SWF26",
+					"cost": -8,
+					"cost_type": "points",
+					"disabled": true,
+					"features": [
+						{
+							"type": "reaction_bonus",
+							"situation": "from Dark Jedi and Sith who sense your aspect",
+							"amount": 2
+						},
+						{
+							"type": "reaction_bonus",
+							"situation": "from Jedi who sense your aspect",
+							"amount": -3
+						},
+						{
+							"type": "spell_bonus",
+							"match": "college_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Light"
+							},
+							"amount": -4
+						},
+						{
+							"type": "spell_bonus",
+							"match": "college_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Dark"
+							},
+							"amount": 3
+						}
+					]
+				},
+				{
+					"id": "edf14853-85a5-45b2-9a5e-db72b4a0dc61",
+					"type": "modifier",
+					"name": "Dark Sider",
+					"reference": "SWF26",
+					"cost": -12,
+					"cost_type": "points",
+					"disabled": true,
+					"features": [
+						{
+							"type": "reaction_bonus",
+							"situation": "from Dark Jedi and Sith who sense your aspect",
+							"amount": 2
+						},
+						{
+							"type": "reaction_bonus",
+							"situation": "from Jedi who sense your aspect",
+							"amount": -4
+						},
+						{
+							"type": "spell_bonus",
+							"match": "college_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Light"
+							},
+							"amount": -8
+						},
+						{
+							"type": "spell_bonus",
+							"match": "college_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Dark"
+							},
+							"amount": 4
+						}
+					]
 				}
 			],
-			"can_level": true,
 			"calc": {
-				"points": 15
+				"points": 0
 			}
 		},
 		{
-			"id": "b4edb4bc-302f-45ed-a7d9-50cc71c8d229",
+			"id": "e5a83a67-e871-4451-88c9-dba21e83ddd4",
 			"type": "trait",
-			"name": "Jedi Rank 1: Padawan Novice",
-			"notes": "These are the younglings. They have only started training as Jedi.\nIt offers no Status.",
+			"name": "Dark Rage",
+			"reference": "SWF21",
 			"tags": [
 				"Advantage",
-				"Mental"
+				"Force"
+			],
+			"modifiers": [
+				{
+					"id": "d6c54718-7e99-4f26-8b79-0f534fb9e32c",
+					"type": "modifier",
+					"name": "Neutral",
+					"disabled": true
+				},
+				{
+					"id": "a0055ab0-78ae-4c0f-a883-34772cedf0e0",
+					"type": "modifier",
+					"name": "Tempted",
+					"cost": 100,
+					"disabled": true
+				},
+				{
+					"id": "7a0185ff-6f57-4aab-8c53-f5dfbc0dab8b",
+					"type": "modifier",
+					"name": "Tainted",
+					"cost": 200,
+					"disabled": true
+				},
+				{
+					"id": "733a1f74-a913-4df0-8f07-51db7afac892",
+					"type": "modifier",
+					"name": "Devoted",
+					"cost": 300,
+					"disabled": true
+				},
+				{
+					"id": "3e72a6c7-c354-416f-89c1-5809ba888c51",
+					"type": "modifier",
+					"name": "Dark Sider",
+					"cost": 400,
+					"disabled": true
+				}
 			],
 			"base_points": 5,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Force Sensitivity"
+						},
+						"level": {
+							"compare": "at_least"
+						}
+					}
+				]
+			},
 			"calc": {
 				"points": 5
 			}
 		},
 		{
-			"id": "a9e14666-25dc-4b6d-b8ad-57b2325f53ba",
+			"id": "c7a3d45a-f6a7-4533-b2a9-93df9d04d594",
 			"type": "trait",
-			"name": "Jedi Rank 2: Padawan Trainee",
-			"notes": "These younglings have completed the first stage of the training. A training lightsaber is given to them by their Masters.",
+			"name": "Energy Reserve (Force)",
 			"tags": [
 				"Advantage",
-				"Mental"
+				"Physical",
+				"Exotic",
+				"Force"
 			],
-			"base_points": 10,
+			"levels": 1,
+			"points_per_level": 2,
+			"features": [
+				{
+					"type": "attribute_bonus",
+					"attribute": "er",
+					"amount": 1,
+					"per_level": true
+				}
+			],
+			"can_level": true,
 			"calc": {
-				"points": 10
+				"points": 2
 			}
 		},
 		{
-			"id": "6e87294a-20cb-46fa-bd75-c02de5694e32",
+			"id": "0c0b2ad9-eb82-4004-8c98-e215006736af",
 			"type": "trait",
-			"name": "Jedi Rank 3: Padawan Student",
-			"notes": "These are pupils who have become of age and are allowed to go on\nassignments under close watch by their mentor. Status is +1.",
+			"name": "Extra Force Ability",
+			"reference": "SWF22",
 			"tags": [
 				"Advantage",
-				"Mental"
+				"Mental",
+				"Force"
 			],
-			"base_points": 15,
-			"calc": {
-				"points": 15
-			}
-		},
-		{
-			"id": "47c5c64c-e555-4f9a-af99-974d43fdbd8a",
-			"type": "trait",
-			"name": "Jedi Rank 4: Padawan Adept",
-			"notes": "These are Jedi pupils who are at the final stage of their training.\nThey must make a lightsaber at this stage before being ready for\nthe trials. Their training lightsaber must be given back to his\nmaster. Their Status is +1.",
-			"tags": [
-				"Advantage",
-				"Mental"
+			"modifiers": [
+				{
+					"id": "7a2e3933-3496-4ba7-bc12-afec9d5e2e40",
+					"type": "modifier",
+					"name": "Combined Force Abilities",
+					"reference": "SWF22",
+					"cost": 20,
+					"disabled": true
+				},
+				{
+					"id": "b531aebd-a4f1-4a02-be4e-1f6f18f3d1a7",
+					"type": "modifier",
+					"name": "Multi-Force Ability",
+					"reference": "SWF22",
+					"cost": 20,
+					"disabled": true
+				},
+				{
+					"id": "5fcbd09a-2a6e-4183-9876-feaf9b3ce9f3",
+					"type": "modifier",
+					"name": "Single Force Ability",
+					"reference": "SWF22",
+					"cost": -20,
+					"disabled": true
+				}
 			],
-			"base_points": 20,
-			"calc": {
-				"points": 20
-			}
-		},
-		{
-			"id": "044ac1bb-26bf-45bf-a462-b3478392737f",
-			"type": "trait",
-			"name": "Jedi Rank 5: Knight",
-			"notes": "Jedi who succeeded their trials are known as Jedi Knights. They\nare the ones who are best known who fulfill assignments and\ncomplete many missions. Their Status is +2.",
-			"tags": [
-				"Advantage",
-				"Mental"
-			],
-			"base_points": 25,
+			"levels": 1,
+			"points_per_level": 25,
+			"can_level": true,
 			"calc": {
 				"points": 25
 			}
 		},
 		{
-			"id": "7c3983b2-5dff-4939-9498-c25701233995",
+			"id": "d7b9f990-b76e-404d-aca1-acbf42171919",
 			"type": "trait",
-			"name": "Jedi Rank 6: Grand Knight",
-			"notes": "These are Jedi Knights granted a seat in the council but not\ngranted the title of Master. Anakin Skywalker was a Grand Knight\nduring the end of the Clone Wars. Status is +3.",
+			"name": "Force Inept",
+			"reference": "SWF27",
 			"tags": [
-				"Advantage",
-				"Mental"
+				"Quirk",
+				"Force"
 			],
-			"base_points": 30,
+			"base_points": -1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Force Sensitivity"
+						}
+					}
+				]
+			},
 			"calc": {
-				"points": 30
+				"points": -1
 			}
 		},
 		{
-			"id": "2ae46bcd-01f0-4328-8485-2a09895359a7",
+			"id": "37830cbf-3083-4d23-bc09-e0f9beeaf939",
 			"type": "trait",
-			"name": "Jedi Rank 7: Master",
-			"notes": "Jedi Knights can only be granted the title of Master by the Jedi\nCouncil. A seat in the Jedi Council is not necessary but a Master is\nmost often appointed to teach a Padawan learner. Status is +4.",
+			"name": "Force Sensitivity",
+			"reference": "SWF22",
 			"tags": [
 				"Advantage",
+				"Force",
 				"Mental"
 			],
-			"base_points": 35,
-			"calc": {
-				"points": 35
-			}
-		},
-		{
-			"id": "b6c01a81-d2ab-4739-ba52-ed15cdb407c2",
-			"type": "trait",
-			"name": "Jedi Rank 8: Grand Master",
-			"notes": "Only one Jedi Grand Master at a time can exist. This is the highest\nrank a Jedi can achieve, and not many did. Status is +5.",
-			"tags": [
-				"Advantage",
-				"Mental"
-			],
-			"base_points": 40,
-			"calc": {
-				"points": 40
-			}
-		},
-		{
-			"id": "3798a4ff-023a-4832-84e6-359a4f299e0e",
-			"type": "trait",
-			"name": "Sith Rank 1: Apprentice",
-			"tags": [
-				"Advantage",
-				"Mental"
+			"modifiers": [
+				{
+					"id": "44658d72-bcac-4243-9eb3-4c71a3af1da9",
+					"type": "modifier",
+					"name": "Dark Aspect",
+					"reference": "SWF22",
+					"reference_highlight": "One Aspect Only",
+					"cost": -40,
+					"disabled": true,
+					"features": [
+						{
+							"type": "spell_bonus",
+							"match": "power_source_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force"
+							},
+							"amount": -1,
+							"per_level": true
+						},
+						{
+							"type": "spell_bonus",
+							"match": "college_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Dark"
+							},
+							"amount": 1,
+							"per_level": true
+						}
+					]
+				},
+				{
+					"id": "f1b13b68-c101-454a-9e98-e9f89554a89e",
+					"type": "modifier",
+					"name": "Light Aspect",
+					"reference": "SWF22",
+					"reference_highlight": "One Aspect Only",
+					"cost": -40,
+					"disabled": true,
+					"features": [
+						{
+							"type": "spell_bonus",
+							"match": "power_source_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force"
+							},
+							"amount": -1,
+							"per_level": true
+						},
+						{
+							"type": "spell_bonus",
+							"match": "college_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Light"
+							},
+							"amount": 1,
+							"per_level": true
+						}
+					]
+				},
+				{
+					"id": "3fed15a2-6798-406d-a8b0-f8fae006ff05",
+					"type": "modifier",
+					"name": "Neutral Aspect",
+					"reference": "SWF22",
+					"reference_highlight": "One Aspect Only",
+					"cost": -40,
+					"disabled": true,
+					"features": [
+						{
+							"type": "spell_bonus",
+							"match": "power_source_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force"
+							},
+							"amount": -1,
+							"per_level": true
+						},
+						{
+							"type": "spell_bonus",
+							"match": "college_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Neutral"
+							},
+							"amount": 1,
+							"per_level": true
+						}
+					]
+				}
 			],
 			"base_points": 5,
-			"calc": {
-				"points": 5
-			}
-		},
-		{
-			"id": "0b730cff-bd05-4a9c-af5c-044840bedd42",
-			"type": "trait",
-			"name": "Sith Rank 2: Darth",
-			"notes": "An original title of the Sith. Normally this title is paired with a Sith\nname other than the character’s own name (e.g., Tyrannus, Vader\nor Maul). A Darth has killed at least one other Force user. More\noften, a Darth is called Lord or Dark Lord.",
-			"tags": [
-				"Advantage",
-				"Mental"
+			"levels": 1,
+			"points_per_level": 10,
+			"features": [
+				{
+					"type": "spell_bonus",
+					"match": "power_source_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Force"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "spell_bonus",
+					"match": "power_source_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Force"
+					},
+					"amount": -6
+				}
 			],
-			"base_points": 10,
-			"calc": {
-				"points": 10
-			}
-		},
-		{
-			"id": "777dbf20-1778-4eef-8de7-0f971432a3bb",
-			"type": "trait",
-			"name": "Sith Rank 3: Master",
-			"notes": "A Sith Master is the terror of the Jedi. Luckily, after the Golden\nAge of the Sith, there is only one Master at a time. A prerequisite\nto this rank is either having an apprentice or just being the last Sith\nalive.",
-			"tags": [
-				"Advantage",
-				"Mental"
-			],
-			"base_points": 15,
+			"can_level": true,
 			"calc": {
 				"points": 15
 			}
 		},
 		{
-			"id": "57bef0b0-b273-4deb-92c5-3a35174081fc",
+			"id": "72f49fa9-4493-4094-bd87-dfc6bf494479",
 			"type": "trait",
-			"name": "Light Aspect of The Force",
-			"notes": "Illuminated",
+			"name": "Force Specialism (@Ability@)",
+			"reference": "SWF22",
+			"tags": [
+				"Mental",
+				"Force"
+			],
+			"levels": 1,
+			"points_per_level": 10,
+			"features": [
+				{
+					"type": "spell_bonus",
+					"match": "spell_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "@Ability@"
+					},
+					"amount": 4,
+					"per_level": true
+				}
+			],
+			"can_level": true,
+			"calc": {
+				"points": 10
+			}
+		},
+		{
+			"id": "710de5b7-f575-4914-9a32-880e482a51f4",
+			"type": "trait",
+			"name": "Insubstantiality",
+			"reference": "SWF23",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Mental",
+				"Physical",
+				"Force"
+			],
+			"modifiers": [
+				{
+					"id": "3fb8878d-5655-445e-9d31-9e33fc0bc493",
+					"type": "modifier",
+					"name": "Affect Substantial",
+					"reference": "B63",
+					"cost": 100,
+					"disabled": true
+				},
+				{
+					"id": "a030dea2-6ace-439d-a795-552b09161162",
+					"type": "modifier",
+					"name": "Always On",
+					"reference": "B63",
+					"cost": -50,
+					"disabled": true
+				},
+				{
+					"id": "4de4ab86-aa6e-4e28-a4b6-7dca6dfce411",
+					"type": "modifier",
+					"name": "Can Carry Objects",
+					"reference": "B63",
+					"notes": "Up to Heavy Encumbrance",
+					"cost": 100,
+					"disabled": true
+				},
+				{
+					"id": "56ce8ce5-33ca-41e9-a1fe-819d61cce1c5",
+					"type": "modifier",
+					"name": "Can Carry Objects",
+					"reference": "B63",
+					"notes": "Up to Light Encumbrance",
+					"cost": 20,
+					"disabled": true
+				},
+				{
+					"id": "ba34ca18-f8d0-4047-8533-24d0bd38937e",
+					"type": "modifier",
+					"name": "Can Carry Objects",
+					"reference": "B63",
+					"notes": "Up to Medium Encumbrance",
+					"cost": 50,
+					"disabled": true
+				},
+				{
+					"id": "96e50e39-6ab0-4026-877e-a35ab64a72c3",
+					"type": "modifier",
+					"name": "Can Carry Objects",
+					"reference": "B63",
+					"notes": "Up to No Encumbrance",
+					"cost": 10,
+					"disabled": true
+				},
+				{
+					"id": "5ef976cc-1ed0-448c-a7ca-1bd58a7001aa",
+					"type": "modifier",
+					"name": "Difficult Materialization",
+					"reference": "H16",
+					"notes": "Mutually exclusive with Usually On.",
+					"cost": -20,
+					"disabled": true
+				},
+				{
+					"id": "b365f8c9-e836-4ab0-b6c7-adf848dcf04c",
+					"type": "modifier",
+					"name": "Ectoplasmic Materialization",
+					"reference": "H16",
+					"cost": -35,
+					"disabled": true
+				},
+				{
+					"id": "3635fae6-7177-46f5-b929-d3320b0d1572",
+					"type": "modifier",
+					"name": "Force",
+					"reference": "SWF22",
+					"cost": -10,
+					"disabled": true
+				},
+				{
+					"id": "25d50ad0-0f0f-4d32-b70a-f5533ac102ea",
+					"type": "modifier",
+					"name": "Ghost Air",
+					"reference": "PSI14",
+					"cost": 10,
+					"disabled": true
+				},
+				{
+					"id": "b4e2c8b3-7cd3-46a0-9c71-140d8cb7a8b5",
+					"type": "modifier",
+					"name": "No Vertical Move",
+					"reference": "P56",
+					"cost": -10,
+					"disabled": true
+				},
+				{
+					"id": "bf4438fc-c350-437f-b39f-b4bfab602bcb",
+					"type": "modifier",
+					"name": "Noisy",
+					"reference": "P56",
+					"cost": -5,
+					"disabled": true
+				},
+				{
+					"id": "c8292ed6-c0b3-492b-889e-b313d90d945b",
+					"type": "modifier",
+					"name": "Partial Change",
+					"reference": "B63",
+					"cost": 20,
+					"disabled": true
+				},
+				{
+					"id": "9e24d3f1-0f0a-456d-9ecb-5a5b86a8be2c",
+					"type": "modifier",
+					"name": "Partial Change",
+					"reference": "B63",
+					"notes": "Can turn an item you are carrying substantial without dropping it",
+					"cost": 100,
+					"disabled": true
+				},
+				{
+					"id": "c6e94b71-4fa4-476c-b672-031da159c414",
+					"type": "modifier",
+					"name": "Projection",
+					"reference": "P56",
+					"cost": -50,
+					"disabled": true
+				},
+				{
+					"id": "77fec951-69aa-44b0-a0cb-a110183fdd95",
+					"type": "modifier",
+					"name": "Reversion",
+					"reference": "H16",
+					"cost": 60,
+					"disabled": true
+				},
+				{
+					"id": "c926816f-6a45-4305-b895-a8b57b203481",
+					"type": "modifier",
+					"name": "Substantial Communication",
+					"reference": "PSI14",
+					"cost": 40,
+					"disabled": true
+				},
+				{
+					"id": "3e818cad-5823-4984-bb58-8e5be1228c42",
+					"type": "modifier",
+					"name": "Touch",
+					"reference": "H16",
+					"notes": "Always On",
+					"disabled": true
+				},
+				{
+					"id": "c130be05-af3b-4e91-896e-2e1f90e27289",
+					"type": "modifier",
+					"name": "Touch",
+					"reference": "H16",
+					"notes": "Switchable",
+					"cost": 5,
+					"disabled": true
+				},
+				{
+					"id": "a12dd6b5-6bb0-4472-829f-e87adb9f370a",
+					"type": "modifier",
+					"name": "Usually On",
+					"reference": "B63",
+					"notes": "Materialization costs 1 FP per second",
+					"cost": -40,
+					"disabled": true
+				}
+			],
+			"base_points": 80,
+			"calc": {
+				"points": 80
+			}
+		},
+		{
+			"id": "475e500b-6aff-46ca-bd71-85d9d9752c09",
+			"type": "trait",
+			"name": "Jedi Rank",
+			"reference": "SWF24",
+			"tags": [
+				"Advantage",
+				"Mental"
+			],
+			"levels": 1,
+			"points_per_level": 5,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Force Sensitivity"
+						},
+						"level": {
+							"compare": "at_least"
+						}
+					}
+				]
+			},
+			"can_level": true,
+			"calc": {
+				"points": 5
+			}
+		},
+		{
+			"id": "43f93348-de96-4fb0-afd4-3f73fa7fff68",
+			"type": "trait",
+			"name": "Light Aspect of the Force",
+			"reference": "SWF27",
 			"tags": [
 				"Disadvantage",
-				"Force",
-				"Supernatural"
+				"Force"
 			],
-			"base_points": -4,
+			"modifiers": [
+				{
+					"id": "2828e007-5ceb-4748-b055-232730bfb8b6",
+					"type": "modifier",
+					"name": "Journeyman",
+					"reference": "SWF27",
+					"cost": -2,
+					"cost_type": "points",
+					"disabled": true,
+					"features": [
+						{
+							"type": "reaction_bonus",
+							"situation": "from Dark Jedi and Sith who sense your aspect",
+							"amount": -2
+						},
+						{
+							"type": "reaction_bonus",
+							"situation": "from Jedi who sense your aspect",
+							"amount": 1
+						},
+						{
+							"type": "spell_bonus",
+							"match": "college_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Light"
+							},
+							"amount": 1
+						},
+						{
+							"type": "spell_bonus",
+							"match": "college_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Dark"
+							},
+							"amount": -1
+						}
+					]
+				},
+				{
+					"id": "350e9e4e-4f4b-4bbc-a422-c3c3f11ccc79",
+					"type": "modifier",
+					"name": "Illuminated",
+					"reference": "SWF27",
+					"cost": -4,
+					"cost_type": "points",
+					"disabled": true,
+					"features": [
+						{
+							"type": "reaction_bonus",
+							"situation": "from Dark Jedi and Sith who sense your aspect",
+							"amount": -2
+						},
+						{
+							"type": "reaction_bonus",
+							"situation": "from Jedi who sense your aspect",
+							"amount": 2
+						},
+						{
+							"type": "spell_bonus",
+							"match": "college_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Light"
+							},
+							"amount": 2
+						},
+						{
+							"type": "spell_bonus",
+							"match": "college_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Dark"
+							},
+							"amount": -2
+						}
+					]
+				},
+				{
+					"id": "dafb33e3-2b6a-485f-9b69-f29197877f74",
+					"type": "modifier",
+					"name": "Enlightened",
+					"reference": "SWF27",
+					"cost": -8,
+					"cost_type": "points",
+					"disabled": true,
+					"features": [
+						{
+							"type": "reaction_bonus",
+							"situation": "from Dark Jedi and Sith who sense your aspect",
+							"amount": -3
+						},
+						{
+							"type": "reaction_bonus",
+							"situation": "from Jedi who sense your aspect",
+							"amount": 2
+						},
+						{
+							"type": "spell_bonus",
+							"match": "college_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Light"
+							},
+							"amount": 3
+						},
+						{
+							"type": "spell_bonus",
+							"match": "college_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Dark"
+							},
+							"amount": -4
+						}
+					]
+				},
+				{
+					"id": "edf14853-85a5-45b2-9a5e-db72b4a0dc61",
+					"type": "modifier",
+					"name": "Harmony",
+					"reference": "SWF26",
+					"cost": -12,
+					"cost_type": "points",
+					"disabled": true,
+					"features": [
+						{
+							"type": "reaction_bonus",
+							"situation": "from Dark Jedi and Sith who sense your aspect",
+							"amount": -4
+						},
+						{
+							"type": "reaction_bonus",
+							"situation": "from Jedi who sense your aspect",
+							"amount": 2
+						},
+						{
+							"type": "spell_bonus",
+							"match": "college_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Light"
+							},
+							"amount": 4
+						},
+						{
+							"type": "spell_bonus",
+							"match": "college_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Dark"
+							},
+							"amount": -8
+						}
+					]
+				}
+			],
+			"calc": {
+				"points": 0
+			}
+		},
+		{
+			"id": "964cad5a-56ca-4d31-a312-5279ccd1bad9",
+			"type": "trait",
+			"name": "Precognition",
+			"reference": "SWF23",
+			"tags": [
+				"Advantage",
+				"Mental",
+				"Force"
+			],
+			"modifiers": [
+				{
+					"id": "89d82798-1d5b-42e4-bc8b-7fd5b94d5cc2",
+					"type": "modifier",
+					"name": "Can't See Own Death",
+					"reference": "B77",
+					"cost": -60,
+					"disabled": true
+				},
+				{
+					"id": "89e18824-fb84-4940-9cfd-3db3debac4ba",
+					"type": "modifier",
+					"name": "One Event",
+					"reference": "B77",
+					"notes": "@Event Type@",
+					"cost": -40,
+					"disabled": true
+				},
+				{
+					"id": "30ba3ae1-d30e-46b1-842e-fa5fe5d55973",
+					"type": "modifier",
+					"name": "Directed",
+					"reference": "P68",
+					"cost": 100,
+					"disabled": true
+				},
+				{
+					"id": "0efb47f3-b9a5-453b-9751-16b0d0163eb3",
+					"type": "modifier",
+					"name": "Active Only",
+					"reference": "P69",
+					"cost": -60,
+					"disabled": true
+				},
+				{
+					"id": "d89bd1d9-35d0-4f89-9aa2-4978ca33321e",
+					"type": "modifier",
+					"name": "Passive Only",
+					"reference": "P69",
+					"cost": -20,
+					"disabled": true
+				},
+				{
+					"id": "62031691-48e2-44b1-984a-968d734802a6",
+					"type": "modifier",
+					"name": "Dreaming",
+					"reference": "PSI16",
+					"cost": -70,
+					"disabled": true
+				},
+				{
+					"id": "39802f82-5c97-46ad-afae-20b7389a3af5",
+					"type": "modifier",
+					"name": "Dreaming",
+					"reference": "PSI16",
+					"notes": "Combined with Active Only or Can't See Own Death",
+					"cost": -20,
+					"disabled": true
+				},
+				{
+					"id": "110e3e0f-fcfe-4c5b-94b8-e0e43aa15d5f",
+					"type": "modifier",
+					"name": "Force",
+					"reference": "SWF25",
+					"cost": -10
+				}
+			],
+			"base_points": 25,
+			"calc": {
+				"points": 23
+			}
+		},
+		{
+			"id": "8289a47e-120e-40ce-ba24-2500d548a8bf",
+			"type": "trait",
+			"name": "Sense Talent",
+			"reference": "SWF24",
+			"tags": [
+				"Advantage",
+				"Force"
+			],
+			"levels": 1,
+			"points_per_level": 10,
 			"prereqs": {
 				"type": "prereq_list",
 				"all": true,
@@ -1213,49 +1296,181 @@
 			},
 			"features": [
 				{
+					"type": "attribute_bonus",
+					"attribute": "forcesight",
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Precognitive Parry"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Blidn Fighting"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Detect Lies"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Force"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Fortune-Telling"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Repair"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Force"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Parry Beam Weapons"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Parry Missile Weapons"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
 					"type": "spell_bonus",
 					"match": "college_name",
 					"name": {
 						"compare": "is",
-						"qualifier": "Light"
+						"qualifier": "Sense"
 					},
-					"amount": 2
-				},
-				{
-					"type": "spell_bonus",
-					"match": "college_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "Dark"
-					},
-					"amount": -2
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Reaction from Jedi",
-					"amount": 2
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Reaction from Dark Jedi \u0026 Sith",
-					"amount": -2
+					"amount": 1,
+					"per_level": true
 				}
 			],
+			"can_level": true,
 			"calc": {
-				"points": -4
+				"points": 10
 			}
 		},
 		{
-			"id": "c8f4619c-3276-46f8-8ddf-f2310a30f037",
+			"id": "78188825-3357-409e-909e-03ac8fa17253",
 			"type": "trait",
-			"name": "Light Aspect of The Force",
-			"notes": "Enlighted",
+			"name": "Sith Rank",
+			"reference": "SWF24",
 			"tags": [
-				"Disadvantage",
-				"Force",
-				"Supernatural"
+				"Advantage",
+				"Mental"
 			],
-			"base_points": -8,
+			"levels": 1,
+			"points_per_level": 5,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Force Sensitivity"
+						},
+						"level": {
+							"compare": "at_least"
+						}
+					}
+				]
+			},
+			"can_level": true,
+			"calc": {
+				"points": 5
+			}
+		},
+		{
+			"id": "b6304d09-a993-4590-936b-d10f9bfec088",
+			"type": "trait",
+			"name": "Style Familiarity (Jar'Kai)",
+			"reference": "SWF25",
+			"reference_highlight": "Jar'Kai",
+			"tags": [
+				"Perk"
+			],
+			"base_points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Saber"
+						},
+						"level": {
+							"compare": "at_least"
+						}
+					}
+				]
+			},
+			"calc": {
+				"points": 1
+			}
+		},
+		{
+			"id": "70d13207-9b77-46a8-962c-7dd9d8c200fd",
+			"type": "trait",
+			"name": "Trained By A Jedi Battlemaster",
+			"reference": "SWF24",
+			"notes": "You have half the usual penalty to make a Rapid Strike, or to parry more than once per turn. These benefits apply to all your unarmed combat skills (Punching, Striking, etc.) and all Lightsaber Weapon skills.",
+			"tags": [
+				"Advantage",
+				"Force",
+				"Mental"
+			],
+			"base_points": 30,
 			"prereqs": {
 				"type": "prereq_list",
 				"all": true,
@@ -1270,109 +1485,20 @@
 					}
 				]
 			},
-			"features": [
-				{
-					"type": "spell_bonus",
-					"match": "college_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "Light"
-					},
-					"amount": 3
-				},
-				{
-					"type": "spell_bonus",
-					"match": "college_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "Dark"
-					},
-					"amount": -4
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Reaction from Jedi",
-					"amount": 2
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Reaction from Dark Jedi \u0026 Sith",
-					"amount": -3
-				}
-			],
 			"calc": {
-				"points": -8
+				"points": 30
 			}
 		},
 		{
-			"id": "152bced4-bfca-4cea-a6c8-e5ca9e0e64cd",
-			"type": "trait",
-			"name": "Light Aspect of The Force",
-			"notes": "Harmony",
-			"tags": [
-				"Disadvantage",
-				"Force",
-				"Supernatural"
-			],
-			"base_points": -12,
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Force Sensitivity"
-						}
-					}
-				]
-			},
-			"features": [
-				{
-					"type": "spell_bonus",
-					"match": "college_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "Light"
-					},
-					"amount": 4
-				},
-				{
-					"type": "spell_bonus",
-					"match": "college_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "Dark"
-					},
-					"amount": -8
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Reaction from Jedi",
-					"amount": 2
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Reaction from Dark Jedi \u0026 Sith",
-					"amount": -4
-				}
-			],
-			"calc": {
-				"points": -12
-			}
-		},
-		{
-			"id": "84afa716-5a2d-4795-bd52-04822fa265ad",
+			"id": "f8ceda3b-53e2-428c-a262-475002069e36",
 			"type": "trait",
 			"name": "Trained By A Jedi Forcemaster",
+			"reference": "SWF25",
 			"notes": "You pay half the FP (rounded up)and may use an extra defensive Force ability in a turn.",
 			"tags": [
 				"Advantage",
 				"Force",
-				"Mental",
-				"Supernatural"
+				"Mental"
 			],
 			"base_points": 30,
 			"calc": {
@@ -1380,47 +1506,19 @@
 			}
 		},
 		{
-			"id": "5c90edc1-790b-4c91-a343-508f9529c654",
+			"id": "97cb14dd-f183-45a0-98ef-c1429fc20aba",
 			"type": "trait",
-			"name": "Precognition",
+			"name": "Weapon Bond (Lightsaber)",
+			"reference": "SWF25",
 			"tags": [
 				"Mental",
-				"Supernatural"
-			],
-			"base_points": 25,
-			"calc": {
-				"points": 25
-			}
-		},
-		{
-			"id": "a93370ed-36e3-49fd-9889-3228d07795d9",
-			"type": "trait",
-			"name": "Sense Talent",
-			"tags": [
-				"Advantage",
-				"Force",
-				"Mental",
-				"Supernatural"
+				"Force"
 			],
 			"levels": 1,
-			"points_per_level": 10,
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Force Sensitivity"
-						}
-					}
-				]
-			},
+			"points_per_level": 5,
 			"can_level": true,
 			"calc": {
-				"points": 10
+				"points": 5
 			}
 		}
 	]


### PR DESCRIPTION
Updated data for Star Wars unofficial libraries based on Dark Lord Azaghtoth's sourcebooks (2016 edition).
Summary of changes:
- Added page references where these were missing.
- Merged some traits which represented the same trait at different ranks with no functional difference or non-standard point scaling.
- Added functionality to Force Ability traits. These now apply the appropriate bonuses to affectes Force Abilities (spells).
- Modified the difficulty of Force Abilities to reflect the books' custom "Extremely Hard" and "Incredibly Hard" difficulties. The former are Will/A, the latter are Will/VH. This, combined with the -6 to all spells given by the "Force Sensitive" trait should result in the desired finall skill level as written.
- Added 2 custom attribute files to account for "Force Sight" and "Energy Reserve (Force)". The latter is a pool attribute but currently has no threshold indicators. This can be amended if need be.