### PR TITLE
Update DFRPG Combat Reflexes, Strongbow, and Elven

### DIFF
--- a/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Equipment Modifiers.eqm
+++ b/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Equipment Modifiers.eqm
@@ -5,7 +5,6 @@
 		{
 			"id": "271218a1-07f9-4717-8cbc-fce3a0450139",
 			"type": "eqp_modifier_container",
-			"open": true,
 			"children": [
 				{
 					"id": "8fac7fc7-3c6a-4c11-b1de-0586d56f1f04",
@@ -23,7 +22,6 @@
 				{
 					"id": "a9c292f1-1faa-4adc-99cc-cbbaa273d049",
 					"type": "eqp_modifier_container",
-					"open": true,
 					"children": [
 						{
 							"id": "aed71883-55b1-45ef-901d-a52dc9e3a050",
@@ -50,12 +48,12 @@
 							]
 						}
 					],
+					"open": true,
 					"name": "For boots only"
 				},
 				{
 					"id": "7621abee-0647-45ba-a32f-bc46adb37055",
 					"type": "eqp_modifier_container",
-					"open": true,
 					"children": [
 						{
 							"id": "42a9c6fa-0243-4c1d-95c6-7c2f460bedc9",
@@ -162,12 +160,12 @@
 							]
 						}
 					],
+					"open": true,
 					"name": "For Heavy Leather only"
 				},
 				{
 					"id": "c684f381-0ba3-4bb5-ba5c-ff5701c0469f",
 					"type": "eqp_modifier_container",
-					"open": true,
 					"children": [
 						{
 							"id": "d4f0ad21-22a9-4a81-8954-329c2e27bdda",
@@ -184,12 +182,12 @@
 							"weight": "+0 lb"
 						}
 					],
+					"open": true,
 					"name": "For Light Cloth armor only"
 				},
 				{
 					"id": "6d4e3e55-5570-4203-a8d9-d693c44c92c7",
 					"type": "eqp_modifier_container",
-					"open": true,
 					"children": [
 						{
 							"id": "903fa020-4a41-4bdf-9785-664685343be7",
@@ -201,12 +199,12 @@
 							"cost": "+19 CF"
 						}
 					],
+					"open": true,
 					"name": "For metal armor only"
 				},
 				{
 					"id": "5f2ac62d-1d75-47b3-88c2-40dfde3e7e34",
 					"type": "eqp_modifier_container",
-					"open": true,
 					"children": [
 						{
 							"id": "53b65396-65a2-410e-82ae-25c69ecdd641",
@@ -229,7 +227,6 @@
 						{
 							"id": "efc758fb-f9f6-47d3-b888-df5948447bae",
 							"type": "eqp_modifier_container",
-							"open": true,
 							"children": [
 								{
 									"id": "c98dc896-6a6c-445e-907e-d8431820c355",
@@ -244,6 +241,7 @@
 									"cost": "+2 CF"
 								}
 							],
+							"open": true,
 							"name": "For Body Armor only"
 						},
 						{
@@ -261,6 +259,7 @@
 							"weight": "x1/3"
 						}
 					],
+					"open": true,
 					"name": "For Plate and Brigandine only"
 				},
 				{
@@ -276,13 +275,13 @@
 					"cost": "+3 CF"
 				}
 			],
+			"open": true,
 			"name": "Armor",
 			"notes": "Meteoric and Orichalcum are mutually exclusive"
 		},
 		{
 			"id": "7c404d40-f964-4907-ae24-f3f7070ea89d",
 			"type": "eqp_modifier_container",
-			"open": true,
 			"children": [
 				{
 					"id": "e74aeb30-4fdc-483f-b429-ee4c5c635d66",
@@ -348,12 +347,12 @@
 					]
 				}
 			],
