### PR TITLE
Add in IQ bonus for PI per B77

### DIFF
--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -21481,6 +21481,18 @@
 			],
 			"levels": 1,
 			"points_per_level": 10,
+			"features": [
+				{
+					"type": "spell_bonus",
+					"match": "college_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Clerical"
+					},
+					"amount": 1,
+					"per_level": true
+				}
+			],
 			"can_level": true,
 			"calc": {
 				"points": 10


### PR DESCRIPTION
Adding in clerical spells to a test character:

Int 10
Power Investiture  2

Added Minor Healing (IQ/H) from the cleric spell list in DF at 1 point, ended up with a skill of 8.

Moved Power Investiture to 1, still had a skill of 8.

With this change

Int 10
Power Investiture  2

Added Minor Healing (IQ/H) from the cleric spell list in DF at 1 point, ended up with a skill of 10.

Moved Power Investiture to 1, with a skill of 9.

Seems to follow the rule on B77: "Add your Power Investiture to your IQ when you learn spells granted by the deity who bestowed this advantage."