### PR TITLE
Five Easy Pieces fixes

### DIFF
--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Brute Warrior 2.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Brute Warrior 2.gct
@@ -2546,7 +2546,7 @@
 	"skills": [
 		{
 			"id": "St8FQ6PUZTTeAq4UE",
-			"name": "Additional Skills",
+			"name": "Brute Warrior 2",
 			"template_picker": {
 				"type": "points",
 				"qualifier": {

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Brute Warrior.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Brute Warrior.gct
@@ -875,1706 +875,1712 @@
 	],
 	"skills": [
 		{
-			"id": "St8FQ6PUZTTeAq4UE",
-			"name": "Additional Skills",
-			"template_picker": {
-				"type": "points",
-				"qualifier": {
-					"compare": "at_most",
-					"qualifier": 9
-				}
-			},
+			"id": "SByVWj-U1ftEbc6R1",
+			"name": "Brute Warrior",
 			"children": [
 				{
-					"id": "sAy44EhFdSwL48vNc",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "s8Z_Fqc5F4jKvCJ3E"
+					"id": "St8FQ6PUZTTeAq4UE",
+					"name": "Additional Skills",
+					"template_picker": {
+						"type": "points",
+						"qualifier": {
+							"compare": "at_most",
+							"qualifier": 9
+						}
 					},
-					"name": "Armory",
-					"reference": "DFA73",
-					"tags": [
-						"Maintenance",
-						"Military",
-						"Repair"
-					],
-					"specialization": "Body Armor",
-					"difficulty": "iq/a",
-					"defaults": [
+					"children": [
 						{
-							"type": "iq",
-							"modifier": -5
-						},
-						{
-							"type": "skill",
-							"name": "Engineer",
+							"id": "sAy44EhFdSwL48vNc",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "s8Z_Fqc5F4jKvCJ3E"
+							},
+							"name": "Armory",
+							"reference": "DFA73",
+							"tags": [
+								"Maintenance",
+								"Military",
+								"Repair"
+							],
 							"specialization": "Body Armor",
-							"modifier": -4
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "srLACHNH2pp4GFZHW",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sv2cn5HXFG3hzzX2I"
-					},
-					"name": "Armory",
-					"reference": "DFA73",
-					"tags": [
-						"Maintenance",
-						"Military",
-						"Repair"
-					],
-					"specialization": "Melee Weapons",
-					"difficulty": "iq/a",
-					"defaults": [
-						{
-							"type": "iq",
-							"modifier": -5
+							"difficulty": "iq/a",
+							"defaults": [
+								{
+									"type": "iq",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Engineer",
+									"specialization": "Body Armor",
+									"modifier": -4
+								}
+							],
+							"points": 1
 						},
 						{
-							"type": "skill",
-							"name": "Engineer",
+							"id": "srLACHNH2pp4GFZHW",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sv2cn5HXFG3hzzX2I"
+							},
+							"name": "Armory",
+							"reference": "DFA73",
+							"tags": [
+								"Maintenance",
+								"Military",
+								"Repair"
+							],
 							"specialization": "Melee Weapons",
-							"modifier": -4
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sheZjJiNTXdq9oEFx",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sgbWsoZDJKKa6ShB4"
-					},
-					"name": "Armory",
-					"reference": "DFA73",
-					"tags": [
-						"Maintenance",
-						"Military",
-						"Repair"
-					],
-					"specialization": "Missile Weapons",
-					"difficulty": "iq/a",
-					"defaults": [
-						{
-							"type": "iq",
-							"modifier": -5
+							"difficulty": "iq/a",
+							"defaults": [
+								{
+									"type": "iq",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Engineer",
+									"specialization": "Melee Weapons",
+									"modifier": -4
+								}
+							],
+							"points": 1
 						},
 						{
-							"type": "skill",
-							"name": "Engineer",
+							"id": "sheZjJiNTXdq9oEFx",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sgbWsoZDJKKa6ShB4"
+							},
+							"name": "Armory",
+							"reference": "DFA73",
+							"tags": [
+								"Maintenance",
+								"Military",
+								"Repair"
+							],
 							"specialization": "Missile Weapons",
-							"modifier": -4
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sVpLg6WhhTmX6yCDr",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sIFnUEojIsUlx7qhk"
-					},
-					"name": "Blowpipe",
-					"reference": "DFA83",
-					"tags": [
-						"Combat",
-						"Ranged Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/h",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -6
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sKArCLyRAjNU7w0y1",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sYDZCCmi6CWN3HSlo"
-					},
-					"name": "Bow",
-					"reference": "DFA83",
-					"tags": [
-						"Combat",
-						"Ranged Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/a",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -5
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sEk2gc_zFNPmK8ho2",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "skT71ydKUK_2EU6B1"
-					},
-					"name": "Boxing",
-					"reference": "DFA93",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/a",
-					"features": [
-						{
-							"type": "weapon_bonus",
-							"selection_type": "weapons_with_required_skill",
-							"name": {
-								"compare": "is",
-								"qualifier": "Boxing"
-							},
-							"level": {
-								"compare": "at_least",
-								"qualifier": 1
-							},
-							"amount": 1,
-							"per_die": true
+							"difficulty": "iq/a",
+							"defaults": [
+								{
+									"type": "iq",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Engineer",
+									"specialization": "Missile Weapons",
+									"modifier": -4
+								}
+							],
+							"points": 1
 						},
 						{
-							"type": "weapon_bonus",
-							"selection_type": "weapons_with_required_skill",
-							"name": {
-								"compare": "is",
-								"qualifier": "Boxing"
+							"id": "sVpLg6WhhTmX6yCDr",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sIFnUEojIsUlx7qhk"
 							},
-							"level": {
-								"compare": "at_least",
-								"qualifier": 2
-							},
-							"amount": 1,
-							"per_die": true
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "s0cOZ4lfX4JlpquA1",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sUMFlX9EbNGNn31gm"
-					},
-					"name": "Brawling",
-					"reference": "DFA93",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/e",
-					"features": [
-						{
-							"type": "weapon_bonus",
-							"selection_type": "weapons_with_required_skill",
-							"name": {
-								"compare": "is",
-								"qualifier": "Brawling"
-							},
-							"level": {
-								"compare": "at_least",
-								"qualifier": 2
-							},
-							"amount": 1,
-							"per_die": true
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sx3Yrj7bbgPB93NGy",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sZETcI3EbwyhIamKv"
-					},
-					"name": "Cloak",
-					"reference": "DFA74",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/a",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -5
+							"name": "Blowpipe",
+							"reference": "DFA83",
+							"tags": [
+								"Combat",
+								"Ranged Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/h",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -6
+								}
+							],
+							"points": 1
 						},
 						{
-							"type": "skill",
-							"name": "Net",
-							"modifier": -4
+							"id": "sKArCLyRAjNU7w0y1",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sYDZCCmi6CWN3HSlo"
+							},
+							"name": "Bow",
+							"reference": "DFA83",
+							"tags": [
+								"Combat",
+								"Ranged Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								}
+							],
+							"points": 1
 						},
 						{
-							"type": "skill",
+							"id": "sEk2gc_zFNPmK8ho2",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "skT71ydKUK_2EU6B1"
+							},
+							"name": "Boxing",
+							"reference": "DFA93",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"features": [
+								{
+									"type": "weapon_bonus",
+									"selection_type": "weapons_with_required_skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "Boxing"
+									},
+									"level": {
+										"compare": "at_least",
+										"qualifier": 1
+									},
+									"amount": 1,
+									"per_die": true
+								},
+								{
+									"type": "weapon_bonus",
+									"selection_type": "weapons_with_required_skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "Boxing"
+									},
+									"level": {
+										"compare": "at_least",
+										"qualifier": 2
+									},
+									"amount": 1,
+									"per_die": true
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "s0cOZ4lfX4JlpquA1",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sUMFlX9EbNGNn31gm"
+							},
+							"name": "Brawling",
+							"reference": "DFA93",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/e",
+							"features": [
+								{
+									"type": "weapon_bonus",
+									"selection_type": "weapons_with_required_skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									},
+									"level": {
+										"compare": "at_least",
+										"qualifier": 2
+									},
+									"amount": 1,
+									"per_die": true
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "sx3Yrj7bbgPB93NGy",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sZETcI3EbwyhIamKv"
+							},
+							"name": "Cloak",
+							"reference": "DFA74",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Net",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Shield",
+									"modifier": -4
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "sav9879ukTfFZNyi6",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sJTFFVKYH-2Xxr-pw"
+							},
+							"name": "Connoisseur",
+							"reference": "DFA74",
+							"tags": [
+								"Arts",
+								"Entertainment",
+								"Knowledge",
+								"Social"
+							],
+							"specialization": "Weapons",
+							"difficulty": "iq/a",
+							"defaults": [
+								{
+									"type": "iq",
+									"modifier": -5
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "s3sL0xHql8f1deiLB",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "siLtfKMGscHt8l2zM"
+							},
+							"name": "Crossbow",
+							"reference": "DFA83",
+							"tags": [
+								"Combat",
+								"Ranged Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/e",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -4
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "sYhKv5PiKI1ySuicF",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sY9q_60yrVFk1zB9C"
+							},
+							"name": "Fast-Draw",
+							"reference": "DFA76",
+							"tags": [
+								"Combat",
+								"Ranged Combat",
+								"Weapon"
+							],
+							"specialization": "@Item@",
+							"difficulty": "dx/e",
+							"points": 1
+						},
+						{
+							"id": "seQzxSaGOfTVLLBD0",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "spl6HsONkP4U_yiGF"
+							},
+							"name": "Fast-Draw",
+							"reference": "DFA76",
+							"tags": [
+								"Combat",
+								"Ranged Combat",
+								"Weapon"
+							],
+							"specialization": "Arrow",
+							"difficulty": "dx/e",
+							"points": 1
+						},
+						{
+							"id": "sF9DHGYOPNQfZzcvW",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sbp0ZIqSgDOsmzl0k"
+							},
+							"name": "Fast-Draw",
+							"reference": "DFA76",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"specialization": "Knife",
+							"difficulty": "dx/e",
+							"points": 1
+						},
+						{
+							"id": "sLQFxhOZX8FumWqEb",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sNMgBBvMxAf6BFBVp"
+							},
+							"name": "Fast-Draw",
+							"reference": "DFA76",
+							"tags": [
+								"Combat",
+								"Weapon"
+							],
+							"specialization": "Potion",
+							"difficulty": "dx/e",
+							"points": 1
+						},
+						{
+							"id": "sG7hzTdkckY_LHbTC",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sewtBLqFyrI5BPm0X"
+							},
+							"name": "Fast-Draw",
+							"reference": "DFA76",
+							"tags": [
+								"Combat",
+								"Weapon"
+							],
+							"specialization": "Scroll",
+							"difficulty": "dx/e",
+							"points": 1
+						},
+						{
+							"id": "saJgM1TPGsSTrpuQK",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sBJfuSGVIOG2aV5YG"
+							},
+							"name": "Fast-Draw",
+							"reference": "DFA76",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"specialization": "Sword",
+							"difficulty": "dx/e",
+							"points": 1
+						},
+						{
+							"id": "suqRG5qRjj7nej6Jm",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sfZexpOBE4RZpeXe8"
+							},
+							"name": "Fast-Draw",
+							"reference": "DFA76",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"specialization": "Two-Handed Sword",
+							"difficulty": "dx/e",
+							"points": 1
+						},
+						{
+							"id": "sEvsajLKbBkbmq5CQ",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sYRTFenqR5dpngPHr"
+							},
+							"name": "Forced Entry",
+							"reference": "DFA77",
+							"tags": [
+								"Criminal",
+								"Police",
+								"Spy",
+								"Street"
+							],
+							"difficulty": "dx/e",
+							"points": 1
+						},
+						{
+							"id": "smBFgvOTYFXrZMLl_",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sMr2Nh2BPvr-6pRxQ"
+							},
+							"name": "Intimidation",
+							"reference": "DFA79",
+							"tags": [
+								"Criminal",
+								"Police",
+								"Social",
+								"Street"
+							],
+							"difficulty": "will/a",
+							"defaults": [
+								{
+									"type": "will",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Acting",
+									"modifier": -3
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "sYm6JaZgeblp6huFx",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "s6U6i0W8Oj1FnQT7E"
+							},
+							"name": "Leadership",
+							"reference": "DFA80",
+							"tags": [
+								"Military",
+								"Social"
+							],
+							"difficulty": "iq/a",
+							"defaults": [
+								{
+									"type": "iq",
+									"modifier": -5
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "sq7OznlR0GRQZi1jF",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "snd5gURyz8oqypWXS"
+							},
+							"name": "Lifting",
+							"reference": "DFA80",
+							"tags": [
+								"Athletic"
+							],
+							"difficulty": "ht/a",
+							"points": 1
+						},
+						{
+							"id": "s7gIHnx1RSEpIK6y9",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sb31vE_obEUqvCSW1"
+							},
 							"name": "Shield",
-							"modifier": -4
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sav9879ukTfFZNyi6",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sJTFFVKYH-2Xxr-pw"
-					},
-					"name": "Connoisseur",
-					"reference": "DFA74",
-					"tags": [
-						"Arts",
-						"Entertainment",
-						"Knowledge",
-						"Social"
-					],
-					"specialization": "Weapons",
-					"difficulty": "iq/a",
-					"defaults": [
-						{
-							"type": "iq",
-							"modifier": -5
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "s3sL0xHql8f1deiLB",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "siLtfKMGscHt8l2zM"
-					},
-					"name": "Crossbow",
-					"reference": "DFA83",
-					"tags": [
-						"Combat",
-						"Ranged Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/e",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -4
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sYhKv5PiKI1ySuicF",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sY9q_60yrVFk1zB9C"
-					},
-					"name": "Fast-Draw",
-					"reference": "DFA76",
-					"tags": [
-						"Combat",
-						"Ranged Combat",
-						"Weapon"
-					],
-					"specialization": "@Item@",
-					"difficulty": "dx/e",
-					"points": 1
-				},
-				{
-					"id": "seQzxSaGOfTVLLBD0",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "spl6HsONkP4U_yiGF"
-					},
-					"name": "Fast-Draw",
-					"reference": "DFA76",
-					"tags": [
-						"Combat",
-						"Ranged Combat",
-						"Weapon"
-					],
-					"specialization": "Arrow",
-					"difficulty": "dx/e",
-					"points": 1
-				},
-				{
-					"id": "sF9DHGYOPNQfZzcvW",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sbp0ZIqSgDOsmzl0k"
-					},
-					"name": "Fast-Draw",
-					"reference": "DFA76",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"specialization": "Knife",
-					"difficulty": "dx/e",
-					"points": 1
-				},
-				{
-					"id": "sLQFxhOZX8FumWqEb",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sNMgBBvMxAf6BFBVp"
-					},
-					"name": "Fast-Draw",
-					"reference": "DFA76",
-					"tags": [
-						"Combat",
-						"Weapon"
-					],
-					"specialization": "Potion",
-					"difficulty": "dx/e",
-					"points": 1
-				},
-				{
-					"id": "sG7hzTdkckY_LHbTC",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sewtBLqFyrI5BPm0X"
-					},
-					"name": "Fast-Draw",
-					"reference": "DFA76",
-					"tags": [
-						"Combat",
-						"Weapon"
-					],
-					"specialization": "Scroll",
-					"difficulty": "dx/e",
-					"points": 1
-				},
-				{
-					"id": "saJgM1TPGsSTrpuQK",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sBJfuSGVIOG2aV5YG"
-					},
-					"name": "Fast-Draw",
-					"reference": "DFA76",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"specialization": "Sword",
-					"difficulty": "dx/e",
-					"points": 1
-				},
-				{
-					"id": "suqRG5qRjj7nej6Jm",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sfZexpOBE4RZpeXe8"
-					},
-					"name": "Fast-Draw",
-					"reference": "DFA76",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"specialization": "Two-Handed Sword",
-					"difficulty": "dx/e",
-					"points": 1
-				},
-				{
-					"id": "sEvsajLKbBkbmq5CQ",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sYRTFenqR5dpngPHr"
-					},
-					"name": "Forced Entry",
-					"reference": "DFA77",
-					"tags": [
-						"Criminal",
-						"Police",
-						"Spy",
-						"Street"
-					],
-					"difficulty": "dx/e",
-					"points": 1
-				},
-				{
-					"id": "smBFgvOTYFXrZMLl_",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sMr2Nh2BPvr-6pRxQ"
-					},
-					"name": "Intimidation",
-					"reference": "DFA79",
-					"tags": [
-						"Criminal",
-						"Police",
-						"Social",
-						"Street"
-					],
-					"difficulty": "will/a",
-					"defaults": [
-						{
-							"type": "will",
-							"modifier": -5
+							"reference": "DFA88",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"specialization": "Buckler",
+							"difficulty": "dx/e",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Shield",
+									"modifier": -2
+								}
+							],
+							"points": 1
 						},
 						{
-							"type": "skill",
-							"name": "Acting",
-							"modifier": -3
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sYm6JaZgeblp6huFx",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "s6U6i0W8Oj1FnQT7E"
-					},
-					"name": "Leadership",
-					"reference": "DFA80",
-					"tags": [
-						"Military",
-						"Social"
-					],
-					"difficulty": "iq/a",
-					"defaults": [
-						{
-							"type": "iq",
-							"modifier": -5
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sq7OznlR0GRQZi1jF",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "snd5gURyz8oqypWXS"
-					},
-					"name": "Lifting",
-					"reference": "DFA80",
-					"tags": [
-						"Athletic"
-					],
-					"difficulty": "ht/a",
-					"points": 1
-				},
-				{
-					"id": "s7gIHnx1RSEpIK6y9",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sb31vE_obEUqvCSW1"
-					},
-					"name": "Shield",
-					"reference": "DFA88",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"specialization": "Buckler",
-					"difficulty": "dx/e",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -4
-						},
-						{
-							"type": "skill",
+							"id": "swqJ6rA0Y76mRSUtw",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sxrJ0547O4bP-EuZX"
+							},
 							"name": "Shield",
