### PR TITLE
DF Druid to Druidic

### DIFF
--- a/Library/Dungeon Fantasy/Dungeon Fantasy 1/Classes/Druid.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 1/Classes/Druid.gct
@@ -1606,6 +1606,7 @@
 						{
 							"id": "39820d4e-6904-48c3-8f94-769033f8cdf7",
 							"type": "trait_container",
+							"open": true,
 							"children": [
 								{
 									"id": "3fa7098c-52bb-426e-bd72-e25db3d84f8c",
@@ -1830,7 +1831,7 @@
 								{
 									"id": "18506251-e188-41de-aead-6ee636bf7adc",
 									"type": "trait",
-									"name": "Power Investiture (Druid)",
+									"name": "Power Investiture (Druidic)",
 									"reference": "DF1:22",
 									"tags": [
 										"Advantage",
@@ -2406,7 +2407,7 @@
 						{
 							"id": "754428bb-0ba1-43e5-8c84-f68ffd3329fe",
 							"type": "trait",
-							"name": "Power Investiture (Druid)",
+							"name": "Power Investiture (Druidic)",
 							"reference": "DF1:22",
 							"tags": [
 								"Advantage",
@@ -5155,7 +5156,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -5193,7 +5194,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -5231,7 +5232,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -5269,7 +5270,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -5307,7 +5308,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -5345,7 +5346,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -5383,7 +5384,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -5421,7 +5422,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -5459,7 +5460,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -5497,7 +5498,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -5535,7 +5536,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -5573,7 +5574,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -5611,7 +5612,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -5649,7 +5650,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -5687,7 +5688,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -5725,7 +5726,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -5763,7 +5764,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -5801,7 +5802,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -5839,7 +5840,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -5877,7 +5878,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -5915,7 +5916,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -5953,7 +5954,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -5991,7 +5992,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -6002,7 +6003,7 @@
 							}
 						}
 					],
-					"name": "Power Investiture (Druid)",
+					"name": "Power Investiture (Druidic)",
 					"notes": "1",
 					"tags": [
 						"Druid"
@@ -6040,7 +6041,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -6078,7 +6079,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -6116,7 +6117,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -6154,7 +6155,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -6192,7 +6193,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -6230,7 +6231,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -6268,7 +6269,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -6306,7 +6307,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -6344,7 +6345,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -6382,7 +6383,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -6420,7 +6421,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -6458,7 +6459,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -6496,7 +6497,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -6534,7 +6535,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -6572,7 +6573,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -6610,7 +6611,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -6648,7 +6649,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -6686,7 +6687,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -6724,7 +6725,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -6762,7 +6763,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -6800,7 +6801,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -6838,7 +6839,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -6876,7 +6877,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -6893,10 +6894,7 @@
 										"type": "Cough/Sneeze"
 									},
 									"usage": "Area",
-									"reach": "Special",
-									"parry": "No",
 									"calc": {
-										"parry": "No",
 										"damage": "Cough/Sneeze"
 									}
 								}
@@ -6930,7 +6928,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -6968,7 +6966,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -7006,7 +7004,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -7044,7 +7042,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -7082,7 +7080,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -7120,7 +7118,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -7158,7 +7156,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -7196,7 +7194,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -7234,7 +7232,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -7272,7 +7270,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -7310,7 +7308,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -7348,7 +7346,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -7386,7 +7384,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -7424,7 +7422,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -7462,7 +7460,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -7501,7 +7499,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -7518,7 +7516,6 @@
 										"type": "grapple ST 10/strand"
 									},
 									"accuracy": "3",
-									"range": "5/point",
 									"defaults": [
 										{
 											"type": "dx",
@@ -7531,7 +7528,6 @@
 										}
 									],
 									"calc": {
-										"range": "5/point",
 										"damage": "grapple ST 10/strand"
 									}
 								}
@@ -7565,7 +7561,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -7603,7 +7599,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -7641,7 +7637,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -7652,7 +7648,7 @@
 							}
 						}
 					],
-					"name": "Power Investiture (Druid)",
+					"name": "Power Investiture (Druidic)",
 					"notes": "2",
 					"tags": [
 						"Druid"
@@ -7691,7 +7687,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -7729,7 +7725,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -7767,7 +7763,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -7805,7 +7801,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -7843,7 +7839,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -7881,7 +7877,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -7919,7 +7915,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -7957,7 +7953,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -7995,7 +7991,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -8033,7 +8029,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -8071,7 +8067,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -8109,7 +8105,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -8147,7 +8143,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -8185,7 +8181,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -8223,7 +8219,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -8261,7 +8257,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -8299,7 +8295,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -8337,7 +8333,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -8375,7 +8371,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -8413,7 +8409,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -8451,7 +8447,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -8489,7 +8485,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -8527,7 +8523,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -8565,7 +8561,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -8603,7 +8599,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -8641,7 +8637,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -8679,7 +8675,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -8717,7 +8713,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -8755,7 +8751,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -8793,7 +8789,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -8831,7 +8827,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -8869,7 +8865,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -8907,7 +8903,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -8945,7 +8941,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -8983,7 +8979,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -9021,7 +9017,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -9059,7 +9055,7 @@
 										"has": true,
 										"name": {
 											"compare": "is",
-											"qualifier": "Power Investiture (Druid)"
+											"qualifier": "Power Investiture (Druidic)"
 										},
 										"level": {
 											"compare": "at_least",
@@ -9070,7 +9066,7 @@
 							}
 						}
 					],
