### PR TITLE
Add support for Low-Tech's chest and abdomen hit locations and armor

### DIFF
--- a/Library/Low Tech/Low Tech Armor (by location).eqp
+++ b/Library/Low Tech/Low Tech Armor (by location).eqp
@@ -2654,6 +2654,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 1
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 1
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 1
 						},
@@ -2675,6 +2685,16 @@
 					"cost": "+50",
 					"weight": "+6 lb",
 					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 1
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 1
+						},
 						{
 							"type": "dr_bonus",
 							"location": "torso",
@@ -2700,6 +2720,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 3
 						},
@@ -2721,6 +2751,16 @@
 					"cost": "+150",
 					"weight": "+12 lb",
 					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 2
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 2
+						},
 						{
 							"type": "dr_bonus",
 							"location": "torso",
@@ -2746,6 +2786,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 3
 						},
@@ -2767,6 +2817,16 @@
 					"cost": "+600",
 					"weight": "+28 lb",
 					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 4
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 4
+						},
 						{
 							"type": "dr_bonus",
 							"location": "torso",
@@ -2792,6 +2852,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 2
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 2
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 2
 						},
@@ -2813,6 +2883,16 @@
 					"cost": "+200",
 					"weight": "+20 lb",
 					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						},
 						{
 							"type": "dr_bonus",
 							"location": "torso",
@@ -2838,6 +2918,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 2
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 2
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 2
 						},
@@ -2859,6 +2949,16 @@
 					"cost": "+100",
 					"weight": "+30 lb",
 					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						},
 						{
 							"type": "dr_bonus",
 							"location": "torso",
@@ -2884,6 +2984,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 2
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 2
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 2
 						},
@@ -2905,6 +3015,16 @@
 					"cost": "+220",
 					"weight": "+26 lb",
 					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						},
 						{
 							"type": "dr_bonus",
 							"location": "torso",
@@ -2930,6 +3050,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 4
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 4
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 4
 						},
@@ -2951,6 +3081,16 @@
 					"cost": "+320",
 					"weight": "+16 lb",
 					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						},
 						{
 							"type": "dr_bonus",
 							"location": "torso",
@@ -2976,6 +3116,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 4
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 4
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 4
 						},
@@ -2997,6 +3147,16 @@
 					"cost": "+1100",
 					"weight": "+40 lb",
 					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 5
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 5
+						},
 						{
 							"type": "dr_bonus",
 							"location": "torso",
@@ -3022,6 +3182,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 2
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 2
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 2
 						},
@@ -3043,6 +3213,16 @@
 					"cost": "+250",
 					"weight": "+25 lb",
 					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						},
 						{
 							"type": "dr_bonus",
 							"location": "torso",
@@ -3068,6 +3248,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 3
 						},
@@ -3089,6 +3279,16 @@
 					"cost": "+500",
 					"weight": "+12 lb",
 					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						},
 						{
 							"type": "dr_bonus",
 							"location": "torso",
@@ -3114,6 +3314,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 4
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 4
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 4
 						},
@@ -3135,6 +3345,16 @@
 					"cost": "+1200",
 					"weight": "+18 lb",
 					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 5
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 5
+						},
 						{
 							"type": "dr_bonus",
 							"location": "torso",
@@ -3160,6 +3380,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 3
 						},
@@ -3181,6 +3411,16 @@
 					"cost": "+900",
 					"weight": "+24 lb",
 					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 4
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 4
+						},
 						{
 							"type": "dr_bonus",
 							"location": "torso",
@@ -3206,6 +3446,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 5
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 5
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 5
 						},
@@ -3227,6 +3477,16 @@
 					"cost": "+1000",
 					"weight": "+20 lb",
 					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 5
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 5
+						},
 						{
 							"type": "dr_bonus",
 							"location": "torso",
@@ -3252,6 +3512,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 6
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 6
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 6
 						},
@@ -3273,6 +3543,16 @@
 					"cost": "+900",
 					"weight": "+10 lb",
 					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						},
 						{
 							"type": "dr_bonus",
 							"location": "torso",
@@ -3298,6 +3578,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 5
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 5
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 5
 						},
@@ -3319,6 +3609,16 @@
 					"cost": "+2000",
 					"weight": "+45 lb",
 					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 6
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 6
+						},
 						{
 							"type": "dr_bonus",
 							"location": "torso",
@@ -3344,6 +3644,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 3
 						},
@@ -3367,6 +3677,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 6
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 6
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 6
 						},
