### PR TITLE
Fix Tired and Reeling damage formula of Centaur

### DIFF
--- a/Library/Dungeon Fantasy RPG/Monsters/Centaur.gcs
+++ b/Library/Dungeon Fantasy RPG/Monsters/Centaur.gcs
@@ -162,7 +162,7 @@
 					},
 					{
 						"state": "Tired",
-						"expression": "round($fp/3)",
+						"expression": "ceil($fp/3)-1",
 						"explanation": "Move, Dodge and ST are halved (B426)",
 						"ops": [
 							"halve_move",
@@ -244,7 +244,7 @@
 					},
 					{
 						"state": "Reeling",
-						"expression": "round($hp/3)",
+						"expression": "ceil($hp/3)-1",
 						"explanation": "Move and Dodge are halved (B419)",
 						"ops": [
 							"halve_move",
@@ -1568,7 +1568,7 @@
 		}
 	],
 	"created_date": "2023-10-29T19:17:28Z",
-	"modified_date": "2023-10-30T08:20:45Z",
+	"modified_date": "2023-10-30T15:55:20Z",
 	"calc": {
 		"swing": "2d-1",
 		"thrust": "1d",


### PR DESCRIPTION
As discovered in https://github.com/richardwilkes/gcs_master_library/pull/253 my GCS was generating sheets with the incorrect default formula.