### PR TITLE
Made various changes

### DIFF
--- a/Library/Basic Set/Basic Set Skills.skl
+++ b/Library/Basic Set/Basic Set Skills.skl
@@ -2869,7 +2869,7 @@
 						"qualifier": 1
 					},
 					"amount": 1,
-					"per_level": true
+					"per_die": true
 				},
 				{
 					"type": "weapon_bonus",
@@ -2883,7 +2883,7 @@
 						"qualifier": 2
 					},
 					"amount": 1,
-					"per_level": true
+					"per_die": true
 				}
 			]
 		},
@@ -2953,7 +2953,7 @@
 						"qualifier": 2
 					},
 					"amount": 1,
-					"per_level": true
+					"per_die": true
 				}
 			]
 		},
@@ -11371,7 +11371,7 @@
 						"compare": "at_least"
 					},
 					"amount": 1,
-					"per_level": true
+					"per_die": true
 				},
 				{
 					"type": "weapon_bonus",
@@ -11385,7 +11385,7 @@
 						"qualifier": 1
 					},
 					"amount": 1,
-					"per_level": true
+					"per_die": true
 				}
 			]
 		},
@@ -18472,6 +18472,39 @@
 			"tags": [
 				"Military"
 			],
+			"specialization": "Air",
+			"difficulty": "iq/h",
+			"points": 1,
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Intelligence Analysis",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Tactics",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Strategy",
+					"modifier": -4
+				}
+			]
+		},
+		{
+			"id": "5f435b5d-c0cc-4f12-8c3f-a5a9736efd24",
+			"type": "skill",
+			"name": "Strategy",
+			"reference": "B222",
+			"tags": [
+				"Military"
+			],
 			"specialization": "Land",
 			"difficulty": "iq/h",
 			"points": 1,
@@ -18832,7 +18865,7 @@
 			}
 		},
 		{
-			"id": "0920cc95-ab25-4cd5-b00e-0ff44bd51a96",
+			"id": "6514b812-6434-4590-85d3-c823b994c547",
 			"type": "skill",
 			"name": "Survival",
 			"reference": "B223",
@@ -18840,7 +18873,7 @@
 				"Exploration",
 				"Outdoor"
 			],
-			"specialization": "@Environment@",
+			"specialization": "@Any Aquatic@",
 			"difficulty": "per/a",
 			"points": 1,
 			"defaults": [
@@ -18892,13 +18925,115 @@
 				{
 					"type": "skill",
 					"name": "Survival",
+					"specialization": "Salt-Water Sea",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Survival",
 					"specialization": "Tropical Lagoon",
 					"modifier": -4
 				}
 			]
 		},
 		{
+			"id": "0920cc95-ab25-4cd5-b00e-0ff44bd51a96",
+			"type": "skill",
+			"name": "Survival",
+			"reference": "B223",
+			"tags": [
+				"Exploration",
+				"Outdoor"
+			],
+			"specialization": "@Any Environment@",
+			"difficulty": "per/a",
+			"points": 1,
+			"defaults": [
+				{
+					"type": "per",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Naturalist",
+					"modifier": -3
+				}
+			]
+		},
+		{
 			"id": "c7cc35bf-4351-4894-a363-328c3d1f22ea",
+			"type": "skill",
+			"name": "Survival",
+			"reference": "B223",
+			"tags": [
+				"Exploration",
+				"Outdoor"
+			],
+			"specialization": "@Any Land@",
+			"difficulty": "per/a",
+			"points": 1,
+			"defaults": [
+				{
+					"type": "per",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Naturalist",
+					"modifier": -3
+				},
+				{
+					"type": "skill",
+					"name": "Survival",
+					"specialization": "Arctic",
+					"modifier": -3
+				},
+				{
+					"type": "skill",
+					"name": "Survival",
+					"specialization": "Desert",
+					"modifier": -3
+				},
+				{
+					"type": "skill",
+					"name": "Survival",
+					"specialization": "Island/Beach",
+					"modifier": -3
+				},
+				{
+					"type": "skill",
+					"name": "Survival",
+					"specialization": "Jungle",
+					"modifier": -3
+				},
+				{
+					"type": "skill",
+					"name": "Survival",
+					"specialization": "Mountain",
+					"modifier": -3
+				},
+				{
+					"type": "skill",
+					"name": "Survival",
+					"specialization": "Plains",
+					"modifier": -3
+				},
+				{
+					"type": "skill",
+					"name": "Survival",
+					"specialization": "Swamplands",
+					"modifier": -3
+				},
+				{
+					"type": "skill",
+					"name": "Survival",
+					"specialization": "Woodlands",
+					"modifier": -3
+				}
+			]
+		},
+		{
+			"id": "e579df57-4000-41cf-83e3-ccade5ce22f5",
 			"type": "skill",
 			"name": "Survival",
 			"reference": "B223",
@@ -18964,7 +19099,7 @@
 			]
 		},
 		{
-			"id": "6514b812-6434-4590-85d3-c823b994c547",
+			"id": "1e854277-d5f8-4d36-9f79-b31dcae13f85",
 			"type": "skill",
 			"name": "Survival",
 			"reference": "B223",

--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -2692,7 +2692,6 @@
 					"usage": "Punch",
 					"reach": "C",
 					"parry": "0",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx"
@@ -2711,8 +2710,6 @@
 						}
 					],
 					"calc": {
-						"parry": "0",
-						"block": "No",
 						"damage": "thr-1 (+1 per die) cr"
 					}
 				},