@@ -3388,6 +3708,16 @@
 					"cost": "+4000",
 					"weight": "+32 lb",
 					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 9
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 9
+						},
 						{
 							"type": "dr_bonus",
 							"location": "torso",
@@ -3434,7 +3764,19 @@
 					"disabled": true,
 					"tech_level": "0",
 					"cost": "+26.25",
-					"weight": "+9 lb"
+					"weight": "+9 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 1
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 1
+						}
+					]
 				},
 				{
 					"id": "53c959e4-6ab3-4f1f-92e4-dae5a01bd24f",
@@ -3445,7 +3787,19 @@
 					"disabled": true,
 					"tech_level": "0",
 					"cost": "+37.5",
-					"weight": "+4.5 lb"
+					"weight": "+4.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 1
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 1
+						}
+					]
 				},
 				{
 					"id": "641dae89-e18c-41e8-b3ea-b398a89d5e9d",
@@ -3456,7 +3810,19 @@
 					"disabled": true,
 					"tech_level": "0",
 					"cost": "+187.5",
-					"weight": "+18.75 lb"
+					"weight": "+18.75 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "267686f7-9768-48ef-9a2d-b868a0746532",
@@ -3467,7 +3833,19 @@
 					"disabled": true,
 					"tech_level": "0",
 					"cost": "+112.5",
-					"weight": "+9 lb"
+					"weight": "+9 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 2
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 2
+						}
+					]
 				},
 				{
 					"id": "99d59b41-adc2-4dca-947e-20a7f2201ddb",
@@ -3478,7 +3856,19 @@
 					"disabled": true,
 					"tech_level": "0",
 					"cost": "+262.5",
-					"weight": "+15 lb"
+					"weight": "+15 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "b01e6f54-7013-4254-85fe-3e39362570a0",
@@ -3489,7 +3879,19 @@
 					"disabled": true,
 					"tech_level": "0",
 					"cost": "+450",
-					"weight": "+21 lb"
+					"weight": "+21 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 4
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 4
+						}
+					]
 				},
 				{
 					"id": "f8f24520-db69-49bb-896e-7e029a6dda96",
@@ -3500,7 +3902,19 @@
 					"disabled": true,
 					"tech_level": "0",
 					"cost": "+75",
-					"weight": "+9 lb"
+					"weight": "+9 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 2
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 2
+						}
+					]
 				},
 				{
 					"id": "3209e445-cf8f-4f04-9812-9db4e9fe161b",
@@ -3511,7 +3925,19 @@
 					"disabled": true,
 					"tech_level": "0",
 					"cost": "+150",
-					"weight": "+15 lb"
+					"weight": "+15 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "a69241f5-3692-4872-a0af-9d79ddd73d2d",
@@ -3522,7 +3948,19 @@
 					"disabled": true,
 					"tech_level": "0",
 					"cost": "+37.5",
-					"weight": "+15 lb"
+					"weight": "+15 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 2
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 2
+						}
+					]
 				},
 				{
 					"id": "e9359a02-4eca-4744-8eb7-2ac5ce3c5709",
@@ -3533,7 +3971,19 @@
 					"disabled": true,
 					"tech_level": "0",
 					"cost": "+75",
-					"weight": "+22.5 lb"
+					"weight": "+22.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "fb9d5e92-46f3-4bd0-a771-dc418793002b",
@@ -3544,7 +3994,19 @@
 					"disabled": true,
 					"tech_level": "1",
 					"cost": "+90",
-					"weight": "+11.25 lb"
+					"weight": "+11.25 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 2
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 2
+						}
+					]
 				},
 				{
 					"id": "20853ba3-b7f8-4179-9be5-16a7ed4122d9",
@@ -3555,7 +4017,19 @@
 					"disabled": true,
 					"tech_level": "1",
 					"cost": "+165",
-					"weight": "+19.5 lb"
+					"weight": "+19.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "0975c195-45c8-4d77-92a2-7a64fd41070c",
@@ -3566,7 +4040,19 @@
 					"disabled": true,
 					"tech_level": "1",
 					"cost": "+393.75",
-					"weight": "+26.25 lb"
+					"weight": "+26.25 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 4
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 4
+						}
+					]
 				},
 				{
 					"id": "3dd2a04d-8932-4c60-b5bd-5a7cfc08357c",
@@ -3577,7 +4063,19 @@
 					"disabled": true,
 					"tech_level": "1",
 					"cost": "+240",
-					"weight": "+12 lb"
+					"weight": "+12 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "62ce2ccf-62e6-46cf-a4f1-42138c6ad15a",
@@ -3588,7 +4086,19 @@
 					"disabled": true,
 					"tech_level": "1",
 					"cost": "+412.5",
-					"weight": "+21 lb"
+					"weight": "+21 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 4
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 4
+						}
+					]
 				},
 				{
 					"id": "d53045bb-eee8-4e8a-888c-be41ba283b18",
@@ -3599,7 +4109,19 @@
 					"disabled": true,
 					"tech_level": "1",
 					"cost": "+825",
-					"weight": "+30 lb"
+					"weight": "+30 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 5
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 5
+						}
+					]
 				},
 				{
 					"id": "e8286f01-559d-4983-8270-81207644a103",
@@ -3610,7 +4132,19 @@
 					"disabled": true,
 					"tech_level": "2",
 					"cost": "+93.75",
-					"weight": "+11.25 lb"
+					"weight": "+11.25 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 2
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 2
+						}
+					]
 				},
 				{
 					"id": "8febb3aa-7be0-4853-bffb-2a1ec10dbc9f",
@@ -3621,7 +4155,19 @@
 					"disabled": true,
 					"tech_level": "2",
 					"cost": "+187.5",
-					"weight": "+18.75 lb"
+					"weight": "+18.75 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "a177bcac-b588-46fe-9058-c9c11d8ceaa1",
@@ -3632,7 +4178,19 @@
 					"disabled": true,
 					"tech_level": "2",
 					"cost": "+225",
-					"weight": "+13.5 lb"
+					"weight": "+13.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "0f54ebf3-199b-4076-8e33-4e0d79d298bf",
@@ -3643,7 +4201,19 @@
 					"disabled": true,
 					"tech_level": "2",
 					"cost": "+375",
-					"weight": "+9 lb"
+					"weight": "+9 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "84a3e45d-2c07-4d5b-afb4-f1435a9f3eb5",
@@ -3654,7 +4224,19 @@
 					"disabled": true,
 					"tech_level": "2",
 					"cost": "+675",
-					"weight": "+11.25 lb"
+					"weight": "+11.25 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 4
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 4
+						}
+					]
 				},
 				{
 					"id": "a1d5b56f-154f-4947-a630-c4752bce27e3",
@@ -3665,7 +4247,19 @@
 					"disabled": true,
 					"tech_level": "2",
 					"cost": "+900",
-					"weight": "+13.5 lb"
+					"weight": "+13.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 5
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 5
+						}
+					]
 				},
 				{
 					"id": "2d381594-5935-4efc-9632-f987dc9220b0",
@@ -3676,7 +4270,19 @@
 					"disabled": true,
 					"tech_level": "2",
 					"cost": "+450",
-					"weight": "+12 lb"
+					"weight": "+12 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "af298a3d-c93c-4ffc-b70e-b9cc22a6c262",
@@ -3687,7 +4293,19 @@
 					"disabled": true,
 					"tech_level": "2",
 					"cost": "+675",
-					"weight": "+18 lb"
+					"weight": "+18 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 4
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 4
+						}
+					]
 				},
 				{
 					"id": "5e356f01-9d46-4e46-8324-578b2f7d9110",
@@ -3698,7 +4316,19 @@
 					"disabled": true,
 					"tech_level": "2",
 					"cost": "+900",
-					"weight": "+24 lb"
+					"weight": "+24 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 5
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 5
+						}
+					]
 				},
 				{
 					"id": "5df2a804-665e-4358-a2dc-03e5a035e6ad",
@@ -3709,7 +4339,19 @@
 					"disabled": true,
 					"tech_level": "3",
 					"cost": "+750",
-					"weight": "+15 lb"
+					"weight": "+15 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 5
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 5
+						}
+					]
 				},
 				{
 					"id": "5f2c797c-2cbb-4e4e-a214-7b46953a0fdc",
@@ -3720,7 +4362,19 @@
 					"disabled": true,
 					"tech_level": "3",
 					"cost": "+1125",
-					"weight": "+22.5 lb"
+					"weight": "+22.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 6
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 6
+						}
+					]
 				},
 				{
 					"id": "4f032a52-d77c-436f-bcbf-52b81e567ad4",
@@ -3731,7 +4385,19 @@
 					"disabled": true,
 					"tech_level": "4",
 					"cost": "+675",
-					"weight": "+7.5 lb"
+					"weight": "+7.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "cd9361a0-0241-4036-96a5-2308c3bf6bcb",
@@ -3742,7 +4408,19 @@
 					"disabled": true,
 					"tech_level": "4",
 					"cost": "+1350",
-					"weight": "+15 lb"
+					"weight": "+15 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 5
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 5
+						}
+					]
 				},
 				{
 					"id": "b3a5f198-1fad-47a0-8409-ce180a292085",
@@ -3753,7 +4431,19 @@
 					"disabled": true,
 					"tech_level": "4",
 					"cost": "+1500",
-					"weight": "+33.75 lb"
+					"weight": "+33.75 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 6
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 6
+						}
+					]
 				},
 				{
 					"id": "6eb09fcd-a098-4250-aafe-08a07c1f1913",
@@ -3764,7 +4454,19 @@
 					"disabled": true,
 					"tech_level": "4",
 					"cost": "+750",
-					"weight": "+6 lb"
+					"weight": "+6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "886faf3f-93e6-4dbf-a768-3024f38ca2f2",
@@ -3775,7 +4477,19 @@
 					"disabled": true,
 					"tech_level": "4",
 					"cost": "+1875",
-					"weight": "+15 lb"
+					"weight": "+15 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 6
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 6
+						}
+					]
 				},
 				{
 					"id": "40abbf51-e3f2-4bbd-a734-2c3d9c198617",
@@ -3786,7 +4500,19 @@
 					"disabled": true,
 					"tech_level": "4",
 					"cost": "+3000",
-					"weight": "+24 lb"
+					"weight": "+24 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 9
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 9
+						}
+					]
 				},
 				{
 					"id": "b7c103d5-ff6a-47c4-bdbc-293d96e17f30",
@@ -3822,7 +4548,19 @@
 					"disabled": true,
 					"tech_level": "0",
 					"cost": "+8.75",
-					"weight": "+3 lb"
+					"weight": "+3 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 1
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 1
+						}
+					]
 				},
 				{
 					"id": "0481b7e8-8812-4d66-ad21-88b17764fac5",
@@ -3833,7 +4571,19 @@
 					"disabled": true,
 					"tech_level": "0",
 					"cost": "+12.5",
-					"weight": "+1.5 lb"
+					"weight": "+1.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 1
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 1
+						}
+					]
 				},
 				{
 					"id": "1e629bae-632a-4f76-be62-277850264dca",
@@ -3844,7 +4594,19 @@
 					"disabled": true,
 					"tech_level": "0",
 					"cost": "+62.5",
-					"weight": "+6.25 lb"
+					"weight": "+6.25 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "e89f005b-8e6c-47d4-938b-e50c6f6b7304",
@@ -3855,7 +4617,19 @@
 					"disabled": true,
 					"tech_level": "0",
 					"cost": "+37.5",
-					"weight": "+3 lb"
+					"weight": "+3 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 2
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 2
+						}
+					]
 				},
 				{
 					"id": "677a5605-7c6f-48e3-8d67-f8796c2bcb06",
@@ -3866,7 +4640,19 @@
 					"disabled": true,
 					"tech_level": "0",
 					"cost": "+87.5",
-					"weight": "+5 lb"
+					"weight": "+5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "5bbc186e-e591-4e1a-8d8e-379ad80b80de",
@@ -3877,7 +4663,19 @@
 					"disabled": true,
 					"tech_level": "0",
 					"cost": "+150",
-					"weight": "+7 lb"
+					"weight": "+7 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 4
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 4
+						}
+					]
 				},
 				{
 					"id": "b4367671-d3f4-40da-8eae-b09dff0d76a4",
@@ -3888,7 +4686,19 @@
 					"disabled": true,
 					"tech_level": "0",
 					"cost": "+25",
-					"weight": "+3 lb"
+					"weight": "+3 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 2
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 2
+						}
+					]
 				},
 				{
 					"id": "eb8eff76-b0b6-4e64-b406-e17054285f1f",
@@ -3899,7 +4709,19 @@
 					"disabled": true,
 					"tech_level": "0",
 					"cost": "+50",
-					"weight": "+5 lb"
+					"weight": "+5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "ba3984e4-e52d-438b-bc00-23b2e8ad7bbe",
@@ -3910,7 +4732,19 @@
 					"disabled": true,
 					"tech_level": "0",
 					"cost": "+12.5",
-					"weight": "+5 lb"
+					"weight": "+5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 2
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 2
+						}
+					]
 				},
 				{
 					"id": "91b8a96e-63b4-49a0-9027-0b7ee28f6125",
@@ -3921,7 +4755,19 @@
 					"disabled": true,
 					"tech_level": "0",
 					"cost": "+25",
-					"weight": "+7.5 lb"
+					"weight": "+7.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "485a1f74-32ff-4a77-a55e-70a46309e2f1",
@@ -3932,7 +4778,19 @@
 					"disabled": true,
 					"tech_level": "1",
 					"cost": "+30",
-					"weight": "+3.75 lb"
+					"weight": "+3.75 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 2
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 2
+						}
+					]
 				},
 				{
 					"id": "c4e343ba-8a80-4a4e-8bea-08737c0f6e73",
@@ -3943,7 +4801,19 @@
 					"disabled": true,
 					"tech_level": "1",
 					"cost": "+55",
-					"weight": "+6.5 lb"
+					"weight": "+6.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "e6f26d29-be6b-43e1-b57e-e0ee48f8fc08",
@@ -3954,7 +4824,19 @@
 					"disabled": true,
 					"tech_level": "1",
 					"cost": "+131.25",
-					"weight": "+8.75 lb"
+					"weight": "+8.75 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 4
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 4
+						}
+					]
 				},
 				{
 					"id": "b1644cdb-ef3b-430d-be50-2bda641ee92f",
@@ -3965,7 +4847,19 @@
 					"disabled": true,
 					"tech_level": "1",
 					"cost": "+80",
-					"weight": "+4 lb"
+					"weight": "+4 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "a546e3d8-3d74-4841-98a0-f5a634ee1188",
@@ -3976,7 +4870,19 @@
 					"disabled": true,
 					"tech_level": "1",
 					"cost": "+137.5",
-					"weight": "+7 lb"
+					"weight": "+7 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 4
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 4
+						}
+					]
 				},
 				{
 					"id": "166fb6e0-6392-43ef-a42d-a2eb97d31f29",
@@ -3987,7 +4893,19 @@
 					"disabled": true,
 					"tech_level": "1",
 					"cost": "+275",
-					"weight": "+10 lb"
+					"weight": "+10 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 5
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 5
+						}
+					]
 				},
 				{
 					"id": "d09ff948-537c-45e7-bd56-99a7034db812",
@@ -3998,7 +4916,19 @@
 					"disabled": true,
 					"tech_level": "2",
 					"cost": "+31.25",
-					"weight": "+3.75 lb"
+					"weight": "+3.75 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 2
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 2
+						}
+					]
 				},
 				{
 					"id": "ad9d8c40-5486-4762-8431-888aecbdbec8",
@@ -4009,7 +4939,19 @@
 					"disabled": true,
 					"tech_level": "2",
 					"cost": "+62.5",
-					"weight": "+6.25 lb"
+					"weight": "+6.25 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "6b019ef0-93d2-4b69-b2d7-03e033105f4e",
@@ -4020,7 +4962,19 @@
 					"disabled": true,
 					"tech_level": "2",
 					"cost": "+75",
-					"weight": "+4.5 lb"
+					"weight": "+4.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "8b698b6e-50af-47a7-ac8e-1c19a2550fca",
@@ -4031,7 +4985,19 @@
 					"disabled": true,
 					"tech_level": "2",
 					"cost": "+125",
-					"weight": "+3 lb"
+					"weight": "+3 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "7cd63330-6d36-4ceb-9764-82cf10c8e24c",
@@ -4042,7 +5008,19 @@
 					"disabled": true,
 					"tech_level": "2",
 					"cost": "+225",
-					"weight": "+3.75 lb"
+					"weight": "+3.75 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 4
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 4
+						}
+					]
 				},
 				{
 					"id": "80cc10ad-cac3-4b25-b0ff-a1c2a97e0fc0",
@@ -4053,7 +5031,19 @@
 					"disabled": true,
 					"tech_level": "2",
 					"cost": "+300",
-					"weight": "+4.5 lb"
+					"weight": "+4.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 5
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 5
+						}
+					]
 				},
 				{
 					"id": "0e50f9f0-8943-4334-ab94-a99e9b150124",
@@ -4064,7 +5054,19 @@
 					"disabled": true,
 					"tech_level": "2",
 					"cost": "+150",
-					"weight": "+4 lb"
+					"weight": "+4 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "b3e52795-a6ec-44d1-88a1-b56d91112e9c",
@@ -4075,7 +5077,19 @@
 					"disabled": true,
 					"tech_level": "2",
 					"cost": "+225",
-					"weight": "+6 lb"
+					"weight": "+6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 4
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 4
+						}
+					]
 				},
 				{
 					"id": "98c128ed-44da-4ae1-86a9-6b16431e5a3d",
@@ -4086,7 +5100,19 @@
 					"disabled": true,
 					"tech_level": "2",
 					"cost": "+300",
-					"weight": "+8 lb"
+					"weight": "+8 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 5
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 5
+						}
+					]
 				},
 				{
 					"id": "a7497314-60e8-4a63-ad2b-05394878e8b0",
@@ -4097,7 +5123,19 @@
 					"disabled": true,
 					"tech_level": "3",
 					"cost": "+250",
-					"weight": "+5 lb"
+					"weight": "+5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 5
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 5
+						}
+					]
 				},
 				{
 					"id": "1c0b16b4-6257-4fb7-af81-aee645d521d5",
@@ -4108,7 +5146,19 @@
 					"disabled": true,
 					"tech_level": "3",
 					"cost": "+375",
-					"weight": "+7.5 lb"
+					"weight": "+7.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 6
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 6
+						}
+					]
 				},
 				{
 					"id": "3fce41fb-22b5-49e1-8bef-e003da4e582d",
@@ -4119,7 +5169,19 @@
 					"disabled": true,
 					"tech_level": "4",
 					"cost": "+225",
-					"weight": "+2.5 lb"
+					"weight": "+2.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "71d8cbd5-5d03-4223-8c2f-3288d81f9bc2",
@@ -4130,7 +5192,19 @@
 					"disabled": true,
 					"tech_level": "4",
 					"cost": "+450",
-					"weight": "+5 lb"
+					"weight": "+5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 5
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 5
+						}
+					]
 				},
 				{
 					"id": "c53ce684-f67b-4843-aa0d-bdf33114f8b8",
@@ -4141,7 +5215,19 @@
 					"disabled": true,
 					"tech_level": "4",
 					"cost": "+500",
-					"weight": "+11.25 lb"
+					"weight": "+11.25 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 6
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 6
+						}
+					]
 				},
 				{
 					"id": "6fba2965-b38d-4e67-9af7-740d18581208",
@@ -4152,7 +5238,19 @@
 					"disabled": true,
 					"tech_level": "4",
 					"cost": "+250",
-					"weight": "+2 lb"
+					"weight": "+2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "0a4fd2b8-87ad-47fe-8c9b-7d9703d629d6",
@@ -4163,7 +5261,19 @@
 					"disabled": true,
 					"tech_level": "4",
 					"cost": "+625",
-					"weight": "+5 lb"
+					"weight": "+5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 6
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 6
+						}
+					]
 				},
 				{
 					"id": "8bb32d5a-0910-4cb5-8277-eb3827d67a10",
@@ -4174,7 +5284,19 @@
 					"disabled": true,
 					"tech_level": "4",
 					"cost": "+1000",
-					"weight": "+8 lb"
+					"weight": "+8 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 9
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 9
+						}
+					]
 				},
 				{
 					"id": "556980fb-7f10-4953-87b5-878834075b5b",

--- a/Library/Low Tech/Low Tech Armor (by material).eqp
+++ b/Library/Low Tech/Low Tech Armor (by material).eqp
@@ -90,6 +90,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 1
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 1
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 1
 						},
@@ -108,7 +118,19 @@
 					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit.; Don time: 21 secs.",
 					"disabled": true,
 					"cost": "+26.25",
-					"weight": "+9 lb"
+					"weight": "+9 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 1
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 1
+						}
+					]
 				},
 				{
 					"id": "0e273cc4-a1cf-49f5-b1c6-a158b166e2a8",
@@ -118,7 +140,19 @@
 					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit.; Don time: 21 secs.",
 					"disabled": true,
 					"cost": "+8.75",
-					"weight": "+3 lb"
+					"weight": "+3 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 1
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 1
+						}
+					]
 				},
 				{
 					"id": "67313c43-ac9e-475d-9284-b6abf29cd277",
@@ -369,6 +403,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 1
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 1
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 1
 						},
@@ -387,7 +431,19 @@
 					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit.; Don time: 12 secs.",
 					"disabled": true,
 					"cost": "+37.5",
-					"weight": "+4.5 lb"
+					"weight": "+4.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 1
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 1
+						}
+					]
 				},
 				{
 					"id": "d57f958a-a9bd-445f-912e-1c730009fdb9",
@@ -397,7 +453,19 @@
 					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit.; Don time: 12 secs.",
 					"disabled": true,
 					"cost": "+12.5",
-					"weight": "+1.5 lb"
+					"weight": "+1.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 1
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 1
+						}
+					]
 				},
 				{
 					"id": "2176877c-ce90-442f-a66c-c6175799be2c",
@@ -648,6 +716,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 3
 						},
@@ -666,7 +744,19 @@
 					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit.; Don time: 23 secs.",
 					"disabled": true,
 					"cost": "+187.5",
-					"weight": "+18.75 lb"
+					"weight": "+18.75 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "16ed5aae-c4c2-44b9-ac9d-99989086be4f",
@@ -676,7 +766,19 @@
 					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit.; Don time: 23 secs.",
 					"disabled": true,
 					"cost": "+62.5",
-					"weight": "+6.25 lb"
+					"weight": "+6.25 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "4e677e95-0e35-4207-a59d-0b74aecb80e5",
@@ -927,6 +1029,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 2
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 2
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 2
 						},
@@ -945,7 +1057,19 @@
 					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit.; Don time: 15 secs.",
 					"disabled": true,
 					"cost": "+112.5",
-					"weight": "+9 lb"
+					"weight": "+9 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 2
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 2
+						}
+					]
 				},
 				{
 					"id": "b54c3cdd-6d03-4a20-b20f-e01a5502365f",
@@ -955,7 +1079,19 @@
 					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit.; Don time: 15 secs.",
 					"disabled": true,
 					"cost": "+37.5",
-					"weight": "+3 lb"
+					"weight": "+3 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 2
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 2
+						}
+					]
 				},
 				{
 					"id": "790860df-fb24-46af-8f16-e6c10ec87c5e",
@@ -1206,6 +1342,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 3
 						},
@@ -1224,7 +1370,19 @@
 					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit.; Don time: 23 secs.",
 					"disabled": true,
 					"cost": "+262.5",
