### PR TITLE
Improve prerequisites for Gift of Letters and Gift of Tongues

### DIFF
--- a/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Spells.spl
+++ b/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Spells.spl
@@ -6071,30 +6071,6 @@
 												}
 											},
 											{
-												"type": "trait_prereq",
-												"has": true,
-												"name": {
-													"compare": "starts_with",
-													"qualifier": "Language:"
-												},
-												"notes": {
-													"compare": "does_not_contain",
-													"qualifier": "Written (None)"
-												}
-											},
-											{
-												"type": "trait_prereq",
-												"has": true,
-												"name": {
-													"compare": "starts_with",
-													"qualifier": "Language:"
-												},
-												"notes": {
-													"compare": "does_not_contain",
-													"qualifier": "Written (None)"
-												}
-											},
-											{
 												"type": "prereq_list",
 												"all": false,
 												"prereqs": [
@@ -6173,30 +6149,6 @@
 												"quantity": {
 													"compare": "at_least",
 													"qualifier": 1
-												}
-											},
-											{
-												"type": "trait_prereq",
-												"has": true,
-												"name": {
-													"compare": "starts_with",
-													"qualifier": "Language:"
-												},
-												"notes": {
-													"compare": "does_not_contain",
-													"qualifier": "Spoken (None)"
-												}
-											},
-											{
-												"type": "trait_prereq",
-												"has": true,
-												"name": {
-													"compare": "starts_with",
-													"qualifier": "Language:"
-												},
-												"notes": {
-													"compare": "does_not_contain",
-													"qualifier": "Spoken (None)"
 												}
 											},
 											{
@@ -19183,30 +19135,6 @@
 										}
 									},
 									{
-										"type": "trait_prereq",
-										"has": true,
-										"name": {
-											"compare": "starts_with",
-											"qualifier": "Language:"
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "Written (None)"
-										}
-									},
-									{
-										"type": "trait_prereq",
-										"has": true,
-										"name": {
-											"compare": "starts_with",
-											"qualifier": "Language:"
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "Written (None)"
-										}
-									},
-									{
 										"type": "prereq_list",
 										"all": false,
 										"prereqs": [
@@ -19285,30 +19213,6 @@
 										"quantity": {
 											"compare": "at_least",
 											"qualifier": 1
-										}
-									},
-									{
-										"type": "trait_prereq",
-										"has": true,
-										"name": {
-											"compare": "starts_with",
-											"qualifier": "Language:"
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "Spoken (None)"
-										}
-									},
-									{
-										"type": "trait_prereq",
-										"has": true,
-										"name": {
-											"compare": "starts_with",
-											"qualifier": "Language:"
-										},
-										"notes": {
-											"compare": "does_not_contain",
-											"qualifier": "Spoken (None)"
 										}
 									},
 									{

--- a/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Spells.spl
+++ b/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Spells.spl
@@ -6062,24 +6062,36 @@
 												"type": "trait_prereq",
 												"has": true,
 												"name": {
-													"compare": "is",
-													"qualifier": "Language"
+													"compare": "starts_with",
+													"qualifier": "Language:"
+												},
+												"notes": {
+													"compare": "does_not_contain",
+													"qualifier": "Written (None)"
 												}
 											},
 											{
 												"type": "trait_prereq",
 												"has": true,
 												"name": {
-													"compare": "is",
-													"qualifier": "Language"
+													"compare": "starts_with",
+													"qualifier": "Language:"
+												},
+												"notes": {
+													"compare": "does_not_contain",
+													"qualifier": "Written (None)"
 												}
 											},
 											{
 												"type": "trait_prereq",
 												"has": true,
 												"name": {
-													"compare": "is",
-													"qualifier": "Language"
+													"compare": "starts_with",
+													"qualifier": "Language:"
+												},
+												"notes": {
+													"compare": "does_not_contain",
+													"qualifier": "Written (None)"
 												}
 											},
 											{
@@ -6167,24 +6179,36 @@
 												"type": "trait_prereq",
 												"has": true,
 												"name": {
-													"compare": "is",
-													"qualifier": "Language"
+													"compare": "starts_with",
+													"qualifier": "Language:"
+												},
+												"notes": {
+													"compare": "does_not_contain",
+													"qualifier": "Spoken (None)"
 												}
 											},
 											{
 												"type": "trait_prereq",
 												"has": true,
 												"name": {
-													"compare": "is",
-													"qualifier": "Language"
+													"compare": "starts_with",
+													"qualifier": "Language:"
+												},
+												"notes": {
+													"compare": "does_not_contain",
+													"qualifier": "Spoken (None)"
 												}
 											},
 											{
 												"type": "trait_prereq",
 												"has": true,
 												"name": {
-													"compare": "is",
-													"qualifier": "Language"
+													"compare": "starts_with",
+													"qualifier": "Language:"
+												},
+												"notes": {
+													"compare": "does_not_contain",
+													"qualifier": "Spoken (None)"
 												}
 											},
 											{
@@ -19150,24 +19174,36 @@
 										"type": "trait_prereq",
 										"has": true,
 										"name": {
-											"compare": "is",
-											"qualifier": "Language"
+											"compare": "starts_with",
+											"qualifier": "Language:"
+										},
+										"notes": {
+											"compare": "does_not_contain",
+											"qualifier": "Written (None)"
 										}
 									},
 									{
 										"type": "trait_prereq",
 										"has": true,
 										"name": {
-											"compare": "is",
-											"qualifier": "Language"
+											"compare": "starts_with",
+											"qualifier": "Language:"
+										},
+										"notes": {
+											"compare": "does_not_contain",
+											"qualifier": "Written (None)"
 										}
 									},
 									{
 										"type": "trait_prereq",
 										"has": true,
 										"name": {
-											"compare": "is",
-											"qualifier": "Language"
+											"compare": "starts_with",
+											"qualifier": "Language:"
+										},
+										"notes": {
+											"compare": "does_not_contain",
+											"qualifier": "Written (None)"
 										}
 									},
 									{
@@ -19255,24 +19291,36 @@
 										"type": "trait_prereq",
 										"has": true,
 										"name": {
-											"compare": "is",
-											"qualifier": "Language"
+											"compare": "starts_with",
+											"qualifier": "Language:"
+										},
+										"notes": {
+											"compare": "does_not_contain",
+											"qualifier": "Spoken (None)"
 										}
 									},
 									{
 										"type": "trait_prereq",
 										"has": true,
 										"name": {
-											"compare": "is",
-											"qualifier": "Language"
+											"compare": "starts_with",
+											"qualifier": "Language:"
+										},
+										"notes": {
+											"compare": "does_not_contain",
+											"qualifier": "Spoken (None)"
 										}
 									},
 									{
 										"type": "trait_prereq",
 										"has": true,
 										"name": {
-											"compare": "is",
-											"qualifier": "Language"
+											"compare": "starts_with",
+											"qualifier": "Language:"
+										},
+										"notes": {
+											"compare": "does_not_contain",
+											"qualifier": "Spoken (None)"
 										}
 									},
 									{

--- a/Library/Magic/Magic Spells.spl
+++ b/Library/Magic/Magic Spells.spl
@@ -18864,7 +18864,7 @@
 				"prereqs": [
 					{
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
 								"type": "trait_prereq",
@@ -18873,12 +18873,9 @@
 									"compare": "starts_with",
 									"qualifier": "Language:"
 								},
-								"level": {
-									"compare": "at_least"
-								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "Written (None)"
+									"compare": "contains",
+									"qualifier": "Written (Native)"
 								}
 							},
 							{
@@ -18889,20 +18886,8 @@
 									"qualifier": "Language:"
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "Written (None)"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": true,
-								"name": {
-									"compare": "starts_with",
-									"qualifier": "Language:"
-								},
-								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "Written (None)"
+									"compare": "contains",
+									"qualifier": "Written (Accented)"
 								}
 							}
 						]
