### PR TITLE
Changes since 4.18 release

### DIFF
--- a/Library/Fantasy Folk/Elves/Profession Templates/Forest Warden.gct
+++ b/Library/Fantasy Folk/Elves/Profession Templates/Forest Warden.gct
@@ -18,15 +18,6 @@
 						"Attribute",
 						"Physical"
 					],
-					"modifiers": [
-						{
-							"id": "26b39aca-fc45-404a-9dbd-be0e55323b67",
-							"type": "modifier",
-							"name": "No Fine Manipulators",
-							"cost": -40,
-							"disabled": true
-						}
-					],
 					"levels": 2,
 					"points_per_level": 20,
 					"features": [
@@ -1868,7 +1859,7 @@
 						{
 							"id": "622cdbbe-4686-4d73-89a4-6c586fda8200",
 							"type": "trait",
-							"name": "Sense of Duty (%Small Group%)",
+							"name": "Sense of Duty (@Small Group@)",
 							"reference": "B153",
 							"tags": [
 								"Disadvantage",

--- a/Library/Fantasy Folk/Elves/Racial Templates/Dark Elf (Yrth).gct
+++ b/Library/Fantasy Folk/Elves/Racial Templates/Dark Elf (Yrth).gct
@@ -43,15 +43,6 @@
 						"Attribute",
 						"Physical"
 					],
-					"modifiers": [
-						{
-							"id": "26b39aca-fc45-404a-9dbd-be0e55323b67",
-							"type": "modifier",
-							"name": "No Fine Manipulators",
-							"cost": -40,
-							"disabled": true
-						}
-					],
 					"levels": 1,
 					"points_per_level": 20,
 					"features": [

--- a/Library/Fantasy Folk/Elves/Racial Templates/Yrth Elf.gct
+++ b/Library/Fantasy Folk/Elves/Racial Templates/Yrth Elf.gct
@@ -43,15 +43,6 @@
 						"Attribute",
 						"Physical"
 					],
-					"modifiers": [
-						{
-							"id": "26b39aca-fc45-404a-9dbd-be0e55323b67",
-							"type": "modifier",
-							"name": "No Fine Manipulators",
-							"cost": -40,
-							"disabled": true
-						}
-					],
 					"levels": 1,
 					"points_per_level": 20,
 					"features": [

--- a/Library/Fantasy Folk/Elves/Traits and Skills/Elvish Traits.adq
+++ b/Library/Fantasy Folk/Elves/Traits and Skills/Elvish Traits.adq
@@ -270,7 +270,7 @@
 		{
 			"id": "94ad34bc-3a6e-4444-b366-c139d9719271",
 			"type": "trait",
-			"name": "Psychic Guidance (%Missile Spell%)",
+			"name": "Psychic Guidance (@Missile Spell@)",
 			"reference": "FFE18",
 			"tags": [
 				"Mental",

--- a/Library/Fantasy Folk/Goblins and Hobgoblins/Profession Templates/Hobgoblin Witch Doctor.gct
+++ b/Library/Fantasy Folk/Goblins and Hobgoblins/Profession Templates/Hobgoblin Witch Doctor.gct
@@ -6117,6 +6117,7 @@
 				{
 					"id": "44ed101c-83ca-474b-bc76-2dbf3d279572",
 					"type": "spell_container",
+					"open": true,
 					"children": [
 						{
 							"id": "6d236153-2f65-4e34-a6db-9236b38a71c6",
@@ -6179,6 +6180,7 @@
 									},
 									"usage": "Area",
 									"parry": "No",
+									"block": "No",
 									"calc": {
 										"damage": "1d-1 burn"
 									}
@@ -6272,6 +6274,8 @@
 										"type": "burn ex/2 points",
 										"base": "1d"
 									},
+									"parry": "0",
+									"block": "0",
 									"accuracy": "1",
 									"range": "25/50",
 									"defaults": [
@@ -6505,6 +6509,8 @@
 										"type": "burn/point",
 										"base": "1d"
 									},
+									"parry": "0",
+									"block": "0",
 									"accuracy": "1",
 									"range": "25/50",
 									"defaults": [
@@ -6768,6 +6774,7 @@
 										"base": "1d"
 									},
 									"parry": "No",
+									"block": "No",
 									"calc": {
 										"damage": "1d /point"
 									}
@@ -6834,6 +6841,7 @@
 									},
 									"usage": "Area",
 									"parry": "No",
+									"block": "No",
 									"calc": {
 										"damage": "Cough/Weep"
 									}
@@ -6888,6 +6896,7 @@
 										"base": "1d"
 									},
 									"parry": "No",
+									"block": "No",
 									"calc": {
 										"damage": "1d /2 points"
 									}
@@ -6900,6 +6909,7 @@
 				{
 					"id": "f159dc62-a8dc-476b-8a62-7db038411c33",
 					"type": "spell_container",
+					"open": true,
 					"children": [
 						{
 							"id": "751805ff-e4c0-4e42-b436-f8ab5e1413ed",
@@ -7191,6 +7201,7 @@
 									},
 									"usage": "Area",
 									"parry": "No",
+									"block": "No",
 									"calc": {
 										"damage": "1d-2 cr"
 									}

--- a/Library/Fantasy Folk/Goblins and Hobgoblins/Racial Templates/Goblin (Smart).gct
+++ b/Library/Fantasy Folk/Goblins and Hobgoblins/Racial Templates/Goblin (Smart).gct
@@ -159,6 +159,7 @@
 						{
 							"id": "57e2bd4f-8a09-40d5-82bb-3beab764346d",
 							"type": "trait_container",
+							"open": true,
 							"children": [
 								{
 									"id": "c1113c9e-e9d4-4ab4-baa1-6698d1e120ce",


### PR DESCRIPTION
Mainly for parry/block, but some fixes on elves and goblins

Going through the releases since 4.18:
- cloak: both cloaks have correct parry/block
- force, light, medium, large shields: have correct parry/block
- shield spike: not a parry/block issue
- low-tech armor: not a parry/block issue
- codeowners: not a parry/block issue
- elves: no parry/block issues
- goblins: removed block from some spells in the witch doctor template: Create Fire, Shatter, Smoke, Weaken and Hail.  Otherwise all OK (including the three weapons)

Some unrelated elf fixes:
- remove "no fine manipulator" option on dexterity from forest warden, dark elf (yrth), yrth elf
- corrected text substitution coding on psychic guidance trait and forest warden sense of duty