### PR TITLE
Add stringed instruments to DFRPG Equipment

### DIFF
--- a/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Equipment.eqp
+++ b/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Equipment.eqp
@@ -2909,6 +2909,23 @@
 			}
 		},
 		{
+			"id": "e8FQTvCjvvZ3R_Q-v",
+			"description": "Cittern",
+			"reference": "DFA112",
+			"notes": "Requires two hands",
+			"tags": [
+				"Musical Instruments"
+			],
+			"value": 150,
+			"weight": "5 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 150,
+				"extended_weight": "5 lb"
+			}
+		},
+		{
 			"id": "eqsfhlQvsv0LvoCn2",
 			"description": "Climbing Spikes",
 			"reference": "DFA113",
@@ -14158,6 +14175,23 @@
 			}
 		},
 		{
+			"id": "eFBV_Gh3XwZ0fLt0e",
+			"description": "Lute",
+			"reference": "DFA112",
+			"notes": "Requires two hands",
+			"tags": [
+				"Musical Instruments"
+			],
+			"value": 150,
+			"weight": "5 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 150,
+				"extended_weight": "5 lb"
+			}
+		},
+		{
 			"id": "e5f22a83i96RGPu6G",
 			"description": "Mace",
 			"reference": "DFA98",
@@ -16549,6 +16583,23 @@
 			"calc": {
 				"extended_value": 100,
 				"extended_weight": "1 lb"
+			}
+		},
+		{
+			"id": "ePETktoOW5kLZIY1c",
+			"description": "Oud",
+			"reference": "DFA112",
+			"notes": "Requires two hands",
+			"tags": [
+				"Musical Instruments"
+			],
+			"value": 150,
+			"weight": "5 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 150,
+				"extended_weight": "5 lb"
 			}
 		},
 		{


### PR DESCRIPTION
Added the cittern, lute, and oud to DFRPG Equipment from Adventurers, p. 112.