+			"open": true,
 			"name": "General"
 		},
 		{
 			"id": "2296e7ec-d954-4aa5-abd6-e22eb47c4147",
 			"type": "eqp_modifier_container",
-			"open": true,
 			"children": [
 				{
 					"id": "98aefb78-8e7a-476b-9c19-432f5257ee25",
@@ -433,7 +432,6 @@
 				{
 					"id": "6ae07fff-8188-4540-8fca-ee82b23a6e69",
 					"type": "eqp_modifier_container",
-					"open": true,
 					"children": [
 						{
 							"id": "15a0253f-220e-4252-ad54-1d1a82914aa7",
@@ -448,12 +446,12 @@
 							"cost": "+2 CF"
 						}
 					],
+					"open": true,
 					"name": "For Dwarven, Meteoric, or Orichalcum shields only"
 				},
 				{
 					"id": "f2a18a63-cffa-4646-95f0-d9ef00cc6663",
 					"type": "eqp_modifier_container",
-					"open": true,
 					"children": [
 						{
 							"id": "2272d235-dec5-4bb7-a99a-f2e968196103",
@@ -468,6 +466,7 @@
 							"cost": "+6 CF"
 						}
 					],
+					"open": true,
 					"name": "For non-Dwarven, -Meteoric, and -Orichalcum shields only"
 				},
 				{
@@ -563,6 +562,7 @@
 					]
 				}
 			],
+			"open": true,
 			"name": "Shields",
 			"reference": "DFA107",
 			"notes": "Dwarven, Meteoric, and Orichalcum are mutually exclusive"
@@ -570,7 +570,6 @@
 		{
 			"id": "676ad3c1-eca0-4594-975e-ddda70a45d59",
 			"type": "eqp_modifier_container",
-			"open": true,
 			"children": [
 				{
 					"id": "21d97c2c-e89a-4ceb-9c86-427adc83a2d8",
@@ -587,7 +586,6 @@
 				{
 					"id": "0d66850a-b6f3-4c5f-925d-7364d3bce5d4",
 					"type": "eqp_modifier_container",
-					"open": true,
 					"children": [
 						{
 							"id": "c72f927a-25ec-4348-ab07-90852284f5c8",
@@ -622,12 +620,12 @@
 							"cost": "+2"
 						}
 					],
+					"open": true,
 					"name": "For arrow and crossbow bolt only"
 				},
 				{
 					"id": "3f66c16a-e9cb-4573-a81c-ef3eb906669c",
 					"type": "eqp_modifier_container",
-					"open": true,
 					"children": [
 						{
 							"id": "4415969f-0120-4fef-9f9e-a68bf47cf37d",
@@ -642,12 +640,12 @@
 							"cost": "+4 CF"
 						}
 					],
+					"open": true,
 					"name": "For blowpipe, bow, and crossbow only"
 				},
 				{
 					"id": "72d5aaa2-6cd4-492c-bd39-d1c6719ff042",
 					"type": "eqp_modifier_container",
-					"open": true,
 					"children": [
 						{
 							"id": "eb16421c-6f5b-4555-9b47-778e9d8ce15a",
@@ -663,32 +661,44 @@
 							"weight": "+1.5 lb"
 						}
 					],
+					"open": true,
 					"name": "For bow and crossbow only"
 				},
 				{
 					"id": "fb9e46ae-f1ea-4c45-b7d4-2f2470a25c40",
 					"type": "eqp_modifier_container",
-					"open": true,
 					"children": [
 						{
 							"id": "ffb2d72b-1f0a-41f2-8e68-461bfeb71323",
 							"type": "eqp_modifier",
 							"name": "Elven",
 							"reference": "DFA106",
-							"notes": "Lets a bow shoot at +2 to ST for range and damage purposes without increasing its required ST (manually adjust)",
+							"reference_highlight": "Elven",
+							"notes": "Lets a bow shoot at +2 to ST for range and damage purposes without increasing its minimum ST (manually adjust Rated ST)",
 							"tags": [
 								"Weapons"
 							],
 							"cost_type": "to_base_cost",
-							"cost": "+16 CF"
+							"cost": "+16 CF",
+							"features": [
+								{
+									"type": "weapon_min_st_bonus",
+									"selection_type": "weapons_with_required_skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "Bow"
+									},
+									"amount": -2
+								}
+							]
 						}
 					],
+					"open": true,
 					"name": "For bow only"
 				},
 				{
 					"id": "a73f984a-c8aa-466a-ab57-23844a64621a",
 					"type": "eqp_modifier_container",
-					"open": true,
 					"children": [
 						{
 							"id": "5c600c07-e924-47ad-8084-badef6e16fa1",
@@ -721,12 +731,12 @@
 							"weight": "+2 lb"
 						}
 					],
+					"open": true,
 					"name": "For crossbow only"
 				},
 				{
 					"id": "b5a0738b-2512-42d9-bdd5-04302755bf51",
 					"type": "eqp_modifier_container",
-					"open": true,
 					"children": [
 						{
 							"id": "73ced81f-3947-4644-b68d-4790dff6cb63",
@@ -745,12 +755,12 @@
 							]
 						}
 					],
+					"open": true,
 					"name": "For fencing weapons and swords only"
 				},
 				{
 					"id": "1a911f98-05c6-4164-b2fe-f2d22ac0caa5",
 					"type": "eqp_modifier_container",
-					"open": true,
 					"children": [
 						{
 							"id": "baffc557-5154-4cd9-bd2a-cf5f88e73b2d",
@@ -775,12 +785,12 @@
 							]
 						}
 					],
+					"open": true,
 					"name": "For hatchet, jutte, pick, sai, sickle, tonfa, and one-handed axe only"
 				},
 				{
 					"id": "93bc466a-8ad8-4db5-afe1-83c50600ccc5",
 					"type": "eqp_modifier_container",
-					"open": true,
 					"children": [
 						{
 							"id": "2c55b8b2-fc7a-42c3-9d98-e440696d911f",
@@ -803,7 +813,6 @@
 						{
 							"id": "7089ba47-8073-4c49-baa2-f865799c9918",
 							"type": "eqp_modifier_container",
-							"open": true,
 							"children": [
 								{
 									"id": "ee94624c-0e91-44aa-bb3e-675c34bef0cf",
@@ -825,12 +834,12 @@
 									]
 								}
 							],
+							"open": true,
 							"name": "For fencing weapons, swords, blowpipes, bows, and crossbows"
 						},
 						{
 							"id": "e9407255-8dcf-41fe-a813-f508cc2bc4ad",
 							"type": "eqp_modifier_container",
-							"open": true,
 							"children": [
 								{
 									"id": "d8e1441e-08aa-45ae-ac76-6496c535ccee",
@@ -852,12 +861,12 @@
 									]
 								}
 							],
+							"open": true,
 							"name": "For other cutting melee or thrown weapons"
 						},
 						{
 							"id": "d57ffab3-a308-467a-b66d-47e401cb3c42",
 							"type": "eqp_modifier_container",
-							"open": true,
 							"children": [
 								{
 									"id": "7c49ff7b-06e8-41dc-8f66-aaea014eb39f",
@@ -879,6 +888,7 @@
 									]
 								}
 							],
+							"open": true,
 							"name": "For projectiles and crushing- or impaling-only melee or thrown weapons"
 						},
 						{
@@ -906,12 +916,12 @@
 							"cost": "+2 CF"
 						}
 					],
