### PR TITLE
Add Magical Bolt advantage from Dungeon Fantasy 11

### DIFF
--- a/Library/Dungeon Fantasy/Dungeon Fantasy 11/Dungeon Fantasy 11 Traits.adq
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 11/Dungeon Fantasy 11 Traits.adq
@@ -808,6 +808,7 @@
 			"id": "tU0G2QZkbxa_y4NrE",
 			"name": "Magical Bolt 1",
 			"reference": "DF11:37",
+			"notes": "Affects undead/golems/spirits but not doors/walls.",
 			"tags": [
 				"Advantage"
 			],
@@ -832,14 +833,21 @@
 			"base_points": 5,
 			"weapons": [
 				{
-					"id": "WNoIW6arMBhfx9tTG",
+					"id": "WJCdAYkaju44_Svnf",
 					"damage": {
 						"type": "cr",
 						"base": "1d-3"
 					},
-					"usage": "Auto-hit on effective skill 3+, can only be dodged",
+					"usage": "Auto-hit on effective skill 3+, can only be dodged.  Ignores DR.",
 					"range": "200",
 					"rate_of_fire": "1",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Innate Attack",
+							"specialization": "Projectile"
+						}
+					],
 					"calc": {
 						"damage": "1d-3 cr"
 					}
@@ -853,6 +861,7 @@
 			"id": "t7rJYglHeMG8bw_0n",
 			"name": "Magical Bolt 2",
 			"reference": "DF11:37",
+			"notes": "Affects undead/golems/spirits but not doors/walls.",
 			"tags": [
 				"Advantage"
 			],
@@ -877,14 +886,21 @@
 			"base_points": 10,
 			"weapons": [
 				{
-					"id": "WFeEnVcmzYO9F2CQx",
+					"id": "WN0xKq8zxxhAlB0nx",
 					"damage": {
 						"type": "cr",
 						"base": "1d-2"
 					},
-					"usage": "Auto-hit on effective skill 3+, can only be dodged",
+					"usage": "Auto-hit on effective skill 3+, can only be dodged.  Ignores DR.",
 					"range": "200",
 					"rate_of_fire": "1",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Innate Attack",
+							"specialization": "Projectile"
+						}
+					],
 					"calc": {
 						"damage": "1d-2 cr"
 					}
@@ -898,6 +914,7 @@
 			"id": "tBMqISOOeSZftD8RG",
 			"name": "Magical Bolt 3",
 			"reference": "DF11:37",
+			"notes": "Affects undead/golems/spirits but not doors/walls.",
 			"tags": [
 				"Advantage"
 			],
@@ -922,14 +939,21 @@
 			"base_points": 20,
 			"weapons": [
 				{
-					"id": "WtQZUCjMQcf0-0n1l",
+					"id": "W-HDCuJBZD8bJx_5r",
 					"damage": {
 						"type": "cr",
 						"base": "1d-1"
 					},
-					"usage": "Auto-hit on effective skill 3+, can only be dodged",
+					"usage": "Auto-hit on effective skill 3+, can only be dodged.  Ignores DR.",
 					"range": "200",
 					"rate_of_fire": "1",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Innate Attack",
+							"specialization": "Projectile"
+						}
+					],
 					"calc": {
 						"damage": "1d-1 cr"
 					}
@@ -943,6 +967,7 @@
 			"id": "taQL_VFbKmxm2LfXO",
 			"name": "Magical Bolt 4",
 			"reference": "DF11:37",
+			"notes": "Affects undead/golems/spirits but not doors/walls.",
 			"tags": [
 				"Advantage"
 			],
@@ -967,14 +992,21 @@
 			"base_points": 25,
 			"weapons": [
 				{
-					"id": "W-uwMgYx9_6FQapgz",
+					"id": "WlOh7nFlwJsCOw8SO",
 					"damage": {
 						"type": "cr",
 						"base": "1d"
 					},
-					"usage": "Auto-hit on effective skill 3+, can only be dodged",
+					"usage": "Auto-hit on effective skill 3+, can only be dodged.  Ignores DR.",
 					"range": "200",
 					"rate_of_fire": "1",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Innate Attack",
+							"specialization": "Projectile"
+						}
+					],
 					"calc": {
 						"damage": "1d cr"
 					}
@@ -988,6 +1020,7 @@
 			"id": "taFpD2BRJaI_v-2Gb",
 			"name": "Magical Bolt 5",
 			"reference": "DF11:37",
+			"notes": "Affects undead/golems/spirits but not doors/walls.",
 			"tags": [
 				"Advantage"
 			],
@@ -1012,14 +1045,21 @@
 			"base_points": 35,
 			"weapons": [
 				{
-					"id": "WTLym5XvU8RtzfSyY",
+					"id": "WeV1ymuXZpBSU4bEe",
 					"damage": {
 						"type": "cr",
 						"base": "1d+1"
 					},
-					"usage": "Auto-hit on effective skill 3+, can only be dodged",
+					"usage": "Auto-hit on effective skill 3+, can only be dodged.  Ignores DR.",
 					"range": "200",
 					"rate_of_fire": "1",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Innate Attack",
+							"specialization": "Projectile"
+						}
+					],
 					"calc": {
 						"damage": "1d+1 cr"
 					}
@@ -1033,6 +1073,7 @@
 			"id": "tmpZd3nh3XA3CQZRX",
 			"name": "Magical Bolt 6",
 			"reference": "DF11:37",
+			"notes": "Affects undead/golems/spirits but not doors/walls.",
 			"tags": [
 				"Advantage"
 			],