@@ -2726,8 +2723,6 @@
 					},
 					"usage": "Kick",
 					"reach": "C,1",
-					"parry": "No",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -2745,8 +2740,6 @@
 						}
 					],
 					"calc": {
-						"parry": "No",
-						"block": "No",
 						"damage": "thr (+1 per die) cr"
 					}
 				}
@@ -4842,7 +4835,7 @@
 								"compare": "at_least"
 							},
 							"amount": -1,
-							"per_level": true
+							"per_die": true
 						}
 					]
 				}
@@ -4859,7 +4852,6 @@
 					},
 					"reach": "C",
 					"parry": "0",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx"
@@ -4870,8 +4862,6 @@
 						}
 					],
 					"calc": {
-						"parry": "0",
-						"block": "No",
 						"damage": "thr (+1 per die) cr"
 					}
 				}
@@ -5032,7 +5022,7 @@
 								"compare": "at_least"
 							},
 							"amount": -1,
-							"per_level": true
+							"per_die": true
 						}
 					]
 				}
@@ -5049,7 +5039,6 @@
 					},
 					"reach": "C",
 					"parry": "0",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "skill",
@@ -5060,8 +5049,6 @@
 						}
 					],
 					"calc": {
-						"parry": "0",
-						"block": "No",
 						"damage": "thr (+1 per die) cut"
 					}
 				}
@@ -8492,8 +8479,6 @@
 					},
 					"usage": "Bite",
 					"reach": "C",
-					"parry": "No",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "skill",
@@ -8504,8 +8489,6 @@
 						}
 					],
 					"calc": {
-						"parry": "No",
-						"block": "No",
 						"damage": "thr-1 imp"
 					}
 				}
@@ -9065,6 +9048,36 @@
 					"name": "Slow, Move 1",
 					"reference": "PSI14",
 					"cost": -45,
+					"disabled": true
+				},
+				{
+					"id": "b53ded9b-d24e-4a5a-ab39-6cdaa574ae3f",
+					"type": "modifier",
+					"name": "Encumbrance-Limited (No encumbrance)",
+					"reference": "FFWF12",
+					"reference_highlight": "Encumbrance-Limited",
+					"notes": "Can only glide at best when overburdened",
+					"cost": -15,
+					"disabled": true
+				},
+				{
+					"id": "d0a74eb5-64d3-4650-978d-6bd539d38d82",
+					"type": "modifier",
+					"name": "Encumbrance-Limited (Light encumbrance)",
+					"reference": "FFWF12",
+					"reference_highlight": "Encumbrance-Limited",
+					"notes": "Can only glide at best when overburdened",
+					"cost": -10,
+					"disabled": true
+				},
+				{
+					"id": "c1f771ed-e5bd-46a6-b67c-e88578c364c6",
+					"type": "modifier",
+					"name": "Encumbrance-Limited (Medium encumbrance)",
+					"reference": "FFWF12",
+					"reference_highlight": "Encumbrance-Limited",
+					"notes": "Can only glide at best when overburdened",
+					"cost": -5,
 					"disabled": true
 				}
 			],
@@ -10483,8 +10496,6 @@
 					},
 					"usage": "Trample",
 					"reach": "C,1",
-					"parry": "No",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -10502,8 +10513,6 @@
 						}
 					],
 					"calc": {
-						"parry": "No",
-						"block": "No",
 						"damage": "thr (+1 per die) cr"
 					}
 				}
@@ -10850,7 +10859,7 @@
 								"compare": "at_least"
 							},
 							"amount": -1,
-							"per_level": true
+							"per_die": true
 						}
 					]
 				}
@@ -10867,7 +10876,6 @@
 					},
 					"reach": "C",
 					"parry": "0",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx"
@@ -10878,8 +10886,6 @@
 						}
 					],
 					"calc": {
-						"parry": "0",
-						"block": "No",
 						"damage": "thr (+1 per die) imp"
 					}
 				}
