### PR TITLE
Add Reskinned from Dungeon Fantasy RPG Monsters 2

### DIFF
--- a/Library/Dungeon Fantasy RPG/Monsters/Greater Reskinned.gcs
+++ b/Library/Dungeon Fantasy RPG/Monsters/Greater Reskinned.gcs
@@ -1,0 +1,1955 @@
+{
+	"type": "character",
+	"version": 4,
+	"id": "810c3e9b-1c95-4e20-8852-72a41fea16c3",
+	"total_points": 635,
+	"points_record": [
+		{
+			"when": "2022-11-19T12:04:01-08:00",
+			"points": 635,
+			"reason": "Reconciliation"
+		}
+	],
+	"profile": {
+		"name": "Greater Reskinned"
+	},
+	"settings": {
+		"page": {
+			"paper_size": "letter",
+			"orientation": "portrait",
+			"top_margin": "0.25 in",
+			"left_margin": "0.25 in",
+			"bottom_margin": "0.25 in",
+			"right_margin": "0.25 in"
+		},
+		"block_layout": [
+			"reactions conditional_modifiers",
+			"melee",
+			"ranged",
+			"traits skills",
+			"spells",
+			"equipment",
+			"other_equipment",
+			"notes"
+		],
+		"attributes": [
+			{
+				"id": "st",
+				"type": "integer",
+				"name": "ST",
+				"full_name": "Strength",
+				"attribute_base": "10",
+				"cost_per_point": 10,
+				"cost_adj_percent_per_sm": 10
+			},
+			{
+				"id": "dx",
+				"type": "integer",
+				"name": "DX",
+				"full_name": "Dexterity",
+				"attribute_base": "10",
+				"cost_per_point": 20
+			},
+			{
+				"id": "iq",
+				"type": "integer",
+				"name": "IQ",
+				"full_name": "Intelligence",
+				"attribute_base": "10",
+				"cost_per_point": 20
+			},
+			{
+				"id": "ht",
+				"type": "integer",
+				"name": "HT",
+				"full_name": "Health",
+				"attribute_base": "10",
+				"cost_per_point": 10
+			},
+			{
+				"id": "will",
+				"type": "integer",
+				"name": "Will",
+				"attribute_base": "$iq",
+				"cost_per_point": 5
+			},
+			{
+				"id": "fright_check",
+				"type": "integer",
+				"name": "Fright Check",
+				"attribute_base": "$will",
+				"cost_per_point": 2
+			},
+			{
+				"id": "per",
+				"type": "integer",
+				"name": "Per",
+				"full_name": "Perception",
+				"attribute_base": "$iq",
+				"cost_per_point": 5
+			},
+			{
+				"id": "vision",
+				"type": "integer",
+				"name": "Vision",
+				"attribute_base": "$per",
+				"cost_per_point": 2
+			},
+			{
+				"id": "hearing",
+				"type": "integer",
+				"name": "Hearing",
+				"attribute_base": "$per",
+				"cost_per_point": 2
+			},
+			{
+				"id": "taste_smell",
+				"type": "integer",
+				"name": "Taste \u0026 Smell",
+				"attribute_base": "$per",
+				"cost_per_point": 2
+			},
+			{
+				"id": "touch",
+				"type": "integer",
+				"name": "Touch",
+				"attribute_base": "$per",
+				"cost_per_point": 2
+			},
+			{
+				"id": "basic_speed",
+				"type": "decimal",
+				"name": "Basic Speed",
+				"attribute_base": "($dx+$ht)/4",
+				"cost_per_point": 20
+			},
+			{
+				"id": "basic_move",
+				"type": "integer",
+				"name": "Basic Move",
+				"attribute_base": "floor($basic_speed)",
+				"cost_per_point": 5
+			},
+			{
+				"id": "hp",
+				"type": "pool",
+				"name": "HP",
+				"full_name": "Hit Points",
+				"attribute_base": "$st",
+				"cost_per_point": 2,
+				"cost_adj_percent_per_sm": 10,
+				"thresholds": [
+					{
+						"state": "Dead",
+						"expression": "round(-$hp*5)",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Dying #4",
+						"expression": "round(-$hp*4)",
+						"explanation": "\u003chtml\u003e\u003cbody\u003e\n\u003cb\u003eRoll vs. HT\u003c/b\u003e to avoid death\u003cbr\u003e\n\u003cb\u003eRoll vs. HT-4\u003c/b\u003e every second to avoid falling unconscious\u003cbr\u003e\nMove and Dodge are halved (B419)\n\u003c/body\u003e\u003c/html\u003e",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Dying #3",
+						"expression": "round(-$hp*3)",
+						"explanation": "\u003chtml\u003e\u003cbody\u003e\n\u003cb\u003eRoll vs. HT\u003c/b\u003e to avoid death\u003cbr\u003e\n\u003cb\u003eRoll vs. HT-3\u003c/b\u003e every second to avoid falling unconscious\u003cbr\u003e\nMove and Dodge are halved (B419)\n\u003c/body\u003e\u003c/html\u003e",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Dying #2",
+						"expression": "round(-$hp*2)",
+						"explanation": "\u003chtml\u003e\u003cbody\u003e\n\u003cb\u003eRoll vs. HT\u003c/b\u003e to avoid death\u003cbr\u003e\n\u003cb\u003eRoll vs. HT-2\u003c/b\u003e every second to avoid falling unconscious\u003cbr\u003e\nMove and Dodge are halved (B419)\n\u003c/body\u003e\u003c/html\u003e",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Dying #1",
+						"expression": "-$hp",
+						"explanation": "\u003chtml\u003e\u003cbody\u003e\n\u003cb\u003eRoll vs. HT\u003c/b\u003e to avoid death\u003cbr\u003e\n\u003cb\u003eRoll vs. HT-1\u003c/b\u003e every second to avoid falling unconscious\u003cbr\u003e\nMove and Dodge are halved (B419)\n\u003c/body\u003e\u003c/html\u003e",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Collapse",
+						"expression": "0",
+						"explanation": "\u003chtml\u003e\u003cbody\u003e\n\u003cb\u003eRoll vs. HT\u003c/b\u003e every second to avoid falling unconscious\u003cbr\u003e\nMove and Dodge are halved (B419)\n\u003c/body\u003e\u003c/html\u003e",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Reeling",
+						"expression": "round($hp/3)",
+						"explanation": "Move and Dodge are halved (B419)",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Wounded",
+						"expression": "$hp-1"
+					},
+					{
+						"state": "Healthy",
+						"expression": "$hp"
+					}
+				]
+			},
+			{
+				"id": "er",
+				"type": "pool",
+				"name": "ER",
+				"full_name": "Energy Reserve",
+				"attribute_base": "0",
+				"thresholds": [
+					{
+						"state": "Empty",
+						"expression": "0"
+					},
+					{
+						"state": "Used",
+						"expression": "1"
+					},
+					{
+						"state": "Full",
+						"expression": "$er"
+					}
+				]
+			}
+		],
+		"body_type": {
+			"name": "Humanoid",
+			"roll": "3d",
+			"locations": [
+				{
+					"id": "eye",
+					"choice_name": "Eyes",
+					"table_name": "Eyes",
+					"hit_penalty": -9,
+					"description": "An attack that misses by 1 hits the torso instead. Only\nimpaling (imp), piercing (pi-, pi, pi+, pi++), and\ntight-beam burning (burn) attacks can target the eye – and\nonly from the front or sides. Injury over HP÷10 blinds the\neye. Otherwise, treat as skull, but without the extra DR!",
+					"calc": {
+						"roll_range": "-",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "skull",
+					"choice_name": "Skull",
+					"table_name": "Skull",
+					"slots": 2,
+					"hit_penalty": -7,
+					"dr_bonus": 2,
+					"description": "An attack that misses by 1 hits the torso instead. Wounding\nmodifier is x4. Knockdown rolls are at -10. Critical hits\nuse the Critical Head Blow Table (B556). Exception: These\nspecial effects do not apply to toxic (tox) damage.",
+					"calc": {
+						"roll_range": "3-4",
+						"dr": {
+							"all": 6
+						}
+					}
+				},
+				{
+					"id": "face",
+					"choice_name": "Face",
+					"table_name": "Face",
+					"slots": 1,
+					"hit_penalty": -5,
+					"description": "An attack that misses by 1 hits the torso instead. Jaw,\ncheeks, nose, ears, etc. If the target has an open-faced\nhelmet, ignore its DR. Knockdown rolls are at -5. Critical\nhits use the Critical Head Blow Table (B556). Corrosion\n(cor) damage gets a x1½ wounding modifier, and if it\ninflicts a major wound, it also blinds one eye (both eyes on\ndamage over full HP). Random attacks from behind hit the\nskull instead.",
+					"calc": {
+						"roll_range": "5",
+						"dr": {
+							"all": 4
+						}
+					}
+				},
+				{
+					"id": "leg",
+					"choice_name": "Leg",
+					"table_name": "Right Leg",
+					"slots": 2,
+					"hit_penalty": -2,
+					"description": "Reduce the wounding multiplier of large piercing (pi+), huge\npiercing (pi++), and impaling (imp) damage to x1. Any major\nwound (loss of over ½ HP from one blow) cripples the limb.\nDamage beyond that threshold is lost.",
+					"calc": {
+						"roll_range": "6-7",
+						"dr": {
+							"all": 4
+						}
+					}
+				},
+				{
+					"id": "arm",
+					"choice_name": "Arm",
+					"table_name": "Right Arm",
+					"slots": 1,
+					"hit_penalty": -2,
+					"description": "Reduce the wounding multiplier of large piercing (pi+), huge\npiercing (pi++), and impaling (imp) damage to x1. Any major\nwound (loss of over ½ HP from one blow) cripples the limb.\nDamage beyond that threshold is lost. If holding a shield,\ndouble the penalty to hit: -4 for shield arm instead of -2.",
+					"calc": {
+						"roll_range": "8",
+						"dr": {
+							"all": 4
+						}
+					}
+				},
+				{
+					"id": "torso",
+					"choice_name": "Torso",
+					"table_name": "Torso",
+					"slots": 2,
+					"calc": {
+						"roll_range": "9-10",
+						"dr": {
+							"all": 4
+						}
+					}
+				},
+				{
+					"id": "groin",
+					"choice_name": "Groin",
+					"table_name": "Groin",
+					"slots": 1,
+					"hit_penalty": -3,
+					"description": "An attack that misses by 1 hits the torso instead. Human\nmales and the males of similar species suffer double shock\nfrom crushing (cr) damage, and get -5 to knockdown rolls.\nOtherwise, treat as a torso hit.",
+					"calc": {
+						"roll_range": "11",
+						"dr": {
+							"all": 4
+						}
+					}
+				},
+				{
+					"id": "arm",
+					"choice_name": "Arm",
+					"table_name": "Left Arm",
+					"slots": 1,
+					"hit_penalty": -2,
+					"description": "Reduce the wounding multiplier of large piercing (pi+), huge\npiercing (pi++), and impaling (imp) damage to x1. Any major\nwound (loss of over ½ HP from one blow) cripples the limb.\nDamage beyond that threshold is lost. If holding a shield,\ndouble the penalty to hit: -4 for shield arm instead of -2.",
+					"calc": {
+						"roll_range": "12",
+						"dr": {
+							"all": 4
+						}
+					}
+				},
+				{
+					"id": "leg",
+					"choice_name": "Leg",
+					"table_name": "Left Leg",
+					"slots": 2,
+					"hit_penalty": -2,
+					"description": "Reduce the wounding multiplier of large piercing (pi+), huge\npiercing (pi++), and impaling (imp) damage to x1. Any major\nwound (loss of over ½ HP from one blow) cripples the limb.\nDamage beyond that threshold is lost.",
+					"calc": {
+						"roll_range": "13-14",
+						"dr": {
+							"all": 4
+						}
+					}
+				},
+				{
+					"id": "hand",
+					"choice_name": "Hand",
+					"table_name": "Hand",
+					"slots": 1,
+					"hit_penalty": -4,
+					"description": "If holding a shield, double the penalty to hit: -8 for\nshield hand instead of -4. Reduce the wounding multiplier of\nlarge piercing (pi+), huge piercing (pi++), and impaling\n(imp) damage to x1. Any major wound (loss of over ⅓ HP\nfrom one blow) cripples the extremity. Damage beyond that\nthreshold is lost.",
+					"calc": {
+						"roll_range": "15",
+						"dr": {
+							"all": 4
+						}
+					}
+				},
+				{
+					"id": "foot",
+					"choice_name": "Foot",
+					"table_name": "Foot",
+					"slots": 1,
+					"hit_penalty": -4,
+					"description": "Reduce the wounding multiplier of large piercing (pi+), huge\npiercing (pi++), and impaling (imp) damage to x1. Any major\nwound (loss of over ⅓ HP from one blow) cripples the\nextremity. Damage beyond that threshold is lost.",
+					"calc": {
+						"roll_range": "16",
+						"dr": {
+							"all": 4
+						}
+					}
+				},
+				{
+					"id": "neck",
+					"choice_name": "Neck",
+					"table_name": "Neck",
+					"slots": 2,
+					"hit_penalty": -5,
+					"description": "An attack that misses by 1 hits the torso instead. Neck and\nthroat. Increase the wounding multiplier of crushing (cr)\nand corrosion (cor) attacks to x1½, and that of cutting\n(cut) damage to x2. At the GM’s option, anyone killed by a\ncutting (cut) blow to the neck is decapitated!",
+					"calc": {
+						"roll_range": "17-18",
+						"dr": {
+							"all": 4
+						}
+					}
+				},
+				{
+					"id": "vitals",
+					"choice_name": "Vitals",
+					"table_name": "Vitals",
+					"hit_penalty": -3,
+					"description": "An attack that misses by 1 hits the torso instead. Heart,\nlungs, kidneys, etc. Increase the wounding modifier for an\nimpaling (imp) or any piercing (pi-, pi, pi+, pi++) attack\nto x3. Increase the wounding modifier for a tight-beam\nburning (burn) attack to x2. Other attacks cannot target the\nvitals.",
+					"calc": {
+						"roll_range": "-",
+						"dr": {
+							"all": 4
+						}
+					}
+				}
+			]
+		},
+		"damage_progression": "basic_set",
+		"default_length_units": "ft_in",
+		"default_weight_units": "lb",
+		"user_description_display": "tooltip",
+		"modifiers_display": "inline",
+		"notes_display": "inline",
+		"skill_level_adj_display": "tooltip",
+		"show_trait_modifier_adj": true,
+		"show_equipment_modifier_adj": true,
+		"show_spell_adj": true,
+		"exclude_unspent_points_from_total": false
+	},
+	"attributes": [
+		{
+			"attr_id": "st",
+			"adj": 4,
+			"calc": {
+				"value": 14,
+				"points": 40
+			}
+		},
+		{
+			"attr_id": "dx",
+			"adj": 2,
+			"calc": {
+				"value": 12,
+				"points": 40
+			}
+		},
+		{
+			"attr_id": "iq",
+			"adj": 6,
+			"calc": {
+				"value": 16,
+				"points": 120
+			}
+		},
+		{
+			"attr_id": "ht",
+			"adj": 4,
+			"calc": {
+				"value": 14,
+				"points": 40
+			}
+		},
+		{
+			"attr_id": "will",
+			"adj": 2,
+			"calc": {
+				"value": 18,
+				"points": 10
+			}
+		},
+		{
+			"attr_id": "fright_check",
+			"adj": 0,
+			"calc": {
+				"value": 18,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "per",
+			"adj": 0,
+			"calc": {
+				"value": 16,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "vision",
+			"adj": 0,
+			"calc": {
+				"value": 16,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "hearing",
+			"adj": 0,
+			"calc": {
+				"value": 16,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "taste_smell",
+			"adj": 0,
+			"calc": {
+				"value": 16,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "touch",
+			"adj": 0,
+			"calc": {
+				"value": 16,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "basic_speed",
+			"adj": 0,
+			"calc": {
+				"value": 6.5,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "basic_move",
+			"adj": 0,
+			"calc": {
+				"value": 6,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "hp",
+			"adj": 4,
+			"calc": {
+				"value": 18,
+				"current": 18,
+				"points": 8
+			}
+		},
+		{
+			"attr_id": "er",
+			"adj": 0,
+			"calc": {
+				"value": 30,
+				"current": 30,
+				"points": 0
+			}
+		}
+	],
+	"traits": [
+		{
+			"id": "0f0d8e4c-3c8c-420c-bf00-b46340d1b37e",
+			"type": "trait",
+			"name": "Appearance",
+			"reference": "DFA47",
+			"tags": [
+				"Advantage",
+				"Physical"
+			],
+			"modifiers": [
+				{
+					"id": "96f5b8ba-8036-429f-b39f-e283b9fd6d71",
+					"type": "modifier",
+					"name": "Androgynous",
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "a96b39cf-83b3-40cb-a450-b2d70f3edd85",
+					"type": "modifier",
+					"name": "Impressive",
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "b4ccdefa-2144-4165-a330-f3fcd057d482",
+					"type": "modifier",
+					"name": "Attractive",
+					"cost": 4,
+					"cost_type": "points"
+				},
+				{
+					"id": "6333b8c8-bd65-4f85-898a-9abd4c8e1b95",
+					"type": "modifier",
+					"name": "Average",
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "b15aae19-f168-4821-9d35-eefbbd90d070",
+					"type": "modifier",
+					"name": "Horrific",
+					"cost": -24,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "49e69b1f-a6a5-4dfb-9c0e-5467039c6571",
+					"type": "modifier",
+					"name": "Monstrous",
+					"cost": -20,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "f995185e-9b68-4ae7-b50b-f7ff5645eeac",
+					"type": "modifier",
+					"name": "Hideous",
+					"cost": -16,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "37824a5b-f827-4318-8a86-d046a10a0937",
+					"type": "modifier",
+					"name": "Ugly",
+					"cost": -8,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "8c61decb-1ab2-4bd8-a8b6-c5b8c6a0347c",
+					"type": "modifier",
+					"name": "Unattractive",
+					"cost": -4,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "04b29ce4-cd7b-4346-8fde-413bae3c4049",
+					"type": "modifier",
+					"name": "Handsome",
+					"cost": 12,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "136b0d72-449e-416b-9867-a020e77029d7",
+					"type": "modifier",
+					"name": "Beautiful",
+					"cost": 12,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "6e6176e6-cfff-47b7-ba5c-339ec723d9d8",
+					"type": "modifier",
+					"name": "Very Handsome",
+					"cost": 16,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "6bbed62f-a5df-4068-b8b9-de209f698975",
+					"type": "modifier",
+					"name": "Very Beautiful",
+					"cost": 16,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "032cf4e0-1ffe-4318-a782-aae212daa02f",
+					"type": "modifier",
+					"name": "Transcendent",
+					"cost": 20,
+					"cost_type": "points",
+					"disabled": true
+				}
+			],
+			"calc": {
+				"points": 4
+			}
+		},
+		{
+			"id": "615e60e8-c372-4ed1-be8d-25d29a595cc2",
+			"type": "trait",
+			"name": "Bad Smell",
+			"reference": "DFM13",
+			"tags": [
+				"Disadvantage",
+				"Physical"
+			],
+			"base_points": -10,
+			"features": [
+				{
+					"type": "reaction_bonus",
+					"situation": "from those able to smell",
+					"amount": -2
+				},
+				{
+					"type": "conditional_modifier",
+					"situation": "on attempts to hide",
+					"amount": -2
+				}
+			],
+			"calc": {
+				"points": -10
+			}
+		},
+		{
+			"id": "37cc5a5f-5a10-4c44-ba87-d87c50487dbb",
+			"type": "trait",
+			"name": "Cannot Float",
+			"reference": "DFM13",
+			"tags": [
+				"Physical",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "8f00aa64-675e-4ae1-b451-189d2079cf27",
+			"type": "trait",
+			"name": "Damage Resistance",
+			"reference": "DFM10",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Physical"
+			],
+			"levels": 4,
+			"points_per_level": 5,
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "skull",
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "dr_bonus",
+					"location": "face",
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "dr_bonus",
+					"location": "neck",
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "dr_bonus",
+					"location": "torso",
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "dr_bonus",
+					"location": "vitals",
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "dr_bonus",
+					"location": "groin",
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "dr_bonus",
+					"location": "arm",
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "dr_bonus",
+					"location": "hand",
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "dr_bonus",
+					"location": "leg",
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "dr_bonus",
+					"location": "foot",
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "dr_bonus",
+					"location": "tail",
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "dr_bonus",
+					"location": "wing",
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "dr_bonus",
+					"location": "fin",
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "dr_bonus",
+					"location": "brain",
+					"amount": 1,
+					"per_level": true
+				}
+			],
+			"can_level": true,
+			"calc": {
+				"points": 20
+			}
+		},
+		{
+			"id": "50ce1997-7f26-4881-bf5f-664800170bdb",
+			"type": "trait",
+			"name": "Dark Vision",
+			"reference": "DFM10",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Physical"
+			],
+			"base_points": 25,
+			"calc": {
+				"points": 25
+			}
+		},
+		{
+			"id": "c14a4434-4fa8-4288-a133-766f90b2758e",
+			"type": "trait",
+			"name": "Dependency (Mana)",
+			"reference": "DFM13",
+			"tags": [
+				"Disadvantage",
+				"Exotic",
+				"Physical"
+			],
+			"modifiers": [
+				{
+					"id": "dc82c6ef-fa25-4001-b050-b8a4b4b88236",
+					"type": "modifier",
+					"name": "Rarity: Rare",
+					"reference": "B130",
+					"cost": -30,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "1a34de92-6150-4f2d-9cd3-7789bf881c4f",
+					"type": "modifier",
+					"name": "Rarity: Occasional",
+					"reference": "B130",
+					"cost": -20,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "215652e4-c7b5-4adc-96e7-3adc4d433eaa",
+					"type": "modifier",
+					"name": "Rarity: Common",
+					"reference": "B130",
+					"cost": -10,
+					"cost_type": "points"
+				},
+				{
+					"id": "12c754ad-660f-4409-a72e-01c96f68d6c8",
+					"type": "modifier",
+					"name": "Rarity: Very Common",
+					"reference": "B130",
+					"cost": -5,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "f65a779a-8812-4546-8113-a62f60ef07d8",
+					"type": "modifier",
+					"name": "Illegal",
+					"reference": "B130",
+					"cost": -5,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "830caef2-36fe-42f3-85e4-2abeddeefe5e",
+					"type": "modifier",
+					"name": "Frequency: Constantly",
+					"reference": "B130",
+					"notes": "Lose 1 HP per minute without it",
+					"cost": 5,
+					"cost_type": "multiplier"
+				},
+				{
+					"id": "ffb500a1-c6af-402b-9f83-63cbecbd9586",
+					"type": "modifier",
+					"name": "Frequency: Hourly",
+					"reference": "B130",
+					"notes": "Lose 1 HP per 10 minutes after missing a hourly dose",
+					"cost": 4,
+					"cost_type": "multiplier",
+					"disabled": true
+				},
+				{
+					"id": "c161ee52-5ba8-4148-9512-0690f6e2cbc5",
+					"type": "modifier",
+					"name": "Frequency: Daily",
+					"reference": "B130",
+					"notes": "Lose 1 HP per hour after missing a daily dose",
+					"cost": 3,
+					"cost_type": "multiplier",
+					"disabled": true
+				},
+				{
+					"id": "b2c4dd0a-4ce5-4b7e-8981-1cdb0eae2847",
+					"type": "modifier",
+					"name": "Frequency: Weekly",
+					"reference": "B130",
+					"notes": "Lose 1 HP per six hours after missing a weekly dose",
+					"cost": 2,
+					"cost_type": "multiplier",
+					"disabled": true
+				},
+				{
+					"id": "4c3d7562-34f9-4140-b1f8-9a683ddaa503",
+					"type": "modifier",
+					"name": "Frequency: Monthly",
+					"reference": "B130",
+					"notes": "Lose 1 HP per day after missing a monthly dose",
+					"cost": 1,
+					"cost_type": "multiplier",
+					"disabled": true
+				},
+				{
+					"id": "81763901-2040-40ce-8351-ff6bc15e814d",
+					"type": "modifier",
+					"name": "Frequency: Seasonally",
+					"reference": "B130",
+					"notes": "Lose 1 HP per 3 days after missing a seasonal dose",
+					"cost": 0.3333,
+					"cost_type": "multiplier",
+					"disabled": true
+				},
+				{
+					"id": "5f950e2d-36cc-4f91-8ca3-eb087812c776",
+					"type": "modifier",
+					"name": "Frequency: Yearly",
+					"reference": "B130",
+					"notes": "Lose 1 HP per 2 weeks after missing a yearly dose",
+					"cost": 0.1,
+					"cost_type": "multiplier",
+					"disabled": true
+				},
+				{
+					"id": "cb8a8677-863b-4560-8249-b8fadca79b26",
+					"type": "modifier",
+					"name": "Aging",
+					"reference": "B130",
+					"notes": "Age 2 years for each HP lost due to this dependency",
+					"cost": 30,
+					"disabled": true
+				}
+			],
+			"calc": {
+				"points": -50
+			}
+		},
+		{
+			"id": "15e62a44-4a93-4356-95d3-384e46e7b832",
+			"type": "trait",
+			"name": "Doesn't Breathe",
+			"reference": "DFM10",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Physical"
+			],
+			"base_points": 20,
+			"calc": {
+				"points": 20
+			}
+		},
+		{
+			"id": "bcc7dafd-538b-496b-a46b-37502e7c022b",
+			"type": "trait",
+			"name": "Doesn't Eat or Drink",
+			"reference": "DFM10",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Physical"
+			],
+			"base_points": 10,
+			"calc": {
+				"points": 10
+			}
+		},
+		{
+			"id": "7ebfec0c-7e3d-44cc-bb1c-2bae8acf83ef",
+			"type": "trait",
+			"name": "Doesn't Sleep",
+			"reference": "DFM10",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Physical"
+			],
+			"base_points": 20,
+			"calc": {
+				"points": 20
+			}
+		},
+		{
+			"id": "e0edafb8-5aa6-4103-bc52-a1a777d019b6",
+			"type": "trait",
+			"name": "Energy Reserve (Magical)",
+			"reference": "DFA48",
+			"tags": [
+				"Advantage",
+				"Attribute",
+				"Exotic",
+				"Physical"
+			],
+			"levels": 30,
+			"points_per_level": 3,
+			"features": [
+				{
+					"type": "attribute_bonus",
+					"attribute": "er",
+					"amount": 1,
+					"per_level": true
+				}
+			],
+			"can_level": true,
+			"calc": {
+				"points": 90
+			}
+		},
+		{
+			"id": "a861aa3d-e856-41b6-9eea-8f173d5e96a0",
+			"type": "trait",
+			"name": "High Pain Threshold",
+			"reference": "DFA50",
+			"notes": "Never suffer shock penalties when injured",
+			"tags": [
+				"Advantage",
+				"Physical"
+			],
+			"base_points": 10,
+			"features": [
+				{
+					"type": "conditional_modifier",
+					"situation": "on all HT rolls to avoid knockdown and stunning",
+					"amount": 3
+				},
+				{
+					"type": "conditional_modifier",
+					"situation": "to resist torture",
+					"amount": 3
+				}
+			],
+			"calc": {
+				"points": 10
+			}
+		},
+		{
+			"id": "bf155a9c-f115-4d86-be6f-a0f2dc1c2870",
+			"type": "trait",
+			"name": "Immunity",
+			"reference": "DFM11",
+			"tags": [
+				"Advantage",
+				"Physical"
+			],
+			"modifiers": [
+				{
+					"id": "7e0f2973-1440-460d-8bc2-541230b2c381",
+					"type": "modifier",
+					"name": "@Very Common: Metabolic Hazards, etc.@",
+					"reference": "B80",
+					"cost": 30,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "a859ff93-82d7-4e44-bf61-2092c7972298",
+					"type": "modifier",
+					"name": "@Common: Poison, Sickness, etc.@",
+					"reference": "B81",
+					"cost": 15,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "d69c599f-b05d-43eb-9b22-18340520adba",
+					"type": "modifier",
+					"name": "Disease",
+					"reference": "B81",
+					"cost": 10,
+					"cost_type": "points"
+				},
+				{
+					"id": "5a1f4275-99b7-4be3-9772-620ebaa6e6bb",
+					"type": "modifier",
+					"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+					"reference": "B81",
+					"cost": 5,
+					"cost_type": "points",
+					"disabled": true
+				}
+			],
+			"calc": {
+				"points": 10
+			}
+		},
+		{
+			"id": "92318800-9d67-4100-8c40-439fbb4e336c",
+			"type": "trait",
+			"name": "Immunity",
+			"reference": "DFM11",
+			"tags": [
+				"Advantage",
+				"Physical"
+			],
+			"modifiers": [
+				{
+					"id": "bd332a85-5587-43e4-804a-8ae2bf221e41",
+					"type": "modifier",
+					"name": "@Very Common: Metabolic Hazards, etc.@",
+					"reference": "B80",
+					"cost": 30,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "aef7bd24-f5c0-48d5-96d1-1f79d7bde703",
+					"type": "modifier",
+					"name": "Poison",
+					"reference": "B81",
+					"cost": 15,
+					"cost_type": "points"
+				},
+				{
+					"id": "8a4e808f-8943-44ad-a06d-fb8d31f28d73",
+					"type": "modifier",
+					"name": "@Occasional: Disease, Ingested Poison, etc.@",
+					"reference": "B81",
+					"cost": 10,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "c829cecb-3af1-4a4d-8ea9-17a38b675d32",
+					"type": "modifier",
+					"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+					"reference": "B81",
+					"cost": 5,
+					"cost_type": "points",
+					"disabled": true
+				}
+			],
+			"calc": {
+				"points": 15
+			}
+		},
+		{
+			"id": "46530f95-2b8d-46cb-9df3-356db9f4154b",
+			"type": "trait",
+			"name": "Magery",
+			"reference": "DFA41",
+			"tags": [
+				"Advantage",
+				"Mental",
+				"Supernatural"
+			],
+			"base_points": 5,
+			"levels": 6,
+			"points_per_level": 10,
+			"features": [
+				{
+					"type": "spell_bonus",
+					"match": "power_source_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Arcane"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "thaumatology"
+					},
+					"amount": 1,
+					"per_level": true
+				}
+			],
+			"can_level": true,
+			"calc": {
+				"points": 65
+			}
+		},
+		{
+			"id": "70d1c995-5fb1-4709-8202-56a27d296741",
+			"type": "trait",
+			"name": "No Blood",
+			"reference": "DFM11",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Physical"
+			],
+			"base_points": 5,
+			"calc": {
+				"points": 5
+			}
+		},
+		{
+			"id": "66792d94-5735-4d1b-83e5-2be468bd7435",
+			"type": "trait",
+			"name": "No Brain",
+			"reference": "DFM11",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Physical"
+			],
+			"base_points": 5,
+			"calc": {
+				"points": 5
+			}
+		},
+		{
+			"id": "d5fece42-8e5c-4548-a4ba-a24fc42a2fd5",
+			"type": "trait",
+			"name": "No Eyes",
+			"reference": "DFM11",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Physical"
+			],
+			"base_points": 5,
+			"calc": {
+				"points": 5
+			}
+		},
+		{
+			"id": "831436db-8161-4c72-b73d-b6f357ba12c8",
+			"type": "trait",
+			"name": "No Sense of Smell/Taste",
+			"reference": "DFM13",
+			"tags": [
+				"Disadvantage",
+				"Physical"
+			],
+			"base_points": -5,
+			"calc": {
+				"points": -5
+			}
+		},
+		{
+			"id": "fd927280-2c08-4b94-a85b-b140e0721d13",
+			"type": "trait",
+			"name": "No Vitals",
+			"reference": "DFM11",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Physical"
+			],
+			"base_points": 5,
+			"calc": {
+				"points": 5
+			}
+		},
+		{
+			"id": "a519d69b-e71c-44a7-9e69-e0ceaaa17281",
+			"type": "trait",
+			"name": "Resist Good",
+			"reference": "DFM11",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Supernatural"
+			],
+			"levels": 4,
+			"points_per_level": 2,
+			"can_level": true,
+			"calc": {
+				"points": 8
+			}
+		},
+		{
+			"id": "c6b15a7d-5717-4a0d-bc9f-f1802cbb1158",
+			"type": "trait",
+			"name": "Temperature Tolerance (Cold)",
+			"reference": "DFA16",
+			"tags": [
+				"Advantage",
+				"Physical"
+			],
+			"levels": 5,
+			"points_per_level": 1,
+			"features": [
+				{
+					"type": "conditional_modifier",
+					"situation": "to HT rolls to resist cold-related effects",
+					"amount": 1,
+					"per_level": true
+				}
+			],
+			"can_level": true,
+			"calc": {
+				"points": 5
+			}
+		},
+		{
+			"id": "77aea322-6ac7-4cb6-a6a0-efa81b5121f5",
+			"type": "trait",
+			"name": "Temperature Tolerance (Heat)",
+			"reference": "DFA16",
+			"tags": [
+				"Advantage",
+				"Physical"
+			],
+			"levels": 5,
+			"points_per_level": 1,
+			"features": [
+				{
+					"type": "conditional_modifier",
+					"situation": "to HT rolls to resist heat-related effects",
+					"amount": 1,
+					"per_level": true
+				}
+			],
+			"can_level": true,
+			"calc": {
+				"points": 5
+			}
+		},
+		{
+			"id": "94968be6-f1ae-4516-9ff1-0f7c0dd9faa3",
+			"type": "trait",
+			"name": "Unfazeable",
+			"reference": "DFA53",
+			"tags": [
+				"Advantage",
+				"Mental"
+			],
+			"base_points": 15,
+			"calc": {
+				"points": 15
+			}
+		},
+		{
+			"id": "e6c126cb-9c52-4b6d-b8e2-2f2523a1f82c",
+			"type": "trait",
+			"name": "Unhealing",
+			"reference": "DFM14",
+			"notes": "Heals only when Unkillable is triggered",
+			"tags": [
+				"Disadvantage",
+				"Exotic",
+				"Physical"
+			],
+			"base_points": -20,
+			"calc": {
+				"points": -20
+			}
+		},
+		{
+			"id": "9eb28a7f-3ca7-4356-b30a-8a602b9ecbe3",
+			"type": "trait",
+			"name": "Unkillable (Total)",
+			"reference": "DFM12",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Physical"
+			],
+			"modifiers": [
+				{
+					"id": "56e2cdd6-7c34-4f1e-af87-a52f71f3a0ee",
+					"type": "modifier",
+					"name": "Achilles' Heal",
+					"reference": "DFM12",
+					"notes": "@Rare Achilles' Heal@",
+					"cost": -10,
+					"disabled": true
+				},
+				{
+					"id": "5f0a4269-f8ba-4b5f-ac67-b002586c5884",
+					"type": "modifier",
+					"name": "Achilles' Heal",
+					"reference": "DFM12",
+					"notes": "Can be truly killed in no-mana areas",
+					"cost": -30
+				},
+				{
+					"id": "b2fa9ad9-5c98-4b39-9467-ca91c76b7e8e",
+					"type": "modifier",
+					"name": "Achilles' Heal",
+					"reference": "DFM12",
+					"notes": "@Common Achilles' Heal@",
+					"cost": -50,
+					"disabled": true
+				}
+			],
+			"base_points": 100,
+			"calc": {
+				"points": 70
+			}
+		},
+		{
+			"id": "cd7f694b-feb2-4013-8288-309eaa370b83",
+			"type": "trait",
+			"name": "Unliving",
+			"reference": "DFM12",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Physical"
+			],
+			"base_points": 20,
+			"calc": {
+				"points": 20
+			}
+		}
+	],
+	"skills": [
+		{
+			"id": "8165706a-1d69-4639-a179-a0c1115d1cb4",
+			"type": "skill",
+			"name": "Alchemy",
+			"reference": "DFA72",
+			"tags": [
+				"Magical",
+				"Natural Science",
+				"Occult"
+			],
+			"difficulty": "iq/vh",
+			"points": 8,
+			"calc": {
+				"level": 16,
+				"rsl": "IQ+0"
+			}
+		},
+		{
+			"id": "8c7fc5f3-f0fb-4ad7-ba83-ab4b3199c4bf",
+			"type": "skill",
+			"name": "Diplomacy",
+			"reference": "DFA75",
+			"tags": [
+				"Business",
+				"Police",
+				"Social"
+			],
+			"difficulty": "iq/h",
+			"points": 4,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -6,
+				"level": 10,
+				"adjusted_level": 10,
+				"points": -10
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Politics",
+					"modifier": -6
+				}
+			],
+			"calc": {
+				"level": 16,
+				"rsl": "IQ+0"
+			}
+		},
+		{
+			"id": "15bed610-c0d0-4cf2-8ab5-d73d3f51c77d",
+			"type": "skill",
+			"name": "Disguise",
+			"reference": "DFA75",
+			"tags": [
+				"Criminal",
+				"Spy",
+				"Street"
+			],
+			"difficulty": "iq/a",
+			"points": 2,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -5,
+				"level": 11,
+				"adjusted_level": 11,
+				"points": -11
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Makeup",
+					"modifier": -3
+				}
+			],
+			"calc": {
+				"level": 16,
+				"rsl": "IQ+0"
+			}
+		},
+		{
+			"id": "ee2c047e-809f-4352-83d3-b79f29d7654f",
+			"type": "skill",
+			"name": "Hidden Lore",
+			"reference": "DFA78",
+			"tags": [
+				"Knowledge"
+			],
+			"difficulty": "iq/a",
+			"points": 2,
+			"calc": {
+				"level": 16,
+				"rsl": "IQ+0"
+			}
+		},
+		{
+			"id": "990983e2-c7c9-4dc2-b76d-bea6cfc786e2",
+			"type": "skill",
+			"name": "Occultism",
+			"reference": "DFA84",
+			"tags": [
+				"Magical",
+				"Occult"
+			],
+			"difficulty": "iq/a",
+			"points": 2,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -5,
+				"level": 11,
+				"adjusted_level": 11,
+				"points": -11
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -5
+				}
+			],
+			"calc": {
+				"level": 16,
+				"rsl": "IQ+0"
+			}
+		},
+		{
+			"id": "62e18c29-67e2-4966-9f91-f54c79325f1a",
+			"type": "skill",
+			"name": "Research",
+			"reference": "DFA86",
+			"tags": [
+				"Scholarly",
+				"Spy"
+			],
+			"difficulty": "iq/a",
+			"points": 2,
+			"defaulted_from": {
+				"type": "skill",
+				"name": "Writing",
+				"modifier": -3,
+				"level": 13,
+				"adjusted_level": 13,
+				"points": -13
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Writing",
+					"modifier": -3
+				}
+			],
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Illiteracy"
+						}
+					}
+				]
+			},
+			"calc": {
+				"level": 16,
+				"rsl": "IQ+0"
+			}
+		},
+		{
+			"id": "86028b4c-4e0c-4e25-8c54-23b11ca5719c",
+			"type": "skill",
+			"name": "Savoir-Faire",
+			"reference": "DFA87",
+			"tags": [
+				"Business",
+				"Knowledge",
+				"Social"
+			],
+			"difficulty": "iq/e",
+			"points": 1,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -4,
+				"level": 12,
+				"adjusted_level": 12,
+				"points": -12
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -4
+				}
+			],
+			"calc": {
+				"level": 16,
+				"rsl": "IQ+0"
+			}
+		},
+		{
+			"id": "7ab48f6e-90e1-4b14-92c1-1e245edf9fc8",
+			"type": "skill",
+			"name": "Speed-Reading",
+			"reference": "DFA89",
+			"tags": [
+				"Scholarly"
+			],
+			"difficulty": "iq/a",
+			"points": 2,
+			"calc": {
+				"level": 16,
+				"rsl": "IQ+0"
+			}
+		},
+		{
+			"id": "0e029d85-b202-4d91-bf4b-c080b1f1e7ef",
+			"type": "skill",
+			"name": "Staff",
+			"reference": "DFA81",
+			"tags": [
+				"Combat",
+				"Melee Combat",
+				"Weapon"
+			],
+			"difficulty": "dx/a",
+			"points": 2,
+			"defaulted_from": {
+				"type": "dx",
+				"modifier": -5,
+				"level": 7,
+				"adjusted_level": 7,
+				"points": -7
+			},
+			"defaults": [
+				{
+					"type": "dx",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Polearm",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Spear",
+					"modifier": -2
+				}
+			],
+			"calc": {
+				"level": 12,
+				"rsl": "DX+0"
+			}
+		},
+		{
+			"id": "6e259077-1ea9-4b89-80b5-b39de8929ec9",
+			"type": "skill",
+			"name": "Thaumatology",
+			"reference": "DFA91",
+			"tags": [
+				"Magical",
+				"Occult"
+			],
+			"difficulty": "iq/vh",
+			"points": 1,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -7,
+				"level": 9,
+				"adjusted_level": 9,
+				"points": -9
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -7
+				}
+			],
+			"calc": {
+				"level": 19,
+				"rsl": "IQ+3"
+			}
+		},
+		{
+			"id": "ed7af0f5-6296-4108-96c1-bb647a09089c",
+			"type": "skill",
+			"name": "Traps",
+			"reference": "DFA92",
+			"tags": [
+				"Criminal",
+				"Military",
+				"Street"
+			],
+			"difficulty": "iq/a",
+			"points": 2,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -5,
+				"level": 11,
+				"adjusted_level": 11,
+				"points": -11
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Lockpicking",
+					"modifier": -3
+				}
+			],
+			"calc": {
+				"level": 16,
+				"rsl": "IQ+0"
+			}
+		},
+		{
+			"id": "2c225b47-e25a-49c3-bf4e-15503f1e10bc",
+			"type": "skill",
+			"name": "Writing",
+			"reference": "DFA94",
+			"tags": [
+				"Arts",
+				"Entertainment",
+				"Scholarly"
+			],
+			"difficulty": "iq/a",
+			"points": 2,
+			"defaulted_from": {
+				"type": "iq",
+				"modifier": -5,
+				"level": 11,
+				"adjusted_level": 11,
+				"points": -11
+			},
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -5
+				}
+			],
+			"calc": {
+				"level": 16,
+				"rsl": "IQ+0"
+			}
+		}
+	],
+	"spells": [
+		{
+			"id": "b769a965-81f3-45c0-8e98-3014fcde11f3",
+			"type": "spell",
+			"name": "Dozens of Spells at IQ 20+",
+			"difficulty": "iq/h",
+			"power_source": "Arcane",
+			"spell_class": "Regular",
+			"casting_cost": "1",
+			"casting_time": "1 sec",
+			"duration": "Instant",
+			"points": 1,
+			"calc": {
+				"level": 20,
+				"rsl": "IQ+4"
+			}
+		}
+	],
+	"equipment": [
+		{
+			"id": "ff6f6bc0-802c-4d2e-98c4-072f38688780",
+			"type": "equipment",
+			"description": "Wizard's Staff",
+			"reference": "DFA118",
+			"notes": "(Staff)",
+			"tags": [
+				"Melee Weapon"
+			],
+			"quantity": 1,
+			"value": 40,
+			"weight": "4 lb",
+			"weapons": [
+				{
+					"id": "0d7b5fc0-7729-4260-b758-a767f24a3b9c",
+					"type": "melee_weapon",
+					"damage": {
+						"type": "cr",
+						"st": "sw",
+						"base": "2"
+					},
+					"strength": "7†",
+					"usage": "Swung",
+					"usage_notes": "Usually with a horrid spell, like 6d worth of Deathtouch.",
+					"reach": "1,2",
+					"parry": "+2",
+					"block": "No",
+					"defaults": [
+						{
+							"type": "dx",
+							"modifier": -5
+						},
+						{
+							"type": "skill",
+							"name": "Staff"
+						},
+						{
+							"type": "skill",
+							"name": "Polearm",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Spear",
+							"modifier": -2
+						}
+					],
+					"calc": {
+						"level": 12,
+						"parry": "11",
+						"block": "No",
+						"damage": "2d+2 cr"
+					}
+				},
+				{
+					"id": "973471c9-9f72-4b8f-ba23-c5efb1b49c2c",
+					"type": "melee_weapon",
+					"damage": {
+						"type": "cr",
+						"st": "thr",
+						"base": "2"
+					},
+					"strength": "7†",
+					"usage": "Thrust",
+					"usage_notes": "Usually with a horrid spell, like 6d worth of Deathtouch.",
+					"reach": "1,2",
+					"parry": "+2",
+					"block": "No",
+					"defaults": [
+						{
+							"type": "dx",
+							"modifier": -5
+						},
+						{
+							"type": "skill",
+							"name": "Staff"
+						},
+						{
+							"type": "skill",
+							"name": "Polearm",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Spear",
+							"modifier": -2
+						}
+					],
+					"calc": {
+						"level": 12,
+						"parry": "11",
+						"block": "No",
+						"damage": "1d+2 cr"
+					}
+				}
+			],
+			"equipped": true,
+			"calc": {
+				"extended_value": 40,
+				"extended_weight": "4 lb"
+			}
+		}
+	],
+	"notes": [
+		{
+			"id": "4d49872e-b075-4a4b-b857-ef54ae323959",
+			"type": "note",
+			"text": "Favorite spells are at ‑2 to energy cost and half casting time – or better – due to skill 20+. Energy Reserve can be any size; 30 points is the minimum, and greater reskinned also wield sizable power items (possibly hidden inside them!). Resist Good means it resists Turning with Will 22 and has an effective Magic Resistance 4 against good clerics. Like liches, greater reskinned make deals . . . and may well do so in the guise of being guildmasters, merchants, and other “trustworthy” mortals in town. Truly evil.",
+			"reference": "DFRM2:39"
+		}
+	],
+	"created_date": "2021-11-15T13:36:00-08:00",
+	"modified_date": "2023-10-15T10:57:52+01:00",
+	"calc": {
+		"swing": "2d",
+		"thrust": "1d",
+		"basic_lift": "39 lb",
+		"move": [
+			6,
+			4,
+			3,
+			2,
+			1
+		],
+		"dodge": [
+			9,
+			8,
+			7,
+			6,
+			5
+		]
+	}
+}