+					"open": true,
 					"name": "For melee weapon, thrown weapon, and projectile only"
 				},
 				{
 					"id": "01f64f9f-c5c2-4f69-b95a-c017a6f7de07",
 					"type": "eqp_modifier_container",
-					"open": true,
 					"children": [
 						{
 							"id": "3d01024f-076d-4987-8441-6e30aba207c4",
@@ -938,9 +948,11 @@
 							"cost": "+29 CF"
 						}
 					],
+					"open": true,
 					"name": "For metal weapons only"
 				}
 			],
+			"open": true,
 			"name": "Weapons",
 			"reference": "DFA106",
 			"notes": "Meteoric, Orichalcum, and solid Silver are mutually exclusive; Fine, Very Fine, and solid Silver are mutually exclusive"

--- a/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Equipment Modifiers.eqm
+++ b/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Equipment Modifiers.eqm
@@ -673,7 +673,6 @@
 							"type": "eqp_modifier",
 							"name": "Elven",
 							"reference": "DFA106",
-							"reference_highlight": "Elven",
 							"notes": "Lets a bow shoot at +2 to ST for range and damage purposes without increasing its minimum ST (manually adjust Rated ST)",
 							"tags": [
 								"Weapons"

--- a/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq
+++ b/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq
@@ -2028,7 +2028,6 @@
 			"type": "trait",
 			"name": "Combat Reflexes",
 			"reference": "DFA48",
-			"reference_highlight": "Combat Reflexes",
 			"tags": [
 				"Advantage",
 				"Mental"
@@ -2080,7 +2079,7 @@
 				},
 				{
 					"type": "conditional_modifier",
-					"situation": "on all IQ rolls to wake up and to recover from mental stun",
+					"situation": "on all IQ rolls to wake up or to recover from mental stun",
 					"amount": 6
 				}
 			],
