### PR TITLE
Update Evil Cleric.gct

### DIFF
--- a/Library/Dungeon Fantasy/Dungeon Fantasy 3/Evil Cleric.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 3/Evil Cleric.gct
@@ -1963,6 +1963,8 @@
 													"id": "7ae9aa1e-141d-4963-8048-f6542618be93",
 													"type": "modifier",
 													"name": "Cosmic, Irresistable Attack",
+													"reference": "B103",
+													"reference_highlight": "Irresistible attack",
 													"cost": 300
 												},
 												{
@@ -1994,13 +1996,42 @@
 													"type": "melee_weapon",
 													"damage": {
 														"type": "tox",
-														"base": "1d",
-														"armor_divisor": 300
+														"base": "1d"
 													},
 													"usage": "Touch",
+													"usage_notes": "Bypasses all DR except cosmic DR",
 													"reach": "C",
+													"defaults": [
+														{
+															"type": "skill",
+															"name": "Boxing"
+														},
+														{
+															"type": "skill",
+															"name": "Judo"
+														},
+														{
+															"type": "skill",
+															"name": "Sumo Wrestling"
+														},
+														{
+															"type": "skill",
+															"name": "Wrestling"
+														},
+														{
+															"type": "skill",
+															"name": "Karate"
+														},
+														{
+															"type": "dx"
+														},
+														{
+															"type": "skill",
+															"name": "Brawling"
+														}
+													],
 													"calc": {
-														"damage": "1d(300) tox"
+														"damage": "1d tox"
 													}
 												}
 											],

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 3/Evil Cleric.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 3/Evil Cleric.gct
@@ -6,6 +6,7 @@
 		{
 			"id": "81bff178-623b-4600-a207-eeab0d4143ba",
 			"type": "trait_container",
+			"open": true,
 			"children": [
 				{
 					"id": "1ad01f74-0f22-4834-8278-0c24146168bf",
@@ -1023,6 +1024,7 @@
 								{
 									"id": "6c60c1ba-73f0-4aa5-a2f4-5ecb6810bb6a",
 									"type": "trait_container",
+									"open": true,
 									"children": [
 										{
 											"id": "30091ffe-b52e-4e8f-b043-ccfd49bfe440",
@@ -1971,6 +1973,13 @@
 													"levels": 1
 												},
 												{
+													"id": "6e7c862b-eb6b-4ab6-b322-8116c007293c",
+													"type": "modifier",
+													"name": "Power Modifier: Unholy",
+													"reference": "DF3:41",
+													"cost": 10
+												},
+												{
 													"id": "79237343-f13b-4580-a93e-0b7799243c3f",
 													"type": "modifier",
 													"name": "Melee Attack, Reach C, Cannot Parry",
@@ -1981,37 +1990,21 @@
 											"points_per_level": 4,
 											"weapons": [
 												{
-													"id": "c4f9c597-12cb-4334-88a2-087072d3e6be",
-													"type": "ranged_weapon",
+													"id": "f94a7c4b-0821-47e9-8d28-4d4c1858e0e8",
+													"type": "melee_weapon",
 													"damage": {
 														"type": "tox",
-														"base": "1d"
+														"base": "1d",
+														"armor_divisor": 300
 													},
-													"accuracy": "3",
-													"range": "100/10",
-													"rate_of_fire": "1",
-													"recoil": "1",
-													"defaults": [
-														{
-															"type": "skill",
-															"name": "Innate Attack"
-														},
-														{
-															"type": "skill",
-															"name": "Innate Attack",
-															"modifier": -2
-														},
-														{
-															"type": "dx",
-															"modifier": -4
-														}
-													],
+													"usage": "Touch",
+													"reach": "C",
 													"calc": {
-														"range": "100/10",
-														"damage": "1d tox"
+														"damage": "1d(300) tox"
 													}
 												}
 											],
+											"round_down": true,
 											"can_level": true,
 											"calc": {
 												"points": 14
@@ -7549,7 +7542,7 @@
 														"type": "trait_prereq",
 														"has": true,
 														"name": {
-															"compare": "is",
+															"compare": "starts_with",
 															"qualifier": "Power Investiture"
 														},
 														"level": {
@@ -7587,7 +7580,7 @@
 														"type": "trait_prereq",
 														"has": true,
 														"name": {
-															"compare": "is",
+															"compare": "starts_with",
 															"qualifier": "Power Investiture"
 														},
 														"level": {
@@ -7625,7 +7618,7 @@
 														"type": "trait_prereq",
 														"has": true,
 														"name": {
-															"compare": "is",
+															"compare": "starts_with",
 															"qualifier": "Power Investiture"
 														},
 														"level": {
@@ -7663,7 +7656,7 @@
 														"type": "trait_prereq",
 														"has": true,
 														"name": {
-															"compare": "is",
+															"compare": "starts_with",
 															"qualifier": "Power Investiture"
 														},
 														"level": {
@@ -7701,7 +7694,7 @@
 														"type": "trait_prereq",
 														"has": true,
 														"name": {
-															"compare": "is",
+															"compare": "starts_with",
 															"qualifier": "Power Investiture"
 														},
 														"level": {
@@ -7739,7 +7732,7 @@
 														"type": "trait_prereq",
 														"has": true,
 														"name": {
-															"compare": "is",
+															"compare": "starts_with",
 															"qualifier": "Power Investiture"
 														}
 													}
@@ -7775,7 +7768,6 @@
 														}
 													],
 													"calc": {
-														"parry": "0",
 														"damage": "thr-1 cr +1d/point"
 													}
 												}
@@ -7808,7 +7800,7 @@
 														"type": "trait_prereq",
 														"has": true,
 														"name": {
-															"compare": "is",
+															"compare": "starts_with",
 															"qualifier": "Power Investiture"
 														},
 														"level": {
@@ -7826,10 +7818,7 @@
 														"type": "dehydrate/point",
 														"base": "1d-1"
 													},
-													"reach": "Special",
-													"parry": "No",
 													"calc": {
-														"parry": "No",
 														"damage": "1d-1 dehydrate/point"
 													}
 												}
@@ -7862,7 +7851,7 @@
 														"type": "trait_prereq",
 														"has": true,
 														"name": {
-															"compare": "is",
+															"compare": "starts_with",
 															"qualifier": "Power Investiture"
 														},
 														"level": {
@@ -7900,7 +7889,7 @@
 														"type": "trait_prereq",
 														"has": true,
 														"name": {
-															"compare": "is",
+															"compare": "starts_with",
 															"qualifier": "Power Investiture"
 														},
 														"level": {
@@ -7938,7 +7927,7 @@
 														"type": "trait_prereq",
 														"has": true,
 														"name": {
-															"compare": "is",
+															"compare": "starts_with",
 															"qualifier": "Power Investiture"
 														},
 														"level": {
@@ -7976,7 +7965,7 @@
 														"type": "trait_prereq",
 														"has": true,
 														"name": {
-															"compare": "is",
+															"compare": "starts_with",
 															"qualifier": "Power Investiture"
 														},
 														"level": {
@@ -8014,7 +8003,7 @@
 														"type": "trait_prereq",
 														"has": true,
 														"name": {
-															"compare": "is",
+															"compare": "starts_with",
 															"qualifier": "Power Investiture"
 														},
 														"level": {
@@ -8052,7 +8041,7 @@
 														"type": "trait_prereq",
 														"has": true,
 														"name": {
-															"compare": "is",
+															"compare": "starts_with",
 															"qualifier": "Power Investiture"
 														},
 														"level": {
@@ -8090,7 +8079,7 @@
 														"type": "trait_prereq",
 														"has": true,
 														"name": {
-															"compare": "is",
+															"compare": "starts_with",
 															"qualifier": "Power Investiture"
 														},
 														"level": {
@@ -8128,7 +8117,7 @@
 														"type": "trait_prereq",
 														"has": true,
 														"name": {
-															"compare": "is",
+															"compare": "starts_with",
 															"qualifier": "Power Investiture"
 														},
 														"level": {
@@ -8166,7 +8155,7 @@
 														"type": "trait_prereq",
 														"has": true,
 														"name": {
-															"compare": "is",
+															"compare": "starts_with",
 															"qualifier": "Power Investiture"
 														},
 														"level": {
@@ -8204,7 +8193,7 @@
 														"type": "trait_prereq",
 														"has": true,
 														"name": {
-															"compare": "is",
+															"compare": "starts_with",
 															"qualifier": "Power Investiture"
 														},
 														"level": {
@@ -8242,7 +8231,7 @@
 														"type": "trait_prereq",
 														"has": true,
 														"name": {
-															"compare": "is",
+															"compare": "starts_with",
 															"qualifier": "Power Investiture"
 														},
 														"level": {
@@ -8280,7 +8269,7 @@
 														"type": "trait_prereq",
 														"has": true,
 														"name": {
-															"compare": "is",
+															"compare": "starts_with",
 															"qualifier": "Power Investiture"
 														},
 														"level": {
@@ -8318,7 +8307,7 @@
 														"type": "trait_prereq",
 														"has": true,
 														"name": {
-															"compare": "is",
+															"compare": "starts_with",
 															"qualifier": "Power Investiture"
 														},
 														"level": {
@@ -8356,7 +8345,7 @@
 														"type": "trait_prereq",
 														"has": true,
 														"name": {
-															"compare": "is",
+															"compare": "starts_with",
 															"qualifier": "Power Investiture"
 														},
 														"level": {
@@ -8394,7 +8383,7 @@
 														"type": "trait_prereq",
 														"has": true,
 														"name": {
-															"compare": "is",
+															"compare": "starts_with",
 															"qualifier": "Power Investiture"
 														},
 														"level": {
@@ -8432,7 +8421,7 @@
 														"type": "trait_prereq",
 														"has": true,
 														"name": {
-															"compare": "is",
+															"compare": "starts_with",
 															"qualifier": "Power Investiture"
 														},
 														"level": {
@@ -8470,7 +8459,7 @@
 														"type": "trait_prereq",
 														"has": true,
 														"name": {
-															"compare": "is",
+															"compare": "starts_with",
 															"qualifier": "Power Investiture"
 														},
 														"level": {
@@ -8508,7 +8497,7 @@
 														"type": "trait_prereq",
 														"has": true,
 														"name": {
-															"compare": "is",
+															"compare": "starts_with",
 															"qualifier": "Power Investiture"
 														},
 														"level": {
@@ -8526,10 +8515,7 @@
 														"type": "freezing/point",
 														"base": "1d"
 													},
-													"reach": "Special",
-													"parry": "No",
 													"calc": {
-														"parry": "No",
 														"damage": "1d freezing/point"
 													}
 												}
@@ -8562,7 +8548,7 @@
 														"type": "trait_prereq",
 														"has": true,
 														"name": {
-															"compare": "is",
+															"compare": "starts_with",
 															"qualifier": "Power Investiture"
 														},
 														"level": {
@@ -8600,7 +8586,7 @@
 														"type": "trait_prereq",
 														"has": true,
 														"name": {
-															"compare": "is",
+															"compare": "starts_with",
 															"qualifier": "Power Investiture"
 														},
 														"level": {
@@ -8638,7 +8624,7 @@
 														"type": "trait_prereq",
 														"has": true,
 														"name": {
-															"compare": "is",
+															"compare": "starts_with",
 															"qualifier": "Power Investiture"
 														},
 														"level": {
@@ -8676,7 +8662,7 @@
 														"type": "trait_prereq",
 														"has": true,
 														"name": {
-															"compare": "is",
+															"compare": "starts_with",
 															"qualifier": "Power Investiture"
 														},
 														"level": {
@@ -8714,7 +8700,7 @@
 														"type": "trait_prereq",
 														"has": true,
 														"name": {
-															"compare": "is",
+															"compare": "starts_with",
 															"qualifier": "Power Investiture"
 														},
 														"level": {
@@ -8752,7 +8738,7 @@
 														"type": "trait_prereq",
 														"has": true,
 														"name": {
-															"compare": "is",
+															"compare": "starts_with",
 															"qualifier": "Power Investiture"
 														},
 														"level": {
@@ -8790,7 +8776,7 @@
 														"type": "trait_prereq",
 														"has": true,
 														"name": {
-															"compare": "is",
+															"compare": "starts_with",
 															"qualifier": "Power Investiture"
 														},
 														"level": {
@@ -8839,7 +8825,7 @@
 														"type": "trait_prereq",
 														"has": true,
 														"name": {
-															"compare": "is",
+															"compare": "starts_with",
 															"qualifier": "Power Investiture"
 														},
 														"level": {
@@ -8877,7 +8863,7 @@
 														"type": "trait_prereq",
 														"has": true,
 														"name": {
-															"compare": "is",
+															"compare": "starts_with",
 															"qualifier": "Power Investiture"
 														},
 														"level": {
@@ -8915,7 +8901,7 @@
 														"type": "trait_prereq",
 														"has": true,
 														"name": {
-															"compare": "is",
+															"compare": "starts_with",
 															"qualifier": "Power Investiture"
 														},
 														"level": {
@@ -8953,7 +8939,7 @@
 														"type": "trait_prereq",
 														"has": true,
 														"name": {
-															"compare": "is",
+															"compare": "starts_with",
 															"qualifier": "Power Investiture"
 														},
 														"level": {
@@ -8991,7 +8977,7 @@
 														"type": "trait_prereq",
 														"has": true,
 														"name": {
-															"compare": "is",
+															"compare": "starts_with",
 															"qualifier": "Power Investiture"
 														},
 														"level": {
@@ -9029,7 +9015,7 @@
 														"type": "trait_prereq",
 														"has": true,
 														"name": {
-															"compare": "is",
+															"compare": "starts_with",
 															"qualifier": "Power Investiture"
 														},
 														"level": {
@@ -9069,7 +9055,6 @@
 														}
 													],
 													"calc": {
-														"parry": "0",
 														"damage": "thr-1 cr +1d-1 tox/second"
 													}
 												}
@@ -9102,7 +9087,7 @@
 														"type": "trait_prereq",
 														"has": true,
 														"name": {
-															"compare": "is",
+															"compare": "starts_with",
 															"qualifier": "Power Investiture"
 														},
 														"level": {
@@ -9140,7 +9125,7 @@
 														"type": "trait_prereq",
 														"has": true,
 														"name": {
-															"compare": "is",
+															"compare": "starts_with",
 															"qualifier": "Power Investiture"
 														},
 														"level": {
@@ -9190,7 +9175,7 @@
 														"type": "trait_prereq",
 														"has": true,
 														"name": {
-															"compare": "is",
+															"compare": "starts_with",
 															"qualifier": "Power Investiture"
 														},
 														"level": {
@@ -9228,7 +9213,7 @@
 														"type": "trait_prereq",
 														"has": true,
 														"name": {
-															"compare": "is",
+															"compare": "starts_with",
 															"qualifier": "Power Investiture"
 														},
 														"level": {
@@ -9266,7 +9251,7 @@
 														"type": "trait_prereq",
 														"has": true,
 														"name": {
-															"compare": "is",
+															"compare": "starts_with",
 															"qualifier": "Power Investiture"
 														},
 														"level": {
@@ -9304,7 +9289,7 @@
 														"type": "trait_prereq",
 														"has": true,
 														"name": {
-															"compare": "is",
+															"compare": "starts_with",
 															"qualifier": "Power Investiture"
 														},
 														"level": {


### PR DESCRIPTION
- Changed the Cleric Spells prerequsites so they work with the Power Investiture on the sheet. It is "Power Investiture (Unholy)", but the spells *were* looking for exactly "Power Investiture", so I changed them to "starts with."
- Updated the Dread Touch trait to the correct cost, and weapon type. (Yes, it needs round down set to true, as its cost in the book is 14 but without rounding down it's 15)