### PR TITLE
Included additional defaults for grenade weapons (Basic Set)

### DIFF
--- a/Library/Basic Set/Basic Set Equipment.eqp
+++ b/Library/Basic Set/Basic Set Equipment.eqp
@@ -7886,6 +7886,15 @@
 						{
 							"type": "skill",
 							"name": "Throwing"
+						},
+						{
+							"type": "skill",
+							"name": "Dropping",
+							"modifier": -4
+						},
+						{
+							"type": "dx",
+							"modifier": -3
 						}
 					],
 					"calc": {
@@ -7924,6 +7933,15 @@
 						{
 							"type": "skill",
 							"name": "Throwing"
+						},
+						{
+							"type": "skill",
+							"name": "Dropping",
+							"modifier": -4
+						},
+						{
+							"type": "dx",
+							"modifier": -3
 						}
 					],
 					"calc": {
@@ -7963,6 +7981,15 @@
 						{
 							"type": "skill",
 							"name": "Throwing"
+						},
+						{
+							"type": "skill",
+							"name": "Dropping",
+							"modifier": -4
+						},
+						{
+							"type": "dx",
+							"modifier": -3
 						}
 					],
 					"calc": {
@@ -8002,6 +8029,15 @@
 						{
 							"type": "skill",
 							"name": "Throwing"
+						},
+						{
+							"type": "skill",
+							"name": "Dropping",
+							"modifier": -4
+						},
+						{
+							"type": "dx",
+							"modifier": -3
 						}
 					],
 					"calc": {
@@ -8043,6 +8079,15 @@
 						{
 							"type": "skill",
 							"name": "Throwing"
+						},
+						{
+							"type": "skill",
+							"name": "Dropping",
+							"modifier": -4
+						},
+						{
+							"type": "dx",
+							"modifier": -3
 						}
 					],
 					"calc": {
@@ -8084,6 +8129,15 @@
 						{
 							"type": "skill",
 							"name": "Throwing"
+						},
+						{
+							"type": "skill",
+							"name": "Dropping",
+							"modifier": -4
+						},
+						{
+							"type": "dx",
+							"modifier": -3
 						}
 					],
 					"calc": {
@@ -8123,6 +8177,15 @@
 						{
 							"type": "skill",
 							"name": "Throwing"
+						},
+						{
+							"type": "skill",
+							"name": "Dropping",
+							"modifier": -4
+						},
+						{
+							"type": "dx",
+							"modifier": -3
 						}
 					],
 					"calc": {
@@ -8161,6 +8224,15 @@
 						{
 							"type": "skill",
 							"name": "Throwing"
+						},
+						{
+							"type": "skill",
+							"name": "Dropping",
+							"modifier": -4
+						},
+						{
+							"type": "dx",
+							"modifier": -3
 						}
 					]
 				}
@@ -12574,6 +12646,15 @@
 						{
 							"type": "skill",
 							"name": "Throwing"
+						},
+						{
+							"type": "skill",
+							"name": "Dropping",
+							"modifier": -4
+						},
+						{
+							"type": "dx",
+							"modifier": -3
 						}
 					],
 					"calc": {


### PR DESCRIPTION
For Hand Grenade weapons, I've included 2 additional Defaults:
- Dropping-4
- DX-3

This can be found on B277 for the Hand Grenade and Incendiary Table.