### PR TITLE
Fix parry and block missing from v5.19.0-v5.20.0 edits

### DIFF
--- a/Library/Basic Set/Basic Set Equipment.eqp
+++ b/Library/Basic Set/Basic Set Equipment.eqp
@@ -1467,7 +1467,6 @@
 					"usage": "Swung",
 					"reach": "1",
 					"parry": "0U",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -2184,7 +2183,6 @@
 					"usage_notes": "1-Handed",
 					"reach": "1-2",
 					"parry": "0U",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -2241,7 +2239,6 @@
 					"usage_notes": "1-Handed",
 					"reach": "2",
 					"parry": "0U",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -2297,7 +2294,7 @@
 					"usage": "Swung",
 					"usage_notes": "2-Handed",
 					"reach": "1-2",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -2338,7 +2335,7 @@
 					"usage": "Thrust",
 					"usage_notes": "2-Handed",
 					"reach": "2",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -2396,7 +2393,7 @@
 					"strength": "6",
 					"usage": "Swung",
 					"reach": "1",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -2460,7 +2457,7 @@
 					"strength": "6",
 					"usage": "Thrust",
 					"reach": "1",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -3161,7 +3158,7 @@
 					"strength": "7",
 					"usage": "Swung",
 					"reach": "C",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "skill",
@@ -3739,7 +3736,7 @@
 					},
 					"usage": "Punch",
 					"reach": "C",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx"
@@ -3791,7 +3788,7 @@
 					"strength": "10",
 					"usage": "Swung",
 					"reach": "1",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -3846,7 +3843,7 @@
 					"strength": "10",
 					"usage": "Thrust",
 					"reach": "1",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -4424,7 +4421,7 @@
 					"strength": "3",
 					"usage": "Thrust",
 					"reach": "1",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -4508,7 +4505,7 @@
 					"strength": "10",
 					"usage": "Swung",
 					"reach": "1",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -4563,7 +4560,7 @@
 					"strength": "10",
 					"usage": "Thrust",
 					"reach": "1",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -4654,8 +4651,6 @@
 					},
 					"strength": "10‡",
 					"reach": "1",
-					"parry": "No",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -5479,7 +5474,6 @@
 					"usage": "Swung",
 					"reach": "1",
 					"parry": "0U",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -5565,7 +5559,7 @@
 					"strength": "8",
 					"usage": "Swung",
 					"reach": "1",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -5629,7 +5623,7 @@
 					"strength": "8",
 					"usage": "Thrust",
 					"reach": "1",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -5751,7 +5745,6 @@
 					"usage": "Thrust",
 					"reach": "C",
 					"parry": "-1",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -6500,7 +6493,6 @@
 					"usage_notes": "Attempts to parry this weapon are at -4 and fencing weapons may not parry it at all; attempts to block this weapon are at -2",
 					"reach": "1-2*",
 					"parry": "0U",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -6892,7 +6884,7 @@
 					},
 					"usage": "Shield Bash",
 					"reach": "1",
-					"parry": "No",
+					"block": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -6958,7 +6950,7 @@
 					"strength": "3",
 					"usage": "Swung",
 					"reach": "1-2",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -7200,8 +7192,6 @@
 						"type": "see B405"
 					},
 					"reach": "C",
-					"parry": "No",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "skill",
@@ -7521,7 +7511,6 @@
 					"usage": "Swung",
 					"reach": "2-3*",
 					"parry": "0U",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -7563,7 +7552,6 @@
 					"usage": "Thrust",
 					"reach": "1-3*",
 					"parry": "0U",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -7677,7 +7665,6 @@
 					"usage": "Swung",
 					"reach": "1-2*",
 					"parry": "0U",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -7773,7 +7760,7 @@
 					"strength": "12†",
 					"usage": "Swung",
 					"reach": "1-2",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -7813,7 +7800,7 @@
 					"strength": "12†",
 					"usage": "Thrust",
 					"reach": "2",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -7992,7 +7979,6 @@
 					"usage": "Swung",
 					"reach": "2-3*",
 					"parry": "0U",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -8034,7 +8020,6 @@
 					"usage": "Swung Hook",
 					"reach": "2-3*",
 					"parry": "0U",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -8076,7 +8061,6 @@
 					"usage": "Thrust",
 					"reach": "1-3*",
 					"parry": "0U",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -8650,7 +8634,7 @@
 					"strength": "8",
 					"usage": "Swung",
 					"reach": "1",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -8804,7 +8788,7 @@
 					},
 					"usage": "Entangle",
 					"reach": "C,1",
