### PR TITLE
Add GURPS Magic - Artillery Spells

### DIFF
--- a/Library/Magic/Magic - Artillery Spells/Magic - Artillery Spells.spl
+++ b/Library/Magic/Magic - Artillery Spells/Magic - Artillery Spells.spl
@@ -1,0 +1,3868 @@
+{
+	"type": "spell_list",
+	"version": 4,
+	"rows": [
+		{
+			"id": "79d47e34-3ac6-4e47-b9ec-a6538ad977fd",
+			"type": "spell",
+			"name": "Cloud of Doom",
+			"reference": "MAS9",
+			"reference_highlight": "Cloud of Doom",
+			"tags": [
+				"Artillery",
+				"Air"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Air"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Area",
+			"casting_cost": "5",
+			"maintenance_cost": "-",
+			"casting_time": "1 sec",
+			"duration": "5 secs",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Stench"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Devitalize Air"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 4
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "college",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Air"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 10
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "092c8ebf-5def-43f0-b69f-682a820db362",
+			"type": "spell",
+			"name": "Falling Sky",
+			"reference": "MAS9",
+			"reference_highlight": "Falling Sky",
+			"tags": [
+				"Artillery",
+				"Air"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Air"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Area",
+			"casting_cost": "2/1d",
+			"maintenance_cost": "-",
+			"casting_time": "1 sec/2 base cost",
+			"duration": "Instant",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Concussion"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Destroy Air"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 4
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "college",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Air"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 8
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "43e36f53-2c66-4663-a784-83cc6dcaff49",
+			"type": "spell",
+			"name": "Twisting Terror",
+			"reference": "MAS10",
+			"reference_highlight": "Twisting Terror",
+			"tags": [
+				"Artillery",
+				"Air"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Air"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Regular",
+			"casting_cost": "2/1 yard moved",
+			"maintenance_cost": "-",
+			"casting_time": "1 sec/2 base cost",
+			"duration": "Special",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Windstorm"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 4
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "college",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Air"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 10
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "da811d5b-5211-4ce6-b8f6-7b4a5114c0f3",
+			"type": "spell",
+			"name": "Creeping Plague",
+			"reference": "MAS10",
+			"reference_highlight": "Creeping Plague",
+			"tags": [
+				"Artillery",
+				"Animal"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Animal"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Area",
+			"casting_cost": "2",
+			"maintenance_cost": "Same",
+			"casting_time": "2 secs",
+			"duration": "1 minute",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": false,
+				"prereqs": [
+					{
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 5
+								}
+							},
+							{
+								"type": "spell_prereq",
+								"sub_type": "name",
+								"has": true,
+								"qualifier": {
+									"compare": "is",
+									"qualifier": "Beast-Summoning"
+								},
+								"quantity": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							},
+							{
+								"type": "spell_prereq",
+								"sub_type": "name",
+								"has": true,
+								"qualifier": {
+									"compare": "is",
+									"qualifier": "Vermin Control"
+								},
+								"quantity": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							}
+						]
+					},
+					{
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Magery"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 4
+								}
+							},
+							{
+								"type": "spell_prereq",
+								"sub_type": "name",
+								"has": true,
+								"qualifier": {
+									"compare": "is",
+									"qualifier": "Create Animal"
+								},
+								"quantity": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							}
+						]
+					}
+				]
+			}
+		},
+		{
+			"id": "dcecebb6-3dfb-43cb-8243-7f89aa6f8127",
+			"type": "spell",
+			"name": "Death Field",
+			"reference": "MAS11",
+			"reference_highlight": "Death Field",
+			"tags": [
+				"Artillery",
+				"Body Control"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Body Control"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Area",
+			"resist": "HT",
+			"casting_cost": "2/1d",
+			"casting_time": "1/2 base cost",
+			"duration": "Intantaneous",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Deathtouch"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 4
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "college",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Body Control"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 10
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "beb717a3-29c5-4785-9b66-ae229a655051",
+			"type": "spell",
+			"name": "Plague Touch",
+			"reference": "MAS11",
+			"reference_highlight": "Plague Touch",
+			"tags": [
+				"Artillery",
+				"Body Control",
+				"Necromancy"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Body Control",
+				"Necromancy"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Melee",
+			"casting_cost": "Any multiple of 3",
+			"casting_time": "2 secs",
+			"duration": "Special",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 4
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Deathtouch"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Pestilence"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Sense Foes"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "2199eb94-f8b8-49f5-859e-b512be6ff5be",
+			"type": "spell",
+			"name": "Psychic Scream",
+			"reference": "MAS12",
+			"reference_highlight": "Psychic Scream",
+			"tags": [
+				"Artillery",
+				"Communication \u0026 Empathy"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Communication \u0026 Empathy"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Regular",
+			"casting_cost": "3/yard radius",
+			"casting_time": "1 sec/yard radius",
+			"duration": "10 secs",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Mind-Sending"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 4
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "college",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Communications \u0026 Empathy"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 10
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "d49048a9-f67d-4de6-ac89-407c225a28f0",
+			"type": "spell",
+			"name": "Boulder Barrage",
+			"reference": "MAS12",
+			"reference_highlight": "Boulder Barrage",
+			"tags": [
+				"Artillery",
+				"Earth"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Earth"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Area",
+			"casting_cost": "2/1d+1",
+			"casting_time": "1/2 base cost",
+			"duration": "Instantaneous",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Rain of Stones"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Stone Missile"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 4
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "college",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Earth"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 10
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "a9332514-44e5-4936-82c0-8a380e813cc7",
+			"type": "spell",
+			"name": "Sand Blast",
+			"reference": "MAS12",
+			"reference_highlight": "Sand Blast",
+			"tags": [
+				"Artillery",
+				"Earth"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Earth"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Regular",
+			"casting_cost": "2/1d×Cone width",
+			"casting_time": "1/1d",
+			"duration": "Instantaneous",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Sand Jet"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Sandstorm"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 4
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "8c3a1085-2440-4641-a4d6-20c5eed70847",
+			"type": "spell",
+			"name": "Seismic Shock",
+			"reference": "MAS13",
+			"reference_highlight": "Seismic Shock",
+			"tags": [
+				"Artillery",
+				"Earth"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Earth"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Area",
+			"casting_cost": "8",
+			"casting_time": "1 sec",
+			"duration": "Instantaneous",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "college",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Earth"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Earthquake"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 4
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "cd2d6606-9e5e-4004-b775-402e052ae10b",
+			"type": "spell",
+			"name": "Doom Wish",
+			"reference": "MAS14",
+			"reference_highlight": "Doom Wish",
+			"tags": [
+				"Artillery",
+				"Enchantment"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Enchantment"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Enchantment",
+			"casting_cost": "2000",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 6
+										}
+									},
+									{
+										"type": "attribute_prereq",
+										"has": true,
+										"qualifier": {
+											"compare": "at_least",
+											"qualifier": 17
+										},
+										"which": "st"
+									}
+								]
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 5
+										}
+									},
+									{
+										"type": "attribute_prereq",
+										"has": true,
+										"qualifier": {
+											"compare": "at_least",
+											"qualifier": 18
+										},
+										"which": "st"
+									}
+								]
+							},
+							{
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 4
+										}
+									},
+									{
+										"type": "attribute_prereq",
+										"has": true,
+										"qualifier": {
+											"compare": "at_least",
+											"qualifier": 19
+										},
+										"which": "iq"
+									}
+								]
+							},
+							{
+								"type": "attribute_prereq",
+								"has": true,
+								"qualifier": {
+									"compare": "at_least",
+									"qualifier": 20
+								},
+								"which": "iq"
+							}
+						]
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Wish"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 3
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "7afdf175-6b1e-43fe-ab02-8242d481c362",
+			"type": "spell",
+			"name": "Vengeful Staff",
+			"reference": "MAS14",
+			"reference_highlight": "Vengeful Staff",
+			"tags": [
+				"Artillery",
+				"Enchantment"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Enchantment"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Enchantment",
+			"casting_cost": "20/1d",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 3
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Enchant"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Explode"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "2231bc78-afd8-4809-8939-ba1673e460be",
+			"type": "spell",
+			"name": "Fire Swarm",
+			"reference": "MAS14",
+			"reference_highlight": "Fire Swarm",
+			"tags": [
+				"Artillery",
+				"Fire"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Fire"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Regular",
+			"casting_cost": "2/1d×cone width",
+			"casting_time": "1 sec/1d",
+			"duration": "Instantaneous",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "college",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Fire"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 10
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 4
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Fireball"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Flame Jet"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "3751f35e-5d17-4a8d-b442-db72a6dcb2c9",
+			"type": "spell",
+			"name": "Improved Explosive Fireball",
+			"reference": "MAS15",
+			"reference_highlight": "Improved Explosive Fireball",
+			"tags": [
+				"Artillery",
+				"Fire"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Fire"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Missile",
+			"casting_cost": "3-3xMagery#",
+			"casting_time": "1-3 secs",
+			"duration": "Instantaneous",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "college",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Fire"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 10
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 4
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Explosive Fireball"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					}
+				]
+			},
+			"weapons": [
+				{
+					"id": "ba0ad782-9676-4461-bfba-15fc6fddd2fb",
+					"type": "ranged_weapon",
+					"damage": {
+						"type": "burn ex/3 points",
+						"base": "1d"
+					},
+					"accuracy": "2",
+					"range": "50/100",
+					"rate_of_fire": "1",
+					"defaults": [
+						{
+							"type": "dx",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Innate Attack",
+							"specialization": "Projectile"
+						}
+					],
+					"calc": {
+						"range": "50/100",
+						"damage": "1d burn ex/3 points"
+					}
+				}
+			]
+		},
+		{
+			"id": "4ab820bb-064c-438a-81b7-b23b9f016b4e",
+			"type": "spell",
+			"name": "Towering Inferno",
+			"reference": "MAS15",
+			"reference_highlight": "Towering Inferno",
+			"tags": [
+				"Artillery",
+				"Fire"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Fire"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Area",
+			"casting_cost": "2/1d",
+			"casting_time": "1/2 base cost",
+			"duration": "Instantaneous",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Rain of Fire"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "college",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Fire"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 7
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 4
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Fire Cloud"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "885ab04e-c32f-4a61-87e8-073c27f8f166",
+			"type": "spell",
+			"name": "Hell Zone",
+			"reference": "MAS16",
+			"reference_highlight": "Hell Zone",
+			"tags": [
+				"Artillery",
+				"Gate"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Gate"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Area",
+			"casting_cost": "10",
+			"maintenance_cost": "Half",
+			"casting_time": "1/2 base cost",
+			"duration": "10 secs",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Beacon"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "contains",
+							"qualifier": "Planar Summons"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 4
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "a09a7560-43ec-4560-9783-4e1bbe7fe514",
+			"type": "spell",
+			"name": "Null Sphere",
+			"reference": "MAS16",
+			"reference_highlight": "Null Sphere",
+			"tags": [
+				"Artillery",
+				"Gate"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Gate"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Missile",
+			"casting_cost": "4-4×Magery#",
+			"casting_time": "1-3 secs",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Create Gate"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 5
+						}
+					}
+				]
+			},
+			"weapons": [
+				{
+					"id": "fd2482df-5240-4836-9df0-67cba1a063ef",
+					"type": "ranged_weapon",
+					"damage": {
+						"type": "Special"
+					},
+					"accuracy": "2",
+					"range": "40/80",
+					"rate_of_fire": "1",
+					"recoil": "1",
+					"defaults": [
+						{
+							"type": "dx",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Innate Attack",
+							"specialization": "Projectile"
+						}
+					],
+					"calc": {
+						"range": "40/80",
+						"damage": "Special"
+					}
+				}
+			]
+		},
+		{
+			"id": "2a56edde-016c-4368-95dd-ed2d397acc21",
+			"type": "spell",
+			"name": "Splat",
+			"reference": "MAS16",
+			"reference_highlight": "Splat",
+			"tags": [
+				"Artillery",
+				"Gate",
+				"Movement"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Gate",
+				"Movement"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Area",
+			"casting_cost": "5",
+			"casting_time": "3 secs",
+			"duration": "Instantaneous",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Create Door"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 4
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "772a2552-86b5-45a2-994b-6e61a834dfad",
+			"type": "spell",
+			"name": "Disinfect",
+			"reference": "MAS17",
+			"reference_highlight": "Disinfect",
+			"tags": [
+				"Artillery",
+				"Healing"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Healing"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Area",
+			"resist": "HT",
+			"casting_cost": "2/1d",
+			"casting_time": "1/2 base cost",
+			"duration": "Instantaneous",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Cure Disease"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Remove Contagion"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "college",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Healing"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 10
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 4
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "6c77ab53-a8f9-4ccd-a858-a6e55a45ee5c",
+			"type": "spell",
+			"name": "Create Trap",
+			"reference": "MAS17",
+			"reference_highlight": "Create Trap",
+			"tags": [
+				"Artillery",
+				"Illusion \u0026 Creation"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Illusion \u0026 Creation"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Area",
+			"casting_cost": "5",
+			"casting_time": "1 sec/yard",
+			"duration": "5 secs",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Create Object"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "college",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Illusion \u0026 Creation"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 4
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "99f8e80e-cf65-467e-b14a-f75a1d28c4a6",
+			"type": "spell",
+			"name": "Mirror, Mirror",
+			"reference": "MAS17",
+			"reference_highlight": "Mirror, Mirror",
+			"tags": [
+				"Artillery",
+				"Illusion \u0026 Creation"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Illusion \u0026 Creation"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Area",
+			"resist": "Special",
+			"casting_cost": "10",
+			"maintenance_cost": "Half",
+			"casting_time": "1 sec/yard",
+			"duration": "1 minute or phantoms destroyed",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Initiative"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Phantom"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 4
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "9b6c4f7d-a6b8-4dca-b3e8-3d95e97534b0",
+			"type": "spell",
+			"name": "Sunburst",
+			"reference": "MAS18",
+			"reference_highlight": "Sunburst",
+			"tags": [
+				"Artillery",
+				"Light \u0026 Darkness"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Light \u0026 Darkness"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Missile",
+			"casting_cost": "2-2×Magery#",
+			"casting_time": "1-3 secs",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "college",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Light \u0026 Darkness"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 10
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Flash"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Sunbolt"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 3
+						}
+					}
+				]
+			},
+			"weapons": [
+				{
+					"id": "7ca2114b-d549-4877-b9c3-42c606c63dc2",
+					"type": "ranged_weapon",
+					"damage": {
+						"type": "Special"
+					},
+					"accuracy": "1",
+					"range": "25/50",
+					"rate_of_fire": "1",
+					"defaults": [
+						{
+							"type": "dx",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Innate Attack",
+							"specialization": "Projectile"
+						}
+					],
+					"calc": {
+						"range": "25/50",
+						"damage": "Special"
+					}
+				}
+			]
+		},
+		{
+			"id": "c0984a58-ba58-4a54-a264-faef8ab5f3d7",
+			"type": "spell",
+			"name": "Sun's Arc",
+			"reference": "MAS18",
+			"reference_highlight": "Sun's Arc",
+			"tags": [
+				"Artillery",
+				"Light \u0026 Darkness"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Light \u0026 Darkness"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Regular",
+			"casting_cost": "5/1d",
+			"casting_time": "1-3 secs",
+			"duration": "Instantaneous",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "college",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Light \u0026 Darkness"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 10
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Light Jet"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Sunbolt"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 4
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "ced88706-0304-449d-ba14-0fd840075ea1",
+			"type": "spell",
+			"name": "Explosive Mine",
+			"reference": "MAS19",
+			"reference_highlight": "Explosive Mine",
+			"tags": [
+				"Artillery",
+				"Making \u0026 Breaking"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Making \u0026 Breaking"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Regular",
+			"casting_cost": "4/1d",
+			"casting_time": "1-3 secs",
+			"duration": "1 minute or triggered",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "college",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Making \u0026 Breaking"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 10
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Explode"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 3
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "30d852de-6755-4c85-9c9f-8763ad5c4fa7",
+			"type": "spell",
+			"name": "Minefield",
+			"reference": "MAS19",
+			"reference_highlight": "Minefield",
+			"tags": [
+				"Artillery",
+				"Making \u0026 Breaking"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Making \u0026 Breaking"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Area",
+			"casting_cost": "2-4×Magery",
+			"casting_time": "1 sec/1d",
+			"duration": "1 minute or minefield cleared",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Explosive Mine"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 4
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "6c5ed454-8b20-4a1b-b5b6-98270fe853bf",
+			"type": "spell",
+			"name": "Mana Storm",
+			"reference": "MAS19",
+			"reference_highlight": "Mana Storm",
+			"tags": [
+				"Artillery",
+				"Meta"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Meta"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Area",
+			"casting_cost": "3",
+			"maintenance_cost": "Same",
+			"casting_time": "1 sec/yard",
+			"duration": "10",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Drain Mana"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Restore Mana"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 4
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "96388d9f-e7e1-456b-9c5c-773df3bd69a2",
+			"type": "spell",
+			"name": "Punishment Circle",
+			"reference": "MAS19",
+			"reference_highlight": "Punishment Circle",
+			"tags": [
+				"Artillery",
+				"Meta",
+				"Necromancy"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Meta",
+				"Necromancy"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Area",
+			"casting_cost": "3",
+			"maintenance_cost": "Same",
+			"casting_time": "1 sec/yard",
+			"duration": "1 minute",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "spell_prereq",
+								"sub_type": "name",
+								"has": true,
+								"qualifier": {
+									"compare": "is",
+									"qualifier": "Pentagram"
+								},
+								"quantity": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							},
+							{
+								"type": "spell_prereq",
+								"sub_type": "name",
+								"has": true,
+								"qualifier": {
+									"compare": "is",
+									"qualifier": "Repel Spirits"
+								},
+								"quantity": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							}
+						]
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 3
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "fd2a9672-dbe3-403b-a67d-9dc8002b4b85",
+			"type": "spell",
+			"name": "Mass Mutilation",
+			"reference": "MAS20",
+			"reference_highlight": "Mass Mutilation",
+			"tags": [
+				"Artillery",
+				"Mind Control"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Mind Control"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Area",
+			"resist": "Will",
+			"casting_cost": "4",
+			"casting_time": "1 sec/yard",
+			"duration": "1 sec",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Madness"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Mass Suggestion"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "college",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Mind Control"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 10
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 4
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "e2ca03d2-7d82-4a41-bf52-f4ec5ea9fb4f",
+			"type": "spell",
+			"name": "Stabbing Party",
+			"reference": "MAS20",
+			"reference_highlight": "Stabbing Party",
+			"tags": [
+				"Artillery",
+				"Mind Control"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Mind Control"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Area",
+			"resist": "Will",
+			"casting_cost": "4",
+			"casting_time": "1 sec/yard",
+			"duration": "1 sec",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Command"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Mass Suggestion"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "college",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Mind Control"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 10
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 4
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "96cd3891-903a-4112-bf11-d0c2ac322d51",
+			"type": "spell",
+			"name": "Collision",
+			"reference": "MAS21",
+			"reference_highlight": "Collision",
+			"tags": [
+				"Artillery",
+				"Movement"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Movement"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Regular",
+			"casting_cost": "1/2ST",
+			"casting_time": "3 secs",
+			"duration": "Instantaneous",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Poltergeist"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Pull"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "college",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Movement"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 10
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 4
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "17bb2254-38db-4716-913e-e072adf58429",
+			"type": "spell",
+			"name": "Crushing Fist",
+			"reference": "MAS21",
+			"reference_highlight": "Crushing Fist",
+			"tags": [
+				"Artillery",
+				"Movement"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Movement"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Area",
+			"casting_cost": "3",
+			"casting_time": "1 sec",
+			"duration": "Instantaneous",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Distant Blow"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Wizard Hand"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "college",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Movement"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 10
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 4
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "1dbf0583-71cc-4934-b602-55bc942553df",
+			"type": "spell",
+			"name": "Slasher",
+			"reference": "MAS22",
+			"reference_highlight": "Slasher",
+			"tags": [
+				"Artillery",
+				"Movement"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Movement"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Area",
+			"casting_cost": "2/lb",
+			"casting_time": "1 sec/yd",
+			"duration": "5 secs or until weapons are destroyed",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Dancing Object"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Winged Knife"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "college",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Movement"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 10
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 4
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "02f938d7-b9f8-441b-bdd9-1be10605a316",
+			"type": "spell",
+			"name": "Spirit Incursion",
+			"reference": "MAS22",
+			"reference_highlight": "Spirit Incursion",
+			"tags": [
+				"Artillery",
+				"Necromancy"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Necromancy"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Area",
+			"casting_cost": "3",
+			"maintenance_cost": "Same",
+			"casting_time": "1 sec/yd",
+			"duration": "10 secs",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Skull-Spirit"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "college",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Necromancy"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 10
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 4
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "40913dde-b1eb-43e7-a63b-dd7473761a13",
+			"type": "spell",
+			"name": "Self-Destruct",
+			"reference": "MAS23",
+			"reference_highlight": "Self-Destruct",
+			"tags": [
+				"Artillery",
+				"Fire",
+				"Meta",
+				"Necromancy"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Fire",
+				"Meta",
+				"Necromancy"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Regular",
+			"casting_cost": "12",
+			"casting_time": "1 sec",
+			"duration": "Instantaneous",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Explode"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "spell_prereq",
+								"sub_type": "college",
+								"has": true,
+								"qualifier": {
+									"compare": "is",
+									"qualifier": "Fire"
+								},
+								"quantity": {
+									"compare": "at_least",
+									"qualifier": 10
+								}
+							},
+							{
+								"type": "spell_prereq",
+								"sub_type": "college",
+								"has": true,
+								"qualifier": {
+									"compare": "is",
+									"qualifier": "Meta"
+								},
+								"quantity": {
+									"compare": "at_least",
+									"qualifier": 10
+								}
+							},
+							{
+								"type": "spell_prereq",
+								"sub_type": "college",
+								"has": true,
+								"qualifier": {
+									"compare": "is",
+									"qualifier": "Necromancy"
+								},
+								"quantity": {
+									"compare": "at_least",
+									"qualifier": 10
+								}
+							}
+						]
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "college_count",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Plant"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 10
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "3a238037-860d-441c-b041-d7337aaaaa9b",
+			"type": "spell",
+			"name": "Devil's Dust",
+			"reference": "MAS23",
+			"reference_highlight": "Devil's Dust",
+			"tags": [
+				"Artillery",
+				"Plant"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Plant"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Area",
+			"resist": "HT",
+			"casting_cost": "5",
+			"casting_time": "1 sec",
+			"duration": "5 secs",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Pollen Cloud"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "college",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Plant"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 10
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 4
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "f23d1b80-8d2b-4ac9-b53b-74bb5a03d381",
+			"type": "spell",
+			"name": "Ironweed",
+			"reference": "MAS23",
+			"reference_highlight": "Ironweed",
+			"tags": [
+				"Artillery",
+				"Plant"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Plant"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Area",
+			"casting_cost": "1",
+			"casting_time": "1 sec/yard",
+			"duration": "1 minute",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Essential Wood"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Plant Growth"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "a620401f-4285-43b7-b1f7-ebf923217eaf",
+			"type": "spell",
+			"name": "Diminishing Dome",
+			"reference": "MAS24",
+			"reference_highlight": "Diminishing Dome",
+			"tags": [
+				"Artillery",
+				"Protection \u0026 Warning"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Protection \u0026 Warning"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Area",
+			"casting_cost": "4",
+			"casting_time": "1 sec",
+			"duration": "1 sec",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Force Dome"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 4
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "409bcd2b-f7ad-45e7-8cbf-be8ccedbed92",
+			"type": "spell",
+			"name": "Force Ball",
+			"reference": "MAS24",
+			"reference_highlight": "Force Ball",
+			"tags": [
+				"Artillery",
+				"Movement",
+				"Protection \u0026 Warning"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Movement",
+				"Protection \u0026 Warning"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Missile",
+			"casting_cost": "2-2×Magery#",
+			"casting_time": "1-3 secs",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Catch Spell"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Force Dome"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Sense Foes"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 4
+						}
+					}
+				]
+			},
+			"weapons": [
+				{
+					"id": "a11729f6-7c01-4218-a0eb-c19a49dcab8b",
+					"type": "ranged_weapon",
+					"damage": {
+						"type": "cr dkb/2 energy",
+						"base": "1d"
+					},
+					"accuracy": "2",
+					"range": "80",
+					"rate_of_fire": "1",
+					"defaults": [
+						{
+							"type": "dx",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Innate Attack",
+							"specialization": "Projectile"
+						}
+					],
+					"calc": {
+						"range": "80",
+						"damage": "1d cr dkb/2 energy"
+					}
+				}
+			]
+		},
+		{
+			"id": "6db8ca54-2110-4f17-8c4f-f955c3a6a168",
+			"type": "spell",
+			"name": "Improved Concussion",
+			"reference": "MAS25",
+			"reference_highlight": "Improved Concussion",
+			"tags": [
+				"Artillery",
+				"Sound"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Sound"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Missile",
+			"casting_cost": "3-3×Magery#",
+			"casting_time": "1-3 secs",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Concussion"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Great Voice"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "college",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Sound"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 7
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 4
+						}
+					}
+				]
+			},
+			"weapons": [
+				{
+					"id": "a11729f6-7c01-4218-a0eb-c19a49dcab8b",
+					"type": "ranged_weapon",
+					"damage": {
+						"type": "cr ex/3 energy",
+						"base": "1d"
+					},
+					"accuracy": "2",
+					"range": "40/80",
+					"rate_of_fire": "1",
+					"defaults": [
+						{
+							"type": "dx",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Innate Attack",
+							"specialization": "Projectile"
+						}
+					],
+					"calc": {
+						"range": "40/80",
+						"damage": "1d cr ex/3 energy"
+					}
+				}
+			]
+		},
+		{
+			"id": "716c8dca-5e69-42a9-8661-92b6401bb649",
+			"type": "spell",
+			"name": "Perilous Pulsations",
+			"reference": "MAS25",
+			"reference_highlight": "Perilous Pulsations",
+			"tags": [
+				"Artillery",
+				"Sound"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Sound"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Area",
+			"casting_cost": "5",
+			"maintenance_cost": "Same",
+			"casting_time": "3 secs",
+			"duration": "5 secs",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Concussion"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Sound Jet"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "college",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Sound"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 7
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 4
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "d3e9429e-f371-4a62-8c2c-17aa6b956d1a",
+			"type": "spell",
+			"name": "Withering Wail",
+			"reference": "MAS25",
+			"reference_highlight": "Withering Wail",
+			"tags": [
+				"Artillery",
+				"Sound"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Sound"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Regular",
+			"casting_cost": "2/1d",
+			"casting_time": "1 sec/1d",
+			"duration": "Instantaneous",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Great Voice"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Noise"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "college",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Sound"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 10
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 4
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "0afe7ce9-f361-42b6-b28f-1dcb3daa2149",
+			"type": "spell",
+			"name": "Death Ray",
+			"reference": "MAS26",
+			"reference_highlight": "Death Ray",
+			"tags": [
+				"Artillery",
+				"Radiation",
+				"Technological"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Technological"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Missile",
+			"casting_cost": "2-2×Magery#",
+			"casting_time": "1-3 secs",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Lightning"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Radiation Jet"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 4
+						}
+					}
+				]
+			},
+			"weapons": [
+				{
+					"id": "8602f1c9-cce3-4d52-a4cd-5853c4b8a948",
+					"type": "ranged_weapon",
+					"damage": {
+						"type": "burn sur/2 energy",
+						"base": "1d",
+						"armor_divisor": 5
+					},
+					"accuracy": "3",
+					"range": "50",
+					"rate_of_fire": "1",
+					"defaults": [
+						{
+							"type": "dx",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Innate Attack",
+							"specialization": "Beam"
+						}
+					],
+					"calc": {
+						"range": "50",
+						"damage": "1d(5) burn sur/2 energy"
+					}
+				}
+			]
+		},
+		{
+			"id": "e6ec5b79-63cb-411f-b777-dc71019020cd",
+			"type": "spell",
+			"name": "Flammability",
+			"reference": "MAS26",
+			"reference_highlight": "Flammability",
+			"tags": [
+				"Artillery",
+				"Energy",
+				"Fire",
+				"Technological"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Fire",
+				"Technological"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Missile",
+			"casting_cost": "2",
+			"maintenance_cost": "Half",
+			"casting_time": "1-3 secs",
+			"duration": "1 minute",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Essential Fuel"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Purify Fuel"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 3
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "fa7147f4-3eeb-4459-9f86-04cd1bba168d",
+			"type": "spell",
+			"name": "Arctic Blast",
+			"reference": "MAS27",
+			"reference_highlight": "Arctic Blast",
+			"tags": [
+				"Artillery",
+				"Water"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Water"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Regular",
+			"casting_cost": "2/1d×Cone width",
+			"casting_time": "1 sec/1d",
+			"duration": "Instantaneous",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Frostbite"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Icy Breath"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 4
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "3810a42a-6afe-4767-821c-92d3cb1d7c18",
+			"type": "spell",
+			"name": "Cone of Corrosion",
+			"reference": "MAS27",
+			"reference_highlight": "Cone of Corrosion",
+			"tags": [
+				"Artillery",
+				"Water"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Water"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Regular",
+			"casting_cost": "2/1d-1×Cone width",
+			"casting_time": "1 sec/1d-1",
+			"duration": "Instantaneous",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Acid Jet"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 4
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "5110d1fb-9c68-4664-b84a-47806a7b08d1",
+			"type": "spell",
+			"name": "Scald",
+			"reference": "MAS27",
+			"reference_highlight": "Scald",
+			"tags": [
+				"Artillery",
+				"Water"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Water"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Area",
+			"casting_cost": "2/1d",
+			"casting_time": "1 sec/1d",
+			"duration": "Instantaneous",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Create Steam"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Steam Jet"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 4
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "07b90b87-0918-4555-8c7b-751616cd3172",
+			"type": "spell",
+			"name": "Wilting",
+			"reference": "MAS28",
+			"reference_highlight": "Wilting",
+			"tags": [
+				"Artillery",
+				"Water"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Water"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Area",
+			"casting_cost": "2/1d",
+			"casting_time": "1 sec/1d",
+			"duration": "Instantaneous",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Dehydrate"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "college",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Water"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 10
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 4
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "565d3fb0-3b9d-4b21-a682-4ba417777851",
+			"type": "spell",
+			"name": "Chain Lightning",
+			"reference": "MAS29",
+			"reference_highlight": "Chain Lightning",
+			"tags": [
+				"Artillery",
+				"Air",
+				"Weather"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Air",
+				"Weather"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Missile",
+			"casting_cost": "2-2×Magery#",
+			"casting_time": "1-3 secs",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Ball of Lightning"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Resist Lightning"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 4
+						}
+					}
+				]
+			},
+			"weapons": [
+				{
+					"id": "dce7d2c1-9551-4a87-8872-2838a3d5b7bc",
+					"type": "ranged_weapon",
+					"damage": {
+						"type": "burn sur",
+						"base": "1d",
+						"modifier_per_die": -1
+					},
+					"accuracy": "3",
+					"range": "100",
+					"rate_of_fire": "1",
+					"defaults": [
+						{
+							"type": "dx",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Innate Attack",
+							"specialization": "Projectile"
+						}
+					],
+					"calc": {
+						"range": "100",
+						"damage": "1d (-1 per die) burn sur"
+					}
+				}
+			]
+		},
+		{
+			"id": "031c12a6-f1db-436f-84b3-53cd1eed5701",
+			"type": "spell",
+			"name": "Ice Storm",
+			"reference": "MAS29",
+			"reference_highlight": "Ice Storm",
+			"tags": [
+				"Artillery",
+				"Water",
+				"Weather"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Water",
+				"Weather"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Area",
+			"casting_cost": "2/1d",
+			"casting_time": "1 sec/1d",
+			"duration": "Instantaneous",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Hail"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Storm"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 4
+						}
+					}
+				]
+			}
+		},
+		{
+			"id": "852fb73e-3c72-4da0-81a9-24dc4bf8f156",
+			"type": "spell",
+			"name": "Improved Explosive Lightning",
+			"reference": "MAS29",
+			"reference_highlight": "Improved Explosive Lightning",
+			"tags": [
+				"Artillery",
+				"Air",
+				"Weather"
+			],
+			"difficulty": "iq/vh",
+			"college": [
+				"Air",
+				"Weather"
+			],
+			"power_source": "Arcane",
+			"spell_class": "Missile",
+			"casting_cost": "3-3×Magery#",
+			"casting_time": "1-3 secs",
+			"points": 1,
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "spell_prereq",
+								"sub_type": "college",
+								"has": true,
+								"qualifier": {
+									"compare": "is",
+									"qualifier": "Air"
+								},
+								"quantity": {
+									"compare": "at_least",
+									"qualifier": 10
+								}
+							},
+							{
+								"type": "spell_prereq",
+								"sub_type": "college",
+								"has": true,
+								"qualifier": {
+									"compare": "is",
+									"qualifier": "Weather"
+								},
+								"quantity": {
+									"compare": "at_least",
+									"qualifier": 10
+								}
+							}
+						]
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "Explosive Lightning"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 4
+						}
+					}
+				]
+			},
+			"weapons": [
+				{
+					"id": "dce7d2c1-9551-4a87-8872-2838a3d5b7bc",
+					"type": "ranged_weapon",
+					"damage": {
+						"type": "burn ex/3 energy",
+						"base": "1d-1"
+					},
+					"accuracy": "3",
+					"range": "50/100",
+					"rate_of_fire": "1",
+					"defaults": [
+						{
+							"type": "dx",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Innate Attack",
+							"specialization": "Projectile"
+						}
+					],
+					"calc": {
+						"range": "50/100",
+						"damage": "1d-1 burn ex/3 energy"
+					}
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
This adds all artillery spells from GURPS Magic - Artillery Spells.

This doesn't include one-college Magery, but it's better than nothing.

The Self-Destruct spell is listed in the sidebar with multiple suggestions of how it could be handled, Adding Explode as a prerequisite is a suggestion for making it more restricted, but is easy for a GM to delete.