-							"modifier": -2
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "swqJ6rA0Y76mRSUtw",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sxrJ0547O4bP-EuZX"
-					},
-					"name": "Shield",
-					"reference": "DFA88",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"specialization": "Shield",
-					"difficulty": "dx/e",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -4
+							"reference": "DFA88",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"specialization": "Shield",
+							"difficulty": "dx/e",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Shield",
+									"modifier": -2
+								}
+							],
+							"points": 1
 						},
 						{
-							"type": "skill",
-							"name": "Shield",
-							"modifier": -2
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "ssl5qTEbQEc4t8nDL",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sShSlwZ4dPx-_E_wX"
-					},
-					"name": "Sling",
-					"reference": "DFA83",
-					"tags": [
-						"Combat",
-						"Ranged Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/h",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -6
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "s6RBqyZ5k43l3Xxte",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sMa_w6SbyAhh9y3Bl"
-					},
-					"name": "Spear Thrower",
-					"reference": "DFA83",
-					"tags": [
-						"Combat",
-						"Ranged Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/a",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -5
+							"id": "ssl5qTEbQEc4t8nDL",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sShSlwZ4dPx-_E_wX"
+							},
+							"name": "Sling",
+							"reference": "DFA83",
+							"tags": [
+								"Combat",
+								"Ranged Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/h",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -6
+								}
+							],
+							"points": 1
 						},
 						{
-							"type": "skill",
-							"name": "Thrown Weapon",
-							"specialization": "Spear",
-							"modifier": -4
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "s27NG3fh2TsxgEeZV",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "s0pHY2syssWuCG-qz"
-					},
-					"name": "Strategy",
-					"reference": "DFA90",
-					"tags": [
-						"Military"
-					],
-					"difficulty": "iq/h",
-					"defaults": [
-						{
-							"type": "iq",
-							"modifier": -6
-						},
-						{
-							"type": "skill",
-							"name": "Intelligence Analysis",
-							"modifier": -6
-						},
-						{
-							"type": "skill",
-							"name": "Tactics",
-							"modifier": -6
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sL74wClldtA_OpxSE",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "s-frTjkdCJ6_KKlLd"
-					},
-					"name": "Sumo Wrestling",
-					"reference": "DFA92",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/a",
-					"points": 1
-				},
-				{
-					"id": "s8dHOZvMe5jGOedFu",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sqbg3yPHHTT0fHqmM"
-					},
-					"name": "Tactics",
-					"reference": "DFA91",
-					"tags": [
-						"Military",
-						"Police"
-					],
-					"difficulty": "iq/h",
-					"defaults": [
-						{
-							"type": "iq",
-							"modifier": -6
-						},
-						{
-							"type": "skill",
-							"name": "Strategy",
-							"modifier": -6
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sqKPu1_2YZAnbrqtV",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sfIBMIcJimmn5pfKb"
-					},
-					"name": "Thrown Weapon",
-					"reference": "DFA91",
-					"tags": [
-						"Combat",
-						"Ranged Combat",
-						"Weapon"
-					],
-					"specialization": "@Specialty@",
-					"difficulty": "dx/e",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -4
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sHQyhWTv2s32IG--e",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "s4m9kK3YxR976CoPq"
-					},
-					"name": "Thrown Weapon",
-					"reference": "DFA91",
-					"tags": [
-						"Combat",
-						"Ranged Combat",
-						"Weapon"
-					],
-					"specialization": "Axe/Mace",
-					"difficulty": "dx/e",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -4
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "spWjokfAMfO_VCyJL",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sYUO1vNflndTvzMrZ"
-					},
-					"name": "Thrown Weapon",
-					"reference": "DFA91",
-					"tags": [
-						"Combat",
-						"Ranged Combat",
-						"Weapon"
-					],
-					"specialization": "Dart",
-					"difficulty": "dx/e",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -4
-						},
-						{
-							"type": "skill",
-							"name": "Throwing",
-							"modifier": -2
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "silmCCjB3xrbjGiRa",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "szmD99yJ2Es1Pz073"
-					},
-					"name": "Thrown Weapon",
-					"reference": "DFA91",
-					"tags": [
-						"Combat",
-						"Ranged Combat",
-						"Weapon"
-					],
-					"specialization": "Harpoon",
-					"difficulty": "dx/e",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -4
-						},
-						{
-							"type": "skill",
-							"name": "Thrown Weapon",
-							"specialization": "Spear",
-							"modifier": -2
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "snNM9QatJB2wG1__M",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sSg3_t4o1EY_D2rUk"
-					},
-					"name": "Thrown Weapon",
-					"reference": "DFA91",
-					"tags": [
-						"Combat",
-						"Ranged Combat",
-						"Weapon"
-					],
-					"specialization": "Knife",
-					"difficulty": "dx/e",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -4
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "ss544AamEMw1PcqVZ",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "szhrMhk40Z91o5EVk"
-					},
-					"name": "Thrown Weapon",
-					"reference": "DFA91",
-					"tags": [
-						"Combat",
-						"Ranged Combat",
-						"Weapon"
-					],
-					"specialization": "Shuriken",
-					"difficulty": "dx/e",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -4
-						},
-						{
-							"type": "skill",
-							"name": "Throwing",
-							"modifier": -2
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sVnXc1t0aVzJWfTEa",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "se0Y7kYJUaeXFj5Ns"
-					},
-					"name": "Thrown Weapon",
-					"reference": "DFA91",
-					"tags": [
-						"Combat",
-						"Ranged Combat",
-						"Weapon"
-					],
-					"specialization": "Spear",
-					"difficulty": "dx/e",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -4
-						},
-						{
-							"type": "skill",
+							"id": "s6RBqyZ5k43l3Xxte",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sMa_w6SbyAhh9y3Bl"
+							},
 							"name": "Spear Thrower",
-							"modifier": -4
+							"reference": "DFA83",
+							"tags": [
+								"Combat",
+								"Ranged Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Thrown Weapon",
+									"specialization": "Spear",
+									"modifier": -4
+								}
+							],
+							"points": 1
 						},
 						{
-							"type": "skill",
+							"id": "s27NG3fh2TsxgEeZV",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "s0pHY2syssWuCG-qz"
+							},
+							"name": "Strategy",
+							"reference": "DFA90",
+							"tags": [
+								"Military"
+							],
+							"difficulty": "iq/h",
+							"defaults": [
+								{
+									"type": "iq",
+									"modifier": -6
+								},
+								{
+									"type": "skill",
+									"name": "Intelligence Analysis",
+									"modifier": -6
+								},
+								{
+									"type": "skill",
+									"name": "Tactics",
+									"modifier": -6
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "sL74wClldtA_OpxSE",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "s-frTjkdCJ6_KKlLd"
+							},
+							"name": "Sumo Wrestling",
+							"reference": "DFA92",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"points": 1
+						},
+						{
+							"id": "s8dHOZvMe5jGOedFu",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sqbg3yPHHTT0fHqmM"
+							},
+							"name": "Tactics",
+							"reference": "DFA91",
+							"tags": [
+								"Military",
+								"Police"
+							],
+							"difficulty": "iq/h",
+							"defaults": [
+								{
+									"type": "iq",
+									"modifier": -6
+								},
+								{
+									"type": "skill",
+									"name": "Strategy",
+									"modifier": -6
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "sqKPu1_2YZAnbrqtV",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sfIBMIcJimmn5pfKb"
+							},
 							"name": "Thrown Weapon",
+							"reference": "DFA91",
+							"tags": [
+								"Combat",
+								"Ranged Combat",
+								"Weapon"
+							],
+							"specialization": "@Specialty@",
+							"difficulty": "dx/e",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -4
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "sHQyhWTv2s32IG--e",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "s4m9kK3YxR976CoPq"
+							},
+							"name": "Thrown Weapon",
+							"reference": "DFA91",
+							"tags": [
+								"Combat",
+								"Ranged Combat",
+								"Weapon"
+							],
+							"specialization": "Axe/Mace",
+							"difficulty": "dx/e",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -4
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "spWjokfAMfO_VCyJL",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sYUO1vNflndTvzMrZ"
+							},
+							"name": "Thrown Weapon",
+							"reference": "DFA91",
+							"tags": [
+								"Combat",
+								"Ranged Combat",
+								"Weapon"
+							],
+							"specialization": "Dart",
+							"difficulty": "dx/e",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Throwing",
+									"modifier": -2
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "silmCCjB3xrbjGiRa",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "szmD99yJ2Es1Pz073"
+							},
+							"name": "Thrown Weapon",
+							"reference": "DFA91",
+							"tags": [
+								"Combat",
+								"Ranged Combat",
+								"Weapon"
+							],
 							"specialization": "Harpoon",
-							"modifier": -2
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sj3AzgP-4fPtXqZQX",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "s4rogZ8xmgXgQVGPl"
-					},
-					"name": "Thrown Weapon",
-					"reference": "DFA91",
-					"tags": [
-						"Combat",
-						"Ranged Combat",
-						"Weapon"
-					],
-					"specialization": "Stick",
-					"difficulty": "dx/e",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -4
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "ssZFNrAV1QeGufDTd",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "s6iSa3lbnEODwEzdw"
-					},
-					"name": "Wrestling",
-					"reference": "DFA93",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/a",
-					"points": 1
-				}
-			]
-		},
-		{
-			"id": "SYnASDmHcZCcl3JuF",
-			"name": "At least 16 Points in Melee Weapon Skills",
-			"template_picker": {
-				"type": "points",
-				"qualifier": {
-					"compare": "at_least",
-					"qualifier": 16
-				}
-			},
-			"children": [
-				{
-					"id": "syc8HWzE-DWCymaRS",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sJWXHIqO1bo3Y5r62"
-					},
-					"name": "Axe/Mace",
-					"reference": "DFA81",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/a",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -5
+							"difficulty": "dx/e",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Thrown Weapon",
+									"specialization": "Spear",
+									"modifier": -2
+								}
+							],
+							"points": 1
 						},
 						{
-							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
-							"modifier": -3
+							"id": "snNM9QatJB2wG1__M",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sSg3_t4o1EY_D2rUk"
+							},
+							"name": "Thrown Weapon",
+							"reference": "DFA91",
+							"tags": [
+								"Combat",
+								"Ranged Combat",
+								"Weapon"
+							],
+							"specialization": "Knife",
+							"difficulty": "dx/e",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -4
+								}
+							],
+							"points": 1
 						},
 						{
-							"type": "skill",
-							"name": "Flail",
-							"modifier": -4
+							"id": "ss544AamEMw1PcqVZ",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "szhrMhk40Z91o5EVk"
+							},
+							"name": "Thrown Weapon",
+							"reference": "DFA91",
+							"tags": [
+								"Combat",
+								"Ranged Combat",
+								"Weapon"
+							],
+							"specialization": "Shuriken",
+							"difficulty": "dx/e",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Throwing",
+									"modifier": -2
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "sVnXc1t0aVzJWfTEa",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "se0Y7kYJUaeXFj5Ns"
+							},
+							"name": "Thrown Weapon",
+							"reference": "DFA91",
+							"tags": [
+								"Combat",
+								"Ranged Combat",
+								"Weapon"
+							],
+							"specialization": "Spear",
+							"difficulty": "dx/e",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Spear Thrower",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Thrown Weapon",
+									"specialization": "Harpoon",
+									"modifier": -2
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "sj3AzgP-4fPtXqZQX",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "s4rogZ8xmgXgQVGPl"
+							},
+							"name": "Thrown Weapon",
+							"reference": "DFA91",
+							"tags": [
+								"Combat",
+								"Ranged Combat",
+								"Weapon"
+							],
+							"specialization": "Stick",
+							"difficulty": "dx/e",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -4
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "ssZFNrAV1QeGufDTd",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "s6iSa3lbnEODwEzdw"
+							},
+							"name": "Wrestling",
+							"reference": "DFA93",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"points": 1
 						}
-					],
-					"points": 1
+					]
 				},
 				{
-					"id": "stigl1-97zF5OyYak",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "s6XXNwVPKmu2l0SjG"
+					"id": "SYnASDmHcZCcl3JuF",
+					"name": "At least 16 Points in Melee Weapon Skills",
+					"template_picker": {
+						"type": "points",
+						"qualifier": {
+							"compare": "at_least",
+							"qualifier": 16
+						}
 					},
-					"name": "Flail",
-					"reference": "DFA81",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/h",
-					"defaults": [
+					"children": [
 						{
-							"type": "dx",
-							"modifier": -6
-						},
-						{
-							"type": "skill",
+							"id": "syc8HWzE-DWCymaRS",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sJWXHIqO1bo3Y5r62"
+							},
 							"name": "Axe/Mace",
-							"modifier": -4
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Two-Handed Axe/Mace",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Flail",
+									"modifier": -4
+								}
+							],
+							"points": 1
 						},
 						{
-							"type": "skill",
-							"name": "Two-Handed Flail",
-							"modifier": -3
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "s9bVyzwkSlIoruOLe",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sYTrvMtG2jRQBtu_P"
-					},
-					"name": "Jitte/Sai",
-					"reference": "DFA81",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/a",
-					"defaults": [
-						{
-							"type": "skill",
-							"name": "Force Sword",
-							"modifier": -4
+							"id": "stigl1-97zF5OyYak",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "s6XXNwVPKmu2l0SjG"
+							},
+							"name": "Flail",
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/h",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -6
+								},
+								{
+									"type": "skill",
+									"name": "Axe/Mace",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Two-Handed Flail",
+									"modifier": -3
+								}
+							],
+							"points": 1
 						},
 						{
-							"type": "skill",
-							"name": "Main-Gauche",
-							"modifier": -4
-						},
-						{
-							"type": "skill",
-							"name": "Shortsword",
-							"modifier": -3
-						},
-						{
-							"type": "dx",
-							"modifier": -5
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sBDJaDEpGS4M4kuqe",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sGMuuC-kk-56K3Qf2"
-					},
-					"name": "Knife",
-					"reference": "DFA81",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/e",
-					"defaults": [
-						{
-							"type": "skill",
-							"name": "Force Sword",
-							"modifier": -3
-						},
-						{
-							"type": "skill",
-							"name": "Main-Gauche",
-							"modifier": -3
-						},
-						{
-							"type": "skill",
-							"name": "Shortsword",
-							"modifier": -3
-						},
-						{
-							"type": "dx",
-							"modifier": -4
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sDPtC0-vDTmRKEZ1J",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "s0tPCgdAoREgWqZIg"
-					},
-					"name": "Kusari",
-					"reference": "DFA82",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/h",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -6
-						},
-						{
-							"type": "skill",
-							"name": "Force Whip",
-							"modifier": -3
-						},
-						{
-							"type": "skill",
-							"name": "Monowire Whip",
-							"modifier": -3
-						},
-						{
-							"type": "skill",
-							"name": "Whip",
-							"modifier": -3
-						},
-						{
-							"type": "skill",
-							"name": "Two-Handed Flail",
-							"modifier": -4
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "snj8TmIzJQhwH3t9u",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sIPa439w__PRt4CT8"
-					},
-					"name": "Broadsword",
-					"reference": "DFA81",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/a",
-					"defaults": [
-						{
-							"type": "skill",
-							"name": "Force Sword",
-							"modifier": -4
-						},
-						{
-							"type": "skill",
-							"name": "Rapier",
-							"modifier": -4
-						},
-						{
-							"type": "skill",
-							"name": "Saber",
-							"modifier": -4
-						},
-						{
-							"type": "skill",
-							"name": "Shortsword",
-							"modifier": -2
-						},
-						{
-							"type": "skill",
-							"name": "Two-Handed Sword",
-							"modifier": -4
-						},
-						{
-							"type": "dx",
-							"modifier": -5
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sqH-kH36vsSAFrhFU",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sKl5_DLlGCMU7G7zk"
-					},
-					"name": "Main-Gauche",
-					"reference": "DFA81",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/a",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -5
-						},
-						{
-							"type": "skill",
+							"id": "s9bVyzwkSlIoruOLe",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sYTrvMtG2jRQBtu_P"
+							},
 							"name": "Jitte/Sai",
-							"modifier": -4
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Force Sword",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Main-Gauche",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Shortsword",
+									"modifier": -3
+								},
+								{
+									"type": "dx",
+									"modifier": -5
+								}
+							],
+							"points": 1
 						},
 						{
-							"type": "skill",
+							"id": "sBDJaDEpGS4M4kuqe",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sGMuuC-kk-56K3Qf2"
+							},
 							"name": "Knife",
-							"modifier": -4
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/e",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Force Sword",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Main-Gauche",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Shortsword",
+									"modifier": -3
+								},
+								{
+									"type": "dx",
+									"modifier": -4
+								}
+							],
+							"points": 1
 						},
 						{
-							"type": "skill",
+							"id": "sDPtC0-vDTmRKEZ1J",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "s0tPCgdAoREgWqZIg"
+							},
+							"name": "Kusari",
+							"reference": "DFA82",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/h",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -6
+								},
+								{
+									"type": "skill",
+									"name": "Force Whip",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Monowire Whip",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Whip",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Two-Handed Flail",
+									"modifier": -4
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "snj8TmIzJQhwH3t9u",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sIPa439w__PRt4CT8"
+							},
+							"name": "Broadsword",
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Force Sword",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Rapier",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Saber",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Shortsword",
+									"modifier": -2
+								},
+								{
+									"type": "skill",
+									"name": "Two-Handed Sword",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -5
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "sqH-kH36vsSAFrhFU",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sKl5_DLlGCMU7G7zk"
+							},
+							"name": "Main-Gauche",
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Jitte/Sai",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Knife",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Rapier",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Saber",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Smallsword",
+									"modifier": -3
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "sQrujlXoM31sLcAXf",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "s2TRfOszdn6Fj48XX"
+							},
+							"name": "Polearm",
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Spear",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Staff",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Two-Handed Axe/Mace",
+									"modifier": -4
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "sLc-pVcs90mp7MfrE",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sIzhGG9-301PPDuRu"
+							},
 							"name": "Rapier",
