### PR TITLE
#312 Talent benefits as modifiers

### DIFF
--- a/Library/Power Ups/Power Ups Traits.adq
+++ b/Library/Power Ups/Power Ups Traits.adq
@@ -7219,6 +7219,41 @@
 				"Mental",
 				"Talent"
 			],
+			"modifiers": [
+				{
+					"id": "MZNwYA232g6m_a_gr",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "meKb__enTQBEUniTq",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From students and teachers.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "myAcgF_Uhz5DkCmuN",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to any roll that benefits from Eidetic Memory",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
+				}
+			],
 			"points_per_level": 5,
 			"features": [
 				{
@@ -7268,18 +7303,6 @@
 						"compare": "is",
 						"qualifier": "Writing"
 					},
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From students and teachers.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to any roll that benefits from Eidetic Memory",
 					"amount": 1,
 					"per_level": true
 				}
@@ -7559,12 +7582,61 @@
 			],
 			"modifiers": [
 				{
-					"id": "mcI-NeYg1SHnqP6a6",
+					"id": "mrq7fOB9e7o0fhn4x",
 					"name": "Alternative Cost",
 					"cost": 1,
 					"cost_type": "points",
 					"affects": "levels_only",
 					"disabled": true
+				},
+				{
+					"id": "M404hUFdeI-g6xyPu",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mcYNEWvdJ_KyaF11a",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From devotees of the old and beautiful.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mt-SZ0b4st-SLNMgJ",
+							"name": "Less severe Time penalties",
+							"reference": "B176",
+							"reference_highlight": "Time",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Counteract Time penalties (p. B176) when dealing with old sruff",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mdYPAJXSEtm4uABp6",
+							"name": "Less-severe Tech-Level Modifiers",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Counteract Tech-Level Modifiers (p. B168) when dealing with sciences of a lower TL",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 5,
@@ -7628,18 +7700,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From devotees of the old and beautiful.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Less-severe penalties from Time (p. B176) when dealing with old stuff, and/or from Tech-Level Modifiers (p. B168) when dealing with sciences of a lower TL.",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -7665,6 +7725,39 @@
 					"cost_type": "points",
 					"affects": "levels_only",
 					"disabled": true
+				},
+				{
+					"id": "MVlWXcsbE1DZPEMmo",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mCDewAlQdEL-79S-i",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From employers.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mmkoamQNMyHLtnOuT",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Eliminate -1/level to a skill with success on another to improvise tools; Apply to Enigmatic Device Table rolls and other unskilled tech rolls.",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 10,
@@ -7758,18 +7851,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From employers.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Eliminate -1/level to a skill with success on another to improvise tools; Apply to Enigmatic Device Table rolls and other unskilled tech rolls.",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -7795,6 +7876,39 @@
 					"cost_type": "points",
 					"affects": "levels_only",
 					"disabled": true
+				},
+				{
+					"id": "Mmc5aO22GO1ulmNMD",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "msaPJN_TCZ0dwf5nY",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From audiences and fellow bards.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mfBMTTFSoj5465was",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to first influence roll made against one or more audience members after a successful performance.",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 5,
@@ -7856,18 +7970,6 @@
 						"compare": "is",
 						"qualifier": "singing"
 					},
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From audiences and fellow bards.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to first influence roll made against one or more audience members after a successful performance.",
 					"amount": 1,
 					"per_level": true
 				}
@@ -8071,6 +8173,39 @@
 					"cost_type": "points",
 					"affects": "levels_only",
 					"disabled": true
+				},
+				{
+					"id": "Mk4bhTUMGFaQ47gsJ",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mCmAhayTr6Kp51mbL",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From crowds.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mx4sMhjQkhFBzoNFN",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to first influence roll made against one or more audience members after a successful performance.",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 5,
@@ -8134,18 +8269,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From crowds.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to first influence roll made against one or more audience members after a successful performance.",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -8179,12 +8302,59 @@
 			},
 			"modifiers": [
 				{
-					"id": "mk2uT27ziH3lkFMsY",
+					"id": "msGEDOjO2ieLp4jEi",
 					"name": "Alternative Cost",
 					"cost": 1,
 					"cost_type": "points",
 					"affects": "levels_only",
 					"disabled": true
+				},
+				{
+					"id": "MLml2LHNgvrCJ4kZn",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mYpTbIYcuNHWIYZ5q",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From sailors.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mmnaK-9ySpNA8HDLI",
+							"name": "Resist seasickness",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "To resist seasickness",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "m0S6MjhlPktECtIyY",
+							"name": "Familiarity",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "To reduce unfamiliarity penalties for systems on an appropriate boat or ship",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 5,
@@ -8262,18 +8432,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From sailors.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to resist seasickness and reduce unfamiliarity penalties for system on an appropriate boat or ship",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -8290,6 +8448,41 @@
 				"Advantage",
 				"Mental",
 				"Talent"
+			],
+			"modifiers": [
+				{
+					"id": "MVn8cXcxDADHSBSp9",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mgdhzOKR01HD_P8k6",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From those you serve with or command.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mQMp2uAbkGYw-fR7Y",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Reduce chance of impersonal battlefield hazards",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
+				}
 			],
 			"points_per_level": 5,
 			"features": [
@@ -8342,18 +8535,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From those you serve with or command.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Reduce chance of impersonal battlefield hazards",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -8373,12 +8554,60 @@
 			],
 			"modifiers": [
 				{
-					"id": "mTj8GFjhoEh5mnLAS",
+					"id": "mVJJ181VGmizJSEBe",
 					"name": "Alternative Cost",
 					"cost": 1,
 					"cost_type": "points",
 					"affects": "levels_only",
 					"disabled": true
+				},
+				{
+					"id": "MjPBoVrf5vxlPipO5",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mzZkB89c6Jec9FRQ5",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From professional Spacers.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "m_ZBikRsHkP7loSK9",
+							"name": "Bonus to pushing off",
+							"reference": "BX350",
+							"reference_highlight": "ST/2",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to ST for zero G push off",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "m9XW6u_kWwQNxZYkY",
+							"name": "Spacecraft Familiarity",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Counteracts Familiarity for spacecraft.",
+									"amount": 1
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 5,
@@ -8478,18 +8707,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From professional Spacers.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to ST for zero G push off.  Reduce penalty for unfamiliar spacecraft.",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -8515,6 +8732,39 @@
 					"cost_type": "points",
 					"affects": "levels_only",
 					"disabled": true
+				},
+				{
+					"id": "MtN14JCAPA-C_TvZP",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mBj4wcIodPpO3RNXJ",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From anyone you serve with or command.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mvBUC4qJNRsYcHtDr",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to initiative rolls if leader",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 10,
@@ -8642,18 +8892,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From anyone you serve with or command.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to initiative rolls if leader",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -8673,12 +8911,59 @@
 			],
 			"modifiers": [
 				{
-					"id": "mL3RY-tXSscbhFM4q",
+					"id": "m-9ipfke3undsSe8U",
 					"name": "Alternative Cost",
 					"cost": 1,
 					"cost_type": "points",
 					"affects": "levels_only",
 					"disabled": true
+				},
+				{
+					"id": "M-_obum90-ccnuMxN",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mw5on9bVYoqdp15m2",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From hackers; people buying stock in your dot-com.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mZCesFTP7lPLHFore",
+							"name": "Familiarity",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Less-severe penalties from Familiarity (p. B169) for unfamiliar computer equipment,",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mhASJxKx8c6qAE1Ys",
+							"name": "Improvised Software",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Success at Computer Hacking or Computer Programming lets you improvise code that removes -1/level from the penalty for not having proper software for a task that requires it (p. B345).",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 5,
@@ -8742,18 +9027,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From hackers; people buying stock in your dot-com.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Less-severe penalties from Familiarity (p. B169) for unfamiliar computer equipment, and/or success at Computer Hacking or Computer Programming lets you improvise code that removes -1/level from the penalty for not having proper software for a task that requires it (p. B345).",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -8770,6 +9043,41 @@
 				"Advantage",
 				"Physical",
 				"Talent"
+			],
+			"modifiers": [
+				{
+					"id": "MNr1NspB-Ul5k7zx_",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mEEPGVqA_adFE0Ssh",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "m469ywcDGys9vGRrk",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to initiative rolls if leader",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
+				}
 			],
 			"points_per_level": 5,
 			"features": [
@@ -8826,18 +9134,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to initiative rolls if leader",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -8857,12 +9153,59 @@
 			],
 			"modifiers": [
 				{
-					"id": "mqoPJttH1-1uzukol",
+					"id": "mREUkndWgqBCkMbWA",
 					"name": "Alternative Cost",
 					"cost": -2,
 					"cost_type": "points",
 					"affects": "levels_only",
 					"disabled": true
+				},
+				{
+					"id": "MwugK85lgsQ_9anuJ",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mELR9p3p7Ql3OpoR-",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From anyone with whom you do business.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mqqIQyA08QRv1-gP8",
+							"name": "Jobs and hirelings",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "To all rolls to find hirelings or jobs (pp. B517-518)",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "m9Vr2mFKZGRkDDiyS",
+							"name": "Resist scams",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "To will rolls to resist others' attempts to use Influence skills to scam money.",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 10,
@@ -8944,18 +9287,6 @@
 						"compare": "is",
 						"qualifier": "Propaganda"
 					},
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From anyone with whom you do business.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to all rolls to find hirelings or jobs (pp. B517-518), and/or to Will rolls to resist others' attempts to use Influence skills to scam money.",
 					"amount": 1,
 					"per_level": true
 				}
@@ -9204,6 +9535,41 @@
 				"Mental",
 				"Talent"
 			],
+			"modifiers": [
+				{
+					"id": "Mz6qsfZrNxKOpkQmX",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mNEIB9hBf7ILZnB1g",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From anyone for whom you use your skills.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "msCdz5SCx_wLSr31N",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Less-severe penalties from Familiarity (p. B169) – which can run to -10 in certain cases (see p. B189) – when using any skill to operate unfamiliar gear that runs on electricity.",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
+				}
+			],
 			"points_per_level": 5,
 			"features": [
 				{
@@ -9245,18 +9611,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From anyone for whom you use your skills.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Less-severe penalties from Familiarity (p. B169) – which can run to -10 in certain cases (see p. B189) – when using any skill to operate unfamiliar gear that runs on electricity.",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -9283,6 +9637,39 @@
 					"cost_type": "points",
 					"affects": "levels_only",
 					"disabled": true
+				},
+				{
+					"id": "MvatOMVEp0na9CjTa",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mCvvUS_FMzsjhv7E8",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From any fellow “religious professional”.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mbOzvviK1j47DBbg7",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "IQ-4+Level to notice omens and blessed items",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 5,
@@ -9352,18 +9739,6 @@
 						"compare": "is",
 						"qualifier": "Exorcism"
 					},
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From any fellow “religious professional”.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "IQ-4+Level to notice omens and blessed items",
 					"amount": 1,
 					"per_level": true
 				}
@@ -9487,6 +9862,41 @@
 				"Supernatural",
 				"Talent"
 			],
+			"modifiers": [
+				{
+					"id": "MlCZurxxitEHuobsX",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mY7MM2IdhNG3HTMVt",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From those who respect nature.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mZYElX_2hDjmTgZM-",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "IQ-4+Level to notice disturbances in nature",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
+				}
+			],
 			"points_per_level": 5,
 			"features": [
 				{
@@ -9570,18 +9980,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From those who respect nature.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "IQ-4+Level to notice disturbances in nature",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -9598,6 +9996,41 @@
 				"Advantage",
 				"Mental",
 				"Talent"
+			],
+			"modifiers": [
+				{
+					"id": "Mj25VIV-Y0w5TB2G0",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mft91QP7pr6s7QlNW",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From audiences, circus performers, vaudevillians, and fellow fools.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mvAygSY5es4cKsW1_",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to first influence roll made against one or more audience members after a successful performance.",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
+				}
 			],
 			"points_per_level": 10,
 			"features": [
@@ -9704,18 +10137,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From audiences, circus performers, vaudevillians, and fellow fools.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to first influence roll made against one or more audience members after a successful performance.",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -9741,6 +10162,39 @@
 					"cost_type": "points",
 					"affects": "levels_only",
 					"disabled": true
+				},
+				{
+					"id": "MDYBILAAK2nkMl0sn",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "m4YNU-pqh_2fi0grN",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From computer professionals and AIs.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "moh49nRVztdGKC8R2",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Reduce Familiarity penalties for computers. Roll Hacking/Programming to improvise software to reduce equipment penalty.",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 5,
@@ -9833,18 +10287,6 @@
 						"qualifier": "AI"
 					},
 					"amount": 1
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From computer professionals and AIs.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Reduce Familiarity penalties for computers. Roll Hacking/Programming to improvise software to reduce equipment penalty.",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -10058,6 +10500,39 @@
 					"cost_type": "points",
 					"affects": "levels_only",
 					"disabled": true
+				},
+				{
+					"id": "MDYZ8bjd0iEZUSsVg",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mZJtWtrsa7LqP3-IJ",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From local peasantry, clients, and acolytes.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mWK2BXofKI-2DMfyz",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "A roll at IQ-4, +1/level of Cunning Folk, to notice anything odd – curses, blights, faeries in the basement, etc. – that happens to animals, crops, or people in an area where you’ve lived for at least (6 - Cunning Folk level) months.",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 10,
@@ -10139,18 +10614,6 @@
 						"compare": "is",
 						"qualifier": "Weather Sense"
 					},
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From local peasantry, clients, and acolytes.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "A roll at IQ-4, +1/level of Cunning Folk, to notice anything odd – curses, blights, faeries in the basement, etc. – that happens to animals, crops, or people in an area where you’ve lived for at least (6 - Cunning Folk level) months.",
 					"amount": 1,
 					"per_level": true
 				}