-					"name": "Power Investiture (Druid)",
+					"name": "Power Investiture (Druidic)",
 					"notes": "3",
 					"tags": [
 						"Druid"
@@ -9112,7 +9108,7 @@
 												"has": true,
 												"name": {
 													"compare": "is",
-													"qualifier": "Power Investiture (Druid)"
+													"qualifier": "Power Investiture (Druidic)"
 												},
 												"level": {
 													"compare": "at_least",
@@ -9150,7 +9146,7 @@
 												"has": true,
 												"name": {
 													"compare": "is",
-													"qualifier": "Power Investiture (Druid)"
+													"qualifier": "Power Investiture (Druidic)"
 												},
 												"level": {
 													"compare": "at_least",
@@ -9188,7 +9184,7 @@
 												"has": true,
 												"name": {
 													"compare": "is",
-													"qualifier": "Power Investiture (Druid)"
+													"qualifier": "Power Investiture (Druidic)"
 												},
 												"level": {
 													"compare": "at_least",
@@ -9226,7 +9222,7 @@
 												"has": true,
 												"name": {
 													"compare": "is",
-													"qualifier": "Power Investiture (Druid)"
+													"qualifier": "Power Investiture (Druidic)"
 												},
 												"level": {
 													"compare": "at_least",
@@ -9264,7 +9260,7 @@
 												"has": true,
 												"name": {
 													"compare": "is",
-													"qualifier": "Power Investiture (Druid)"
+													"qualifier": "Power Investiture (Druidic)"
 												},
 												"level": {
 													"compare": "at_least",
@@ -9302,7 +9298,7 @@
 												"has": true,
 												"name": {
 													"compare": "is",
-													"qualifier": "Power Investiture (Druid)"
+													"qualifier": "Power Investiture (Druidic)"
 												},
 												"level": {
 													"compare": "at_least",
@@ -9340,7 +9336,7 @@
 												"has": true,
 												"name": {
 													"compare": "is",
-													"qualifier": "Power Investiture (Druid)"
+													"qualifier": "Power Investiture (Druidic)"
 												},
 												"level": {
 													"compare": "at_least",
@@ -9378,7 +9374,7 @@
 												"has": true,
 												"name": {
 													"compare": "is",
-													"qualifier": "Power Investiture (Druid)"
+													"qualifier": "Power Investiture (Druidic)"
 												},
 												"level": {
 													"compare": "at_least",
@@ -9416,7 +9412,7 @@
 												"has": true,
 												"name": {
 													"compare": "is",
-													"qualifier": "Power Investiture (Druid)"
+													"qualifier": "Power Investiture (Druidic)"
 												},
 												"level": {
 													"compare": "at_least",
@@ -9454,7 +9450,7 @@
 												"has": true,
 												"name": {
 													"compare": "is",
-													"qualifier": "Power Investiture (Druid)"
+													"qualifier": "Power Investiture (Druidic)"
 												},
 												"level": {
 													"compare": "at_least",
@@ -9492,7 +9488,7 @@
 												"has": true,
 												"name": {
 													"compare": "is",
-													"qualifier": "Power Investiture (Druid)"
+													"qualifier": "Power Investiture (Druidic)"
 												},
 												"level": {
 													"compare": "at_least",
@@ -9530,7 +9526,7 @@
 												"has": true,
 												"name": {
 													"compare": "is",
-													"qualifier": "Power Investiture (Druid)"
+													"qualifier": "Power Investiture (Druidic)"
 												},
 												"level": {
 													"compare": "at_least",
@@ -9568,7 +9564,7 @@
 												"has": true,
 												"name": {
 													"compare": "is",
-													"qualifier": "Power Investiture (Druid)"
+													"qualifier": "Power Investiture (Druidic)"
 												},
 												"level": {
 													"compare": "at_least",
@@ -9606,7 +9602,7 @@
 												"has": true,
 												"name": {
 													"compare": "is",
-													"qualifier": "Power Investiture (Druid)"
+													"qualifier": "Power Investiture (Druidic)"
 												},
 												"level": {
 													"compare": "at_least",
@@ -9644,7 +9640,7 @@
 												"has": true,
 												"name": {
 													"compare": "is",
-													"qualifier": "Power Investiture (Druid)"
+													"qualifier": "Power Investiture (Druidic)"
 												},
 												"level": {
 													"compare": "at_least",
@@ -9661,10 +9657,7 @@
 												"type": "freezing/point",
 												"base": "1d"
 											},
-											"reach": "Special",
-											"parry": "No",
 											"calc": {
-												"parry": "No",
 												"damage": "1d freezing/point"
 											}
 										}
@@ -9699,7 +9692,7 @@
 												"has": true,
 												"name": {
 													"compare": "is",
-													"qualifier": "Power Investiture (Druid)"
+													"qualifier": "Power Investiture (Druidic)"
 												},
 												"level": {
 													"compare": "at_least",
@@ -9717,10 +9710,7 @@
 												"base": "1d-2"
 											},
 											"usage": "Area",
-											"reach": "Special",
-											"parry": "No",
 											"calc": {
-												"parry": "No",
 												"damage": "1d-2 cr"
 											}
 										}
@@ -9754,7 +9744,7 @@
 												"has": true,
 												"name": {
 													"compare": "is",
-													"qualifier": "Power Investiture (Druid)"
+													"qualifier": "Power Investiture (Druidic)"
 												},
 												"level": {
 													"compare": "at_least",
@@ -9785,7 +9775,6 @@
 												}
 											],
 											"calc": {
-												"range": "50/100",
 												"damage": "1d-1 burn/point"
 											}
 										}
@@ -9819,7 +9808,7 @@
 												"has": true,
 												"name": {
 													"compare": "is",
-													"qualifier": "Power Investiture (Druid)"
+													"qualifier": "Power Investiture (Druidic)"
 												},
 												"level": {
 													"compare": "at_least",
@@ -9857,7 +9846,7 @@
 												"has": true,
 												"name": {
 													"compare": "is",
-													"qualifier": "Power Investiture (Druid)"
+													"qualifier": "Power Investiture (Druidic)"
 												},
 												"level": {
 													"compare": "at_least",
@@ -9895,7 +9884,7 @@
 												"has": true,
 												"name": {
 													"compare": "is",
-													"qualifier": "Power Investiture (Druid)"
+													"qualifier": "Power Investiture (Druidic)"
 												},
 												"level": {
 													"compare": "at_least",
@@ -9933,7 +9922,7 @@
 												"has": true,
 												"name": {
 													"compare": "is",
-													"qualifier": "Power Investiture (Druid)"
+													"qualifier": "Power Investiture (Druidic)"
 												},
 												"level": {
 													"compare": "at_least",
@@ -9971,7 +9960,7 @@
 												"has": true,
 												"name": {
 													"compare": "is",
-													"qualifier": "Power Investiture (Druid)"
+													"qualifier": "Power Investiture (Druidic)"
 												},
 												"level": {
 													"compare": "at_least",
@@ -10009,7 +9998,7 @@
 												"has": true,
 												"name": {
 													"compare": "is",
-													"qualifier": "Power Investiture (Druid)"
+													"qualifier": "Power Investiture (Druidic)"
 												},
 												"level": {
 													"compare": "at_least",
@@ -10047,7 +10036,7 @@
 												"has": true,
 												"name": {
 													"compare": "is",
-													"qualifier": "Power Investiture (Druid)"
+													"qualifier": "Power Investiture (Druidic)"
 												},
 												"level": {
 													"compare": "at_least",
@@ -10058,7 +10047,7 @@
 									}
 								}
 							],
-							"name": "Power Investiture (Druid)",
+							"name": "Power Investiture (Druidic)",
 							"notes": "4",
 							"tags": [
 								"Druid"
@@ -10096,7 +10085,7 @@
 												"has": true,
 												"name": {
 													"compare": "is",
-													"qualifier": "Power Investiture (Druid)"
+													"qualifier": "Power Investiture (Druidic)"
 												},
 												"level": {
 													"compare": "at_least",
@@ -10134,7 +10123,7 @@
 												"has": true,
 												"name": {
 													"compare": "is",
-													"qualifier": "Power Investiture (Druid)"
+													"qualifier": "Power Investiture (Druidic)"
 												},
 												"level": {
 													"compare": "at_least",
@@ -10172,7 +10161,7 @@
 												"has": true,
 												"name": {
 													"compare": "is",
-													"qualifier": "Power Investiture (Druid)"
+													"qualifier": "Power Investiture (Druidic)"
 												},
 												"level": {
 													"compare": "at_least",
@@ -10210,7 +10199,7 @@
 												"has": true,
 												"name": {
 													"compare": "is",
-													"qualifier": "Power Investiture (Druid)"
+													"qualifier": "Power Investiture (Druidic)"
 												},
 												"level": {
 													"compare": "at_least",
@@ -10248,7 +10237,7 @@
 												"has": true,
 												"name": {
 													"compare": "is",
-													"qualifier": "Power Investiture (Druid)"
+													"qualifier": "Power Investiture (Druidic)"
 												},
 												"level": {
 													"compare": "at_least",
@@ -10286,7 +10275,7 @@
 												"has": true,
 												"name": {
 													"compare": "is",
-													"qualifier": "Power Investiture (Druid)"
+													"qualifier": "Power Investiture (Druidic)"
 												},
 												"level": {
 													"compare": "at_least",
@@ -10324,7 +10313,7 @@
 												"has": true,
 												"name": {
 													"compare": "is",
-													"qualifier": "Power Investiture (Druid)"
+													"qualifier": "Power Investiture (Druidic)"
 												},
 												"level": {
 													"compare": "at_least",
@@ -10362,7 +10351,7 @@
 												"has": true,
 												"name": {
 													"compare": "is",
-													"qualifier": "Power Investiture (Druid)"
+													"qualifier": "Power Investiture (Druidic)"
 												},
 												"level": {
 													"compare": "at_least",
@@ -10400,7 +10389,7 @@
 												"has": true,
 												"name": {
 													"compare": "is",
-													"qualifier": "Power Investiture (Druid)"
+													"qualifier": "Power Investiture (Druidic)"
 												},
 												"level": {
 													"compare": "at_least",
@@ -10438,7 +10427,7 @@
 												"has": true,
 												"name": {
 													"compare": "is",
-													"qualifier": "Power Investiture (Druid)"
+													"qualifier": "Power Investiture (Druidic)"
 												},
 												"level": {
 													"compare": "at_least",
@@ -10476,7 +10465,7 @@
 												"has": true,
 												"name": {
 													"compare": "is",
-													"qualifier": "Power Investiture (Druid)"
+													"qualifier": "Power Investiture (Druidic)"
 												},
 												"level": {
 													"compare": "at_least",
@@ -10487,7 +10476,7 @@
 									}
 								}
 							],
-							"name": "Power Investiture (Druid)",
+							"name": "Power Investiture (Druidic)",
 							"notes": "5",
 							"tags": [
 								"Druid"
@@ -10603,9 +10592,8 @@
 							},
 							"strength": "7†",
 							"usage": "Swung",
-							"reach": "1,2",
-							"parry": "+2",
-							"block": "No",
+							"reach": "1-2",
+							"parry": "2",
 							"defaults": [
 								{
 									"type": "dx",
@@ -10627,8 +10615,6 @@
 								}
 							],
 							"calc": {
-								"parry": "+2",
-								"block": "No",
 								"damage": "sw+2 cr"
 							}
 						},
@@ -10642,9 +10628,8 @@
 							},
 							"strength": "7†",
 							"usage": "Thrust",
-							"reach": "1,2",
-							"parry": "+2",
-							"block": "No",
+							"reach": "1-2",
+							"parry": "2",
 							"defaults": [
 								{
 									"type": "dx",
@@ -10666,8 +10651,6 @@
 								}
 							],
 							"calc": {
-								"parry": "+2",
-								"block": "No",
 								"damage": "thr+2 cr"
 							}
 						},
@@ -10681,9 +10664,8 @@
 							},
 							"strength": "9†",
 							"usage": "Sword Swing",
-							"reach": "1,2",
+							"reach": "1-2",
 							"parry": "0",
-							"block": "No",
 							"defaults": [
 								{
 									"type": "dx",
@@ -10705,8 +10687,6 @@
 								}
 							],
 							"calc": {
-								"parry": "0",
-								"block": "No",
 								"damage": "sw+2 cr"
 							}
 						},
@@ -10722,7 +10702,6 @@
 							"usage": "Sword Thrust",
 							"reach": "2",
 							"parry": "0",
-							"block": "No",
 							"defaults": [
 								{
 									"type": "dx",
@@ -10744,8 +10723,6 @@
 								}
 							],
 							"calc": {
-								"parry": "0",
-								"block": "No",
 								"damage": "thr+1 cr"
 							}
 						}
@@ -10776,9 +10753,8 @@
 							},
 							"strength": "8",
 							"accuracy": "1",
-							"range": "spec",
 							"rate_of_fire": "1",
-							"shots": "T(1)",
+							"shots": "T",
 							"bulk": "-4",
 							"defaults": [
 								{
@@ -10792,7 +10768,6 @@
 								}
 							],
 							"calc": {
-								"range": "spec",
 								"damage": "see B411"
 							}
 						}
@@ -10926,10 +10901,7 @@
 							"damage": {
 								"type": "-"
 							},
-							"strength": "-",
-							"reach": "-",
-							"parry": "No",
-							"block": "+0",
+							"block": "0",
 							"defaults": [
 								{
 									"type": "block",
@@ -10937,8 +10909,6 @@
 								}
 							],
 							"calc": {
-								"parry": "No",
-								"block": "+0",
 								"damage": "-"
 							}
 						},
@@ -10950,10 +10920,10 @@
 							},
 							"strength": "8",
 							"usage": "Thrown",
-							"accuracy": "+1",
+							"accuracy": "1",
 							"range": "2",
 							"rate_of_fire": "1",
-							"shots": "T(1)",
+							"shots": "T",
 							"bulk": "-6",
 							"defaults": [
 								{
@@ -10976,7 +10946,6 @@
 								}
 							],
 							"calc": {
-								"range": "2",
 								"damage": "Special"
 							}
 						}
@@ -11026,7 +10995,6 @@
 							},
 							"strength": "6",
 							"usage": "Shoot",
-							"accuracy": "0",
 							"range": "x6/x10",
 							"rate_of_fire": "1",
 							"shots": "1(2)",
@@ -11042,7 +11010,6 @@
 								}
 							],
 							"calc": {
-								"range": "x6/x10",
 								"damage": "sw pi"
 							}
 						}
@@ -11071,11 +11038,9 @@
 								"type": "cr",
 								"st": "thr"
 							},
-							"strength": "0",
 							"usage": "Shield Bash",
 							"reach": "1",
-							"parry": "No",
-							"block": "+0",
+							"block": "0",
 							"defaults": [
 								{
 									"type": "dx",
@@ -11100,8 +11065,6 @@
 								}
 							],
 							"calc": {
-								"parry": "No",
-								"block": "+0",
 								"damage": "thr cr"
 							}
 						}
@@ -11169,7 +11132,6 @@
 							"usage": "Swung",
 							"reach": "1",
 							"parry": "0",
-							"block": "No",
 							"defaults": [
 								{
 									"type": "dx",
@@ -11216,8 +11178,6 @@
 								}
 							],
 							"calc": {
-								"parry": "0",
-								"block": "No",
 								"damage": "sw cut"
 							}
 						},
@@ -11233,7 +11193,6 @@
 							"usage": "Thrust",
 							"reach": "1",
 							"parry": "0",
-							"block": "No",
 							"defaults": [
 								{
 									"type": "dx",
@@ -11280,8 +11239,6 @@
 								}
 							],
 							"calc": {
-								"parry": "0",
-								"block": "No",
 								"damage": "thr+1 imp"
 							}
 						}
@@ -11347,7 +11304,6 @@
 							"usage": "Swing",
 							"reach": "1",
 							"parry": "0U",
-							"block": "No",
 							"defaults": [
 								{
 									"type": "dx",
@@ -11369,8 +11325,6 @@
 								}
 							],
 							"calc": {
-								"parry": "0U",
-								"block": "No",
 								"damage": "sw+2 cut"
 							}
 						},
@@ -11386,7 +11340,6 @@
 							"usage": "Swing - two handed",
 							"reach": "1",
 							"parry": "0U",
-							"block": "No",
 							"defaults": [
 								{
 									"type": "dx",
@@ -11413,8 +11366,6 @@
 								}
 							],
 							"calc": {
-								"parry": "0U",
-								"block": "No",
 								"damage": "sw+3 cut"
 							}
 						}
@@ -11577,11 +11528,9 @@
 								"type": "cr",
 								"st": "thr"
 							},
-							"strength": "0",
 							"usage": "Shield Bash",
 							"reach": "1",
-							"parry": "No",
-							"block": "+0",
+							"block": "0",
 							"defaults": [
 								{
 									"type": "dx",
@@ -11606,8 +11555,6 @@
 								}
 							],
 							"calc": {
-								"parry": "No",
-								"block": "+0",
 								"damage": "thr cr"
 							}
 						}

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 1/Classes/Druid.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 1/Classes/Druid.gct
@@ -1606,7 +1606,6 @@
 						{
 							"id": "39820d4e-6904-48c3-8f94-769033f8cdf7",
 							"type": "trait_container",
-							"open": true,
 							"children": [
 								{
 									"id": "3fa7098c-52bb-426e-bd72-e25db3d84f8c",
@@ -1848,7 +1847,8 @@
 												"compare": "is",
 												"qualifier": "Druid"
 											},
-											"amount": 1
+											"amount": 1,
+											"per_level": true
 										}
 									],
 									"can_level": true,
@@ -2424,7 +2424,8 @@
 										"compare": "is",
 										"qualifier": "Druid"
 									},
