### PR TITLE
Add Dungeon Fantasy 6 - 40 Artifacts Magic Armour

### DIFF
--- a/Library/Dungeon Fantasy/Dungeon Fantasy 6/Dungeon Fantasy 6 Equipment.eqp
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 6/Dungeon Fantasy 6 Equipment.eqp
@@ -1,0 +1,234 @@
+{
+	"type": "equipment_list",
+	"version": 4,
+	"rows": [
+		{
+			"id": "6a106f3c-5bbc-4c5a-b7b4-9e0f913c370c",
+			"type": "equipment",
+			"description": "Bracers of Force",
+			"reference": "DF6:5",
+			"reference_highlight": "Bracers of Force",
+			"notes": "11 FP as power item",
+			"legality_class": "4",
+			"tags": [
+				"Armor"
+			],
+			"quantity": 1,
+			"value": 2500,
+			"weight": "6.75 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "all",
+					"amount": 1
+				},
+				{
+					"type": "dr_bonus",
+					"location": "arm",
+					"amount": 6
+				}
+			],
+			"equipped": true,
+			"calc": {
+				"extended_value": 2500,
+				"extended_weight": "6.75 lb"
+			}
+		},
+		{
+			"id": "67128375-bd2e-4ad3-80e3-c477a57222b7",
+			"type": "equipment",
+			"description": "Bracers of Force",
+			"reference": "DF6:5",
+			"reference_highlight": "Bracers of Force",
+			"notes": "11 FP as power item",
+			"legality_class": "4",
+			"tags": [
+				"Armor"
+			],
+			"quantity": 1,
+			"value": 10000,
+			"weight": "6.75 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "all",
+					"amount": 2
+				},
+				{
+					"type": "dr_bonus",
+					"location": "arm",
+					"amount": 6
+				}
+			],
+			"equipped": true,
+			"calc": {
+				"extended_value": 10000,
+				"extended_weight": "6.75 lb"
+			}
+		},
+		{
+			"id": "bb078dbe-6a2f-481a-86c5-dbe7bb4273fa",
+			"type": "equipment",
+			"description": "Bracers of Force",
+			"reference": "DF6:5",
+			"reference_highlight": "Bracers of Force",
+			"notes": "11 FP as power item",
+			"legality_class": "4",
+			"tags": [
+				"Armor"
+			],
+			"quantity": 1,
+			"value": 40000,
+			"weight": "6.75 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "all",
+					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"location": "arm",
+					"amount": 6
+				}
+			],
+			"equipped": true,
+			"calc": {
+				"extended_value": 40000,
+				"extended_weight": "6.75 lb"
+			}
+		},
+		{
+			"id": "df270e22-fd3d-450a-a683-017dba2b263f",
+			"type": "equipment",
+			"description": "Bracers of Force",
+			"reference": "DF6:5",
+			"reference_highlight": "Bracers of Force",
+			"notes": "11 FP as power item",
+			"legality_class": "4",
+			"tags": [
+				"Armor"
+			],
+			"quantity": 1,
+			"value": 150000,
+			"weight": "6.75 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "all",
+					"amount": 4
+				},
+				{
+					"type": "dr_bonus",
+					"location": "arm",
+					"amount": 6
+				}
+			],
+			"equipped": true,
+			"calc": {
+				"extended_value": 150000,
+				"extended_weight": "6.75 lb"
+			}
+		},
+		{
+			"id": "88361cb4-af1f-4e99-94c2-71d4933e5c5f",
+			"type": "equipment",
+			"description": "Bracers of Force",
+			"reference": "DF6:5",
+			"reference_highlight": "Bracers of Force",
+			"notes": "11 FP as power item",
+			"legality_class": "4",
+			"tags": [
+				"Armor"
+			],
+			"quantity": 1,
+			"value": 400000,
+			"weight": "6.75 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "all",
+					"amount": 5
+				},
+				{
+					"type": "dr_bonus",
+					"location": "arm",
+					"amount": 6
+				}
+			],
+			"equipped": true,
+			"calc": {
+				"extended_value": 400000,
+				"extended_weight": "6.75 lb"
+			}
+		},
+		{
+			"id": "0ca15145-d020-4e7b-97f1-31140277d8d7",
+			"type": "equipment",
+			"description": "Hooded Robe of Protection",
+			"reference": "DF6:7",
+			"reference_highlight": "Hooded Robe of Protection",
+			"notes": "25 FP as power item",
+			"legality_class": "4",
+			"tags": [
+				"Armor",
+				"Power Item"
+			],
+			"quantity": 1,
+			"value": 9600,
+			"weight": "5 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "arm",
+					"amount": 2
+				},
+				{
+					"type": "dr_bonus",
+					"location": "foot",
+					"amount": 2
+				},
+				{
+					"type": "dr_bonus",
+					"location": "groin",
+					"amount": 2
+				},
+				{
+					"type": "dr_bonus",
+					"location": "hand",
+					"amount": 2
+				},
+				{
+					"type": "dr_bonus",
+					"location": "leg",
+					"amount": 2
+				},
+				{
+					"type": "dr_bonus",
+					"location": "neck",
+					"amount": 2
+				},
+				{
+					"type": "dr_bonus",
+					"location": "skull",
+					"amount": 2
+				},
+				{
+					"type": "dr_bonus",
+					"location": "torso",
+					"amount": 2
+				},
+				{
+					"type": "dr_bonus",
+					"location": "vitals",
+					"amount": 2
+				}
+			],
+			"equipped": true,
+			"calc": {
+				"extended_value": 9600,
+				"extended_weight": "5 lb"
+			}
+		}
+	]
+}


### PR DESCRIPTION
Most items in [Dungeon Fantasy 6 - 40 Artifacts][] do not have a listed price
and require a subjective process to asses their value,
but the Bracers of Force and Hooded Robe of Protection _do_ have listed prices and are useful for equipping spellcasters.

[Dungeon Fantasy 6 - 40 Artifacts]: https://warehouse23.com/products/gurps-dungeon-fantasy-6-40-artifacts