@@ -18947,7 +18932,7 @@
 				"prereqs": [
 					{
 						"type": "prereq_list",
-						"all": true,
+						"all": false,
 						"prereqs": [
 							{
 								"type": "trait_prereq",
@@ -18956,12 +18941,9 @@
 									"compare": "starts_with",
 									"qualifier": "Language:"
 								},
-								"level": {
-									"compare": "at_least"
-								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "Spoken (None)"
+									"compare": "contains",
+									"qualifier": "Spoken (Native)"
 								}
 							},
 							{
@@ -18972,20 +18954,8 @@
 									"qualifier": "Language:"
 								},
 								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "Spoken (None)"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": true,
-								"name": {
-									"compare": "starts_with",
-									"qualifier": "Language:"
-								},
-								"notes": {
-									"compare": "does_not_contain",
-									"qualifier": "Spoken (None)"
+									"compare": "contains",
+									"qualifier": "Spoken (Accented)"
 								}
 							}
 						]

--- a/Library/Magic/Magic Spells.spl
+++ b/Library/Magic/Magic Spells.spl
@@ -18864,18 +18864,21 @@
 				"prereqs": [
 					{
 						"type": "prereq_list",
-						"all": false,
+						"all": true,
 						"prereqs": [
 							{
 								"type": "trait_prereq",
 								"has": true,
 								"name": {
 									"compare": "starts_with",
-									"qualifier": "Language"
+									"qualifier": "Language:"
+								},
+								"level": {
+									"compare": "at_least"
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "Written (Native)"
+									"compare": "does_not_contain",
+									"qualifier": "Written (None)"
 								}
 							},
 							{
@@ -18883,11 +18886,23 @@
 								"has": true,
 								"name": {
 									"compare": "starts_with",
-									"qualifier": "Language"
+									"qualifier": "Language:"
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "Written (Accented)"
+									"compare": "does_not_contain",
+									"qualifier": "Written (None)"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": true,
+								"name": {
+									"compare": "starts_with",
+									"qualifier": "Language:"
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "Written (None)"
 								}
 							}
 						]
@@ -18932,18 +18947,21 @@
 				"prereqs": [
 					{
 						"type": "prereq_list",
-						"all": false,
+						"all": true,
 						"prereqs": [
 							{
 								"type": "trait_prereq",
 								"has": true,
 								"name": {
 									"compare": "starts_with",
-									"qualifier": "Language"
+									"qualifier": "Language:"
+								},
+								"level": {
+									"compare": "at_least"
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "Spoken (Native)"
+									"compare": "does_not_contain",
+									"qualifier": "Spoken (None)"
 								}
 							},
 							{
@@ -18951,11 +18969,23 @@
 								"has": true,
 								"name": {
 									"compare": "starts_with",
-									"qualifier": "Language"
+									"qualifier": "Language:"
 								},
 								"notes": {
-									"compare": "contains",
-									"qualifier": "Spoken (Accented)"
+									"compare": "does_not_contain",
+									"qualifier": "Spoken (None)"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": true,
+								"name": {
+									"compare": "starts_with",
+									"qualifier": "Language:"
+								},
+								"notes": {
+									"compare": "does_not_contain",
+									"qualifier": "Spoken (None)"
 								}
 							}
 						]


### PR DESCRIPTION
The requirement in GURPS Magic is Borrow Language plus three languages at Accented or better (written for Letters, spoken for Tongues).  Note that GCS shows languages like "Language: English" so the right way to check for a language is "starts with: 'Language:'". (If you miss the colon then the Language Talent advantage is a false positive.)

Previously the GCS Magic version of these spells just required one language at Accented or better, which was wrong.  I've changed it to three languages and comprehension other than None, which is closer but still not quite correct since Broken comprehension is not supposed to count.  I don't see a way to express "3 or more languages at Accented or better" within the current GCS system; it would require nested levels of boolean logic, or mapping the language levels to numbers.

Dungeon Fantasy RPG doesn't have Broken or Accented languages, so "3 or more languages with Spoken/Written not set to None" is correct. (And the alternate clerical prerequisite of Power Investiture 4 is kept.)