-									"amount": 1
+									"amount": 1,
+									"per_level": true
 								}
 							],
 							"can_level": true,

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 1/Dungeon Fantasy 1 Traits.adq
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 1/Dungeon Fantasy 1 Traits.adq
@@ -221,7 +221,7 @@
 		{
 			"id": "fcd37c25-2d70-4cc0-9638-c66419508ae0",
 			"type": "trait",
-			"name": "Power Investiture (Druid)",
+			"name": "Power Investiture (Druidic)",
 			"reference": "DF1:22",
 			"tags": [
 				"Advantage",

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 1/Dungeon Fantasy 1 Traits.adq
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 1/Dungeon Fantasy 1 Traits.adq
@@ -238,7 +238,8 @@
 						"compare": "is",
 						"qualifier": "Druid"
 					},
-					"amount": 1
+					"amount": 1,
+					"per_level": true
 				}
 			],
 			"can_level": true,

--- a/Library/Dungeon Fantasy/Dungeon Fantasy Adventure 1/Rivals/Master of Elements - Druid.gcs
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy Adventure 1/Rivals/Master of Elements - Druid.gcs
@@ -11,10 +11,7 @@
 		}
 	],
 	"profile": {
-		"player_name": "Mirror of the Fire Demon",
 		"name": "Gav of Oldwater",
-		"title": "Master of the Elements (Druid)",
-		"organization": "Rival Adventure Group",
 		"age": "47",
 		"birthday": "November 14",
 		"eyes": "Brown",
@@ -22,9 +19,12 @@
 		"skin": "Tanned, bearded",
 		"handedness": "Right",
 		"gender": "Male",
-		"tech_level": "3",
 		"height": "5'5\"",
-		"weight": "166 lb"
+		"weight": "166 lb",
+		"player_name": "Mirror of the Fire Demon",
+		"title": "Master of the Elements (Druid)",
+		"organization": "Rival Adventure Group",
+		"tech_level": "3"
 	},
 	"settings": {
 		"page": {
@@ -917,7 +917,7 @@
 		{
 			"id": "f1ec6711-40ab-4150-9151-adec8f759b1e",
 			"type": "trait",
-			"name": "Power Investiture (Druid)",
+			"name": "Power Investiture (Druidic)",
 			"reference": "DF1:22",
 			"tags": [
 				"Advantage",
@@ -1087,8 +1087,6 @@
 					},
 					"usage": "Bite",
 					"reach": "C",
-					"parry": "No",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx"
@@ -1100,8 +1098,6 @@
 					],
 					"calc": {
 						"level": 12,
-						"parry": "No",
-						"block": "No",
 						"damage": "1d-2 cr"
 					}
 				},
@@ -1135,8 +1131,8 @@
 					],
 					"calc": {
 						"level": 12,
-						"parry": "12",
-						"damage": "1d-2 cr"
+						"damage": "1d-2 cr",
+						"parry": "12"
 					}
 				},
 				{
@@ -1148,7 +1144,6 @@
 					},
 					"usage": "Kick",
 					"reach": "C,1",
