### PR TITLE
use correct name for skill in prereqs

### DIFF
--- a/Library/Magic/Magic Spells.spl
+++ b/Library/Magic/Magic Spells.spl
@@ -13126,7 +13126,7 @@
 						"has": true,
 						"name": {
 							"compare": "is",
-							"qualifier": "symbol-drawing"
+							"qualifier": "Symbol Drawing"
 						},
 						"level": {
 							"compare": "at_least",


### PR DESCRIPTION
In  the spell `Divination: Symbol-Casting`

```	
"type": "spell",
			"name": "Divination: Symbol-Casting",
			"reference": "M109",
			"tags": [
				"Knowledge"
			],
			"difficulty": "iq/h",
			"college": [
				"Knowledge"
			],
			"power_source": "Arcane",
			"spell_class": "Info",
			"casting_cost": "10",
			"maintenance_cost": "-",
			"casting_time": "1 hr",
			"duration": "Instant",
			"points": 1,
			"prereqs": {
				"type": "prereq_list",
				"all": true,
				"prereqs": [
					{
						"type": "spell_prereq",
						"sub_type": "name",
						"has": true,
						"qualifier": {
							"compare": "is",
							"qualifier": "history"
						},
						"quantity": {
							"compare": "at_least",
							"qualifier": 1
						}
					},
					{
						"type": "skill_prereq",
						"has": true,
						"name": {
							"compare": "is",
							"qualifier": "Symbol Drawing"
```

the `skill_prereq` could not find the skill `symbol_drawing` - changing it to `Symbol Drawing` allowed the spell to find the pre-req successfully.
