### PR TITLE
Fix for perfect balance - Issue #271

### DIFF
--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -20830,6 +20830,24 @@
 					"selection_type": "skills_with_name",
 					"name": {
 						"compare": "is",
+						"qualifier": "aerobatics"
+					},
+					"amount": 1
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "aquabatics"
+					},
+					"amount": 1
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
 						"qualifier": "climbing"
 					},
 					"amount": 1


### PR DESCRIPTION
As per Basic Set - Characters p. 174 under "Acrobatics", you should add +1 to Aquabatics and Aerobatics as well.