-					"parry": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -1171,7 +1166,6 @@
 					],
 					"calc": {
 						"level": 10,
-						"parry": "No",
 						"damage": "1d cr"
 					}
 				}
@@ -2208,7 +2202,8 @@
 					},
 					"calc": {
 						"level": 16,
-						"rsl": "IQ+2"
+						"rsl": "IQ+2",
+						"unsatisfied_reason": "Prerequisites have not been met:\n● Requires at least one of:\n  ● Has a trait whose name is \"animal friend\" and level is at least 1\n  ● Has is at least 1 spell whose name is \"persuasion\"\n  ● Has a trait whose name is \"animal empathy\" and level is anything"
 					}
 				},
 				{
@@ -2312,7 +2307,8 @@
 					},
 					"calc": {
 						"level": 16,
-						"rsl": "IQ+2"
+						"rsl": "IQ+2",
+						"unsatisfied_reason": "Prerequisites have not been met:\n● Requires all of:\n  ● Has is at least 1 spell whose name is \"body of air\"\n  ● Requires at least one of:\n    ● Has a trait whose name is \"magery\", notes does not contain \"one college\", and level is at least 3\n    ● Has a trait whose name is \"magery\", notes contains \"one college (air)\", and level is at least 3"
 					}
 				},
 				{
@@ -2394,7 +2390,8 @@
 					},
 					"calc": {
 						"level": 16,
-						"rsl": "IQ+2"
+						"rsl": "IQ+2",
+						"unsatisfied_reason": "Prerequisites have not been met:\n● Requires all of:\n  ● Has is at least 1 spell whose name is \"plant form\"\n  ● Requires at least one of:\n    ● Has a trait whose name is \"magery\", notes does not contain \"one college\", and level is at least 2\n    ● Has a trait whose name is \"magery\", notes contains \"one college (plant)\", and level is at least 2"
 					}
 				},
 				{
@@ -2532,7 +2529,8 @@
 					},
 					"calc": {
 						"level": 16,
-						"rsl": "IQ+2"
+						"rsl": "IQ+2",
+						"unsatisfied_reason": "Prerequisites have not been met:\n● Requires all of:\n  ● Has is at least 1 spell whose name is \"relieve sickness\"\n  ● Has is at least 1 spell whose name is \"major healing\""
 					}
 				},
 				{
@@ -2594,7 +2592,8 @@
 					},
 					"calc": {
 						"level": 16,
-						"rsl": "IQ+2"
+						"rsl": "IQ+2",
+						"unsatisfied_reason": "Prerequisites have not been met:\n● Requires at least one of:\n  ● Has a trait whose name is \"magery\", notes does not contain \"one college\", and level is at least 1\n  ● Has a trait whose name is \"magery\", notes contains \"one college (knowledge)\", and level is at least 1"
 					}
 				},
 				{
@@ -2652,7 +2651,8 @@
 					},
 					"calc": {
 						"level": 16,
-						"rsl": "IQ+2"
+						"rsl": "IQ+2",
+						"unsatisfied_reason": "Prerequisites have not been met:\n● Requires at least one of:\n  ● Has is at least 1 spell whose name is \"sense danger\"\n  ● Has is at least 1 spell whose name is \"test food\""
 					}
 				},
 				{
@@ -2705,7 +2705,8 @@
 					},
 					"calc": {
 						"level": 16,
-						"rsl": "IQ+2"
+						"rsl": "IQ+2",
+						"unsatisfied_reason": "Prerequisites have not been met:\n● Requires all of:\n  ● Has is at least 1 spell whose name is \"counterspell\""
 					}
 				},
 				{
@@ -2851,7 +2852,8 @@
 					},
 					"calc": {
 						"level": 16,
-						"rsl": "IQ+2"
+						"rsl": "IQ+2",
+						"unsatisfied_reason": "Prerequisites have not been met:\n● Requires at least one of:\n  ● Has is at least 1 spell whose name is \"cold\"\n  ● Has is at least 1 spell whose name is \"create water\""
 					}
 				},
 				{
@@ -2951,7 +2953,8 @@
 					},
 					"calc": {
 						"level": 16,
-						"rsl": "IQ+2"
+						"rsl": "IQ+2",
+						"unsatisfied_reason": "Prerequisites have not been met:\n● Requires all of:\n  ● Requires at least one of:\n    ● Has is at least 1 spell whose name is \"watchdog\"\n    ● Has is at least 1 spell whose name is \"shield\"\n  ● Requires at least one of:\n    ● Has a trait whose name is \"magery\", notes does not contain \"one college\", and level is at least 1\n    ● Has a trait whose name is \"magery\", notes contains \"one college (protection \u0026 warning)\", and level is at least 1"
 					}
 				},
 				{
@@ -3079,7 +3082,8 @@
 					},
 					"calc": {
 						"level": 16,
-						"rsl": "IQ+2"
+						"rsl": "IQ+2",
+						"unsatisfied_reason": "Prerequisites have not been met:\n● Requires all of:\n  ● Requires at least one of:\n    ● Has a trait whose name is \"magery\", notes does not contain \"one college\", and level is at least 1\n    ● Has a trait whose name is \"magery\", notes contains \"one college (healing)\", and level is at least 1\n  ● Has is at least 1 spell whose name is \"lend energy\""
 					}
 				},
 				{
@@ -3122,7 +3126,8 @@
 					},
 					"calc": {
 						"level": 16,
-						"rsl": "IQ+2"
+						"rsl": "IQ+2",
+						"unsatisfied_reason": "Prerequisites have not been met:\n● Requires all of:\n  ● Has is at least 1 spell whose name is \"Animal Control (Equine)\""
 					}
 				},
 				{
@@ -3180,7 +3185,8 @@
 					},
 					"calc": {
 						"level": 16,
-						"rsl": "IQ+2"
+						"rsl": "IQ+2",
+						"unsatisfied_reason": "Prerequisites have not been met:\n● Requires all of:\n  ● Has is at least 1 spell whose name is \"create earth\""
 					}
 				},
 				{
@@ -3271,7 +3277,8 @@
 					},
 					"calc": {
 						"level": 16,
-						"rsl": "IQ+2"
+						"rsl": "IQ+2",
+						"unsatisfied_reason": "Prerequisites have not been met:\n● Requires all of:\n  ● Has is at least 1 spell whose name is \"create air\""
 					}
 				},
 				{
@@ -3314,7 +3321,8 @@
 					},
 					"calc": {
 						"level": 16,
-						"rsl": "IQ+2"
+						"rsl": "IQ+2",
+						"unsatisfied_reason": "Prerequisites have not been met:\n● Requires all of:\n  ● Has is at least 1 spell whose name is \"seek earth\""
 					}
 				},
 				{
@@ -3357,7 +3365,8 @@
 					},
 					"calc": {
 						"level": 16,
-						"rsl": "IQ+2"
+						"rsl": "IQ+2",
+						"unsatisfied_reason": "Prerequisites have not been met:\n● Requires all of:\n  ● Has is at least 1 spell whose name is \"create water\""
 					}
 				},
 				{
@@ -3504,7 +3513,6 @@
 								"type": "grapple ST 10/strand"
 							},
 							"accuracy": "3",