@@ -11870,7 +11876,6 @@
 						}
 					],
 					"calc": {
-						"range": "10/100",
 						"damage": "1d burn"
 					}
 				}
@@ -12181,7 +12186,6 @@
 						}
 					],
 					"calc": {
-						"range": "10/100",
 						"damage": "1d cor"
 					}
 				}
@@ -12389,7 +12393,6 @@
 						}
 					],
 					"calc": {
-						"range": "10/100",
 						"damage": "1d cr"
 					}
 				}
@@ -12598,7 +12601,6 @@
 						}
 					],
 					"calc": {
-						"range": "10/100",
 						"damage": "1d cut"
 					}
 				}
@@ -12946,7 +12948,6 @@
 						}
 					],
 					"calc": {
-						"range": "10/100",
 						"damage": "1d fat"
 					}
 				}
@@ -13154,7 +13155,6 @@
 						}
 					],
 					"calc": {
-						"range": "10/100",
 						"damage": "1d pi++"
 					}
 				}
@@ -13362,7 +13362,6 @@
 						}
 					],
 					"calc": {
-						"range": "10/100",
 						"damage": "1d imp"
 					}
 				}
@@ -13587,7 +13586,6 @@
 						}
 					],
 					"calc": {
-						"range": "10/100",
 						"damage": "1d pi+"
 					}
 				}
@@ -13812,7 +13810,6 @@
 						}
 					],
 					"calc": {
-						"range": "10/100",
 						"damage": "1d pi"
 					}
 				}
@@ -14021,7 +14018,6 @@
 						}
 					],
 					"calc": {
-						"range": "10/100",
 						"damage": "1d pi-"
 					}
 				}
@@ -14340,7 +14336,6 @@
 						}
 					],
 					"calc": {
-						"range": "10/100",
 						"damage": "1d tox"
 					}
 				}
@@ -15278,6 +15273,17 @@
 				"Disadvantage",
 				"Physical"
 			],
+			"modifiers": [
+				{
+					"id": "2090b232-beec-4250-b58a-373f0021b0ff",
+					"type": "modifier",
+					"name": "Mitigator: Flight",
+					"reference": "FFWF13",
+					"reference_highlight": "Lame",
+					"cost": -80,
+					"disabled": true
+				}
+			],
 			"base_points": -10,
 			"features": [
 				{
@@ -15299,6 +15305,17 @@
 			"tags": [
 				"Disadvantage",
 				"Physical"
+			],
+			"modifiers": [
+				{
+					"id": "9702217e-975e-472a-a03e-62d8220b9a11",
+					"type": "modifier",
+					"name": "Mitigator: Flight",
+					"reference": "FFWF13",
+					"reference_highlight": "Lame",
+					"cost": -80,
+					"disabled": true
+				}
 			],
 			"base_points": -30,
 			"features": [
@@ -15322,6 +15339,17 @@
 				"Disadvantage",
 				"Physical"
 			],
+			"modifiers": [
+				{
+					"id": "9277fdb9-781f-4da2-8389-9bff54237422",
+					"type": "modifier",
+					"name": "Mitigator: Flight",
+					"reference": "FFWF13",
+					"reference_highlight": "Lame",
+					"cost": -80,
+					"disabled": true
+				}
+			],
 			"base_points": -20,
 			"features": [
 				{
@@ -15343,6 +15371,17 @@
 			"tags": [
 				"Disadvantage",
 				"Physical"
+			],
+			"modifiers": [
+				{
+					"id": "78413b18-70ca-4693-b572-26b5549ca56d",
+					"type": "modifier",
+					"name": "Mitigator: Flight",
+					"reference": "FFWF13",
+					"reference_highlight": "Lame",
+					"cost": -80,
+					"disabled": true
+				}
 			],
 			"base_points": -30,
 			"features": [
@@ -15467,6 +15506,23 @@
 					"disabled": true
 				}
 			],
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Language Talent"
+						},
+						"level": {
+							"compare": "at_least"
+						}
+					}
+				]
+			},
 			"calc": {
 				"points": 4
 			}
@@ -15613,7 +15669,7 @@
 								"compare": "at_least"
 							},
 							"amount": -1,
-							"per_level": true
+							"per_die": true
 						}
 					]
 				}
@@ -15630,7 +15686,6 @@
 					},
 					"reach": "C",
 					"parry": "0",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx"
@@ -15641,8 +15696,6 @@
 						}
 					],
 					"calc": {
-						"parry": "0",
-						"block": "No",
 						"damage": "thr (+1 per die) pi+"
 					}
 				}
@@ -15953,8 +16006,6 @@
 					},
 					"usage": "Stab",
 					"reach": "C",