@@ -8685,7 +8684,6 @@
 			"type": "trait",
 			"name": "Strongbow",
 			"reference": "DFA35",
-			"reference_highlight": "Strongbow",
 			"notes": "Manually adjust Rated ST for purchased bow(s).",
 			"tags": [
 				"Advantage",

--- a/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq
+++ b/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq
@@ -754,8 +754,8 @@
 				"Disadvantage",
 				"Mental"
 			],
-			"base_points": -10,
 			"cr": 12,
+			"base_points": -10,
 			"calc": {
 				"points": -10
 			}
@@ -763,7 +763,6 @@
 		{
 			"id": "df5794e1-3b12-4567-97b1-9b8861b79e2c",
 			"type": "trait_container",
-			"open": true,
 			"children": [
 				{
 					"id": "aa938ea1-cb23-4681-99d0-05f5a8f60952",
@@ -856,6 +855,7 @@
 					}
 				}
 			],
+			"open": true,
 			"name": "Bard-Song Abilities",
 			"reference": "DFA18",
 			"tags": [
@@ -968,8 +968,8 @@
 				"Disadvantage",
 				"Mental"
 			],
-			"base_points": -15,
 			"cr": 12,
+			"base_points": -15,
 			"calc": {
 				"points": -15
 			}
@@ -983,8 +983,8 @@
 				"Disadvantage",
 				"Mental"
 			],
-			"base_points": -10,
 			"cr": 12,
+			"base_points": -10,
 			"calc": {
 				"points": -10
 			}
@@ -1020,8 +1020,8 @@
 				"Disadvantage",
 				"Mental"
 			],
-			"base_points": -10,
 			"cr": 12,
+			"base_points": -10,
 			"calc": {
 				"points": -10
 			}
@@ -1227,8 +1227,8 @@
 				"Disadvantage",
 				"Mental"
 			],
-			"base_points": -10,
 			"cr": 12,
+			"base_points": -10,
 			"calc": {
 				"points": -10
 			}
@@ -1411,8 +1411,8 @@
 				"Disadvantage",
 				"Mental"
 			],
-			"base_points": -15,
 			"cr": 12,
+			"base_points": -15,
 			"calc": {
 				"points": -15
 			}
@@ -1420,7 +1420,6 @@
 		{
 			"id": "cc4efe59-279a-414b-aeb4-58ff9ae424cb",
 			"type": "trait_container",
-			"open": true,
 			"children": [
 				{
 					"id": "11a620a9-7929-4a34-b1b5-6aae7309ceff",
@@ -1621,6 +1620,7 @@
 					}
 				}
 			],