-							"modifier": -3
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Broadsword",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Main-Gauche",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Saber",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Smallsword",
+									"modifier": -3
+								}
+							],
+							"points": 1
 						},
 						{
-							"type": "skill",
+							"id": "syzYQpGY45HyBtwfm",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "smMdtUOUAPQA6C9-Z"
+							},
 							"name": "Saber",
-							"modifier": -3
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Broadsword",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Shortswort",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Main-Gauche",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Rapier",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Smallsword",
+									"modifier": -3
+								}
+							],
+							"points": 1
 						},
 						{
-							"type": "skill",
+							"id": "senX4uaDPc_xc1FHf",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sREf0R4fH6zX2LRi2"
+							},
+							"name": "Shortsword",
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Broadsword",
+									"modifier": -2
+								},
+								{
+									"type": "skill",
+									"name": "Force Sword",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Jitte/Sai",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Knife",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Saber",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Smallsword",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Tonfa",
+									"modifier": -3
+								},
+								{
+									"type": "dx",
+									"modifier": -5
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "sMQUZsAV2FYJVgvZV",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "shd2T3Rmivpbf6QJ_"
+							},
 							"name": "Smallsword",
-							"modifier": -3
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sQrujlXoM31sLcAXf",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "s2TRfOszdn6Fj48XX"
-					},
-					"name": "Polearm",
-					"reference": "DFA81",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/a",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -5
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Shortsword",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Main-Gauche",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Rapier",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Saber",
+									"modifier": -3
+								}
+							],
+							"points": 1
 						},
 						{
-							"type": "skill",
+							"id": "sylhFfo74A9DEwdaO",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sNk63TpccCvsiXKd0"
+							},
 							"name": "Spear",
-							"modifier": -4
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Polearm",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Staff",
+									"modifier": -2
+								}
+							],
+							"points": 1
 						},
 						{
-							"type": "skill",
+							"id": "szTTFNyAzWp2c-CE5",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "soilUSeitMyIlPAtg"
+							},
 							"name": "Staff",
-							"modifier": -4
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Polearm",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Spear",
+									"modifier": -2
+								}
+							],
+							"points": 1
 						},
 						{
-							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
-							"modifier": -4
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sLc-pVcs90mp7MfrE",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sIzhGG9-301PPDuRu"
-					},
-					"name": "Rapier",
-					"reference": "DFA81",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/a",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -5
-						},
-						{
-							"type": "skill",
-							"name": "Broadsword",
-							"modifier": -4
-						},
-						{
-							"type": "skill",
-							"name": "Main-Gauche",
-							"modifier": -3
-						},
-						{
-							"type": "skill",
-							"name": "Saber",
-							"modifier": -3
-						},
-						{
-							"type": "skill",
-							"name": "Smallsword",
-							"modifier": -3
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "syzYQpGY45HyBtwfm",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "smMdtUOUAPQA6C9-Z"
-					},
-					"name": "Saber",
-					"reference": "DFA81",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/a",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -5
-						},
-						{
-							"type": "skill",
-							"name": "Broadsword",
-							"modifier": -4
-						},
-						{
-							"type": "skill",
-							"name": "Shortswort",
-							"modifier": -4
-						},
-						{
-							"type": "skill",
-							"name": "Main-Gauche",
-							"modifier": -3
-						},
-						{
-							"type": "skill",
-							"name": "Rapier",
-							"modifier": -3
-						},
-						{
-							"type": "skill",
-							"name": "Smallsword",
-							"modifier": -3
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "senX4uaDPc_xc1FHf",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sREf0R4fH6zX2LRi2"
-					},
-					"name": "Shortsword",
-					"reference": "DFA81",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/a",
-					"defaults": [
-						{
-							"type": "skill",
-							"name": "Broadsword",
-							"modifier": -2
-						},
-						{
-							"type": "skill",
-							"name": "Force Sword",
-							"modifier": -4
-						},
-						{
-							"type": "skill",
-							"name": "Jitte/Sai",
-							"modifier": -3
-						},
-						{
-							"type": "skill",
-							"name": "Knife",
-							"modifier": -4
-						},
-						{
-							"type": "skill",
-							"name": "Saber",
-							"modifier": -4
-						},
-						{
-							"type": "skill",
-							"name": "Smallsword",
-							"modifier": -4
-						},
-						{
-							"type": "skill",
+							"id": "sZvxlsyXzzcVKJUAz",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "s-qaex6gJlE3JswZv"
+							},
 							"name": "Tonfa",
-							"modifier": -3
+							"reference": "DFA82",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Shortsword",
+									"modifier": -3
+								}
+							],
+							"points": 1
 						},
 						{
-							"type": "dx",
-							"modifier": -5
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sMQUZsAV2FYJVgvZV",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "shd2T3Rmivpbf6QJ_"
-					},
-					"name": "Smallsword",
-					"reference": "DFA81",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/a",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -5
-						},
-						{
-							"type": "skill",
-							"name": "Shortsword",
-							"modifier": -4
-						},
-						{
-							"type": "skill",
-							"name": "Main-Gauche",
-							"modifier": -3
-						},
-						{
-							"type": "skill",
-							"name": "Rapier",
-							"modifier": -3
-						},
-						{
-							"type": "skill",
-							"name": "Saber",
-							"modifier": -3
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sylhFfo74A9DEwdaO",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sNk63TpccCvsiXKd0"
-					},
-					"name": "Spear",
-					"reference": "DFA81",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/a",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -5
-						},
-						{
-							"type": "skill",
-							"name": "Polearm",
-							"modifier": -4
-						},
-						{
-							"type": "skill",
-							"name": "Staff",
-							"modifier": -2
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "szTTFNyAzWp2c-CE5",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "soilUSeitMyIlPAtg"
-					},
-					"name": "Staff",
-					"reference": "DFA81",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/a",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -5
-						},
-						{
-							"type": "skill",
-							"name": "Polearm",
-							"modifier": -4
-						},
-						{
-							"type": "skill",
-							"name": "Spear",
-							"modifier": -2
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sZvxlsyXzzcVKJUAz",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "s-qaex6gJlE3JswZv"
-					},
-					"name": "Tonfa",
-					"reference": "DFA82",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/a",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -5
-						},
-						{
-							"type": "skill",
-							"name": "Shortsword",
-							"modifier": -3
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "s4HwUUSPAuwoLGm0h",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sRxrEmc3lfEEy4VAa"
-					},
-					"name": "Two-Handed Axe/Mace",
-					"reference": "DFA81",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/a",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -5
-						},
-						{
-							"type": "skill",
-							"name": "Axe/Mace",
-							"modifier": -3
-						},
-						{
-							"type": "skill",
-							"name": "Polearm",
-							"modifier": -4
-						},
-						{
-							"type": "skill",
-							"name": "Two-Handed Flail",
-							"modifier": -4
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "skGgWKWCv4LN9SxZn",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sZFEG08s5VXd1ZIMn"
-					},
-					"name": "Two-Handed Flail",
-					"reference": "DFA81",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/h",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -6
-						},
-						{
-							"type": "skill",
-							"name": "Flail",
-							"modifier": -3
-						},
-						{
-							"type": "skill",
-							"name": "Kusari",
-							"modifier": -4
-						},
-						{
-							"type": "skill",
+							"id": "s4HwUUSPAuwoLGm0h",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sRxrEmc3lfEEy4VAa"
+							},
 							"name": "Two-Handed Axe/Mace",
-							"modifier": -4
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Axe/Mace",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Polearm",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Two-Handed Flail",
+									"modifier": -4
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "skGgWKWCv4LN9SxZn",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sZFEG08s5VXd1ZIMn"
+							},
+							"name": "Two-Handed Flail",
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/h",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -6
+								},
+								{
+									"type": "skill",
+									"name": "Flail",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Kusari",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Two-Handed Axe/Mace",
+									"modifier": -4
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "ssfvubUwcAoB1EAdO",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "snAFDxOB3UqelcxN5"
+							},
+							"name": "Two-Handed Sword",
+							"reference": "DFA82",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Broadsword",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Force Sword",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -5
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "sSkB5WafXTMP75mvj",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "s2u7PEdv1s5_cIKdV"
+							},
+							"name": "Whip",
+							"reference": "DFA82",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Force Whip",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Kusari",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Monowire Whip",
+									"modifier": -3
+								}
+							],
+							"points": 1
 						}
-					],
-					"points": 1
-				},
-				{
-					"id": "ssfvubUwcAoB1EAdO",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "snAFDxOB3UqelcxN5"
-					},
-					"name": "Two-Handed Sword",
-					"reference": "DFA82",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/a",
-					"defaults": [
-						{
-							"type": "skill",
-							"name": "Broadsword",
-							"modifier": -4
-						},
-						{
-							"type": "skill",
-							"name": "Force Sword",
-							"modifier": -4
-						},
-						{
-							"type": "dx",
-							"modifier": -5
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sSkB5WafXTMP75mvj",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "s2u7PEdv1s5_cIKdV"
-					},
-					"name": "Whip",
-					"reference": "DFA82",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/a",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -5
-						},
-						{
-							"type": "skill",
-							"name": "Force Whip",
-							"modifier": -3
-						},
-						{
-							"type": "skill",
-							"name": "Kusari",
-							"modifier": -3
-						},
-						{
-							"type": "skill",
-							"name": "Monowire Whip",
-							"modifier": -3
-						}
-					],
-					"points": 1
+					]
 				}
 			]
 		}

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Crusader 2.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Crusader 2.gct
@@ -1546,6 +1546,39 @@
 							"points": 1
 						},
 						{
+							"id": "sXnO3a9mwAGzbS_-X",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "soilUSeitMyIlPAtg"
+							},
+							"name": "Staff",
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Polearm",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Spear",
+									"modifier": -2
+								}
+							],
+							"points": 1
+						},
+						{
 							"id": "sHIWOGGlp9-KRejZ3",
 							"name": "Fast-Draw",
 							"reference": "DFA76",

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Crusader.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Crusader.gct
@@ -1802,6 +1802,39 @@
 							"points": 1
 						},
 						{
+							"id": "sKTP_eoPjb1ggEp_W",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "soilUSeitMyIlPAtg"
+							},
+							"name": "Staff",
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Polearm",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Spear",
+									"modifier": -2
+								}
+							],
+							"points": 1
+						},
+						{
 							"id": "sHIWOGGlp9-KRejZ3",
 							"name": "Fast-Draw",
 							"reference": "DFA76",

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Finesse Warrior 2.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Finesse Warrior 2.gct
@@ -6756,6 +6756,29 @@
 					"points": 1
 				},
 				{
+					"id": "s2yQ3vo1HomKZWXRX",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+						"id": "sIFnUEojIsUlx7qhk"
+					},
+					"name": "Blowpipe",
+					"reference": "DFA83",
+					"tags": [
+						"Combat",
+						"Ranged Combat",
+						"Weapon"
+					],
+					"difficulty": "dx/h",
+					"defaults": [
+						{
+							"type": "dx",
+							"modifier": -6
+						}
+					],
+					"points": 1
+				},
+				{
 					"id": "svTDCEhXiA__3RGkk",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
@@ -6770,6 +6793,29 @@
 						"Weapon"
 					],
 					"difficulty": "dx/a",
+					"points": 1
+				},
+				{
+					"id": "skyhU9x3SprdPrlVT",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+						"id": "sYDZCCmi6CWN3HSlo"
+					},
+					"name": "Bow",
+					"reference": "DFA83",
+					"tags": [
+						"Combat",
+						"Ranged Combat",
+						"Weapon"
+					],
+					"difficulty": "dx/a",
+					"defaults": [
+						{
+							"type": "dx",
+							"modifier": -5
+						}
+					],
 					"points": 1
 				},
 				{
@@ -6954,6 +7000,29 @@
 						{
 							"type": "iq",
 							"modifier": -5
+						}
+					],
+					"points": 1
+				},
+				{
+					"id": "saExUBHdZ87V2slEY",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+						"id": "siLtfKMGscHt8l2zM"
+					},
+					"name": "Crossbow",
+					"reference": "DFA83",
+					"tags": [
+						"Combat",
+						"Ranged Combat",
+						"Weapon"
+					],
+					"difficulty": "dx/e",
+					"defaults": [
+						{
+							"type": "dx",
+							"modifier": -4
 						}
 					],
 					"points": 1
@@ -7654,6 +7723,29 @@
 					"points": 1
 				},
 				{
+					"id": "sasIw3dMPFJeKCDMA",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+						"id": "sShSlwZ4dPx-_E_wX"
+					},
+					"name": "Sling",
+					"reference": "DFA83",
+					"tags": [
+						"Combat",
+						"Ranged Combat",
+						"Weapon"
+					],
+					"difficulty": "dx/h",
+					"defaults": [
+						{
+							"type": "dx",
+							"modifier": -6
+						}
+					],
+					"points": 1
+				},
+				{
 					"id": "sBFADleJ6stRAEFx4",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
@@ -7725,6 +7817,35 @@
 							"type": "skill",
 							"name": "Staff",
 							"modifier": -2
+						}
+					],
+					"points": 1
+				},
+				{
+					"id": "sLt2JVFhd3qhrOqxU",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+						"id": "sMa_w6SbyAhh9y3Bl"
+					},
+					"name": "Spear Thrower",
+					"reference": "DFA83",
+					"tags": [
+						"Combat",
+						"Ranged Combat",
+						"Weapon"
+					],
+					"difficulty": "dx/a",
+					"defaults": [
+						{
+							"type": "dx",
+							"modifier": -5
+						},
+						{
+							"type": "skill",
+							"name": "Thrown Weapon",
+							"specialization": "Spear",
+							"modifier": -4
 						}
 					],
 					"points": 1

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Finesse Warrior 2.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Finesse Warrior 2.gct
@@ -6592,7 +6592,7 @@
 	"skills": [
 		{
 			"id": "StpplE_qO6UnIZnqz",
-			"name": "More skills",
+			"name": "Finesse Warrior 2",
 			"template_picker": {
 				"type": "points",
 				"qualifier": {

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Finesse Warrior 2.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Finesse Warrior 2.gct
@@ -52,7 +52,7 @@
 						"type": "points",
 						"qualifier": {
 							"compare": "is",
-							"qualifier": 30
+							"qualifier": 20
 						}
 					},
 					"children": [

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Finesse Warrior.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Finesse Warrior.gct
@@ -6458,1704 +6458,1710 @@
 	],
 	"skills": [
 		{
-			"id": "SBLHkQ9A2nuPTyr8q",
-			"name": "At least 16 Points in Melee Weapon Skills",
-			"template_picker": {
-				"type": "points",
-				"qualifier": {
-					"compare": "at_least",
-					"qualifier": 16
-				}
-			},
+			"id": "SBx-IS2LEuDG4YSnx",
+			"name": "Finesse Warrior",
 			"children": [
 				{
-					"id": "sCETLq9puyw873LUs",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sJWXHIqO1bo3Y5r62"
-					},
-					"name": "Axe/Mace",
-					"reference": "DFA81",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/a",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -5
-						},
-						{
-							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
-							"modifier": -3
-						},
-						{
-							"type": "skill",
-							"name": "Flail",
-							"modifier": -4
+					"id": "SBLHkQ9A2nuPTyr8q",
+					"name": "At least 16 Points in Melee Weapon Skills",
+					"template_picker": {
+						"type": "points",
+						"qualifier": {
+							"compare": "at_least",
+							"qualifier": 16
 						}
-					],
-					"points": 1
-				},
-				{
-					"id": "spI_ca4t0O2mQ6SdD",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sIPa439w__PRt4CT8"
 					},
-					"name": "Broadsword",
-					"reference": "DFA81",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/a",
-					"defaults": [
+					"children": [
 						{
-							"type": "skill",
-							"name": "Force Sword",
-							"modifier": -4
-						},
-						{
-							"type": "skill",
-							"name": "Rapier",
-							"modifier": -4
-						},
-						{
-							"type": "skill",
-							"name": "Saber",
-							"modifier": -4
-						},
-						{
-							"type": "skill",
-							"name": "Shortsword",
-							"modifier": -2
-						},
-						{
-							"type": "skill",
-							"name": "Two-Handed Sword",
-							"modifier": -4
-						},
-						{
-							"type": "dx",
-							"modifier": -5
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "s6GEVwV2f6tvrJaE4",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "s6XXNwVPKmu2l0SjG"
-					},
-					"name": "Flail",
-					"reference": "DFA81",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/h",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -6
-						},
-						{
-							"type": "skill",
+							"id": "sCETLq9puyw873LUs",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sJWXHIqO1bo3Y5r62"
+							},
 							"name": "Axe/Mace",
-							"modifier": -4
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Two-Handed Axe/Mace",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Flail",
+									"modifier": -4
+								}
+							],
+							"points": 1
 						},
 						{
-							"type": "skill",
-							"name": "Two-Handed Flail",
-							"modifier": -3
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sDJTzwI7r8VZZQRRc",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sAo8rd_Q17KHFt1tW"
-					},
-					"name": "Garrote",
-					"reference": "DFA77",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/e",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -4
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "shZ84rQ09JztnimZ3",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sYTrvMtG2jRQBtu_P"
-					},
-					"name": "Jitte/Sai",
-					"reference": "DFA81",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/a",
-					"defaults": [
-						{
-							"type": "skill",
-							"name": "Force Sword",
-							"modifier": -4
+							"id": "spI_ca4t0O2mQ6SdD",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sIPa439w__PRt4CT8"
+							},
+							"name": "Broadsword",
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Force Sword",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Rapier",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Saber",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Shortsword",
+									"modifier": -2
+								},
+								{
+									"type": "skill",
+									"name": "Two-Handed Sword",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -5
+								}
+							],
+							"points": 1
 						},
 						{
-							"type": "skill",
-							"name": "Main-Gauche",
-							"modifier": -4
+							"id": "s6GEVwV2f6tvrJaE4",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "s6XXNwVPKmu2l0SjG"
+							},
+							"name": "Flail",
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/h",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -6
+								},
+								{
+									"type": "skill",
+									"name": "Axe/Mace",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Two-Handed Flail",
+									"modifier": -3
+								}
+							],
+							"points": 1
 						},
 						{
-							"type": "skill",
-							"name": "Shortsword",
-							"modifier": -3
+							"id": "sDJTzwI7r8VZZQRRc",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sAo8rd_Q17KHFt1tW"
+							},
+							"name": "Garrote",
+							"reference": "DFA77",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/e",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -4
+								}
+							],
+							"points": 1
 						},
 						{
-							"type": "dx",
-							"modifier": -5
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sMrkfeUXMgq7CP-hU",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sGMuuC-kk-56K3Qf2"
-					},
-					"name": "Knife",
-					"reference": "DFA81",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/e",
-					"defaults": [
-						{
-							"type": "skill",
-							"name": "Force Sword",
-							"modifier": -3
-						},
-						{
-							"type": "skill",
-							"name": "Main-Gauche",
-							"modifier": -3
-						},
-						{
-							"type": "skill",
-							"name": "Shortsword",
-							"modifier": -3
-						},
-						{
-							"type": "dx",
-							"modifier": -4
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sqJdTsw4s5Ep9Rq-B",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "s0tPCgdAoREgWqZIg"
-					},
-					"name": "Kusari",
-					"reference": "DFA82",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/h",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -6
-						},
-						{
-							"type": "skill",
-							"name": "Force Whip",
-							"modifier": -3
-						},
-						{
-							"type": "skill",
-							"name": "Monowire Whip",
-							"modifier": -3
-						},
-						{
-							"type": "skill",
-							"name": "Whip",
-							"modifier": -3
-						},
-						{
-							"type": "skill",
-							"name": "Two-Handed Flail",
-							"modifier": -4
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "s-CbcJ8lDRxnfKpgL",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sKl5_DLlGCMU7G7zk"
-					},
-					"name": "Main-Gauche",
-					"reference": "DFA81",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/a",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -5
-						},
-						{
-							"type": "skill",
+							"id": "shZ84rQ09JztnimZ3",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sYTrvMtG2jRQBtu_P"
+							},
 							"name": "Jitte/Sai",