@@ -10252,6 +10715,41 @@
 				"Mental",
 				"Talent"
 			],
+			"modifiers": [
+				{
+					"id": "MeCVDSQ7z3hmGDdAT",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mA-rbrFOydHMos5U3",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From coreligionists and sympathizers.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mmzM2Ar6EcvjamOVo",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to will to resist \"evil influences\"",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
+				}
+			],
 			"points_per_level": 5,
 			"features": [
 				{
@@ -10293,18 +10791,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From coreligionists and sympathizers.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to will to resist \"evil influences\"",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -10321,6 +10807,41 @@
 				"Advantage",
 				"Mental",
 				"Talent"
+			],
+			"modifiers": [
+				{
+					"id": "M59weqGn-stUKiqAW",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mhkNr4Z4QeJJwTLEy",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From passengers; gamblers betting on you at the Grand Prix.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mKI8EM_uGn4VNPzpv",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus on Per rolls to notice dangers in the path of your ride: running children, oncoming vehicles, landmines...",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
+				}
 			],
 			"points_per_level": 5,
 			"features": [
@@ -10363,18 +10884,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From passengers; gamblers betting on you at the Grand Prix.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus on Per rolls to notice dangers in the path of your ride: running children, oncoming vehicles, landmines...",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -10401,6 +10910,39 @@
 					"cost_type": "points",
 					"affects": "levels_only",
 					"disabled": true
+				},
+				{
+					"id": "Mo3mX9LdDBb6VPEeu",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "m93IxpZ4-yfdDHwbq",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From potential Buyers.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mQddz8kcAm_Qad3FV",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Roll appropriate skill to scrounge equipment for other covered skills and apply level against the penalty.  Shift rolls to avoid ill effects from mysterious artifacts by level in either direction.",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 5,
@@ -10470,18 +11012,6 @@
 						"compare": "is",
 						"qualifier": "Traps"
 					},
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From potential Buyers.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Roll appropriate skill to scrounge equipment for other covered skills and apply level against the penalty.  Shift rolls to avoid ill effects from mysterious artifacts by level in either direction.",
 					"amount": 1,
 					"per_level": true
 				}
@@ -10755,6 +11285,39 @@
 					"cost_type": "points",
 					"affects": "levels_only",
 					"disabled": true
+				},
+				{
+					"id": "M_qYLdk5lYkNYaQgK",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mhIrCkTNtKK4xqFxm",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From fellow explorers and backers.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mxnx5ytoy1IxRvgEA",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Reduce distance and area class penalties for all skills",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 5,
@@ -10821,18 +11384,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From fellow explorers and backers.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Reduce distance and area class penalties for all skills",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -10859,6 +11410,39 @@
 					"cost_type": "points",
 					"affects": "levels_only",
 					"disabled": true
+				},
+				{
+					"id": "MnUpRS6rnunFswZBz",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mjj_nqNg3tkJ8Ultp",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From honourable opponents, Hard stylists, Lovers.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mB2_01adHoWrKtkP5",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to be heard or to Intimidation after using a covered skill",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 15,
@@ -11002,18 +11586,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From honourable opponents, Hard stylists, Lovers.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to be heard or to Intimidation after using a covered skill",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -11039,6 +11611,39 @@
 					"cost_type": "points",
 					"affects": "levels_only",
 					"disabled": true
+				},
+				{
+					"id": "MxGdnNvpZtKHytLmw",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mOOjsc9LV1IK6L4Ah",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From crime-lab employers and detectives.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mwduaNVqxjarmi_FW",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to Per to spot clues when no skill applies",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 5,
@@ -11102,18 +11707,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From crime-lab employers and detectives.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to Per to spot clues when no skill applies",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -11147,6 +11740,41 @@
 					}
 				]
 			},
+			"modifiers": [
+				{
+					"id": "MWkThVQQvNOwfqg9Z",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "m94PNTfpxN3YqhRgH",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From druids, Faeries, and bunnies.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "m-K6YCrnt84kqMutz",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to notice intruders, etc in woodland where you've lived from 6-level months.",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
+				}
+			],
 			"points_per_level": 5,
 			"features": [
 				{
@@ -11196,18 +11824,6 @@
 						"compare": "is",
 						"qualifier": "Survival"
 					},
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From druids, Faeries, and bunnies.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to notice intruders, etc in woodland where you've lived from 6-level months.",
 					"amount": 1,
 					"per_level": true
 				}
@@ -11301,6 +11917,41 @@
 				"Mental",
 				"Talent"
 			],
+			"modifiers": [
+				{
+					"id": "MqNLIVY2GdA25lzrc",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mX5tMTF2inMi6-ak-",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From beneficiaries, prospective spouses, other housewives.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "m7pQuUe8y0XmVgX7s",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to defaults made in your own home to repair, maintain, and protect it.",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
+				}
+			],
 			"points_per_level": 5,
 			"features": [
 				{
@@ -11352,18 +12003,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From beneficiaries, prospective spouses, other housewives.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to defaults made in your own home to repair, maintain, and protect it.",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -11380,6 +12019,41 @@
 				"Advantage",
 				"Mental",
 				"Talent"
+			],
+			"modifiers": [
+				{
+					"id": "MHgvzADscCMnOWywL",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mEF7Uh9xJ9QPr6wQV",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From gardeners and Sentient plants.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "m9cQGat28fuK4iuSf",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to rolls to survive made by plants in your care.",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
+				}
 			],
 			"points_per_level": 5,
 			"features": [
@@ -11432,18 +12106,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From gardeners and Sentient plants.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to rolls to survive made by plants in your care.",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -11491,6 +12153,39 @@
 					"cost_type": "points",
 					"affects": "levels_only",
 					"disabled": true
+				},
+				{
+					"id": "MvFo3GwmvASxraPp3",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mzEEE_3gQUCuNOCNN",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From patients.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "myjQcfnkFd6A147xN",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to HT rolls for a specific patient and condition if treated full time.",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 10,
@@ -11611,18 +12306,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From patients.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to HT rolls for a specific patient and condition if treated full time.",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -11671,6 +12354,39 @@
 					"cost_type": "points",
 					"affects": "levels_only",
 					"disabled": true
+				},
+				{
+					"id": "MkZu_pJTt7D_aqIDW",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "m0GxYKa0SMPdVqp9k",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From patients.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mSnAPpt3Q74JHn4y2",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to HT rolls for a specific patient and condition if treated full time.",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 10,
@@ -11792,18 +12508,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From patients.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to HT rolls for a specific patient and condition if treated full time.",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -11820,6 +12524,41 @@
 				"Advantage",
 				"Mental",
 				"Talent"
+			],
+			"modifiers": [
+				{
+					"id": "MxD7-90m_ARK88hYl",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mDqoizHLB0dc-RH4b",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From other Pilots.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "m0IHLV7gDgWqNPk9J",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Reduce penalties for unfamiliar systems of vehicles you have Piloting skill for",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
+				}
 			],
 			"points_per_level": 5,
 			"features": [
@@ -11868,18 +12607,6 @@
 						"compare": "is",
 						"qualifier": "Piloting"
 					},
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From other Pilots.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Reduce penalties for unfamiliar systems of vehicles you have Piloting skill for",
 					"amount": 1,
 					"per_level": true
 				}