+			"open": true,
 			"name": "Chi Abilities",
 			"reference": "DFA30",
 			"tags": [
@@ -2028,7 +2028,7 @@
 			"type": "trait",
 			"name": "Combat Reflexes",
 			"reference": "DFA48",
-			"notes": "Never freeze",
+			"reference_highlight": "Combat Reflexes",
 			"tags": [
 				"Advantage",
 				"Mental"
@@ -2080,13 +2080,8 @@
 				},
 				{
 					"type": "conditional_modifier",
-					"situation": "on all IQ rolls to wake up or to recover from surprise or mental stun",
+					"situation": "on all IQ rolls to wake up and to recover from mental stun",
 					"amount": 6
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "to initiative rolls for your side (+2 if you are the leader)",
-					"amount": 1
 				}
 			],
 			"calc": {
@@ -2119,8 +2114,8 @@
 				"Disadvantage",
 				"Mental"
 			],
-			"base_points": -5,
 			"cr": 12,
+			"base_points": -5,
 			"calc": {
 				"points": -5
 			}
@@ -2134,8 +2129,8 @@
 				"Disadvantage",
 				"Mental"
 			],
-			"base_points": -5,
 			"cr": 12,
+			"base_points": -5,
 			"calc": {
 				"points": -5
 			}
@@ -2149,6 +2144,7 @@
 				"Disadvantage",
 				"Mental"
 			],
+			"cr": 12,
 			"base_points": -5,
 			"prereqs": {
 				"type": "prereq_list",
@@ -2164,7 +2160,6 @@
 					}
 				]
 			},
-			"cr": 12,
 			"calc": {
 				"points": -5
 			}
@@ -2178,8 +2173,8 @@
 				"Disadvantage",
 				"Mental"
 			],
-			"base_points": -15,
 			"cr": 12,
+			"base_points": -15,
 			"calc": {
 				"points": -15
 			}
@@ -2193,6 +2188,7 @@
 				"Disadvantage",
 				"Mental"
 			],
+			"cr": 12,
 			"base_points": -5,
 			"prereqs": {
 				"type": "prereq_list",
@@ -2208,7 +2204,6 @@
 					}
 				]
 			},
-			"cr": 12,
 			"calc": {
 				"points": -5
 			}
@@ -2222,8 +2217,8 @@
 				"Disadvantage",
 				"Mental"
 			],
-			"base_points": -5,
 			"cr": 12,
+			"base_points": -5,
 			"calc": {
 				"points": -5
 			}
@@ -2252,8 +2247,8 @@
 				"Disadvantage",
 				"Mental"
 			],
-			"base_points": -10,
 			"cr": 12,
+			"base_points": -10,
 			"calc": {
 				"points": -10
 			}
@@ -2281,8 +2276,8 @@
 				"Disadvantage",
 				"Mental"
 			],
-			"base_points": -5,
 			"cr": 12,
+			"base_points": -5,
 			"calc": {
 				"points": -5
 			}
@@ -3228,7 +3223,6 @@
 		{
 			"id": "8635937f-9430-483b-8265-348c9a2e0169",
 			"type": "trait_container",
-			"open": true,
 			"children": [
 				{
 					"id": "6c42c92f-40c5-4c1d-9aae-1d59ce2c2e1a",
@@ -3321,6 +3315,7 @@
 					}
 				}
 			],
+			"open": true,
 			"name": "Druidic Abilities",
 			"reference": "DFA23",
 			"tags": [
@@ -4322,8 +4317,8 @@
 				"Disadvantage",
 				"Mental"
 			],
-			"base_points": -5,
 			"cr": 12,
+			"base_points": -5,
 			"calc": {
 				"points": -5
 			}
@@ -4351,8 +4346,8 @@
 				"Disadvantage",
 				"Mental"
 			],
-			"base_points": -15,
 			"cr": 12,
+			"base_points": -15,
 			"calc": {
 				"points": -15
 			}
@@ -4447,6 +4442,7 @@
 				"Disadvantage",
 				"Mental"
 			],