-							"modifier": -4
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Force Sword",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Main-Gauche",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Shortsword",
+									"modifier": -3
+								},
+								{
+									"type": "dx",
+									"modifier": -5
+								}
+							],
+							"points": 1
 						},
 						{
-							"type": "skill",
+							"id": "sMrkfeUXMgq7CP-hU",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sGMuuC-kk-56K3Qf2"
+							},
 							"name": "Knife",
-							"modifier": -4
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/e",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Force Sword",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Main-Gauche",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Shortsword",
+									"modifier": -3
+								},
+								{
+									"type": "dx",
+									"modifier": -4
+								}
+							],
+							"points": 1
 						},
 						{
-							"type": "skill",
+							"id": "sqJdTsw4s5Ep9Rq-B",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "s0tPCgdAoREgWqZIg"
+							},
+							"name": "Kusari",
+							"reference": "DFA82",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/h",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -6
+								},
+								{
+									"type": "skill",
+									"name": "Force Whip",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Monowire Whip",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Whip",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Two-Handed Flail",
+									"modifier": -4
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "s-CbcJ8lDRxnfKpgL",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sKl5_DLlGCMU7G7zk"
+							},
+							"name": "Main-Gauche",
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Jitte/Sai",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Knife",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Rapier",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Saber",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Smallsword",
+									"modifier": -3
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "sqJVNpopP1F1TCcKm",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "s2TRfOszdn6Fj48XX"
+							},
+							"name": "Polearm",
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Spear",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Staff",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Two-Handed Axe/Mace",
+									"modifier": -4
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "si3clY4z-twgI21Ho",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sIzhGG9-301PPDuRu"
+							},
 							"name": "Rapier",
-							"modifier": -3
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Broadsword",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Main-Gauche",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Saber",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Smallsword",
+									"modifier": -3
+								}
+							],
+							"points": 1
 						},
 						{
-							"type": "skill",
+							"id": "sz4l275E6f_mubYb6",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "smMdtUOUAPQA6C9-Z"
+							},
 							"name": "Saber",
-							"modifier": -3
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Broadsword",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Shortswort",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Main-Gauche",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Rapier",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Smallsword",
+									"modifier": -3
+								}
+							],
+							"points": 1
 						},
 						{
-							"type": "skill",
+							"id": "sA8jNdZDpdMERV5V9",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sREf0R4fH6zX2LRi2"
+							},
+							"name": "Shortsword",
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Broadsword",
+									"modifier": -2
+								},
+								{
+									"type": "skill",
+									"name": "Force Sword",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Jitte/Sai",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Knife",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Saber",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Smallsword",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Tonfa",
+									"modifier": -3
+								},
+								{
+									"type": "dx",
+									"modifier": -5
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "sWzmfJMaCu_AxqCd4",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "shd2T3Rmivpbf6QJ_"
+							},
 							"name": "Smallsword",
-							"modifier": -3
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sqJVNpopP1F1TCcKm",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "s2TRfOszdn6Fj48XX"
-					},
-					"name": "Polearm",
-					"reference": "DFA81",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/a",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -5
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Shortsword",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Main-Gauche",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Rapier",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Saber",
+									"modifier": -3
+								}
+							],
+							"points": 1
 						},
 						{
-							"type": "skill",
+							"id": "sayWmXg17dCgt47yt",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sNk63TpccCvsiXKd0"
+							},
 							"name": "Spear",
-							"modifier": -4
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Polearm",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Staff",
+									"modifier": -2
+								}
+							],
+							"points": 1
 						},
 						{
-							"type": "skill",
+							"id": "sBQwzWsYq0Gs0sIXr",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "soilUSeitMyIlPAtg"
+							},
 							"name": "Staff",
-							"modifier": -4
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Polearm",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Spear",
+									"modifier": -2
+								}
+							],
+							"points": 1
 						},
 						{
-							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
-							"modifier": -4
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "si3clY4z-twgI21Ho",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sIzhGG9-301PPDuRu"
-					},
-					"name": "Rapier",
-					"reference": "DFA81",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/a",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -5
-						},
-						{
-							"type": "skill",
-							"name": "Broadsword",
-							"modifier": -4
-						},
-						{
-							"type": "skill",
-							"name": "Main-Gauche",
-							"modifier": -3
-						},
-						{
-							"type": "skill",
-							"name": "Saber",
-							"modifier": -3
-						},
-						{
-							"type": "skill",
-							"name": "Smallsword",
-							"modifier": -3
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sz4l275E6f_mubYb6",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "smMdtUOUAPQA6C9-Z"
-					},
-					"name": "Saber",
-					"reference": "DFA81",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/a",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -5
-						},
-						{
-							"type": "skill",
-							"name": "Broadsword",
-							"modifier": -4
-						},
-						{
-							"type": "skill",
-							"name": "Shortswort",
-							"modifier": -4
-						},
-						{
-							"type": "skill",
-							"name": "Main-Gauche",
-							"modifier": -3
-						},
-						{
-							"type": "skill",
-							"name": "Rapier",
-							"modifier": -3
-						},
-						{
-							"type": "skill",
-							"name": "Smallsword",
-							"modifier": -3
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sA8jNdZDpdMERV5V9",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sREf0R4fH6zX2LRi2"
-					},
-					"name": "Shortsword",
-					"reference": "DFA81",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/a",
-					"defaults": [
-						{
-							"type": "skill",
-							"name": "Broadsword",
-							"modifier": -2
-						},
-						{
-							"type": "skill",
-							"name": "Force Sword",
-							"modifier": -4
-						},
-						{
-							"type": "skill",
-							"name": "Jitte/Sai",
-							"modifier": -3
-						},
-						{
-							"type": "skill",
-							"name": "Knife",
-							"modifier": -4
-						},
-						{
-							"type": "skill",
-							"name": "Saber",
-							"modifier": -4
-						},
-						{
-							"type": "skill",
-							"name": "Smallsword",
-							"modifier": -4
-						},
-						{
-							"type": "skill",
+							"id": "sLGfiyRAw0R80U45V",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "s-qaex6gJlE3JswZv"
+							},
 							"name": "Tonfa",
-							"modifier": -3
+							"reference": "DFA82",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Shortsword",
+									"modifier": -3
+								}
+							],
+							"points": 1
 						},
 						{
-							"type": "dx",
-							"modifier": -5
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sWzmfJMaCu_AxqCd4",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "shd2T3Rmivpbf6QJ_"
-					},
-					"name": "Smallsword",
-					"reference": "DFA81",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/a",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -5
-						},
-						{
-							"type": "skill",
-							"name": "Shortsword",
-							"modifier": -4
-						},
-						{
-							"type": "skill",
-							"name": "Main-Gauche",
-							"modifier": -3
-						},
-						{
-							"type": "skill",
-							"name": "Rapier",
-							"modifier": -3
-						},
-						{
-							"type": "skill",
-							"name": "Saber",
-							"modifier": -3
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sayWmXg17dCgt47yt",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sNk63TpccCvsiXKd0"
-					},
-					"name": "Spear",
-					"reference": "DFA81",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/a",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -5
-						},
-						{
-							"type": "skill",
-							"name": "Polearm",
-							"modifier": -4
-						},
-						{
-							"type": "skill",
-							"name": "Staff",
-							"modifier": -2
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sBQwzWsYq0Gs0sIXr",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "soilUSeitMyIlPAtg"
-					},
-					"name": "Staff",
-					"reference": "DFA81",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/a",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -5
-						},
-						{
-							"type": "skill",
-							"name": "Polearm",
-							"modifier": -4
-						},
-						{
-							"type": "skill",
-							"name": "Spear",
-							"modifier": -2
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sLGfiyRAw0R80U45V",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "s-qaex6gJlE3JswZv"
-					},
-					"name": "Tonfa",
-					"reference": "DFA82",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/a",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -5
-						},
-						{
-							"type": "skill",
-							"name": "Shortsword",
-							"modifier": -3
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sT5NyGNmCBvCEOckR",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sRxrEmc3lfEEy4VAa"
-					},
-					"name": "Two-Handed Axe/Mace",
-					"reference": "DFA81",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/a",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -5
-						},
-						{
-							"type": "skill",
-							"name": "Axe/Mace",
-							"modifier": -3
-						},
-						{
-							"type": "skill",
-							"name": "Polearm",
-							"modifier": -4
-						},
-						{
-							"type": "skill",
-							"name": "Two-Handed Flail",
-							"modifier": -4
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sKMHPQ_DaUOBVxbRw",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sZFEG08s5VXd1ZIMn"
-					},
-					"name": "Two-Handed Flail",
-					"reference": "DFA81",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/h",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -6
-						},
-						{
-							"type": "skill",
-							"name": "Flail",
-							"modifier": -3
-						},
-						{
-							"type": "skill",
-							"name": "Kusari",
-							"modifier": -4
-						},
-						{
-							"type": "skill",
+							"id": "sT5NyGNmCBvCEOckR",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sRxrEmc3lfEEy4VAa"
+							},
 							"name": "Two-Handed Axe/Mace",
-							"modifier": -4
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Axe/Mace",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Polearm",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Two-Handed Flail",
+									"modifier": -4
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "sKMHPQ_DaUOBVxbRw",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sZFEG08s5VXd1ZIMn"
+							},
+							"name": "Two-Handed Flail",
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/h",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -6
+								},
+								{
+									"type": "skill",
+									"name": "Flail",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Kusari",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Two-Handed Axe/Mace",
+									"modifier": -4
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "s90b4uTYjSyuvsE4G",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "snAFDxOB3UqelcxN5"
+							},
+							"name": "Two-Handed Sword",
+							"reference": "DFA82",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Broadsword",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Force Sword",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -5
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "sd5LiR7yi456yGc0_",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "s2u7PEdv1s5_cIKdV"
+							},
+							"name": "Whip",
+							"reference": "DFA82",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Force Whip",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Kusari",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Monowire Whip",
+									"modifier": -3
+								}
+							],
+							"points": 1
 						}