@@ -12002,6 +12729,39 @@
 					"cost_type": "points",
 					"affects": "levels_only",
 					"disabled": true
+				},
+				{
+					"id": "MhTA4c-JBht1imB3_",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mGIFrAkvi9bEV9SN1",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From pacifists, Ascetics, Soft stylists.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mCJK3Ha7MFLsP47dr",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to resist mundane disease",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 15,
@@ -12154,18 +12914,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From pacifists, Ascetics, Soft stylists.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to resist mundane disease",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -12191,6 +12939,39 @@
 					"cost_type": "points",
 					"affects": "levels_only",
 					"disabled": true
+				},
+				{
+					"id": "M317Z8N-Ao19cBM0M",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mQvgxQtHRivy-FV84",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From anyone you serve with or command.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mUk08niUNDSBIxdO1",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to initiative roll if leader",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 10,
@@ -12318,18 +13099,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From anyone you serve with or command.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to initiative roll if leader",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -12355,6 +13124,39 @@
 					"cost_type": "points",
 					"affects": "levels_only",
 					"disabled": true
+				},
+				{
+					"id": "MHqJAOpMoHKoj47At",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mirZWwHLBhHpv6ll8",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From anyone you serve with or command.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mExQVDd1sPurwLNz8",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to initiative roll if leader",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 10,
@@ -12472,18 +13274,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From anyone you serve with or command.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to initiative roll if leader",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -12500,6 +13290,41 @@
 				"Advantage",
 				"Mental",
 				"Talent"
+			],
+			"modifiers": [
+				{
+					"id": "MMI-_MB_8T3Ip8BVr",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mKx6GbVTUyYR5CKj-",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From political parties seeking candidates; Anyone who put you in power.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mxQtncnoloIABBPo0",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to influence rolls to be chosen over another for a job or posting, or to cover up a failure with a covered skill.",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
+				}
 			],
 			"points_per_level": 10,
 			"features": [
@@ -12634,18 +13459,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From political parties seeking candidates; Anyone who put you in power.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to influence rolls to be chosen over another for a job or posting, or to cover up a failure with a covered skill.",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -12696,12 +13509,59 @@
 			},
 			"modifiers": [
 				{
-					"id": "mIoCifKCPqEdSFsbv",
+					"id": "m4z61nvq6uWW70HFW",
 					"name": "Alternative Cost",
 					"cost": -3,
 					"cost_type": "points",
 					"affects": "levels_only",
 					"disabled": true
+				},
+				{
+					"id": "MgAzn98YEQuw-ccag",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mhXMaitTsRtw-9AVi",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From seafarers.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mag8K4T0vbSeRE4nQ",
+							"name": "Resist seasickness",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to resist seasicknes",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mVn_FsO0ajMbkMmZ6",
+							"name": "Familiarity",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "To reduce unfamiliarity penalties for systems on an appropriate boat or ship",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 10,
@@ -12789,18 +13649,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From seafarers.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to resist seasicknes and reduce unfamiliarity penalties for system on an appropriate boat or ship",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -12817,6 +13665,41 @@
 				"Advantage",
 				"Mental",
 				"Talent"
+			],
+			"modifiers": [
+				{
+					"id": "MIYEPWa72pByHVKv9",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mBTkFiO1phECTmpPv",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From workers on projects, prospective employers.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mVCZ0QBRE_iOAhplg",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to avoid common workplace hazards, even if used as traps",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
+				}
 			],
 			"points_per_level": 5,
 			"features": [
@@ -12869,18 +13752,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From workers on projects, prospective employers.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to avoid common workplace hazards, even if used as traps",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -12906,6 +13777,39 @@
 					"cost_type": "points",
 					"affects": "levels_only",
 					"disabled": true
+				},
+				{
+					"id": "MRUcX4Z0CI5uL70YM",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "m84Xjr2Ooa2g8seju",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From engineers and scientists.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mJ3V2a2FhfT_lbNRt",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to resist deception involving numbers",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 10,
@@ -12989,18 +13893,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From engineers and scientists.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to resist deception involving numbers",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -13027,6 +13919,39 @@
 					"cost_type": "points",
 					"affects": "levels_only",
 					"disabled": true
+				},
+				{
+					"id": "MKI2ViX1KjbuikV-R",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "m9GNaZxVjrlAy_sqc",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From other memeticists who see you working.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mu7dAEeGhfPL0hvlq",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to resist Brainwashing, Fast-Talk, and Propaganda",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 10,
@@ -13150,18 +14075,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From other memeticists who see you working.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to resist Brainwashing, Fast-Talk, and Propaganda",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -13178,6 +14091,41 @@
 				"Advantage",
 				"Mental",
 				"Talent"
+			],
+			"modifiers": [
+				{
+					"id": "M11euDWZy2l9VBsIR",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "m_NnxZdTtQs61nom-",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From the foolish and weak-minded.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mFom00dPn1E27Qmr_",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to resist any of the affected skills.",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
+				}
 			],
 			"points_per_level": 10,
 			"features": [
@@ -13280,18 +14228,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From the foolish and weak-minded.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to resist any of the affected skills.",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -13392,6 +14328,41 @@
 				"Mental",
 				"Talent"
 			],
+			"modifiers": [
+				{
+					"id": "MPWeI2Z2UTOb3h1VU",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mO5xarrRB9Vm012X2",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From audiences and Critics.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mPzrLmqgx9UyGppo_",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to first influence roll made against one or more audience members after a successful performance.",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
+				}
+			],
 			"points_per_level": 5,
 			"features": [
 				{
@@ -13447,18 +14418,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From audiences and Critics.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to first influence roll made against one or more audience members after a successful performance.",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -13484,6 +14443,39 @@
 					"cost_type": "points",
 					"affects": "levels_only",
 					"disabled": true
+				},
+				{
+					"id": "MBeaj1XN5Cc8YSEfE",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "m6VvIOZwAe50u29Fs",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From sports fans, coaches, and recruiters.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mJB8_Of_-zFZrBrkv",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to HT to recover from injuries resulting from failures with covered skills",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 10,
@@ -13597,18 +14589,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From sports fans, coaches, and recruiters.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to HT to recover from injuries resulting from failures with covered skills",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -13625,6 +14605,41 @@
 				"Advantage",
 				"Mental",
 				"Talent"
+			],
+			"modifiers": [
+				{
+					"id": "MMzfaSj_kRBp92p78",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mXhvLWj6OjsrKGyqI",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From police and PIs.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mrP0see6irttwW7mu",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to unskilled Per rolls to notice clues, and to all rolls to use Intuition",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
+				}
 			],
 			"points_per_level": 10,
 			"features": [
@@ -13727,18 +14742,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From police and PIs.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to unskilled Per rolls to notice clues, and to all rolls to use Intuition",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -13755,6 +14758,41 @@
 				"Advantage",
 				"Mental",
 				"Talent"
+			],
+			"modifiers": [
+				{
+					"id": "MBGgEPL16E8mRjB6z",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mt1qVsjCq-L5v9Aom",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From expert divers and aquatic beings.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mrL5vJ4lbXymlMWHP",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to HT for breath holding time and resisting the Bends, Nitrogen Narcosis, etc.",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
+				}
 			],
 			"points_per_level": 5,
 			"features": [
@@ -13807,18 +14845,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From expert divers and aquatic beings.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to HT for breath holding time and resisting the Bends, Nitrogen Narcosis, etc.",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -13844,6 +14870,39 @@
 					"cost_type": "points",
 					"affects": "levels_only",
 					"disabled": true
+				},
+				{
+					"id": "MyNGZm5-DXhY15-Yt",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "myhWaeQFsr5OnXV1f",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From scientists and those impressed by \"smart people\".",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mDxD-nXfbwMWCB7VT",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Reduce TL and familiarity penalties for gear examined for an hour with a covered skill",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 10,
@@ -13977,18 +15036,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From scientists and those impressed by \"smart people\".",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Reduce TL and familiarity penalties for gear examined for an hour with a covered skill",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -14094,6 +15141,39 @@
 					"cost_type": "points",
 					"affects": "levels_only",
 					"disabled": true
+				},
+				{
+					"id": "My6WKJLwX8_-MPexL",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mzwVyFp5QdBm5KlZ1",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From students of the arcane, gullible college students, monster-hunters.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mgbN_8bD1FK27ioHe",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to Fright Checks caused by supernatural beings and effects, and by reading sanity-destroying tomes (because you know what to expect).",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 10,
@@ -14217,18 +15297,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From students of the arcane, gullible college students, monster-hunters.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to Fright Checks caused by supernatural beings and effects, and by reading sanity-destroying tomes (because you know what to expect).",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -14254,6 +15322,39 @@
 					"cost_type": "points",
 					"affects": "levels_only",
 					"disabled": true
+				},
+				{
+					"id": "MU-IBwHZMEPEGvbLH",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "m_ZIAnESbzqh4gBGv",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From explorers and nature lovers.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mua01MpK2h_1f_HNN",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to HT rolls to avoid harm from failure of covered skills",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 10,
@@ -14327,18 +15428,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From explorers and nature lovers.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to HT rolls to avoid harm from failure of covered skills",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -14365,6 +15454,39 @@
 					"cost_type": "points",
 					"affects": "levels_only",
 					"disabled": true
+				},
+				{
+					"id": "MNl6gonIsNVS2v1kW",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "miciCHQVZink3ponR",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From psis and beleivers.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mQ3b8ON-FnAjxrO1A",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to resist powers that have been examined with covered skills",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 5,
@@ -14448,18 +15570,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From psis and beleivers.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to resist powers that have been examined with covered skills",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -14499,6 +15609,39 @@
 					"cost_type": "points",
 					"affects": "levels_only",
 					"disabled": true
+				},
+				{
+					"id": "MKDonf8hRtowANoXc",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mAuHyKB0_9GKSHdJU",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From miners.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mhXFuXvJiIFGpWTvt",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to will for Extra Effort when digging, HT on failure at such, and all rolls to avoid disasters in mines",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 5,
@@ -14552,18 +15695,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From miners.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to will for Extra Effort when digging, HT on failure at such, and all rolls to avoid disasters in mines",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -14580,6 +15711,41 @@
 				"Advantage",
 				"Mental",
 				"Talent"
+			],
+			"modifiers": [
+				{
+					"id": "M1P8qu0u2BB7gHESP",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "m3J61HQ82laHi5Xo-",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From readers and listeners of your work; literati.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mhfmwm62Ho78QsbU7",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to the first Influence roll (p. B359) of any kind made on an audience member (or several of them as a group) after a successful performance.",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
+				}
 			],
 			"points_per_level": 5,
 			"features": [
@@ -14632,18 +15798,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From readers and listeners of your work; literati.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to the first Influence roll (p. B359) of any kind made on an audience member (or several of them as a group) after a successful performance.",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -14660,6 +15814,41 @@
 				"Advantage",
 				"Mental",
 				"Talent"
+			],
+			"modifiers": [
+				{
+					"id": "MvKk-vw2BgC-gPcxA",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "m-Lhwow-diFqnqjQ3",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From obsessive pop culture devotees.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mA6R600Y0Uwu7fAnF",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to Influence or Carousing to demonstrate you are \"cool\".",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
+				}
 			],
 			"points_per_level": 5,
 			"features": [
@@ -14712,18 +15901,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From obsessive pop culture devotees.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to Influence or Carousing to demonstrate you are \"cool\".",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -14750,6 +15927,39 @@
 					"cost_type": "points",
 					"affects": "levels_only",
 					"disabled": true
+				},
+				{
+					"id": "M2q--sapqjFxNqwOM",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "maWvDG8c0U95jmrNF",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From psis.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mdQT4iRQxDbJS35Zx",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to self control rolls after a successful Meditation, Mental Strength, or Mind Block",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 5,
@@ -14831,18 +16041,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From psis.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to self control rolls after a successful Meditation, Mental Strength, or Mind Block",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -14868,6 +16066,39 @@
 					"cost_type": "points",
 					"affects": "levels_only",
 					"disabled": true
+				},
+				{
+					"id": "M_96uHLII0Nau5F6n",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "m-to8kwup0HwyoOdv",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From scholars, students, and people who consult you.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "meH9_ibij4EQaQJxY",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to IQ defaults to non-covered skills for general knowledge only",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 10,
@@ -14991,18 +16222,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From scholars, students, and people who consult you.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to IQ defaults to non-covered skills for general knowledge only",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -15050,6 +16269,39 @@
 					"cost_type": "points",
 					"affects": "levels_only",
 					"disabled": true
+				},
+				{
+					"id": "MTAguIKxv2qvXtCrT",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mRry5k67NEPXis171",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From sailors, pirates, and aquatic races sympathetic to sea travel.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mhxt-oQmIJXtKEwpL",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to resist seasicknes and reduce unfamiliarity penalties for system on an appropriate boat or ship. Bonus to Carousing and Streetwise in port towns.",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 10,
@@ -15153,18 +16405,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From sailors, pirates, and aquatic races sympathetic to sea travel.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to resist seasicknes and reduce unfamiliarity penalties for system on an appropriate boat or ship. Bonus to Carousing and Streetwise in port towns.",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -15190,6 +16430,39 @@
 					"cost_type": "points",
 					"affects": "levels_only",
 					"disabled": true
+				},
+				{
+					"id": "MyzPJxiqmZEA7S4uT",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mx9T4vjERFscPD1Ze",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From con artists, politicians, salesmen, etc. – but only if you aren’t trying to manipulate them.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mlrpC3YirJxqpGI5X",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to resist covered skills",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 15,
@@ -15359,18 +16632,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From con artists, politicians, salesmen, etc. – but only if you aren’t trying to manipulate them.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to resist covered skills",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -15396,6 +16657,39 @@
 					"cost_type": "points",
 					"affects": "levels_only",
 					"disabled": true
+				},
+				{
+					"id": "MdmYFHve4zVb1uJgK",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mdEneMhH1xPptGeDs",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From social and political thinkers, theorists, and activists.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mzPGazm3q2eEzp51G",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to Acting, Disguise, and Fast-Talk to pass as a member of another political/religious group.",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 10,
@@ -15515,18 +16809,6 @@
 						"compare": "is",
 						"qualifier": "Comparative"
 					},
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From social and political thinkers, theorists, and activists.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to Acting, Disguise, and Fast-Talk to pass as a member of another political/religious group.",
 					"amount": 1,
 					"per_level": true
 				}
@@ -15650,6 +16932,41 @@
 				"Mental",
 				"Talent"
 			],