+			"cr": 12,
 			"base_points": -10,
 			"prereqs": {
 				"type": "prereq_list",
@@ -4473,7 +4469,6 @@
 					"amount": -3
 				}
 			],
-			"cr": 12,
 			"calc": {
 				"points": -10
 			}
@@ -5153,7 +5148,6 @@
 		{
 			"id": "c1c5635d-c0d9-4a8e-942f-3556a166720e",
 			"type": "trait_container",
-			"open": true,
 			"children": [
 				{
 					"id": "75e272e6-29aa-4cc4-8191-a88207c65fe0",
@@ -5331,6 +5325,7 @@
 					}
 				}
 			],
+			"open": true,
 			"name": "Holy Abilities",
 			"reference": "DFA20",
 			"tags": [
@@ -5379,8 +5374,8 @@
 				"Disadvantage",
 				"Mental"
 			],
-			"base_points": -10,
 			"cr": 12,
+			"base_points": -10,
 			"calc": {
 				"points": -10
 			}
@@ -5491,8 +5486,8 @@
 				"Disadvantage",
 				"Mental"
 			],
-			"base_points": -10,
 			"cr": 12,
+			"base_points": -10,
 			"calc": {
 				"points": -10
 			}
@@ -5707,8 +5702,8 @@
 				"Disadvantage",
 				"Mental"
 			],
-			"base_points": -5,
 			"cr": 12,
+			"base_points": -5,
 			"calc": {
 				"points": -5
 			}
@@ -5876,8 +5871,8 @@
 				"Disadvantage",
 				"Mental"
 			],
-			"base_points": -15,
 			"cr": 12,
+			"base_points": -15,
 			"calc": {
 				"points": -15
 			}
@@ -6113,8 +6108,8 @@
 				"Disadvantage",
 				"Mental"
 			],
-			"base_points": -15,
 			"cr": 12,
+			"base_points": -15,
 			"calc": {
 				"points": -15
 			}
@@ -6184,8 +6179,8 @@
 				"Disadvantage",
 				"Mental"
 			],
-			"base_points": -5,
 			"cr": 12,
+			"base_points": -5,
 			"calc": {
 				"points": -5
 			}
@@ -6387,8 +6382,8 @@
 				"Disadvantage",
 				"Mental"
 			],
-			"base_points": -10,
 			"cr": 12,
+			"base_points": -10,
 			"calc": {
 				"points": -10
 			}
@@ -7082,8 +7077,8 @@
 				"Disadvantage",
 				"Mental"
 			],
-			"base_points": -5,
 			"cr": 12,
+			"base_points": -5,
 			"calc": {
 				"points": -5
 			}
@@ -7238,8 +7233,8 @@
 				"Disadvantage",
 				"Mental"
 			],
-			"base_points": -10,
 			"cr": 12,
+			"base_points": -10,
 			"calc": {
 				"points": -10
 			}
@@ -7253,8 +7248,8 @@
 				"Disadvantage",
 				"Mental"
 			],
-			"base_points": -5,
 			"cr": 12,
+			"base_points": -5,
 			"calc": {
 				"points": -5
 			}
@@ -7268,8 +7263,8 @@
 				"Disadvantage",
 				"Mental"
 			],
-			"base_points": -15,
 			"cr": 12,
+			"base_points": -15,
 			"calc": {
 				"points": -15
 			}
@@ -7283,8 +7278,8 @@
 				"Disadvantage",
 				"Mental"
 			],
-			"base_points": -20,
 			"cr": 12,
+			"base_points": -20,
 			"calc": {
 				"points": -20
 			}
@@ -7404,8 +7399,8 @@
 				"Disadvantage",
 				"Mental"
 			],
-			"base_points": -5,
 			"cr": 12,
+			"base_points": -5,
 			"calc": {
 				"points": -5
 			}
@@ -7494,8 +7489,8 @@
 				"Disadvantage",
 				"Mental"
 			],