-					"parry": "No",
+					"block": "0",
 					"defaults": [
 						{
 							"type": "skill",
@@ -8827,9 +8811,7 @@
 						}
 					],
 					"calc": {
-						"level": 5,
-						"damage": "See B404",
-						"block": "5"
+						"damage": "See B404"
 					}
 				},
 				{
@@ -8866,7 +8848,6 @@
 						}
 					],
 					"calc": {
-						"level": 5,
 						"damage": "See B411"
 					}
 				}
@@ -9813,7 +9794,7 @@
 					"strength": "6",
 					"usage": "Thrust",
 					"reach": "1",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -9910,7 +9891,7 @@
 					"usage": "Swung",
 					"usage_notes": "1-handed",
 					"reach": "1-2",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -9966,7 +9947,7 @@
 					"usage": "Thrust",
 					"usage_notes": "1-handed",
 					"reach": "1",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -10022,7 +10003,7 @@
 					"usage": "Swung",
 					"usage_notes": "2-handed",
 					"reach": "1-2",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -10063,7 +10044,7 @@
 					"usage": "Thrust",
 					"usage_notes": "2-handed",
 					"reach": "1",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -10157,7 +10138,6 @@
 					"usage_notes": "Attempts to parry this weapon are at -4 and fencing weapons may not parry it at all; attempts to block this weapon are at -2",
 					"reach": "1-4*",
 					"parry": "-2U",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -10217,8 +10197,6 @@
 					"strength": "12",
 					"usage": "Thrust",
 					"reach": "4",
-					"parry": "No",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -10324,7 +10302,6 @@
 					"usage": "Swung",
 					"reach": "C,1",
 					"parry": "-1",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -10369,7 +10346,6 @@
 					"usage": "Thrust",
 					"reach": "C",
 					"parry": "-1",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -10505,7 +10481,7 @@
 					},
 					"usage": "Shield Bash",
 					"reach": "1",
-					"parry": "No",
+					"block": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -11355,7 +11331,7 @@
 						"st": "thr"
 					},
 					"reach": "1",
-					"parry": "No",
+					"block": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -11418,7 +11394,7 @@
 						"base": "1"
 					},
 					"reach": "1",
-					"parry": "No",
+					"block": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -11481,7 +11457,7 @@
 					},
 					"usage": "Entangle",
 					"reach": "C,1",
-					"parry": "No",
+					"block": "0",
 					"defaults": [
 						{
 							"type": "skill",
@@ -11504,9 +11480,7 @@
 						}
 					],
 					"calc": {
-						"level": 5,
-						"damage": "See B404",
-						"block": "5"
+						"damage": "See B404"
 					}
 				},
 				{
@@ -11543,7 +11517,6 @@
 						}
 					],
 					"calc": {
-						"level": 5,
 						"damage": "See B411"
 					}
 				}
@@ -11584,7 +11557,7 @@
 					"strength": "10",
 					"usage": "Swung",
 					"reach": "1",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -11639,7 +11612,7 @@
 					"strength": "10",
 					"usage": "Thrust",
 					"reach": "1",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -11741,7 +11714,7 @@
 					},
 					"usage": "Shield Bash",
 					"reach": "1",
-					"parry": "No",
+					"block": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -11927,7 +11900,6 @@
 					"usage": "Thrust",
 					"reach": "2-3*",
 					"parry": "0U",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -11963,7 +11935,7 @@
 					"strength": "10†",
 					"usage": "Thrust",
 					"reach": "2-3*",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -12099,7 +12071,6 @@
 					"usage": "Swung",
 					"reach": "1",
 					"parry": "0U",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -12623,7 +12594,6 @@
 					"usage": "Swung",
 					"reach": "1-2*",
 					"parry": "0U",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -12680,7 +12650,7 @@
 						"st": "thr"
 					},
 					"reach": "1",
-					"parry": "No",
+					"block": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -12743,7 +12713,7 @@
 						"base": "1"
 					},
 					"reach": "1",
-					"parry": "No",
+					"block": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -12807,7 +12777,7 @@
 					},
 					"usage": "Shield Bash",
 					"reach": "1",