+			"modifiers": [
+				{
+					"id": "MKZGW9PonFgNP4DDz",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mzMScUIDS83YrecDl",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From hunters, trackers, etc.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mPzDhvz4vr2VtJ-jB",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to Per rolls to keep track of a specific quarry you’ve already spotted using other skills.",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
+				}
+			],
 			"points_per_level": 5,
 			"features": [
 				{
@@ -15699,18 +17016,6 @@
 						"compare": "is",
 						"qualifier": "Tracking"
 					},
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From hunters, trackers, etc.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to Per rolls to keep track of a specific quarry you’ve already spotted using other skills.",
 					"amount": 1,
 					"per_level": true
 				}
@@ -15850,6 +17155,39 @@
 					"cost_type": "points",
 					"affects": "levels_only",
 					"disabled": true
+				},
+				{
+					"id": "M4nn1vf6AlFtIMhi8",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mp4bxRx1pEg-T9TaT",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From other street operators.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mublj5O2PnXOOb6E1",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to notice inner city dangers and scams and to Tracking in built up areas.",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 10,
@@ -15955,18 +17293,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From other street operators.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to notice inner city dangers and scams and to Tracking in built up areas.",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -16006,6 +17332,39 @@
 					"cost_type": "points",
 					"affects": "levels_only",
 					"disabled": true
+				},
+				{
+					"id": "MbyP00TrG8mRlGall",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mrR6qy5tjT_qsuFHK",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From shady characters in town.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mOqTOgBhKwNfAhgZ2",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to notice inner city dangers and scams and to Tracking in built up areas.",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 5,
@@ -16069,18 +17428,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From shady characters in town.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to notice inner city dangers and scams and to Tracking in built up areas.",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -16097,6 +17444,41 @@
 				"Advantage",
 				"Mental",
 				"Talent"
+			],
+			"modifiers": [
+				{
+					"id": "MQ96teXGbaBc7Yu6D",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "m5L7SNUXo44enzJlt",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From other martial artists, especially potential masters or students.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mFoSVUf5nqx_H_iwv",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus on rolls to be heard (compare Penetrating Voice, p. B101), and to Intimidation attempts made after using one of the affected skills.",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
+				}
 			],
 			"points_per_level": 5,
 			"features": [
@@ -16149,18 +17531,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From other martial artists, especially potential masters or students.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus on rolls to be heard (compare Penetrating Voice, p. B101), and to Intimidation attempts made after using one of the affected skills.",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -16177,6 +17547,41 @@
 				"Advantage",
 				"Mental",
 				"Talent"
+			],
+			"modifiers": [
+				{
+					"id": "MSuLxF9GcbOZqCKoQ",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mfNYJvgncT_ZWSSQz",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From all members of the character’s organization below his Rank, as well as enemy agents of roughly equal Rank who are aware of his identity.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "miI44AiFGBJCaY4xA",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to rank for clearance and aid, but not for authority or pay.",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
+				}
 			],
 			"points_per_level": 15,
 			"features": [
@@ -16333,18 +17738,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From all members of the character’s organization below his Rank, as well as enemy agents of roughly equal Rank who are aware of his identity.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to rank for clearance and aid, but not for authority or pay.",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -16361,6 +17754,41 @@
 				"Advantage",
 				"Mental",
 				"Talent"
+			],
+			"modifiers": [
+				{
+					"id": "M5CFdb0d-yR5LBNc1",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mLFZYjhROXAombV2k",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From acrobats, skydivers, and commandos who slide down ropes.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mOnt-kAuD-6JjoNYO",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to DX anywhere Perfect Balance would apply",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
+				}
 			],
 			"points_per_level": 5,
 			"features": [
@@ -16433,18 +17861,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From acrobats, skydivers, and commandos who slide down ropes.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to DX anywhere Perfect Balance would apply",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -16461,6 +17877,41 @@
 				"Advantage",
 				"Mental",
 				"Talent"
+			],
+			"modifiers": [
+				{
+					"id": "MUPPiFcjZDud9ub9S",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "m9KhYxw-0n16bFsKC",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From scouts, campers, and survivalists.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "m6ygZpFrOzm2tC35t",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Success with Scrounging improvises simple equipment for other skills that removes -1/level from the penalty for being improvised (p. B345).",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
+				}
 			],
 			"points_per_level": 5,
 			"features": [
@@ -16513,18 +17964,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From scouts, campers, and survivalists.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Success with Scrounging improvises simple equipment for other skills that removes -1/level from the penalty for being improvised (p. B345).",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -16541,6 +17980,41 @@
 				"Advantage",
 				"Mental",
 				"Talent"
+			],
+			"modifiers": [
+				{
+					"id": "MmlUF0ioIFuQIYu8x",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mAIX256P8G58iLZcK",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From investigators and anybody hiring you to investigate.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mRFqRwekb5S1IsZYh",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to resist verbal influence attempts",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
+				}
 			],
 			"points_per_level": 5,
 			"features": [
@@ -16593,18 +18067,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From investigators and anybody hiring you to investigate.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to resist verbal influence attempts",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -16631,6 +18093,39 @@
 					"cost_type": "points",
 					"affects": "levels_only",
 					"disabled": true
+				},
+				{
+					"id": "M5wEM5mgsXgPGd3uT",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mvcCx-_quq_Uixnpg",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From death-worshippers and sapient undead you don’t try to exorcize or banish.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mC7f6e3gt8VNtR1Ur",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to fright checks from undead and bodies",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 5,
@@ -16702,18 +18197,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From death-worshippers and sapient undead you don’t try to exorcize or banish.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to fright checks from undead and bodies",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -16730,6 +18213,41 @@
 				"Advantage",
 				"Mental",
 				"Talent"
+			],
+			"modifiers": [
+				{
+					"id": "MkSJZo1_Cv60iAfpl",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "miZOCGT-ZZtkZ8zjn",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From most police officers and detectives, bouncers, gangsters, and street thugs.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mZwojlFNrIrqgAB2w",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to resist Interrogation and Intimidation, and to Fright Checks resulting from encountering murder victims, bloody torture scenes, etc.",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
+				}
 			],
 			"points_per_level": 5,
 			"features": [
@@ -16782,18 +18300,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From most police officers and detectives, bouncers, gangsters, and street thugs.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus to resist Interrogation and Intimidation, and to Fright Checks resulting from encountering murder victims, bloody torture scenes, etc.",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -16810,6 +18316,41 @@
 				"Advantage",
 				"Mental",
 				"Talent"
+			],
+			"modifiers": [
+				{
+					"id": "Mjq82gzrflTIwjFsB",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mukWk0NhprcSSoi2H",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From anybody who cares about trivia.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "maYvU7hSeTKq9g1cr",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus anywhere Eidetic Memory gives a bonus",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
+				}
 			],
 			"points_per_level": 5,
 			"features": [
@@ -16852,18 +18393,6 @@
 					},
 					"amount": 1,
 					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From anybody who cares about trivia.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus anywhere Eidetic Memory gives a bonus",