-					],
-					"points": 1
+					]
 				},
 				{
-					"id": "s90b4uTYjSyuvsE4G",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "snAFDxOB3UqelcxN5"
-					},
-					"name": "Two-Handed Sword",
-					"reference": "DFA82",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/a",
-					"defaults": [
-						{
-							"type": "skill",
-							"name": "Broadsword",
-							"modifier": -4
-						},
-						{
-							"type": "skill",
-							"name": "Force Sword",
-							"modifier": -4
-						},
-						{
-							"type": "dx",
-							"modifier": -5
+					"id": "StpplE_qO6UnIZnqz",
+					"name": "More skills",
+					"template_picker": {
+						"type": "points",
+						"qualifier": {
+							"compare": "at_most",
+							"qualifier": 4
 						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sd5LiR7yi456yGc0_",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "s2u7PEdv1s5_cIKdV"
 					},
-					"name": "Whip",
-					"reference": "DFA82",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/a",
-					"defaults": [
+					"children": [
 						{
-							"type": "dx",
-							"modifier": -5
+							"id": "sMSbWdcR-myBL2oqK",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "scuenh7R9rYWqfYAS"
+							},
+							"name": "Acrobatics",
+							"reference": "DFA72",
+							"tags": [
+								"Athletic"
+							],
+							"difficulty": "dx/h",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -6
+								},
+								{
+									"type": "skill",
+									"name": "Aerobatics",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Aquabatics",
+									"modifier": -4
+								}
+							],
+							"points": 1
 						},
 						{
-							"type": "skill",
-							"name": "Force Whip",
-							"modifier": -3
-						},
-						{
-							"type": "skill",
-							"name": "Kusari",
-							"modifier": -3
-						},
-						{
-							"type": "skill",
-							"name": "Monowire Whip",
-							"modifier": -3
-						}
-					],
-					"points": 1
-				}
-			]
-		},
-		{
-			"id": "StpplE_qO6UnIZnqz",
-			"name": "More skills",
-			"template_picker": {
-				"type": "points",
-				"qualifier": {
-					"compare": "at_most",
-					"qualifier": 4
-				}
-			},
-			"children": [
-				{
-					"id": "sMSbWdcR-myBL2oqK",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "scuenh7R9rYWqfYAS"
-					},
-					"name": "Acrobatics",
-					"reference": "DFA72",
-					"tags": [
-						"Athletic"
-					],
-					"difficulty": "dx/h",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -6
-						},
-						{
-							"type": "skill",
-							"name": "Aerobatics",
-							"modifier": -4
-						},
-						{
-							"type": "skill",
-							"name": "Aquabatics",
-							"modifier": -4
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sav-0_jmO6JCuA9wX",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "s8Z_Fqc5F4jKvCJ3E"
-					},
-					"name": "Armory",
-					"reference": "DFA73",
-					"tags": [
-						"Maintenance",
-						"Military",
-						"Repair"
-					],
-					"specialization": "Body Armor",
-					"difficulty": "iq/a",
-					"defaults": [
-						{
-							"type": "iq",
-							"modifier": -5
-						},
-						{
-							"type": "skill",
-							"name": "Engineer",
+							"id": "sav-0_jmO6JCuA9wX",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "s8Z_Fqc5F4jKvCJ3E"
+							},
+							"name": "Armory",
+							"reference": "DFA73",
+							"tags": [
+								"Maintenance",
+								"Military",
+								"Repair"
+							],
 							"specialization": "Body Armor",
-							"modifier": -4
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sAVIqTAESbxVuNkEI",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sv2cn5HXFG3hzzX2I"
-					},
-					"name": "Armory",
-					"reference": "DFA73",
-					"tags": [
-						"Maintenance",
-						"Military",
-						"Repair"
-					],
-					"specialization": "Melee Weapons",
-					"difficulty": "iq/a",
-					"defaults": [
-						{
-							"type": "iq",
-							"modifier": -5
+							"difficulty": "iq/a",
+							"defaults": [
+								{
+									"type": "iq",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Engineer",
+									"specialization": "Body Armor",
+									"modifier": -4
+								}
+							],
+							"points": 1
 						},
 						{
-							"type": "skill",
-							"name": "Engineer",
+							"id": "sAVIqTAESbxVuNkEI",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sv2cn5HXFG3hzzX2I"
+							},
+							"name": "Armory",
+							"reference": "DFA73",
+							"tags": [
+								"Maintenance",
+								"Military",
+								"Repair"
+							],
 							"specialization": "Melee Weapons",
-							"modifier": -4
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sbB257PZ1qA_fNfmu",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sgbWsoZDJKKa6ShB4"
-					},
-					"name": "Armory",
-					"reference": "DFA73",
-					"tags": [
-						"Maintenance",
-						"Military",
-						"Repair"
-					],
-					"specialization": "Missile Weapons",
-					"difficulty": "iq/a",
-					"defaults": [
-						{
-							"type": "iq",
-							"modifier": -5
+							"difficulty": "iq/a",
+							"defaults": [
+								{
+									"type": "iq",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Engineer",
+									"specialization": "Melee Weapons",
+									"modifier": -4
+								}
+							],
+							"points": 1
 						},
 						{
-							"type": "skill",
-							"name": "Engineer",
+							"id": "sbB257PZ1qA_fNfmu",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sgbWsoZDJKKa6ShB4"
+							},
+							"name": "Armory",
+							"reference": "DFA73",
+							"tags": [
+								"Maintenance",
+								"Military",
+								"Repair"
+							],
 							"specialization": "Missile Weapons",
-							"modifier": -4
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "svTDCEhXiA__3RGkk",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sFJjexRTguaUFx_dl"
-					},
-					"name": "Bolas",
-					"reference": "DFA73",
-					"tags": [
-						"Combat",
-						"Ranged Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/a",
-					"points": 1
-				},
-				{
-					"id": "s_zDa19WVADkfH6OO",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "skT71ydKUK_2EU6B1"
-					},
-					"name": "Boxing",
-					"reference": "DFA93",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/a",
-					"features": [
-						{
-							"type": "weapon_bonus",
-							"selection_type": "weapons_with_required_skill",
-							"name": {
-								"compare": "is",
-								"qualifier": "Boxing"
-							},
-							"level": {
-								"compare": "at_least",
-								"qualifier": 1
-							},
-							"amount": 1,
-							"per_die": true
+							"difficulty": "iq/a",
+							"defaults": [
+								{
+									"type": "iq",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Engineer",
+									"specialization": "Missile Weapons",
+									"modifier": -4
+								}
+							],
+							"points": 1
 						},
 						{
-							"type": "weapon_bonus",
-							"selection_type": "weapons_with_required_skill",
-							"name": {
-								"compare": "is",
-								"qualifier": "Boxing"
+							"id": "svTDCEhXiA__3RGkk",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sFJjexRTguaUFx_dl"
 							},
-							"level": {
-								"compare": "at_least",
-								"qualifier": 2
-							},
-							"amount": 1,
-							"per_die": true
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "stgHUe4Mi2l4rTKNY",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sUMFlX9EbNGNn31gm"
-					},
-					"name": "Brawling",
-					"reference": "DFA93",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/e",
-					"features": [
-						{
-							"type": "weapon_bonus",
-							"selection_type": "weapons_with_required_skill",
-							"name": {
-								"compare": "is",
-								"qualifier": "Brawling"
-							},
-							"level": {
-								"compare": "at_least",
-								"qualifier": 2
-							},
-							"amount": 1,
-							"per_die": true
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sAwQ_ORxYeFqfqnVt",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sZETcI3EbwyhIamKv"
-					},
-					"name": "Cloak",
-					"reference": "DFA74",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/a",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -5
+							"name": "Bolas",
+							"reference": "DFA73",
+							"tags": [
+								"Combat",
+								"Ranged Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"points": 1
 						},
 						{
-							"type": "skill",
-							"name": "Net",
-							"modifier": -4
+							"id": "s_zDa19WVADkfH6OO",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "skT71ydKUK_2EU6B1"
+							},
+							"name": "Boxing",
+							"reference": "DFA93",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"features": [
+								{
+									"type": "weapon_bonus",
+									"selection_type": "weapons_with_required_skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "Boxing"
+									},
+									"level": {
+										"compare": "at_least",
+										"qualifier": 1
+									},
+									"amount": 1,
+									"per_die": true
+								},
+								{
+									"type": "weapon_bonus",
+									"selection_type": "weapons_with_required_skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "Boxing"
+									},
+									"level": {
+										"compare": "at_least",
+										"qualifier": 2
+									},
+									"amount": 1,
+									"per_die": true
+								}
+							],
+							"points": 1
 						},
 						{
-							"type": "skill",
-							"name": "Shield",
-							"modifier": -4
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sRUDxMd8wXUZQSUW1",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sJTFFVKYH-2Xxr-pw"
-					},
-					"name": "Connoisseur",
-					"reference": "DFA74",
-					"tags": [
-						"Arts",
-						"Entertainment",
-						"Knowledge",
-						"Social"
-					],
-					"specialization": "Weapons",
-					"difficulty": "iq/a",
-					"defaults": [
+							"id": "stgHUe4Mi2l4rTKNY",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sUMFlX9EbNGNn31gm"
+							},
+							"name": "Brawling",
+							"reference": "DFA93",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/e",
+							"features": [
+								{
+									"type": "weapon_bonus",
+									"selection_type": "weapons_with_required_skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									},
+									"level": {
+										"compare": "at_least",
+										"qualifier": 2
+									},
+									"amount": 1,
+									"per_die": true
+								}
+							],
+							"points": 1
+						},
 						{
-							"type": "iq",
-							"modifier": -5
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "svjkF3q9LWIPXQmfi",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sY9q_60yrVFk1zB9C"
-					},
-					"name": "Fast-Draw",
-					"reference": "DFA76",
-					"tags": [
-						"Combat",
-						"Ranged Combat",
-						"Weapon"
-					],
-					"specialization": "@Item@",
-					"difficulty": "dx/e",
-					"points": 1
-				},
-				{
-					"id": "sHkJ1Z35BNoL4bK-j",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "spl6HsONkP4U_yiGF"
-					},
-					"name": "Fast-Draw",
-					"reference": "DFA76",
-					"tags": [
-						"Combat",
-						"Ranged Combat",
-						"Weapon"
-					],
-					"specialization": "Arrow",
-					"difficulty": "dx/e",
-					"points": 1
-				},
-				{
-					"id": "s66peu5eYh3uYehVn",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sbp0ZIqSgDOsmzl0k"
-					},
-					"name": "Fast-Draw",
-					"reference": "DFA76",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"specialization": "Knife",
-					"difficulty": "dx/e",
-					"points": 1
-				},
-				{
-					"id": "s-9wdlEFHJBfUJLzb",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sbp0ZIqSgDOsmzl0k"
-					},
-					"name": "Fast-Draw",
-					"reference": "DFA76",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"specialization": "Knife",
-					"difficulty": "dx/e",
-					"points": 1
-				},
-				{
-					"id": "stUUylGolOG0u226d",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sNMgBBvMxAf6BFBVp"
-					},
-					"name": "Fast-Draw",
-					"reference": "DFA76",
-					"tags": [
-						"Combat",
-						"Weapon"
-					],
-					"specialization": "Potion",
-					"difficulty": "dx/e",
-					"points": 1
-				},
-				{
-					"id": "sn6TeYGGJtNCL-7hH",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sewtBLqFyrI5BPm0X"
-					},
-					"name": "Fast-Draw",
-					"reference": "DFA76",
-					"tags": [
-						"Combat",
-						"Weapon"
-					],
-					"specialization": "Scroll",
-					"difficulty": "dx/e",
-					"points": 1
-				},
-				{
-					"id": "sh2qQZ0ubgU1SQ16Q",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sBJfuSGVIOG2aV5YG"
-					},
-					"name": "Fast-Draw",
-					"reference": "DFA76",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"specialization": "Sword",
-					"difficulty": "dx/e",
-					"points": 1
-				},
-				{
-					"id": "s_gPIDM43TSa2P9wJ",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sBJfuSGVIOG2aV5YG"
-					},
-					"name": "Fast-Draw",
-					"reference": "DFA76",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"specialization": "Sword",
-					"difficulty": "dx/e",
-					"points": 1
-				},
-				{
-					"id": "sW2s9BGA3G_mIWOgx",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sfZexpOBE4RZpeXe8"
-					},
-					"name": "Fast-Draw",
-					"reference": "DFA76",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"specialization": "Two-Handed Sword",
-					"difficulty": "dx/e",
-					"points": 1
-				},
-				{
-					"id": "sVgdZZN2aLtE_5t-q",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sfZexpOBE4RZpeXe8"
-					},
-					"name": "Fast-Draw",
-					"reference": "DFA76",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"specialization": "Two-Handed Sword",
-					"difficulty": "dx/e",
-					"points": 1
-				},
-				{
-					"id": "s3WAgyMtDruby8uMq",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "suSyUUdWZczFn4d5U"
-					},
-					"name": "Jumping",
-					"reference": "DFA79",
-					"tags": [
-						"Athletic"
-					],
-					"difficulty": "dx/e",
-					"points": 1
-				},
-				{
-					"id": "skIbF7dGz58HmCZpz",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "siGeFFoCAvEPuROH-"
-					},
-					"name": "Lasso",
-					"reference": "DFA80",
-					"tags": [
-						"Combat",
-						"Ranged Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/a",
-					"points": 1
-				},
-				{
-					"id": "swP-DWwYtWr5JKJ3A",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "s6U6i0W8Oj1FnQT7E"
-					},
-					"name": "Leadership",
-					"reference": "DFA80",
-					"tags": [
-						"Military",
-						"Social"
-					],
-					"difficulty": "iq/a",
-					"defaults": [
-						{
-							"type": "iq",
-							"modifier": -5
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sCz1jwQez5N0h9dff",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sZoNkW0Seu6Iy40ZF"
-					},
-					"name": "Net",
-					"reference": "DFA84",
-					"tags": [
-						"Combat",
-						"Ranged Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/h",
-					"defaults": [
-						{
-							"type": "skill",
+							"id": "sAwQ_ORxYeFqfqnVt",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sZETcI3EbwyhIamKv"
+							},
 							"name": "Cloak",
-							"modifier": -5
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sEwlXgWrq2006XqFQ",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sb31vE_obEUqvCSW1"
-					},
-					"name": "Shield",
-					"reference": "DFA88",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"specialization": "Buckler",
-					"difficulty": "dx/e",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -4
+							"reference": "DFA74",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Net",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Shield",
+									"modifier": -4
+								}
+							],
+							"points": 1
 						},
 						{
-							"type": "skill",
+							"id": "sRUDxMd8wXUZQSUW1",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sJTFFVKYH-2Xxr-pw"
+							},
+							"name": "Connoisseur",
+							"reference": "DFA74",
+							"tags": [
+								"Arts",
+								"Entertainment",
+								"Knowledge",
+								"Social"
+							],
+							"specialization": "Weapons",
+							"difficulty": "iq/a",
+							"defaults": [
+								{
+									"type": "iq",
+									"modifier": -5
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "svjkF3q9LWIPXQmfi",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sY9q_60yrVFk1zB9C"
+							},
+							"name": "Fast-Draw",
+							"reference": "DFA76",
+							"tags": [
+								"Combat",
+								"Ranged Combat",
+								"Weapon"
+							],
+							"specialization": "@Item@",
+							"difficulty": "dx/e",
+							"points": 1
+						},
+						{
+							"id": "sHkJ1Z35BNoL4bK-j",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "spl6HsONkP4U_yiGF"
+							},
+							"name": "Fast-Draw",
+							"reference": "DFA76",
+							"tags": [
+								"Combat",
+								"Ranged Combat",
+								"Weapon"
+							],
+							"specialization": "Arrow",
+							"difficulty": "dx/e",
+							"points": 1
+						},
+						{
+							"id": "s66peu5eYh3uYehVn",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sbp0ZIqSgDOsmzl0k"
+							},
+							"name": "Fast-Draw",
+							"reference": "DFA76",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"specialization": "Knife",
+							"difficulty": "dx/e",
+							"points": 1
+						},
+						{
+							"id": "s-9wdlEFHJBfUJLzb",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sbp0ZIqSgDOsmzl0k"
+							},
+							"name": "Fast-Draw",
+							"reference": "DFA76",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"specialization": "Knife",
+							"difficulty": "dx/e",
+							"points": 1
+						},
+						{
+							"id": "stUUylGolOG0u226d",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sNMgBBvMxAf6BFBVp"
+							},
+							"name": "Fast-Draw",
+							"reference": "DFA76",
+							"tags": [
+								"Combat",
+								"Weapon"
+							],
+							"specialization": "Potion",
+							"difficulty": "dx/e",
+							"points": 1
+						},
+						{
+							"id": "sn6TeYGGJtNCL-7hH",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sewtBLqFyrI5BPm0X"
+							},
+							"name": "Fast-Draw",
+							"reference": "DFA76",
+							"tags": [
+								"Combat",
+								"Weapon"
+							],
+							"specialization": "Scroll",
+							"difficulty": "dx/e",
+							"points": 1
+						},
+						{
+							"id": "sh2qQZ0ubgU1SQ16Q",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sBJfuSGVIOG2aV5YG"
+							},
+							"name": "Fast-Draw",
+							"reference": "DFA76",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"specialization": "Sword",
+							"difficulty": "dx/e",
+							"points": 1
+						},
+						{
+							"id": "s_gPIDM43TSa2P9wJ",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sBJfuSGVIOG2aV5YG"
+							},
+							"name": "Fast-Draw",
+							"reference": "DFA76",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"specialization": "Sword",
+							"difficulty": "dx/e",
+							"points": 1
+						},
+						{
+							"id": "sW2s9BGA3G_mIWOgx",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sfZexpOBE4RZpeXe8"
+							},
+							"name": "Fast-Draw",
+							"reference": "DFA76",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"specialization": "Two-Handed Sword",
+							"difficulty": "dx/e",
+							"points": 1
+						},
+						{
+							"id": "sVgdZZN2aLtE_5t-q",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sfZexpOBE4RZpeXe8"
+							},
+							"name": "Fast-Draw",
+							"reference": "DFA76",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"specialization": "Two-Handed Sword",
+							"difficulty": "dx/e",
+							"points": 1
+						},
+						{
+							"id": "s3WAgyMtDruby8uMq",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "suSyUUdWZczFn4d5U"
+							},
+							"name": "Jumping",
+							"reference": "DFA79",
+							"tags": [
+								"Athletic"
+							],
+							"difficulty": "dx/e",
+							"points": 1
+						},
+						{
+							"id": "skIbF7dGz58HmCZpz",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "siGeFFoCAvEPuROH-"
+							},
+							"name": "Lasso",
+							"reference": "DFA80",
+							"tags": [
+								"Combat",
+								"Ranged Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"points": 1
+						},
+						{
+							"id": "swP-DWwYtWr5JKJ3A",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "s6U6i0W8Oj1FnQT7E"
+							},
+							"name": "Leadership",
+							"reference": "DFA80",
+							"tags": [
+								"Military",
+								"Social"
+							],
+							"difficulty": "iq/a",
+							"defaults": [
+								{
+									"type": "iq",
+									"modifier": -5
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "sCz1jwQez5N0h9dff",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sZoNkW0Seu6Iy40ZF"
+							},
+							"name": "Net",
+							"reference": "DFA84",
+							"tags": [
+								"Combat",
+								"Ranged Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/h",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Cloak",
+									"modifier": -5
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "sEwlXgWrq2006XqFQ",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sb31vE_obEUqvCSW1"
+							},
 							"name": "Shield",
-							"modifier": -2
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sZ8x7ECBEgIl_V7e5",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sxrJ0547O4bP-EuZX"
-					},
-					"name": "Shield",
-					"reference": "DFA88",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"specialization": "Shield",
-					"difficulty": "dx/e",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -4
+							"reference": "DFA88",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"specialization": "Buckler",
+							"difficulty": "dx/e",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Shield",
+									"modifier": -2
+								}
+							],
+							"points": 1
 						},
 						{
-							"type": "skill",
+							"id": "sZ8x7ECBEgIl_V7e5",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sxrJ0547O4bP-EuZX"
+							},
 							"name": "Shield",
