### PR TITLE
Fixes AAI XM19 Weight

### DIFF
--- a/Library/High Tech/High Tech Equipment.eqp
+++ b/Library/High Tech/High Tech Equipment.eqp
@@ -3886,7 +3886,7 @@
 			],
 			"quantity": 1,
 			"value": 1500,
-			"weight": "750 lb",
+			"weight": "7.4 lb",
 			"weapons": [
 				{
 					"id": "538e7e8b-a4a1-422a-a8f9-ec4431109f27",


### PR DESCRIPTION
Was showing 750lb while the book says 7.4lb

That puts this handheld rifle's weight above even the M1938 mortar. A hefty gun indeed!