-					"parry": "No",
+					"block": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -13041,7 +13011,6 @@
 					"strength": "5",
 					"reach": "1-7*",
 					"parry": "-2U",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -13098,7 +13067,6 @@
 					"usage_notes": "Attempts to parry this weapon are at -4 and fencing weapons may not parry it at all; attempts to block this weapon are at -2",
 					"reach": "1",
 					"parry": "0U",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -13155,7 +13123,6 @@
 					"usage_notes": "The sharp end, Polearm",
 					"reach": "1-2*",
 					"parry": "0U",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -13197,7 +13164,7 @@
 					"usage": "Thrust",
 					"usage_notes": "The sharp end, Polearm",
 					"reach": "2",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -13240,7 +13207,6 @@
 					"usage_notes": "The blunt end",
 					"reach": "1-2",
 					"parry": "0U",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -13277,7 +13243,7 @@
 					"usage": "Thrust",
 					"usage_notes": "The blunt end",
 					"reach": "1-2",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -13315,7 +13281,6 @@
 					"usage_notes": "Two-handed sword",
 					"reach": "2",
 					"parry": "0U",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -13356,7 +13321,7 @@
 					"usage": "Thrust",
 					"usage_notes": "Two-handed sword",
 					"reach": "2",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -13532,7 +13497,6 @@
 					"usage_notes": "Attempts to parry this weapon are at -2 and fencing weapons may not parry it at all; attempts to block this weapon are at -1",
 					"reach": "1",
 					"parry": "0U",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "skill",
@@ -13742,7 +13706,6 @@
 					"usage": "Swung",
 					"reach": "1",
 					"parry": "0U",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -13985,7 +13948,6 @@
 					"usage": "Swung",
 					"reach": "2-3*",
 					"parry": "0U",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -14027,7 +13989,6 @@
 					"usage": "Swung",
 					"reach": "2-3*",
 					"parry": "0U",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -15054,7 +15015,6 @@
 					"usage_notes": "Staff",
 					"reach": "1-2",
 					"parry": "2",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -15092,7 +15052,6 @@
 					"usage_notes": "Staff",
 					"reach": "1-2",
 					"parry": "2",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -15129,7 +15088,7 @@
 					"usage": "Swung",
 					"usage_notes": "Two-Handed Sword",
 					"reach": "1-2",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -15170,7 +15129,7 @@
 					"usage": "Thrust",
 					"usage_notes": "Two-Handed Sword",
 					"reach": "2",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -15302,7 +15261,6 @@
 					"usage": "Thrust",
 					"reach": "1-2",
 					"parry": "0F",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -16235,7 +16193,6 @@
 					"usage": "Swung",
 					"reach": "1",
 					"parry": "0F",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -16291,7 +16248,6 @@
 					"usage": "Thrust",
 					"reach": "1",
 					"parry": "0F",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -16491,7 +16447,7 @@
 					"strength": "7",
 					"usage": "Swung",
 					"reach": "C",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx"
@@ -16884,7 +16840,6 @@
 					"usage": "Swung",
 					"reach": "1",
 					"parry": "0U",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -16925,7 +16880,6 @@
 					"usage": "Thrust",
 					"reach": "1",
 					"parry": "0U",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -17159,7 +17113,6 @@
 					"usage": "Swung",
 					"reach": "1",
 					"parry": "0F",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -17209,7 +17162,6 @@
 					"usage": "Thrust",
 					"reach": "1",
 					"parry": "0F",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -17277,7 +17229,7 @@
 					"strength": "8",
 					"usage": "Swung",
 					"reach": "1",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -17341,7 +17293,7 @@
 					"strength": "8",
 					"usage": "Thrust",
 					"reach": "1",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -17682,7 +17634,7 @@
 						"st": "thr"
 					},
 					"reach": "1",
-					"parry": "No",
+					"block": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -17745,7 +17697,7 @@
 						"base": "1"
 					},
 					"reach": "1",
-					"parry": "No",
+					"block": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -17812,7 +17764,6 @@
 					"usage": "Swung",
 					"reach": "C,1",
 					"parry": "-1",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -17858,7 +17809,6 @@
 					"usage": "Thrust",
 					"reach": "C",
 					"parry": "-1",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -17953,7 +17903,6 @@
 					"usage": "Swung",
 					"reach": "1",
 					"parry": "0U",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -18037,7 +17986,7 @@
 					},
 					"usage": "Shield Bash",
 					"reach": "1",
-					"parry": "No",
+					"block": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -18103,7 +18052,6 @@
 					"usage": "Thrust",
 					"reach": "1",
 					"parry": "0F",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -19146,7 +19094,7 @@
 					"strength": "9",
 					"usage": "Thrust",
 					"reach": "1*",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -19182,7 +19130,7 @@
 					"strength": "9†",
 					"usage": "Thrust",
 					"reach": "1-2*",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -19561,8 +19509,6 @@
 					},
 					"strength": "2",
 					"reach": "C,1",