-							"modifier": -2
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "scy5GtNxrsEk3oy3r",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "s0pHY2syssWuCG-qz"
-					},
-					"name": "Strategy",
-					"reference": "DFA90",
-					"tags": [
-						"Military"
-					],
-					"difficulty": "iq/h",
-					"defaults": [
-						{
-							"type": "iq",
-							"modifier": -6
+							"reference": "DFA88",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"specialization": "Shield",
+							"difficulty": "dx/e",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Shield",
+									"modifier": -2
+								}
+							],
+							"points": 1
 						},
 						{
-							"type": "skill",
-							"name": "Intelligence Analysis",
-							"modifier": -6
-						},
-						{
-							"type": "skill",
-							"name": "Tactics",
-							"modifier": -6
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sewFXFL-P3_t_7OK9",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "s-frTjkdCJ6_KKlLd"
-					},
-					"name": "Sumo Wrestling",
-					"reference": "DFA92",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/a",
-					"points": 1
-				},
-				{
-					"id": "s5JI7Nxpjh3Nw7E1p",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sqbg3yPHHTT0fHqmM"
-					},
-					"name": "Tactics",
-					"reference": "DFA91",
-					"tags": [
-						"Military",
-						"Police"
-					],
-					"difficulty": "iq/h",
-					"defaults": [
-						{
-							"type": "iq",
-							"modifier": -6
-						},
-						{
-							"type": "skill",
+							"id": "scy5GtNxrsEk3oy3r",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "s0pHY2syssWuCG-qz"
+							},
 							"name": "Strategy",
-							"modifier": -6
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sI9GJfhv9GoKSNxWQ",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sfIBMIcJimmn5pfKb"
-					},
-					"name": "Thrown Weapon",
-					"reference": "DFA91",
-					"tags": [
-						"Combat",
-						"Ranged Combat",
-						"Weapon"
-					],
-					"specialization": "@Specialty@",
-					"difficulty": "dx/e",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -4
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "s9wVhNWU4hKBpaSlA",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "s4m9kK3YxR976CoPq"
-					},
-					"name": "Thrown Weapon",
-					"reference": "DFA91",
-					"tags": [
-						"Combat",
-						"Ranged Combat",
-						"Weapon"
-					],
-					"specialization": "Axe/Mace",
-					"difficulty": "dx/e",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -4
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "scAw2Cl5sORCsUcQU",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sYUO1vNflndTvzMrZ"
-					},
-					"name": "Thrown Weapon",
-					"reference": "DFA91",
-					"tags": [
-						"Combat",
-						"Ranged Combat",
-						"Weapon"
-					],
-					"specialization": "Dart",
-					"difficulty": "dx/e",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -4
+							"reference": "DFA90",
+							"tags": [
+								"Military"
+							],
+							"difficulty": "iq/h",
+							"defaults": [
+								{
+									"type": "iq",
+									"modifier": -6
+								},
+								{
+									"type": "skill",
+									"name": "Intelligence Analysis",
+									"modifier": -6
+								},
+								{
+									"type": "skill",
+									"name": "Tactics",
+									"modifier": -6
+								}
+							],
+							"points": 1
 						},
 						{
-							"type": "skill",
-							"name": "Throwing",
-							"modifier": -2
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sA7gtdXFOlfsDLpJR",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "szmD99yJ2Es1Pz073"
-					},
-					"name": "Thrown Weapon",
-					"reference": "DFA91",
-					"tags": [
-						"Combat",
-						"Ranged Combat",
-						"Weapon"
-					],
-					"specialization": "Harpoon",
-					"difficulty": "dx/e",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -4
+							"id": "sewFXFL-P3_t_7OK9",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "s-frTjkdCJ6_KKlLd"
+							},
+							"name": "Sumo Wrestling",
+							"reference": "DFA92",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"points": 1
 						},
 						{
-							"type": "skill",
+							"id": "s5JI7Nxpjh3Nw7E1p",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sqbg3yPHHTT0fHqmM"
+							},
+							"name": "Tactics",
+							"reference": "DFA91",
+							"tags": [
+								"Military",
+								"Police"
+							],
+							"difficulty": "iq/h",
+							"defaults": [
+								{
+									"type": "iq",
+									"modifier": -6
+								},
+								{
+									"type": "skill",
+									"name": "Strategy",
+									"modifier": -6
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "sI9GJfhv9GoKSNxWQ",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sfIBMIcJimmn5pfKb"
+							},
 							"name": "Thrown Weapon",
-							"specialization": "Spear",
-							"modifier": -2
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "swiIjH9I1hQsVr0wR",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "sSg3_t4o1EY_D2rUk"
-					},
-					"name": "Thrown Weapon",
-					"reference": "DFA91",
-					"tags": [
-						"Combat",
-						"Ranged Combat",
-						"Weapon"
-					],
-					"specialization": "Knife",
-					"difficulty": "dx/e",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -4
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sVux6EqLQjBla9ezD",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "szhrMhk40Z91o5EVk"
-					},
-					"name": "Thrown Weapon",
-					"reference": "DFA91",
-					"tags": [
-						"Combat",
-						"Ranged Combat",
-						"Weapon"
-					],
-					"specialization": "Shuriken",
-					"difficulty": "dx/e",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -4
+							"reference": "DFA91",
+							"tags": [
+								"Combat",
+								"Ranged Combat",
+								"Weapon"
+							],
+							"specialization": "@Specialty@",
+							"difficulty": "dx/e",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -4
+								}
+							],
+							"points": 1
 						},
 						{
-							"type": "skill",
-							"name": "Throwing",
-							"modifier": -2
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sU-XdTpeiXFjSZm32",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "se0Y7kYJUaeXFj5Ns"
-					},
-					"name": "Thrown Weapon",
-					"reference": "DFA91",
-					"tags": [
-						"Combat",
-						"Ranged Combat",
-						"Weapon"
-					],
-					"specialization": "Spear",
-					"difficulty": "dx/e",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -4
-						},
-						{
-							"type": "skill",
-							"name": "Spear Thrower",
-							"modifier": -4
-						},
-						{
-							"type": "skill",
+							"id": "s9wVhNWU4hKBpaSlA",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "s4m9kK3YxR976CoPq"
+							},
 							"name": "Thrown Weapon",
+							"reference": "DFA91",
+							"tags": [
+								"Combat",
+								"Ranged Combat",
+								"Weapon"
+							],
+							"specialization": "Axe/Mace",
+							"difficulty": "dx/e",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -4
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "scAw2Cl5sORCsUcQU",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sYUO1vNflndTvzMrZ"
+							},
+							"name": "Thrown Weapon",
+							"reference": "DFA91",
+							"tags": [
+								"Combat",
+								"Ranged Combat",
+								"Weapon"
+							],
+							"specialization": "Dart",
+							"difficulty": "dx/e",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Throwing",
+									"modifier": -2
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "sA7gtdXFOlfsDLpJR",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "szmD99yJ2Es1Pz073"
+							},
+							"name": "Thrown Weapon",
+							"reference": "DFA91",
+							"tags": [
+								"Combat",
+								"Ranged Combat",
+								"Weapon"
+							],
 							"specialization": "Harpoon",
-							"modifier": -2
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sSJezeFqWqfuDVgXm",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "s4rogZ8xmgXgQVGPl"
-					},
-					"name": "Thrown Weapon",
-					"reference": "DFA91",
-					"tags": [
-						"Combat",
-						"Ranged Combat",
-						"Weapon"
-					],
-					"specialization": "Stick",
-					"difficulty": "dx/e",
-					"defaults": [
+							"difficulty": "dx/e",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Thrown Weapon",
+									"specialization": "Spear",
+									"modifier": -2
+								}
+							],
+							"points": 1
+						},
 						{
-							"type": "dx",
-							"modifier": -4
+							"id": "swiIjH9I1hQsVr0wR",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sSg3_t4o1EY_D2rUk"
+							},
+							"name": "Thrown Weapon",
+							"reference": "DFA91",
+							"tags": [
+								"Combat",
+								"Ranged Combat",
+								"Weapon"
+							],
+							"specialization": "Knife",
+							"difficulty": "dx/e",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -4
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "sVux6EqLQjBla9ezD",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "szhrMhk40Z91o5EVk"
+							},
+							"name": "Thrown Weapon",
+							"reference": "DFA91",
+							"tags": [
+								"Combat",
+								"Ranged Combat",
+								"Weapon"
+							],
+							"specialization": "Shuriken",
+							"difficulty": "dx/e",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Throwing",
+									"modifier": -2
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "sU-XdTpeiXFjSZm32",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "se0Y7kYJUaeXFj5Ns"
+							},
+							"name": "Thrown Weapon",
+							"reference": "DFA91",
+							"tags": [
+								"Combat",
+								"Ranged Combat",
+								"Weapon"
+							],
+							"specialization": "Spear",
+							"difficulty": "dx/e",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Spear Thrower",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Thrown Weapon",
+									"specialization": "Harpoon",
+									"modifier": -2
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "sSJezeFqWqfuDVgXm",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "s4rogZ8xmgXgQVGPl"
+							},
+							"name": "Thrown Weapon",
+							"reference": "DFA91",
+							"tags": [
+								"Combat",
+								"Ranged Combat",
+								"Weapon"
+							],
+							"specialization": "Stick",
+							"difficulty": "dx/e",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -4
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "s5PC2VHqH81F-Aj2Z",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "s6iSa3lbnEODwEzdw"
+							},
+							"name": "Wrestling",
+							"reference": "DFA93",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"points": 1
 						}
-					],
-					"points": 1
-				},
-				{
-					"id": "s5PC2VHqH81F-Aj2Z",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "s6iSa3lbnEODwEzdw"
-					},
-					"name": "Wrestling",
-					"reference": "DFA93",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/a",
-					"points": 1
+					]
 				}
 			]
 		}

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Finesse Warrior.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Finesse Warrior.gct
@@ -7382,6 +7382,29 @@
 							"points": 1
 						},
 						{
+							"id": "sWwn55xZPvV7IqqXK",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sIFnUEojIsUlx7qhk"
+							},
+							"name": "Blowpipe",
+							"reference": "DFA83",
+							"tags": [
+								"Combat",
+								"Ranged Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/h",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -6
+								}
+							],
+							"points": 1
+						},
+						{
 							"id": "svTDCEhXiA__3RGkk",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
@@ -7396,6 +7419,29 @@
 								"Weapon"
 							],
 							"difficulty": "dx/a",
+							"points": 1
+						},
+						{
+							"id": "stoZUPhp7yKTc6cMd",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sYDZCCmi6CWN3HSlo"
+							},
+							"name": "Bow",
+							"reference": "DFA83",
+							"tags": [
+								"Combat",
+								"Ranged Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								}
+							],
 							"points": 1
 						},
 						{
@@ -7532,6 +7578,29 @@
 								{
 									"type": "iq",
 									"modifier": -5
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "sBcGRqb_835A_3nVO",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "siLtfKMGscHt8l2zM"
+							},
+							"name": "Crossbow",
+							"reference": "DFA83",
+							"tags": [
+								"Combat",
+								"Ranged Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/e",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -4
 								}
 							],
 							"points": 1
@@ -7792,6 +7861,58 @@
 									"type": "skill",
 									"name": "Shield",
 									"modifier": -2
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "sl1Mg-x8f7T_VXGns",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sShSlwZ4dPx-_E_wX"
+							},
+							"name": "Sling",
+							"reference": "DFA83",
+							"tags": [
+								"Combat",
+								"Ranged Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/h",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -6
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "sGjN6K2mPPDkZogL6",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sMa_w6SbyAhh9y3Bl"
+							},
+							"name": "Spear Thrower",
+							"reference": "DFA83",
+							"tags": [
+								"Combat",
+								"Ranged Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Thrown Weapon",
+									"specialization": "Spear",
+									"modifier": -4
 								}
 							],
 							"points": 1

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Finesse Warrior.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Finesse Warrior.gct
@@ -7573,24 +7573,6 @@
 							"points": 1
 						},
 						{
-							"id": "s66peu5eYh3uYehVn",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-								"id": "sbp0ZIqSgDOsmzl0k"
-							},
-							"name": "Fast-Draw",
-							"reference": "DFA76",
-							"tags": [
-								"Combat",
-								"Melee Combat",
-								"Weapon"
-							],
-							"specialization": "Knife",
-							"difficulty": "dx/e",
-							"points": 1
-						},
-						{
 							"id": "s-9wdlEFHJBfUJLzb",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
@@ -7643,24 +7625,6 @@
 							"points": 1
 						},
 						{
-							"id": "sh2qQZ0ubgU1SQ16Q",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-								"id": "sBJfuSGVIOG2aV5YG"
-							},
-							"name": "Fast-Draw",
-							"reference": "DFA76",
-							"tags": [
-								"Combat",
-								"Melee Combat",
-								"Weapon"
-							],
-							"specialization": "Sword",
-							"difficulty": "dx/e",
-							"points": 1
-						},
-						{
 							"id": "s_gPIDM43TSa2P9wJ",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
@@ -7675,24 +7639,6 @@
 								"Weapon"
 							],
 							"specialization": "Sword",