-			"base_points": -5,
 			"cr": 12,
+			"base_points": -5,
 			"calc": {
 				"points": -5
 			}
@@ -7885,8 +7880,8 @@
 				"Disadvantage",
 				"Mental"
 			],
-			"base_points": -15,
 			"cr": 12,
+			"base_points": -15,
 			"calc": {
 				"points": -15
 			}
@@ -7930,8 +7925,8 @@
 				"Disadvantage",
 				"Mental"
 			],
-			"base_points": -5,
 			"cr": 12,
+			"base_points": -5,
 			"calc": {
 				"points": -5
 			}
@@ -8079,7 +8074,6 @@
 					"usage": "Slash",
 					"reach": "C",
 					"parry": "0",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx"
@@ -8098,8 +8092,6 @@
 						}
 					],
 					"calc": {
-						"parry": "0",
-						"block": "No",
 						"damage": "thr-1 cut"
 					}
 				},
@@ -8112,8 +8104,6 @@
 					},
 					"usage": "Kick",
 					"reach": "C,1",
-					"parry": "No",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "dx",
@@ -8131,8 +8121,6 @@
 						}
 					],
 					"calc": {
-						"parry": "No",
-						"block": "No",
 						"damage": "thr cut"
 					}
 				}
@@ -8272,8 +8260,8 @@
 				"Disadvantage",
 				"Mental"
 			],
-			"base_points": -10,
 			"cr": 12,
+			"base_points": -10,
 			"calc": {
 				"points": -10
 			}
@@ -8697,11 +8685,41 @@
 			"type": "trait",
 			"name": "Strongbow",
 			"reference": "DFA35",
+			"reference_highlight": "Strongbow",
+			"notes": "Manually adjust Rated ST for purchased bow(s).",
 			"tags": [
 				"Advantage",
 				"Physical"
 			],
 			"base_points": 1,
+			"features": [
+				{
+					"type": "weapon_min_st_bonus",
+					"selection_type": "weapons_with_required_skill",
+					"name": {
+						"compare": "is",
+						"qualifier": "Bow"
+					},
+					"level": {
+						"compare": "at_least",
+						"qualifier": 1
+					},
+					"amount": -1
+				},
+				{
+					"type": "weapon_min_st_bonus",
+					"selection_type": "weapons_with_required_skill",
+					"name": {
+						"compare": "is",
+						"qualifier": "Bow"
+					},
+					"level": {
+						"compare": "at_least",
+						"qualifier": 2
+					},
+					"amount": -1
+				}
+			],
 			"calc": {
 				"points": 1
 			}
@@ -8715,8 +8733,8 @@
 				"Disadvantage",
 				"Mental"
 			],
-			"base_points": -5,
 			"cr": 12,
+			"base_points": -5,
 			"calc": {
 				"points": -5
 			}
@@ -8810,8 +8828,6 @@
 					},
 					"usage": "Bite",
 					"reach": "C",
-					"parry": "No",
-					"block": "No",
 					"defaults": [
 						{
 							"type": "skill",
@@ -8822,8 +8838,6 @@
 						}
 					],
 					"calc": {
-						"parry": "No",
-						"block": "No",
 						"damage": "thr-1 cut"
 					}
 				}
@@ -9106,8 +9120,8 @@
 				"Disadvantage",
 				"Mental"
 			],
-			"base_points": -15,
 			"cr": 12,
+			"base_points": -15,
 			"calc": {
 				"points": -15
 			}
@@ -9121,6 +9135,7 @@
 				"Disadvantage",
 				"Mental"
 			],
+			"cr": 12,
 			"base_points": -5,
 			"features": [
 				{
@@ -9133,7 +9148,6 @@
 					"amount": -5
 				}
 			],
-			"cr": 12,
 			"calc": {
 				"points": -5
 			}
@@ -9148,8 +9162,8 @@
 				"Mental",
 				"Supernatural"
 			],
-			"base_points": -15,
 			"cr": 12,