-					"weight": "+15 lb"
+					"weight": "+15 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "856f4823-697a-44b1-be13-c2b6eeb87cde",
@@ -1234,7 +1392,19 @@
 					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit.; Don time: 23 secs.",
 					"disabled": true,
 					"cost": "+87.5",
-					"weight": "+5 lb"
+					"weight": "+5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "049466f1-2e2a-4163-ba47-7f49a1c253dc",
@@ -1485,6 +1655,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 4
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 4
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 4
 						},
@@ -1503,7 +1683,19 @@
 					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit.; Don time: 23 secs.",
 					"disabled": true,
 					"cost": "+450",
-					"weight": "+21 lb"
+					"weight": "+21 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 4
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 4
+						}
+					]
 				},
 				{
 					"id": "8b971fd6-e1c3-4a6a-8940-1299ea763725",
@@ -1513,7 +1705,19 @@
 					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit.; Don time: 23 secs.",
 					"disabled": true,
 					"cost": "+150",
-					"weight": "+7 lb"
+					"weight": "+7 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 4
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 4
+						}
+					]
 				},
 				{
 					"id": "2aca0289-cdcf-480d-be71-09a86796d928",
@@ -1764,6 +1968,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 2
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 2
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 2
 						},
@@ -1782,7 +1996,19 @@
 					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit.; Don time: 23 secs.",
 					"disabled": true,
 					"cost": "+75",
-					"weight": "+9 lb"
+					"weight": "+9 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 2
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 2
+						}
+					]
 				},
 				{
 					"id": "b0017f66-9961-4069-bd5a-0decda8a01d2",
@@ -1792,7 +2018,19 @@
 					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit.; Don time: 23 secs.",
 					"disabled": true,
 					"cost": "+25",
-					"weight": "+3 lb"
+					"weight": "+3 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 2
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 2
+						}
+					]
 				},
 				{
 					"id": "fd697dcf-36f5-4568-b38e-abc4da780419",
@@ -2043,6 +2281,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 3
 						},
@@ -2061,7 +2309,19 @@
 					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit.; Don time: 23 secs.",
 					"disabled": true,
 					"cost": "+150",
-					"weight": "+15 lb"
+					"weight": "+15 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "c10d39dd-cd5f-4eaa-9043-ff5c3af4833e",
@@ -2071,7 +2331,19 @@
 					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit.; Don time: 23 secs.",
 					"disabled": true,
 					"cost": "+50",
-					"weight": "+5 lb"
+					"weight": "+5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "564f63fb-579c-4bc3-90ec-8c42293c63f7",
@@ -2322,6 +2594,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 2
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 2
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 2
 						},
@@ -2340,7 +2622,19 @@
 					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit.; Don time: 23 secs.",
 					"disabled": true,
 					"cost": "+37.5",
-					"weight": "+15 lb"
+					"weight": "+15 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 2
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 2
+						}
+					]
 				},
 				{
 					"id": "ac098090-d140-41fc-84a0-196ba025b6de",
@@ -2350,7 +2644,19 @@
 					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit.; Don time: 23 secs.",
 					"disabled": true,
 					"cost": "+12.5",
-					"weight": "+5 lb"
+					"weight": "+5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 2
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 2
+						}
+					]
 				},
 				{
 					"id": "24056108-5ea2-40c2-9178-3a0648ef90e0",
@@ -2601,6 +2907,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 3
 						},
@@ -2619,7 +2935,19 @@
 					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit.; Don time: 23 secs.",
 					"disabled": true,
 					"cost": "+75",
-					"weight": "+22.5 lb"
+					"weight": "+22.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "fd5831e6-fcfe-4f80-baa9-1c60a1df8eb4",
@@ -2629,7 +2957,19 @@
 					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit.; Don time: 23 secs.",
 					"disabled": true,
 					"cost": "+25",
-					"weight": "+7.5 lb"
+					"weight": "+7.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "db68b48d-672d-40c9-aed6-197ccfb5b6f2",
@@ -2880,6 +3220,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 2
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 2
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 2
 						},
@@ -2898,7 +3248,19 @@
 					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit.; Don time: 15 secs.",
 					"disabled": true,
 					"cost": "+90",
-					"weight": "+11.25 lb"
+					"weight": "+11.25 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 2
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 2
+						}
+					]
 				},
 				{
 					"id": "e3241542-c8fa-4987-87c4-5eee06e1e8ea",
@@ -2908,7 +3270,19 @@
 					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit.; Don time: 15 secs.",
 					"disabled": true,
 					"cost": "+30",
-					"weight": "+3.75 lb"
+					"weight": "+3.75 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 2
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 2
+						}
+					]
 				},
 				{
 					"id": "20980154-97ee-4f0e-b12b-23ca0c751a11",
@@ -3159,6 +3533,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 3
 						},
@@ -3177,7 +3561,19 @@
 					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit.; Don time: 23 secs.",
 					"disabled": true,
 					"cost": "+165",
-					"weight": "+19.5 lb"
+					"weight": "+19.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "8a19d0b7-831d-4818-9974-5daa9f231cc9",
@@ -3187,7 +3583,19 @@
 					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit.; Don time: 23 secs.",
 					"disabled": true,
 					"cost": "+55",
-					"weight": "+6.5 lb"
+					"weight": "+6.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "b00dd9a2-a3be-4fd9-8d6d-431b51f582b2",
@@ -3438,6 +3846,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 4
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 4
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 4
 						},
@@ -3456,7 +3874,19 @@
 					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit.; Don time: 23 secs.",
 					"disabled": true,
 					"cost": "+393.75",
-					"weight": "+26.25 lb"
+					"weight": "+26.25 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 4
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 4
+						}
+					]
 				},
 				{
 					"id": "97005a5b-d5ce-4b94-b45d-1e46a92b54e0",
@@ -3466,7 +3896,19 @@
 					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit.; Don time: 23 secs.",
 					"disabled": true,
 					"cost": "+131.25",
-					"weight": "+8.75 lb"
+					"weight": "+8.75 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 4
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 4
+						}
+					]
 				},
 				{
 					"id": "40226efe-7408-4584-ad88-955fdcf4dcad",
@@ -3717,6 +4159,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 3
 						},
@@ -3735,7 +4187,19 @@
 					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit.; Don time: 23 secs.",
 					"disabled": true,
 					"cost": "+240",
-					"weight": "+12 lb"
+					"weight": "+12 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "0e9850d3-b25c-46a5-9ca8-2119ceae130b",
@@ -3745,7 +4209,19 @@
 					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit.; Don time: 23 secs.",
 					"disabled": true,
 					"cost": "+80",
-					"weight": "+4 lb"
+					"weight": "+4 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "c5b2370b-2bc8-46c6-a069-0e983c30f655",
@@ -3996,6 +4472,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 4
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 4
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 4
 						},
@@ -4014,7 +4500,19 @@
 					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit.; Don time: 23 secs.",
 					"disabled": true,
 					"cost": "+412.5",
-					"weight": "+21 lb"
+					"weight": "+21 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 4
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 4
+						}
+					]
 				},
 				{
 					"id": "6a05062d-443a-430d-801f-a1b58e0159ae",
@@ -4024,7 +4522,19 @@
 					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit.; Don time: 23 secs.",
 					"disabled": true,
 					"cost": "+137.5",
-					"weight": "+7 lb"
+					"weight": "+7 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 4
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 4
+						}
+					]
 				},
 				{
 					"id": "543cf0c2-06c3-4366-b413-c899f24fbdd3",
@@ -4275,6 +4785,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 5
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 5
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 5
 						},
@@ -4293,7 +4813,19 @@
 					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit.; Don time: 23 secs.",
 					"disabled": true,
 					"cost": "+825",
-					"weight": "+30 lb"
+					"weight": "+30 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 5
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 5
+						}
+					]
 				},
 				{
 					"id": "4e069c4f-5722-4c21-9d3b-abdc6f12b87f",
@@ -4303,7 +4835,19 @@
 					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit.; Don time: 23 secs.",
 					"disabled": true,
 					"cost": "+275",
-					"weight": "+10 lb"
+					"weight": "+10 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 5
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 5
+						}
+					]
 				},
 				{
 					"id": "8a24637f-f0f4-486e-b29b-42e2ce5ca7bc",
@@ -4554,6 +5098,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 2
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 2
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 2
 						},
@@ -4572,7 +5126,19 @@
 					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit.; Don time: 23 secs.",
 					"disabled": true,
 					"cost": "+93.75",
-					"weight": "+11.25 lb"
+					"weight": "+11.25 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 2
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 2
+						}
+					]
 				},
 				{
 					"id": "df3640a9-3808-4b08-a6b9-99f8a3746f22",
@@ -4582,7 +5148,19 @@
 					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit.; Don time: 23 secs.",
 					"disabled": true,
 					"cost": "+31.25",
-					"weight": "+3.75 lb"
+					"weight": "+3.75 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 2
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 2
+						}
+					]
 				},
 				{
 					"id": "3d135621-59e2-49f2-be82-4bb06f29e0e2",
@@ -4833,6 +5411,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 3
 						},
@@ -4851,7 +5439,19 @@
 					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit.; Don time: 23 secs.",
 					"disabled": true,
 					"cost": "+187.5",
-					"weight": "+18.75 lb"
+					"weight": "+18.75 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "5923588e-a049-4415-b210-41cd87c5427d",
@@ -4861,7 +5461,19 @@
 					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit.; Don time: 23 secs.",
 					"disabled": true,
 					"cost": "+62.5",
-					"weight": "+6.25 lb"
+					"weight": "+6.25 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "517af517-5dfb-4af1-85b2-8886a17984f8",
@@ -5112,6 +5724,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 3
 						},
@@ -5130,7 +5752,19 @@
 					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit.; Don time: 23 secs.",
 					"disabled": true,
 					"cost": "+225",
-					"weight": "+13.5 lb"
+					"weight": "+13.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "0469da3e-fa6f-49d1-9dbf-80f3489d732f",
@@ -5140,7 +5774,19 @@
 					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit.; Don time: 23 secs.",
 					"disabled": true,
 					"cost": "+75",
-					"weight": "+4.5 lb"
+					"weight": "+4.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "70419a53-2cdc-4341-ad8e-445d7c8f3ba9",
@@ -5391,6 +6037,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 3
 						},
@@ -5409,7 +6065,19 @@
 					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit.; Don time: 12 secs.",
 					"disabled": true,
 					"cost": "+375",
-					"weight": "+9 lb"
+					"weight": "+9 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "3656e5e5-15f1-4454-9745-299b9d5ba334",
@@ -5419,7 +6087,19 @@
 					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit.; Don time: 12 secs.",
 					"disabled": true,
 					"cost": "+125",
-					"weight": "+3 lb"
+					"weight": "+3 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "5a93f7d3-81af-4bf0-b597-b984253f26fe",
@@ -5670,6 +6350,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 4
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 4
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 4
 						},
@@ -5688,7 +6378,19 @@
 					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit.; Don time: 12 secs.",
 					"disabled": true,
 					"cost": "+675",
-					"weight": "+11.25 lb"
+					"weight": "+11.25 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 4
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 4
+						}
+					]
 				},
 				{
 					"id": "c85a4e61-58de-4b09-8ea3-428c869d6819",
@@ -5698,7 +6400,19 @@
 					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit.; Don time: 12 secs.",
 					"disabled": true,
 					"cost": "+225",
-					"weight": "+3.75 lb"
+					"weight": "+3.75 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 4
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 4
+						}
+					]
 				},
 				{
 					"id": "7f8d0fd4-cf48-4a18-83db-55ec1d2c2be9",
@@ -5949,6 +6663,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 5
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 5
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 5
 						},
@@ -5967,7 +6691,19 @@
 					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit.; Don time: 12 secs.",
 					"disabled": true,
 					"cost": "+900",
-					"weight": "+13.5 lb"
+					"weight": "+13.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 5
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 5
+						}
+					]
 				},
 				{
 					"id": "7b4564fb-b923-4be6-b6c1-20f1065c6c02",
@@ -5977,7 +6713,19 @@
 					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit.; Don time: 12 secs.",
 					"disabled": true,
 					"cost": "+300",
-					"weight": "+4.5 lb"
+					"weight": "+4.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 5
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 5
+						}
+					]
 				},
 				{
 					"id": "d3d053d2-dfd1-44c4-b133-e5fa753d53b3",
@@ -6228,6 +6976,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 3
 						},
@@ -6246,7 +7004,19 @@
 					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit.; Don time: 34 secs.",
 					"disabled": true,
 					"cost": "+450",
-					"weight": "+12 lb"
+					"weight": "+12 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "56808633-9dff-4e92-97ae-8fcf0ea2981f",
@@ -6256,7 +7026,19 @@
 					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit.; Don time: 34 secs.",
 					"disabled": true,
 					"cost": "+150",
-					"weight": "+4 lb"
+					"weight": "+4 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "7dd30a58-5e74-467f-8eaa-c60145a41174",
@@ -6507,6 +7289,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 4
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 4
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 4
 						},
@@ -6525,7 +7317,19 @@
 					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit.; Don time: 34 secs.",
 					"disabled": true,
 					"cost": "+675",
-					"weight": "+18 lb"
+					"weight": "+18 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 4
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 4
+						}
+					]
 				},
 				{
 					"id": "ce958b44-a686-40ec-98ba-3d5bb3015ce3",
@@ -6535,7 +7339,19 @@
 					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit.; Don time: 34 secs.",
 					"disabled": true,
 					"cost": "+225",
-					"weight": "+6 lb"
+					"weight": "+6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 4
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 4
+						}
+					]
 				},
 				{
 					"id": "b0e63d3e-f87d-444c-922e-0c60fdc24fc5",
@@ -6786,6 +7602,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 5
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 5
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 5
 						},
@@ -6804,7 +7630,19 @@
 					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit.; Don time: 34 secs.",
 					"disabled": true,
 					"cost": "+900",