--- a/Library/Dungeon Fantasy RPG/Monsters/Reskinned.gcs
+++ b/Library/Dungeon Fantasy RPG/Monsters/Reskinned.gcs
@@ -1,0 +1,2065 @@
+{
+	"type": "character",
+	"version": 4,
+	"id": "e41b71a0-9e9e-4483-b456-740c1aa3478c",
+	"total_points": 60,
+	"points_record": [
+		{
+			"when": "2022-11-19T12:04:01-08:00",
+			"points": 60,
+			"reason": "Reconciliation"
+		}
+	],
+	"profile": {
+		"name": "Reskinned"
+	},
+	"settings": {
+		"page": {
+			"paper_size": "letter",
+			"orientation": "portrait",
+			"top_margin": "0.25 in",
+			"left_margin": "0.25 in",
+			"bottom_margin": "0.25 in",
+			"right_margin": "0.25 in"
+		},
+		"block_layout": [
+			"reactions conditional_modifiers",
+			"melee",
+			"ranged",
+			"traits skills",
+			"spells",
+			"equipment",
+			"other_equipment",
+			"notes"
+		],
+		"attributes": [
+			{
+				"id": "st",
+				"type": "integer",
+				"name": "ST",
+				"full_name": "Strength",
+				"attribute_base": "10",
+				"cost_per_point": 10,
+				"cost_adj_percent_per_sm": 10
+			},
+			{
+				"id": "dx",
+				"type": "integer",
+				"name": "DX",
+				"full_name": "Dexterity",
+				"attribute_base": "10",
+				"cost_per_point": 20
+			},
+			{
+				"id": "iq",
+				"type": "integer",
+				"name": "IQ",
+				"full_name": "Intelligence",
+				"attribute_base": "10",
+				"cost_per_point": 20
+			},
+			{
+				"id": "ht",
+				"type": "integer",
+				"name": "HT",
+				"full_name": "Health",
+				"attribute_base": "10",
+				"cost_per_point": 10
+			},
+			{
+				"id": "will",
+				"type": "integer",
+				"name": "Will",
+				"attribute_base": "$iq",
+				"cost_per_point": 5
+			},
+			{
+				"id": "fright_check",
+				"type": "integer",
+				"name": "Fright Check",
+				"attribute_base": "$will",
+				"cost_per_point": 2
+			},
+			{
+				"id": "per",
+				"type": "integer",
+				"name": "Per",
+				"full_name": "Perception",
+				"attribute_base": "$iq",
+				"cost_per_point": 5
+			},
+			{
+				"id": "vision",
+				"type": "integer",
+				"name": "Vision",
+				"attribute_base": "$per",
+				"cost_per_point": 2
+			},
+			{
+				"id": "hearing",
+				"type": "integer",
+				"name": "Hearing",
+				"attribute_base": "$per",
+				"cost_per_point": 2
+			},
+			{
+				"id": "taste_smell",
+				"type": "integer",
+				"name": "Taste \u0026 Smell",
+				"attribute_base": "$per",
+				"cost_per_point": 2
+			},
+			{
+				"id": "touch",
+				"type": "integer",
+				"name": "Touch",
+				"attribute_base": "$per",
+				"cost_per_point": 2
+			},
+			{
+				"id": "basic_speed",
+				"type": "decimal",
+				"name": "Basic Speed",
+				"attribute_base": "($dx+$ht)/4",
+				"cost_per_point": 20
+			},
+			{
+				"id": "basic_move",
+				"type": "integer",
+				"name": "Basic Move",
+				"attribute_base": "floor($basic_speed)",
+				"cost_per_point": 5
+			},
+			{
+				"id": "hp",
+				"type": "pool",
+				"name": "HP",
+				"full_name": "Hit Points",
+				"attribute_base": "$st",
+				"cost_per_point": 2,
+				"cost_adj_percent_per_sm": 10,
+				"thresholds": [
+					{
+						"state": "Dead",
+						"expression": "round(-$hp*5)",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Dying #4",
+						"expression": "round(-$hp*4)",
+						"explanation": "\u003chtml\u003e\u003cbody\u003e\n\u003cb\u003eRoll vs. HT\u003c/b\u003e to avoid death\u003cbr\u003e\n\u003cb\u003eRoll vs. HT-4\u003c/b\u003e every second to avoid falling unconscious\u003cbr\u003e\nMove and Dodge are halved (B419)\n\u003c/body\u003e\u003c/html\u003e",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Dying #3",
+						"expression": "round(-$hp*3)",
+						"explanation": "\u003chtml\u003e\u003cbody\u003e\n\u003cb\u003eRoll vs. HT\u003c/b\u003e to avoid death\u003cbr\u003e\n\u003cb\u003eRoll vs. HT-3\u003c/b\u003e every second to avoid falling unconscious\u003cbr\u003e\nMove and Dodge are halved (B419)\n\u003c/body\u003e\u003c/html\u003e",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Dying #2",
+						"expression": "round(-$hp*2)",
+						"explanation": "\u003chtml\u003e\u003cbody\u003e\n\u003cb\u003eRoll vs. HT\u003c/b\u003e to avoid death\u003cbr\u003e\n\u003cb\u003eRoll vs. HT-2\u003c/b\u003e every second to avoid falling unconscious\u003cbr\u003e\nMove and Dodge are halved (B419)\n\u003c/body\u003e\u003c/html\u003e",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Dying #1",
+						"expression": "-$hp",
+						"explanation": "\u003chtml\u003e\u003cbody\u003e\n\u003cb\u003eRoll vs. HT\u003c/b\u003e to avoid death\u003cbr\u003e\n\u003cb\u003eRoll vs. HT-1\u003c/b\u003e every second to avoid falling unconscious\u003cbr\u003e\nMove and Dodge are halved (B419)\n\u003c/body\u003e\u003c/html\u003e",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Collapse",
+						"expression": "0",
+						"explanation": "\u003chtml\u003e\u003cbody\u003e\n\u003cb\u003eRoll vs. HT\u003c/b\u003e every second to avoid falling unconscious\u003cbr\u003e\nMove and Dodge are halved (B419)\n\u003c/body\u003e\u003c/html\u003e",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Reeling",
+						"expression": "round($hp/3)",
+						"explanation": "Move and Dodge are halved (B419)",
+						"ops": [
+							"halve_move",
+							"halve_dodge"
+						]
+					},
+					{
+						"state": "Wounded",
+						"expression": "$hp-1"
+					},
+					{
+						"state": "Healthy",
+						"expression": "$hp"
+					}
+				]
+			}
+		],
+		"body_type": {
+			"name": "Humanoid",
+			"roll": "3d",
+			"locations": [
+				{
+					"id": "eye",
+					"choice_name": "Eyes",
+					"table_name": "Eyes",
+					"hit_penalty": -9,
+					"description": "An attack that misses by 1 hits the torso instead. Only\nimpaling (imp), piercing (pi-, pi, pi+, pi++), and\ntight-beam burning (burn) attacks can target the eye – and\nonly from the front or sides. Injury over HP÷10 blinds the\neye. Otherwise, treat as skull, but without the extra DR!",
+					"calc": {
+						"roll_range": "-",
+						"dr": {
+							"all": 0
+						}
+					}
+				},
+				{
+					"id": "skull",
+					"choice_name": "Skull",
+					"table_name": "Skull",
+					"slots": 2,
+					"hit_penalty": -7,
+					"description": "An attack that misses by 1 hits the torso instead. Wounding\nmodifier is x4. Knockdown rolls are at -10. Critical hits\nuse the Critical Head Blow Table (B556). Exception: These\nspecial effects do not apply to toxic (tox) damage.",
+					"calc": {
+						"roll_range": "3-4",
+						"dr": {
+							"all": 4
+						}
+					}
+				},
+				{
+					"id": "face",
+					"choice_name": "Face",
+					"table_name": "Face",
+					"slots": 1,
+					"hit_penalty": -5,
+					"description": "An attack that misses by 1 hits the torso instead. Jaw,\ncheeks, nose, ears, etc. If the target has an open-faced\nhelmet, ignore its DR. Knockdown rolls are at -5. Critical\nhits use the Critical Head Blow Table (B556). Corrosion\n(cor) damage gets a x1½ wounding modifier, and if it\ninflicts a major wound, it also blinds one eye (both eyes on\ndamage over full HP). Random attacks from behind hit the\nskull instead.",
+					"calc": {
+						"roll_range": "5",
+						"dr": {
+							"all": 4
+						}
+					}
+				},
+				{
+					"id": "leg",
+					"choice_name": "Leg",
+					"table_name": "Right Leg",
+					"slots": 2,
+					"hit_penalty": -2,
+					"description": "Reduce the wounding multiplier of large piercing (pi+), huge\npiercing (pi++), and impaling (imp) damage to x1. Any major\nwound (loss of over ½ HP from one blow) cripples the limb.\nDamage beyond that threshold is lost.",
+					"calc": {
+						"roll_range": "6-7",
+						"dr": {
+							"all": 4
+						}
+					}
+				},
+				{
+					"id": "arm",
+					"choice_name": "Arm",
+					"table_name": "Right Arm",
+					"slots": 1,
+					"hit_penalty": -2,
+					"description": "Reduce the wounding multiplier of large piercing (pi+), huge\npiercing (pi++), and impaling (imp) damage to x1. Any major\nwound (loss of over ½ HP from one blow) cripples the limb.\nDamage beyond that threshold is lost. If holding a shield,\ndouble the penalty to hit: -4 for shield arm instead of -2.",
+					"calc": {
+						"roll_range": "8",
+						"dr": {
+							"all": 4
+						}
+					}
+				},
+				{
+					"id": "torso",
+					"choice_name": "Torso",
+					"table_name": "Torso",
+					"slots": 2,
+					"calc": {
+						"roll_range": "9-10",
+						"dr": {
+							"all": 4
+						}
+					}
+				},
+				{
+					"id": "groin",
+					"choice_name": "Groin",
+					"table_name": "Groin",
+					"slots": 1,
+					"hit_penalty": -3,
+					"description": "An attack that misses by 1 hits the torso instead. Human\nmales and the males of similar species suffer double shock\nfrom crushing (cr) damage, and get -5 to knockdown rolls.\nOtherwise, treat as a torso hit.",
+					"calc": {
+						"roll_range": "11",
+						"dr": {
+							"all": 4
+						}
+					}
+				},
+				{
+					"id": "arm",
+					"choice_name": "Arm",
+					"table_name": "Left Arm",
+					"slots": 1,
+					"hit_penalty": -2,
+					"description": "Reduce the wounding multiplier of large piercing (pi+), huge\npiercing (pi++), and impaling (imp) damage to x1. Any major\nwound (loss of over ½ HP from one blow) cripples the limb.\nDamage beyond that threshold is lost. If holding a shield,\ndouble the penalty to hit: -4 for shield arm instead of -2.",
+					"calc": {
+						"roll_range": "12",
+						"dr": {
+							"all": 4
+						}
+					}
+				},
+				{
+					"id": "leg",
+					"choice_name": "Leg",
+					"table_name": "Left Leg",
+					"slots": 2,
+					"hit_penalty": -2,
+					"description": "Reduce the wounding multiplier of large piercing (pi+), huge\npiercing (pi++), and impaling (imp) damage to x1. Any major\nwound (loss of over ½ HP from one blow) cripples the limb.\nDamage beyond that threshold is lost.",
+					"calc": {
+						"roll_range": "13-14",
+						"dr": {
+							"all": 4
+						}
+					}
+				},
+				{
+					"id": "hand",
+					"choice_name": "Hand",
+					"table_name": "Hand",
+					"slots": 1,
+					"hit_penalty": -4,
+					"description": "If holding a shield, double the penalty to hit: -8 for\nshield hand instead of -4. Reduce the wounding multiplier of\nlarge piercing (pi+), huge piercing (pi++), and impaling\n(imp) damage to x1. Any major wound (loss of over ⅓ HP\nfrom one blow) cripples the extremity. Damage beyond that\nthreshold is lost.",
+					"calc": {
+						"roll_range": "15",
+						"dr": {
+							"all": 4
+						}
+					}
+				},
+				{
+					"id": "foot",
+					"choice_name": "Foot",
+					"table_name": "Foot",
+					"slots": 1,
+					"hit_penalty": -4,
+					"description": "Reduce the wounding multiplier of large piercing (pi+), huge\npiercing (pi++), and impaling (imp) damage to x1. Any major\nwound (loss of over ⅓ HP from one blow) cripples the\nextremity. Damage beyond that threshold is lost.",
+					"calc": {
+						"roll_range": "16",
+						"dr": {
+							"all": 4
+						}
+					}
+				},
+				{
+					"id": "neck",
+					"choice_name": "Neck",
+					"table_name": "Neck",
+					"slots": 2,
+					"hit_penalty": -5,
+					"description": "An attack that misses by 1 hits the torso instead. Neck and\nthroat. Increase the wounding multiplier of crushing (cr)\nand corrosion (cor) attacks to x1½, and that of cutting\n(cut) damage to x2. At the GM’s option, anyone killed by a\ncutting (cut) blow to the neck is decapitated!",
+					"calc": {
+						"roll_range": "17-18",
+						"dr": {
+							"all": 4
+						}
+					}
+				},
+				{
+					"id": "vitals",
+					"choice_name": "Vitals",
+					"table_name": "Vitals",
+					"hit_penalty": -3,
+					"description": "An attack that misses by 1 hits the torso instead. Heart,\nlungs, kidneys, etc. Increase the wounding modifier for an\nimpaling (imp) or any piercing (pi-, pi, pi+, pi++) attack\nto x3. Increase the wounding modifier for a tight-beam\nburning (burn) attack to x2. Other attacks cannot target the\nvitals.",
+					"calc": {
+						"roll_range": "-",
+						"dr": {
+							"all": 4
+						}
+					}
+				}
+			]
+		},
+		"damage_progression": "basic_set",
+		"default_length_units": "ft_in",
+		"default_weight_units": "lb",
+		"user_description_display": "tooltip",
+		"modifiers_display": "inline",
+		"notes_display": "inline",
+		"skill_level_adj_display": "tooltip",
+		"show_trait_modifier_adj": true,
+		"show_equipment_modifier_adj": true,
+		"show_spell_adj": true,
+		"exclude_unspent_points_from_total": false
+	},
+	"attributes": [
+		{
+			"attr_id": "st",
+			"adj": 7,
+			"calc": {
+				"value": 17,
+				"points": 70
+			}
+		},
+		{
+			"attr_id": "dx",
+			"adj": 2,
+			"calc": {
+				"value": 12,
+				"points": 40
+			}
+		},
+		{
+			"attr_id": "iq",
+			"adj": -2,
+			"calc": {
+				"value": 8,
+				"points": -40
+			}
+		},
+		{
+			"attr_id": "ht",
+			"adj": 2,
+			"calc": {
+				"value": 12,
+				"points": 20
+			}
+		},
+		{
+			"attr_id": "will",
+			"adj": 0,
+			"calc": {
+				"value": 8,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "fright_check",
+			"adj": 0,
+			"calc": {
+				"value": 8,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "per",
+			"adj": 0,
+			"calc": {
+				"value": 8,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "vision",
+			"adj": 0,
+			"calc": {
+				"value": 8,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "hearing",
+			"adj": 0,
+			"calc": {
+				"value": 8,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "taste_smell",
+			"adj": 0,
+			"calc": {
+				"value": 8,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "touch",
+			"adj": 0,
+			"calc": {
+				"value": 8,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "basic_speed",
+			"adj": 0,
+			"calc": {
+				"value": 6,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "basic_move",
+			"adj": 0,
+			"calc": {
+				"value": 6,
+				"points": 0
+			}
+		},
+		{
+			"attr_id": "hp",
+			"adj": 4,
+			"calc": {
+				"value": 21,
+				"current": 21,
+				"points": 8
+			}
+		}
+	],
+	"traits": [
+		{
+			"id": "315a01fd-87c6-47e7-b0da-4977d25eff39",
+			"type": "trait",
+			"name": "Appearance",
+			"reference": "DFA47",
+			"tags": [
+				"Advantage",
+				"Physical"
+			],
+			"modifiers": [
+				{
+					"id": "96f5b8ba-8036-429f-b39f-e283b9fd6d71",
+					"type": "modifier",
+					"name": "Androgynous",
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "a96b39cf-83b3-40cb-a450-b2d70f3edd85",
+					"type": "modifier",
+					"name": "Impressive",
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "b4ccdefa-2144-4165-a330-f3fcd057d482",
+					"type": "modifier",
+					"name": "Attractive",
+					"cost": 4,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "6333b8c8-bd65-4f85-898a-9abd4c8e1b95",
+					"type": "modifier",
+					"name": "Average",
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "b15aae19-f168-4821-9d35-eefbbd90d070",
+					"type": "modifier",
+					"name": "Horrific",
+					"cost": -24,
+					"cost_type": "points"
+				},
+				{
+					"id": "49e69b1f-a6a5-4dfb-9c0e-5467039c6571",
+					"type": "modifier",
+					"name": "Monstrous",
+					"cost": -20,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "f995185e-9b68-4ae7-b50b-f7ff5645eeac",
+					"type": "modifier",
+					"name": "Hideous",
+					"cost": -16,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "37824a5b-f827-4318-8a86-d046a10a0937",
+					"type": "modifier",
+					"name": "Ugly",
+					"cost": -8,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "8c61decb-1ab2-4bd8-a8b6-c5b8c6a0347c",
+					"type": "modifier",
+					"name": "Unattractive",
+					"cost": -4,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "04b29ce4-cd7b-4346-8fde-413bae3c4049",
+					"type": "modifier",
+					"name": "Handsome",
+					"cost": 12,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "136b0d72-449e-416b-9867-a020e77029d7",
+					"type": "modifier",
+					"name": "Beautiful",
+					"cost": 12,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "6e6176e6-cfff-47b7-ba5c-339ec723d9d8",
+					"type": "modifier",
+					"name": "Very Handsome",
+					"cost": 16,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "6bbed62f-a5df-4068-b8b9-de209f698975",
+					"type": "modifier",
+					"name": "Very Beautiful",
+					"cost": 16,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "032cf4e0-1ffe-4318-a782-aae212daa02f",
+					"type": "modifier",
+					"name": "Transcendent",
+					"cost": 20,
+					"cost_type": "points",
+					"disabled": true
+				}
+			],
+			"calc": {
+				"points": -24
+			}
+		},
+		{
+			"id": "b44b50c0-8a75-49b1-9c3b-6913f57239f1",
+			"type": "trait",
+			"name": "Automaton",
+			"reference": "DFM12",
+			"tags": [
+				"Disadvantage",
+				"Exotic",
+				"Physical"
+			],
+			"base_points": -85,
+			"calc": {
+				"points": -85
+			}
+		},
+		{
+			"id": "fbaa5cfa-af9f-465d-a56f-9b29486ce0d9",
+			"type": "trait",
+			"name": "Bad Smell",
+			"reference": "DFM13",
+			"tags": [
+				"Disadvantage",
+				"Physical"
+			],
+			"base_points": -10,
+			"features": [
+				{
+					"type": "reaction_bonus",
+					"situation": "from those able to smell",
+					"amount": -2
+				},
+				{
+					"type": "conditional_modifier",
+					"situation": "on attempts to hide",
+					"amount": -2
+				}
+			],
+			"calc": {
+				"points": -10
+			}
+		},
+		{
+			"id": "46a996c2-1460-4341-b6ae-0550d9702448",
+			"type": "trait",
+			"name": "Cannot Float",
+			"reference": "DFM13",
+			"tags": [
+				"Physical",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "b71e9201-fa88-497d-829d-cbf61e730807",
+			"type": "trait",
+			"name": "Cannot Learn",
+			"reference": "DFM13",
+			"tags": [
+				"Disadvantage",
+				"Mental"
+			],
+			"base_points": -30,
+			"calc": {
+				"points": -30
+			}
+		},
+		{
+			"id": "846a74dc-671a-4bfa-9dad-35752558879c",
+			"type": "trait",
+			"name": "Damage Resistance",
+			"reference": "DFM10",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Physical"
+			],
+			"levels": 4,
+			"points_per_level": 5,
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "skull",
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "dr_bonus",
+					"location": "face",
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "dr_bonus",
+					"location": "neck",
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "dr_bonus",
+					"location": "torso",
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "dr_bonus",
+					"location": "vitals",
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "dr_bonus",
+					"location": "groin",
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "dr_bonus",
+					"location": "arm",
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "dr_bonus",
+					"location": "hand",
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "dr_bonus",
+					"location": "leg",
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "dr_bonus",
+					"location": "foot",
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "dr_bonus",
+					"location": "tail",
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "dr_bonus",
+					"location": "wing",
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "dr_bonus",
+					"location": "fin",
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "dr_bonus",
+					"location": "brain",
+					"amount": 1,
+					"per_level": true
+				}
+			],
+			"can_level": true,
+			"calc": {
+				"points": 20
+			}
+		},
+		{
+			"id": "aac48a2d-c294-4f20-aa90-009f1b1dcfb8",
+			"type": "trait",
+			"name": "Dependency (Mana)",
+			"reference": "DFM13",
+			"tags": [
+				"Disadvantage",
+				"Exotic",
+				"Physical"
+			],
+			"modifiers": [
+				{
+					"id": "6730aada-bec0-4b1d-918e-bdca5b7c71a3",
+					"type": "modifier",
+					"name": "Rarity: Rare",
+					"reference": "B130",
+					"cost": -30,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "321d184a-0025-470a-bb44-e0e1a8b8eb24",
+					"type": "modifier",
+					"name": "Rarity: Occasional",
+					"reference": "B130",
+					"cost": -20,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "4c659a79-4b88-49b4-93c6-587f0a7fcd1a",
+					"type": "modifier",
+					"name": "Rarity: Common",
+					"reference": "B130",
+					"cost": -10,
+					"cost_type": "points"
+				},
+				{
+					"id": "463e4fb3-6bdd-4a38-96f0-593759942333",
+					"type": "modifier",
+					"name": "Rarity: Very Common",
+					"reference": "B130",
+					"cost": -5,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "53a55dd7-5fc9-4c73-be71-8d188e01b002",
+					"type": "modifier",
+					"name": "Illegal",
+					"reference": "B130",
+					"cost": -5,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "82dd6414-8205-4de0-9aee-4a2b750908c6",
+					"type": "modifier",
+					"name": "Frequency: Constantly",
+					"reference": "B130",
+					"notes": "Lose 1 HP per minute without it",
+					"cost": 5,
+					"cost_type": "multiplier"
+				},
+				{
+					"id": "5370b0ee-69c4-4eec-b0a3-192d059eb8f7",
+					"type": "modifier",
+					"name": "Frequency: Hourly",
+					"reference": "B130",
+					"notes": "Lose 1 HP per 10 minutes after missing a hourly dose",
+					"cost": 4,
+					"cost_type": "multiplier",
+					"disabled": true
+				},
+				{
+					"id": "372cf918-21bd-4ae1-a96d-94c615c1fc45",
+					"type": "modifier",
+					"name": "Frequency: Daily",
+					"reference": "B130",
+					"notes": "Lose 1 HP per hour after missing a daily dose",
+					"cost": 3,
+					"cost_type": "multiplier",
+					"disabled": true
+				},
+				{
+					"id": "de374b05-fc65-410d-bf34-1bc0fba0bf4e",
+					"type": "modifier",
+					"name": "Frequency: Weekly",
+					"reference": "B130",
+					"notes": "Lose 1 HP per six hours after missing a weekly dose",
+					"cost": 2,
+					"cost_type": "multiplier",
+					"disabled": true
+				},
+				{
+					"id": "c81776b7-4ae3-48c5-b69b-1a72f24bf1e8",
+					"type": "modifier",
+					"name": "Frequency: Monthly",
+					"reference": "B130",
+					"notes": "Lose 1 HP per day after missing a monthly dose",
+					"cost": 1,
+					"cost_type": "multiplier",
+					"disabled": true
+				},
+				{
+					"id": "770af4e4-a240-434b-a1dd-bb042688a4d6",
+					"type": "modifier",
+					"name": "Frequency: Seasonally",
+					"reference": "B130",
+					"notes": "Lose 1 HP per 3 days after missing a seasonal dose",
+					"cost": 0.3333,
+					"cost_type": "multiplier",
+					"disabled": true
+				},
+				{
+					"id": "2155aefa-3b21-4c9e-a654-0535329000c1",
+					"type": "modifier",
+					"name": "Frequency: Yearly",
+					"reference": "B130",
+					"notes": "Lose 1 HP per 2 weeks after missing a yearly dose",
+					"cost": 0.1,
+					"cost_type": "multiplier",
+					"disabled": true
+				},
+				{
+					"id": "bfd94739-875d-4e77-a003-3e3a9d573cef",
+					"type": "modifier",
+					"name": "Aging",
+					"reference": "B130",
+					"notes": "Age 2 years for each HP lost due to this dependency",
+					"cost": 30,
+					"disabled": true
+				}
+			],
+			"calc": {
+				"points": -50
+			}
+		},
+		{
+			"id": "49ae8ff9-2d03-44ef-b809-ad703bdefb2c",
+			"type": "trait",
+			"name": "Doesn't Breathe",
+			"reference": "DFM10",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Physical"
+			],
+			"base_points": 20,
+			"calc": {
+				"points": 20
+			}
+		},
+		{
+			"id": "e1e0569a-a74d-43f7-9984-f2cd0da3c258",
+			"type": "trait",
+			"name": "Doesn't Eat or Drink",
+			"reference": "DFM10",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Physical"
+			],
+			"base_points": 10,
+			"calc": {
+				"points": 10
+			}
+		},
+		{
+			"id": "f6045997-dd23-4735-bc7e-ecdab3e30b71",
+			"type": "trait",
+			"name": "Doesn't Sleep",
+			"reference": "DFM10",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Physical"
+			],
+			"base_points": 20,
+			"calc": {
+				"points": 20
+			}
+		},
+		{
+			"id": "5d05da25-fb79-4c58-a750-60fcba0d712a",
+			"type": "trait",
+			"name": "High Pain Threshold",
+			"reference": "DFA50",
+			"notes": "Never suffer shock penalties when injured",
+			"tags": [
+				"Advantage",
+				"Physical"
+			],
+			"base_points": 10,
+			"features": [
+				{
+					"type": "conditional_modifier",
+					"situation": "on all HT rolls to avoid knockdown and stunning",
+					"amount": 3
+				},
+				{
+					"type": "conditional_modifier",
+					"situation": "to resist torture",
+					"amount": 3
+				}
+			],
+			"calc": {
+				"points": 10
+			}
+		},
+		{
+			"id": "47bbd419-eae8-4057-86df-3ef56cc23d79",
+			"type": "trait",
+			"name": "Immunity",
+			"reference": "DFM11",
+			"tags": [
+				"Advantage",
+				"Physical"
+			],
+			"modifiers": [
+				{
+					"id": "53b4ef1b-c354-4eba-8d12-30e525608342",
+					"type": "modifier",
+					"name": "@Very Common: Metabolic Hazards, etc.@",
+					"reference": "B80",
+					"cost": 30,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "df78d2bd-d660-4f5c-9969-6753b53cd4df",
+					"type": "modifier",
+					"name": "@Common: Poison, Sickness, etc.@",
+					"reference": "B81",
+					"cost": 15,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "b7cd47cb-94da-4a66-9217-df93da45d8f1",
+					"type": "modifier",
+					"name": "Disease",
+					"reference": "B81",
+					"cost": 10,
+					"cost_type": "points"
+				},
+				{
+					"id": "7e01e000-fdc4-43e1-a103-28ef690371d4",
+					"type": "modifier",
+					"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+					"reference": "B81",
+					"cost": 5,
+					"cost_type": "points",
+					"disabled": true
+				}
+			],
+			"calc": {
+				"points": 10
+			}
+		},
+		{
+			"id": "e519bbe5-d25d-4fd7-a713-2a7d2ddc070d",
+			"type": "trait",
+			"name": "Immunity",
+			"reference": "DFM11",
+			"tags": [
+				"Advantage",
+				"Physical"
+			],
+			"modifiers": [
+				{
+					"id": "1c337b8c-e245-4343-98e3-a471a7019ee6",
+					"type": "modifier",
+					"name": "@Very Common: Metabolic Hazards, etc.@",
+					"reference": "B80",
+					"cost": 30,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "0d6a2726-e74c-4e17-8dc3-65f52ad69a09",
+					"type": "modifier",
+					"name": "@Common: Poison, Sickness, etc.@",
+					"reference": "B81",
+					"cost": 15,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "49ca3abe-58e0-4bf4-9dd0-30c7aec17a64",
+					"type": "modifier",
+					"name": "Mind Control",
+					"reference": "B81",
+					"cost": 10,
+					"cost_type": "points"
+				},
+				{
+					"id": "fae0ab47-3319-4e82-8574-96760287c9e9",
+					"type": "modifier",
+					"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+					"reference": "B81",
+					"cost": 5,
+					"cost_type": "points",
+					"disabled": true
+				}
+			],
+			"calc": {
+				"points": 10
+			}
+		},
+		{
+			"id": "225f28df-2a14-41e1-85d9-029b54472b31",
+			"type": "trait",
+			"name": "Immunity",
+			"reference": "DFM11",
+			"tags": [
+				"Advantage",
+				"Physical"
+			],
+			"modifiers": [
+				{
+					"id": "65393b68-b87f-46fd-badc-d63032000232",
+					"type": "modifier",
+					"name": "@Very Common: Metabolic Hazards, etc.@",
+					"reference": "B80",
+					"cost": 30,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "b222c645-c6a7-436d-8ff4-cf64e180d33c",
+					"type": "modifier",
+					"name": "Poison",
+					"reference": "B81",
+					"cost": 15,
+					"cost_type": "points"
+				},
+				{
+					"id": "5f7ed45b-785f-4ba5-a451-d600e4430504",
+					"type": "modifier",
+					"name": "@Occasional: Disease, Ingested Poison, etc.@",
+					"reference": "B81",
+					"cost": 10,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "972b2dc0-5fe2-454c-bde0-7f4a53ea142b",
+					"type": "modifier",
+					"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+					"reference": "B81",
+					"cost": 5,
+					"cost_type": "points",
+					"disabled": true
+				}
+			],
+			"calc": {
+				"points": 15
+			}
+		},
+		{
+			"id": "3bdb3342-984e-4643-859a-467aea34c6be",
+			"type": "trait",
+			"name": "Indomitable",
+			"reference": "DFM11",
+			"tags": [
+				"Advantage",
+				"Mental"
+			],
+			"base_points": 15,
+			"calc": {
+				"points": 15
+			}
+		},
+		{
+			"id": "042cd913-9ecb-49ad-9b88-92d53e9b7d36",
+			"type": "trait",
+			"name": "Mute",
+			"reference": "DFM13",
+			"tags": [
+				"Disadvantage",
+				"Physical"
+			],
+			"base_points": -25,
+			"calc": {
+				"points": -25
+			}
+		},
+		{
+			"id": "c610dbac-3ef5-448d-9fc0-5d18cde8be09",
+			"type": "trait",
+			"name": "Natural Attacks",
+			"reference": "B271",
+			"weapons": [
+				{
+					"id": "d11039eb-2fa1-48ea-b280-164e6d3d745b",
+					"type": "melee_weapon",
+					"damage": {
+						"type": "cr",
+						"st": "thr",
+						"base": "0"
+					},
+					"usage": "Gaping Bite",
+					"reach": "C",
+					"parry": "No",
+					"block": "No",
+					"defaults": [
+						{
+							"type": "dx"
+						},
+						{
+							"type": "skill",
+							"name": "Brawling"
+						}
+					],
+					"calc": {
+						"level": 14,
+						"parry": "No",
+						"block": "No",
+						"damage": "1d+3 cr"
+					}
+				},
+				{
+					"id": "da18dcfd-96cd-428b-af14-42d161bf63f6",
+					"type": "melee_weapon",
+					"damage": {
+						"type": "cr",
+						"st": "thr",
+						"base": "1"
+					},
+					"usage": "Bony Claw",
+					"reach": "C,1",
+					"parry": "0",
+					"defaults": [
+						{
+							"type": "dx"
+						},
+						{
+							"type": "skill",
+							"name": "Boxing"
+						},
+						{
+							"type": "skill",
+							"name": "Brawling"
+						},
+						{
+							"type": "skill",
+							"name": "Karate"
+						}
+					],
+					"calc": {
+						"level": 14,
+						"parry": "10",
+						"damage": "1d+4 cr"
+					}
+				}
+			],
+			"calc": {
+				"points": 0
+			}
+		},
+		{
+			"id": "53f6beb6-37c9-4291-81b1-12195deb2f20",
+			"type": "trait",
+			"name": "No Blood",
+			"reference": "DFM11",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Physical"
+			],
+			"base_points": 5,
+			"calc": {
+				"points": 5
+			}
+		},
+		{
+			"id": "707e608d-f71c-48f3-94e0-53b37ebe8c2e",
+			"type": "trait",
+			"name": "No Brain",
+			"reference": "DFM11",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Physical"
+			],
+			"base_points": 5,
+			"calc": {
+				"points": 5
+			}
+		},
+		{
+			"id": "865085a8-ac16-4a99-946d-a67f689cb545",
+			"type": "trait",
+			"name": "No Eyes",
+			"reference": "DFM11",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Physical"
+			],
+			"base_points": 5,
+			"calc": {
+				"points": 5
+			}
+		},
+		{
+			"id": "6a3fd779-a211-4ea9-85fe-d17ad3bb9dd9",
+			"type": "trait",
+			"name": "No Vitals",
+			"reference": "DFM11",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Physical"
+			],
+			"base_points": 5,
+			"calc": {
+				"points": 5
+			}
+		},
+		{
+			"id": "f242b0a0-dc57-4f2d-b5eb-0ce9d88b03e6",
+			"type": "trait",
+			"name": "No Sense of Smell/Taste",
+			"reference": "DFM13",
+			"tags": [
+				"Disadvantage",
+				"Physical"
+			],
+			"base_points": -5,
+			"calc": {
+				"points": -5
+			}
+		},
+		{
+			"id": "7b9c791f-e2b5-4d39-a8dd-d658a7f6e18b",
+			"type": "trait",
+			"name": "Reprogrammable",
+			"reference": "DFM13",
+			"tags": [
+				"Disadvantage",
+				"Exotic",
+				"Mental"
+			],
+			"base_points": -10,
+			"calc": {
+				"points": -10
+			}
+		},
+		{
+			"id": "858ad977-3473-4e74-9b4f-a2d87ef91f2f",
+			"type": "trait",
+			"name": "Resist Good",
+			"reference": "DFM11",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Supernatural"
+			],
+			"levels": 4,
+			"points_per_level": 2,
+			"can_level": true,
+			"calc": {
+				"points": 8
+			}
+		},
+		{
+			"id": "4652ec29-9254-41a1-84a3-6a225839d364",
+			"type": "trait",
+			"name": "Single-Minded",
+			"reference": "DFM11",
+			"tags": [
+				"Advantage",
+				"Mental"
+			],
+			"base_points": 5,
+			"calc": {
+				"points": 5
+			}
+		},
+		{
+			"id": "1a7615c5-16e2-4f87-84ee-31ddf19f037a",
+			"type": "trait",
+			"name": "Temperature Tolerance (Cold)",
+			"reference": "DFA16",
+			"tags": [
+				"Advantage",
+				"Physical"
+			],
+			"levels": 5,
+			"points_per_level": 1,
+			"can_level": true,
+			"calc": {
+				"points": 5
+			}
+		},
+		{
+			"id": "c81ed984-3bbf-4e12-8e1f-232b820ab95f",
+			"type": "trait",
+			"name": "Temperature Tolerance (Hot)",
+			"reference": "DFA16",
+			"tags": [
+				"Advantage",
+				"Physical"
+			],
+			"levels": 5,
+			"points_per_level": 1,
+			"can_level": true,
+			"calc": {
+				"points": 5
+			}
+		},
+		{
+			"id": "f44e89ab-1c1d-4736-9fa8-88ee4647132e",
+			"type": "trait",
+			"name": "Unfazeable",
+			"reference": "DFA53",
+			"tags": [
+				"Advantage",
+				"Mental"
+			],
+			"base_points": 15,
+			"calc": {
+				"points": 15
+			}
+		},
+		{
+			"id": "6a3ea8d1-296d-4d9c-aa6c-d9505e32ac44",
+			"type": "trait",
+			"name": "Unhealing (Total)",
+			"reference": "DFM14",
+			"tags": [
+				"Disadvantage",
+				"Exotic",
+				"Physical"
+			],
+			"base_points": -30,
+			"calc": {
+				"points": -30
+			}
+		},
+		{
+			"id": "38b4cac6-9cf6-4f46-95b2-576d1fa5621e",
+			"type": "trait",
+			"name": "Unliving",
+			"reference": "DFM12",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Physical"
+			],
+			"base_points": 20,
+			"calc": {
+				"points": 20
+			}
+		}
+	],
+	"skills": [
+		{
+			"id": "b70f581b-a42f-4bb8-bef8-b1fc6d9b9980",
+			"type": "skill",
+			"name": "Brawling",
+			"reference": "DFA93",
+			"tags": [
+				"Combat",
+				"Melee Combat",
+				"Weapon"
+			],
+			"difficulty": "dx/e",
+			"points": 4,
+			"features": [
+				{
+					"type": "weapon_bonus",
+					"selection_type": "weapons_with_required_skill",
+					"name": {
+						"compare": "is",
+						"qualifier": "Brawling"
+					},
+					"level": {
+						"compare": "at_least",
+						"qualifier": 2
+					},
+					"amount": 1,
+					"per_level": true
+				}
+			],
+			"calc": {
+				"level": 14,
+				"rsl": "DX+2"
+			}
+		},
+		{
+			"id": "7153f6c7-4cda-4f35-8925-c202534d8233",
+			"type": "skill",
+			"name": "Wrestling",
+			"reference": "DFA93",
+			"tags": [
+				"Combat",
+				"Melee Combat",
+				"Weapon"
+			],
+			"difficulty": "dx/a",
+			"points": 8,
+			"calc": {
+				"level": 14,
+				"rsl": "DX+2"
+			}
+		},
+		{
+			"id": "7f4246f2-a36f-41be-a35d-55b1eb9d3015",
+			"type": "skill_container",
+			"open": true,
+			"children": [
+				{
+					"id": "950cfdc9-2b33-4647-bf04-a217e54f595e",
+					"type": "skill",
+					"name": "Axe/Mace",
+					"reference": "DFA81",
+					"tags": [
+						"Combat",
+						"Melee Combat",
+						"Weapon"
+					],
+					"difficulty": "dx/a",
+					"points": 4,
+					"defaulted_from": {
+						"type": "dx",
+						"modifier": -5,
+						"level": 7,
+						"adjusted_level": 7,
+						"points": -7
+					},
+					"defaults": [
+						{
+							"type": "dx",
+							"modifier": -5
+						},
+						{
+							"type": "skill",
+							"name": "Two-Handed Axe/Mace",
+							"modifier": -3
+						},
+						{
+							"type": "skill",
+							"name": "Flail",
+							"modifier": -4
+						}
+					],
+					"calc": {
+						"level": 13,
+						"rsl": "DX+1"
+					}
+				},
+				{
+					"id": "48b080be-0aa5-4925-b226-ccf20ae5edae",
+					"type": "skill",
+					"name": "Broadsword",
+					"reference": "DFA81",
+					"tags": [
+						"Combat",
+						"Melee Combat",
+						"Weapon"
+					],
+					"difficulty": "dx/a",
+					"points": 4,
+					"defaulted_from": {
+						"type": "dx",
+						"modifier": -5,
+						"level": 7,
+						"adjusted_level": 7,
+						"points": -7
+					},
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Force Sword",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Rapier",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Saber",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Shortsword",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Two-Handed Sword",
+							"modifier": -4
+						},
+						{
+							"type": "dx",
+							"modifier": -5
+						}
+					],
+					"calc": {
+						"level": 13,
+						"rsl": "DX+1"
+					}
+				},
+				{
+					"id": "ade7b93f-1c4f-4910-928a-6d242fa269b1",
+					"type": "skill",
+					"name": "Flail",
+					"reference": "DFA81",
+					"tags": [
+						"Combat",
+						"Melee Combat",
+						"Weapon"
+					],
+					"difficulty": "dx/h",
+					"points": 4,
+					"defaulted_from": {
+						"type": "skill",
+						"name": "Axe/Mace",
+						"modifier": -4,
+						"level": 9,
+						"adjusted_level": 9,
+						"points": -9
+					},
+					"defaults": [
+						{
+							"type": "dx",
+							"modifier": -6
+						},
+						{
+							"type": "skill",
+							"name": "Axe/Mace",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Two-Handed Flail",
+							"modifier": -3
+						}
+					],
+					"calc": {
+						"level": 12,
+						"rsl": "DX+0"
+					}
+				}
+			],
+			"name": "One of:",
+			"calc": {}
+		}
+	],
+	"other_equipment": [
+		{
+			"id": "212e17a1-86e7-4965-a63e-d2972ae1b933",
+			"type": "equipment_container",
+			"open": true,
+			"children": [
+				{
+					"id": "0d53c0f4-e694-4257-85a9-63f3521b9708",
+					"type": "equipment",
+					"description": "Mace",
+					"reference": "DFA98",
+					"tags": [
+						"Melee Weapon",
+						"Missile Weapon"
+					],
+					"quantity": 1,
+					"value": 50,
+					"weight": "5 lb",
+					"weapons": [
+						{
+							"id": "2a1ed4b5-25fa-4833-8e78-c2a4bac3ad85",
+							"type": "melee_weapon",
+							"damage": {
+								"type": "cr",
+								"st": "sw",
+								"base": "3"
+							},
+							"strength": "12",
+							"usage": "Swung",
+							"reach": "1,2",
+							"parry": "0U",
+							"block": "No",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Axe/Mace"
+								},
+								{
+									"type": "skill",
+									"name": "Flail",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Two-Handed Axe/Mace",
+									"modifier": -3
+								}
+							],
+							"calc": {
+								"level": 13,
+								"parry": "9U",
+								"block": "No",
+								"damage": "3d+2 cr"
+							}
+						},
+						{
+							"id": "15aadc2b-6b07-4005-aa03-f2f04ab9c94d",
+							"type": "ranged_weapon",
+							"damage": {
+								"type": "cr",
+								"st": "sw",
+								"base": "3"
+							},
+							"strength": "12",
+							"accuracy": "1",
+							"range": "x0.5/x1",
+							"rate_of_fire": "1",
+							"shots": "T(1)",
+							"bulk": "-4",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Thrown Weapon",
+									"specialization": "Axe/Mace"
+								}
+							],
+							"calc": {
+								"level": 8,
+								"range": "8/17",
+								"damage": "3d+2 cr"
+							}
+						}
+					],
+					"equipped": true,
+					"calc": {
+						"extended_value": 50,
+						"extended_weight": "5 lb"
+					}
+				},
+				{
+					"id": "f32a44d2-8b0e-4332-a557-07d3fb15212f",
+					"type": "equipment",
+					"description": "Axe",
+					"reference": "DFA98",
+					"tags": [
+						"Melee Weapon"
+					],
+					"quantity": 1,
+					"value": 50,
+					"weight": "4 lb",
+					"weapons": [
+						{
+							"id": "af39d164-98d7-4149-85b4-c4983657d5a8",
+							"type": "melee_weapon",
+							"damage": {
+								"type": "cut",
+								"st": "sw",
+								"base": "2"
+							},
+							"strength": "11",
+							"usage": "Swung",
+							"reach": "1,2",
+							"parry": "0U",
+							"block": "No",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Axe/Mace"
+								},
+								{
+									"type": "skill",
+									"name": "Flail",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Two-Handed Axe/Mace",
+									"modifier": -3
+								}
+							],
+							"calc": {
+								"level": 13,
+								"parry": "9U",
+								"block": "No",
+								"damage": "3d+1 cut"
+							}
+						}
+					],
+					"equipped": true,
+					"calc": {
+						"extended_value": 50,
+						"extended_weight": "4 lb"
+					}
+				},
+				{
+					"id": "27cb2545-62de-43cc-9ded-1ca7fe11c2d9",
+					"type": "equipment",
+					"description": "Broadsword",
+					"reference": "DFA99",
+					"tags": [
+						"Melee Weapon"
+					],
+					"quantity": 1,
+					"value": 600,
+					"weight": "3 lb",
+					"weapons": [
+						{
+							"id": "aeab6355-9989-42fc-971a-29ee251ff067",
+							"type": "melee_weapon",
+							"damage": {
+								"type": "cut",
+								"st": "sw",
+								"base": "1"
+							},
+							"strength": "10",
+							"usage": "Swing",
+							"reach": "1,2",
+							"parry": "0",
+							"block": "No",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Broadsword"
+								},
+								{
+									"type": "skill",
+									"name": "Force Sword",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Rapier",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Saber",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Shortsword",
+									"modifier": -2
+								},
+								{
+									"type": "skill",
+									"name": "Two-Handed Sword",
+									"modifier": -4
+								}
+							],
+							"calc": {
+								"level": 13,
+								"parry": "9",
+								"block": "No",
+								"damage": "3d cut"
+							}
+						},
+						{
+							"id": "fcafb0e2-6b23-4da5-8796-b62b7b2076ad",
+							"type": "melee_weapon",
+							"damage": {
+								"type": "imp",
+								"st": "thr",
+								"base": "2"
+							},
+							"strength": "10",
+							"usage": "Thrust",
+							"reach": "1,2",
+							"parry": "0",
+							"block": "No",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Broadsword"
+								},
+								{
+									"type": "skill",
+									"name": "Force Sword",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Rapier",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Saber",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Shortsword",
+									"modifier": -2
+								},
+								{
+									"type": "skill",
+									"name": "Two-Handed Sword",
+									"modifier": -4
+								}
+							],
+							"calc": {
+								"level": 13,
+								"parry": "9",
+								"block": "No",
+								"damage": "1d+4 imp"
+							}
+						}
+					],
+					"equipped": true,
+					"calc": {
+						"extended_value": 600,
+						"extended_weight": "3 lb"
+					}
+				},
+				{
+					"id": "7eec76d8-b775-4db9-ace3-5490ae5ae6b6",
+					"type": "equipment",
+					"description": "Flail",
+					"reference": "DFA102",
+					"tags": [
+						"Melee Weapon"
+					],
+					"quantity": 1,
+					"value": 100,
+					"weight": "8 lb",
+					"weapons": [
+						{
+							"id": "094449b0-dea5-44f3-a61b-d77269cf74e7",
+							"type": "melee_weapon",
+							"damage": {
+								"type": "cr",
+								"st": "sw",
+								"base": "4"
+							},
+							"strength": "13†",
+							"usage": "Swung",
+							"reach": "2,3*",
+							"parry": "0U",
+							"block": "No",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -6
+								},
+								{
+									"type": "skill",
+									"name": "Two-Handed Flail"
+								},
+								{
+									"type": "skill",
+									"name": "Flail",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Kusari",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Two-Handed Axe/Mace",
+									"modifier": -4
+								}
+							],
+							"calc": {
+								"level": 9,
+								"parry": "7U",
+								"block": "No",
+								"damage": "3d+3 cr"
+							}
+						}
+					],
+					"equipped": true,
+					"calc": {
+						"extended_value": 100,
+						"extended_weight": "8 lb"
+					}
+				}
+			],
+			"description": "One of:",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 800,
+				"extended_weight": "20 lb"
+			}
+		}
+	],
+	"notes": [
+		{
+			"id": "1e032c92-60de-46f0-b2ab-a30a1a36d64f",
+			"type": "note",
+			"text": "Unaffected by Death Vision or Sense Life, but susceptible to Pentagram, Sense Spirit, and Turn Zombie. For reskinned, the main benefits of Resist Good are that it resists Turning with Will 12 instead of 8, and that Turn Zombie spells must succeed by 4+ to have any effect. Effective grappling ST is 19, thanks to Wrestling. Almost all reskinned are made from better-than-average starting material, but even higher ST, DX, HT, and combat skills are conceivable. A one-handed melee weapon and nothing else is typical gear, as armor that fits reskinned is rare; a wealthy reanimator might spring for better weapons or custom armor (which would add its DR to the monster’s natural DR 4). Not truly evil, though the magic animating it is. No undead servitor will negotiate or reveal useful information.",
+			"reference": "DFRM2:38"
+		}
+	],
+	"created_date": "2021-11-17T01:45:00-08:00",
+	"modified_date": "2023-10-15T10:34:16+01:00",
+	"calc": {
+		"swing": "3d-1",
+		"thrust": "1d+2",
+		"basic_lift": "58 lb",
+		"move": [
+			6,
+			4,
+			3,
+			2,
+			1
+		],
+		"dodge": [
+			9,
+			8,
+			7,
+			6,
+			5
+		]
+	}
+}


### PR DESCRIPTION
This adds monster entries for the Reskinned, and the Greater Reskinned Lich variant undead from Dungeon Fantasy RPG Monsters 2..

As with the Lich template, the exact skill and spell list is left to the GM, but I've taken the liberty of keeping the example Lich skills in addition to adding Disguise and suggested Social skills.