### PR TITLE
Wizardry Refined: Fix prerequisites, TL and VH vs H

### DIFF
--- a/Library/Pyramid Magazine/Pyramid 60/Wizardry Redefined Spells.spl
+++ b/Library/Pyramid Magazine/Pyramid 60/Wizardry Redefined Spells.spl
@@ -813,36 +813,17 @@
 				"all": true,
 				"prereqs": [
 					{
-						"type": "prereq_list",
-						"all": false,
-						"prereqs": [
-							{
-								"type": "spell_prereq",
-								"sub_type": "name",
-								"has": true,
-								"qualifier": {
-									"compare": "contains",
-									"qualifier": "shapeshifting"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
-							},
-							{
-								"type": "spell_prereq",
-								"sub_type": "name",
-								"has": true,
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "perfect illusion"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
-							}
-						]
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Perfect Illusion"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
 					},
 					{
 						"type": "spell_prereq",
@@ -1036,11 +1017,11 @@
 			"type": "spell",
 			"name": "Animate Machine",
 			"reference": "M177",
+			"notes": "Cast at -5 on machines that emulate TL4 machinery, and at -10 to TL5-emulating machinery; Only for non-muscle-powered machines",
 			"tags": [
 				"Machine",
 				"Technological"
 			],
-			"tech_level": "",
 			"difficulty": "iq/vh",
 			"college": [
 				"Technological"
@@ -1875,6 +1856,7 @@
 			"type": "spell",
 			"name": "Beacon",
 			"reference": "M83",
+			"notes": "Only assists Plane Shift",
 			"tags": [
 				"Gate",
 				"Movement"
@@ -4450,7 +4432,7 @@
 						"has": true,
 						"qualifier": {
 							"compare": "is",
-							"qualifier": "walk on air"
+							"qualifier": "cloud walking"
 						},
 						"quantity": {
 							"compare": "at_least",
@@ -5270,11 +5252,11 @@
 			"type": "spell",
 			"name": "Conduct Power",
 			"reference": "M180",
+			"notes": "Cast at -5 on machines that emulate TL4 machinery, and at -10 to TL5-emulating machinery",
 			"tags": [
 				"Energy",
 				"Technological"
 			],
-			"tech_level": "",
 			"difficulty": "iq/vh",
 			"college": [
 				"Technological"
@@ -6967,11 +6949,11 @@
 			"type": "spell",
 			"name": "Create Fuel",
 			"reference": "M179",
+			"notes": "Cast at -5 on machines that emulate TL4 machinery, and at -10 to TL5-emulating machinery",
 			"tags": [
 				"Energy",
 				"Technological"
 			],
-			"tech_level": "",
 			"difficulty": "iq/h",
 			"college": [
 				"Technological"
@@ -7792,7 +7774,7 @@
 			"tags": [
 				"Body Control"
 			],
-			"difficulty": "iq/h",
+			"difficulty": "iq/vh",
 			"college": [
 				"Body Control"
 			],
@@ -8091,6 +8073,7 @@
 			"type": "spell",
 			"name": "Delay",
 			"reference": "M130",
+			"notes": "Caster may only have as many Hang Spell/Delay/Link/Reflex spells on as they have levels of Magery",
 			"tags": [
 				"Linking",
 				"Meta"
@@ -9030,6 +9013,19 @@
 						"has": true,
 						"qualifier": {
 							"compare": "is",
+							"qualifier": "history"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
 							"qualifier": "bright vision"
 						},
 						"quantity": {
@@ -9101,6 +9097,19 @@
 				"type": "prereq_list",
 				"all": true,
 				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "history"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
 					{
 						"type": "spell_prereq",
 						"sub_type": "college",
@@ -9179,6 +9188,19 @@
 				"type": "prereq_list",
 				"all": true,
 				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "history"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
 					{
 						"type": "spell_prereq",
 						"sub_type": "college",
@@ -9263,6 +9285,19 @@
 						"has": true,
 						"qualifier": {
 							"compare": "is",
+							"qualifier": "history"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
 							"qualifier": "earth vision"
 						},
 						"quantity": {
@@ -9309,6 +9344,19 @@
 				"type": "prereq_list",
 				"all": true,
 				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "history"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
 					{
 						"type": "spell_prereq",
 						"sub_type": "college",
@@ -9389,6 +9437,19 @@
 				"prereqs": [
 					{
 						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "history"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
 						"sub_type": "college",
 						"has": true,
 						"qualifier": {
@@ -9426,6 +9487,19 @@
 				"type": "prereq_list",
 				"all": true,
 				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "history"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
 					{
 						"type": "spell_prereq",
 						"sub_type": "college",
@@ -9479,6 +9553,19 @@
 				"prereqs": [
 					{
 						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "history"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
 						"sub_type": "college",
 						"has": true,
 						"qualifier": {
@@ -9516,6 +9603,19 @@
 				"type": "prereq_list",
 				"all": true,
 				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "history"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
 					{
 						"type": "spell_prereq",
 						"sub_type": "college",
@@ -9556,6 +9656,19 @@
 				"all": true,
 				"prereqs": [
 					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "history"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
 						"type": "trait_prereq",
 						"has": true,
 						"name": {
@@ -9589,6 +9702,19 @@
 				"type": "prereq_list",
 				"all": true,
 				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "history"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
 					{
 						"type": "spell_prereq",
 						"sub_type": "college",
@@ -9630,6 +9756,19 @@
 				"prereqs": [
 					{
 						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "history"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
 						"sub_type": "college",
 						"has": true,
 						"qualifier": {
@@ -9669,6 +9808,19 @@
 				"prereqs": [
 					{
 						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "history"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
 						"sub_type": "college",
 						"has": true,
 						"qualifier": {
@@ -9706,6 +9858,19 @@
 				"type": "prereq_list",
 				"all": true,
 				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "history"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
 					{
 						"type": "spell_prereq",
 						"sub_type": "name",
@@ -9784,6 +9949,19 @@
 				"type": "prereq_list",
 				"all": true,
 				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "history"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
 					{
 						"type": "skill_prereq",
 						"has": true,
@@ -10304,7 +10482,7 @@
 						"has": true,
 						"qualifier": {
 							"compare": "is",
-							"qualifier": "create earth"
+							"qualifier": "create object"
 						},
 						"quantity": {
 							"compare": "at_least",
@@ -11784,11 +11962,11 @@
 			"type": "spell",
 			"name": "Essential Fuel",
 			"reference": "M179",
+			"notes": "Cast at -5 on machines that emulate TL4 machinery, and at -10 to TL5-emulating machinery",
 			"tags": [
 				"Energy",
 				"Technological"
 			],
-			"tech_level": "",
 			"difficulty": "iq/h",
 			"college": [
 				"Technological"
@@ -12961,14 +13139,6 @@
 						"quantity": {
 							"compare": "at_least",
 							"qualifier": 1
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "empathy"
 						}
 					}
 				]
@@ -14143,7 +14313,7 @@
 								},
 								"level": {
 									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": 2
 								},
 								"notes": {
 									"compare": "does_not_contain",
@@ -14159,7 +14329,7 @@
 								},
 								"level": {
 									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": 2
 								},
 								"notes": {
 									"compare": "contains",
@@ -14348,45 +14518,6 @@
 								}
 							}
 						]
-					}
-				]
-			}
-		},
-		{
-			"id": "b1198bd2-9387-4ff3-975b-dbf2becd889d",
-			"type": "spell",
-			"name": "Fortify",
-			"reference": "M66",
-			"tags": [
-				"Armor Enchantment"
-			],
-			"difficulty": "iq/h",
-			"college": [
-				"Enchantment"
-			],
-			"power_source": "Arcane",
-			"spell_class": "Enchantment",
-			"casting_cost": "Varies",
-			"maintenance_cost": "-",
-			"casting_time": "-",
-			"duration": "Permanent",
-			"points": 1,
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "spell_prereq",
-						"sub_type": "name",
-						"has": true,
-						"qualifier": {
-							"compare": "is",
-							"qualifier": "enchant"
-						},
-						"quantity": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
 					}
 				]
 			}
@@ -14742,7 +14873,7 @@
 			"tags": [
 				"Body Control"
 			],
-			"difficulty": "iq/h",
+			"difficulty": "iq/vh",
 			"college": [
 				"Body Control"
 			],
@@ -14858,7 +14989,7 @@
 			"tags": [
 				"Water"
 			],
-			"difficulty": "iq/h",
+			"difficulty": "iq/vh",
 			"college": [
 				"Water"
 			],
@@ -14916,19 +15047,6 @@
 						"quantity": {
 							"compare": "at_least",
 							"qualifier": 6
-						}
-					},
-					{
-						"type": "spell_prereq",
-						"sub_type": "name",
-						"has": true,
-						"qualifier": {
-							"compare": "is",
-							"qualifier": "create spring"
-						},
-						"quantity": {
-							"compare": "at_least",
-							"qualifier": 1
 						}
 					}
 				]
@@ -15168,11 +15286,11 @@
 			"type": "spell",
 			"name": "Glitch",
 			"reference": "M176",
+			"notes": "Cast at -5 on machines that emulate TL4 machinery, and at -10 to TL5-emulating machinery; only for non-muscle-powered machines",
 			"tags": [
 				"Machine",
 				"Technological"
 			],
-			"tech_level": "",
 			"difficulty": "iq/h",
 			"college": [
 				"Technological"
@@ -15351,58 +15469,6 @@
 						"qualifier": {
 							"compare": "is",
 							"qualifier": "clumsiness"
-						},
-						"quantity": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
-					}
-				]
-			}
-		},
-		{
-			"id": "4f38d5f3-1eaf-4ca6-a294-342e0e275a35",
-			"type": "spell",
-			"name": "Graceful Weapon",
-			"reference": "M63",
-			"tags": [
-				"Weapon Enchantment"
-			],
-			"difficulty": "iq/h",
-			"college": [
-				"Enchantment"
-			],
-			"power_source": "Arcane",
-			"spell_class": "Enchantment",
-			"casting_cost": "150/lb",
-			"maintenance_cost": "-",
-			"casting_time": "-",
-			"duration": "Permanent",
-			"points": 1,
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "spell_prereq",
-						"sub_type": "name",
-						"has": true,
-						"qualifier": {
-							"compare": "is",
-							"qualifier": "apportation"
-						},
-						"quantity": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
-					},
-					{
-						"type": "spell_prereq",
-						"sub_type": "name",
-						"has": true,
-						"qualifier": {
-							"compare": "is",
-							"qualifier": "enchant"
 						},
 						"quantity": {
 							"compare": "at_least",
@@ -15968,6 +16034,7 @@
 			"type": "spell",
 			"name": "Hang Spell",
 			"reference": "M128",
+			"notes": "Caster may only have as many Hang Spell/Delay/Link/Reflex spells on as they have levels of Magery",
 			"tags": [
 				"Meta"
 			],
@@ -16334,15 +16401,26 @@
 				"prereqs": [
 					{
 						"type": "spell_prereq",
-						"sub_type": "name",
+						"sub_type": "college_count",
 						"has": true,
 						"qualifier": {
-							"compare": "is",
-							"qualifier": "teleport"
+							"compare": "is"
 						},
 						"quantity": {
 							"compare": "at_least",
-							"qualifier": 1
+							"qualifier": 10
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "college_count",
+						"has": true,
+						"qualifier": {
+							"compare": "is"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 10
 						}
 					},
 					{
@@ -16351,12 +16429,21 @@
 						"has": true,
 						"qualifier": {
 							"compare": "is",
-							"qualifier": "hideaway"
+							"qualifier": "plane shift other"
 						},
 						"quantity": {
 							"compare": "at_least",
 							"qualifier": 1
 						}
+					},
+					{
+						"type": "attribute_prereq",
+						"has": true,
+						"qualifier": {
+							"compare": "at_least",
+							"qualifier": 13
+						},
+						"which": "iq"
 					}
 				]
 			}
@@ -16874,7 +16961,7 @@
 						"has": true,
 						"qualifier": {
 							"compare": "is",
-							"qualifier": "frost"
+							"qualifier": "create water"
 						},
 						"quantity": {
 							"compare": "at_least",
@@ -16958,7 +17045,7 @@
 			"tags": [
 				"Water"
 			],
-			"difficulty": "iq/h",
+			"difficulty": "iq/vh",
 			"college": [
 				"Water"
 			],
@@ -17575,71 +17662,6 @@
 						"qualifier": {
 							"compare": "is",
 							"qualifier": "voices"
-						},
-						"quantity": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
-					}
-				]
-			}
-		},
-		{
-			"id": "5bafa4f4-c985-4e30-9690-e19198c1bc60",
-			"type": "spell",
-			"name": "Impression Blocker",
-			"reference": "M60",
-			"tags": [
-				"Enchantment"
-			],
-			"difficulty": "iq/h",
-			"college": [
-				"Enchantment"
-			],
-			"power_source": "Arcane",
-			"spell_class": "Enchantment",
-			"casting_cost": "20/lb",
-			"maintenance_cost": "-",
-			"casting_time": "-",
-			"duration": "Permanent",
-			"points": 1,
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "spell_prereq",
-						"sub_type": "name",
-						"has": true,
-						"qualifier": {
-							"compare": "is",
-							"qualifier": "enchant"
-						},
-						"quantity": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
-					},
-					{
-						"type": "spell_prereq",
-						"sub_type": "name",
-						"has": true,
-						"qualifier": {
-							"compare": "is",
-							"qualifier": "seeker"
-						},
-						"quantity": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
-					},
-					{
-						"type": "spell_prereq",
-						"sub_type": "name",
-						"has": true,
-						"qualifier": {
-							"compare": "is",
-							"qualifier": "scry wall"
 						},
 						"quantity": {
 							"compare": "at_least",
@@ -18610,19 +18632,6 @@
 								"has": true,
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "plant form"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
-							},
-							{
-								"type": "spell_prereq",
-								"sub_type": "name",
-								"has": true,
-								"qualifier": {
-									"compare": "is",
 									"qualifier": "alter body"
 								},
 								"quantity": {
@@ -18792,19 +18801,6 @@
 							"compare": "at_least",
 							"qualifier": 3
 						}
-					},
-					{
-						"type": "spell_prereq",
-						"sub_type": "name",
-						"has": true,
-						"qualifier": {
-							"compare": "is",
-							"qualifier": "beast speech"
-						},
-						"quantity": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
 					}
 				]
 			}
@@ -18814,11 +18810,11 @@
 			"type": "spell",
 			"name": "Lend Power",
 			"reference": "M180",
+			"notes": "Cast at -5 on machines that emulate TL4 machinery, and at -10 to TL5-emulating machinery; only for non-muscle-powered machines",
 			"tags": [
 				"Energy",
 				"Technological"
 			],
-			"tech_level": "",
 			"difficulty": "iq/h",
 			"college": [
 				"Technological"
@@ -19059,7 +19055,7 @@
 								},
 								"level": {
 									"compare": "at_least",
-									"qualifier": 3
+									"qualifier": 2
 								},
 								"notes": {
 									"compare": "does_not_contain",
@@ -19075,7 +19071,7 @@
 								},
 								"level": {
 									"compare": "at_least",
-									"qualifier": 3
+									"qualifier": 2
 								},
 								"notes": {
 									"compare": "contains",
@@ -19090,7 +19086,7 @@
 						"has": true,
 						"qualifier": {
 							"compare": "contains",
-							"qualifier": "shapeshifting"
+							"qualifier": "alter body"
 						},
 						"quantity": {
 							"compare": "at_least",
@@ -19624,7 +19620,7 @@
 			"tags": [
 				"Air"
 			],
-			"difficulty": "iq/h",
+			"difficulty": "iq/vh",
 			"college": [
 				"Air"
 			],
@@ -19854,6 +19850,7 @@
 			"type": "spell",
 			"name": "Link",
 			"reference": "M131",
+			"notes": "Caster may only have as many Hang Spell/Delay/Link/Reflex spells on as they have levels of Magery",
 			"tags": [
 				"Linking",
 				"Meta"
@@ -20216,11 +20213,11 @@
 			"type": "spell",
 			"name": "Machine Control",
 			"reference": "M176",
+			"notes": "Cast at -5 on machines that emulate TL4 machinery, and at -10 to TL5-emulating machinery; only for non-muscle-powered machines",
 			"tags": [
 				"Machine",
 				"Technological"
 			],
-			"tech_level": "",
 			"difficulty": "iq/h",
 			"college": [
 				"Technological"
@@ -20255,7 +20252,7 @@
 						"has": true,
 						"qualifier": {
 							"compare": "is",
-							"qualifier": "locksmith"
+							"qualifier": "dancing object"
 						},
 						"quantity": {
 							"compare": "at_least",
@@ -20268,7 +20265,7 @@
 						"has": true,
 						"qualifier": {
 							"compare": "is",
-							"qualifier": "lightning"
+							"qualifier": "manipulate"
 						},
 						"quantity": {
 							"compare": "at_least",
@@ -20283,11 +20280,11 @@
 			"type": "spell",
 			"name": "Machine Possession",
 			"reference": "M178",
+			"notes": "Cast at -5 on machines that emulate TL4 machinery, and at -10 to TL5-emulating machinery; only for non-muscle-powered machines",
 			"tags": [
 				"Machine",
 				"Technological"
 			],
-			"tech_level": "",
 			"difficulty": "iq/h",
 			"college": [
 				"Technological"
@@ -20319,19 +20316,6 @@
 									"compare": "at_least",
 									"qualifier": 1
 								}
-							},
-							{
-								"type": "spell_prereq",
-								"sub_type": "name",
-								"has": true,
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "rider within"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
 							}
 						]
 					},
@@ -20356,11 +20340,11 @@
 			"type": "spell",
 			"name": "Machine Summoning",
 			"reference": "M176",
+			"notes": "Cast at -5 on machines that emulate TL4 machinery, and at -10 to TL5-emulating machinery; only for non-muscle-powered machines",
 			"tags": [
 				"Machine",
 				"Technological"
 			],
-			"tech_level": "",
 			"difficulty": "iq/h",
 			"college": [
 				"Technological"
@@ -20808,11 +20792,11 @@
 			"type": "spell",
 			"name": "Malfunction",
 			"reference": "M177",
+			"notes": "Cast at -5 on machines that emulate TL4 machinery, and at -10 to TL5-emulating machinery; only for non-muscle-powered machines",
 			"tags": [
 				"Machine",
 				"Technological"
 			],
-			"tech_level": "",
 			"difficulty": "iq/h",
 			"college": [
 				"Technological"
@@ -21869,7 +21853,7 @@
 			"tags": [
 				"Earth"
 			],
-			"difficulty": "iq/h",
+			"difficulty": "iq/vh",
 			"college": [
 				"Earth"
 			],
@@ -21936,33 +21920,71 @@
 			"points": 1,
 			"prereqs": {
 				"type": "prereq_list",
-				"all": true,
+				"all": false,
 				"prereqs": [
 					{
-						"type": "spell_prereq",
-						"sub_type": "name",
-						"has": true,
-						"qualifier": {
-							"compare": "is",
-							"qualifier": "sand jet"
-						},
-						"quantity": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "spell_prereq",
+								"sub_type": "name",
+								"has": true,
+								"qualifier": {
+									"compare": "is",
+									"qualifier": "create earth"
+								},
+								"quantity": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							},
+							{
+								"type": "spell_prereq",
+								"sub_type": "name",
+								"has": true,
+								"qualifier": {
+									"compare": "is",
+									"qualifier": "water jet"
+								},
+								"quantity": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							}
+						]
 					},
 					{
-						"type": "spell_prereq",
-						"sub_type": "name",
-						"has": true,
-						"qualifier": {
-							"compare": "is",
-							"qualifier": "create water"
-						},
-						"quantity": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "spell_prereq",
+								"sub_type": "name",
+								"has": true,
+								"qualifier": {
+									"compare": "is",
+									"qualifier": "create water"
+								},
+								"quantity": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							},
+							{
+								"type": "spell_prereq",
+								"sub_type": "name",
+								"has": true,
+								"qualifier": {
+									"compare": "is",
+									"qualifier": "sand jet"
+								},
+								"quantity": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							}
+						]
 					}
 				]
 			},
@@ -22798,7 +22820,7 @@
 			"tags": [
 				"Earth"
 			],
-			"difficulty": "iq/h",
+			"difficulty": "iq/vh",
 			"college": [
 				"Earth"
 			],
@@ -24031,6 +24053,44 @@
 				"all": true,
 				"prereqs": [
 					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (gate)"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							}
+						]
+					},
+					{
 						"type": "spell_prereq",
 						"sub_type": "name",
 						"has": true,
@@ -24304,19 +24364,6 @@
 									"compare": "at_least",
 									"qualifier": 1
 								}
-							},
-							{
-								"type": "spell_prereq",
-								"sub_type": "name",
-								"has": true,
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "beast possession"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
 							}
 						]
 					}
@@ -24536,11 +24583,11 @@
 			"type": "spell",
 			"name": "Preserve Fuel",
 			"reference": "M179",
+			"notes": "Cast at -5 on machines that emulate TL4 machinery, and at -10 to TL5-emulating machinery",
 			"tags": [
 				"Energy",
 				"Technological"
 			],
-			"tech_level": "",
 			"difficulty": "iq/h",
 			"college": [
 				"Technological"
@@ -24774,15 +24821,15 @@
 					},
 					{
 						"type": "spell_prereq",
-						"sub_type": "name",
+						"sub_type": "college",
 						"has": true,
 						"qualifier": {
 							"compare": "is",
-							"qualifier": "plant growth"
+							"qualifier": "earth"
 						},
 						"quantity": {
 							"compare": "at_least",
-							"qualifier": 1
+							"qualifier": 6
 						}
 					}
 				]
@@ -24832,11 +24879,11 @@
 			"type": "spell",
 			"name": "Purify Fuel",
 			"reference": "M179",
+			"notes": "Cast at -5 on machines that emulate TL4 machinery, and at -10 to TL5-emulating machinery",
 			"tags": [
 				"Energy",
 				"Technological"
 			],
-			"tech_level": "",
 			"difficulty": "iq/h",
 			"college": [
 				"Technological"
@@ -25035,15 +25082,15 @@
 					},
 					{
 						"type": "spell_prereq",
-						"sub_type": "name",
+						"sub_type": "college",
 						"has": true,
 						"qualifier": {
 							"compare": "is",
-							"qualifier": "hail"
+							"qualifier": "air"
 						},
 						"quantity": {
 							"compare": "at_least",
-							"qualifier": 1
+							"qualifier": 6
 						}
 					},
 					{
@@ -25443,12 +25490,12 @@
 			"type": "spell",
 			"name": "Rebuild",
 			"reference": "M177",
+			"notes": "Cast at -5 on machines that emulate TL4 machinery, and at -10 to TL5-emulating machinery",
 			"tags": [
 				"Machine",
 				"Making \u0026 Breaking",
 				"Technological"
 			],
-			"tech_level": "",
 			"difficulty": "iq/vh",
 			"college": [
 				"Making \u0026 Breaking",
@@ -25835,44 +25882,6 @@
 				"all": true,
 				"prereqs": [
 					{
-						"type": "prereq_list",
-						"all": false,
-						"prereqs": [
-							{
-								"type": "trait_prereq",
-								"has": true,
-								"name": {
-									"compare": "is",
-									"qualifier": "magery"
-								},
-								"level": {
-									"compare": "at_least",
-									"qualifier": 1
-								},
-								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": true,
-								"name": {
-									"compare": "is",
-									"qualifier": "magery"
-								},
-								"level": {
-									"compare": "at_least",
-									"qualifier": 1
-								},
-								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (meta-spell)"
-								}
-							}
-						]
-					},
-					{
 						"type": "spell_prereq",
 						"sub_type": "name",
 						"has": true,
@@ -25971,6 +25980,7 @@
 			"type": "spell",
 			"name": "Reflex",
 			"reference": "M132",
+			"notes": "Caster may only have as many Hang Spell/Delay/Link/Reflex spells on as they have levels of Magery",
 			"tags": [
 				"Linking",
 				"Meta"
@@ -26251,13 +26261,35 @@
 				"all": true,
 				"prereqs": [
 					{
-						"type": "spell_prereq",
-						"sub_type": "college_count",
-						"has": true,
-						"quantity": {
-							"compare": "at_least",
-							"qualifier": 15
-						}
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "spell_prereq",
+								"sub_type": "college_count",
+								"has": true,
+								"qualifier": {
+									"compare": "is"
+								},
+								"quantity": {
+									"compare": "at_least",
+									"qualifier": 15
+								}
+							},
+							{
+								"type": "spell_prereq",
+								"sub_type": "name",
+								"has": true,
+								"qualifier": {
+									"compare": "is",
+									"qualifier": "suspend curse"
+								},
+								"quantity": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							}
+						]
 					},
 					{
 						"type": "prereq_list",
@@ -26629,19 +26661,6 @@
 								"has": true,
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "shape plant"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
-							},
-							{
-								"type": "spell_prereq",
-								"sub_type": "name",
-								"has": true,
-								"qualifier": {
-									"compare": "is",
 									"qualifier": "shape earth"
 								},
 								"quantity": {
@@ -26971,7 +26990,7 @@
 						"has": true,
 						"qualifier": {
 							"compare": "is",
-							"qualifier": "weather dome"
+							"qualifier": "atmosphere dome"
 						},
 						"quantity": {
 							"compare": "at_least",
@@ -27045,11 +27064,11 @@
 			"points": 1,
 			"prereqs": {
 				"type": "prereq_list",
-				"all": true,
+				"all": false,
 				"prereqs": [
 					{
 						"type": "prereq_list",
-						"all": false,
+						"all": true,
 						"prereqs": [
 							{
 								"type": "spell_prereq",
@@ -27070,7 +27089,7 @@
 								"has": true,
 								"qualifier": {
 									"compare": "is",
-									"qualifier": "umbrella"
+									"qualifier": "destroy water"
 								},
 								"quantity": {
 									"compare": "at_least",
@@ -27085,7 +27104,7 @@
 						"has": true,
 						"qualifier": {
 							"compare": "is",
-							"qualifier": "destroy water"
+							"qualifier": "umbrella"
 						},
 						"quantity": {
 							"compare": "at_least",
@@ -27280,7 +27299,7 @@
 						"has": true,
 						"qualifier": {
 							"compare": "is",
-							"qualifier": "mind-reading"
+							"qualifier": "mind-search"
 						},
 						"quantity": {
 							"compare": "at_least",
@@ -27347,11 +27366,11 @@
 			"type": "spell",
 			"name": "Reveal Function",
 			"reference": "M176",
+			"notes": "Cast at -5 on machines that emulate TL4 machinery, and at -10 to TL5-emulating machinery",
 			"tags": [
 				"Machine",
 				"Technological"
 			],
-			"tech_level": "",
 			"difficulty": "iq/h",
 			"college": [
 				"Technological"
@@ -27388,6 +27407,7 @@
 			"type": "spell",
 			"name": "Reverse Missiles",
 			"reference": "M168",
+			"notes": "Damage that can be reflected is limited to 1d per level of magery. Attacks that do more than this are deflected like Missile Shield.",
 			"tags": [
 				"Protection \u0026 Warning"
 			],
@@ -27847,24 +27867,44 @@
 				"prereqs": [
 					{
 						"type": "spell_prereq",
-						"sub_type": "name",
+						"sub_type": "college_count",
 						"has": true,
 						"qualifier": {
-							"compare": "is",
-							"qualifier": "hideaway"
+							"compare": "is"
 						},
 						"quantity": {
 							"compare": "at_least",
-							"qualifier": 1
+							"qualifier": 10
 						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "college_count",
+						"has": true,
+						"qualifier": {
+							"compare": "is"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 10
+						}
+					},
+					{
+						"type": "attribute_prereq",
+						"has": true,
+						"qualifier": {
+							"compare": "at_least",
+							"qualifier": 13
+						},
+						"which": "iq"
 					},
 					{
 						"type": "spell_prereq",
 						"sub_type": "name",
 						"has": true,
 						"qualifier": {
-							"compare": "is",
-							"qualifier": "teleport"
+							"compare": "contains",
+							"qualifier": "plane shift other"
 						},
 						"quantity": {
 							"compare": "at_least",
@@ -28107,13 +28147,13 @@
 			"type": "spell",
 			"name": "Schematic",
 			"reference": "M177",
+			"notes": "Cast at -5 on machines that emulate TL4 machinery, and at -10 to TL5-emulating machinery",
 			"tags": [
 				"Knowledge",
 				"Machine",
 				"Technological"
 			],
-			"tech_level": "",
-			"difficulty": "iq/vh",
+			"difficulty": "iq/h",
 			"college": [
 				"Knowledge",
 				"Technological"
@@ -28565,6 +28605,7 @@
 			"type": "spell",
 			"name": "See Secrets",
 			"reference": "M107",
+			"notes": "Spots inanimate objects made hard to see through physical craft. Make an uncontested Vision roll modified for distance, darkness and size.",
 			"tags": [
 				"Knowledge"
 			],
@@ -28736,11 +28777,11 @@
 			"type": "spell",
 			"name": "Seek Fuel",
 			"reference": "M179",
+			"notes": "Cast at -5 on machines that emulate TL4 machinery, and at -10 to TL5-emulating machinery",
 			"tags": [
 				"Energy",
 				"Technological"
 			],
-			"tech_level": "",
 			"difficulty": "iq/h",
 			"college": [
 				"Technological"
@@ -28844,11 +28885,11 @@
 			"type": "spell",
 			"name": "Seek Machine",
 			"reference": "M175",
+			"notes": "Cast at -5 on machines that emulate TL4 machinery, and at -10 to TL5-emulating machinery",
 			"tags": [
 				"Machine",
 				"Technological"
 			],
-			"tech_level": "",
 			"difficulty": "iq/h",
 			"college": [
 				"Technological"
@@ -28944,11 +28985,11 @@
 			"type": "spell",
 			"name": "Seek Power",
 			"reference": "M179",
+			"notes": "Cast at -5 on machines that emulate TL4 machinery, and at -10 to TL5-emulating machinery",
 			"tags": [
 				"Energy",
 				"Technological"
 			],
-			"tech_level": "",
 			"difficulty": "iq/h",
 			"college": [
 				"Technological"
@@ -31321,7 +31362,7 @@
 						},
 						"quantity": {
 							"compare": "at_least",
-							"qualifier": 1
+							"qualifier": 6
 						}
 					},
 					{
@@ -31527,18 +31568,6 @@
 				"all": false,
 				"prereqs": [
 					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "acute hearing"
-						},
-						"level": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
-					},
-					{
 						"type": "spell_prereq",
 						"sub_type": "name",
 						"has": true,
@@ -31740,7 +31769,7 @@
 				"Energy",
 				"Technological"
 			],
-			"difficulty": "iq/h",
+			"difficulty": "iq/vh",
 			"college": [
 				"Technological"
 			],
@@ -32825,6 +32854,7 @@
 			"type": "spell",
 			"name": "Steelwraith",
 			"reference": "M54",
+			"notes": "Everything but 6lbs of DR0 clothing fails to pass through Steel, and carried magical items' properties are suspended while in transit",
 			"tags": [
 				"Earth"
 			],
@@ -35165,6 +35195,9 @@
 						"type": "spell_prereq",
 						"sub_type": "college_count",
 						"has": true,
+						"qualifier": {
+							"compare": "is"
+						},
 						"quantity": {
 							"compare": "at_least",
 							"qualifier": 10
@@ -35172,16 +35205,21 @@
 					},
 					{
 						"type": "spell_prereq",
-						"sub_type": "name",
+						"sub_type": "college_count",
 						"has": true,
-						"qualifier": {
-							"compare": "is",
-							"qualifier": "teleport"
-						},
 						"quantity": {
 							"compare": "at_least",
-							"qualifier": 1
+							"qualifier": 10
 						}
+					},
+					{
+						"type": "attribute_prereq",
+						"has": true,
+						"qualifier": {
+							"compare": "at_least",
+							"qualifier": 13
+						},
+						"which": "iq"
 					},
 					{
 						"type": "spell_prereq",
@@ -35330,19 +35368,6 @@
 									"compare": "at_least",
 									"qualifier": 1
 								}
-							},
-							{
-								"type": "spell_prereq",
-								"sub_type": "name",
-								"has": true,
-								"qualifier": {
-									"compare": "is",
-									"qualifier": "teleport"
-								},
-								"quantity": {
-									"compare": "at_least",
-									"qualifier": 1
-								}
 							}
 						]
 					}
@@ -35472,11 +35497,11 @@
 			"type": "spell",
 			"name": "Test Fuel",
 			"reference": "M179",
+			"notes": "Cast at -5 on machines that emulate TL4 machinery, and at -10 to TL5-emulating machinery",
 			"tags": [
 				"Energy",
 				"Technological"
 			],
-			"tech_level": "",
 			"difficulty": "iq/h",
 			"college": [
 				"Technological"
@@ -35606,7 +35631,7 @@
 			"tags": [
 				"Meta"
 			],
-			"difficulty": "iq/h",
+			"difficulty": "iq/vh",
 			"college": [
 				"Meta"
 			],
@@ -35744,7 +35769,7 @@
 						"has": true,
 						"qualifier": {
 							"compare": "is",
-							"qualifier": "itch"
+							"qualifier": "spasm"
 						},
 						"quantity": {
 							"compare": "at_least",
@@ -35779,16 +35804,62 @@
 				"prereqs": [
 					{
 						"type": "spell_prereq",
-						"sub_type": "name",
+						"sub_type": "college_count",
 						"has": true,
 						"qualifier": {
-							"compare": "is",
-							"qualifier": "timeport"
+							"compare": "is"
 						},
 						"quantity": {
 							"compare": "at_least",
-							"qualifier": 1
+							"qualifier": 10
 						}
+					},
+					{
+						"type": "attribute_prereq",
+						"has": true,
+						"qualifier": {
+							"compare": "at_least",
+							"qualifier": 13
+						},
+						"which": "iq"
+					},
+					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (gate)"
+								}
+							}
+						]
 					}
 				]
 			}
@@ -35822,7 +35893,7 @@
 						"has": true,
 						"qualifier": {
 							"compare": "is",
-							"qualifier": "timeport"
+							"qualifier": "timeslip"
 						},
 						"quantity": {
 							"compare": "at_least",
@@ -36027,46 +36098,81 @@
 			"points": 1,
 			"prereqs": {
 				"type": "prereq_list",
-				"all": false,
+				"all": true,
 				"prereqs": [
 					{
 						"type": "spell_prereq",
-						"sub_type": "name",
+						"sub_type": "college_count",
 						"has": true,
 						"qualifier": {
-							"compare": "is",
-							"qualifier": "teleport"
+							"compare": "is"
 						},
 						"quantity": {
 							"compare": "at_least",
-							"qualifier": 1
+							"qualifier": 10
 						}
 					},
 					{
-						"type": "spell_prereq",
-						"sub_type": "name",
+						"type": "attribute_prereq",
 						"has": true,
 						"qualifier": {
-							"compare": "is",
-							"qualifier": "timeport"
-						},
-						"quantity": {
 							"compare": "at_least",
-							"qualifier": 1
-						}
+							"qualifier": 13
+						},
+						"which": "iq"
 					},
 					{
-						"type": "spell_prereq",
-						"sub_type": "name",
-						"has": true,
-						"qualifier": {
-							"compare": "is",
-							"qualifier": "plane shift"
-						},
-						"quantity": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (movement)"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 2
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (gate)"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least"
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							}
+						]
 					}
 				]
 			}
@@ -36079,7 +36185,7 @@
 			"tags": [
 				"Body Control"
 			],
-			"difficulty": "iq/h",
+			"difficulty": "iq/vh",
 			"college": [
 				"Body Control"
 			],
@@ -36095,6 +36201,44 @@
 				"all": true,
 				"prereqs": [
 					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "one college (body control)"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 3
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "one college"
+								}
+							}
+						]
+					},
+					{
 						"type": "spell_prereq",
 						"sub_type": "name",
 						"has": true,
@@ -36105,19 +36249,6 @@
 						"quantity": {
 							"compare": "at_least",
 							"qualifier": 1
-						}
-					},
-					{
-						"type": "spell_prereq",
-						"sub_type": "name",
-						"has": true,
-						"qualifier": {
-							"compare": "contains",
-							"qualifier": "shapeshift"
-						},
-						"quantity": {
-							"compare": "at_least",
-							"qualifier": 3
 						}
 					}
 				]
@@ -36221,7 +36352,7 @@
 			"tags": [
 				"Body Control"
 			],
-			"difficulty": "iq/h",
+			"difficulty": "iq/vh",
 			"college": [
 				"Body Control"
 			],
@@ -36243,19 +36374,6 @@
 						"qualifier": {
 							"compare": "is",
 							"qualifier": "transform body (@race@)"
-						},
-						"quantity": {
-							"compare": "at_least",
-							"qualifier": 1
-						}
-					},
-					{
-						"type": "spell_prereq",
-						"sub_type": "name",
-						"has": true,
-						"qualifier": {
-							"compare": "is",
-							"qualifier": "shapeshift others"
 						},
 						"quantity": {
 							"compare": "at_least",
@@ -36704,44 +36822,6 @@
 							"compare": "at_least",
 							"qualifier": 1
 						}
-					},
-					{
-						"type": "prereq_list",
-						"all": false,
-						"prereqs": [
-							{
-								"type": "trait_prereq",
-								"has": true,
-								"name": {
-									"compare": "is",
-									"qualifier": "magery"
-								},
-								"level": {
-									"compare": "at_least",
-									"qualifier": 2
-								},
-								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "one college"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": true,
-								"name": {
-									"compare": "is",
-									"qualifier": "magery"
-								},
-								"level": {
-									"compare": "at_least",
-									"qualifier": 2
-								},
-								"notes": {
-									"compare": "contains",
-									"qualifier": "one college (protection \u0026 warning)"
-								}
-							}
-						]
 					}
 				]
 			}
@@ -36866,7 +36946,7 @@
 						"has": true,
 						"qualifier": {
 							"compare": "is",
-							"qualifier": "lend vitality"
+							"qualifier": "might"
 						},
 						"quantity": {
 							"compare": "at_least",
@@ -37063,6 +37143,7 @@
 			"type": "spell",
 			"name": "Walk Through Earth",
 			"reference": "M52",
+			"notes": "Everything but 6lbs of DR0 clothing fails to pass through earth, and carried magical items' properties are suspended while in transit",
 			"tags": [
 				"Earth"
 			],
@@ -37863,7 +37944,7 @@
 			"tags": [
 				"Making \u0026 Breaking"
 			],
-			"difficulty": "iq/h",
+			"difficulty": "iq/vh",
 			"college": [
 				"Making \u0026 Breaking"
 			],
@@ -38215,7 +38296,7 @@
 								},
 								"level": {
 									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": 2
 								},
 								"notes": {
 									"compare": "does_not_contain",
@@ -38231,7 +38312,7 @@
 								},
 								"level": {
 									"compare": "at_least",
-									"qualifier": 1
+									"qualifier": 2
 								},
 								"notes": {
 									"compare": "contains",
@@ -38627,7 +38708,7 @@
 						"has": true,
 						"qualifier": {
 							"compare": "is",
-							"qualifier": "lend vitality"
+							"qualifier": "share energy"
 						},
 						"quantity": {
 							"compare": "at_least",


### PR DESCRIPTION
I noticed some prerequisites in the Wizardry Refined Spells Library were impossible, so I went through all the spells in the library and changed them to match.

There's a lot of changes, but they broadly fit into the following categories:
* Change prerequisites from their GURPS Magic version to their Wizardry Refined version.
* Change prerequisites where they seem to be incorrect (the same in GURPS Magic and Wizardry Refined).
* Drop Magery requirements that are removed in Wizardry Refined (for mysterious reasons; those might be a mistake in Wizardry Refined, but I did this for all of them except Steal Dexterity, Steal Might, Steal Vigor and Steal Wisdom, because I could see a way they accidentally overlooked those).
* Fix spell difficulty.
* Untick "Requires TL" from Technological spells and leave a note for how more complicated machines are affected (as per Sufficiently Advanced Technology, Pyramid 3-60 page 6).
* Left a note on Delay, Hang Spell, Link and Reflex that the number you can have "on" is limited by Magery (as per Contingency Plans)
* Removed some Enchantment spells that were in the spell library.

The full list of changes are:
* Alter Visage requires Perfect Illusion and 8 Body Control spells
* Animate Machine follows the "Sufficiently Advanced Technology" rule on magic
* Beacon only assists Plane Shift
* Cloud-Vaulting depends on Cloud-Walking instead of Walk on Air
* Conceal Magic depends only on Detect Magic (surprising, but that's what Pyramid 3-60 says)
* Conduct Power follows the "Sufficiently Advanced Technology" rule
* Create Fuel follows the "Sufficiently Advanced Technology" rule
* Decapitation is an IQ/VH spell (GURPS Magic is inconsistent on whether this should be H or VH)
* Delay follows the "Contingency Plans" rule
* All Divination spells also depend on History (this should also be true of GURPS Magic)
* Duplicate requires Create Object instead of Create Earth (this should also be true of GURPS Magic)
* Essential Fuel follows the "Sufficiently Advanced Technology" rule
* Fear loses the alternate prerequisite of Empathy
* Force Dome requires Magery 2 instead of Magery 1
* Fortify, an enchantment spell, was removed
* Gauntness is an IQ/VH spell (this should also be true of GURPS Magic)
* Geyser is IQ/VH and no longer depends on Create Spring
* Glitch follows the "Sufficiently Advanced Technology" rule
* Graceful Weapon, an enchantment spell, was removed
* Hang Spell follows the "Contingeny Plans" rule
* Hide Object is IQ 13+, Plane Shift Other and 2 spells from each of 10 colleges instead of Teleport and Hideaway
* Ice Slick depend on Create Water instead of Frost
* Icy Breath is an IQ/VH spell (this should also be true of GURPS Magic)
* Impression Blocker, an enchantment spell, was removed
* Know True Shape loses the possible prerequisite of Plant Form
* Lend Language loses the alternate prerequisite of Beast Speech
* Lend Power follows the "Sufficiently Advanced Technology" rule on magic
* Lengthen Limb requires Magery 2 and Alter Body instead of Magery 3 and Shapeshifting
* Lightning Stare is IQ/VH (GURPS Magic is inconsistent on this)
* Link follows the "Contingeny Plans" rule
* Machine Control requires Dancing Object and Manipulate instead of Locksmith and Lightning, and follows the "Sufficiently Advanced Technology" rule on magic
* Machine Possession doesn't optionally depend on Rider Within and follows the "Sufficiently Advanced Technology" rule on magic
* Machine Summoning follows the "Sufficiently Advanced Technology" rule on magic
* Malfunction follows the "Sufficiently Advanced Technology" rule on magic
* Move Terrain is IQ/VH (this should also be true of GURPS Magic)
* Mud Jet may also be satisfied with Water Jet and Create Earth
* Partial Petrification is IQ/VH (this should also be true of GURPS Magic; also, GURPS Magic calls it Partial Petrifaction in the actual spell name, but Petrification in Suspend Curse and Remove Curse)
* Plane Shift requires Magery 2
* Possession no longer optionally depends on beast possession
* Preserve Fuel follows the "Sufficiently Advanced Technology" rule on magic
* Purify Earth requires 6 Earth spells instead of Plant Growth
* Purify Fuel follows the "Sufficiently Advanced Technology" rule on magic
* Rain of Ice Daggers requires 6 Air spells instead of Hail
* Rebuild follows the "Sufficiently Advanced Technology" rule on magic
* Recover Energy does not depend on Magery 1 (I don't know why it was dropped, but that's what it says)
* Reflex follows the "Contingeny Plans" rule
* Remove Curse may depend on Suspend Curse instead of 15 spells from different colleges (GURPS Magic is inconsistent on this)
* Reshape no longer optionally depends on Shape Plant
* Resist Pressure depends on Atmosphere Dome instead of Weather Dome
* Resist Water depends on Umbrella, or Shape Water and Destroy Water; instead of Destroy Water, and Shape Water or Umbrella (this should also be true of GURPS Magic)
* Retrogression depends on mind-search instead of mind-reading (this should also be true of GURPS Magic
* Reveal Function follows the "Sufficiently Advanced Technology" rule on magic
* Reverse Missiles deflects instead of reflects missiles that do more than 1d per level of magery
* Sanctuary depends on IQ 13+, Plane Shift Other, and spells from 10 different colleges
* Schematic is IQ/H instead of VH (it's inconsistent in GURPS Magic), and follows the "Sufficiently Advanced Technology" rule on magic
* See Secrets explains how hidden objects are seen
* Seek Fuel follows the "Sufficiently Advanced Technology" rule on magic
* Seek Machine follows the "Sufficiently Advanced Technology" rule on magic
* Seek Power follows the "Sufficiently Advanced Technology" rule on magic
* Soul Jar requires 6 Necromancy spells instead of 1 necromancy spell (this should also be true for GURPS Magic).
* Sound Vision cannot be satisfied with the Acute Hearing trait.
* Spectrum Vision is IQ/VH not H (this should also be true of GURPS Magic).
* Spit Acid is IQ/VH (this should also be true of GURPS Magic).
* Steelwraith limits the equipment you can carry through metal barriers.
* Telecast requires IQ 13+ and 2 spells from 10 colleges instead of Teleport
* Teleport Shield no longer optionally depends on Teleport
* Test Fuel follows the "Sufficiently Advanced Technology" rule on magic
* Throw Spell is IQ/VH not H (GURPS Magic is inconsistent on this)
* Tickle depends on Spasm instead of Itch (this should also be true of GURPS Magic)
* Timeslip depends on Magery 3, IQ 13+ and 1 spell from 10 colleges, instead of Timeport.
* Timeslip Other depends on Timeslip instead of Timeport (this should also be true of GURPS Magic)
* Trace Teleport depends on Magery 2, IQ 13+ and 1 spell from 10 colleges, instead of Teleport, Timeport or Plane Shift
* Transform Body requires Magery 3 instead of 3 shapeshifting spells and is now IQ/VH.
* Transform Other no longer requires Shapeshift Others and is IQ/VH.
* Utter Dome no longer requires on Magery 2 (I don't know why it was dropped)
* Vigor depends on Might instead of Lend Vitality
* Walk Through Earth limits the equipment you can carry through earthen barriers.
* Weapon Self is an IQ/VH spell (this should also be true of GURPS Magic)
* Wither Limb requires Magery 2 (this should also be true of GURPS Magic)
* Zombie requires Share Energy instead of Lend Vitality