-					"parry": "No",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -15962,8 +16013,6 @@
 						}
 					],
 					"calc": {
-						"parry": "No",
-						"block": "No",
 						"damage": "1d imp"
 					}
 				}
@@ -15995,7 +16044,6 @@
 					"usage": "Slash",
 					"reach": "C,1",
 					"parry": "0",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx"
@@ -16014,8 +16062,6 @@
 						}
 					],
 					"calc": {
-						"parry": "0",
-						"block": "No",
 						"damage": "thr-1 (+1 per die) cut"
 					}
 				},
@@ -16031,7 +16077,6 @@
 					"usage": "Stab",
 					"reach": "C,1",
 					"parry": "0",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx"
@@ -16050,8 +16095,6 @@
 						}
 					],
 					"calc": {
-						"parry": "0",
-						"block": "No",
 						"damage": "thr-1 (+1 per die) imp"
 					}
 				}
@@ -21041,7 +21084,7 @@
 								"compare": "at_least"
 							},
 							"amount": -1,
-							"per_level": true
+							"per_die": true
 						}
 					]
 				}
@@ -21058,7 +21101,6 @@
 					},
 					"reach": "C",
 					"parry": "0",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "skill",
@@ -21069,8 +21111,6 @@
 						}
 					],
 					"calc": {
-						"parry": "0",
-						"block": "No",
 						"damage": "thr (+1 per die) pi"
 					}
 				}
@@ -23806,8 +23846,6 @@
 					},
 					"usage": "Peck",
 					"reach": "C",
-					"parry": "No",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx"
@@ -23818,8 +23856,6 @@
 						}
 					],
 					"calc": {
-						"parry": "No",
-						"block": "No",
 						"damage": "thr-1 pi+"
 					}
 				}
@@ -23850,7 +23886,6 @@
 					"usage": "Slash",
 					"reach": "C",
 					"parry": "0",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx"
@@ -23869,8 +23904,6 @@
 						}
 					],
 					"calc": {
-						"parry": "0",
-						"block": "No",
 						"damage": "thr-1 cut"
 					}
 				},
@@ -23883,8 +23916,6 @@
 					},
 					"usage": "Kick",
 					"reach": "C,1",
-					"parry": "No",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -23902,8 +23933,6 @@
 						}
 					],
 					"calc": {
-						"parry": "No",
-						"block": "No",
 						"damage": "thr cut"
 					}
 				}
@@ -23945,8 +23974,6 @@
 					},
 					"usage": "Bite",
 					"reach": "C",
-					"parry": "No",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "skill",
@@ -23957,8 +23984,6 @@
 						}
 					],
 					"calc": {
-						"parry": "No",
-						"block": "No",
 						"damage": "thr-1 cut"
 					}
 				}
@@ -24021,8 +24046,6 @@
 					},
 					"usage": "Stab",
 					"reach": "C",
-					"parry": "No",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -24030,8 +24053,6 @@
 						}
 					],
 					"calc": {
-						"parry": "No",
-						"block": "No",
 						"damage": "1d-2 imp"
 					}
 				}
@@ -28175,7 +28196,6 @@
 					"usage": "Slash",
 					"reach": "C",
 					"parry": "0",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx"
@@ -28194,8 +28214,6 @@
 						}
 					],
 					"calc": {
-						"parry": "0",
-						"block": "No",
 						"damage": "thr-1 cut"
 					}
 				},
@@ -28210,7 +28228,6 @@
 					"usage": "Stab",
 					"reach": "C",
 					"parry": "0",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx"
@@ -28229,8 +28246,6 @@
 						}
 					],
 					"calc": {
-						"parry": "0",
-						"block": "No",
 						"damage": "thr-1 imp"
 					}
 				}
@@ -30667,8 +30682,6 @@
 					},
 					"usage": "Bite",
 					"reach": "C",
-					"parry": "No",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx"
@@ -30679,8 +30692,6 @@
 						}
 					],
 					"calc": {
-						"parry": "No",
-						"block": "No",
 						"damage": "thr-1 (-2 per die) cr"
 					}
 				}

--- a/Library/Magic/Magic Spells.spl
+++ b/Library/Magic/Magic Spells.spl
@@ -244,7 +244,6 @@
 						}
 					],
 					"calc": {
-						"range": "20/40",
 						"damage": "1d cor/point"
 					}
 				}
@@ -348,8 +347,7 @@
 						"base": "1d-1"
 					},
 					"usage": "Jet",
-					"reach": "1/point",
-					"parry": "No",
+					"reach": "1",
 					"defaults": [
 						{
 							"type": "dx",
@@ -362,7 +360,6 @@
 						}
 					],
 					"calc": {
-						"parry": "No",
 						"damage": "1d-1 cor/point"
 					}
 				}