-							"range": "5/point",
 							"defaults": [
 								{
 									"type": "dx",
@@ -3518,14 +3526,14 @@
 							],
 							"calc": {
 								"level": 8,
-								"range": "5/point",
 								"damage": "grapple ST 10/strand"
 							}
 						}
 					],
 					"calc": {
 						"level": 16,
-						"rsl": "IQ+2"
+						"rsl": "IQ+2",
+						"unsatisfied_reason": "Prerequisites have not been met:\n● Requires all of:\n  ● Requires at least one of:\n    ● Has a trait whose name is \"magery\", notes does not contain \"one college\", and level is at least 1\n    ● Has a trait whose name is \"magery\", notes contains \"one college (animal)\", and level is at least 1"
 					}
 				},
 				{
@@ -3585,7 +3593,8 @@
 					},
 					"calc": {
 						"level": 16,
-						"rsl": "IQ+2"
+						"rsl": "IQ+2",
+						"unsatisfied_reason": "Prerequisites have not been met:\n● Requires all of:\n  ● Has is at least 1 spell whose name is \"hail\""
 					}
 				},
 				{
@@ -3736,7 +3745,8 @@
 					},
 					"calc": {
 						"level": 16,
-						"rsl": "IQ+2"
+						"rsl": "IQ+2",
+						"unsatisfied_reason": "Prerequisites have not been met:\n● Requires all of:\n  ● Requires at least one of:\n    ● Has a trait whose name is \"magery\", notes does not contain \"one college\", and level is at least 1\n    ● Has a trait whose name is \"magery\", notes contains \"one college (air)\", and level is at least 1"
 					}
 				},
 				{
@@ -3887,7 +3897,8 @@
 					},
 					"calc": {
 						"level": 16,
-						"rsl": "IQ+2"
+						"rsl": "IQ+2",
+						"unsatisfied_reason": "Prerequisites have not been met:\n● Requires all of:\n  ● Requires at least one of:\n    ● Requires all of:\n      ● Has is at least 4 spells whose college contains \"Earth\"\n    ● Has is at least 8 spells whose college contains \"Earth\"\n  ● Requires at least one of:\n    ● Has a trait whose name is \"magery\", notes does not contain \"one college\", and level is at least 1\n    ● Has a trait whose name is \"magery\", notes contains \"one college (earth)\", and level is at least 1"
 					}
 				},
 				{
@@ -4038,7 +4049,8 @@
 					},
 					"calc": {
 						"level": 16,
-						"rsl": "IQ+2"
+						"rsl": "IQ+2",
+						"unsatisfied_reason": "Prerequisites have not been met:\n● Requires all of:\n  ● Requires at least one of:\n    ● Has a trait whose name is \"magery\", notes does not contain \"one college\", and level is at least 1\n    ● Has a trait whose name is \"magery\", notes contains \"one college (fire)\", and level is at least 1\n  ● Requires at least one of:\n    ● Requires all of:\n      ● Has is at least 4 spells whose college contains \"Fire\"\n    ● Has is at least 8 spells whose college contains \"Fire\""
 					}
 				},
 				{
@@ -4189,7 +4201,8 @@
 					},
 					"calc": {
 						"level": 16,
-						"rsl": "IQ+2"
+						"rsl": "IQ+2",
+						"unsatisfied_reason": "Prerequisites have not been met:\n● Requires all of:\n  ● Requires at least one of:\n    ● Has a trait whose name is \"magery\", notes does not contain \"one college\", and level is at least 1\n    ● Has a trait whose name is \"magery\", notes contains \"one college (water)\", and level is at least 1"
 					}
 				},
 				{
@@ -4441,7 +4454,6 @@
 					"usage": "Swung",
 					"reach": "1",
 					"parry": "0",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -4489,9 +4501,8 @@
 					],
 					"calc": {
 						"level": 15,
-						"parry": "13",
-						"block": "No",
-						"damage": "1d+1 cut"
+						"damage": "1d+1 cut",
+						"parry": "13"
 					}
 				},
 				{
@@ -4506,7 +4517,6 @@
 					"usage": "Thrust",
 					"reach": "1",
 					"parry": "0",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -4554,9 +4564,8 @@
 					],
 					"calc": {
 						"level": 15,
-						"parry": "13",
-						"block": "No",
-						"damage": "1d imp"
+						"damage": "1d imp",
+						"parry": "13"
 					}
 				}
 			],