-					"amount": 1,
-					"per_level": true
 				}
 			],
 			"can_level": true,
@@ -16889,6 +18418,39 @@
 					"cost_type": "points",
 					"affects": "levels_only",
 					"disabled": true
+				},
+				{
+					"id": "MnRZ1tz1ADdsq5-4q",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mBkcosKwP4uEt_s8P",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From anyone who is Curious or harbors Delusions about conspiracies.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "m4yKMVKbzIs8bEncC",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus in Contests against attempts to perpetrate a cover-up.",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 5,
@@ -16958,18 +18520,6 @@
 						"compare": "is",
 						"qualifier": "Research"
 					},
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From anyone who is Curious or harbors Delusions about conspiracies.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Bonus in Contests against attempts to perpetrate a cover-up.",
 					"amount": 1,
 					"per_level": true
 				}
@@ -17096,6 +18646,41 @@
 					}
 				]
 			},
+			"modifiers": [
+				{
+					"id": "MKB3eL1L0AQqa4Hx1",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "ma1mp0wxeRFo8CmBK",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From those who benefit directly from your skills.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "m6_Wh2roWNYIU9II9",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Success at an appropriate covered skill lets you scround equipment for another skill and eliminates level of the penalty for improvised equipment. Shift rolls by level to avoid harm from tampering with mundane mechanisms.",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
+				}
+			],
 			"points_per_level": 5,
 			"features": [
 				{
@@ -17145,18 +18730,6 @@
 						"compare": "is",
 						"qualifier": "Traps"
 					},
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "reaction_bonus",
-					"situation": "From those who benefit directly from your skills.",
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "conditional_modifier",
-					"situation": "Success at an appropriate covered skill lets you scround equipment for another skill and eliminates level of the penalty for improvised equipment. Shift rolls by level to avoid harm from tampering with mundane mechanisms.",
 					"amount": 1,
 					"per_level": true
 				}

--- a/Library/Power Ups/Power Ups Traits.adq
+++ b/Library/Power Ups/Power Ups Traits.adq
@@ -92,7 +92,6 @@
 				"Perk",
 				"Physical"
 			],
-			"base_points": 1,
 			"prereqs": {
 				"type": "prereq_list",
 				"all": true,
@@ -107,6 +106,7 @@
 					}
 				]
 			},
+			"base_points": 1,
 			"calc": {
 				"points": 1
 			}
@@ -268,7 +268,6 @@
 				"Mental",
 				"Talent"
 			],
-			"levels": 1,
 			"points_per_level": -15,
 			"features": [
 				{
@@ -455,6 +454,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": -15
 			}
@@ -468,7 +468,6 @@
 				"Mental",
 				"Talent"
 			],
-			"levels": 1,
 			"points_per_level": -10,
 			"features": [
 				{
@@ -605,6 +604,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": -10
 			}
@@ -618,7 +618,6 @@
 				"Mental",
 				"Talent"
 			],
-			"levels": 1,
 			"points_per_level": -5,
 			"features": [
 				{
@@ -695,6 +694,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": -5
 			}
@@ -708,7 +708,6 @@
 				"Mental",
 				"Talent"
 			],
-			"levels": 1,
 			"points_per_level": -5,
 			"features": [
 				{
@@ -785,6 +784,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": -5
 			}
@@ -798,7 +798,6 @@
 				"Mental",
 				"Talent"
 			],
-			"levels": 1,
 			"points_per_level": -10,
 			"features": [
 				{
@@ -935,6 +934,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": -10
 			}
@@ -948,7 +948,6 @@
 				"Mental",
 				"Talent"
 			],
-			"levels": 1,
 			"points_per_level": -5,
 			"features": [
 				{
@@ -1025,6 +1024,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": -5
 			}
@@ -1038,7 +1038,6 @@
 				"Mental",
 				"Talent"
 			],
-			"levels": 1,
 			"points_per_level": -15,
 			"features": [
 				{
@@ -1244,6 +1243,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": -15
 			}
@@ -1257,7 +1257,6 @@
 				"Mental",
 				"Talent"
 			],
-			"levels": 1,
 			"points_per_level": -15,
 			"features": [
 				{
@@ -1278,6 +1277,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": -15
 			}
@@ -1291,7 +1291,6 @@
 				"Mental",
 				"Talent"
 			],
-			"levels": 1,
 			"points_per_level": -5,
 			"features": [
 				{
@@ -1368,6 +1367,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": -5
 			}
@@ -1380,9 +1380,9 @@
 				"Perk",
 				"Physical"
 			],
-			"levels": 1,
 			"points_per_level": 1,
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 1
 			}
@@ -1598,7 +1598,6 @@
 				"Mental",
 				"Perk"
 			],
-			"base_points": 1,
 			"prereqs": {
 				"type": "prereq_list",
 				"all": true,
@@ -1613,6 +1612,7 @@
 					}
 				]
 			},
+			"base_points": 1,
 			"calc": {
 				"points": 1
 			}
@@ -2145,9 +2145,9 @@
 				"Perk",
 				"Social"
 			],
-			"levels": 1,
 			"points_per_level": 1,
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 1
 			}
@@ -2560,9 +2560,9 @@
 				"Cinematic",
 				"Perk"
 			],
-			"levels": 1,
 			"points_per_level": 1,
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 1
 			}
@@ -2762,9 +2762,9 @@
 				"Perk",
 				"Social"
 			],
-			"levels": 1,
 			"points_per_level": 1,
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 1
 			}
@@ -2792,9 +2792,9 @@
 				"Perk",
 				"Social"
 			],
-			"levels": 1,
 			"points_per_level": 1,
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 1
 			}
@@ -3145,7 +3145,6 @@
 				"Perk",
 				"Physical"
 			],
-			"base_points": 1,
 			"prereqs": {
 				"type": "prereq_list",
 				"all": true,
@@ -3168,6 +3167,7 @@
 					}
 				]
 			},
+			"base_points": 1,
 			"calc": {
 				"points": 1
 			}
@@ -3529,9 +3529,9 @@
 				"Perk",
 				"Physical"
 			],
-			"levels": 1,
 			"points_per_level": 1,
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 1
 			}
@@ -3545,9 +3545,9 @@
 				"Perk",
 				"Physical"
 			],
-			"levels": 1,
 			"points_per_level": 1,
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 1
 			}
@@ -3792,7 +3792,6 @@
 				"Supernatural",
 				"Transformation"
 			],
-			"levels": 1,
 			"points_per_level": 10,
 			"features": [
 				{
@@ -4437,6 +4436,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 10
 			}
@@ -4614,7 +4614,6 @@
 				"Mental",
 				"Quirk"
 			],
-			"base_points": -1,
 			"prereqs": {
 				"type": "prereq_list",
 				"all": true,
@@ -4629,6 +4628,7 @@
 					}
 				]
 			},
+			"base_points": -1,
 			"calc": {
 				"points": -1
 			}
@@ -4792,7 +4792,6 @@
 				"Mental",
 				"Quirk"
 			],
-			"base_points": -1,
 			"prereqs": {
 				"type": "prereq_list",
 				"all": true,
@@ -4807,6 +4806,7 @@
 					}
 				]
 			},
+			"base_points": -1,
 			"calc": {
 				"points": -1
 			}
@@ -5289,7 +5289,6 @@
 				"Perk",
 				"Physical"
 			],
-			"base_points": 1,
 			"prereqs": {
 				"type": "prereq_list",
 				"all": true,
@@ -5304,6 +5303,7 @@
 					}
 				]
 			},
+			"base_points": 1,
 			"calc": {
 				"points": 1
 			}
@@ -5493,7 +5493,6 @@
 				"Mental",
 				"Quirk"
 			],
-			"base_points": -1,
 			"prereqs": {
 				"type": "prereq_list",
 				"all": true,
@@ -5512,6 +5511,7 @@
 					}
 				]
 			},
+			"base_points": -1,
 			"calc": {
 				"points": -1
 			}
@@ -5631,7 +5631,6 @@
 				"Mental",
 				"Perk"
 			],
-			"base_points": 1,
 			"prereqs": {
 				"type": "prereq_list",
 				"all": true,
@@ -5646,6 +5645,7 @@
 					}
 				]
 			},
+			"base_points": 1,
 			"calc": {
 				"points": 1
 			}
@@ -6561,7 +6561,6 @@
 				"Mental",
 				"Quirk"
 			],