@@ -637,8 +634,7 @@
 						"base": "2d"
 					},
 					"usage": "Jet",
-					"reach": "1/point",
-					"parry": "No",
+					"reach": "1",
 					"defaults": [
 						{
 							"type": "dx",
@@ -651,7 +647,6 @@
 						}
 					],
 					"calc": {
-						"parry": "No",
 						"damage": "2d kb/point"
 					}
 				}
@@ -2579,10 +2574,7 @@
 						"type": "burn ex/point",
 						"base": "1d-1"
 					},
-					"reach": "Special",
-					"parry": "No",
 					"calc": {
-						"parry": "No",
 						"damage": "1d-1 burn ex/point"
 					}
 				}
@@ -3840,7 +3832,6 @@
 						}
 					],
 					"calc": {
-						"parry": "0",
 						"damage": "1d burn"
 					}
 				}
@@ -4061,7 +4052,6 @@
 						}
 					],
 					"calc": {
-						"parry": "0",
 						"damage": "1d burn"
 					}
 				}
@@ -5195,8 +5185,7 @@
 						"base": "1d+1"
 					},
 					"usage": "Breath",
-					"reach": "1/point",
-					"parry": "No",
+					"reach": "1",
 					"defaults": [
 						{
 							"type": "dx",
@@ -5209,7 +5198,6 @@
 						}
 					],
 					"calc": {
-						"parry": "No",
 						"damage": "1d+1 burn/point"
 					}
 				}
@@ -5391,8 +5379,7 @@
 						"base": "1d"
 					},
 					"usage": "Breath",
-					"reach": "1/point",
-					"parry": "No",
+					"reach": "1",
 					"defaults": [
 						{
 							"type": "dx",
@@ -5405,7 +5392,6 @@
 						}
 					],
 					"calc": {
-						"parry": "No",
 						"damage": "1d burn/point"
 					}
 				}
@@ -5669,7 +5655,6 @@
 						}
 					],
 					"calc": {
-						"parry": "0",
 						"damage": "thr-1 cr +1d-1 burn/second"
 					}
 				}
@@ -5794,7 +5779,6 @@
 						}
 					],
 					"calc": {
-						"parry": "0",
 						"damage": "thr-1 +1d burn/point"
 					}
 				}
@@ -7246,7 +7230,6 @@
 						}
 					],
 					"calc": {
-						"range": "20/40",
 						"damage": "1d cr ex/2 points"
 					}
 				}
@@ -9107,10 +9090,7 @@
 						"base": "1d-1"
 					},
 					"usage": "Area",
-					"reach": "Special",
-					"parry": "No",
 					"calc": {
-						"parry": "No",
 						"damage": "1d-1 burn"
 					}
 				}
@@ -10695,7 +10675,6 @@
 						}
 					],
 					"calc": {
-						"parry": "0",
 						"damage": "thr-1 cr +1d/point"
 					}
 				}
@@ -11159,10 +11138,7 @@
 						"type": "dehydrate/point",
 						"base": "1d-1"
 					},
-					"reach": "Special",
-					"parry": "No",
 					"calc": {
-						"parry": "No",
 						"damage": "1d-1 dehydrate/point"
 					}
 				}
@@ -11698,10 +11674,7 @@
 						"type": "/point",
 						"base": "1d"
 					},
-					"reach": "Special",
-					"parry": "No",
 					"calc": {
-						"parry": "No",
 						"damage": "1d /point"
 					}
 				}
@@ -15507,10 +15480,7 @@
 						"base": "1d"
 					},
 					"usage": "Area",
-					"reach": "Special",
-					"parry": "No",
 					"calc": {
-						"parry": "No",
 						"damage": "1d burn"
 					}
 				}
@@ -15901,7 +15871,6 @@
 						}
 					],
 					"calc": {
-						"parry": "0",
 						"damage": "removes vital organ"
 					}
 				}
@@ -16058,10 +16027,7 @@
 						"type": "frag/2 points",
 						"base": "1d"
 					},
-					"reach": "Special",
-					"parry": "No",
 					"calc": {
-						"parry": "No",
 						"damage": "1d frag/2 points"
 					}
 				}
@@ -16127,7 +16093,6 @@
 						}
 					],
 					"calc": {
-						"range": "25/50",
 						"damage": "1d burn ex/2 points"
 					}
 				}
@@ -16195,7 +16160,6 @@
 						}
 					],
 					"calc": {
-						"range": "50/100",
 						"damage": "1d-1 burn ex/2 points"
 					}
 				}
@@ -17305,10 +17269,7 @@
 						"base": "1"
 					},
 					"usage": "Area",
