### PR TITLE
Fixes Affliction Gives Disadvantage enhancement cost per level

### DIFF
--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -872,7 +872,7 @@
 							"name": "Gives @Disadvantage@",
 							"reference": "B36",
 							"notes": "1 point per level",
-							"cost": 10,
+							"cost": 1,
 							"levels": 1,
 							"disabled": true
 						},


### PR DESCRIPTION
The cost of the enhancement "Gives Disadvantage" for the Affliction trait on GCS is 10% per level, as opposed to B36, where it says it costs 1% per level. This fixes that.