-			"base_points": -1,
 			"prereqs": {
 				"type": "prereq_list",
 				"all": true,
@@ -6580,6 +6579,7 @@
 					}
 				]
 			},
+			"base_points": -1,
 			"calc": {
 				"points": -1
 			}
@@ -6710,9 +6710,9 @@
 			"tags": [
 				"Perk"
 			],
-			"levels": 1,
 			"points_per_level": 1,
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 1
 			}
@@ -6895,7 +6895,6 @@
 				"Perk",
 				"Physical"
 			],
-			"base_points": 1,
 			"prereqs": {
 				"type": "prereq_list",
 				"all": true,
@@ -6914,6 +6913,7 @@
 					}
 				]
 			},
+			"base_points": 1,
 			"calc": {
 				"points": 1
 			}
@@ -7219,7 +7219,6 @@
 				"Mental",
 				"Talent"
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -7286,6 +7285,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -7299,7 +7299,6 @@
 				"Mental",
 				"Talent"
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -7376,6 +7375,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -7389,7 +7389,6 @@
 				"Physical",
 				"Talent"
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -7450,6 +7449,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -7468,12 +7468,11 @@
 					"id": "my6PQXtw0w7b8iut2",
 					"name": "Alternative Cost",
 					"cost": 1,
-					"affects": "levels_only",
 					"cost_type": "points",
+					"affects": "levels_only",
 					"disabled": true
 				}
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -7544,6 +7543,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -7562,12 +7562,11 @@
 					"id": "mcI-NeYg1SHnqP6a6",
 					"name": "Alternative Cost",
 					"cost": 1,
-					"affects": "levels_only",
 					"cost_type": "points",
+					"affects": "levels_only",
 					"disabled": true
 				}
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -7644,6 +7643,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -7662,12 +7662,11 @@
 					"id": "m9evC7J7LypH6e15b",
 					"name": "Alternative Cost",
 					"cost": -1,
-					"affects": "levels_only",
 					"cost_type": "points",
+					"affects": "levels_only",
 					"disabled": true
 				}
 			],
-			"levels": 1,
 			"points_per_level": 10,
 			"features": [
 				{
@@ -7774,6 +7773,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 10
 			}
@@ -7792,12 +7792,11 @@
 					"id": "mXYxS3UxcEBjSyTyC",
 					"name": "Alternative Cost",
 					"cost": 1,
-					"affects": "levels_only",
 					"cost_type": "points",
+					"affects": "levels_only",
 					"disabled": true
 				}
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -7874,6 +7873,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -7893,12 +7893,11 @@
 					"id": "meUN6gt24QZEG0csr",
 					"name": "Alternative Cost",
 					"cost": 2,
-					"affects": "levels_only",
 					"cost_type": "points",
+					"affects": "levels_only",
 					"disabled": true
 				}
 			],
-			"levels": 1,
 			"points_per_level": 10,
 			"features": [
 				{
@@ -8050,6 +8049,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 10
 			}
@@ -8068,12 +8068,11 @@
 					"id": "m0NNTMcP20CA8JvoT",
 					"name": "Alternative Cost",
 					"cost": 1,
-					"affects": "levels_only",
 					"cost_type": "points",
+					"affects": "levels_only",
 					"disabled": true
 				}
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -8150,6 +8149,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -8163,18 +8163,6 @@
 				"Mental",
 				"Talent"
 			],
-			"modifiers": [
-				{
-					"id": "mk2uT27ziH3lkFMsY",
-					"name": "Alternative Cost",
-					"cost": 1,
-					"affects": "levels_only",
-					"cost_type": "points",
-					"disabled": true
-				}
-			],
-			"levels": 1,
-			"points_per_level": 5,
 			"prereqs": {
 				"type": "prereq_list",
 				"all": true,
@@ -8189,6 +8177,17 @@
 					}
 				]
 			},
+			"modifiers": [
+				{
+					"id": "mk2uT27ziH3lkFMsY",
+					"name": "Alternative Cost",
+					"cost": 1,
+					"cost_type": "points",
+					"affects": "levels_only",
+					"disabled": true
+				}
+			],
+			"points_per_level": 5,
 			"features": [
 				{
 					"type": "skill_bonus",
@@ -8278,6 +8277,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -8291,7 +8291,6 @@
 				"Mental",
 				"Talent"
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -8358,6 +8357,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -8376,12 +8376,11 @@
 					"id": "mTj8GFjhoEh5mnLAS",
 					"name": "Alternative Cost",
 					"cost": 1,
-					"affects": "levels_only",
 					"cost_type": "points",
+					"affects": "levels_only",
 					"disabled": true
 				}
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -8494,6 +8493,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -8512,12 +8512,11 @@
 					"id": "mN3fhHPdgHvt4JpEm",
 					"name": "Alternative Cost",
 					"cost": -2,
-					"affects": "levels_only",
 					"cost_type": "points",
+					"affects": "levels_only",
 					"disabled": true
 				}
 			],
-			"levels": 1,
 			"points_per_level": 10,
 			"features": [
 				{
@@ -8658,6 +8657,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 10
 			}
@@ -8676,12 +8676,11 @@
 					"id": "mL3RY-tXSscbhFM4q",
 					"name": "Alternative Cost",
 					"cost": 1,
-					"affects": "levels_only",
 					"cost_type": "points",
+					"affects": "levels_only",
 					"disabled": true
 				}
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -8758,6 +8757,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -8771,7 +8771,6 @@
 				"Physical",
 				"Talent"
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -8842,6 +8841,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -8860,12 +8860,11 @@
 					"id": "mqoPJttH1-1uzukol",
 					"name": "Alternative Cost",
 					"cost": -2,
-					"affects": "levels_only",
 					"cost_type": "points",
+					"affects": "levels_only",
 					"disabled": true
 				}
 			],
-			"levels": 1,
 			"points_per_level": 10,
 			"features": [
 				{
@@ -8962,6 +8961,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 10
 			}
@@ -8981,12 +8981,11 @@
 					"id": "msXmh44cEcWGnE696",
 					"name": "Alternative Cost",
 					"cost": 5,
-					"affects": "levels_only",
 					"cost_type": "points",
+					"affects": "levels_only",
 					"disabled": true
 				}
 			],
-			"levels": 1,
 			"points_per_level": 15,
 			"features": [
 				{
@@ -9191,6 +9190,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 15
 			}
@@ -9204,7 +9204,6 @@
 				"Mental",
 				"Talent"
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -9261,6 +9260,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -9280,12 +9280,11 @@
 					"id": "mV6P1hNHhmslPAPyD",
 					"name": "Alternative Cost",
 					"cost": 1,
-					"affects": "levels_only",
 					"cost_type": "points",
+					"affects": "levels_only",
 					"disabled": true
 				}
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -9370,6 +9369,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -9389,12 +9389,11 @@
 					"id": "mHM6oen0jTJzFrerT",
 					"name": "Alternative Cost",
 					"cost": 1,
-					"affects": "levels_only",
 					"cost_type": "points",
+					"affects": "levels_only",
 					"disabled": true
 				}
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -9473,6 +9472,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -9487,7 +9487,6 @@
 				"Supernatural",
 				"Talent"
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -9586,6 +9585,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -9599,7 +9599,6 @@
 				"Mental",
 				"Talent"
 			],
-			"levels": 1,
 			"points_per_level": 10,
 			"features": [
 				{
@@ -9720,6 +9719,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 10
 			}
@@ -9738,12 +9738,11 @@
 					"id": "mUhv32QybYAPedoe_",
 					"name": "Alternative Cost",
 					"cost": 1,
-					"affects": "levels_only",
 					"cost_type": "points",
+					"affects": "levels_only",
 					"disabled": true
 				}
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -9849,6 +9848,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -9867,12 +9867,11 @@
 					"id": "mN7WeWOzoviR_-TZ4",
 					"name": "Alternative Cost",
 					"cost": 1,
-					"affects": "levels_only",
 					"cost_type": "points",
+					"affects": "levels_only",
 					"disabled": true
 				}
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -9943,6 +9942,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -9961,12 +9961,11 @@
 					"id": "mxAv1RT486_5wHMLT",
 					"name": "Alternative Cost",
 					"cost": 1,
-					"affects": "levels_only",
 					"cost_type": "points",
+					"affects": "levels_only",
 					"disabled": true
 				}
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -10037,6 +10036,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -10055,12 +10055,11 @@
 					"id": "mispLTT6lX5jrTucB",
 					"name": "Alternative Cost",
 					"cost": -2,
-					"affects": "levels_only",
 					"cost_type": "points",
+					"affects": "levels_only",
 					"disabled": true
 				}
 			],
-			"levels": 1,
 			"points_per_level": 10,
 			"features": [
 				{
@@ -10157,6 +10156,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 10
 			}
@@ -10170,7 +10170,6 @@
 				"Mental",
 				"Talent"
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -10239,6 +10238,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -10252,7 +10252,6 @@
 				"Mental",
 				"Talent"
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -10309,6 +10308,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -10322,7 +10322,6 @@
 				"Mental",
 				"Talent"
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -10379,6 +10378,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -10398,12 +10398,11 @@
 					"id": "mSG3rheYjDWZKoruZ",
 					"name": "Alternative Cost",
 					"cost": 1,
-					"affects": "levels_only",
 					"cost_type": "points",
+					"affects": "levels_only",
 					"disabled": true
 				}
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -10488,6 +10487,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -10503,7 +10503,6 @@
 				"Supernatural",
 				"Talent"
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -10554,6 +10553,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -10567,7 +10567,6 @@
 				"Mental",
 				"Talent"
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -10628,6 +10627,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -10642,18 +10642,6 @@
 				"Mental",
 				"Talent"
 			],
-			"modifiers": [
-				{
-					"id": "m9v2Lt36s9bzsr7Ze",
-					"name": "Alternative Cost",
-					"cost": 1,
-					"affects": "levels_only",
-					"cost_type": "points",
-					"disabled": true
-				}
-			],
-			"levels": 1,
-			"points_per_level": 5,
 			"prereqs": {
 				"type": "prereq_list",
 				"all": true,
@@ -10668,6 +10656,17 @@
 					}
 				]
 			},