-					"weight": "+24 lb"
+					"weight": "+24 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 5
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 5
+						}
+					]
 				},
 				{
 					"id": "da13b583-cf93-4d3b-815b-1dff0cd5db36",
@@ -6814,7 +7652,19 @@
 					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit.; Don time: 34 secs.",
 					"disabled": true,
 					"cost": "+300",
-					"weight": "+8 lb"
+					"weight": "+8 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 5
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 5
+						}
+					]
 				},
 				{
 					"id": "7c6851b2-f60d-4882-aa6d-2354ea7a2c23",
@@ -7065,6 +7915,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 5
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 5
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 5
 						},
@@ -7083,7 +7943,19 @@
 					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit.; Don time: 15 secs.",
 					"disabled": true,
 					"cost": "+750",
-					"weight": "+15 lb"
+					"weight": "+15 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 5
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 5
+						}
+					]
 				},
 				{
 					"id": "1cc91a43-aefb-4db0-8770-e8e336c2d776",
@@ -7093,7 +7965,19 @@
 					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit.; Don time: 15 secs.",
 					"disabled": true,
 					"cost": "+250",
-					"weight": "+5 lb"
+					"weight": "+5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 5
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 5
+						}
+					]
 				},
 				{
 					"id": "b8d4e8c1-1998-4b20-9262-fe9d0210c28e",
@@ -7344,6 +8228,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 6
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 6
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 6
 						},
@@ -7362,7 +8256,19 @@
 					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit.; Don time: 23 secs.",
 					"disabled": true,
 					"cost": "+1125",
-					"weight": "+22.5 lb"
+					"weight": "+22.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 6
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 6
+						}
+					]
 				},
 				{
 					"id": "79d4a03b-6184-4109-adb1-51e02452f26c",
@@ -7372,7 +8278,19 @@
 					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit.; Don time: 23 secs.",
 					"disabled": true,
 					"cost": "+375",
-					"weight": "+7.5 lb"
+					"weight": "+7.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 6
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 6
+						}
+					]
 				},
 				{
 					"id": "1dfe1d6a-f224-4e53-a341-c86bc691a784",
@@ -7623,6 +8541,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 3
 						},
@@ -7641,7 +8569,19 @@
 					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit.; Don time: 23 secs.",
 					"disabled": true,
 					"cost": "+675",
-					"weight": "+7.5 lb"
+					"weight": "+7.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "ca6de16d-1ec4-4714-bfe7-cf500c8ce2b4",
@@ -7651,7 +8591,19 @@
 					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit.; Don time: 23 secs.",
 					"disabled": true,
 					"cost": "+225",
-					"weight": "+2.5 lb"
+					"weight": "+2.5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "e1eeabde-e8c0-475c-9e94-e2d327ba63d8",
@@ -7902,6 +8854,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 5
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 5
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 5
 						},
@@ -7920,7 +8882,19 @@
 					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit.; Don time: 23 secs.",
 					"disabled": true,
 					"cost": "+1350",
-					"weight": "+15 lb"
+					"weight": "+15 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 5
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 5
+						}
+					]
 				},
 				{
 					"id": "f1ac34e2-d93e-484b-8278-40f470660548",
@@ -7930,7 +8904,19 @@
 					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit.; Don time: 23 secs.",
 					"disabled": true,
 					"cost": "+450",
-					"weight": "+5 lb"
+					"weight": "+5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 5
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 5
+						}
+					]
 				},
 				{
 					"id": "89884e8e-b998-49fc-b136-b7da4a45d0b5",
@@ -8181,6 +9167,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 6
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 6
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 6
 						},
@@ -8199,7 +9195,19 @@
 					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit.; Don time: 15 secs.",
 					"disabled": true,
 					"cost": "+1500",
-					"weight": "+33.75 lb"
+					"weight": "+33.75 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 6
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 6
+						}
+					]
 				},
 				{
 					"id": "3ec84705-d7dc-45ce-b52c-7eca47f72b29",
@@ -8209,7 +9217,19 @@
 					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit.; Don time: 15 secs.",
 					"disabled": true,
 					"cost": "+500",
-					"weight": "+11.25 lb"
+					"weight": "+11.25 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 6
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 6
+						}
+					]
 				},
 				{
 					"id": "0ed649c3-ca70-4e60-8360-e9dc9319789a",
@@ -8460,6 +9480,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 3
 						},
@@ -8478,7 +9508,19 @@
 					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit.; Don time: 34 secs.",
 					"disabled": true,
 					"cost": "+750",
-					"weight": "+6 lb"
+					"weight": "+6 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "073a958b-2f22-42ce-8145-d3300e00b5b0",
@@ -8488,7 +9530,19 @@
 					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit.; Don time: 34 secs.",
 					"disabled": true,
 					"cost": "+250",
-					"weight": "+2 lb"
+					"weight": "+2 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 3
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 3
+						}
+					]
 				},
 				{
 					"id": "1b45db21-24c4-4ac6-a52d-caab9631beb9",
@@ -8739,6 +9793,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 6
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 6
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 6
 						},
@@ -8757,7 +9821,19 @@
 					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit.; Don time: 34 secs.",
 					"disabled": true,
 					"cost": "+1875",