@@ -4585,11 +4594,9 @@
 						"type": "cr",
 						"st": "thr"
 					},
-					"strength": "0",
 					"usage": "Shield Bash",
 					"reach": "1",
-					"parry": "No",
-					"block": "+0",
+					"block": "0",
 					"defaults": [
 						{
 							"type": "dx",
@@ -4615,9 +4622,8 @@
 					],
 					"calc": {
 						"level": 14,
-						"parry": "No",
-						"block": "13",
-						"damage": "1d-1 cr"
+						"damage": "1d-1 cr",
+						"block": "13"
 					}
 				}
 			],
@@ -4727,10 +4733,7 @@
 							"damage": {
 								"type": "-"
 							},
-							"strength": "-",
-							"reach": "-",
-							"parry": "No",
-							"block": "+0",
+							"block": "0",
 							"defaults": [
 								{
 									"type": "block",
@@ -4738,8 +4741,6 @@
 								}
 							],
 							"calc": {
-								"parry": "No",
-								"block": "0",
 								"damage": "-"
 							}
 						},
@@ -4751,10 +4752,10 @@
 							},
 							"strength": "8",
 							"usage": "Thrown",
-							"accuracy": "+1",
+							"accuracy": "1",
 							"range": "2",
 							"rate_of_fire": "1",