+			"modifiers": [
+				{
+					"id": "m9v2Lt36s9bzsr7Ze",
+					"name": "Alternative Cost",
+					"cost": 1,
+					"cost_type": "points",
+					"affects": "levels_only",
+					"disabled": true
+				}
+			],
+			"points_per_level": 5,
 			"features": [
 				{
 					"type": "skill_bonus",
@@ -10735,6 +10734,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -10752,12 +10752,11 @@
 				{
 					"id": "mfJNAa6CLDnsjv6DT",
 					"name": "Alternative Cost",
-					"affects": "levels_only",
 					"cost_type": "points",
+					"affects": "levels_only",
 					"disabled": true
 				}
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -10837,6 +10836,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -10856,12 +10856,11 @@
 					"id": "mQ_-iDzzNaW0QMKM9",
 					"name": "Alternative Cost",
 					"cost": -1,
-					"affects": "levels_only",
 					"cost_type": "points",
+					"affects": "levels_only",
 					"disabled": true
 				}
 			],
-			"levels": 1,
 			"points_per_level": 15,
 			"features": [
 				{
@@ -11018,6 +11017,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 15
 			}
@@ -11036,12 +11036,11 @@
 					"id": "mOcFeyud5P6g35Z4d",
 					"name": "Alternative Cost",
 					"cost": 1,
-					"affects": "levels_only",
 					"cost_type": "points",
+					"affects": "levels_only",
 					"disabled": true
 				}
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -11118,6 +11117,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -11133,8 +11133,6 @@
 				"Supernatural",
 				"Talent"
 			],
-			"levels": 1,
-			"points_per_level": 5,
 			"prereqs": {
 				"type": "prereq_list",
 				"all": true,
@@ -11149,6 +11147,7 @@
 					}
 				]
 			},
+			"points_per_level": 5,
 			"features": [
 				{
 					"type": "skill_bonus",
@@ -11214,6 +11213,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -11227,7 +11227,6 @@
 				"Mental",
 				"Talent"
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -11288,6 +11287,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -11301,7 +11301,6 @@
 				"Mental",
 				"Talent"
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -11368,6 +11367,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -11381,7 +11381,6 @@
 				"Mental",
 				"Talent"
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -11448,6 +11447,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -11461,18 +11461,6 @@
 				"Mental",
 				"Talent"
 			],
-			"modifiers": [
-				{
-					"id": "m2k2iKFdgEz7Ww4tM",
-					"name": "Alternative Cost",
-					"cost": -1,
-					"affects": "levels_only",
-					"cost_type": "points",
-					"disabled": true
-				}
-			],
-			"levels": 1,
-			"points_per_level": 10,
 			"prereqs": {
 				"type": "prereq_list",
 				"all": true,
@@ -11495,6 +11483,17 @@
 					}
 				]
 			},
+			"modifiers": [
+				{
+					"id": "m2k2iKFdgEz7Ww4tM",
+					"name": "Alternative Cost",
+					"cost": -1,
+					"cost_type": "points",
+					"affects": "levels_only",
+					"disabled": true
+				}
+			],
+			"points_per_level": 10,
 			"features": [
 				{
 					"type": "skill_bonus",
@@ -11627,6 +11626,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 10
 			}
@@ -11641,18 +11641,6 @@
 				"Mental",
 				"Talent"
 			],
-			"modifiers": [
-				{
-					"id": "m1sXjxvFfG0x3cvfZ",
-					"name": "Alternative Cost",
-					"cost": 1,
-					"affects": "levels_only",
-					"cost_type": "points",
-					"disabled": true
-				}
-			],
-			"levels": 1,
-			"points_per_level": 10,
 			"prereqs": {
 				"type": "prereq_list",
 				"all": true,
@@ -11675,6 +11663,17 @@
 					}
 				]
 			},
+			"modifiers": [
+				{
+					"id": "m1sXjxvFfG0x3cvfZ",
+					"name": "Alternative Cost",
+					"cost": 1,
+					"cost_type": "points",
+					"affects": "levels_only",
+					"disabled": true
+				}
+			],
+			"points_per_level": 10,
 			"features": [
 				{
 					"type": "skill_bonus",
@@ -11808,6 +11807,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 10
 			}
@@ -11821,7 +11821,6 @@
 				"Mental",
 				"Talent"
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -11886,6 +11885,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -11904,12 +11904,11 @@
 					"id": "mjLrUTO8cka-p58H5",
 					"name": "Alternative Cost",
 					"cost": 1,
-					"affects": "levels_only",
 					"cost_type": "points",
+					"affects": "levels_only",
 					"disabled": true
 				}
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -11980,6 +11979,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -11999,12 +11999,11 @@
 					"id": "m7zppcaencUUbs2yX",
 					"name": "Alternative Cost",
 					"cost": -1,
-					"affects": "levels_only",
 					"cost_type": "points",
+					"affects": "levels_only",
 					"disabled": true
 				}
 			],
-			"levels": 1,
 			"points_per_level": 15,
 			"features": [
 				{
@@ -12170,6 +12169,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 15
 			}
@@ -12188,12 +12188,11 @@
 					"id": "m01DGTqfGKgs3iQOj",
 					"name": "Alternative Cost",
 					"cost": -2,
-					"affects": "levels_only",
 					"cost_type": "points",
+					"affects": "levels_only",
 					"disabled": true
 				}
 			],
-			"levels": 1,
 			"points_per_level": 10,
 			"features": [
 				{
@@ -12334,6 +12333,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 10
 			}
@@ -12352,12 +12352,11 @@
 					"id": "m0JlgSyfV3fs4PAbF",
 					"name": "Alternative Cost",
 					"cost": -2,
-					"affects": "levels_only",
 					"cost_type": "points",
+					"affects": "levels_only",
 					"disabled": true
 				}
 			],
-			"levels": 1,
 			"points_per_level": 10,
 			"features": [
 				{
@@ -12488,6 +12487,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 10
 			}
@@ -12501,7 +12501,6 @@
 				"Mental",
 				"Talent"
 			],
-			"levels": 1,
 			"points_per_level": 10,
 			"features": [
 				{
@@ -12650,6 +12649,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 10
 			}
@@ -12664,9 +12664,9 @@
 				"Mental",
 				"Talent"
 			],
-			"levels": 1,
 			"points_per_level": 10,
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 10
 			}
@@ -12680,18 +12680,6 @@
 				"Mental",
 				"Talent"
 			],
-			"modifiers": [
-				{
-					"id": "mIoCifKCPqEdSFsbv",
-					"name": "Alternative Cost",
-					"cost": -3,
-					"affects": "levels_only",
-					"cost_type": "points",
-					"disabled": true
-				}
-			],
-			"levels": 1,
-			"points_per_level": 10,
 			"prereqs": {
 				"type": "prereq_list",
 				"all": true,
@@ -12706,6 +12694,17 @@
 					}
 				]
 			},
+			"modifiers": [
+				{
+					"id": "mIoCifKCPqEdSFsbv",
+					"name": "Alternative Cost",
+					"cost": -3,
+					"cost_type": "points",
+					"affects": "levels_only",
+					"disabled": true
+				}
+			],
+			"points_per_level": 10,
 			"features": [
 				{
 					"type": "skill_bonus",
@@ -12805,6 +12804,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 10
 			}
@@ -12818,7 +12818,6 @@
 				"Mental",
 				"Talent"
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -12885,6 +12884,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -12903,12 +12903,11 @@
 					"id": "mJ5BTpsNjB4HZ-_f4",
 					"name": "Alternative Cost",
 					"cost": -2,
-					"affects": "levels_only",
 					"cost_type": "points",
+					"affects": "levels_only",
 					"disabled": true
 				}
 			],
-			"levels": 1,
 			"points_per_level": 10,
 			"features": [
 				{
@@ -13005,6 +13004,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 10
 			}
@@ -13024,12 +13024,11 @@
 					"id": "mZ5Quwzvz3RZv-fVr",
 					"name": "Alternative Cost",
 					"cost": 2,
-					"affects": "levels_only",
 					"cost_type": "points",
+					"affects": "levels_only",
 					"disabled": true
 				}
 			],
-			"levels": 1,
 			"points_per_level": 10,
 			"features": [
 				{
@@ -13166,6 +13165,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 10
 			}
@@ -13179,7 +13179,6 @@
 				"Mental",
 				"Talent"
 			],
-			"levels": 1,
 			"points_per_level": 10,
 			"features": [
 				{
@@ -13296,6 +13295,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 10
 			}
@@ -13310,7 +13310,6 @@
 				"Mental",
 				"Talent"
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -13379,6 +13378,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -13392,7 +13392,6 @@
 				"Mental",
 				"Talent"
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -13463,6 +13462,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -13481,12 +13481,11 @@
 					"id": "m_G9naNpGesAACisl",
 					"name": "Alternative Cost",
 					"cost": 1,
-					"affects": "levels_only",
 					"cost_type": "points",
+					"affects": "levels_only",
 					"disabled": true
 				}
 			],
-			"levels": 1,
 			"points_per_level": 10,
 			"features": [
 				{
@@ -13613,6 +13612,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 10
 			}
@@ -13626,7 +13626,6 @@
 				"Mental",
 				"Talent"
 			],
-			"levels": 1,
 			"points_per_level": 10,
 			"features": [
 				{
@@ -13743,6 +13742,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 10
 			}
@@ -13756,7 +13756,6 @@
 				"Mental",
 				"Talent"
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -13823,6 +13822,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -13841,12 +13841,11 @@
 					"id": "mOmw8Dc0Pq2tOiO7Y",
 					"name": "Alternative Cost",
 					"cost": 1,
-					"affects": "levels_only",
 					"cost_type": "points",
+					"affects": "levels_only",
 					"disabled": true
 				}
 			],
-			"levels": 1,
 			"points_per_level": 10,
 			"features": [
 				{
@@ -13993,6 +13992,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 10
 			}
@@ -14013,12 +14013,11 @@
 					"name": "Power Talent",
 					"reference": "DF12:4",
 					"cost": 5,
-					"affects": "levels_only",
 					"cost_type": "points",
+					"affects": "levels_only",
 					"disabled": true
 				}
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -14073,6 +14072,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -14091,12 +14091,11 @@
 					"id": "mPZXkT6JI_yMM7Lbt",
 					"name": "Alternative Cost",
 					"cost": 2,