-					"reach": "Special",
-					"parry": "No",
 					"calc": {
-						"parry": "No",
 						"damage": "1 point burn/point"
 					}
 				}
@@ -17425,7 +17386,6 @@
 						}
 					],
 					"calc": {
-						"range": "25/50",
 						"damage": "1d burn/point"
 					}
 				}
@@ -17530,8 +17490,7 @@
 						"base": "1d"
 					},
 					"usage": "Jet",
-					"reach": "1/point",
-					"parry": "No",
+					"reach": "1",
 					"defaults": [
 						{
 							"type": "dx",
@@ -17544,7 +17503,6 @@
 						}
 					],
 					"calc": {
-						"parry": "No",
 						"damage": "1d burn/point"
 					}
 				}
@@ -17806,10 +17764,7 @@
 						"type": "Blinds"
 					},
 					"usage": "Area",
-					"reach": "Special",
-					"parry": "No",
 					"calc": {
-						"parry": "No",
 						"damage": "Blinds"
 					}
 				}
@@ -18891,10 +18846,7 @@
 						"type": "freezing/point",
 						"base": "1d"
 					},
-					"reach": "Special",
-					"parry": "No",
 					"calc": {
-						"parry": "No",
 						"damage": "1d freezing/point"
 					}
 				}
@@ -20514,10 +20466,7 @@
 						"base": "1d-2"
 					},
 					"usage": "Area",
-					"reach": "Special",
-					"parry": "No",
 					"calc": {
-						"parry": "No",
 						"damage": "1d-2 cr"
 					}
 				}
@@ -22002,7 +21951,6 @@
 						}
 					],
 					"calc": {
-						"range": "30/60",
 						"damage": "1d-1 imp/point"
 					}
 				}
@@ -22107,7 +22055,6 @@
 						}
 					],
 					"calc": {
-						"range": "40/80",
 						"damage": "1d cr/point"
 					}
 				}
@@ -22211,8 +22158,7 @@
 						"base": "1d+1"
 					},
 					"usage": "Breath",
-					"reach": "1/point",
-					"parry": "No",
+					"reach": "1",
 					"defaults": [
 						{
 							"type": "dx",
@@ -22225,7 +22171,6 @@
 						}
 					],
 					"calc": {
-						"parry": "No",
 						"damage": "1d+1 freezing/point"
 					}
 				}
@@ -22377,7 +22322,6 @@
 						}
 					],
 					"calc": {
-						"parry": "0",
 						"damage": "thr-1 +paralysis"
 					}
 				}
@@ -25084,7 +25028,6 @@
 					},
 					"usage": "Jet",
 					"reach": "10",
-					"parry": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -25097,7 +25040,6 @@
 						}
 					],
 					"calc": {
-						"parry": "No",
 						"damage": "Blinds"
 					}
 				}
@@ -25349,7 +25291,6 @@
 						}
 					],
 					"calc": {
-						"range": "50/100",
 						"damage": "1d-1 burn/point"
 					}
 				}
@@ -25513,8 +25454,7 @@
 						"base": "1d"
 					},
 					"usage": "Gaze",
-					"reach": "2/point",
-					"parry": "No",
+					"reach": "2",
 					"defaults": [
 						{
 							"type": "dx",
@@ -25527,7 +25467,6 @@
 						}
 					],
 					"calc": {
-						"parry": "No",
 						"damage": "1d burn/point"
 					}
 				}
@@ -25677,8 +25616,7 @@
 						"type": "burn",
 						"base": "1d"
 					},
-					"reach": "2/point",
-					"parry": "No",
+					"reach": "2",
 					"defaults": [
 						{
 							"type": "dx",
@@ -25700,7 +25638,6 @@
 						}
 					],
 					"calc": {
-						"parry": "No",
 						"damage": "1d burn"
 					}
 				}
@@ -28363,8 +28300,7 @@
 						"base": "1d"
 					},
 					"usage": "Jet",
-					"reach": "1/point",
-					"parry": "No",
+					"reach": "1",
 					"defaults": [
 						{
 							"type": "dx",
@@ -28377,7 +28313,6 @@
 						}
 					],
 					"calc": {
-						"parry": "No",
 						"damage": "1d kb/point - Blinds"
 					}
 				}
@@ -29471,7 +29406,6 @@
 						}
 					],
 					"calc": {
-						"parry": "0",
 						"damage": "Petrification"
 					}
 				}
@@ -31735,10 +31669,7 @@
 						"type": "Cough/Sneeze"
 					},
 					"usage": "Area",
-					"reach": "Special",
-					"parry": "No",
 					"calc": {
-						"parry": "No",
 						"damage": "Cough/Sneeze"
 					}
 				}