-							"shots": "T(1)",
+							"shots": "T",
 							"bulk": "-6",
 							"defaults": [
 								{
@@ -4778,7 +4779,6 @@
 							],
 							"calc": {
 								"level": 10,
-								"range": "2",
 								"damage": "Special"
 							}
 						}

--- a/Library/Dungeon Fantasy/Dungeon Fantasy Spells.spl
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy Spells.spl
@@ -5594,7 +5594,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -5632,7 +5632,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -5670,7 +5670,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -5708,7 +5708,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -5746,7 +5746,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -5784,7 +5784,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -5822,7 +5822,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -5860,7 +5860,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -5898,7 +5898,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -5936,7 +5936,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -5974,7 +5974,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -6012,7 +6012,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -6050,7 +6050,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -6088,7 +6088,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -6126,7 +6126,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -6164,7 +6164,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -6202,7 +6202,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -6240,7 +6240,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -6278,7 +6278,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -6316,7 +6316,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -6354,7 +6354,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -6392,7 +6392,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -6430,7 +6430,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -6441,7 +6441,7 @@
 					}
 				}
 			],
-			"name": "Power Investiture (Druid) 1",
+			"name": "Power Investiture (Druidic) 1",
 			"tags": [
 				"Druid"
 			]
@@ -6479,7 +6479,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -6517,7 +6517,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -6555,7 +6555,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -6593,7 +6593,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -6631,7 +6631,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -6669,7 +6669,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -6707,7 +6707,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -6745,7 +6745,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -6783,7 +6783,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -6821,7 +6821,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -6859,7 +6859,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -6897,7 +6897,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -6935,7 +6935,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -6973,7 +6973,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -7011,7 +7011,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -7049,7 +7049,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -7087,7 +7087,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -7125,7 +7125,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -7163,7 +7163,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -7201,7 +7201,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -7239,7 +7239,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -7277,7 +7277,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -7315,7 +7315,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -7369,7 +7369,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -7407,7 +7407,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -7445,7 +7445,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -7483,7 +7483,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -7521,7 +7521,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -7559,7 +7559,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -7597,7 +7597,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -7635,7 +7635,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -7673,7 +7673,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -7711,7 +7711,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -7749,7 +7749,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -7787,7 +7787,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -7825,7 +7825,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -7863,7 +7863,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -7901,7 +7901,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -7940,7 +7940,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -8004,7 +8004,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -8042,7 +8042,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -8080,7 +8080,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -8091,7 +8091,7 @@
 					}
 				}
 			],