-					"parry": "No",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "skill",
@@ -20207,7 +20153,6 @@
 					"usage": "Swung",
 					"reach": "1",
 					"parry": "0U",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -20294,7 +20239,6 @@
 					"usage_notes": "1-handed",
 					"reach": "1-2",
 					"parry": "0U",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -20350,7 +20294,6 @@
 					"usage_notes": "1-handed",
 					"reach": "2",
 					"parry": "0U",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -20405,7 +20348,7 @@
 					"usage": "Swung",
 					"usage_notes": "2-handed",
 					"reach": "1-2",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -20446,7 +20389,7 @@
 					"usage": "Thrust",
 					"usage_notes": "2-handed",
 					"reach": "2",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -20505,7 +20448,7 @@
 					"strength": "10",
 					"usage": "Swung",
 					"reach": "1",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -20560,7 +20503,7 @@
 					"strength": "10",
 					"usage": "Thrust",
 					"reach": "1",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -20634,7 +20577,7 @@
 					"strength": "12†",
 					"usage": "Swung",
 					"reach": "1-2",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -20674,7 +20617,7 @@
 					"strength": "12†",
 					"usage": "Thrust",
 					"reach": "2",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -21266,7 +21209,6 @@
 					"usage": "Swung",
 					"reach": "1-2*",
 					"parry": "0U",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -21534,7 +21476,6 @@
 					"strength": "6",
 					"reach": "1",
 					"parry": "-2U",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -21590,7 +21531,6 @@
 					"strength": "7",
 					"reach": "1-2*",
 					"parry": "-2U",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -21646,7 +21586,6 @@
 					"strength": "8",
 					"reach": "1-3*",
 					"parry": "-2U",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -21702,7 +21641,6 @@
 					"strength": "9",
 					"reach": "1-4*",
 					"parry": "-2U",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -21758,7 +21696,6 @@
 					"strength": "10",
 					"reach": "1-5*",
 					"parry": "-2U",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -21814,7 +21751,6 @@
 					"strength": "11",
 					"reach": "1-6*",
 					"parry": "-2U",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -21870,7 +21806,6 @@
 					"strength": "12",
 					"reach": "1-7*",
 					"parry": "-2U",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -21959,7 +21894,6 @@
 					"usage": "Thrust",
 					"reach": "C",
 					"parry": "-1",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",

--- a/Library/Fantasy Folk/Goblins and Hobgoblins/Equipment/Goblin Equipment.eqp
+++ b/Library/Fantasy Folk/Goblins and Hobgoblins/Equipment/Goblin Equipment.eqp
@@ -27,7 +27,7 @@
 					"strength": "7",
 					"usage": "Swing (Knife)",
 					"reach": "C,1",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -71,7 +71,7 @@
 					"strength": "7",
 					"usage": "Thrust (Knife)",
 					"reach": "C,1",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -116,7 +116,7 @@
 					"strength": "7",
 					"usage": "Swing (Shortsword)",
 					"reach": "1",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -180,7 +180,7 @@
 					"strength": "7",
 					"usage": "Thrust (Shortsword)",
 					"reach": "C,1",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -264,7 +264,6 @@
 					"usage": "Swing (Staff)",
 					"reach": "1",
 					"parry": "2",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -301,7 +300,6 @@
 					"usage": "Thrust (Staff)",
 					"reach": "1",
 					"parry": "2",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -337,7 +335,7 @@
 					"strength": "8†",
 					"usage": "Swing (2H Sword)",
 					"reach": "1",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -377,7 +375,7 @@
 					"strength": "8†",
 					"usage": "Thrust (2H Sword)",
 					"reach": "1",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -436,7 +434,6 @@
 					"usage": "Swing",
 					"reach": "1-2*",
 					"parry": "0U",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -477,7 +474,7 @@
 					"strength": "9†",
 					"usage": "Thrust",
 					"reach": "1-2*",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",


### PR DESCRIPTION
This mechanically fixes the missing Block and Parry scores for Basic Set and Goblins equipment.

```bash
for f in Basic\ Set/Basic\ Set\ Equipment.eqp Fantasy\ Folk/Goblins\ and\ Hobgoblins/Equipment/Goblin\ Equipment.eqp; do jq --tab 'walk(if (type=="object" and .type=="melee_weapon" and (.parry == null or .block==null)) then {block: "0", parry: "0"} + . else . end)' "$f" >"$f.new" && mv "$f.new" "$f" && gcs --convert "$f"; done
```

This is sufficient on its own, though `gcs --convert` currently also adds parry and block scores to ranged attacks, so I've filtered those changes out of the patch.