-					"affects": "levels_only",
 					"cost_type": "points",
+					"affects": "levels_only",
 					"disabled": true
 				}
 			],
-			"levels": 1,
 			"points_per_level": 10,
 			"features": [
 				{
@@ -14233,6 +14232,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 10
 			}
@@ -14251,12 +14251,11 @@
 					"id": "mFOih2Rwlw0xQeWR7",
 					"name": "Alternative Cost",
 					"cost": -3,
-					"affects": "levels_only",
 					"cost_type": "points",
+					"affects": "levels_only",
 					"disabled": true
 				}
 			],
-			"levels": 1,
 			"points_per_level": 10,
 			"features": [
 				{
@@ -14343,6 +14342,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 10
 			}
@@ -14362,12 +14362,11 @@
 					"id": "mmNJ__imgbgkpSwFR",
 					"name": "Alternative Cost",
 					"cost": 1,
-					"affects": "levels_only",
 					"cost_type": "points",
+					"affects": "levels_only",
 					"disabled": true
 				}
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -14464,6 +14463,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -14478,17 +14478,6 @@
 				"Supernatural",
 				"Talent"
 			],
-			"modifiers": [
-				{
-					"id": "meNDlMDipp8GKZBFn",
-					"name": "Alternative Cost",
-					"affects": "levels_only",
-					"cost_type": "points",
-					"disabled": true
-				}
-			],
-			"levels": 1,
-			"points_per_level": 5,
 			"prereqs": {
 				"type": "prereq_list",
 				"all": true,
@@ -14503,6 +14492,16 @@
 					}
 				]
 			},
+			"modifiers": [
+				{
+					"id": "meNDlMDipp8GKZBFn",
+					"name": "Alternative Cost",
+					"cost_type": "points",
+					"affects": "levels_only",
+					"disabled": true
+				}
+			],
+			"points_per_level": 5,
 			"features": [
 				{
 					"type": "skill_bonus",
@@ -14568,6 +14567,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -14581,7 +14581,6 @@
 				"Mental",
 				"Talent"
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -14648,6 +14647,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -14661,7 +14661,6 @@
 				"Mental",
 				"Talent"
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -14728,6 +14727,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -14747,12 +14747,11 @@
 					"id": "mG4qr1D9OwKOi1OH8",
 					"name": "Alternative Cost",
 					"cost": 1,
-					"affects": "levels_only",
 					"cost_type": "points",
+					"affects": "levels_only",
 					"disabled": true
 				}
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -14847,6 +14846,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -14865,12 +14865,11 @@
 					"id": "m6qi5oGlVdqYGr5NO",
 					"name": "Alternative Cost",
 					"cost": 2,
-					"affects": "levels_only",
 					"cost_type": "points",
+					"affects": "levels_only",
 					"disabled": true
 				}
 			],
-			"levels": 1,
 			"points_per_level": 10,
 			"features": [
 				{
@@ -15007,6 +15006,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 10
 			}
@@ -15020,18 +15020,6 @@
 				"Mental",
 				"Talent"
 			],
-			"modifiers": [
-				{
-					"id": "m40cDllLZ5tzBc8A-",
-					"name": "Alternative Cost",
-					"cost": -1,
-					"affects": "levels_only",
-					"cost_type": "points",
-					"disabled": true
-				}
-			],
-			"levels": 1,
-			"points_per_level": 10,
 			"prereqs": {
 				"type": "prereq_list",
 				"all": true,
@@ -15054,6 +15042,17 @@
 					}
 				]
 			},
+			"modifiers": [
+				{
+					"id": "m40cDllLZ5tzBc8A-",
+					"name": "Alternative Cost",
+					"cost": -1,
+					"cost_type": "points",
+					"affects": "levels_only",
+					"disabled": true
+				}
+			],
+			"points_per_level": 10,
 			"features": [
 				{
 					"type": "skill_bonus",
@@ -15169,6 +15168,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 10
 			}
@@ -15187,12 +15187,11 @@
 					"id": "m3tWAVrxvbEn1HDYo",
 					"name": "Alternative Cost",
 					"cost": -2,
-					"affects": "levels_only",
 					"cost_type": "points",
+					"affects": "levels_only",
 					"disabled": true
 				}
 			],
-			"levels": 1,
 			"points_per_level": 15,
 			"features": [
 				{
@@ -15375,6 +15374,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 15
 			}
@@ -15393,12 +15393,11 @@
 					"id": "m1lGw8RbcolqZtWp2",
 					"name": "Alternative Cost",
 					"cost": 1,
-					"affects": "levels_only",
 					"cost_type": "points",
+					"affects": "levels_only",
 					"disabled": true
 				}
 			],
-			"levels": 1,
 			"points_per_level": 10,
 			"features": [
 				{
@@ -15533,6 +15532,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 10
 			}
@@ -15551,12 +15551,11 @@
 					"id": "mu9p3u1TO-3ZzuZdE",
 					"name": "Alternative Cost",
 					"cost": 1,
-					"affects": "levels_only",
 					"cost_type": "points",
+					"affects": "levels_only",
 					"disabled": true
 				}
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -15637,6 +15636,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -15650,7 +15650,6 @@
 				"Mental",
 				"Talent"
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -15717,6 +15716,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -15731,8 +15731,6 @@
 				"Supernatural",
 				"Talent"
 			],
-			"levels": 1,
-			"points_per_level": 5,
 			"prereqs": {
 				"type": "prereq_list",
 				"all": true,
@@ -15747,6 +15745,7 @@
 					}
 				]
 			},
+			"points_per_level": 5,
 			"features": [
 				{
 					"type": "skill_bonus",
@@ -15814,6 +15813,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -15828,18 +15828,6 @@
 				"Mental",
 				"Talent"
 			],
-			"modifiers": [
-				{
-					"id": "mCScNYYoP5_jAikhM",
-					"name": "Alternative Cost",
-					"cost": -1,
-					"affects": "levels_only",
-					"cost_type": "points",
-					"disabled": true
-				}
-			],
-			"levels": 1,
-			"points_per_level": 10,
 			"prereqs": {
 				"type": "prereq_list",
 				"all": true,
@@ -15854,6 +15842,17 @@
 					}
 				]
 			},
+			"modifiers": [
+				{
+					"id": "mCScNYYoP5_jAikhM",
+					"name": "Alternative Cost",
+					"cost": -1,
+					"cost_type": "points",
+					"affects": "levels_only",
+					"disabled": true
+				}
+			],
+			"points_per_level": 10,
 			"features": [
 				{
 					"type": "skill_bonus",
@@ -15971,6 +15970,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 10
 			}
@@ -15984,18 +15984,6 @@
 				"Mental",
 				"Talent"
 			],
-			"modifiers": [
-				{
-					"id": "mlcx6vKzHM5COoQKA",
-					"name": "Alternative Cost",
-					"cost": 1,
-					"affects": "levels_only",
-					"cost_type": "points",
-					"disabled": true
-				}
-			],
-			"levels": 1,
-			"points_per_level": 5,
 			"prereqs": {
 				"type": "prereq_list",
 				"all": true,
@@ -16010,6 +15998,17 @@
 					}
 				]
 			},
+			"modifiers": [
+				{
+					"id": "mlcx6vKzHM5COoQKA",
+					"name": "Alternative Cost",
+					"cost": 1,
+					"cost_type": "points",
+					"affects": "levels_only",
+					"disabled": true
+				}
+			],
+			"points_per_level": 5,
 			"features": [
 				{
 					"type": "skill_bonus",
@@ -16085,6 +16084,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -16098,7 +16098,6 @@
 				"Mental",
 				"Talent"
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -16165,6 +16164,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -16178,7 +16178,6 @@
 				"Mental",
 				"Talent"
 			],
-			"levels": 1,
 			"points_per_level": 15,
 			"features": [
 				{
@@ -16349,6 +16348,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 15
 			}
@@ -16362,7 +16362,6 @@
 				"Mental",
 				"Talent"
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -16449,6 +16448,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -16462,7 +16462,6 @@
 				"Mental",
 				"Talent"
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -16529,6 +16528,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -16542,7 +16542,6 @@
 				"Mental",
 				"Talent"
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -16609,6 +16608,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -16628,12 +16628,11 @@
 					"id": "mbuk109WeDw-LRoLb",
 					"name": "Alternative Cost",
 					"cost": 1,
-					"affects": "levels_only",
 					"cost_type": "points",
+					"affects": "levels_only",
 					"disabled": true
 				}
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -16718,6 +16717,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -16731,7 +16731,6 @@
 				"Mental",
 				"Talent"
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -16798,6 +16797,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -16811,7 +16811,6 @@
 				"Mental",
 				"Talent"
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -16868,6 +16867,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -16886,12 +16886,11 @@
 					"id": "mrlrUrU6Za_RkMG5B",
 					"name": "Alternative Cost",
 					"cost": 1,
-					"affects": "levels_only",
 					"cost_type": "points",
+					"affects": "levels_only",
 					"disabled": true
 				}
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -16976,6 +16975,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -16994,12 +16994,11 @@
 					"id": "mdyZEFirDjc6fftR2",
 					"name": "Alternative Cost",
 					"cost": 1,
-					"affects": "levels_only",
 					"cost_type": "points",
+					"affects": "levels_only",
 					"disabled": true
 				}
 			],
-			"levels": 1,
 			"points_per_level": 5,
 			"features": [
 				{
@@ -17068,6 +17067,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}
@@ -17082,8 +17082,6 @@
 				"Supernatural",
 				"Talent"
 			],
-			"levels": 1,
-			"points_per_level": 5,
 			"prereqs": {
 				"type": "prereq_list",
 				"all": true,
@@ -17098,6 +17096,7 @@
 					}
 				]
 			},
+			"points_per_level": 5,
 			"features": [
 				{
 					"type": "skill_bonus",
@@ -17163,6 +17162,7 @@
 				}
 			],
 			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}


### PR DESCRIPTION
Returned the alternate benefits of talents in the Power Ups library to being modifiers so they can be easily switched between.  For talents that have no alternate benefit I left  the reaction bonus directly on the trait for simplicity.