### PR TITLE
Magic Spells : Add History prerequisite to Dinvination Spells.

### DIFF
--- a/Library/Magic/Magic Spells.spl
+++ b/Library/Magic/Magic Spells.spl
@@ -12225,6 +12225,19 @@
 						"has": true,
 						"qualifier": {
 							"compare": "is",
+							"qualifier": "history"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
 							"qualifier": "predict weather"
 						},
 						"quantity": {
@@ -12270,6 +12283,19 @@
 				"type": "prereq_list",
 				"all": true,
 				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "history"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
 					{
 						"type": "spell_prereq",
 						"sub_type": "college",
@@ -12348,6 +12374,19 @@
 				"type": "prereq_list",
 				"all": true,
 				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "history"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
 					{
 						"type": "spell_prereq",
 						"sub_type": "college",
@@ -12432,6 +12471,19 @@
 						"has": true,
 						"qualifier": {
 							"compare": "is",
+							"qualifier": "history"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
 							"qualifier": "earth vision"
 						},
 						"quantity": {
@@ -12478,6 +12530,19 @@
 				"type": "prereq_list",
 				"all": true,
 				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "history"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
 					{
 						"type": "spell_prereq",
 						"sub_type": "college",
@@ -12558,6 +12623,19 @@
 				"prereqs": [
 					{
 						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "history"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
 						"sub_type": "college",
 						"has": true,
 						"qualifier": {
@@ -12595,6 +12673,19 @@
 				"type": "prereq_list",
 				"all": true,
 				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "history"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
 					{
 						"type": "spell_prereq",
 						"sub_type": "college",
@@ -12648,6 +12739,19 @@
 				"prereqs": [
 					{
 						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "history"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
 						"sub_type": "college",
 						"has": true,
 						"qualifier": {
@@ -12685,6 +12789,19 @@
 				"type": "prereq_list",
 				"all": true,
 				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "history"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
 					{
 						"type": "spell_prereq",
 						"sub_type": "college",
@@ -12725,6 +12842,19 @@
 				"all": true,
 				"prereqs": [
 					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "history"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
 						"type": "trait_prereq",
 						"has": true,
 						"name": {
@@ -12758,6 +12888,19 @@
 				"type": "prereq_list",
 				"all": true,
 				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "history"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
 					{
 						"type": "spell_prereq",
 						"sub_type": "college",
@@ -12799,6 +12942,19 @@
 				"prereqs": [
 					{
 						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "history"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
 						"sub_type": "college",
 						"has": true,
 						"qualifier": {
@@ -12838,6 +12994,19 @@
 				"prereqs": [
 					{
 						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "history"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "spell_prereq",
 						"sub_type": "college",
 						"has": true,
 						"qualifier": {
@@ -12875,6 +13044,19 @@
 				"type": "prereq_list",
 				"all": true,
 				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "history"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
 					{
 						"type": "spell_prereq",
 						"sub_type": "name",
@@ -12953,6 +13135,19 @@
 				"type": "prereq_list",
 				"all": true,
 				"prereqs": [
+					{
+						"type": "spell_prereq",
+						"sub_type": "name",
+						"has": true,
+						"qualifier": {
+							"compare": "is",
+							"qualifier": "history"
+						},
+						"quantity": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
 					{
 						"type": "skill_prereq",
 						"has": true,


### PR DESCRIPTION
In the Magic book page 108 Divination has a prequisite of : History, and other spells as specified for the particular method of divination.

Unfortunately the History prequisite was missed off in the library.