### PR TITLE
Cripped Leg and Missing Leg are singular in DFRPG.

### DIFF
--- a/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq
+++ b/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq
@@ -5718,7 +5718,7 @@
 		},
 		{
 			"id": "tFAg-E245JQdBHI8x",
-			"name": "Lame (Crippled Legs)",
+			"name": "Lame (Crippled Leg)",
 			"reference": "DFA62",
 			"tags": [
 				"Disadvantage",
@@ -5744,7 +5744,7 @@
 		},
 		{
 			"id": "t_tiaNsDGsMN-cBDj",
-			"name": "Lame (Missing Legs)",
+			"name": "Lame (Missing Leg)",
 			"reference": "DFA62",
 			"tags": [
 				"Disadvantage",


### PR DESCRIPTION
(They're plural in Basic Set, because Basic Set does not assume you belong to a two-legged species.  But DFRPG does.)