-							"difficulty": "dx/e",
-							"points": 1
-						},
-						{
-							"id": "sW2s9BGA3G_mIWOgx",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-								"id": "sfZexpOBE4RZpeXe8"
-							},
-							"name": "Fast-Draw",
-							"reference": "DFA76",
-							"tags": [
-								"Combat",
-								"Melee Combat",
-								"Weapon"
-							],
-							"specialization": "Two-Handed Sword",
 							"difficulty": "dx/e",
 							"points": 1
 						},

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Mage 2.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Mage 2.gct
@@ -192,7 +192,7 @@
 	"spells": [
 		{
 			"id": "P-z2OUbKB_0iB-6lA",
-			"name": "More Wizardly Spells",
+			"name": "Mage 2 Wizard Spells",
 			"template_picker": {
 				"type": "points",
 				"qualifier": {

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Mage.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Mage.gct
@@ -210,7 +210,7 @@
 	"spells": [
 		{
 			"id": "P-z2OUbKB_0iB-6lA",
-			"name": "Wizard Spells",
+			"name": "Mage Wizard Spells",
 			"template_picker": {
 				"type": "points",
 				"qualifier": {

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Master Archer 2.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Master Archer 2.gct
@@ -9,7 +9,7 @@
 			"children": [
 				{
 					"id": "T4e1ENbMtxCTEhxsu",
-					"name": "Class Advantages",
+					"name": "Advantages",
 					"children": [
 						{
 							"id": "TmM7VMCwe0nnOiiRF",

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Master Archer.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Master Archer.gct
@@ -9,7 +9,7 @@
 			"children": [
 				{
 					"id": "T4e1ENbMtxCTEhxsu",
-					"name": "Class Advantages",
+					"name": "Advantages",
 					"children": [
 						{
 							"id": "t6NiS9PY7bk2Vg1JH",

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Medic.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Medic.gct
@@ -273,793 +273,787 @@
 	],
 	"skills": [
 		{
-			"id": "S1fRbMadC2Yiqf93q",
+			"id": "SVYvoOQxZl0L6ziAs",
 			"name": "Medic",
+			"template_picker": {
+				"type": "points",
+				"qualifier": {
+					"compare": "at_most",
+					"qualifier": 50
+				}
+			},
 			"children": [
 				{
-					"id": "SVYvoOQxZl0L6ziAs",
-					"name": "Medic",
-					"template_picker": {
-						"type": "points",
-						"qualifier": {
-							"compare": "at_most",
-							"qualifier": 50
-						}
+					"id": "sY5PunyodsqZXJpAw",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+						"id": "sJLYZTE4QWPQ1g2SM"
 					},
-					"children": [
+					"name": "Alchemy",
+					"reference": "DFA72",
+					"tags": [
+						"Magical",
+						"Natural Science",
+						"Occult"
+					],
+					"difficulty": "iq/vh",
+					"points": 1
+				},
+				{
+					"id": "soUb-BZdfWuOhGN8o",
+					"name": "Diagnosis",
+					"reference": "DFA75",
+					"tags": [
+						"Medical"
+					],
+					"difficulty": "iq/h",
+					"defaults": [
 						{
-							"id": "sY5PunyodsqZXJpAw",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-								"id": "sJLYZTE4QWPQ1g2SM"
-							},
-							"name": "Alchemy",
-							"reference": "DFA72",
-							"tags": [
-								"Magical",
-								"Natural Science",
-								"Occult"
-							],
-							"difficulty": "iq/vh",
-							"points": 1
+							"type": "iq",
+							"modifier": -6
 						},
 						{
-							"id": "soUb-BZdfWuOhGN8o",
-							"name": "Diagnosis",
-							"reference": "DFA75",
-							"tags": [
-								"Medical"
-							],
-							"difficulty": "iq/h",
-							"defaults": [
-								{
-									"type": "iq",
-									"modifier": -6
-								},
-								{
-									"type": "skill",
-									"name": "First Aid",
-									"modifier": -8
-								},
-								{
-									"type": "skill",
-									"name": "Physician",
-									"modifier": -4
-								},
-								{
-									"type": "skill",
-									"name": "Veterinary",
-									"modifier": -5
-								}
-							],
-							"points": 1
-						},
-						{
-							"id": "sNtGI3kROP8jFqN0i",
+							"type": "skill",
 							"name": "First Aid",
-							"reference": "DFA76",
-							"tags": [
-								"Everyman",
-								"Medical"
-							],
-							"difficulty": "iq/e",
-							"defaults": [
-								{
-									"type": "iq",
-									"modifier": -4
-								},
-								{
-									"type": "skill",
-									"name": "Esoteric Medicine"
-								},
-								{
-									"type": "skill",
-									"name": "Physician"
-								},
-								{
-									"type": "skill",
-									"name": "Veterinary",
-									"modifier": -4
-								}
-							],
-							"points": 1
+							"modifier": -8
 						},
 						{
-							"id": "svM_9-5Yvq4Fjtq_q",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-								"id": "s6OY3-_51fIBpUIJy"
-							},
-							"name": "Pharmacy",
-							"reference": "DFA85",
-							"tags": [
-								"Design",
-								"Invention",
-								"Medical",
-								"Plant"
-							],
-							"difficulty": "iq/h",
-							"defaults": [
-								{
-									"type": "iq",
-									"modifier": -6
-								},
-								{
-									"type": "skill",
-									"name": "Biology",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Herb Lore",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Naturalist",
-									"modifier": -5
-								}
-							],
-							"prereqs": {
-								"type": "prereq_list",
-								"all": true,
-								"prereqs": [
-									{
-										"type": "skill_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "naturalist"
-										}
-									}
-								]
-							},
-							"points": 1
+							"type": "skill",
+							"name": "Physician",
+							"modifier": -4
 						},
 						{
-							"id": "sUR8FrW5aM_UvaAsE",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-								"id": "seUvUs272kXMrn8kV"
-							},
-							"name": "Physiology",
-							"reference": "DFA85",
-							"tags": [
-								"Medical",
-								"Natural Science"
-							],
-							"specialization": "@Specialty@",
-							"difficulty": "iq/h",
-							"defaults": [
-								{
-									"type": "iq",
-									"modifier": -6
-								},
-								{
-									"type": "skill",
-									"name": "Diagnosis",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Physician",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Surgery",
-									"modifier": -5
-								}
-							],
-							"points": 1
-						},
-						{
-							"id": "sNQ3HOTzqO01ZnKt3",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-								"id": "swkojEOpeCdjVGSkp"
-							},
-							"name": "Physiology",
-							"reference": "DFA85",
-							"tags": [
-								"Medical",
-								"Natural Science"
-							],
-							"specialization": "Animals",
-							"difficulty": "iq/h",
-							"defaults": [
-								{
-									"type": "iq",
-									"modifier": -6
-								},
-								{
-									"type": "skill",
-									"name": "Diagnosis",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Physician",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Surgery",
-									"modifier": -5
-								}
-							],
-							"points": 1
-						},
-						{
-							"id": "sOa1ETi-z86_AoF9B",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-								"id": "saGZWGOpaJoIHnSOY"
-							},
-							"name": "Physiology",
-							"reference": "DFA85",
-							"tags": [
-								"Medical",
-								"Natural Science"
-							],
-							"specialization": "Constructs",
-							"difficulty": "iq/h",
-							"defaults": [
-								{
-									"type": "iq",
-									"modifier": -6
-								},
-								{
-									"type": "skill",
-									"name": "Diagnosis",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Physician",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Surgery",
-									"modifier": -5
-								}
-							],
-							"points": 1
-						},
-						{
-							"id": "sYTeXIexCbbUU1ofh",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-								"id": "sTapQXf_vUfqQ4sFz"
-							},
-							"name": "Physiology",
-							"reference": "DFA85",
-							"tags": [
-								"Medical",
-								"Natural Science"
-							],
-							"specialization": "Demons",
-							"difficulty": "iq/h",
-							"defaults": [
-								{
-									"type": "iq",
-									"modifier": -6
-								},
-								{
-									"type": "skill",
-									"name": "Diagnosis",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Physician",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Surgery",
-									"modifier": -5
-								}
-							],
-							"points": 1
-						},
-						{
-							"id": "sovAJHeSHx1CH-iFj",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-								"id": "sg2FK6QXcC6YI91KQ"
-							},
-							"name": "Physiology",
-							"reference": "DFA85",
-							"tags": [
-								"Medical",
-								"Natural Science"
-							],
-							"specialization": "Elementals",
-							"difficulty": "iq/h",
-							"defaults": [
-								{
-									"type": "iq",
-									"modifier": -6
-								},
-								{
-									"type": "skill",
-									"name": "Diagnosis",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Physician",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Surgery",
-									"modifier": -5
-								}
-							],
-							"points": 1
-						},
-						{
-							"id": "sqdyldeOt6gH60GYl",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-								"id": "sninxx38w0NwPYxEY"
-							},
-							"name": "Physiology",
-							"reference": "DFA85",
-							"tags": [
-								"Medical",
-								"Natural Science"
-							],
-							"specialization": "Faeries",
-							"difficulty": "iq/h",
-							"defaults": [
-								{
-									"type": "iq",
-									"modifier": -6
-								},
-								{
-									"type": "skill",
-									"name": "Diagnosis",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Physician",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Surgery",
-									"modifier": -5
-								}
-							],
-							"points": 1
-						},
-						{
-							"id": "s0satzds-TW7zuG6P",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-								"id": "sHtMGKXgEs3fccdDs"
-							},
-							"name": "Physiology",
-							"reference": "DFA85",
-							"tags": [
-								"Medical",
-								"Natural Science"
-							],
-							"specialization": "Hybrids",
-							"difficulty": "iq/h",
-							"defaults": [
-								{
-									"type": "iq",
-									"modifier": -6
-								},
-								{
-									"type": "skill",
-									"name": "Diagnosis",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Physician",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Surgery",
-									"modifier": -5
-								}
-							],
-							"points": 1
-						},
-						{
-							"id": "s0aa_qZYTPBROX6pJ",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-								"id": "sS7e5O92FHxMh6YMG"
-							},
-							"name": "Physiology",
-							"reference": "DFA85",
-							"tags": [
-								"Medical",
-								"Natural Science"
-							],
-							"specialization": "Plants",
-							"difficulty": "iq/h",
-							"defaults": [
-								{
-									"type": "iq",
-									"modifier": -6
-								},
-								{
-									"type": "skill",
-									"name": "Diagnosis",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Physician",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Surgery",
-									"modifier": -5
-								}
-							],
-							"points": 1
-						},
-						{
-							"id": "sHdHKfLlsNkWyGo7Z",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-								"id": "s78aEoTl2PodAOKZg"
-							},
-							"name": "Physiology",
-							"reference": "DFA85",
-							"tags": [
-								"Medical",
-								"Natural Science"
-							],
-							"specialization": "Undead",
-							"difficulty": "iq/h",
-							"defaults": [
-								{
-									"type": "iq",
-									"modifier": -6
-								},
-								{
-									"type": "skill",
-									"name": "Diagnosis",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Physician",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Surgery",
-									"modifier": -5
-								}
-							],
-							"points": 1
-						},
-						{
-							"id": "sRnRTnDRZ-iJow5L8",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-								"id": "sdCxwV_3hVKSqFI_D"
-							},
-							"name": "Poisons",
-							"reference": "DFA85",
-							"tags": [
-								"Criminal",
-								"Medical",
-								"Spy",
-								"Street"
-							],
-							"difficulty": "iq/h",
-							"defaults": [
-								{
-									"type": "iq",
-									"modifier": -6
-								},
-								{
-									"type": "skill",
-									"name": "Chemistry",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Pharmacy",
-									"modifier": -3
-								},
-								{
-									"type": "skill",
-									"name": "Physician",
-									"modifier": -3
-								}
-							],
-							"points": 1
-						},
-						{
-							"id": "sXmhnkWA2bx9U1_K_",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-								"id": "sBBc8Wnwoz4U2-6b8"
-							},
-							"name": "Psychology",
-							"reference": "DFA86",
-							"tags": [
-								"Humanities",
-								"Social Sciences"
-							],
-							"specialization": "@Specialty@",
-							"difficulty": "iq/h",
-							"defaults": [
-								{
-									"type": "iq",
-									"modifier": -6
-								},
-								{
-									"type": "skill",
-									"name": "Sociology",
-									"modifier": -4
-								}
-							],
-							"points": 1
-						},
-						{
-							"id": "suUweH4X2M7yliEOT",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-								"id": "sRIpwO4cRfNcyPoxA"
-							},
-							"name": "Psychology",
-							"reference": "DFA86",
-							"tags": [
-								"Humanities",
-								"Social Sciences"
-							],
-							"specialization": "Constructs",
-							"difficulty": "iq/h",
-							"defaults": [
-								{
-									"type": "iq",
-									"modifier": -6
-								},
-								{
-									"type": "skill",
-									"name": "Sociology",
-									"modifier": -4
-								}
-							],
-							"points": 1
-						},
-						{
-							"id": "s7sBG0GKTl_MABowo",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-								"id": "s2VRslPIZ_xcE4GSj"
-							},
-							"name": "Psychology",
-							"reference": "DFA86",
-							"tags": [
-								"Humanities",
-								"Social Sciences"
-							],
-							"specialization": "Demons",
-							"difficulty": "iq/h",
-							"defaults": [
-								{
-									"type": "iq",
-									"modifier": -6
-								},
-								{
-									"type": "skill",
-									"name": "Sociology",
-									"modifier": -4
-								}
-							],
-							"points": 1
-						},
-						{
-							"id": "sDtGUMiKvLCQFPdj9",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-								"id": "sX5mhj-90odRSFsc3"
-							},
-							"name": "Psychology",
-							"reference": "DFA86",
-							"tags": [
-								"Humanities",
-								"Social Sciences"
-							],
-							"specialization": "Elementals",
-							"difficulty": "iq/h",
-							"defaults": [
-								{
-									"type": "iq",
-									"modifier": -6
-								},
-								{
-									"type": "skill",
-									"name": "Sociology",
-									"modifier": -4
-								}
-							],
-							"points": 1
-						},
-						{
-							"id": "srjBtuoWd2GVnlNGB",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-								"id": "svbmguWl7xKUYK1lP"
-							},
-							"name": "Psychology",
-							"reference": "DFA86",
-							"tags": [
-								"Humanities",
-								"Social Sciences"
-							],
-							"specialization": "Faeries",
-							"difficulty": "iq/h",
-							"defaults": [
-								{
-									"type": "iq",
-									"modifier": -6
-								},
-								{
-									"type": "skill",
-									"name": "Sociology",
-									"modifier": -4
-								}
-							],
-							"points": 1
-						},
-						{
-							"id": "s379G5Z6mHnbs9mN8",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-								"id": "sREhRSZB1iizxsZ4B"
-							},
-							"name": "Psychology",
-							"reference": "DFA86",
-							"tags": [
-								"Humanities",
-								"Social Sciences"
-							],
-							"specialization": "Undead",
-							"difficulty": "iq/h",
-							"defaults": [
-								{
-									"type": "iq",
-									"modifier": -6
-								},
-								{
-									"type": "skill",
-									"name": "Sociology",
-									"modifier": -4
-								}
-							],
-							"points": 1
-						},
-						{
-							"id": "s2mqDa_ubdHkiMUbv",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-								"id": "sGh3GER1SZtvucXxe"
-							},
-							"name": "Surgery",
-							"reference": "DFA90",
-							"tags": [
-								"Medical"
-							],
-							"difficulty": "iq/vh",
-							"defaults": [
-								{
-									"type": "skill",
-									"name": "First Aid",
-									"modifier": -12
-								},
-								{
-									"type": "skill",
-									"name": "Physician",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Physiology",
-									"modifier": -8
-								},
-								{
-									"type": "skill",
-									"name": "Veterinary",
-									"modifier": -5
-								}
-							],
-							"prereqs": {
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "skill_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "first aid"
-										}
-									},
-									{
-										"type": "skill_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "physician"
-										}
-									}
-								]
-							},
-							"points": 1
-						},
-						{
-							"id": "sYMnyzLLdPhqkd8j7",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-								"id": "sOt0ouAuX_84rlANE"
-							},
+							"type": "skill",
 							"name": "Veterinary",
-							"reference": "DFA94",
-							"tags": [
-								"Animal",
-								"Medical"
-							],
-							"difficulty": "iq/h",
-							"defaults": [
-								{
-									"type": "skill",
-									"name": "Animal Handling",
-									"modifier": -6
-								},
-								{
-									"type": "skill",
-									"name": "Esoteric Medicine",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Surgery",
-									"modifier": -5
-								}
-							],
-							"points": 1
+							"modifier": -5
 						}