-			"name": "Power Investiture (Druid) 2",
+			"name": "Power Investiture (Druidic) 2",
 			"tags": [
 				"Druid"
 			]
@@ -8130,7 +8130,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -8168,7 +8168,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -8206,7 +8206,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -8244,7 +8244,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -8282,7 +8282,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -8320,7 +8320,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -8358,7 +8358,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -8396,7 +8396,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -8434,7 +8434,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -8472,7 +8472,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -8510,7 +8510,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -8548,7 +8548,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -8586,7 +8586,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -8624,7 +8624,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -8662,7 +8662,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -8700,7 +8700,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -8738,7 +8738,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -8776,7 +8776,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -8814,7 +8814,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -8852,7 +8852,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -8890,7 +8890,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -8928,7 +8928,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -8966,7 +8966,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -9004,7 +9004,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -9042,7 +9042,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -9080,7 +9080,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -9118,7 +9118,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -9156,7 +9156,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -9194,7 +9194,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -9232,7 +9232,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -9270,7 +9270,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -9308,7 +9308,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -9346,7 +9346,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -9384,7 +9384,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -9422,7 +9422,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -9460,7 +9460,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -9498,7 +9498,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -9509,7 +9509,7 @@
 					}
 				}
 			],
-			"name": "Power Investiture (Druid) 3",
+			"name": "Power Investiture (Druidic) 3",
 			"tags": [
 				"Druid"
 			]
@@ -9547,7 +9547,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -9585,7 +9585,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -9623,7 +9623,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -9661,7 +9661,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -9699,7 +9699,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -9737,7 +9737,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -9775,7 +9775,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -9813,7 +9813,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -9851,7 +9851,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -9889,7 +9889,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -9927,7 +9927,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -9965,7 +9965,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -10003,7 +10003,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -10041,7 +10041,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -10079,7 +10079,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -10134,7 +10134,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -10189,7 +10189,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -10254,7 +10254,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -10292,7 +10292,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -10330,7 +10330,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -10368,7 +10368,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -10406,7 +10406,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -10444,7 +10444,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -10482,7 +10482,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -10493,7 +10493,7 @@
 					}
 				}
 			],
-			"name": "Power Investiture (Druid) 4",
+			"name": "Power Investiture (Druidic) 4",
 			"tags": [
 				"Druid"
 			]
@@ -10531,7 +10531,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -10569,7 +10569,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -10607,7 +10607,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -10645,7 +10645,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -10683,7 +10683,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -10721,7 +10721,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -10759,7 +10759,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -10797,7 +10797,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -10835,7 +10835,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -10873,7 +10873,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -10911,7 +10911,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -10922,7 +10922,7 @@
 					}
 				}
 			],
-			"name": "Power Investiture (Druid) 5",
+			"name": "Power Investiture (Druidic) 5",
 			"tags": [
 				"Druid"
 			]
@@ -10960,7 +10960,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -10998,7 +10998,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -11036,7 +11036,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -11074,7 +11074,7 @@
 								"has": true,
 								"name": {
 									"compare": "is",
-									"qualifier": "Power Investiture (Druid)"
+									"qualifier": "Power Investiture (Druidic)"
 								},
 								"level": {
 									"compare": "at_least",
@@ -11085,7 +11085,7 @@
 					}
 				}
 			],
-			"name": "Power Investiture (Druid) 6",
+			"name": "Power Investiture (Druidic) 6",
 			"tags": [
 				"Druid"
 			]


### PR DESCRIPTION
Changed Power Investiture (Druid) to Power Investiture (Druidic) to match the terminology used in the rules and DFRPG. Adjusted it in the Traits and Spells libraries, Druid template, and the  rival druid in Mirror of the Fire Demon.