@@ -1057,14 +1098,21 @@
 			"base_points": 45,
 			"weapons": [
 				{
-					"id": "W2nXEmrkqE59T74A3",
+					"id": "W6Dg7d8v0WHyPmYxL",
 					"damage": {
 						"type": "cr",
 						"base": "2d-1"
 					},
-					"usage": "Auto-hit on effective skill 3+, can only be dodged",
+					"usage": "Auto-hit on effective skill 3+, can only be dodged.  Ignores DR.",
 					"range": "200",
 					"rate_of_fire": "1",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Innate Attack",
+							"specialization": "Projectile"
+						}
+					],
 					"calc": {
 						"damage": "2d-1 cr"
 					}

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 11/Dungeon Fantasy 11 Traits.adq
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 11/Dungeon Fantasy 11 Traits.adq
@@ -803,6 +803,276 @@
 			"calc": {
 				"points": 5
 			}
+		},
+		{
+			"id": "tU0G2QZkbxa_y4NrE",
+			"name": "Magical Bolt 1",
+			"reference": "DF11:37",
+			"tags": [
+				"Advantage"
+			],
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					}
+				]
+			},
+			"base_points": 5,
+			"weapons": [
+				{
+					"id": "WNoIW6arMBhfx9tTG",
+					"damage": {
+						"type": "cr",
+						"base": "1d-3"
+					},
+					"usage": "Auto-hit on effective skill 3+, can only be dodged",
+					"range": "200",
+					"rate_of_fire": "1",
+					"calc": {
+						"damage": "1d-3 cr"
+					}
+				}
+			],
+			"calc": {
+				"points": 5
+			}
+		},
+		{
+			"id": "t7rJYglHeMG8bw_0n",
+			"name": "Magical Bolt 2",
+			"reference": "DF11:37",
+			"tags": [
+				"Advantage"
+			],
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 2
+						}
+					}
+				]
+			},
+			"base_points": 10,
+			"weapons": [
+				{
+					"id": "WFeEnVcmzYO9F2CQx",
+					"damage": {
+						"type": "cr",
+						"base": "1d-2"
+					},
+					"usage": "Auto-hit on effective skill 3+, can only be dodged",
+					"range": "200",
+					"rate_of_fire": "1",
+					"calc": {
+						"damage": "1d-2 cr"
+					}
+				}
+			],
+			"calc": {
+				"points": 10
+			}
+		},
+		{
+			"id": "tBMqISOOeSZftD8RG",
+			"name": "Magical Bolt 3",
+			"reference": "DF11:37",
+			"tags": [
+				"Advantage"
+			],
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 3
+						}
+					}
+				]
+			},
+			"base_points": 20,
+			"weapons": [
+				{
+					"id": "WtQZUCjMQcf0-0n1l",
+					"damage": {
+						"type": "cr",
+						"base": "1d-1"
+					},
+					"usage": "Auto-hit on effective skill 3+, can only be dodged",
+					"range": "200",
+					"rate_of_fire": "1",
+					"calc": {
+						"damage": "1d-1 cr"
+					}
+				}
+			],
+			"calc": {
+				"points": 20
+			}
+		},
+		{
+			"id": "taQL_VFbKmxm2LfXO",
+			"name": "Magical Bolt 4",
+			"reference": "DF11:37",
+			"tags": [
+				"Advantage"
+			],
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 4
+						}
+					}
+				]
+			},
+			"base_points": 25,
+			"weapons": [
+				{
+					"id": "W-uwMgYx9_6FQapgz",
+					"damage": {
+						"type": "cr",
+						"base": "1d"
+					},
+					"usage": "Auto-hit on effective skill 3+, can only be dodged",
+					"range": "200",
+					"rate_of_fire": "1",
+					"calc": {
+						"damage": "1d cr"
+					}
+				}
+			],
+			"calc": {
+				"points": 25
+			}
+		},
+		{
+			"id": "taFpD2BRJaI_v-2Gb",
+			"name": "Magical Bolt 5",
+			"reference": "DF11:37",
+			"tags": [
+				"Advantage"
+			],
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 5
+						}
+					}
+				]
+			},
+			"base_points": 35,
+			"weapons": [
+				{
+					"id": "WTLym5XvU8RtzfSyY",
+					"damage": {
+						"type": "cr",
+						"base": "1d+1"
+					},
+					"usage": "Auto-hit on effective skill 3+, can only be dodged",
+					"range": "200",
+					"rate_of_fire": "1",
+					"calc": {
+						"damage": "1d+1 cr"
+					}
+				}
+			],
+			"calc": {
+				"points": 35
+			}
+		},
+		{
+			"id": "tmpZd3nh3XA3CQZRX",
+			"name": "Magical Bolt 6",
+			"reference": "DF11:37",
+			"tags": [
+				"Advantage"
+			],
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 6
+						}
+					}
+				]
+			},
+			"base_points": 45,
+			"weapons": [
+				{
+					"id": "W2nXEmrkqE59T74A3",
+					"damage": {
+						"type": "cr",
+						"base": "2d-1"
+					},
+					"usage": "Auto-hit on effective skill 3+, can only be dodged",
+					"range": "200",
+					"rate_of_fire": "1",
+					"calc": {
+						"damage": "2d-1 cr"
+					}
+				}
+			],
+			"calc": {
+				"points": 45
+			}
 		}
 	]
 }


### PR DESCRIPTION
Did this as 6 advantages because I didn't see an easy way to make this a leveled trait.  (The cost and damage go up linearly for the first 4 levels but then get non-linear.)