+			"base_points": -15,
 			"calc": {
 				"points": -15
 			}
@@ -9906,7 +9920,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -9920,7 +9934,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -9934,7 +9948,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -9948,7 +9962,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -9962,7 +9976,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -9976,7 +9990,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -9990,7 +10004,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10004,7 +10018,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10018,7 +10032,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10032,7 +10046,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10046,7 +10060,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10060,7 +10074,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10074,7 +10088,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10088,7 +10102,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10102,7 +10116,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10116,7 +10130,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10130,7 +10144,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10144,7 +10158,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10158,7 +10172,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10172,7 +10186,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10186,7 +10200,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10200,7 +10214,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10214,7 +10228,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10228,7 +10242,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10242,7 +10256,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10256,7 +10270,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10270,7 +10284,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10284,7 +10298,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10298,7 +10312,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10312,7 +10326,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10326,7 +10340,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10340,7 +10354,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10354,7 +10368,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10368,7 +10382,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10382,7 +10396,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10396,7 +10410,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10410,7 +10424,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10424,7 +10438,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10438,7 +10452,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10452,7 +10466,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10466,7 +10480,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10480,7 +10494,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10494,7 +10508,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10508,7 +10522,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10522,7 +10536,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10536,7 +10550,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10550,7 +10564,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10564,7 +10578,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10578,7 +10592,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10592,7 +10606,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10606,7 +10620,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10620,7 +10634,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10634,7 +10648,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10648,7 +10662,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10662,7 +10676,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10676,7 +10690,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						}
 					]
 				},
@@ -10701,7 +10715,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10715,7 +10729,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						}
 					]
 				},
@@ -10740,7 +10754,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10754,7 +10768,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10768,7 +10782,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10782,7 +10796,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						}
 					]
 				},
@@ -10807,7 +10821,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10821,7 +10835,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10835,7 +10849,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10849,7 +10863,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10863,7 +10877,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10877,7 +10891,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10891,7 +10905,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10905,7 +10919,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						}
 					]
 				},
@@ -10930,7 +10944,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10944,7 +10958,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10958,7 +10972,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10972,7 +10986,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -10986,7 +11000,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -11000,7 +11014,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -11014,7 +11028,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -11028,7 +11042,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						}
 					]
 				},
@@ -11053,7 +11067,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -11067,7 +11081,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						}
 					]
 				},
@@ -11092,7 +11106,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -11106,7 +11120,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -11120,7 +11134,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -11134,7 +11148,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						}
 					]
 				},
@@ -11159,7 +11173,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -11173,7 +11187,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -11187,7 +11201,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -11201,7 +11215,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -11215,7 +11229,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -11229,7 +11243,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -11243,7 +11257,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -11257,7 +11271,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -11271,7 +11285,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -11285,7 +11299,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -11299,7 +11313,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -11313,7 +11327,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -11327,7 +11341,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -11341,7 +11355,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -11355,7 +11369,7 @@
 								"qualifier": 1
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						},
 						{
 							"type": "weapon_bonus",
@@ -11369,7 +11383,7 @@
 								"qualifier": 2
 							},
 							"amount": 1,
-							"per_level": true
+							"per_die": true
 						}
 					]
 				}
@@ -11544,8 +11558,8 @@
 				"Disadvantage",
 				"Mental"
 			],
-			"base_points": -10,
 			"cr": 12,
+			"base_points": -10,
 			"calc": {
 				"points": -10
 			}


### PR DESCRIPTION
- Updated Combat Reflexes in DFRPG Traits to reflect the language in DFRPG Adventurers (removed holdover bits from mainline GURPS about "never freezing" and initiative bonuses).
- Updated Strongbow in DFRPG Traits to automatically reduce the minimum ST of bows by 1 or 2 points, depending on RSL (per Adventurers, p. 35).
- Updated the Elven equipment modifier in DFRPG Equipment Modifiers to automatically reduce minimum ST by 2.
- Added relevant Page Highlight text.