-					"weight": "+15 lb"
+					"weight": "+15 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 6
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 6
+						}
+					]
 				},
 				{
 					"id": "c8643d1d-4147-48e5-a28a-d4969f23cd7c",
@@ -8767,7 +9843,19 @@
 					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit.; Don time: 34 secs.",
 					"disabled": true,
 					"cost": "+625",
-					"weight": "+5 lb"
+					"weight": "+5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 6
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 6
+						}
+					]
 				},
 				{
 					"id": "861ad70d-71fc-4112-a794-1c2bf7c7e824",
@@ -9018,6 +10106,16 @@
 					"features": [
 						{
 							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 9
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 9
+						},
+						{
+							"type": "dr_bonus",
 							"location": "torso",
 							"amount": 9
 						},
@@ -9036,7 +10134,19 @@
 					"notes": "Hit location 9-10. Roll 1d; on 1, the vitals are hit.; Don time: 34 secs.",
 					"disabled": true,
 					"cost": "+3000",
-					"weight": "+24 lb"
+					"weight": "+24 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "torso",
+							"amount": 9
+						},
+						{
+							"type": "dr_bonus",
+							"location": "vitals",
+							"amount": 9
+						}
+					]
 				},
 				{
 					"id": "54fee43d-1cbb-4b03-bac1-0ed38674732b",
@@ -9046,7 +10156,19 @@
 					"notes": "Hit location 11. Roll 1d; on 1, the vitals are hit.; Don time: 34 secs.",
 					"disabled": true,
 					"cost": "+1000",
-					"weight": "+8 lb"
+					"weight": "+8 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"location": "abdomen",
+							"amount": 9
+						},
+						{
+							"type": "dr_bonus",
+							"location": "groin",
+							"amount": 9
+						}
+					]
 				},
 				{
 					"id": "2353e00c-bb74-44c5-b289-52073dcc648e",

--- a/Library/Low Tech/Low Tech Instant Armor.eqp
+++ b/Library/Low Tech/Low Tech Instant Armor.eqp
@@ -95,6 +95,36 @@
 			}
 		},
 		{
+			"id": "b82bcea7-98a0-4c79-8def-2896ec93407b",
+			"type": "equipment",
+			"description": "Brigandine, Light Abdomen Armor",
+			"reference": "LTIA6",
+			"notes": "Don: 23 secs; Holdout: -2; Reaction Pen.-2",
+			"tech_level": "4",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 225,
+			"weight": "2.5 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"location": "groin",
+					"amount": 3
+				}
+			],
+			"calc": {
+				"extended_value": 225,
+				"extended_weight": "2.5 lb"
+			}
+		},
+		{
 			"id": "bdcd4d91-0eab-42e5-aeba-94af674c7621",
 			"type": "equipment",
 			"description": "Brigandine, Light Arm Armor",
@@ -177,6 +207,36 @@
 			"calc": {
 				"extended_value": 238,
 				"extended_weight": "2.7 lb"
+			}
+		},
+		{
+			"id": "c4bca982-086a-40c5-83a3-0aa8a168cc4f",
+			"type": "equipment",
+			"description": "Brigandine, Light Chest Armor",
+			"reference": "LTIA6",
+			"notes": "Don: 23 secs; Holdout: -2; Reaction Pen.-2",
+			"tech_level": "4",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 675,
+			"weight": "7.5 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "torso",
+					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"location": "vitals",
+					"amount": 3
+				}
+			],
+			"calc": {
+				"extended_value": 675,
+				"extended_weight": "7.5 lb"
 			}
 		},
 		{
@@ -345,6 +405,37 @@
 			}
 		},
 		{
+			"id": "876bb337-b07e-4579-b56a-cb73cdbe9787",
+			"type": "equipment",
+			"description": "Brigandine, Medium Abdomen Armor",
+			"reference": "LTIA6",
+			"notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2",
+			"tech_level": "4",
+			"legality_class": "3",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 450,
+			"weight": "5 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 5
+				},
+				{
+					"type": "dr_bonus",
+					"location": "groin",
+					"amount": 5
+				}
+			],
+			"calc": {
+				"extended_value": 450,
+				"extended_weight": "5 lb"
+			}
+		},
+		{
 			"id": "0540bcaa-5c4c-4a3e-874d-3b13e88c063f",
 			"type": "equipment",
 			"description": "Brigandine, Medium Arm Armor",
@@ -430,6 +521,37 @@
 			"calc": {
 				"extended_value": 463,
 				"extended_weight": "5.2 lb"
+			}
+		},
+		{
+			"id": "afd0e8e8-6a97-4f1a-8a70-39d24119db24",
+			"type": "equipment",
+			"description": "Brigandine, Medium Chest Armor",
+			"reference": "LTIA6",
+			"notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2",
+			"tech_level": "4",
+			"legality_class": "3",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 1350,
+			"weight": "15 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "torso",
+					"amount": 5
+				},
+				{
+					"type": "dr_bonus",
+					"location": "vitals",
+					"amount": 5
+				}
+			],
+			"calc": {
+				"extended_value": 1350,
+				"extended_weight": "15 lb"
 			}
 		},
 		{
@@ -604,6 +726,36 @@
 			}
 		},
 		{
+			"id": "c69f8f3e-c813-4c9e-ba1e-f50796ef2f44",
+			"type": "equipment",
+			"description": "Cane Abdomen Armor",
+			"reference": "LTIA6",
+			"notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433); treat as resistant.",
+			"tech_level": "0",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 9,
+			"weight": "3 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 1
+				},
+				{
+					"type": "dr_bonus",
+					"location": "groin",
+					"amount": 1
+				}
+			],
+			"calc": {
+				"extended_value": 9,
+				"extended_weight": "3 lb"
+			}
+		},
+		{
 			"id": "957ddd69-697f-471b-b510-62fe90782b21",
 			"type": "equipment",
 			"description": "Cane Arm Armor",
@@ -686,6 +838,36 @@
 			"calc": {
 				"extended_value": 22,
 				"extended_weight": "3.2 lb"
+			}
+		},
+		{
+			"id": "f5e10d0f-82f6-4388-9f18-bcde7ca8986d",
+			"type": "equipment",
+			"description": "Cane Chest Armor",
+			"reference": "LTIA5",
+			"notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433); treat as resistant.",
+			"tech_level": "0",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 26,
+			"weight": "9 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "torso",
+					"amount": 1
+				},
+				{
+					"type": "dr_bonus",
+					"location": "vitals",
+					"amount": 1
+				}
+			],
+			"calc": {
+				"extended_value": 26,
+				"extended_weight": "9 lb"
 			}
 		},
 		{
@@ -829,6 +1011,36 @@
 			}
 		},
 		{
+			"id": "97cb959d-afe0-4b6f-940d-f79bdb68167d",
+			"type": "equipment",
+			"description": "Cloth, Padded Abdomen Armor",
+			"reference": "LTIA6",
+			"notes": "Don: 11 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
+			"tech_level": "0",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 13,
+			"weight": "1.5 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 1
+				},
+				{
+					"type": "dr_bonus",
+					"location": "groin",
+					"amount": 1
+				}
+			],
+			"calc": {
+				"extended_value": 13,
+				"extended_weight": "1.5 lb"
+			}
+		},
+		{
 			"id": "44c5db30-12aa-4516-9620-618909b6efc5",
 			"type": "equipment",
 			"description": "Cloth, Padded Arm Armor",
@@ -911,6 +1123,36 @@
 			"calc": {
 				"extended_value": 26,
 				"extended_weight": "1.7 lb"
+			}
+		},
+		{
+			"id": "2e8baabf-be6b-4974-a02c-ac4b9fb48603",
+			"type": "equipment",
+			"description": "Cloth, Padded Chest Armor",
+			"reference": "LTIA5",
+			"notes": "Don: 11secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
+			"tech_level": "0",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 38,
+			"weight": "4.5 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "torso",
+					"amount": 1
+				},
+				{
+					"type": "dr_bonus",
+					"location": "vitals",
+					"amount": 1
+				}
+			],
+			"calc": {
+				"extended_value": 38,
+				"extended_weight": "4.5 lb"
 			}
 		},
 		{
@@ -1383,6 +1625,36 @@
 			}
 		},
 		{
+			"id": "6f441f1f-60b5-450d-b717-695ee867e613",
+			"type": "equipment",
+			"description": "Hardened Leather, Heavy Abdomen Armor",
+			"reference": "LTIA6",
+			"notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2",
+			"tech_level": "1",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 63,
+			"weight": "6.3 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"location": "groin",
+					"amount": 3
+				}
+			],
+			"calc": {
+				"extended_value": 63,
+				"extended_weight": "6.3 lb"
+			}
+		},
+		{
 			"id": "78a6fb10-cf24-48b9-a694-66e424e7caae",
 			"type": "equipment",
 			"description": "Hardened Leather, Heavy Arm Armor",
@@ -1465,6 +1737,36 @@
 			"calc": {
 				"extended_value": 76,
 				"extended_weight": "6.5 lb"
+			}
+		},
+		{
+			"id": "2b004e14-b7d1-4f43-895b-63c97366625c",
+			"type": "equipment",
+			"description": "Hardened Leather, Heavy Chest Armor",
+			"reference": "LTIA5",
+			"notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2",
+			"tech_level": "1",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 188,
+			"weight": "18.8 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "torso",
+					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"location": "vitals",
+					"amount": 3
+				}
+			],
+			"calc": {
+				"extended_value": 188,
+				"extended_weight": "18.8 lb"
 			}
 		},
 		{
@@ -1693,6 +1995,36 @@
 			}
 		},
 		{
+			"id": "0545a57e-59f4-4756-a543-3de1f612bf09",
+			"type": "equipment",
+			"description": "Hardened Leather, Medium Abdomen Armor",
+			"reference": "LTIA6",
+			"notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-2",
+			"tech_level": "1",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 31,
+			"weight": "3.8 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 2
+				},
+				{
+					"type": "dr_bonus",
+					"location": "groin",
+					"amount": 2
+				}
+			],
+			"calc": {
+				"extended_value": 31,
+				"extended_weight": "3.8 lb"
+			}
+		},
+		{
 			"id": "45cd35a8-4e6e-414a-9601-0e43b337b768",
 			"type": "equipment",
 			"description": "Hardened Leather, Medium Arm Armor",
@@ -1775,6 +2107,36 @@
 			"calc": {
 				"extended_value": 44,
 				"extended_weight": "4 lb"
+			}
+		},
+		{
+			"id": "87479104-34a6-495a-a73a-a7faf3219cd9",
+			"type": "equipment",
+			"description": "Hardened Leather, Medium Chest Armor",
+			"reference": "LTIA5",
+			"notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-2",
+			"tech_level": "1",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 94,
+			"weight": "11.3 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "torso",
+					"amount": 2
+				},
+				{
+					"type": "dr_bonus",
+					"location": "vitals",
+					"amount": 2
+				}
+			],
+			"calc": {
+				"extended_value": 94,
+				"extended_weight": "11.3 lb"
 			}
 		},
 		{
@@ -2003,6 +2365,36 @@
 			}
 		},
 		{
+			"id": "0854fd33-01b3-4029-964b-c028251b1e98",
+			"type": "equipment",
+			"description": "Horn Abdomen Armor",
+			"reference": "LTIA6",
+			"notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2",
+			"tech_level": "0",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 63,
+			"weight": "6.3 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"location": "groin",
+					"amount": 3
+				}
+			],
+			"calc": {
+				"extended_value": 63,
+				"extended_weight": "6.3 lb"
+			}
+		},
+		{
 			"id": "d7fffc73-d9f0-4806-b056-06583d2fbec7",
 			"type": "equipment",
 			"description": "Horn Arm Armor",
@@ -2085,6 +2477,36 @@
 			"calc": {
 				"extended_value": 76,
 				"extended_weight": "6.5 lb"
+			}
+		},
+		{
+			"id": "4aa8b88d-f6f7-4cd7-82c4-d7599e2991b6",
+			"type": "equipment",
+			"description": "Horn Chest Armor",
+			"reference": "LTIA5",
+			"notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2",
+			"tech_level": "0",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 188,
+			"weight": "18.8 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "torso",
+					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"location": "vitals",
+					"amount": 3
+				}
+			],
+			"calc": {
+				"extended_value": 188,
+				"extended_weight": "18.8 lb"
 			}
 		},
 		{
@@ -2203,6 +2625,36 @@
 			}
 		},
 		{
+			"id": "4f893ec8-db21-4995-afca-ea560d00604e",
+			"type": "equipment",
+			"description": "Jack of Plates Abdomen Armor",
+			"reference": "LTIA6",
+			"notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
+			"tech_level": "2",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 75,
+			"weight": "4.5 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"location": "groin",
+					"amount": 3
+				}
+			],
+			"calc": {
+				"extended_value": 75,
+				"extended_weight": "4.5 lb"
+			}
+		},
+		{
 			"id": "03360a4a-20f9-41c2-85d3-d2aa7a9e12dd",
 			"type": "equipment",
 			"description": "Jack of Plates Arm Armor",
@@ -2225,6 +2677,36 @@
 			"calc": {
 				"extended_value": 150,
 				"extended_weight": "9 lb"
+			}
+		},
+		{
+			"id": "2c78bd4c-c129-49a4-b692-f9f0be65353c",
+			"type": "equipment",
+			"description": "Jack of Plates Chest Armor",
+			"reference": "LTIA6",
+			"notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
+			"tech_level": "2",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 225,
+			"weight": "13.5 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "torso",
+					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"location": "vitals",
+					"amount": 3
+				}
+			],
+			"calc": {
+				"extended_value": 225,
+				"extended_weight": "13.5 lb"
 			}
 		},
 		{
@@ -2315,6 +2797,66 @@
 			"calc": {
 				"extended_value": 300,
 				"extended_weight": "18 lb"
+			}
+		},
+		{
+			"id": "65e2c15f-d90e-4306-9ce2-cebddf1e1082",
+			"type": "equipment",
+			"description": "Layered Cloth, Heavy Abdomen Armor",
+			"reference": "LTIA6",
+			"notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-2",
+			"tech_level": "0",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 150,
+			"weight": "7 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 4
+				},
+				{
+					"type": "dr_bonus",
+					"location": "groin",
+					"amount": 4
+				}
+			],
+			"calc": {
+				"extended_value": 150,
+				"extended_weight": "7 lb"
+			}
+		},
+		{
+			"id": "c66bfad7-8621-46bf-b709-f54ea32377cd",
+			"type": "equipment",
+			"description": "Layered Cloth, Heavy Chest Armor",
+			"reference": "LTIA5",
+			"notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2",
+			"tech_level": "0",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 450,
+			"weight": "21 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "torso",
+					"amount": 4
+				},
+				{
+					"type": "dr_bonus",
+					"location": "vitals",
+					"amount": 4
+				}
+			],
+			"calc": {
+				"extended_value": 450,
+				"extended_weight": "21 lb"
 			}
 		},
 		{
@@ -2433,6 +2975,36 @@
 			}
 		},
 		{
+			"id": "7d230ed0-d247-4271-981d-52ddcfdf85d7",
+			"type": "equipment",
+			"description": "Layered Cloth, Light Abdomen Armor",
+			"reference": "LTIA6",
+			"notes": "Don: 15 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
+			"tech_level": "0",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 38,
+			"weight": "3 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 2
+				},
+				{
+					"type": "dr_bonus",
+					"location": "groin",
+					"amount": 2
+				}
+			],
+			"calc": {
+				"extended_value": 38,
+				"extended_weight": "3 lb"
+			}
+		},
+		{
 			"id": "e766ad6b-fcb6-4eb9-bc22-8d7d28c8803f",
 			"type": "equipment",
 			"description": "Layered Cloth, Light Arm Armor",
@@ -2515,6 +3087,36 @@
 			"calc": {
 				"extended_value": 51,
 				"extended_weight": "3.2 lb"
+			}
+		},
+		{
+			"id": "9f13c8c5-6664-4692-ad25-cb4e83a7c431",
+			"type": "equipment",
+			"description": "Layered Cloth, Light Chest Armor",
+			"reference": "LTIA5",
+			"notes": "Don: 15 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
+			"tech_level": "0",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 113,
+			"weight": "9 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "torso",
+					"amount": 2
+				},
+				{
+					"type": "dr_bonus",
+					"location": "vitals",
+					"amount": 2
+				}
+			],
+			"calc": {
+				"extended_value": 113,
+				"extended_weight": "9 lb"
 			}
 		},
 		{
@@ -2683,6 +3285,36 @@
 			}
 		},
 		{
+			"id": "b5ea29d2-cc98-41db-9be9-5dacb83fa4f8",
+			"type": "equipment",
+			"description": "Layered Cloth, Medium Abdomen Armor",
+			"reference": "LTIA6",
+			"notes": "Don: 23 secs; Holdout: -2; Reaction Pen.-2",
+			"tech_level": "0",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 88,
+			"weight": "5 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"location": "groin",
+					"amount": 3
+				}
+			],
+			"calc": {
+				"extended_value": 88,
+				"extended_weight": "5 lb"
+			}
+		},
+		{
 			"id": "aa7967b5-fe05-4099-9586-3b852dd2f0ed",
 			"type": "equipment",
 			"description": "Layered Cloth, Medium Arm Armor",
@@ -2765,6 +3397,36 @@
 			"calc": {
 				"extended_value": 101,
 				"extended_weight": "5.2 lb"
+			}
+		},
+		{
+			"id": "86fcdd56-c01f-42ed-80fe-e0512b0bb09a",
+			"type": "equipment",
+			"description": "Layered Cloth, Medium Chest Armor",
+			"reference": "LTIA5",
+			"notes": "Don: 23 secs; Holdout: -2; Reaction Pen.-2",
+			"tech_level": "0",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 263,
+			"weight": "15 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "torso",
+					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"location": "vitals",
+					"amount": 3
+				}
+			],
+			"calc": {
+				"extended_value": 263,
+				"extended_weight": "15 lb"
 			}
 		},
 		{
@@ -2933,6 +3595,66 @@
 			}
 		},
 		{
+			"id": "c6fdd7d8-9399-40c3-807b-34e4cc71605c",
+			"type": "equipment",
+			"description": "Layered Leather, Heavy Abdomen Armor",
+			"reference": "LTIA6",
+			"notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2",
+			"tech_level": "1",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 131,
+			"weight": "8.8 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 4
+				},
+				{
+					"type": "dr_bonus",
+					"location": "groin",
+					"amount": 4
+				}
+			],
+			"calc": {
+				"extended_value": 131,
+				"extended_weight": "8.8 lb"
+			}
+		},
+		{
+			"id": "fbf55e11-a222-497f-ad0b-998d59b96d1d",
+			"type": "equipment",
+			"description": "Layered Leather, Heavy Chest Armor",
+			"reference": "LTIA5",
+			"notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2",
+			"tech_level": "1",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 394,
+			"weight": "26.3 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "torso",
+					"amount": 4
+				},
+				{
+					"type": "dr_bonus",
+					"location": "vitals",
+					"amount": 4
+				}
+			],
+			"calc": {
+				"extended_value": 394,
+				"extended_weight": "26.3 lb"
+			}
+		},
+		{
 			"id": "2cfe296c-61e3-4f60-acb1-7bc39a1c6751",
 			"type": "equipment",
 			"description": "Layered Leather, Heavy Groin Armor",
@@ -3048,6 +3770,36 @@
 			}
 		},
 		{
+			"id": "1354ae25-fd6c-4e1b-8dd4-49e038feb782",
+			"type": "equipment",
+			"description": "Layered Leather, Light Abdomen Armor",
+			"reference": "LTIA6",
+			"notes": "Don: 15 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
+			"tech_level": "1",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 30,
+			"weight": "3.8 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 2
+				},
+				{
+					"type": "dr_bonus",
+					"location": "groin",
+					"amount": 2
+				}
+			],
+			"calc": {
+				"extended_value": 30,
+				"extended_weight": "3.8 lb"
+			}
+		},
+		{
 			"id": "80d4a779-8f54-49d0-b620-b081bdd61abb",
 			"type": "equipment",
 			"description": "Layered Leather, Light Arm Armor",
@@ -3130,6 +3882,36 @@
 			"calc": {
 				"extended_value": 43,
 				"extended_weight": "4 lb"
+			}
+		},
+		{
+			"id": "b0464097-887a-407b-86b4-23b1d7da78eb",
+			"type": "equipment",
+			"description": "Layered Leather, Light Chest Armor",
+			"reference": "LTIA5",
+			"notes": "Don: 15 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
+			"tech_level": "1",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 90,
+			"weight": "11.3 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "torso",
+					"amount": 2
+				},
+				{
+					"type": "dr_bonus",
+					"location": "vitals",
+					"amount": 2
+				}
+			],
+			"calc": {
+				"extended_value": 90,
+				"extended_weight": "11.3 lb"
 			}
 		},
 		{
@@ -3298,6 +4080,36 @@
 			}
 		},
 		{
+			"id": "106ddbde-3d1d-454b-937e-8cf73c29beaa",
+			"type": "equipment",
+			"description": "Layered Leather, Medium Abdomen Armor",
+			"reference": "LTIA6",
+			"notes": "Don: 23 secs; Holdout: -2; Reaction Pen.-2",
+			"tech_level": "1",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 55,
+			"weight": "6.5 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"location": "groin",
+					"amount": 3
+				}
+			],
+			"calc": {
+				"extended_value": 55,
+				"extended_weight": "6.5 lb"
+			}
+		},
+		{
 			"id": "7706d204-d5d3-48b6-9ec4-621e9896ae07",
 			"type": "equipment",
 			"description": "Layered Leather, Medium Arm Armor",
@@ -3380,6 +4192,36 @@
 			"calc": {
 				"extended_value": 68,
 				"extended_weight": "6.7 lb"
+			}
+		},
+		{
+			"id": "1c1820b9-7a2a-406f-8f28-07e753475601",
+			"type": "equipment",
+			"description": "Layered Leather, Medium Chest Armor",
+			"reference": "LTIA5",
+			"notes": "Don: 23 secs; Holdout: -2; Reaction Pen.-2",
+			"tech_level": "1",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 165,
+			"weight": "19.5 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "torso",
+					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"location": "vitals",
+					"amount": 3
+				}
+			],
+			"calc": {
+				"extended_value": 165,
+				"extended_weight": "19.5 lb"
 			}
 		},
 		{
@@ -3548,6 +4390,36 @@
 			}
 		},
 		{
+			"id": "bd0d72a7-a4b9-46df-ad3c-dc00530ed45a",
+			"type": "equipment",
+			"description": "Leather, Heavy Abdomen Armor",
+			"reference": "LTIA6",
+			"notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. impaling.",
+			"tech_level": "0",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 50,
+			"weight": "5 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"location": "groin",
+					"amount": 3
+				}
+			],
+			"calc": {
+				"extended_value": 50,
+				"extended_weight": "5 lb"
+			}
+		},
+		{
 			"id": "777f3b7a-843d-4a13-81bb-45c8d2ea2649",
 			"type": "equipment",
 			"description": "Leather, Heavy Arm Armor",
@@ -3630,6 +4502,36 @@
 			"calc": {
 				"extended_value": 63,
 				"extended_weight": "5.2 lb"
+			}
+		},
+		{
+			"id": "7b24fa58-b782-4d55-9806-9256ab311e28",
+			"type": "equipment",
+			"description": "Leather, Heavy Chest Armor",
+			"reference": "LTIA5",
+			"notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. impaling.",
+			"tech_level": "0",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 150,
+			"weight": "15 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "torso",
+					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"location": "vitals",
+					"amount": 3
+				}
+			],
+			"calc": {
+				"extended_value": 150,
+				"extended_weight": "15 lb"
 			}
 		},
 		{
@@ -3798,6 +4700,37 @@
 			}
 		},
 		{
+			"id": "42242ba9-0c93-490e-b6fe-c4481d77e33d",
+			"type": "equipment",
+			"description": "Leather, Light Abdomen Armor",
+			"reference": "LTIA6",
+			"notes": "Don: 23 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
+			"tech_level": "0",
+			"legality_class": "5",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 45,
+			"weight": "0.8 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 0
+				},
+				{
+					"type": "dr_bonus",
+					"location": "groin",
+					"amount": 0
+				}
+			],
+			"calc": {
+				"extended_value": 45,
+				"extended_weight": "0.8 lb"
+			}
+		},
+		{
 			"id": "8f16044d-6543-4899-b66e-0309ad5c53bf",
 			"type": "equipment",
 			"description": "Leather, Light Arm Armor",
@@ -3883,6 +4816,37 @@
 			"calc": {
 				"extended_value": 58,
 				"extended_weight": "1 lb"
+			}
+		},
+		{
+			"id": "7de65a4b-a7c7-48b8-8c75-a3c12d78e1b6",
+			"type": "equipment",
+			"description": "Leather, Light Chest Armor",
+			"reference": "LTIA5",
+			"notes": "Don: 23 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
+			"tech_level": "0",
+			"legality_class": "5",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 135,
+			"weight": "2.5 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "torso",
+					"amount": 0
+				},
+				{
+					"type": "dr_bonus",
+					"location": "vitals",
+					"amount": 0
+				}
+			],
+			"calc": {
+				"extended_value": 135,
+				"extended_weight": "2.5 lb"
 			}
 		},
 		{
@@ -4057,6 +5021,36 @@
 			}
 		},
 		{
+			"id": "79302c4a-0f10-4638-adaf-93b41a6e2fd5",
+			"type": "equipment",
+			"description": "Leather, Medium Abdomen Armor",
+			"reference": "LTIA6",
+			"notes": "Don: 23 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
+			"tech_level": "0",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 25,
+			"weight": "3 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 2
+				},
+				{
+					"type": "dr_bonus",
+					"location": "groin",
+					"amount": 2
+				}
+			],
+			"calc": {
+				"extended_value": 25,
+				"extended_weight": "3 lb"
+			}
+		},
+		{
 			"id": "a23cb1ce-282f-4573-bea5-5f2e11a1415e",
 			"type": "equipment",
 			"description": "Leather, Medium Arm Armor",
@@ -4139,6 +5133,36 @@
 			"calc": {
 				"extended_value": 38,
 				"extended_weight": "3.2 lb"
+			}
+		},
+		{
+			"id": "1a86532b-f2d2-4b38-9400-f1c785bfeb6b",
+			"type": "equipment",
+			"description": "Leather, Medium Chest Armor",
+			"reference": "LTIA5",
+			"notes": "Don: 23 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
+			"tech_level": "0",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 75,
+			"weight": "9 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "torso",
+					"amount": 2
+				},
+				{
+					"type": "dr_bonus",
+					"location": "vitals",
+					"amount": 2
+				}
+			],
+			"calc": {
+				"extended_value": 75,
+				"extended_weight": "9 lb"
 			}
 		},
 		{
@@ -4307,6 +5331,37 @@
 			}
 		},
 		{
+			"id": "1817c510-1d47-426d-9495-0952aa2ed1b2",
+			"type": "equipment",
+			"description": "Mail and Plates Abdomen Armor",
+			"reference": "LTIA6",
+			"notes": "Don: 15 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
+			"tech_level": "3",
+			"legality_class": "3",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 250,
+			"weight": "5 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 5
+				},
+				{
+					"type": "dr_bonus",
+					"location": "groin",
+					"amount": 5
+				}
+			],
+			"calc": {
+				"extended_value": 250,
+				"extended_weight": "5 lb"
+			}
+		},
+		{
 			"id": "bc0d21fe-120f-45f1-9ca5-146183df4df8",
 			"type": "equipment",
 			"description": "Mail and Plates Arm Armor",
@@ -4330,6 +5385,37 @@
 			"calc": {
 				"extended_value": 500,
 				"extended_weight": "10 lb"
+			}
+		},
+		{
+			"id": "8bd20be1-52db-4f97-90d7-528f0929f22b",
+			"type": "equipment",
+			"description": "Mail and Plates Chest Armor",
+			"reference": "LTIA6",
+			"notes": "Don: 15 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
+			"tech_level": "3",
+			"legality_class": "3",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 750,
+			"weight": "15 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "torso",
+					"amount": 5
+				},
+				{
+					"type": "dr_bonus",
+					"location": "vitals",
+					"amount": 5
+				}
+			],
+			"calc": {
+				"extended_value": 750,
+				"extended_weight": "15 lb"
 			}
 		},
 		{
@@ -4524,6 +5610,37 @@
 			}
 		},
 		{
+			"id": "e6af4413-1bcb-4095-a0b9-97d3d97dea01",
+			"type": "equipment",
+			"description": "Mail, Fine Abdomen Armor",
+			"reference": "LTIA6",
+			"notes": "Don: 11 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"tech_level": "2",
+			"legality_class": "3",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 225,
+			"weight": "3.8 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 4
+				},
+				{
+					"type": "dr_bonus",
+					"location": "groin",
+					"amount": 4
+				}
+			],
+			"calc": {
+				"extended_value": 225,
+				"extended_weight": "3.8 lb"
+			}
+		},
+		{
 			"id": "6fdfe337-2cd7-4518-8f70-fc16abeeed4d",
 			"type": "equipment",
 			"description": "Mail, Fine Arm Armor",
@@ -4547,6 +5664,37 @@
 			"calc": {
 				"extended_value": 450,
 				"extended_weight": "7.5 lb"
+			}
+		},
+		{
+			"id": "fc500c6b-6e7a-4849-be15-852d6dca833a",
+			"type": "equipment",
+			"description": "Mail, Fine Chest Armor",
+			"reference": "LTIA6",
+			"notes": "Don: 11 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"tech_level": "2",
+			"legality_class": "3",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 675,
+			"weight": "11.3 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "torso",
+					"amount": 4
+				},
+				{
+					"type": "dr_bonus",
+					"location": "vitals",
+					"amount": 4
+				}
+			],
+			"calc": {
+				"extended_value": 675,
+				"extended_weight": "11.3 lb"
 			}
 		},
 		{
@@ -4739,6 +5887,37 @@
 			}
 		},
 		{
+			"id": "327a0255-cf37-44dd-92e8-5ab724c1ec30",
+			"type": "equipment",
+			"description": "Mail, Heavy Abdomen Armor",
+			"reference": "LTIA6",
+			"notes": "Don: 11 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"tech_level": "2",
+			"legality_class": "3",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 300,
+			"weight": "4.5 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 5
+				},
+				{
+					"type": "dr_bonus",
+					"location": "groin",
+					"amount": 5
+				}
+			],
+			"calc": {
+				"extended_value": 300,
+				"extended_weight": "4.5 lb"
+			}
+		},
+		{
 			"id": "5aa93686-0992-44e8-9d73-7bac7d00bf32",
 			"type": "equipment",
 			"description": "Mail, Heavy Arm Armor",
@@ -4762,6 +5941,37 @@
 			"calc": {
 				"extended_value": 600,
 				"extended_weight": "9 lb"
+			}
+		},
+		{
+			"id": "3d93fd12-2cae-41f2-a5ac-a8472e271a54",
+			"type": "equipment",
+			"description": "Mail, Heavy Chest Armor",
+			"reference": "LTIA6",
+			"notes": "Don: 11 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"tech_level": "2",
+			"legality_class": "3",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 900,
+			"weight": "13.5 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "torso",
+					"amount": 5
+				},
+				{
+					"type": "dr_bonus",
+					"location": "vitals",
+					"amount": 5
+				}
+			],
+			"calc": {
+				"extended_value": 900,
+				"extended_weight": "13.5 lb"
 			}
 		},
 		{
@@ -4956,6 +6166,68 @@
 			}
 		},
 		{
+			"id": "dfc37d77-b496-4aa3-b29e-584e130809b0",
+			"type": "equipment",
+			"description": "Mail, Jousting Abdomen Armor",
+			"reference": "LTIA6",
+			"notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-2; Gives -1 DX, except for Lance skill.ushing",
+			"tech_level": "3",
+			"legality_class": "3",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 375,
+			"weight": "7.5 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 6
+				},
+				{
+					"type": "dr_bonus",
+					"location": "groin",
+					"amount": 6
+				}
+			],
+			"calc": {
+				"extended_value": 375,
+				"extended_weight": "7.5 lb"
+			}
+		},
+		{
+			"id": "733f2c14-cdcb-4b1b-a34f-9bbb73117bb1",
+			"type": "equipment",
+			"description": "Mail, Jousting Chest Armor",
+			"reference": "LTIA6",
+			"notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-2; Gives -1 DX, except for Lance skill.ushing",
+			"tech_level": "3",
+			"legality_class": "3",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 1125,
+			"weight": "22.5 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "torso",
+					"amount": 6
+				},
+				{
+					"type": "dr_bonus",
+					"location": "vitals",
+					"amount": 6
+				}
+			],
+			"calc": {
+				"extended_value": 1125,
+				"extended_weight": "22.5 lb"
+			}
+		},
+		{
 			"id": "367b593b-f03e-4d05-9cca-b21fd37a0d2d",
 			"type": "equipment",
 			"description": "Mail, Jousting Coif",
@@ -5095,6 +6367,36 @@
 			}
 		},
 		{
+			"id": "f8151bfd-b297-435f-a64e-8d0a830e5857",
+			"type": "equipment",
+			"description": "Mail, Light Abdomen Armor",
+			"reference": "LTIA6",
+			"notes": "Don: 11 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"tech_level": "2",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 125,
+			"weight": "3 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"location": "groin",
+					"amount": 3
+				}
+			],
+			"calc": {
+				"extended_value": 125,
+				"extended_weight": "3 lb"
+			}
+		},
+		{
 			"id": "73256105-2bff-447f-a6cc-a7092ae82b75",
 			"type": "equipment",
 			"description": "Mail, Light Arm Armor",
@@ -5117,6 +6419,36 @@
 			"calc": {
 				"extended_value": 250,
 				"extended_weight": "6 lb"
+			}
+		},
+		{
+			"id": "20a91ee5-19cc-413e-8759-3a6284683e05",
+			"type": "equipment",
+			"description": "Mail, Light Chest Armor",
+			"reference": "LTIA6",
+			"notes": "Don: 11 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"tech_level": "2",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 375,
+			"weight": "9 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "torso",
+					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"location": "vitals",
+					"amount": 3
+				}
+			],
+			"calc": {
+				"extended_value": 375,
+				"extended_weight": "9 lb"
 			}
 		},
 		{
@@ -5406,6 +6738,37 @@
 			}
 		},
 		{
+			"id": "eb6ab9f0-ca1f-484b-b650-03c2eb58de67",
+			"type": "equipment",
+			"description": "Paper, Proofed Chest Armor",
+			"reference": "LTIA6",
+			"notes": "Don: 15 secs; Holdout: -6; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433); treat as resistant.",
+			"tech_level": "4",
+			"legality_class": "3",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 1500,
+			"weight": "33.8 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "torso",
+					"amount": 6
+				},
+				{
+					"type": "dr_bonus",
+					"location": "vitals",
+					"amount": 6
+				}
+			],
+			"calc": {
+				"extended_value": 1500,
+				"extended_weight": "33.8 lb"
+			}
+		},
+		{
 			"id": "698623a1-bb20-456f-a652-ab51c49da610",
 			"type": "equipment",
 			"description": "Paper, Proofed Pot Helm",
@@ -5558,6 +6921,37 @@
 			"calc": {
 				"extended_value": 1013,
 				"extended_weight": "8.2 lb"
+			}
+		},
+		{
+			"id": "2aadfacf-fc69-44f2-933d-e4104a349b08",
+			"type": "equipment",
+			"description": "Plate, Heavy Chest Armor",
+			"reference": "LTIA6",
+			"notes": "Don: 34 secs; Holdout: -7; Reaction Pen.-2",
+			"tech_level": "4",
+			"legality_class": "3",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 3000,
+			"weight": "24 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "torso",
+					"amount": 9
+				},
+				{
+					"type": "dr_bonus",
+					"location": "vitals",
+					"amount": 9
+				}
+			],
+			"calc": {
+				"extended_value": 3000,
+				"extended_weight": "24 lb"
 			}
 		},
 		{
@@ -5860,6 +7254,36 @@
 			"calc": {
 				"extended_value": 263,
 				"extended_weight": "2.2 lb"
+			}
+		},
+		{
+			"id": "efa8afe3-84b7-4199-bc74-c7298c8f037e",
+			"type": "equipment",
+			"description": "Plate, Light Chest Armor",
+			"reference": "LTIA6",
+			"notes": "Don: 34 secs; Holdout: -3; Reaction Pen.-2",
+			"tech_level": "4",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 750,
+			"weight": "6 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "torso",
+					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"location": "vitals",
+					"amount": 3
+				}
+			],
+			"calc": {
+				"extended_value": 750,
+				"extended_weight": "6 lb"
 			}
 		},
 		{
@@ -6208,6 +7632,37 @@
 			"calc": {
 				"extended_value": 638,
 				"extended_weight": "5.2 lb"
+			}
+		},
+		{
+			"id": "971b15be-373e-4295-b2dc-00da11afe577",
+			"type": "equipment",
+			"description": "Plate, Medium Chest Armor",
+			"reference": "LTIA6",
+			"notes": "Don: 34 secs; Holdout: -5; Reaction Pen.-2",
+			"tech_level": "4",
+			"legality_class": "3",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 1875,
+			"weight": "15 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "torso",
+					"amount": 6
+				},
+				{
+					"type": "dr_bonus",
+					"location": "vitals",
+					"amount": 6
+				}
+			],
+			"calc": {
+				"extended_value": 1875,
+				"extended_weight": "15 lb"
 			}
 		},
 		{
@@ -6632,6 +8087,68 @@
 			}
 		},
 		{
+			"id": "52204ba3-2c5b-4c41-9be8-f5de467ad635",
+			"type": "equipment",
+			"description": "Scale, Heavy Abdomen Armor",
+			"reference": "LTIA6",
+			"notes": "Don: 23 secs; Holdout: -6; Reaction Pen.-2",
+			"tech_level": "1",
+			"legality_class": "3",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 275,
+			"weight": "10 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 5
+				},
+				{
+					"type": "dr_bonus",
+					"location": "groin",
+					"amount": 5
+				}
+			],
+			"calc": {
+				"extended_value": 275,
+				"extended_weight": "10 lb"
+			}
+		},
+		{
+			"id": "c76438cf-5921-4a9a-9006-25ebf929603d",
+			"type": "equipment",
+			"description": "Scale, Heavy Chest Armor",
+			"reference": "LTIA6",
+			"notes": "Don: 23 secs; Holdout: -6; Reaction Pen.-2",
+			"tech_level": "1",
+			"legality_class": "3",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 825,
+			"weight": "30 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "torso",
+					"amount": 5
+				},
+				{
+					"type": "dr_bonus",
+					"location": "vitals",
+					"amount": 5
+				}
+			],
+			"calc": {
+				"extended_value": 825,
+				"extended_weight": "30 lb"
+			}
+		},
+		{
 			"id": "a9abde47-865d-4002-8e6d-9479e28808a7",
 			"type": "equipment",
 			"description": "Scale, Heavy Groin Armor",
@@ -6751,6 +8268,36 @@
 			}
 		},
 		{
+			"id": "ee9f451e-226b-435f-b12e-a839eb6c4316",
+			"type": "equipment",
+			"description": "Scale, Light Abdomen Armor",
+			"reference": "LTIA6",
+			"notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
+			"tech_level": "1",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 80,
+			"weight": "4 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"location": "groin",
+					"amount": 3
+				}
+			],
+			"calc": {
+				"extended_value": 80,
+				"extended_weight": "4 lb"
+			}
+		},
+		{
 			"id": "30e33544-8f91-4fb6-9563-b1c866b61f31",
 			"type": "equipment",
 			"description": "Scale, Light Arm Armor",
@@ -6833,6 +8380,36 @@
 			"calc": {
 				"extended_value": 93,
 				"extended_weight": "4.2 lb"
+			}
+		},
+		{
+			"id": "deea7ba4-d080-4688-a698-e3143286fe5c",
+			"type": "equipment",
+			"description": "Scale, Light Chest Armor",
+			"reference": "LTIA5",
+			"notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
+			"tech_level": "1",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 240,
+			"weight": "12 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "torso",
+					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"location": "vitals",
+					"amount": 3
+				}
+			],
+			"calc": {
+				"extended_value": 240,
+				"extended_weight": "12 lb"
 			}
 		},
 		{
@@ -7001,6 +8578,37 @@
 			}
 		},
 		{
+			"id": "c443e0a4-f271-4295-bb21-fd62e258cb80",
+			"type": "equipment",
+			"description": "Scale, Medium Abdomen Armor",
+			"reference": "LTIA6",
+			"notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. crushing.",
+			"tech_level": "1",
+			"legality_class": "3",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 138,
+			"weight": "7 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 4
+				},
+				{
+					"type": "dr_bonus",
+					"location": "groin",
+					"amount": 4
+				}
+			],
+			"calc": {
+				"extended_value": 138,
+				"extended_weight": "7 lb"
+			}
+		},
+		{
 			"id": "97a27969-ca85-462d-af33-e783768f5cfd",
 			"type": "equipment",
 			"description": "Scale, Medium Arm Armor",
@@ -7086,6 +8694,37 @@
 			"calc": {
 				"extended_value": 151,
 				"extended_weight": "7.2 lb"
+			}
+		},
+		{
+			"id": "5292a4e1-d2c0-4857-b77d-9c6a5b3dc110",
+			"type": "equipment",
+			"description": "Scale, Medium Chest Armor",
+			"reference": "LTIA5",
+			"notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. crushing.",
+			"tech_level": "1",
+			"legality_class": "3",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 413,
+			"weight": "21 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "torso",
+					"amount": 4
+				},
+				{
+					"type": "dr_bonus",
+					"location": "vitals",
+					"amount": 4
+				}
+			],
+			"calc": {
+				"extended_value": 413,
+				"extended_weight": "21 lb"
 			}
 		},
 		{
@@ -7260,6 +8899,68 @@
 			}
 		},
 		{
+			"id": "a9e24808-a7a9-4d2f-84b5-616de820bea9",
+			"type": "equipment",
+			"description": "Segmented Plate, Heavy Abdomen Armor",
+			"reference": "LTIA6",
+			"notes": "Don: 34 secs; Holdout: -5; Reaction Pen.-2",
+			"tech_level": "2",
+			"legality_class": "3",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 300,
+			"weight": "8 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 5
+				},
+				{
+					"type": "dr_bonus",
+					"location": "groin",
+					"amount": 5
+				}
+			],
+			"calc": {
+				"extended_value": 300,
+				"extended_weight": "8 lb"
+			}
+		},
+		{
+			"id": "07d2b2a8-260a-4791-98bc-fb4e8ef30eaa",
+			"type": "equipment",
+			"description": "Segmented Plate, Heavy Chest Armor",
+			"reference": "LTIA6",
+			"notes": "Don: 34 secs; Holdout: -5; Reaction Pen.-2",
+			"tech_level": "2",
+			"legality_class": "3",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 900,
+			"weight": "24 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "torso",
+					"amount": 5
+				},
+				{
+					"type": "dr_bonus",
+					"location": "vitals",
+					"amount": 5
+				}
+			],
+			"calc": {
+				"extended_value": 900,
+				"extended_weight": "24 lb"
+			}
+		},
+		{
 			"id": "7c68fa46-3f2b-4af2-90bf-5d97eefe3acd",
 			"type": "equipment",
 			"description": "Segmented Plate, Heavy Torso Armor",
@@ -7301,6 +9002,36 @@
 			}
 		},
 		{
+			"id": "5a136767-9469-4fdd-be67-b82e56f81854",
+			"type": "equipment",
+			"description": "Segmented Plate, Light Abdomen Armor",
+			"reference": "LTIA6",
+			"notes": "Don: 34 secs; Holdout: -3; Reaction Pen.-2",
+			"tech_level": "2",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 150,
+			"weight": "4 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"location": "groin",
+					"amount": 3
+				}
+			],
+			"calc": {
+				"extended_value": 150,
+				"extended_weight": "4 lb"
+			}
+		},
+		{
 			"id": "db369d54-ee67-46a5-ac0d-287e8144b449",
 			"type": "equipment",
 			"description": "Segmented Plate, Light Arm Armor",
@@ -7323,6 +9054,36 @@
 			"calc": {
 				"extended_value": 300,
 				"extended_weight": "8 lb"
+			}
+		},
+		{
+			"id": "0505f52f-35cf-4e7b-8dc9-860a89582c4a",
+			"type": "equipment",
+			"description": "Segmented Plate, Light Chest Armor",
+			"reference": "LTIA6",
+			"notes": "Don: 34 secs; Holdout: -3; Reaction Pen.-2",
+			"tech_level": "2",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 450,
+			"weight": "12 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "torso",
+					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"location": "vitals",
+					"amount": 3
+				}
+			],
+			"calc": {
+				"extended_value": 450,
+				"extended_weight": "12 lb"
 			}
 		},
 		{
@@ -7416,6 +9177,37 @@
 			}
 		},
 		{
+			"id": "a7a6bba3-b24c-41b2-8d4e-972e6706f498",
+			"type": "equipment",
+			"description": "Segmented Plate, Medium Abdomen Armor",
+			"reference": "LTIA6",
+			"notes": "Don: 34 secs; Holdout: -4; Reaction Pen.-2",
+			"tech_level": "2",
+			"legality_class": "3",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 225,
+			"weight": "6 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 4
+				},
+				{
+					"type": "dr_bonus",
+					"location": "groin",
+					"amount": 4
+				}
+			],
+			"calc": {
+				"extended_value": 225,
+				"extended_weight": "6 lb"
+			}
+		},
+		{
 			"id": "8f4c5891-7ca8-42d8-bf54-ea4e4f140d1a",
 			"type": "equipment",
 			"description": "Segmented Plate, Medium Arm Armor",
@@ -7439,6 +9231,37 @@
 			"calc": {
 				"extended_value": 450,
 				"extended_weight": "12 lb"
+			}
+		},
+		{
+			"id": "624a7cd0-bf18-4e75-b8df-058b4a3923c7",
+			"type": "equipment",
+			"description": "Segmented Plate, Medium Chest Armor",
+			"reference": "LTIA6",
+			"notes": "Don: 34 secs; Holdout: -4; Reaction Pen.-2",
+			"tech_level": "2",
+			"legality_class": "3",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 675,
+			"weight": "18 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "torso",
+					"amount": 4
+				},
+				{
+					"type": "dr_bonus",
+					"location": "vitals",
+					"amount": 4
+				}
+			],
+			"calc": {
+				"extended_value": 675,
+				"extended_weight": "18 lb"
 			}
 		},
 		{
@@ -7712,6 +9535,36 @@
 			}
 		},
 		{
+			"id": "bcbf3fdd-a6aa-4aea-9d89-35cd3992a608",
+			"type": "equipment",
+			"description": "Straw Chest Armor",
+			"reference": "LTIA5",
+			"notes": "Don: 23 secs; Holdout: -9; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433); treat as resistant.",
+			"tech_level": "0",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 38,
+			"weight": "15 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "torso",
+					"amount": 2
+				},
+				{
+					"type": "dr_bonus",
+					"location": "vitals",
+					"amount": 2
+				}
+			],
+			"calc": {
+				"extended_value": 38,
+				"extended_weight": "15 lb"
+			}
+		},
+		{
 			"id": "bf5f9eb2-0a51-40e8-bfb7-9d14df44c372",
 			"type": "equipment",
 			"description": "Straw Torso Armor",
@@ -7749,6 +9602,36 @@
 			"calc": {
 				"extended_value": 50,
 				"extended_weight": "20 lb"
+			}
+		},
+		{
+			"id": "af31ad3d-031b-451d-9937-1e196e6993b5",
+			"type": "equipment",
+			"description": "Wood Abdomen Armor",
+			"reference": "LTIA6",
+			"notes": "Don: 23 secs; Holdout: -8; Reaction Pen.-2; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
+			"tech_level": "0",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 25,
+			"weight": "7.5 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"location": "groin",
+					"amount": 3
+				}
+			],
+			"calc": {
+				"extended_value": 25,
+				"extended_weight": "7.5 lb"
 			}
 		},
 		{
@@ -7834,6 +9717,36 @@
 			"calc": {
 				"extended_value": 38,
 				"extended_weight": "7.7 lb"
+			}
+		},
+		{
+			"id": "64fa4789-825c-40b8-8ea2-e8beb866e9f5",
+			"type": "equipment",
+			"description": "Wood Chest Armor",
+			"reference": "LTIA5",
+			"notes": "Don: 23 secs; Holdout: -8; Reaction Pen.-2; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
+			"tech_level": "0",
+			"tags": [
+				"Body Armor"
+			],
+			"quantity": 1,
+			"value": 75,
+			"weight": "22.5 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "torso",
+					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"location": "vitals",
+					"amount": 3
+				}
+			],
+			"calc": {
+				"extended_value": 75,
+				"extended_weight": "22.5 lb"
 			}
 		},
 		{

--- a/Library/Low Tech/Low Tech Instant Armor.eqp
+++ b/Library/Low Tech/Low Tech Instant Armor.eqp
@@ -19,6 +19,11 @@
 			"features": [
 				{
 					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 0
+				},
+				{
+					"type": "dr_bonus",
 					"location": "torso",
 					"amount": 0
 				},
@@ -315,6 +320,11 @@
 			"features": [
 				{
 					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
 					"location": "torso",
 					"amount": 3
 				},
@@ -569,6 +579,11 @@
 			"features": [
 				{
 					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 5
+				},
+				{
+					"type": "dr_bonus",
 					"location": "torso",
 					"amount": 5
 				},
@@ -787,6 +802,11 @@
 			"value": 35,
 			"weight": "12 lb",
 			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 1
+				},
 				{
 					"type": "dr_bonus",
 					"location": "torso",
@@ -1032,6 +1052,11 @@
 			"value": 50,
 			"weight": "6 lb",
 			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 1
+				},
 				{
 					"type": "dr_bonus",
 					"location": "torso",
@@ -1643,6 +1668,11 @@
 			"features": [
 				{
 					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
 					"location": "torso",
 					"amount": 3
 				},
@@ -1948,6 +1978,11 @@
 			"features": [
 				{
 					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 2
+				},
+				{
+					"type": "dr_bonus",
 					"location": "torso",
 					"amount": 2
 				},
@@ -2143,6 +2178,11 @@
 			"features": [
 				{
 					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
 					"location": "torso",
 					"amount": 3
 				},
@@ -2253,6 +2293,11 @@
 			"features": [
 				{
 					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
 					"location": "torso",
 					"amount": 3
 				},
@@ -2361,6 +2406,11 @@
 			"value": 600,
 			"weight": "28 lb",
 			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 4
+				},
 				{
 					"type": "dr_bonus",
 					"location": "torso",
@@ -2608,6 +2658,11 @@
 			"features": [
 				{
 					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 2
+				},
+				{
+					"type": "dr_bonus",
 					"location": "torso",
 					"amount": 2
 				},
@@ -2853,6 +2908,11 @@
 			"features": [
 				{
 					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
 					"location": "torso",
 					"amount": 3
 				},
@@ -2961,6 +3021,11 @@
 			"value": 525,
 			"weight": "35 lb",
 			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 4
+				},
 				{
 					"type": "dr_bonus",
 					"location": "torso",
@@ -3208,6 +3273,11 @@
 			"features": [
 				{
 					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 2
+				},
+				{
+					"type": "dr_bonus",
 					"location": "torso",
 					"amount": 2
 				},
@@ -3453,6 +3523,11 @@
 			"features": [
 				{
 					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
 					"location": "torso",
 					"amount": 3
 				},
@@ -3696,6 +3771,11 @@
 			"value": 200,
 			"weight": "20 lb",
 			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 3
+				},
 				{
 					"type": "dr_bonus",
 					"location": "torso",
@@ -3952,6 +4032,11 @@
 			"features": [
 				{
 					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 0
+				},
+				{
+					"type": "dr_bonus",
 					"location": "torso",
 					"amount": 0
 				},
@@ -4197,6 +4282,11 @@
 			"features": [
 				{
 					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 2
+				},
+				{
+					"type": "dr_bonus",
 					"location": "torso",
 					"amount": 2
 				},
@@ -4409,6 +4499,11 @@
 			"features": [
 				{
 					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 5
+				},
+				{
+					"type": "dr_bonus",
 					"location": "torso",
 					"amount": 5
 				},
@@ -4617,6 +4712,11 @@
 			"value": 900,
 			"weight": "15 lb",
 			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 4
+				},
 				{
 					"type": "dr_bonus",
 					"location": "torso",
@@ -4831,6 +4931,11 @@
 			"features": [
 				{
 					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 5
+				},
+				{
+					"type": "dr_bonus",
 					"location": "torso",
 					"amount": 5
 				},
@@ -4963,6 +5068,11 @@
 			"value": 1500,
 			"weight": "30 lb",
 			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 6
+				},
 				{
 					"type": "dr_bonus",
 					"location": "torso",
@@ -5170,6 +5280,11 @@
 			"features": [
 				{
 					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
 					"location": "torso",
 					"amount": 3
 				},
@@ -5357,6 +5472,11 @@
 			"value": 2000,
 			"weight": "45 lb",
 			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 6
+				},
 				{
 					"type": "dr_bonus",
 					"location": "torso",
@@ -5631,6 +5751,11 @@
 			"value": 4000,
 			"weight": "32 lb",
 			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 9
+				},
 				{
 					"type": "dr_bonus",
 					"location": "torso",
@@ -5971,6 +6096,11 @@
 			"value": 1000,
 			"weight": "8 lb",
 			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 3
+				},
 				{
 					"type": "dr_bonus",
 					"location": "torso",
@@ -6325,6 +6455,11 @@
 			"features": [
 				{
 					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 6
+				},
+				{
+					"type": "dr_bonus",
 					"location": "torso",
 					"amount": 6
 				},
@@ -6591,6 +6726,11 @@
 			"features": [
 				{
 					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 5
+				},
+				{
+					"type": "dr_bonus",
 					"location": "torso",
 					"amount": 5
 				},
@@ -6834,6 +6974,11 @@
 			"value": 320,
 			"weight": "16 lb",
 			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 3
+				},
 				{
 					"type": "dr_bonus",
 					"location": "torso",
@@ -7090,6 +7235,11 @@
 			"features": [
 				{
 					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 4
+				},
+				{
+					"type": "dr_bonus",
 					"location": "torso",
 					"amount": 4
 				},
@@ -7124,6 +7274,11 @@
 			"value": 1200,
 			"weight": "32 lb",
 			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 5
+				},
 				{
 					"type": "dr_bonus",
 					"location": "torso",
@@ -7234,6 +7389,11 @@
 			"value": 600,
 			"weight": "16 lb",
 			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 3
+				},
 				{
 					"type": "dr_bonus",
 					"location": "torso",
@@ -7348,6 +7508,11 @@
 			"value": 900,
 			"weight": "24 lb",
 			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 4
+				},
 				{
 					"type": "dr_bonus",
 					"location": "torso",
@@ -7560,6 +7725,11 @@
 			"value": 50,
 			"weight": "20 lb",
 			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 2
+				},
 				{
 					"type": "dr_bonus",
 					"location": "torso",
@@ -7865,6 +8035,11 @@
 			"value": 100,
 			"weight": "30 lb",
 			"features": [
+				{
+					"type": "dr_bonus",
+					"location": "abdomen",
+					"amount": 3
+				},
 				{
 					"type": "dr_bonus",
 					"location": "torso",

--- a/Library/Settings/Body Types/Humanoid (Low-Tech).body
+++ b/Library/Settings/Body Types/Humanoid (Low-Tech).body
@@ -1,0 +1,201 @@
+{
+	"type": "body_type",
+	"version": 4,
+	"name": "Humanoid",
+	"roll": "3d",
+	"locations": [
+		{
+			"id": "eye",
+			"choice_name": "Eyes",
+			"table_name": "Eyes",
+			"hit_penalty": -9,
+			"description": "An attack that misses by 1 hits the torso instead. Only\nimpaling (imp), piercing (pi-, pi, pi+, pi++), and\ntight-beam burning (burn) attacks can target the eye – and\nonly from the front or sides. Injury over HP÷10 blinds the\neye. Otherwise, treat as skull, but without the extra DR!",
+			"calc": {
+				"roll_range": "-",
+				"dr": {
+					"all": 0
+				}
+			}
+		},
+		{
+			"id": "skull",
+			"choice_name": "Skull",
+			"table_name": "Skull",
+			"slots": 2,
+			"hit_penalty": -7,
+			"dr_bonus": 2,
+			"description": "An attack that misses by 1 hits the torso instead. Wounding\nmodifier is x4. Knockdown rolls are at -10. Critical hits\nuse the Critical Head Blow Table (B556). Exception: These\nspecial effects do not apply to toxic (tox) damage.",
+			"calc": {
+				"roll_range": "3-4",
+				"dr": {
+					"all": 2
+				}
+			}
+		},
+		{
+			"id": "face",
+			"choice_name": "Face",
+			"table_name": "Face",
+			"slots": 1,
+			"hit_penalty": -5,
+			"description": "An attack that misses by 1 hits the torso instead. Jaw,\ncheeks, nose, ears, etc. If the target has an open-faced\nhelmet, ignore its DR. Knockdown rolls are at -5. Critical\nhits use the Critical Head Blow Table (B556). Corrosion\n(cor) damage gets a x1½ wounding modifier, and if it\ninflicts a major wound, it also blinds one eye (both eyes on\ndamage over full HP). Random attacks from behind hit the\nskull instead.",
+			"calc": {
+				"roll_range": "5",
+				"dr": {
+					"all": 0
+				}
+			}
+		},
+		{
+			"id": "leg",
+			"choice_name": "Leg",
+			"table_name": "Right Leg",
+			"slots": 2,
+			"hit_penalty": -2,
+			"description": "Reduce the wounding multiplier of large piercing (pi+), huge\npiercing (pi++), and impaling (imp) damage to x1. Any major\nwound (loss of over ½ HP from one blow) cripples the limb.\nDamage beyond that threshold is lost.",
+			"calc": {
+				"roll_range": "6-7",
+				"dr": {
+					"all": 0
+				}
+			}
+		},
+		{
+			"id": "arm",
+			"choice_name": "Arm",
+			"table_name": "Right Arm",
+			"slots": 1,
+			"hit_penalty": -2,
+			"description": "Reduce the wounding multiplier of large piercing (pi+), huge\npiercing (pi++), and impaling (imp) damage to x1. Any major\nwound (loss of over ½ HP from one blow) cripples the limb.\nDamage beyond that threshold is lost. If holding a shield,\ndouble the penalty to hit: -4 for shield arm instead of -2.",
+			"calc": {
+				"roll_range": "8",
+				"dr": {
+					"all": 0
+				}
+			}
+		},
+		{
+			"id": "torso",
+			"choice_name": "Chest",
+			"table_name": "Chest",
+			"slots": 2,
+			"description": "Roll 1d; on a 1, the vitals are hit.",
+			"calc": {
+				"roll_range": "9-10",
+				"dr": {
+					"all": 0
+				}
+			}
+		},
+		{
+			"id": "abdomen",
+			"choice_name": "Abdomen",
+			"table_name": "Abdomen",
+			"slots": 1,
+			"hit_penalty": -1,
+			"description": "Roll 1d; on a 1, the vitals are hit.",
+			"calc": {
+				"roll_range": "11",
+				"dr": {
+					"all": 0
+				}
+			}
+		},
+		{
+			"id": "groin",
+			"choice_name": "Groin",
+			"table_name": "Groin",
+			"hit_penalty": -3,
+			"description": "An attack that misses by 1 hits the torso instead. Human\nmales and the males of similar species suffer double shock\nfrom crushing (cr) damage, and get -5 to knockdown rolls.\nOtherwise, treat as a torso hit.",
+			"calc": {
+				"roll_range": "-",
+				"dr": {
+					"all": 0
+				}
+			}
+		},
+		{
+			"id": "arm",
+			"choice_name": "Arm",
+			"table_name": "Left Arm",
+			"slots": 1,
+			"hit_penalty": -2,
+			"description": "Reduce the wounding multiplier of large piercing (pi+), huge\npiercing (pi++), and impaling (imp) damage to x1. Any major\nwound (loss of over ½ HP from one blow) cripples the limb.\nDamage beyond that threshold is lost. If holding a shield,\ndouble the penalty to hit: -4 for shield arm instead of -2.",
+			"calc": {
+				"roll_range": "12",
+				"dr": {
+					"all": 0
+				}
+			}
+		},
+		{
+			"id": "leg",
+			"choice_name": "Leg",
+			"table_name": "Left Leg",
+			"slots": 2,
+			"hit_penalty": -2,
+			"description": "Reduce the wounding multiplier of large piercing (pi+), huge\npiercing (pi++), and impaling (imp) damage to x1. Any major\nwound (loss of over ½ HP from one blow) cripples the limb.\nDamage beyond that threshold is lost.",
+			"calc": {
+				"roll_range": "13-14",
+				"dr": {
+					"all": 0
+				}
+			}
+		},
+		{
+			"id": "hand",
+			"choice_name": "Hand",
+			"table_name": "Hand",
+			"slots": 1,
+			"hit_penalty": -4,
+			"description": "If holding a shield, double the penalty to hit: -8 for\nshield hand instead of -4. Reduce the wounding multiplier of\nlarge piercing (pi+), huge piercing (pi++), and impaling\n(imp) damage to x1. Any major wound (loss of over ⅓ HP\nfrom one blow) cripples the extremity. Damage beyond that\nthreshold is lost.",
+			"calc": {
+				"roll_range": "15",
+				"dr": {
+					"all": 0
+				}
+			}
+		},
+		{
+			"id": "foot",
+			"choice_name": "Foot",
+			"table_name": "Foot",
+			"slots": 1,
+			"hit_penalty": -4,
+			"description": "Reduce the wounding multiplier of large piercing (pi+), huge\npiercing (pi++), and impaling (imp) damage to x1. Any major\nwound (loss of over ⅓ HP from one blow) cripples the\nextremity. Damage beyond that threshold is lost.",
+			"calc": {
+				"roll_range": "16",
+				"dr": {
+					"all": 0
+				}
+			}
+		},
+		{
+			"id": "neck",
+			"choice_name": "Neck",
+			"table_name": "Neck",
+			"slots": 2,
+			"hit_penalty": -5,
+			"description": "An attack that misses by 1 hits the torso instead. Neck and\nthroat. Increase the wounding multiplier of crushing (cr)\nand corrosion (cor) attacks to x1½, and that of cutting\n(cut) damage to x2. At the GM’s option, anyone killed by a\ncutting (cut) blow to the neck is decapitated!",
+			"calc": {
+				"roll_range": "17-18",
+				"dr": {
+					"all": 0
+				}
+			}
+		},
+		{
+			"id": "vitals",
+			"choice_name": "Vitals",
+			"table_name": "Vitals",
+			"hit_penalty": -3,
+			"description": "An attack that misses by 1 hits the torso instead. Heart,\nlungs, kidneys, etc. Increase the wounding modifier for an\nimpaling (imp) or any piercing (pi-, pi, pi+, pi++) attack\nto x3. Increase the wounding modifier for a tight-beam\nburning (burn) attack to x2. Other attacks cannot target the\nvitals.",
+			"calc": {
+				"roll_range": "-",
+				"dr": {
+					"all": 0
+				}
+			}
+		}
+	]
+}


### PR DESCRIPTION
* Added the _Humanoid (Low-Tech)_ body type. This body type separates the _torso_ hit location into _chest_ and _abdomen_ as per GURPS Low-Tech. The _chest_ still has the ID of "torso", to maintain as much compatibility with non-Low-Tech armor pieces as possible, so any armor piece that adds DR to the default body type's _torso_ will add it to this body type's _chest_.
* Updated _Low Tech Armor (by location) and (by material)_ to support this new body type, while maintaining compatibility with the default body type.
    * Armor that covers the "torso" now adds DR to the _abdomen_ and _groin_ locations, as the groin is considered part of the abdomen in Low-Tech, hence also part of the torso.
    * Armor that covers the "chest" now adds DR to the _chest_ (id: torso) and _vitals_ locations.
    * Armor that covers the "abdomen" now adds DR to the _abdomen_ and _groin_ locations. Technically the vitals can be targeted through the abdomen as well as the chest, but I decided against adding vitals DR to abdomen armor, as it would stack with vitals DR from chest armor.
* Added DR to the _abdomen_ location for all torso armor in Low-Tech Instant Armor. They already correctly had groin DR.
* Added all chest and abdomen armor pieces from GURPS Low-Tech Instant Armor.