@@ -31804,7 +31735,6 @@
 						}
 					],
 					"calc": {
-						"range": "20/60",
 						"damage": "Special cr"
 					}
 				}
@@ -33223,10 +33153,7 @@
 						"base": "1d-1"
 					},
 					"usage": "Area",
-					"reach": "Special",
-					"parry": "No",
 					"calc": {
-						"parry": "No",
 						"damage": "1d-1 cor"
 					}
 				}
@@ -33317,10 +33244,7 @@
 						"base": "1d-1"
 					},
 					"usage": "Area",
-					"reach": "Special",
-					"parry": "No",
 					"calc": {
-						"parry": "No",
 						"damage": "1d-1 burn"
 					}
 				}
@@ -33424,10 +33348,7 @@
 						"base": "1d-2"
 					},
 					"usage": "Area",
-					"reach": "Special",
-					"parry": "No",
 					"calc": {
-						"parry": "No",
 						"damage": "1d-2 imp"
 					}
 				}
@@ -33608,10 +33529,7 @@
 						"base": "1d-1"
 					},
 					"usage": "Area",
-					"reach": "Special",
-					"parry": "No",
 					"calc": {
-						"parry": "No",
 						"damage": "1d-1 cr/point"
 					}
 				}
@@ -37214,10 +37132,7 @@
 						"type": "(pi ++)/point",
 						"base": "1d"
 					},
-					"reach": "Special",
-					"parry": "No",
 					"calc": {
-						"parry": "No",
 						"damage": "1d (pi ++)/point"
 					}
 				}
@@ -37383,7 +37298,6 @@
 						}
 					],
 					"calc": {
-						"parry": "0",
 						"damage": "thr-1 cr +1d-1 tox/second"
 					}
 				}
@@ -37617,8 +37531,7 @@
 						"type": "Blinds"
 					},
 					"usage": "Jet",
-					"reach": "1/point",
-					"parry": "No",
+					"reach": "1",
 					"defaults": [
 						{
 							"type": "dx",
@@ -37631,7 +37544,6 @@
 						}
 					],
 					"calc": {
-						"parry": "No",
 						"damage": "Blinds"
 					}
 				}
@@ -39876,7 +39788,7 @@
 		{
 			"id": "cdbce272-4b66-439b-a0fe-75f304a4eafe",
 			"type": "spell",
-			"name": "Shapeshift Others",
+			"name": "Shapeshift Others (@Specialty@)",
 			"reference": "M33",
 			"tags": [
 				"Animal"
@@ -39941,7 +39853,7 @@
 						"has": true,
 						"qualifier": {
 							"compare": "is",
-							"qualifier": "shapeshifting (@specialty@)"
+							"qualifier": "shapeshifting (@Specialty@)"
 						},
 						"quantity": {
 							"compare": "at_least",
@@ -40226,10 +40138,7 @@
 						"type": "/point",
 						"base": "1d"
 					},
-					"reach": "Special",
-					"parry": "No",
 					"calc": {
-						"parry": "No",
 						"damage": "1d /point"
 					}
 				}
@@ -40415,7 +40324,6 @@
 						}
 					],
 					"calc": {
-						"parry": "0",
 						"damage": "thr-1 cr +1d+1 burn/point"
 					}
 				}
@@ -41516,10 +41424,7 @@
 						"type": "Cough/Weep"
 					},
 					"usage": "Area",
-					"reach": "Special",
-					"parry": "No",
 					"calc": {
-						"parry": "No",
 						"damage": "Cough/Weep"
 					}
 				}
@@ -41641,8 +41546,7 @@
 						"base": "1d"
 					},
 					"usage": "Jet",
-					"reach": "1/point",
-					"parry": "No",
+					"reach": "1",
 					"defaults": [
 						{
 							"type": "dx",
@@ -41655,7 +41559,6 @@
 						}
 					],
 					"calc": {
-						"parry": "No",
 						"damage": "1d kb/point - Blinds"
 					}
 				}
@@ -42065,8 +41968,7 @@
 						"type": "Stuns"
 					},
 					"usage": "Jet",
-					"reach": "1/point",
-					"parry": "No",
+					"reach": "1",
 					"defaults": [
 						{
 							"type": "dx",
@@ -42079,7 +41981,6 @@
 						}
 					],
 					"calc": {
-						"parry": "No",
 						"damage": "Stuns"
 					}
 				}
@@ -42198,10 +42099,7 @@
 						"base": "1"
 					},
 					"usage": "Area",
-					"reach": "Special",
-					"parry": "No",
 					"calc": {
-						"parry": "No",
 						"damage": "1 point burn/second"
 					}
 				}
