### PR TITLE
Some changes to the Goblin files allow for latest GCS version

### DIFF
--- a/Library/Fantasy Folk/Goblins and Hobgoblins/Equipment/Goblin Equipment.eqp
+++ b/Library/Fantasy Folk/Goblins and Hobgoblins/Equipment/Goblin Equipment.eqp
@@ -27,7 +27,7 @@
 					"strength": "7",
 					"usage": "Swing (Knife)",
 					"reach": "C,1",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -71,7 +71,7 @@
 					"strength": "7",
 					"usage": "Thrust (Knife)",
 					"reach": "C,1",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -116,7 +116,7 @@
 					"strength": "7",
 					"usage": "Swing (Shortsword)",
 					"reach": "1",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -180,7 +180,7 @@
 					"strength": "7",
 					"usage": "Thrust (Shortsword)",
 					"reach": "C,1",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -264,7 +264,6 @@
 					"usage": "Swing (Staff)",
 					"reach": "1",
 					"parry": "2",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -301,7 +300,6 @@
 					"usage": "Thrust (Staff)",
 					"reach": "1",
 					"parry": "2",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -337,7 +335,7 @@
 					"strength": "8†",
 					"usage": "Swing (2H Sword)",
 					"reach": "1",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -377,7 +375,7 @@
 					"strength": "8†",
 					"usage": "Thrust (2H Sword)",
 					"reach": "1",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -436,7 +434,6 @@
 					"usage": "Swing",
 					"reach": "1-2*",
 					"parry": "0U",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -477,7 +474,7 @@
 					"strength": "9†",
 					"usage": "Thrust",
 					"reach": "1-2*",
-					"block": "No",
+					"parry": "0",
 					"defaults": [
 						{
 							"type": "dx",

--- a/Library/Fantasy Folk/Goblins and Hobgoblins/Profession Templates/Goblin Emissary.gct
+++ b/Library/Fantasy Folk/Goblins and Hobgoblins/Profession Templates/Goblin Emissary.gct
@@ -3889,14 +3889,6 @@
 							"calc": {
 								"points": -10
 							}
-						},
-						{
-							"id": "4c9a46f3-4991-44a0-89ee-8f4a1fcbb325",
-							"type": "trait",
-							"name": "Placeholder",
-							"calc": {
-								"points": 0
-							}
 						}
 					],
 					"name": "Choose -25 points from",

--- a/Library/Fantasy Folk/Goblins and Hobgoblins/Profession Templates/Hobgoblin Witch Doctor.gct
+++ b/Library/Fantasy Folk/Goblins and Hobgoblins/Profession Templates/Hobgoblin Witch Doctor.gct
@@ -6117,7 +6117,6 @@
 				{
 					"id": "44ed101c-83ca-474b-bc76-2dbf3d279572",
 					"type": "spell_container",
-					"open": true,
 					"children": [
 						{
 							"id": "6d236153-2f65-4e34-a6db-9236b38a71c6",
@@ -6179,8 +6178,6 @@
 										"base": "1d-1"
 									},
 									"usage": "Area",
-									"parry": "No",
-									"block": "No",
 									"calc": {
 										"damage": "1d-1 burn"
 									}
@@ -6274,8 +6271,6 @@
 										"type": "burn ex/2 points",
 										"base": "1d"
 									},
-									"parry": "0",
-									"block": "0",
 									"accuracy": "1",
 									"range": "25/50",
 									"defaults": [
@@ -6509,8 +6504,6 @@
 										"type": "burn/point",
 										"base": "1d"
 									},
-									"parry": "0",
-									"block": "0",
 									"accuracy": "1",
 									"range": "25/50",
 									"defaults": [
@@ -6773,8 +6766,6 @@
 										"type": "/point",
 										"base": "1d"
 									},
-									"parry": "No",
-									"block": "No",
 									"calc": {
 										"damage": "1d /point"
 									}
@@ -6840,8 +6831,6 @@
 										"type": "Cough/Weep"
 									},
 									"usage": "Area",
-									"parry": "No",
-									"block": "No",
 									"calc": {
 										"damage": "Cough/Weep"
 									}
@@ -6895,8 +6884,6 @@
 										"type": "/2 points",
 										"base": "1d"
 									},
-									"parry": "No",
-									"block": "No",
 									"calc": {
 										"damage": "1d /2 points"
 									}
@@ -6909,7 +6896,6 @@
 				{
 					"id": "f159dc62-a8dc-476b-8a62-7db038411c33",
 					"type": "spell_container",
-					"open": true,
 					"children": [
 						{
 							"id": "751805ff-e4c0-4e42-b436-f8ab5e1413ed",
@@ -7200,8 +7186,6 @@
 										"base": "1d-2"
 									},
 									"usage": "Area",
-									"parry": "No",
-									"block": "No",
 									"calc": {
 										"damage": "1d-2 cr"
 									}
@@ -8034,7 +8018,6 @@
 				{
 					"id": "0a11d1ef-c0b0-465e-97d5-c2a2099998ec",
 					"type": "spell_container",
-					"open": true,
 					"children": [
 						{
 							"id": "7ee1a30d-016f-4626-89a6-6de449300d68",


### PR DESCRIPTION
Equipment file:
Amended all weapons to have +0 parry (except for some of the Glaive ones which retained their +2 parry)

Goblin Emissary:
Removed a "Placeholder" trait I use to make it easier to add new traits to the end in the right group.

Hobgoblin Witch Doctor:
Didn't really make any changes as it all looked OK with no parry or block permitted on the spells.  Saving it seems to have removed those rows from the save file so it shows up as a change.