-					]
+					],
+					"points": 1
+				},
+				{
+					"id": "sNtGI3kROP8jFqN0i",
+					"name": "First Aid",
+					"reference": "DFA76",
+					"tags": [
+						"Everyman",
+						"Medical"
+					],
+					"difficulty": "iq/e",
+					"defaults": [
+						{
+							"type": "iq",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Esoteric Medicine"
+						},
+						{
+							"type": "skill",
+							"name": "Physician"
+						},
+						{
+							"type": "skill",
+							"name": "Veterinary",
+							"modifier": -4
+						}
+					],
+					"points": 1
+				},
+				{
+					"id": "svM_9-5Yvq4Fjtq_q",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+						"id": "s6OY3-_51fIBpUIJy"
+					},
+					"name": "Pharmacy",
+					"reference": "DFA85",
+					"tags": [
+						"Design",
+						"Invention",
+						"Medical",
+						"Plant"
+					],
+					"difficulty": "iq/h",
+					"defaults": [
+						{
+							"type": "iq",
+							"modifier": -6
+						},
+						{
+							"type": "skill",
+							"name": "Biology",
+							"modifier": -5
+						},
+						{
+							"type": "skill",
+							"name": "Herb Lore",
+							"modifier": -5
+						},
+						{
+							"type": "skill",
+							"name": "Naturalist",
+							"modifier": -5
+						}
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "skill_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "naturalist"
+								}
+							}
+						]
+					},
+					"points": 1
+				},
+				{
+					"id": "sUR8FrW5aM_UvaAsE",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+						"id": "seUvUs272kXMrn8kV"
+					},
+					"name": "Physiology",
+					"reference": "DFA85",
+					"tags": [
+						"Medical",
+						"Natural Science"
+					],
+					"specialization": "@Specialty@",
+					"difficulty": "iq/h",
+					"defaults": [
+						{
+							"type": "iq",
+							"modifier": -6
+						},
+						{
+							"type": "skill",
+							"name": "Diagnosis",
+							"modifier": -5
+						},
+						{
+							"type": "skill",
+							"name": "Physician",
+							"modifier": -5
+						},
+						{
+							"type": "skill",
+							"name": "Surgery",
+							"modifier": -5
+						}
+					],
+					"points": 1
+				},
+				{
+					"id": "sNQ3HOTzqO01ZnKt3",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+						"id": "swkojEOpeCdjVGSkp"
+					},
+					"name": "Physiology",
+					"reference": "DFA85",
+					"tags": [
+						"Medical",
+						"Natural Science"
+					],
+					"specialization": "Animals",
+					"difficulty": "iq/h",
+					"defaults": [
+						{
+							"type": "iq",
+							"modifier": -6
+						},
+						{
+							"type": "skill",
+							"name": "Diagnosis",
+							"modifier": -5
+						},
+						{
+							"type": "skill",
+							"name": "Physician",
+							"modifier": -5
+						},
+						{
+							"type": "skill",
+							"name": "Surgery",
+							"modifier": -5
+						}
+					],
+					"points": 1
+				},
+				{
+					"id": "sOa1ETi-z86_AoF9B",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+						"id": "saGZWGOpaJoIHnSOY"
+					},
+					"name": "Physiology",
+					"reference": "DFA85",
+					"tags": [
+						"Medical",
+						"Natural Science"
+					],
+					"specialization": "Constructs",
+					"difficulty": "iq/h",
+					"defaults": [
+						{
+							"type": "iq",
+							"modifier": -6
+						},
+						{
+							"type": "skill",
+							"name": "Diagnosis",
+							"modifier": -5
+						},
+						{
+							"type": "skill",
+							"name": "Physician",
+							"modifier": -5
+						},
+						{
+							"type": "skill",
+							"name": "Surgery",
+							"modifier": -5
+						}
+					],
+					"points": 1
+				},
+				{
+					"id": "sYTeXIexCbbUU1ofh",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+						"id": "sTapQXf_vUfqQ4sFz"
+					},
+					"name": "Physiology",
+					"reference": "DFA85",
+					"tags": [
+						"Medical",
+						"Natural Science"
+					],
+					"specialization": "Demons",
+					"difficulty": "iq/h",
+					"defaults": [
+						{
+							"type": "iq",
+							"modifier": -6
+						},
+						{
+							"type": "skill",
+							"name": "Diagnosis",
+							"modifier": -5
+						},
+						{
+							"type": "skill",
+							"name": "Physician",
+							"modifier": -5
+						},
+						{
+							"type": "skill",
+							"name": "Surgery",
+							"modifier": -5
+						}
+					],
+					"points": 1
+				},
+				{
+					"id": "sovAJHeSHx1CH-iFj",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+						"id": "sg2FK6QXcC6YI91KQ"
+					},
+					"name": "Physiology",
+					"reference": "DFA85",
+					"tags": [
+						"Medical",
+						"Natural Science"
+					],
+					"specialization": "Elementals",
+					"difficulty": "iq/h",
+					"defaults": [
+						{
+							"type": "iq",
+							"modifier": -6
+						},
+						{
+							"type": "skill",
+							"name": "Diagnosis",
+							"modifier": -5
+						},
+						{
+							"type": "skill",
+							"name": "Physician",
+							"modifier": -5
+						},
+						{
+							"type": "skill",
+							"name": "Surgery",
+							"modifier": -5
+						}
+					],
+					"points": 1
+				},
+				{
+					"id": "sqdyldeOt6gH60GYl",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+						"id": "sninxx38w0NwPYxEY"
+					},
+					"name": "Physiology",
+					"reference": "DFA85",
+					"tags": [
+						"Medical",
+						"Natural Science"
+					],
+					"specialization": "Faeries",
+					"difficulty": "iq/h",
+					"defaults": [
+						{
+							"type": "iq",
+							"modifier": -6
+						},
+						{
+							"type": "skill",
+							"name": "Diagnosis",
+							"modifier": -5
+						},
+						{
+							"type": "skill",
+							"name": "Physician",
+							"modifier": -5
+						},
+						{
+							"type": "skill",
+							"name": "Surgery",
+							"modifier": -5
+						}
+					],
+					"points": 1
+				},
+				{
+					"id": "s0satzds-TW7zuG6P",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+						"id": "sHtMGKXgEs3fccdDs"
+					},
+					"name": "Physiology",
+					"reference": "DFA85",
+					"tags": [
+						"Medical",
+						"Natural Science"
+					],
+					"specialization": "Hybrids",
+					"difficulty": "iq/h",
+					"defaults": [
+						{
+							"type": "iq",
+							"modifier": -6
+						},
+						{
+							"type": "skill",
+							"name": "Diagnosis",
+							"modifier": -5
+						},
+						{
+							"type": "skill",
+							"name": "Physician",
+							"modifier": -5
+						},
+						{
+							"type": "skill",
+							"name": "Surgery",
+							"modifier": -5
+						}
+					],
+					"points": 1
+				},
+				{
+					"id": "s0aa_qZYTPBROX6pJ",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+						"id": "sS7e5O92FHxMh6YMG"
+					},
+					"name": "Physiology",
+					"reference": "DFA85",
+					"tags": [
+						"Medical",
+						"Natural Science"
+					],
+					"specialization": "Plants",
+					"difficulty": "iq/h",
+					"defaults": [
+						{
+							"type": "iq",
+							"modifier": -6
+						},
+						{
+							"type": "skill",
+							"name": "Diagnosis",
+							"modifier": -5
+						},
+						{
+							"type": "skill",
+							"name": "Physician",
+							"modifier": -5
+						},
+						{
+							"type": "skill",
+							"name": "Surgery",
+							"modifier": -5
+						}
+					],
+					"points": 1
+				},
+				{
+					"id": "sHdHKfLlsNkWyGo7Z",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+						"id": "s78aEoTl2PodAOKZg"
+					},
+					"name": "Physiology",
+					"reference": "DFA85",
+					"tags": [
+						"Medical",
+						"Natural Science"
+					],
+					"specialization": "Undead",
+					"difficulty": "iq/h",
+					"defaults": [
+						{
+							"type": "iq",
+							"modifier": -6
+						},
+						{
+							"type": "skill",
+							"name": "Diagnosis",
+							"modifier": -5
+						},
+						{
+							"type": "skill",
+							"name": "Physician",
+							"modifier": -5
+						},
+						{
+							"type": "skill",
+							"name": "Surgery",
+							"modifier": -5
+						}
+					],
+					"points": 1
+				},
+				{
+					"id": "sRnRTnDRZ-iJow5L8",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+						"id": "sdCxwV_3hVKSqFI_D"
+					},
+					"name": "Poisons",
+					"reference": "DFA85",
+					"tags": [
+						"Criminal",
+						"Medical",
+						"Spy",
+						"Street"
+					],
+					"difficulty": "iq/h",
+					"defaults": [
+						{
+							"type": "iq",
+							"modifier": -6
+						},
+						{
+							"type": "skill",
+							"name": "Chemistry",
+							"modifier": -5
+						},
+						{
+							"type": "skill",
+							"name": "Pharmacy",
+							"modifier": -3
+						},
+						{
+							"type": "skill",
+							"name": "Physician",
+							"modifier": -3
+						}
+					],
+					"points": 1
+				},
+				{
+					"id": "sXmhnkWA2bx9U1_K_",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+						"id": "sBBc8Wnwoz4U2-6b8"
+					},
+					"name": "Psychology",
+					"reference": "DFA86",
+					"tags": [
+						"Humanities",
+						"Social Sciences"
+					],
+					"specialization": "@Specialty@",
+					"difficulty": "iq/h",
+					"defaults": [
+						{
+							"type": "iq",
+							"modifier": -6
+						},
+						{
+							"type": "skill",
+							"name": "Sociology",
+							"modifier": -4
+						}
+					],
+					"points": 1
+				},
+				{
+					"id": "suUweH4X2M7yliEOT",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+						"id": "sRIpwO4cRfNcyPoxA"
+					},
+					"name": "Psychology",
+					"reference": "DFA86",
+					"tags": [
+						"Humanities",
+						"Social Sciences"
+					],
+					"specialization": "Constructs",
+					"difficulty": "iq/h",
+					"defaults": [
+						{
+							"type": "iq",
+							"modifier": -6
+						},
+						{
+							"type": "skill",
+							"name": "Sociology",
+							"modifier": -4
+						}
+					],
+					"points": 1
+				},
+				{
+					"id": "s7sBG0GKTl_MABowo",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+						"id": "s2VRslPIZ_xcE4GSj"
+					},
+					"name": "Psychology",
+					"reference": "DFA86",
+					"tags": [
+						"Humanities",
+						"Social Sciences"
+					],
+					"specialization": "Demons",
+					"difficulty": "iq/h",
+					"defaults": [
+						{
+							"type": "iq",
+							"modifier": -6
+						},
+						{
+							"type": "skill",
+							"name": "Sociology",
+							"modifier": -4
+						}
+					],
+					"points": 1
+				},
+				{
+					"id": "sDtGUMiKvLCQFPdj9",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+						"id": "sX5mhj-90odRSFsc3"
+					},
+					"name": "Psychology",
+					"reference": "DFA86",
+					"tags": [
+						"Humanities",
+						"Social Sciences"
+					],
+					"specialization": "Elementals",
+					"difficulty": "iq/h",
+					"defaults": [
+						{
+							"type": "iq",
+							"modifier": -6
+						},
+						{
+							"type": "skill",
+							"name": "Sociology",
+							"modifier": -4
+						}
+					],
+					"points": 1
+				},
+				{
+					"id": "srjBtuoWd2GVnlNGB",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+						"id": "svbmguWl7xKUYK1lP"
+					},
+					"name": "Psychology",
+					"reference": "DFA86",
+					"tags": [
+						"Humanities",
+						"Social Sciences"
+					],
+					"specialization": "Faeries",
+					"difficulty": "iq/h",
+					"defaults": [
+						{
+							"type": "iq",
+							"modifier": -6
+						},
+						{
+							"type": "skill",
+							"name": "Sociology",
+							"modifier": -4
+						}
+					],
+					"points": 1
+				},
+				{
+					"id": "s379G5Z6mHnbs9mN8",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+						"id": "sREhRSZB1iizxsZ4B"
+					},
+					"name": "Psychology",
+					"reference": "DFA86",
+					"tags": [
+						"Humanities",
+						"Social Sciences"
+					],
+					"specialization": "Undead",
+					"difficulty": "iq/h",
+					"defaults": [
+						{
+							"type": "iq",
+							"modifier": -6
+						},
+						{
+							"type": "skill",
+							"name": "Sociology",
+							"modifier": -4
+						}
+					],
+					"points": 1
+				},
+				{
+					"id": "s2mqDa_ubdHkiMUbv",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+						"id": "sGh3GER1SZtvucXxe"
+					},
+					"name": "Surgery",
+					"reference": "DFA90",
+					"tags": [
+						"Medical"
+					],
+					"difficulty": "iq/vh",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "First Aid",
+							"modifier": -12
+						},
+						{
+							"type": "skill",
+							"name": "Physician",
+							"modifier": -5
+						},
+						{
+							"type": "skill",
+							"name": "Physiology",
+							"modifier": -8
+						},
+						{
+							"type": "skill",
+							"name": "Veterinary",
+							"modifier": -5
+						}
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "skill_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "first aid"
+								}
+							},
+							{
+								"type": "skill_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "physician"
+								}
+							}
+						]
+					},
+					"points": 1
+				},
+				{
+					"id": "sYMnyzLLdPhqkd8j7",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+						"id": "sOt0ouAuX_84rlANE"
+					},
+					"name": "Veterinary",
+					"reference": "DFA94",
+					"tags": [
+						"Animal",
+						"Medical"
+					],
+					"difficulty": "iq/h",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Animal Handling",
+							"modifier": -6
+						},
+						{
+							"type": "skill",
+							"name": "Esoteric Medicine",
+							"modifier": -5
+						},
+						{
+							"type": "skill",
+							"name": "Surgery",
+							"modifier": -5
+						}
+					],
+					"points": 1
 				}
 			]
 		}

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Nature Priest 2.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Nature Priest 2.gct
@@ -4,7 +4,7 @@
 	"traits": [
 		{
 			"id": "TtOG1U8WotqneK06y",
-			"name": "Nature Priest",
+			"name": "Nature Priest 2",
 			"reference": "PY113:7",
 			"children": [
 				{

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Nature Priest 2.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Nature Priest 2.gct
@@ -275,132 +275,144 @@
 	],
 	"skills": [
 		{
-			"id": "SjHotAoabd4iurvDv",
-			"name": "Split 15 or more points among more skills and spells",
+			"id": "SDrprXC4s9UAZxHb9",
+			"name": "Nature Priest 2",
 			"children": [
 				{
-					"id": "sDhTgU1QCY6GMpMFH",
-					"name": "Esoteric Medicine",
-					"reference": "DFA25",
-					"tags": [
-						"Esoteric",
-						"Medical"
-					],
-					"specialization": "Druidic",
-					"difficulty": "per/h",
-					"defaults": [
+					"id": "SjHotAoabd4iurvDv",
+					"name": "Split 15 or more points among more skills and spells",
+					"children": [
 						{
-							"type": "per",
-							"modifier": -6
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "sWPL0l9td1vRryYds",
-					"name": "Herb Lore",
-					"reference": "DFA25",
-					"tags": [
-						"Plant"
-					],
-					"difficulty": "iq/vh",
-					"prereqs": {
-						"type": "prereq_list",
-						"all": true,
-						"prereqs": [
-							{
-								"type": "skill_prereq",
-								"has": true,
-								"name": {
-									"compare": "contains",
-									"qualifier": "naturalist"
+							"id": "sDhTgU1QCY6GMpMFH",
+							"name": "Esoteric Medicine",
+							"reference": "DFA25",
+							"tags": [
+								"Esoteric",
+								"Medical"
+							],
+							"specialization": "Druidic",
+							"difficulty": "per/h",
+							"defaults": [
+								{
+									"type": "per",
+									"modifier": -6
 								}
-							}
-						]
-					},
-					"points": 1
-				},
-				{
-					"id": "stfOmPDHipU1fm_tU",
-					"name": "Naturalist",
-					"reference": "DFA83",
-					"tags": [
-						"Animal",
-						"Exploration",
-						"Natural Science",
-						"Outdoor",
-						"Plant"
-					],
-					"difficulty": "iq/h",
-					"defaults": [
-						{
-							"type": "iq",
-							"modifier": -6
+							],
+							"points": 1
 						},
 						{
-							"type": "skill",
-							"name": "Biology",
-							"modifier": -3
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "s-aAjYHZMFdmWtEAP",
-					"name": "Religious Ritual",
-					"reference": "DFA86",
-					"tags": [
-						"Magical",
-						"Occult"
-					],
-					"specialization": "Druidic",
-					"difficulty": "iq/h",
-					"defaults": [
-						{
-							"type": "skill",
-							"name": "Ritual Magic",
-							"modifier": -6
+							"id": "sWPL0l9td1vRryYds",
+							"name": "Herb Lore",
+							"reference": "DFA25",
+							"tags": [
+								"Plant"
+							],
+							"difficulty": "iq/vh",
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "skill_prereq",
+										"has": true,
+										"name": {
+											"compare": "contains",
+											"qualifier": "naturalist"
+										}
+									}
+								]
+							},
+							"points": 1
 						},
 						{
-							"type": "skill",
-							"name": "Theology",
-							"specialization": "Druidic",
-							"modifier": -4
-						}
-					],
-					"points": 1
-				},
-				{
-					"id": "suSMLNstmtFj4cssT",
-					"name": "Theology",
-					"reference": "DFA91",
-					"tags": [
-						"Humanities",
-						"Social Sciences"
-					],
-					"specialization": "Druidic",
-					"difficulty": "iq/h",
-					"defaults": [
-						{
-							"type": "iq",
-							"modifier": -6
+							"id": "stfOmPDHipU1fm_tU",
+							"name": "Naturalist",
+							"reference": "DFA83",
+							"tags": [
+								"Animal",
+								"Exploration",
+								"Natural Science",
+								"Outdoor",
+								"Plant"
+							],
+							"difficulty": "iq/h",
+							"defaults": [
+								{
+									"type": "iq",
+									"modifier": -6
+								},
+								{
+									"type": "skill",
+									"name": "Biology",
+									"modifier": -3
+								}
+							],
+							"points": 1
 						},
 						{
-							"type": "skill",
+							"id": "s-aAjYHZMFdmWtEAP",
 							"name": "Religious Ritual",
+							"reference": "DFA86",
+							"tags": [
+								"Magical",
+								"Occult"
+							],
 							"specialization": "Druidic",
-							"modifier": -4
+							"difficulty": "iq/h",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Ritual Magic",
+									"modifier": -6
+								},
+								{
+									"type": "skill",
+									"name": "Theology",
+									"specialization": "Druidic",
+									"modifier": -4
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "suSMLNstmtFj4cssT",
+							"name": "Theology",
+							"reference": "DFA91",
+							"tags": [
+								"Humanities",
+								"Social Sciences"
+							],
+							"specialization": "Druidic",
+							"difficulty": "iq/h",
+							"defaults": [
+								{
+									"type": "iq",
+									"modifier": -6
+								},
+								{
+									"type": "skill",
+									"name": "Religious Ritual",
+									"specialization": "Druidic",
+									"modifier": -4
+								}
+							],
+							"points": 1
 						}
-					],
-					"points": 1
+					]
 				}
 			]
 		}
 	],
 	"spells": [
 		{
-			"id": "PLelp_3Zk1OIGidca",
-			"name": "Split 15 or more points among more skills and spells"
+			"id": "P79bwhFFUBysAETQV",
+			"name": "Nature Priest 2",
+			"children": [
+				{
+					"id": "PLelp_3Zk1OIGidca",
+					"name": "Split 15 or more points among more skills and spells"
+				}
+			]
 		}
 	]
 }

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Nature Priest.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Nature Priest.gct
@@ -427,15 +427,21 @@
 	],
 	"spells": [
 		{
-			"id": "PLelp_3Zk1OIGidca",
-			"name": "Choose 5 or more Druidic Spells",
-			"template_picker": {
-				"type": "points",
-				"qualifier": {
-					"compare": "at_least",
-					"qualifier": 5
+			"id": "PaBX_LqOXs42_pGPr",
+			"name": "Nature Priest",
+			"children": [
+				{
+					"id": "PLelp_3Zk1OIGidca",
+					"name": "Choose 5 or more Druidic Spells",
+					"template_picker": {
+						"type": "points",
+						"qualifier": {
+							"compare": "at_least",
+							"qualifier": 5
+						}
+					}
 				}
-			}
+			]
 		}
 	]
 }

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Nature Priest.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Nature Priest.gct
@@ -322,7 +322,7 @@
 							"modifier": -6
 						}
 					],
-					"points": 4
+					"points": 1
 				},
 				{
 					"id": "sWPL0l9td1vRryYds",
@@ -346,7 +346,7 @@
 							}
 						]
 					},
-					"points": 4
+					"points": 1
 				},
 				{
 					"id": "stfOmPDHipU1fm_tU",
@@ -371,7 +371,7 @@
 							"modifier": -3
 						}
 					],
-					"points": 2
+					"points": 1
 				},
 				{
 					"id": "s-aAjYHZMFdmWtEAP",

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Outdoorsy 2.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Outdoorsy 2.gct
@@ -1052,7 +1052,7 @@
 							"modifier": -5
 						}
 					],
-					"points": 2
+					"points": 1
 				},
 				{
 					"id": "s71zTzoN6g1Hwfn1t",
@@ -1839,7 +1839,7 @@
 							"modifier": -5
 						}
 					],
-					"points": 2
+					"points": 1
 				}
 			]
 		}

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Outdoorsy.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Outdoorsy.gct
@@ -1017,7 +1017,7 @@
 							"modifier": -5
 						}
 					],
-					"points": 2
+					"points": 1
 				},
 				{
 					"id": "s71zTzoN6g1Hwfn1t",
@@ -1804,7 +1804,7 @@
 							"modifier": -5
 						}
 					],
-					"points": 2
+					"points": 1
 				}
 			]
 		}

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Priest 2.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Priest 2.gct
@@ -346,7 +346,7 @@
 	"skills": [
 		{
 			"id": "S1fRbMadC2Yiqf93q",
-			"name": "Priest",
+			"name": "Priest 2",
 			"reference": "PY113:8",
 			"children": [
 				{
@@ -456,7 +456,7 @@
 	"spells": [
 		{
 			"id": "PKcw1mX3eFxw4aPV0",
-			"name": "Cleric",
+			"name": "Priest 2",
 			"children": [
 				{
 					"id": "PhaTWVrvAvV1t8Ynh",

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Priest 2.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Priest 2.gct
@@ -4,7 +4,7 @@
 	"traits": [
 		{
 			"id": "TUmR2nSYJtuNAsFBR",
-			"name": "Priest",
+			"name": "Priest 2",
 			"reference": "PY113:8",
 			"children": [
 				{

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Priest.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Priest.gct
@@ -620,7 +620,7 @@
 	"spells": [
 		{
 			"id": "PKcw1mX3eFxw4aPV0",
-			"name": "Cleric",
+			"name": "Priest",
 			"children": [
 				{
 					"id": "PhaTWVrvAvV1t8Ynh",

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Rogue.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Rogue.gct
@@ -605,133 +605,6 @@
 							}
 						},
 						{
-							"id": "tIReshbEmsWRJOwVU",
-							"name": "High Manual Dexterity",
-							"reference": "DFA39",
-							"tags": [
-								"Advantage",
-								"Physical"
-							],
-							"points_per_level": 5,
-							"features": [
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "contains",
-										"qualifier": "artist"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "jeweler"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "knot-tying"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "leatherworking"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "lockpicking"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "pickpocket"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "sewing"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "sleight of hand"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "surgery"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "machinist"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "contains",
-										"qualifier": "mechanic"
-									},
-									"amount": 1,
-									"per_level": true
-								}
-							],
-							"can_level": true,
-							"levels": 1,
-							"calc": {
-								"points": 5
-							}
-						},
-						{
 							"id": "tKqIdXmW_tYfDlPlx",
 							"name": "Sensitive Touch",
 							"reference": "DFA39",
@@ -774,12 +647,12 @@
 						}
 					],
 					"calc": {
-						"points": 224
+						"points": 219
 					}
 				}
 			],
 			"calc": {
-				"points": 224
+				"points": 219
 			}
 		}
 	],

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Spellsinger 2.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Spellsinger 2.gct
@@ -456,15 +456,21 @@
 	],
 	"spells": [
 		{
-			"id": "PPrLa0Dn_wIpFO6H5",
-			"name": "Choose 10 Or More Spells",
-			"template_picker": {
-				"type": "points",
-				"qualifier": {
-					"compare": "at_least",
-					"qualifier": 10
+			"id": "P_JqYz8ufOsN9j-Bi",
+			"name": "Spellsinger 2",
+			"children": [
+				{
+					"id": "PPrLa0Dn_wIpFO6H5",
+					"name": "Choose 10 Or More Spells",
+					"template_picker": {
+						"type": "points",
+						"qualifier": {
+							"compare": "at_least",
+							"qualifier": 10
+						}
+					}
 				}
-			}
+			]
 		}
 	]
 }

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Spellsinger.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Spellsinger.gct
@@ -586,15 +586,21 @@
 	],
 	"spells": [
 		{
-			"id": "PPrLa0Dn_wIpFO6H5",
-			"name": "Choose 6 Or More Spells",
-			"template_picker": {
-				"type": "points",
-				"qualifier": {
-					"compare": "at_least",
-					"qualifier": 6
+			"id": "Py6zCN5TD_tBJ8b47",
+			"name": "Spellsinger",
+			"children": [
+				{
+					"id": "PPrLa0Dn_wIpFO6H5",
+					"name": "Choose 6 Or More Spells",
+					"template_picker": {
+						"type": "points",
+						"qualifier": {
+							"compare": "at_least",
+							"qualifier": 6
+						}
+					}
 				}
-			}
+			]
 		}
 	]
 }


### PR DESCRIPTION
A few fixes for Five Easy Pieces for Dungeon Fantasy / DFRPG from Pyramid 113

Put headers at the top of every Piece's traits, and remove a duplicate advantage from Rogue.