@@ -42269,10 +42167,7 @@
 						"base": "1d-1"
 					},
 					"usage": "Area",
-					"reach": "Special",
-					"parry": "No",
 					"calc": {
-						"parry": "No",
 						"damage": "1d-1 burn/2 points"
 					}
 				}
@@ -42808,7 +42703,6 @@
 						"type": "grapple ST 10/strand"
 					},
 					"accuracy": "3",
-					"range": "5/point",
 					"defaults": [
 						{
 							"type": "dx",
@@ -42821,7 +42715,6 @@
 						}
 					],
 					"calc": {
-						"range": "5/point",
 						"damage": "grapple ST 10/strand"
 					}
 				}
@@ -42925,8 +42818,7 @@
 						"base": "1d"
 					},
 					"usage": "Breath",
-					"reach": "1/point",
-					"parry": "No",
+					"reach": "1",
 					"defaults": [
 						{
 							"type": "dx",
@@ -42939,7 +42831,6 @@
 						}
 					],
 					"calc": {
-						"parry": "No",
 						"damage": "1d cor/point"
 					}
 				}
@@ -43878,8 +43769,7 @@
 						"base": "1d-1"
 					},
 					"usage": "Jet",
-					"reach": "1/point",
-					"parry": "No",
+					"reach": "1",
 					"defaults": [
 						{
 							"type": "dx",
@@ -43892,7 +43782,6 @@
 						}
 					],
 					"calc": {
-						"parry": "No",
 						"damage": "1d-1 burn/point"
 					}
 				}
@@ -44115,7 +44004,6 @@
 						}
 					],
 					"calc": {
-						"range": "40/80",
 						"damage": "1d+1 cr/point"
 					}
 				}
@@ -45943,7 +45831,6 @@
 						}
 					],
 					"calc": {
-						"range": "75/150",
 						"damage": "1d-1 imp/point"
 					}
 				}
@@ -47499,7 +47386,6 @@
 						}
 					],
 					"calc": {
-						"range": "80",
 						"damage": "Special"
 					}
 				}
@@ -47966,7 +47852,6 @@
 						}
 					],
 					"calc": {
-						"parry": "0",
 						"damage": "thr-1 cr + Paralysis"
 					}
 				}
@@ -49906,8 +49791,7 @@
 						"base": "1d"
 					},
 					"usage": "Jet",
-					"reach": "1/point",
-					"parry": "No",
+					"reach": "1",
 					"defaults": [
 						{
 							"type": "dx",
@@ -49920,7 +49804,6 @@
 						}
 					],
 					"calc": {
-						"parry": "No",
 						"damage": "1d cr/point"
 					}
 				}
@@ -50108,10 +49991,7 @@
 						"type": "/2 points",
 						"base": "1d"
 					},
-					"reach": "Special",
-					"parry": "No",
 					"calc": {
-						"parry": "No",
 						"damage": "1d /2 points"
 					}
 				}
@@ -50704,7 +50584,6 @@
 						}
 					],
 					"calc": {
-						"range": "20/40",
 						"damage": "per weapon"
 					}
 				}
@@ -50904,7 +50783,6 @@
 						}
 					],
 					"calc": {
-						"parry": "0",
 						"damage": "thr-1 cr +1d"
 					}
 				}

--- a/Library/Thaumatology/Thaumatology - Magical Styles Traits.adq
+++ b/Library/Thaumatology/Thaumatology - Magical Styles Traits.adq
@@ -671,7 +671,7 @@
 			"type": "trait",
 			"name": "Intuitive Cantrip, Kindle",
 			"reference": "TMS26",
-			"notes": "Produce time flame with a touch",
+			"notes": "Produce tiny flame with a touch",
 			"tags": [
 				"Magic Perk",
 				"Supernatural"


### PR DESCRIPTION
While going through adding stuff from Fantasy Folk: Winged Folk, I spotted a couple of fixes needed in the main library.  Plus a couple of things from the FFWF book which could usefully be added to the main part of the library.  Will follow up with a separate PR to add in the FFWF stuff.

Full details of changes should be in the separate comment, repeated here just in case:

From Fantasy Folk: Winged Folk
- Limitation "Encumbrance-Limited" on Flight
- "Mitigator: Flight" on Lame
- Added "Strategy (Air)" skill, alongside Land/Sea/Space

General fixes:
- typo on Thamatology Styles, "Cantrip Kindle": *tiny* flame
- added @specialty@ to the Shapeshift Other spell in Magic
- removed aquatic defaults from the "Survival @Environment@" general skill in the Basic Set
- Added "Survival @Any Land@" and "Survival @Any Aquatic@" skills with the relevant land or aquatic defaults in Basic Set
- Added prerequiste of no language talent to the full price language trait