### PR TITLE
Add some missing / change things in Basic Set,  Bio-Tech and Ultra-Tech to support Loadouts: Spaceship Crew

### DIFF
--- a/Library/Basic Set/Basic Set Equipment.eqp
+++ b/Library/Basic Set/Basic Set Equipment.eqp
@@ -6663,6 +6663,108 @@
 			}
 		},
 		{
+			"id": "epQVmSEP9O5b3Yf3-",
+			"description": "Formal Wear",
+			"reference": "B266",
+			"notes": "Status -2",
+			"tags": [
+				"Clothing"
+			],
+			"value": 40,
+			"weight": "2 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 40,
+				"extended_weight": "2 lb"
+			}
+		},
+		{
+			"id": "edaH7PgT59tJIw9hM",
+			"description": "Formal Wear",
+			"reference": "B266",
+			"notes": "Status -1",
+			"tags": [
+				"Clothing"
+			],
+			"value": 120,
+			"weight": "2 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 120,
+				"extended_weight": "2 lb"
+			}
+		},
+		{
+			"id": "ew0bZs8eD_-b2iMtU",
+			"description": "Formal Wear",
+			"reference": "B266",
+			"notes": "Status 0",
+			"tags": [
+				"Clothing"
+			],
+			"value": 240,
+			"weight": "2 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 240,
+				"extended_weight": "2 lb"
+			}
+		},
+		{
+			"id": "ex73BdgC-KzoilauR",
+			"description": "Formal Wear",
+			"reference": "B266",
+			"notes": "Status 1",
+			"tags": [
+				"Clothing"
+			],
+			"value": 480,
+			"weight": "2 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 480,
+				"extended_weight": "2 lb"
+			}
+		},
+		{
+			"id": "e5UE7oCCXj41LPhIT",
+			"description": "Formal Wear",
+			"reference": "B266",
+			"notes": "Status 2",
+			"tags": [
+				"Clothing"
+			],
+			"value": 1200,
+			"weight": "2 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 1200,
+				"extended_weight": "2 lb"
+			}
+		},
+		{
+			"id": "eafxbL_MsqAoAZecF",
+			"description": "Formal Wear",
+			"reference": "B266",
+			"notes": "Status 3",
+			"tags": [
+				"Clothing"
+			],
+			"value": 4800,
+			"weight": "2 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 4800,
+				"extended_weight": "2 lb"
+			}
+		},
+		{
 			"id": "emLpKDf7E3sN-_gDA",
 			"description": "Frag Helmet",
 			"reference": "B285",
@@ -13051,6 +13153,108 @@
 			"calc": {
 				"extended_value": 2,
 				"extended_weight": "1 lb"
+			}
+		},
+		{
+			"id": "eyERK2z5J0P5RDdDJ",
+			"description": "Ordinary Clothes",
+			"reference": "B266",
+			"notes": "Status -2",
+			"tags": [
+				"Clothing"
+			],
+			"value": 20,
+			"weight": "4 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 20,
+				"extended_weight": "4 lb"
+			}
+		},
+		{
+			"id": "ec7dxIgBphcpGL-dM",
+			"description": "Ordinary Clothes",
+			"reference": "B266",
+			"notes": "Status -1",
+			"tags": [
+				"Clothing"
+			],
+			"value": 60,
+			"weight": "4 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 60,
+				"extended_weight": "4 lb"
+			}
+		},
+		{
+			"id": "eLpY_lV7JPT_Srj5A",
+			"description": "Ordinary Clothes",
+			"reference": "B266",
+			"notes": "Status 0",
+			"tags": [
+				"Clothing"
+			],
+			"value": 120,
+			"weight": "4 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 120,
+				"extended_weight": "4 lb"
+			}
+		},
+		{
+			"id": "e9F8zNWEjYh2hx1fi",
+			"description": "Ordinary Clothes",
+			"reference": "B266",
+			"notes": "Status 1",
+			"tags": [
+				"Clothing"
+			],
+			"value": 240,
+			"weight": "4 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 240,
+				"extended_weight": "4 lb"
+			}
+		},
+		{
+			"id": "eWmwdkgcDBfCjspyD",
+			"description": "Ordinary Clothes",
+			"reference": "B266",
+			"notes": "Status 2",
+			"tags": [
+				"Clothing"
+			],
+			"value": 600,
+			"weight": "4 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 600,
+				"extended_weight": "4 lb"
+			}
+		},
+		{
+			"id": "ehxYtcIJh-F_qPNrn",
+			"description": "Ordinary Clothes",
+			"reference": "B266",
+			"notes": "Status 3",
+			"tags": [
+				"Clothing"
+			],
+			"value": 2400,
+			"weight": "4 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 2400,
+				"extended_weight": "4 lb"
 			}
 		},
 		{
@@ -20887,6 +21091,108 @@
 			"calc": {
 				"extended_value": 10,
 				"extended_weight": "0.25 lb"
+			}
+		},
+		{
+			"id": "eoLUSbLbRk1A_9ICz",
+			"description": "Winter Clothes",
+			"reference": "B266",
+			"notes": "Status -2",
+			"tags": [
+				"Clothing"
+			],
+			"value": 30,
+			"weight": "4 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 30,
+				"extended_weight": "4 lb"
+			}
+		},
+		{
+			"id": "euZnx_ucuv2Z9j1tg",
+			"description": "Winter Clothes",
+			"reference": "B266",
+			"notes": "Status -1",
+			"tags": [
+				"Clothing"
+			],
+			"value": 90,
+			"weight": "4 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 90,
+				"extended_weight": "4 lb"
+			}
+		},
+		{
+			"id": "e24V1_w4hI1Y5_jks",
+			"description": "Winter Clothes",
+			"reference": "B266",
+			"notes": "Status 0",
+			"tags": [
+				"Clothing"
+			],
+			"value": 180,
+			"weight": "4 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 180,
+				"extended_weight": "4 lb"
+			}
+		},
+		{
+			"id": "e_cSxP1TJ4hArvY2s",
+			"description": "Winter Clothes",
+			"reference": "B266",
+			"notes": "Status 1",
+			"tags": [
+				"Clothing"
+			],
+			"value": 360,
+			"weight": "4 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 360,
+				"extended_weight": "4 lb"
+			}
+		},
+		{
+			"id": "eaqmPUV41qo_EAh4u",
+			"description": "Winter Clothes",
+			"reference": "B266",
+			"notes": "Status 2",
+			"tags": [
+				"Clothing"
+			],
+			"value": 900,
+			"weight": "4 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 900,
+				"extended_weight": "4 lb"
+			}
+		},
+		{
+			"id": "eAu3A6PMF3U0OHUIL",
+			"description": "Winter Clothes",
+			"reference": "B266",
+			"notes": "Status 3",
+			"tags": [
+				"Clothing"
+			],
+			"value": 3600,
+			"weight": "4 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 3600,
+				"extended_weight": "4 lb"
 			}
 		},
 		{

--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -9930,21 +9930,21 @@
 			},
 			"modifiers": [
 				{
-					"id": "m5fj7DUSbr1c68hLb",
+					"id": "m7jOl1jCf3hYkPNKS",
 					"name": "Extended Low-Band",
 					"reference": "B60",
 					"cost": 30,
 					"disabled": true
 				},
 				{
-					"id": "mO1eFOP_fyf1RKCWZ",
+					"id": "mebPBveBMnXuH_rdr",
 					"name": "Extended High-Band",
 					"reference": "B60",
 					"cost": 30,
 					"disabled": true
 				},
 				{
-					"id": "mRm7CwfPL4R271adb",
+					"id": "mD0ade4ptOrw2CIr4",
 					"name": "Extended",
 					"reference": "P52",
 					"notes": "@Special@",
@@ -9953,6 +9953,27 @@
 				}
 			],
 			"base_points": 25,
+			"features": [
+				{
+					"type": "conditional_modifier",
+					"situation": "spot hidden clues or objects with Forensics, Observation or Search",
+					"amount": 3
+				},
+				{
+					"type": "attribute_bonus",
+					"attribute": "vision",
+					"amount": 3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Tracking"
+					},
+					"amount": 3
+				}
+			],
 			"calc": {
 				"points": 25
 			}

--- a/Library/Bio-Tech/Bio-Tech Equipment.eqp
+++ b/Library/Bio-Tech/Bio-Tech Equipment.eqp
@@ -1,0 +1,2053 @@
+{
+	"version": 5,
+	"rows": [
+		{
+			"id": "e5Jf7JMG_fNpTlARC",
+			"description": "Abortifacient",
+			"reference": "BT149",
+			"notes": "Toxic. HT-2 or inflicts 2d injury to the carrier as well",
+			"tech_level": "0",
+			"legality_class": "3",
+			"tags": [
+				"Drug"
+			],
+			"value": 10,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 10,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eafJLJVNfl8j4t5V_",
+			"description": "Abortifacient",
+			"reference": "BT149",
+			"tech_level": "8",
+			"legality_class": "3",
+			"tags": [
+				"Drug"
+			],
+			"value": 10,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 10,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eLFz6wjjl_SvK5Xoq",
+			"description": "Chloroform",
+			"reference": "BT149",
+			"tech_level": "5",
+			"tags": [
+				"Drug"
+			],
+			"value": 5,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 5,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eSlfJRLoReSs64jcT",
+			"description": "Ether",
+			"reference": "BT149",
+			"tech_level": "5",
+			"tags": [
+				"Drug"
+			],
+			"value": 5,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 5,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "ek6Qnkf-NyXuD9Diw",
+			"description": "Aspirin",
+			"reference": "BT149",
+			"tech_level": "6",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 0.03,
+			"quantity": 100,
+			"equipped": true,
+			"calc": {
+				"extended_value": 3,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "e_BCMQR_PGTJpWKz_",
+			"description": "Narcotic Painkiller",
+			"reference": "BT149",
+			"notes": "e.g. Morphine",
+			"tech_level": "5",
+			"legality_class": "3",
+			"tags": [
+				"Drug"
+			],
+			"value": 3,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 3,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "e91cv34dSUYIRXbd1",
+			"description": "Acetaminophen",
+			"reference": "BT149",
+			"tech_level": "7",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 3,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 3,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "etXcdY09RGaOSNceE",
+			"description": "Analgine",
+			"reference": "BT149",
+			"tech_level": "9",
+			"legality_class": "3",
+			"tags": [
+				"Drug"
+			],
+			"value": 2,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 2,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eHeWSyigYw2DdqWdM",
+			"description": "Painaway",
+			"reference": "BT149",
+			"tech_level": "9",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 0.1,
+			"quantity": 100,
+			"equipped": true,
+			"calc": {
+				"extended_value": 10,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eGEo6VB98vqrvxc-q",
+			"description": "Antiallergen",
+			"reference": "BT150",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 2,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 2,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "ery2S8qwv2kBh-UNm",
+			"description": "Sulfanilamide",
+			"reference": "BT150",
+			"tech_level": "6",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 0.5,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 0.5,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "euFYFSG70L9aNLYRh",
+			"description": "Penicillin",
+			"reference": "BT150",
+			"notes": "Must be taken daily for two weeks to be effective",
+			"tech_level": "6",
+			"legality_class": "3",
+			"tags": [
+				"Drug"
+			],
+			"value": 0.7142,
+			"quantity": 14,
+			"equipped": true,
+			"calc": {
+				"extended_value": 9.9988,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "ebq1KhvcM1tAhM-n1",
+			"description": "Broad-Spectrum Antibiotic",
+			"reference": "BT150",
+			"notes": "Must be taken daily for two weeks to be effective",
+			"tech_level": "8",
+			"legality_class": "3",
+			"tags": [
+				"Drug"
+			],
+			"value": 7.1428,
+			"quantity": 14,
+			"equipped": true,
+			"calc": {
+				"extended_value": 99.9992,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "egwYolELDYplnq7mh",
+			"description": "Broad-Spectrum Antibiotic",
+			"reference": "BT150",
+			"notes": "Must be taken daily for two weeks to be effective",
+			"tech_level": "9",
+			"legality_class": "3",
+			"tags": [
+				"Drug"
+			],
+			"value": 0.7142,
+			"quantity": 14,
+			"equipped": true,
+			"calc": {
+				"extended_value": 9.9988,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "ebYW3BnTrClUkFpWZ",
+			"description": "Genericillin",
+			"reference": "BT150",
+			"notes": "one dose lasts a week",
+			"tech_level": "10",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 25,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 25,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "egwDy8G4zmmgnnG3a",
+			"description": "Enzyme Blocker (@microbe@)",
+			"reference": "BT151",
+			"notes": "must be taken daily for two weeks to be effective",
+			"tech_level": "8",
+			"tags": [
+				"Drug"
+			],
+			"value": 7.1428,
+			"quantity": 14,
+			"equipped": true,
+			"calc": {
+				"extended_value": 99.9992,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eCbSwKQAh_w6dBYtj",
+			"description": "Enzyme Blocker (@microbe@)",
+			"reference": "BT151",
+			"notes": "must be taken daily for two weeks to be effective",
+			"tech_level": "9",
+			"tags": [
+				"Drug"
+			],
+			"value": 1.4285,
+			"quantity": 14,
+			"equipped": true,
+			"calc": {
+				"extended_value": 19.999,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "e8uOwXxeIVwaXTxx4",
+			"description": "Enzyme Blocker (@microbe@)",
+			"reference": "BT151",
+			"notes": "must be taken daily for two weeks to be effective",
+			"tech_level": "10",
+			"tags": [
+				"Drug"
+			],
+			"value": 0.7142,
+			"quantity": 14,
+			"equipped": true,
+			"calc": {
+				"extended_value": 9.9988,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eHsu7tMlpT6hv1m2-",
+			"description": "Enzyme Blocker (@microbe@)",
+			"reference": "BT151",
+			"notes": "must be taken daily for two weeks to be effective",
+			"tech_level": "11",
+			"tags": [
+				"Drug"
+			],
+			"value": 0.3571,
+			"quantity": 14,
+			"equipped": true,
+			"calc": {
+				"extended_value": 4.9994,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "ekDviwRvxdRyG2J6E",
+			"description": "Interferon",
+			"reference": "BT151",
+			"notes": "regular injections needed for 4-12 months. Price is for one month",
+			"tech_level": "8",
+			"tags": [
+				"Drug"
+			],
+			"value": 2000,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 2000,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "e93Kqr6c2dx6CXBbs",
+			"description": "Hypercoagulin",
+			"reference": "BT151",
+			"tech_level": "9",
+			"legality_class": "3",
+			"tags": [
+				"Drug"
+			],
+			"value": 25,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 25,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eV0phB_Gd2_Aisi3o",
+			"description": "Ursaline",
+			"reference": "BT151",
+			"tech_level": "9",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 25,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 25,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "edah4annBL8mECitO",
+			"description": "Antirad",
+			"reference": "BT152",
+			"notes": "gives Radiation Tolerance 2",
+			"tech_level": "9",
+			"legality_class": "3",
+			"tags": [
+				"Drug"
+			],
+			"value": 50,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 50,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eiVH5MDuE6qyc6g8P",
+			"description": "Antirad",
+			"reference": "BT152",
+			"notes": "gives Radiation Tolerance 5",
+			"tech_level": "10",
+			"legality_class": "3",
+			"tags": [
+				"Drug"
+			],
+			"value": 50,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 50,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "epC3C6vK06PAATS1J",
+			"description": "Ascepaline",
+			"reference": "BT152",
+			"tech_level": "10",
+			"legality_class": "3",
+			"tags": [
+				"Drug"
+			],
+			"value": 20,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 20,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eUsGuY3hhAgx-uEPP",
+			"description": "Chloral Hydrate",
+			"reference": "BT152",
+			"tech_level": "5",
+			"legality_class": "3",
+			"tags": [
+				"Drug"
+			],
+			"value": 1,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 1,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "ebBAmRf5efqW-KoDC",
+			"description": "Flunitrazepam",
+			"reference": "BT152",
+			"tech_level": "7",
+			"legality_class": "2",
+			"tags": [
+				"Drug"
+			],
+			"value": 5,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 5,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "ehVTDACHtbVMsMDq3",
+			"description": "Smelling Salts",
+			"reference": "BT152",
+			"tech_level": "5",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 0.2,
+			"max_uses": 20,
+			"quantity": 1,
+			"uses": 20,
+			"equipped": true,
+			"calc": {
+				"extended_value": 0.2,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eXUz8Bc2fCPqNLBMG",
+			"description": "Modafinil",
+			"reference": "BT152",
+			"tech_level": "8",
+			"legality_class": "3",
+			"tags": [
+				"Drug"
+			],
+			"value": 2,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 2,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "epVNfjTeOFkjbX8Ke",
+			"description": "Revive Capsule",
+			"reference": "BT152",
+			"tech_level": "9",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 5,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 5,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eU-e8frDyDIpFiw2U",
+			"description": "Superstim",
+			"reference": "BT152",
+			"tech_level": "9",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 10,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 10,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eXwZ2RaEg1NstR3cG",
+			"description": "Wideawake",
+			"reference": "BT152",
+			"notes": "one dose lasts a week",
+			"tech_level": "10",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 20,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 20,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eea-O60Ez3p62EOg4",
+			"description": "Arsenic",
+			"reference": "BT153",
+			"tech_level": "5",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 1,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 1,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eIrjGZjJl-O5bfTjI",
+			"description": "Calomel",
+			"reference": "BT153",
+			"tech_level": "5",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 1,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 1,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eFZ2KWrlVBGhLzxYm",
+			"description": "Quinine",
+			"reference": "BT153",
+			"tech_level": "5",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 2,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 2,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eB2SFc864cK8AcG7R",
+			"description": "Tartar Emetic",
+			"reference": "BT153",
+			"tech_level": "5",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 2,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 2,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eMg4qtrRc_B27MjOQ",
+			"description": "Growth Hormone",
+			"reference": "BT154",
+			"notes": "taken daily for a number of years",
+			"tech_level": "7",
+			"legality_class": "3",
+			"tags": [
+				"Drug"
+			],
+			"value": 136.9863,
+			"quantity": 365,
+			"equipped": true,
+			"calc": {
+				"extended_value": 49999.9995,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eKKB7jTmmt7OmFfpD",
+			"description": "Growth Hormone",
+			"reference": "BT154",
+			"notes": "taken daily for a number of years",
+			"tech_level": "8",
+			"legality_class": "3",
+			"tags": [
+				"Drug"
+			],
+			"value": 54.7945,
+			"quantity": 365,
+			"equipped": true,
+			"calc": {
+				"extended_value": 19999.9925,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eRWxMJ5ZmaMnLsJPs",
+			"description": "Anabolic Steroids",
+			"reference": "BT154",
+			"tech_level": "7",
+			"legality_class": "3",
+			"tags": [
+				"Drug"
+			],
+			"value": 3,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 3,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "e9zYRE-wfq5ZfJ9M3",
+			"description": "Erythropoietin",
+			"reference": "BT154",
+			"tech_level": "8",
+			"legality_class": "3",
+			"tags": [
+				"Drug"
+			],
+			"value": 500,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 500,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "e1McO_kD9mKl33oDj",
+			"description": "Nootropic Drug",
+			"reference": "BT154",
+			"notes": "taken daily",
+			"tech_level": "8",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 2.8571,
+			"quantity": 7,
+			"equipped": true,
+			"calc": {
+				"extended_value": 19.9997,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "ekkq9_ae9Ixq3R97C",
+			"description": "Adder (ST)",
+			"reference": "BT155",
+			"notes": "lasts (25-HT)/4 hours",
+			"tech_level": "9",
+			"legality_class": "3",
+			"tags": [
+				"Drug"
+			],
+			"value": 25,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 25,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "epE_e-1WbBXnObwLC",
+			"description": "Adder (DX)",
+			"reference": "BT155",
+			"notes": "lasts (25-HT)/4 hours",
+			"tech_level": "9",
+			"legality_class": "3",
+			"tags": [
+				"Drug"
+			],
+			"value": 25,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 25,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "er0csnhilBRz4bK2x",
+			"description": "Adder (IQ)",
+			"reference": "BT155",
+			"notes": "lasts (25-HT)/4 hours",
+			"tech_level": "9",
+			"legality_class": "3",
+			"tags": [
+				"Drug"
+			],
+			"value": 25,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 25,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eSLcFv_K-bQycUu-1",
+			"description": "Adder (HT)",
+			"reference": "BT155",
+			"notes": "lasts (25-HT)/4 hours",
+			"tech_level": "9",
+			"legality_class": "3",
+			"tags": [
+				"Drug"
+			],
+			"value": 25,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 25,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "ef3jLekN2lUqtfEHV",
+			"description": "Adder (Basic Move)",
+			"reference": "BT155",
+			"notes": "lasts (25-HT)/4 hours",
+			"tech_level": "9",
+			"legality_class": "3",
+			"tags": [
+				"Drug"
+			],
+			"value": 25,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 25,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "ehBZIjnH6r65lMEF1",
+			"description": "Bone Stimulation",
+			"reference": "BT155",
+			"notes": "Treatment takes two weeks. Effect is permanent.",
+			"tech_level": "9",
+			"tags": [
+				"Drug"
+			],
+			"value": 10000,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 10000,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eInMDU7AH6b_7I0QB",
+			"description": "Mnemosin",
+			"reference": "BT155",
+			"notes": "Lasts (25-HT) minutes",
+			"tech_level": "9",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 20,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 20,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eN8Glt4rlgGgGOoTR",
+			"description": "Peter Pan Process",
+			"reference": "BT155",
+			"notes": "cost is per month of treatment",
+			"tech_level": "9",
+			"legality_class": "3",
+			"tags": [
+				"Drug"
+			],
+			"value": 500,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 500,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eZ19ma3Bt0XUYJ0sl",
+			"description": "Super-Steroid",
+			"reference": "BT156",
+			"notes": "taken daily",
+			"tech_level": "9",
+			"legality_class": "3",
+			"tags": [
+				"Drug"
+			],
+			"value": 50,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 50,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "enI-8-6ZfJxo8Stl1",
+			"description": "Basic",
+			"reference": "BT156",
+			"notes": "Lasts (25-HT)/4 minutes",
+			"tech_level": "10",
+			"legality_class": "1",
+			"tags": [
+				"Drug"
+			],
+			"value": 12,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 12,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "etV_gqDKIX448VQCS",
+			"description": "NERV",
+			"reference": "BT156",
+			"notes": "Treatment takes 20 weeks. Effect is permanent. Price is per week",
+			"tech_level": "10",
+			"legality_class": "3",
+			"tags": [
+				"Drug"
+			],
+			"value": 2000,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 2000,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eO59ZeKfxIkxGCGjK",
+			"description": "Hypoxyline",
+			"reference": "BT156",
+			"notes": "Lasts 1 day",
+			"tech_level": "10",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 50,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 50,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "efuwwCGnTHfK9cqsQ",
+			"description": "Tempo",
+			"reference": "BT156",
+			"notes": "Lasts (25-HT) minutes",
+			"tech_level": "10",
+			"legality_class": "2",
+			"tags": [
+				"Drug"
+			],
+			"value": 45,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 45,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eewV1_MkvUSyM_-Mn",
+			"description": "Gravanol",
+			"reference": "BT157",
+			"tech_level": "10",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 70,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 70,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "e7tgVDZaO0orFOcol",
+			"description": "Truth Serum",
+			"reference": "BT157",
+			"notes": "Lasts (20-HT)/2 minutes",
+			"tech_level": "6",
+			"legality_class": "3",
+			"tags": [
+				"Drug"
+			],
+			"value": 10,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 10,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eX5W2StpFIeA2eQ0w",
+			"description": "Dimethyl Sulfoxide",
+			"reference": "BT157",
+			"tech_level": "7",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 1,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 1,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eDDyU-eMBVYGY7DIK",
+			"description": "Aware",
+			"reference": "BT157",
+			"notes": "Lasts 24 hours",
+			"tech_level": "9",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 50,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 50,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eS6juGvZhzxrXp_55",
+			"description": "Anti-Sed",
+			"reference": "BT157",
+			"notes": "Lasts 24 hours",
+			"tech_level": "9",
+			"legality_class": "2",
+			"tags": [
+				"Drug"
+			],
+			"value": 50,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 50,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "ezb3U8AkhKqoR_pe-",
+			"description": "Crediline",
+			"reference": "BT157",
+			"notes": "Lasts (25-HT) minutes",
+			"tech_level": "9",
+			"legality_class": "2",
+			"tags": [
+				"Drug"
+			],
+			"value": 24,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 24,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "ebg0ST5B_WsdRGpBe",
+			"description": "Torpine",
+			"reference": "BT157",
+			"notes": "Lasts a day",
+			"tech_level": "9",
+			"legality_class": "3",
+			"tags": [
+				"Drug"
+			],
+			"value": 20,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 20,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "e9zApk7VVVtc3_w8H",
+			"description": "Lethe",
+			"reference": "BT157",
+			"notes": "Lasts (25-HT) minutes",
+			"tech_level": "10",
+			"legality_class": "2",
+			"tags": [
+				"Drug"
+			],
+			"value": 24,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 24,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "e7SUnMLxe3NSrtrZV",
+			"description": "Neurovine",
+			"reference": "BT157",
+			"notes": "Effective if taken within 15 minutes of poisoning",
+			"tech_level": "10",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 30,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 30,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "e_zW36lrU7CsuVAGb",
+			"description": "Oral Contraceptive Pill",
+			"reference": "BT157",
+			"notes": "Price is for a monthly supply",
+			"tech_level": "7",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 20,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 20,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eth0RhKr1Efc51geh",
+			"description": "Vitamin",
+			"reference": "BT157",
+			"tech_level": "7",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 0.1,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 0.1,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "e16voaUMo26OoklNv",
+			"description": "Aphrozine",
+			"reference": "BT158",
+			"notes": "Lasts for one hour",
+			"tech_level": "9",
+			"legality_class": "3",
+			"tags": [
+				"Drug"
+			],
+			"value": 20,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 20,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eLsmOS7WnhWK21yFi",
+			"description": "Male Contraceptive Pill",
+			"reference": "BT158",
+			"notes": "Price is for a monthly supply; Must be taken for a week to be effective",
+			"tech_level": "9",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 20,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 20,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eAI4wnyXJqP3fcBON",
+			"description": "Melatan",
+			"reference": "BT158",
+			"tech_level": "9",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 50,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 50,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eWxwKQLdeanPqjoNh",
+			"description": "Musk (pleasant odor)",
+			"reference": "BT158",
+			"notes": "Lasts for 12 hours",
+			"tech_level": "9",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 5,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 5,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "e__iUT5vqRwmJxtFm",
+			"description": "Musk (@scent masking or insect repellent@)",
+			"reference": "BT158",
+			"notes": "Lasts for 12 hours",
+			"tech_level": "9",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 10,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 10,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "elHFzhW9xwPzViZUG",
+			"description": "Sex Pheromones",
+			"reference": "BT158",
+			"notes": "Lasts for 2 hours",
+			"tech_level": "9",
+			"legality_class": "3",
+			"tags": [
+				"Drug"
+			],
+			"value": 60,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 60,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "etgBN_qj2R0KMb-7A",
+			"description": "Sobriety Pill",
+			"reference": "BT158",
+			"tech_level": "9",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 2,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 2,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eiCt1aSUDi10bbBlK",
+			"description": "Genetically Targeted Pheromones",
+			"reference": "BT158",
+			"notes": "Lasts for 2 hours",
+			"tech_level": "10",
+			"legality_class": "1",
+			"tags": [
+				"Drug"
+			],
+			"value": 1000,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 1000,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "erjApvib8BnlDe6I5",
+			"description": "Deep-Sleep",
+			"reference": "BT158",
+			"tech_level": "10",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 5,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 5,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eIgPiCNyRuQG1lvE2",
+			"description": "Life Extension Drug",
+			"reference": "BT159",
+			"notes": "Price is for a year's supply; Must be taken for for 6 months to 2 years to be effective, depending on age",
+			"tech_level": "9",
+			"legality_class": "3",
+			"tags": [
+				"Drug"
+			],
+			"value": 30000,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 30000,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eJ-KOLD_Kr67P--na",
+			"description": "Longevity Drug",
+			"reference": "BT159",
+			"notes": "Taken monthly; Must be taken for for 1 year to be effective",
+			"tech_level": "10",
+			"legality_class": "3",
+			"tags": [
+				"Drug"
+			],
+			"value": 3000,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 3000,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "ekDihEVl-_VhJJxcf",
+			"description": "Insenium",
+			"reference": "BT159",
+			"notes": "Taken yearly",
+			"tech_level": "^",
+			"legality_class": "2",
+			"tags": [
+				"Drug"
+			],
+			"value": 25000,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 25000,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "e_16DGaVm_s3NDPs7",
+			"description": "Stasine",
+			"reference": "BT159",
+			"notes": "Taken monthly",
+			"tech_level": "^",
+			"legality_class": "3",
+			"tags": [
+				"Drug"
+			],
+			"value": 10000,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 10000,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "e1UPlOr3bbiptUh2U",
+			"description": "Blocker",
+			"reference": "BT160",
+			"notes": "Lasts 6 hours",
+			"tech_level": "^",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 100,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 100,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eO0dA4aR2bwvzF0D5",
+			"description": "Booster (@psionic talent@)",
+			"reference": "BT160",
+			"notes": "Lasts one day",
+			"tech_level": "^",
+			"legality_class": "2",
+			"tags": [
+				"Drug"
+			],
+			"value": 250,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 250,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "ehfbXSQUoc9dS-3UM",
+			"description": "Muffler",
+			"reference": "BT160",
+			"notes": "Lasts for (25-HT)/4 hours",
+			"tech_level": "^",
+			"legality_class": "2",
+			"tags": [
+				"Drug"
+			],
+			"value": 800,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 800,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eh_5rWMP6QyhWn4M7",
+			"description": "Window",
+			"reference": "BT160",
+			"notes": "Lasts for (25-HT)/4 hours",
+			"tech_level": "^",
+			"legality_class": "2",
+			"tags": [
+				"Drug"
+			],
+			"value": 250,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 250,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eB7_ilqmGWA-73ELo",
+			"description": "Antitox",
+			"reference": "BT161",
+			"notes": "Lasts for 24 hours",
+			"tech_level": "10",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 400,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 400,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "es7rUld_Qetv0Eqv1",
+			"description": "Atman",
+			"reference": "BT161",
+			"notes": "Lasts for one day",
+			"tech_level": "10",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 500,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 500,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eQmVbkC3pSqP2vJys",
+			"description": "BodyHeat",
+			"reference": "BT161",
+			"notes": "Lasts for one day",
+			"tech_level": "10",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 1100,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 1100,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "e5irsvquA5QxTjac9",
+			"description": "Destruct Nano (@triggering condition@)",
+			"reference": "BT162",
+			"notes": "Permanent unless cured",
+			"tech_level": "10",
+			"legality_class": "1",
+			"tags": [
+				"Drug"
+			],
+			"value": 100,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 100,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eOyt3JvGkE7D6mtz_",
+			"description": "Focus",
+			"reference": "BT162",
+			"notes": "Lasts (25-HT)/4 hours",
+			"tech_level": "10",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 160,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 160,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eGs4XHNjDsonXprZW",
+			"description": "Hepaclean",
+			"reference": "BT162",
+			"notes": "Takes effect after 30 minutes",
+			"tech_level": "10",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 30,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 30,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eNA-i4zSSiXKU4QCj",
+			"description": "Morlock",
+			"reference": "BT162",
+			"notes": "Lasts (25-HT)/4 hours",
+			"tech_level": "10",
+			"legality_class": "2",
+			"tags": [
+				"Drug"
+			],
+			"value": 450,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 450,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eRXn7s1zXV5gfDUdH",
+			"description": "Verazene",
+			"reference": "BT162",
+			"notes": "Lasts (25-HT)/4 minutes",
+			"tech_level": "10",
+			"legality_class": "2",
+			"tags": [
+				"Drug"
+			],
+			"value": 16,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 16,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eE2UcOkf0nIWemF1D",
+			"description": "Tailored Immune Machines (@common disease@)",
+			"reference": "BT162",
+			"tech_level": "10",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 50,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 50,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "e6J7RZUhhueOhZ9ST",
+			"description": "Tailored Immune Machines (@rare ailment@)",
+			"reference": "BT162",
+			"tech_level": "10",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 500,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 500,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "ee3-pHEyQkYd_H9sv",
+			"description": "Programmable Immune Machines",
+			"reference": "BT162",
+			"tech_level": "11",
+			"legality_class": "3",
+			"tags": [
+				"Drug"
+			],
+			"value": 500,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 500,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "ec6cvLRRoS1xLMYMP",
+			"description": "Disassembly Nanovirus",
+			"reference": "BT163",
+			"notes": "Can disassemble up to 200lbs per dose; Takes 24 hours",
+			"tech_level": "12",
+			"legality_class": "3",
+			"tags": [
+				"Drug"
+			],
+			"value": 100000,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 100000,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eTl4orhW_IEGDnG6k",
+			"description": "Reassembly Nanovirus",
+			"reference": "BT163",
+			"notes": "Can reassemble up to 200lbs per dose; Takes a week",
+			"tech_level": "12",
+			"legality_class": "3",
+			"tags": [
+				"Drug"
+			],
+			"value": 500000,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 500000,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eHrkYyFZY_QWdUaJJ",
+			"description": "Reanimation",
+			"reference": "BT163",
+			"notes": "Brings a dead or reassembled body back to life",
+			"tech_level": "12",
+			"legality_class": "3",
+			"tags": [
+				"Drug"
+			],
+			"value": 1000000,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 1000000,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "e_IDafJSnS7QTaswZ",
+			"description": "Panimmunity (Level 1)",
+			"reference": "BT164",
+			"notes": "Lasts one day to two weeks; Takes effect in one hour",
+			"tech_level": "9",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 150,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 150,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "ez3FTS57Y4pXAqK-o",
+			"description": "Panimmunity (Level 2)",
+			"reference": "BT165",
+			"notes": "Lasts one day to two weeks; Takes effect in one hour",
+			"tech_level": "10",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 250,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 250,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eWfLOGzNB2nefIEAp",
+			"description": "Panimmunity (Level 3)",
+			"reference": "BT165",
+			"notes": "Lasts one day to two weeks; Takes effect in one hour",
+			"tech_level": "12",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 500,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 500,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eJALjSej24n91DBxg",
+			"description": "Artery Cleaners",
+			"reference": "BT165",
+			"notes": "Lasts one day to two weeks; Needs to be used for at least 6 months",
+			"tech_level": "10",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 50,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 50,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "e3gIeo3PQ5jZnfIdz",
+			"description": "Nano-Bacteriophages",
+			"reference": "BT165",
+			"notes": "Lasts one day to two weeks; Takes effect in one hour",
+			"tech_level": "10",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 250,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 250,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eIv-EuJskVfnrAj6u",
+			"description": "Blood Cops",
+			"reference": "BT165",
+			"notes": "Lasts one day to two weeks; Takes effect in one hour",
+			"tech_level": "10",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 850,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 850,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "e1vE274BSxpqWKGX0",
+			"description": "Carcinophages",
+			"reference": "BT165",
+			"notes": "Lasts one day to two weeks; Takes effect in one hour",
+			"tech_level": "10",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 250,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 250,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "ebc3OFJE8Blffjmbe",
+			"description": "Guardians",
+			"reference": "BT165",
+			"notes": "Lasts one day to two weeks; Takes effect in one hour",
+			"tech_level": "10",
+			"legality_class": "3",
+			"tags": [
+				"Drug"
+			],
+			"value": 100,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 100,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eIGk5MQhFopkOySOR",
+			"description": "Lung Cleaners",
+			"reference": "BT165",
+			"notes": "Lasts one day to two weeks; Takes effect in one hour",
+			"tech_level": "10",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 250,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 250,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eBwo_w8elw70calCZ",
+			"description": "Microgravity Biochemistry",
+			"reference": "BT165",
+			"notes": "Lasts one day to two weeks; Takes effect in one hour",
+			"tech_level": "10",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 100,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 100,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eSAwPI3aJT6KqrIXA",
+			"description": "Pore Cleaners",
+			"reference": "BT165",
+			"notes": "Lasts one day to two weeks; Takes effect in one hour",
+			"tech_level": "10",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 50,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 50,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eI6BztPotYJEndkZH",
+			"description": "Tooth Cleaners",
+			"reference": "BT166",
+			"notes": "Lasts one day to two weeks; Takes effect in one hour",
+			"tech_level": "10",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 20,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 20,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eDEhceBks7kdEQ9Rc",
+			"description": "Virus Hunters",
+			"reference": "BT166",
+			"notes": "Lasts one day to two weeks; Takes effect in one hour",
+			"tech_level": "10",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 250,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 250,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "enpVKg4Pj73_dAV1e",
+			"description": "Brain Boosters",
+			"reference": "BT166",
+			"notes": "Lasts one day to two weeks; Takes effect in one hour",
+			"tech_level": "11",
+			"legality_class": "2",
+			"tags": [
+				"Drug"
+			],
+			"value": 4500,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 4500,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "enw_VUqHAMg1zEmIv",
+			"description": "Cell Surgeons",
+			"reference": "BT166",
+			"notes": "Lasts one day to two weeks; Takes effect in one hour",
+			"tech_level": "11",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 1200,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 1200,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "evRCOJ8t0DNmUBPDw",
+			"description": "Electroreceptors",
+			"reference": "BT166",
+			"notes": "Lasts one day to two weeks; Takes effect in one hour",
+			"tech_level": "11",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 500,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 500,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eLyGRC58ZGZLqShrT",
+			"description": "DNA Repair",
+			"reference": "BT166",
+			"notes": "Lasts one day to two weeks; Takes effect in one hour",
+			"tech_level": "11",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 300,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 300,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eghqArAZCXQEPIeeT",
+			"description": "Metabolic Regulators",
+			"reference": "BT166",
+			"notes": "Lasts one day to two weeks; Takes effect in one hour",
+			"tech_level": "11",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 700,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 700,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eXldRcqZXNoGxgjlN",
+			"description": "Respirocytes",
+			"reference": "BT166",
+			"notes": "Lasts one day to two weeks; Takes effect in one hour",
+			"tech_level": "11",
+			"legality_class": "4",
+			"tags": [
+				"Drug"
+			],
+			"value": 300,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 300,
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eKGOo_lMK5kfHtisD",
+			"description": "Cell Communion",
+			"reference": "BT166",
+			"notes": "Lasts one day to two weeks; Takes effect in one hour",
+			"tech_level": "12",
+			"legality_class": "1",
+			"tags": [
+				"Drug"
+			],
+			"value": 900,
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 900,
+				"extended_weight": "0 lb"
+			}
+		}
+	]
+}

--- a/Library/Bio-Tech/Bio-Tech Traits.adq
+++ b/Library/Bio-Tech/Bio-Tech Traits.adq
@@ -1,0 +1,2574 @@
+{
+	"version": 5,
+	"rows": [
+		{
+			"id": "TxtxxADYNjHcokGFN",
+			"name": "Panimmunity (Level 1)",
+			"reference": "BT165",
+			"notes": "TL9; $7500; LC4",
+			"tags": [
+				"Nanosymbionts"
+			],
+			"children": [
+				{
+					"id": "tWNhklq0LHcojLWu6",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tJTfFdHM7YI5IZR7I"
+					},
+					"name": "Resistant",
+					"reference": "B81,P71,MA47",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mgtHLWq57587wI0ty",
+							"name": "@Very Common: Metabolic Hazards, etc.@",
+							"reference": "B80",
+							"cost": 30,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mU2cGoxOJBIlIzmKQ",
+							"name": "@Common: Poison, Sickness, etc.@",
+							"reference": "B81",
+							"cost": 15,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mFuoRFBJqLxGoRum-",
+							"name": "Disease",
+							"reference": "B81",
+							"cost": 10,
+							"cost_type": "points"
+						},
+						{
+							"id": "m5J27lbWi5xfJF6TL",
+							"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+							"reference": "B81",
+							"cost": 5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mpTa_JRbPM_krP25r",
+							"name": "Immunity",
+							"reference": "B81",
+							"cost": 1,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "mVxLSZlGk57K_VOul",
+							"name": "+8 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.5,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "mpQu8yJUgMPTMGPav",
+							"name": "+3 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.33,
+							"cost_type": "multiplier"
+						}
+					],
+					"round_down": true,
+					"calc": {
+						"points": 3
+					}
+				}
+			],
+			"calc": {
+				"points": 3
+			}
+		},
+		{
+			"id": "TPPY7lw2faT5MbmJO",
+			"name": "Panimmunity (Level 2)",
+			"reference": "BT165",
+			"notes": "TL10; $12500; LC4",
+			"tags": [
+				"Nanosymbionts"
+			],
+			"children": [
+				{
+					"id": "tM_w4YVrmNmEZQYna",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tJTfFdHM7YI5IZR7I"
+					},
+					"name": "Resistant",
+					"reference": "B81,P71,MA47",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mpNQseGBQK1t6LInJ",
+							"name": "@Very Common: Metabolic Hazards, etc.@",
+							"reference": "B80",
+							"cost": 30,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mu13vB6qdjFGOxbEw",
+							"name": "@Common: Poison, Sickness, etc.@",
+							"reference": "B81",
+							"cost": 15,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mK96vKeZSuOGPA0Un",
+							"name": "Disease",
+							"reference": "B81",
+							"cost": 10,
+							"cost_type": "points"
+						},
+						{
+							"id": "mugi-BrN6ZId8dzt-",
+							"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+							"reference": "B81",
+							"cost": 5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "m72AB1gPFeI2PY6e1",
+							"name": "Immunity",
+							"reference": "B81",
+							"cost": 1,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "mK_pMbPxKG631mt-o",
+							"name": "+8 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.5,
+							"cost_type": "multiplier"
+						},
+						{
+							"id": "mca5XbGN_2t1Nrq62",
+							"name": "+3 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.33,
+							"cost_type": "multiplier",
+							"disabled": true
+						}
+					],
+					"round_down": true,
+					"calc": {
+						"points": 5
+					}
+				}
+			],
+			"calc": {
+				"points": 5
+			}
+		},
+		{
+			"id": "T5Vt2jT7EW9_SnyHc",
+			"name": "Panimmunity (Level 3)",
+			"reference": "BT165",
+			"notes": "TL12; $25000; LC4",
+			"tags": [
+				"Nanosymbionts"
+			],
+			"children": [
+				{
+					"id": "tVOCkxPvI3QUrhUZn",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tJTfFdHM7YI5IZR7I"
+					},
+					"name": "Resistant",
+					"reference": "B81,P71,MA47",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mg6_7ofsNTla0o1MT",
+							"name": "@Very Common: Metabolic Hazards, etc.@",
+							"reference": "B80",
+							"cost": 30,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mqMYDfkvD2xwQCRJR",
+							"name": "@Common: Poison, Sickness, etc.@",
+							"reference": "B81",
+							"cost": 15,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "m6KhjvIzYA73z_23D",
+							"name": "Disease",
+							"reference": "B81",
+							"cost": 10,
+							"cost_type": "points"
+						},
+						{
+							"id": "mzp2phPZ1ma2McAX5",
+							"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+							"reference": "B81",
+							"cost": 5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "muKqMIQKJOzxgvbUS",
+							"name": "Immunity",
+							"reference": "B81",
+							"cost": 1,
+							"cost_type": "multiplier"
+						},
+						{
+							"id": "m8_52_U6rT1A4E2p8",
+							"name": "+8 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.5,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "mXvPMzvq69z5FeuND",
+							"name": "+3 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.33,
+							"cost_type": "multiplier",
+							"disabled": true
+						}
+					],
+					"round_down": true,
+					"calc": {
+						"points": 10
+					}
+				}
+			],
+			"calc": {
+				"points": 10
+			}
+		},
+		{
+			"id": "TFzmkTLwNXYITfntT",
+			"name": "Artery Cleaners",
+			"reference": "BT165",
+			"notes": "TL10; $2500; LC4",
+			"tags": [
+				"Nanosymbionts"
+			],
+			"children": [
+				{
+					"id": "tpy6L80YLsc5qr6se",
+					"name": "50% chance of not losing HT on a failed aging role",
+					"reference": "BT165",
+					"calc": {
+						"points": 0
+					}
+				}
+			],
+			"calc": {
+				"points": 0
+			}
+		},
+		{
+			"id": "TZwsI7AuP747ealuK",
+			"name": "Nano-Bacteriophages",
+			"reference": "BT165",
+			"notes": "TL10; $12500; LC4",
+			"tags": [
+				"Nanosymbionts"
+			],
+			"children": [
+				{
+					"id": "tE6A-Xkif1W9cfw5W",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tJTfFdHM7YI5IZR7I"
+					},
+					"name": "Resistant",
+					"reference": "B81,P71,MA47",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mC7tgc4FgAZ9T2jOt",
+							"name": "@Very Common: Metabolic Hazards, etc.@",
+							"reference": "B80",
+							"cost": 30,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "m6TMOd-xR3jhIpv4n",
+							"name": "@Common: Poison, Sickness, etc.@",
+							"reference": "B81",
+							"cost": 15,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mHTQP-2OqSeRt9LNX",
+							"name": "@Occasional: Disease, Ingested Poison, etc.@",
+							"reference": "B81",
+							"cost": 10,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mrs312Hn55oyxMVlw",
+							"name": "Known Bacteria",
+							"reference": "B81",
+							"cost": 5,
+							"cost_type": "points"
+						},
+						{
+							"id": "mA_2kBQ6Lnv8MYRP5",
+							"name": "Immunity",
+							"reference": "B81",
+							"cost": 1,
+							"cost_type": "multiplier"
+						},
+						{
+							"id": "mX1jfJWJnzWxw4sQF",
+							"name": "+8 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.5,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "mOTb2h5c86ID1Ok5I",
+							"name": "+3 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.33,
+							"cost_type": "multiplier",
+							"disabled": true
+						}
+					],
+					"round_down": true,
+					"calc": {
+						"points": 5
+					}
+				}
+			],
+			"calc": {
+				"points": 5
+			}
+		},
+		{
+			"id": "TD9kB4SXB-WAe40k9",
+			"name": "Blood Cops",
+			"reference": "BT165",
+			"notes": "TL10; $42500; LC4",
+			"tags": [
+				"Nanosymbionts"
+			],
+			"children": [
+				{
+					"id": "tK9qlkcalAM6GpL0J",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "thdJ55ghf__io9AQa"
+					},
+					"name": "Longevity",
+					"reference": "B66",
+					"notes": "You fail aging rolls only on a 17 or 18, or only on an 18 if your modified HT is 17 or better",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"base_points": 2,
+					"calc": {
+						"points": 2
+					}
+				},
+				{
+					"id": "thYzgeghRlQDUATrU",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tJTfFdHM7YI5IZR7I"
+					},
+					"name": "Resistant",
+					"reference": "B81,P71,MA47",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mjfzddK-fAA0hjxPV",
+							"name": "Metabolic Hazards",
+							"reference": "B80",
+							"cost": 30,
+							"cost_type": "points"
+						},
+						{
+							"id": "mcivW2c5tjih2A4Bw",
+							"name": "@Common: Poison, Sickness, etc.@",
+							"reference": "B81",
+							"cost": 15,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "m5HZE_h95x2Chy8ce",
+							"name": "@Occasional: Disease, Ingested Poison, etc.@",
+							"reference": "B81",
+							"cost": 10,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mK2A4eyethccA4DKj",
+							"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+							"reference": "B81",
+							"cost": 5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mdmAUg3MfG7ZpdU-R",
+							"name": "Immunity",
+							"reference": "B81",
+							"cost": 1,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "m3fDQ5kfyORTLrOWS",
+							"name": "+8 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.5,
+							"cost_type": "multiplier"
+						},
+						{
+							"id": "msKqK1NvtcxRhGE2i",
+							"name": "+3 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.33,
+							"cost_type": "multiplier",
+							"disabled": true
+						}
+					],
+					"round_down": true,
+					"calc": {
+						"points": 15
+					}
+				}
+			],
+			"calc": {
+				"points": 17
+			}
+		},
+		{
+			"id": "TQO5W1WLJT2tooJMt",
+			"name": "Carcinophages",
+			"reference": "BT165",
+			"notes": "TL10; $17500; LC4",
+			"tags": [
+				"Nanosymbionts"
+			],
+			"children": [
+				{
+					"id": "tCr5zkwIZNyfMpH9x",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tJTfFdHM7YI5IZR7I"
+					},
+					"name": "Resistant",
+					"reference": "B81,P71,MA47",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mcQOfPXZBjflh3hOh",
+							"name": "@Very Common: Metabolic Hazards, etc.@",
+							"reference": "B80",
+							"cost": 30,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mhkhcD95AL4pnbUJx",
+							"name": "@Common: Poison, Sickness, etc.@",
+							"reference": "B81",
+							"cost": 15,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mpy2uJK6aY5dotMoP",
+							"name": "@Occasional: Disease, Ingested Poison, etc.@",
+							"reference": "B81",
+							"cost": 10,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mm88ElMp6slMyu5G7",
+							"name": "Cancers",
+							"reference": "B81",
+							"cost": 5,
+							"cost_type": "points"
+						},
+						{
+							"id": "mU301K1M6v79fzan6",
+							"name": "Immunity",
+							"reference": "B81",
+							"cost": 1,
+							"cost_type": "multiplier"
+						},
+						{
+							"id": "mgHXPL9BgwNeRhEL7",
+							"name": "+8 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.5,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "mDKB0QY3o7viceKKV",
+							"name": "+3 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.33,
+							"cost_type": "multiplier",
+							"disabled": true
+						}
+					],
+					"round_down": true,
+					"calc": {
+						"points": 5
+					}
+				},
+				{
+					"id": "t91snBX_vG7HDmasH",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tUJz4wvVveMiGDX0R"
+					},
+					"name": "Extended Lifespan",
+					"reference": "B53",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"points_per_level": 2,
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 2
+					}
+				}
+			],
+			"calc": {
+				"points": 7
+			}
+		},
+		{
+			"id": "TDVWo7CywsDeb6pAg",
+			"name": "Guardians",
+			"reference": "BT165",
+			"notes": "TL10; $5000; LC3",
+			"tags": [
+				"Nanosymbionts"
+			],
+			"children": [
+				{
+					"id": "t1J71w_wGFiChle5b",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tJTfFdHM7YI5IZR7I"
+					},
+					"name": "Resistant",
+					"reference": "B81,P71,MA47",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mFrXAN6nI4zQcgcQc",
+							"name": "@Very Common: Metabolic Hazards, etc.@",
+							"reference": "B80",
+							"cost": 30,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "msT3BkC8Dy5Dm1tLZ",
+							"name": "@Common: Poison, Sickness, etc.@",
+							"reference": "B81",
+							"cost": 15,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mkDXkYRevW8qRS3Q6",
+							"name": "@Occasional: Disease, Ingested Poison, etc.@",
+							"reference": "B81",
+							"cost": 10,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mFS4K0-LQRmjMv2Ws",
+							"name": "Bio-Nanomachines",
+							"reference": "B81",
+							"cost": 5,
+							"cost_type": "points"
+						},
+						{
+							"id": "m0nrTNjqmREHNtBQj",
+							"name": "Immunity",
+							"reference": "B81",
+							"cost": 1,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "mAzyCXc3-qbyO7CKK",
+							"name": "+8 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.5,
+							"cost_type": "multiplier"
+						},
+						{
+							"id": "mVaRW6LmvMBQW-JaZ",
+							"name": "+3 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.33,
+							"cost_type": "multiplier",
+							"disabled": true
+						}
+					],
+					"round_down": true,
+					"calc": {
+						"points": 2
+					}
+				}
+			],
+			"calc": {
+				"points": 2
+			}
+		},
+		{
+			"id": "TvmRfGp43qV78rZUl",
+			"name": "Lung Cleaners",
+			"reference": "BT165",
+			"notes": "TL10; $12500; LC4",
+			"tags": [
+				"Nanosymbionts"
+			],
+			"children": [
+				{
+					"id": "t5dY8NEJ-YjOyNw03",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tFY7tz3BT0k253ky_"
+					},
+					"name": "Filter Lungs",
+					"reference": "B55",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"base_points": 5,
+					"calc": {
+						"points": 5
+					}
+				}
+			],
+			"calc": {
+				"points": 5
+			}
+		},
+		{
+			"id": "TzxK-1Ky16RFAm4Fh",
+			"name": "Microgravity Biochemistry",
+			"reference": "BT165",
+			"notes": "TL10; $5000; LC4",
+			"tags": [
+				"Nanosymbionts"
+			],
+			"children": [
+				{
+					"id": "tXW-vF_5pECFNqbYi",
+					"name": "No Degeneration in Zero-G",
+					"reference": "BT211",
+					"tags": [
+						"Perk"
+					],
+					"base_points": 1,
+					"calc": {
+						"points": 1
+					}
+				}
+			],
+			"calc": {
+				"points": 1
+			}
+		},
+		{
+			"id": "TjoY87aoO-4YX1PM6",
+			"name": "Pore Cleaners",
+			"reference": "BT165",
+			"notes": "TL10; $2500; LC4",
+			"tags": [
+				"Nanosymbionts"
+			],
+			"children": [
+				{
+					"id": "t9vjCqjgqUEpAdw9b",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tf5DfdQFaNUVbkPV2"
+					},
+					"name": "Sanitized Metabolism",
+					"reference": "B101",
+					"tags": [
+						"Perk",
+						"Physical"
+					],
+					"base_points": 1,
+					"features": [
+						{
+							"type": "reaction_bonus",
+							"situation": "from others in close confines",
+							"amount": 1
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to attempts to track you by scent",
+							"amount": -1
+						}
+					],
+					"calc": {
+						"points": 1
+					}
+				}
+			],
+			"calc": {
+				"points": 1
+			}
+		},
+		{
+			"id": "T3S2bBdhy4boNwqYE",
+			"name": "Tooth Cleaners",
+			"reference": "BT166",
+			"notes": "TL10; $1000; LC4",
+			"tags": [
+				"Nanosymbionts"
+			],
+			"children": [
+				{
+					"id": "tWWm917jepJF7yixU",
+					"name": "Teeth are clean and healthy without needing brushing or toothpaste",
+					"calc": {
+						"points": 0
+					}
+				}
+			],
+			"calc": {
+				"points": 0
+			}
+		},
+		{
+			"id": "TxjJwdEDx9QwOZP-c",
+			"name": "Virus Hunters",
+			"reference": "BT166",
+			"notes": "TL10; $12500; LC4",
+			"tags": [
+				"Nanosymbionts"
+			],
+			"children": [
+				{
+					"id": "tIKrk3o9lyfF3A8B8",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tJTfFdHM7YI5IZR7I"
+					},
+					"name": "Resistant",
+					"reference": "B81,P71,MA47",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mRUG8iGfxmSBK5kmw",
+							"name": "@Very Common: Metabolic Hazards, etc.@",
+							"reference": "B80",
+							"cost": 30,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mUKwm22RvOIaXmlGX",
+							"name": "@Common: Poison, Sickness, etc.@",
+							"reference": "B81",
+							"cost": 15,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mxL5GyXCKykIERrPn",
+							"name": "@Occasional: Disease, Ingested Poison, etc.@",
+							"reference": "B81",
+							"cost": 10,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mYok_OJgn4aOjnift",
+							"name": "Known Viruses",
+							"reference": "B81",
+							"cost": 5,
+							"cost_type": "points"
+						},
+						{
+							"id": "mC18jUOyfoedasY1E",
+							"name": "Immunity",
+							"reference": "B81",
+							"cost": 1,
+							"cost_type": "multiplier"
+						},
+						{
+							"id": "mv9S43zXVhL99nRqM",
+							"name": "+8 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.5,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "mXRjW-oEJKxJv5rjf",
+							"name": "+3 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.33,
+							"cost_type": "multiplier",
+							"disabled": true
+						}
+					],
+					"round_down": true,
+					"calc": {
+						"points": 5
+					}
+				}
+			],
+			"calc": {
+				"points": 5
+			}
+		},
+		{
+			"id": "TBaIEBHBxoo5a4-dH",
+			"name": "Brain Boosters",
+			"reference": "BT166",
+			"notes": "TL11; $225000; LC2",
+			"tags": [
+				"Nanosymbionts"
+			],
+			"children": [
+				{
+					"id": "toNekzhnViAYHCwV1",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tAdgvQpc5XxYoM2Zu"
+					},
+					"name": "Enhanced Time Sense",
+					"reference": "B52,MA44",
+					"notes": "You immediately act in combat before those without Enhanced Time Sense; Never freeze",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Mental"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Combat Reflexes"
+								}
+							}
+						]
+					},
+					"base_points": 45,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "contains",
+								"qualifier": "fast-draw"
+							},
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "dodge",
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "parry",
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "block",
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "fright_check",
+							"amount": 2
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "on all IQ rolls to wake up or to recover from surprise or mental stun",
+							"amount": 6
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to your side on initiative rolls (+2 if you're the leader)",
+							"amount": 1
+						}
+					],
+					"calc": {
+						"points": 45
+					}
+				}
+			],
+			"calc": {
+				"points": 45
+			}
+		},
+		{
+			"id": "TDNrcbZqe-QeEpA_0",
+			"name": "Cell Surgeons",
+			"reference": "BT166",
+			"notes": "TL11; $60000; LC4",
+			"tags": [
+				"Nanosymbionts"
+			],
+			"children": [
+				{
+					"id": "tjGw5p4Cn-78Araqr",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tQrNIZ1kbn0I6UAZf"
+					},
+					"name": "Regeneration",
+					"reference": "B80,P70,MA47",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mtY7htO2-jLfpcT1W",
+							"name": "Slow",
+							"reference": "B80",
+							"notes": "You recover 1 HP per 12 hours",
+							"cost": 10,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mWyHVvmrsgblIgiW1",
+							"name": "Regular",
+							"reference": "B80",
+							"notes": "You recover 1 HP per hour",
+							"cost": 25,
+							"cost_type": "points"
+						},
+						{
+							"id": "mp4Prh_ogKIO5eSgo",
+							"name": "Fast",
+							"reference": "B80",
+							"notes": "You recover 1 HP per minute",
+							"cost": 50,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mqz33L41y7OLEvA0A",
+							"name": "Very Fast",
+							"reference": "B80",
+							"notes": "You recover 1 HP per second",
+							"cost": 100,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mxv0dHzYLet5eVhtT",
+							"name": "Extreme",
+							"reference": "B80",
+							"notes": "You recover 10 HP per second",
+							"cost": 150,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mjIkIXjQ7da5s-Vux",
+							"name": "Heals Radiation",
+							"reference": "B80",
+							"cost": 40,
+							"disabled": true
+						},
+						{
+							"id": "mpzr-DM8gY_hX9Xuh",
+							"name": "Radiation Only",
+							"reference": "B80",
+							"cost": -60,
+							"disabled": true
+						},
+						{
+							"id": "mIRdq16gzIb6Ji19K",
+							"name": "Fatigue Recovery",
+							"reference": "P70",
+							"cost": 100,
+							"disabled": true
+						},
+						{
+							"id": "mJMxoWc6uzSy_h3eg",
+							"name": "Fatigue Only",
+							"reference": "P70",
+							"disabled": true
+						},
+						{
+							"id": "mJF1F4bxHGWGogE0n",
+							"name": "Limited: @Advantage@ Only",
+							"reference": "P70",
+							"cost": -40,
+							"disabled": true
+						},
+						{
+							"id": "mbZ9Rf0-V8OP-e9rq",
+							"name": "Bane",
+							"reference": "H18",
+							"notes": "@Common or Very Common@",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "mBqo5P1avZPGfIGSI",
+							"name": "Bane",
+							"reference": "H18",
+							"notes": "@Occasional@",
+							"cost": -30,
+							"disabled": true
+						},
+						{
+							"id": "my1yJ8IOaEFfta7bR",
+							"name": "Bane",
+							"reference": "H18",
+							"notes": "@Rare@",
+							"cost": -10,
+							"disabled": true
+						},
+						{
+							"id": "m0NvIRiEGeCBh56-B",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+								"id": "mKEOStlk_5M2lC_K3"
+							},
+							"name": "Nuisance Effect",
+							"reference": "B112,P104",
+							"notes": "sweat heavily while regenerating",
+							"cost": -5,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from sweating heavily while regenerating",
+									"amount": -1
+								}
+							]
+						}
+					],
+					"calc": {
+						"points": 24
+					}
+				}
+			],
+			"calc": {
+				"points": 24
+			}
+		},
+		{
+			"id": "T7MtUQKbk7qbI1iNy",
+			"name": "Electroreceptors",
+			"reference": "BT166",
+			"notes": "TL11; $25000; LC4",
+			"tags": [
+				"Nanosymbionts"
+			],
+			"children": [
+				{
+					"id": "tidujM63oAo8ppELH",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tap6QZdAg9aCR_Tvf"
+					},
+					"name": "Detect",
+					"reference": "B48,P47,PSI14",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Mental",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mgcmJHnz4NEgwKrTc",
+							"name": "@Rare Substance/Condition@",
+							"reference": "B48",
+							"cost": 5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mYBkYNow9Rq97B8BL",
+							"name": "Electric and Magnetic Fields",
+							"reference": "B48",
+							"cost": 10,
+							"cost_type": "points"
+						},
+						{
+							"id": "m3a1hXuTZuMSBOLAO",
+							"name": "@Common Substance/Condition@",
+							"reference": "B48",
+							"cost": 20,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "my8eseVJEdkMZyJns",
+							"name": "@Very Common Substance/Condition@",
+							"reference": "B48",
+							"cost": 30,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mDk-6SMwSUoJtvl4l",
+							"name": "Precise",
+							"reference": "B48",
+							"cost": 100,
+							"disabled": true
+						},
+						{
+							"id": "mJEgINfRgXXk7c9TE",
+							"name": "Signal Detection",
+							"reference": "B48",
+							"disabled": true
+						},
+						{
+							"id": "mSM4LAuLvZnaHvYyp",
+							"name": "Vague",
+							"reference": "B48",
+							"cost": -50
+						},
+						{
+							"id": "mza1zZKc78Lcy6Nd0",
+							"name": "Analyzing",
+							"reference": "P47",
+							"cost": 100,
+							"disabled": true
+						},
+						{
+							"id": "mCS69Sh8jVNXyIecE",
+							"name": "Lock-On",
+							"reference": "PSI14",
+							"cost": 50,
+							"disabled": true
+						},
+						{
+							"id": "mx6kZ8uuV4h1c0ylU",
+							"name": "Precise, Nontargeting",
+							"reference": "PSI14",
+							"cost": 90,
+							"disabled": true
+						},
+						{
+							"id": "ml3Ja-4FspTpDcEyl",
+							"name": "Analysis Only",
+							"reference": "PSI14",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "myZ6wPOOy1RSPbgcy",
+							"name": "Cannot Analyze",
+							"reference": "PSI14",
+							"cost": -10,
+							"disabled": true
+						}
+					],
+					"calc": {
+						"points": 5
+					}
+				}
+			],
+			"calc": {
+				"points": 5
+			}
+		},
+		{
+			"id": "TkW_3QJ_HLUIeJQQL",
+			"name": "DNA Repair",
+			"reference": "BT166",
+			"notes": "TL11; $15000; LC4",
+			"tags": [
+				"Nanosymbionts"
+			],
+			"children": [
+				{
+					"id": "t3us0jHlp2eo4jEA9",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tQrNIZ1kbn0I6UAZf"
+					},
+					"name": "Regeneration",
+					"reference": "B80,P70,MA47",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "m67l-cJN-28ivn17W",
+							"name": "Slow",
+							"reference": "B80",
+							"notes": "You recover 1 HP per 12 hours",
+							"cost": 10,
+							"cost_type": "points"
+						},
+						{
+							"id": "m_WGMFWC9TLLi8hjg",
+							"name": "Regular",
+							"reference": "B80",
+							"notes": "You recover 1 HP per hour",
+							"cost": 25,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mX2QnAj8yLCNRVL4R",
+							"name": "Fast",
+							"reference": "B80",
+							"notes": "You recover 1 HP per minute",
+							"cost": 50,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mk1xqcp2DV6h_0K97",
+							"name": "Very Fast",
+							"reference": "B80",
+							"notes": "You recover 1 HP per second",
+							"cost": 100,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "m6sKyE8zxdE_zU69A",
+							"name": "Extreme",
+							"reference": "B80",
+							"notes": "You recover 10 HP per second",
+							"cost": 150,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mNvYTa4ppnL54piYx",
+							"name": "Heals Radiation",
+							"reference": "B80",
+							"cost": 40,
+							"disabled": true
+						},
+						{
+							"id": "muiV4Zc3i_S8qY7fH",
+							"name": "Radiation Only",
+							"reference": "B80",
+							"cost": -60
+						},
+						{
+							"id": "mmAdVxWkWnAmlz-D6",
+							"name": "Fatigue Recovery",
+							"reference": "P70",
+							"cost": 100,
+							"disabled": true
+						},
+						{
+							"id": "mEm_p5f0nhJDMNr1u",
+							"name": "Fatigue Only",
+							"reference": "P70",
+							"disabled": true
+						},
+						{
+							"id": "mSK9qSa5YuFkxQo_9",
+							"name": "Limited: @Advantage@ Only",
+							"reference": "P70",
+							"cost": -40,
+							"disabled": true
+						},
+						{
+							"id": "maFSDSA9degN-u0K-",
+							"name": "Bane",
+							"reference": "H18",
+							"notes": "@Common or Very Common@",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "mfQEWauD_PNmTGQoV",
+							"name": "Bane",
+							"reference": "H18",
+							"notes": "@Occasional@",
+							"cost": -30,
+							"disabled": true
+						},
+						{
+							"id": "mLsj_Yqgybycv6iPI",
+							"name": "Bane",
+							"reference": "H18",
+							"notes": "@Rare@",
+							"cost": -10,
+							"disabled": true
+						}
+					],
+					"calc": {
+						"points": 4
+					}
+				},
+				{
+					"id": "t8Q3YESXQFl8wVXk6",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tUJz4wvVveMiGDX0R"
+					},
+					"name": "Extended Lifespan",
+					"reference": "B53",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"points_per_level": 2,
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 2
+					}
+				}
+			],
+			"calc": {
+				"points": 6
+			}
+		},
+		{
+			"id": "TcGS1fygJv4Kduggx",
+			"name": "Metabolic Regulators",
+			"reference": "BT166",
+			"notes": "TL11; $35000; LC4",
+			"tags": [
+				"Nanosymbionts"
+			],
+			"children": [
+				{
+					"id": "tBr9qykDiMtO9eMUm",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t6p_KdmzfBCpkYoyn"
+					},
+					"name": "Metabolism Control",
+					"reference": "B68,P60",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mJOs0feoqtuPkpI-e",
+							"name": "Hibernation",
+							"reference": "B68",
+							"cost": -60,
+							"disabled": true
+						},
+						{
+							"id": "mw9-K_GPJrmRSE2CX",
+							"name": "Maestry",
+							"reference": "P60",
+							"cost": 40
+						}
+					],
+					"points_per_level": 5,
+					"can_level": true,
+					"levels": 2,
+					"calc": {
+						"points": 14
+					}
+				}
+			],
+			"calc": {
+				"points": 14
+			}
+		},
+		{
+			"id": "TJFY3tHkBJgZoqDM4",
+			"name": "Respirocytes",
+			"reference": "BT166",
+			"notes": "TL11; $15000; LC4",
+			"tags": [
+				"Nanosymbionts"
+			],
+			"children": [
+				{
+					"id": "tFfVERlkJfgZpmgIB",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tsIfS0jZqdshsDFOM"
+					},
+					"name": "Extra Fatigue Points",
+					"reference": "B16",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"points_per_level": 3,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "fp",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 2,
+					"calc": {
+						"points": 6
+					}
+				},
+				{
+					"id": "t5PzrfQ6dkGvO3hzM",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tUX_zxoB4sWyeNpHi"
+					},
+					"name": "Doesn't Breathe",
+					"reference": "B49",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mmdEbDbgH-v4Vt05c",
+							"name": "Gills",
+							"reference": "B49",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "mFHk2l2HPoluTljdf",
+							"name": "Gills",
+							"reference": "B49",
+							"notes": "Suffocates in air",
+							"cost": -20,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mHSC8dMLMoit4RHcQ",
+							"name": "Oxygen Absorption",
+							"reference": "B49",
+							"cost": -25,
+							"disabled": true
+						},
+						{
+							"id": "mraEE0Hq41RoaTfg1",
+							"name": "Oxygen Storage",
+							"reference": "B49",
+							"notes": "Can hold breath 25 times as long as normal",
+							"cost": -50
+						},
+						{
+							"id": "miB6_Knl3CXtlWo2p",
+							"name": "Oxygen Storage",
+							"reference": "B49",
+							"notes": "Can hold breath 50 times as long as normal",
+							"cost": -40,
+							"disabled": true
+						},
+						{
+							"id": "mk9iZ5CPhLxgR_G-P",
+							"name": "Oxygen Storage",
+							"reference": "B49",
+							"notes": "Can hold breath 100 times as long as normal",
+							"cost": -30,
+							"disabled": true
+						},
+						{
+							"id": "meqV5JytQrKjmfYdl",
+							"name": "Oxygen Storage",
+							"reference": "B49",
+							"notes": "Can hold breath 200 times as long as normal",
+							"cost": -20,
+							"disabled": true
+						},
+						{
+							"id": "mrL_5Tw3v-Mx7rdHY",
+							"name": "Oxygen Storage",
+							"reference": "B49",
+							"notes": "Can hold breath 300 times as long as normal",
+							"cost": -10,
+							"disabled": true
+						},
+						{
+							"id": "mZFqzHGpPFy9sr4j1",
+							"name": "Oxygen Combustion",
+							"reference": "B49",
+							"cost": -50,
+							"disabled": true
+						}
+					],
+					"base_points": 20,
+					"calc": {
+						"points": 10
+					}
+				}
+			],
+			"calc": {
+				"points": 16
+			}
+		},
+		{
+			"id": "TwGwezXX_sh43Qo5u",
+			"name": "Cell Communion",
+			"reference": "BT166",
+			"notes": "TL12; $45000; LC1",
+			"tags": [
+				"Nanosymbionts"
+			],
+			"children": [
+				{
+					"id": "t7BI6i8E8IXhJuJoM",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tnhMF2YViX6AhTHKD"
+					},
+					"name": "Telecommunication",
+					"reference": "B91,P81,PSI17",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Mental",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mMgGigLFweGUuPGo_",
+							"name": "Infrared Communication",
+							"reference": "B91",
+							"cost": 10,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mTiZKzu-pQPIwfEcK",
+							"name": "Laser Communication",
+							"reference": "B91",
+							"cost": 15,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mYIXUVOdsr82swKI7",
+							"name": "Radio",
+							"reference": "B91",
+							"cost": 10,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "muX-N-Fz3KdqiGZEx",
+							"name": "Telesend",
+							"reference": "B91",
+							"cost": 30,
+							"cost_type": "points"
+						},
+						{
+							"id": "m_fKVT2e9SCGqr9y-",
+							"name": "Broadcast",
+							"reference": "B91",
+							"cost": 50,
+							"disabled": true
+						},
+						{
+							"id": "mNhDUhsel9ZAAiVYT",
+							"name": "Short Wave",
+							"reference": "B91",
+							"cost": 50,
+							"disabled": true
+						},
+						{
+							"id": "m6JBzbH6lCLXMVplX",
+							"name": "Universal",
+							"reference": "B91",
+							"cost": 50
+						},
+						{
+							"id": "mi0Pv8RiThHnQKw9D",
+							"name": "Video",
+							"reference": "B91",
+							"cost": 40,
+							"disabled": true
+						},
+						{
+							"id": "mbtqz5e8-exYFAr90",
+							"name": "Racial",
+							"reference": "B91",
+							"cost": -20
+						},
+						{
+							"id": "m3Ri3UfxOsUDlm9D_",
+							"name": "Receive Only",
+							"reference": "B91",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "mITaLsl6I5DE_XkW6",
+							"name": "Send Only",
+							"reference": "B91",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "m-9xE78NrRTTgbCdO",
+							"name": "Vague",
+							"reference": "B91",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "mlM4Y6zCEOsD8RQzo",
+							"name": "Directional Sound",
+							"reference": "P81",
+							"cost": 5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mFVqMBZ-zls0HT1Zd",
+							"name": "Gravity Ripple",
+							"reference": "P81",
+							"cost": 20,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mFTwZo_JZwbtOJRWJ",
+							"name": "Neutrino",
+							"reference": "P81",
+							"cost": 25,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "moPKD9zt-nm1FcKVP",
+							"name": "Sonar",
+							"reference": "P81",
+							"cost": 10,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "m24FLkgWoXr6eZuqa",
+							"name": "Burst",
+							"reference": "P81",
+							"cost": 30,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "moduxeUWOWxaVKQkY",
+							"name": "FTL",
+							"reference": "P82",
+							"cost": 120,
+							"disabled": true
+						},
+						{
+							"id": "miCOh0j7fvHw15biG",
+							"name": "Secure",
+							"reference": "P82",
+							"cost": 20,
+							"disabled": true
+						},
+						{
+							"id": "md0bJeLQRpuIOE8qw",
+							"name": "Sensie",
+							"reference": "P82",
+							"cost": 80,
+							"disabled": true
+						},
+						{
+							"id": "mhnjdxmgj54zJk8bA",
+							"name": "Cable Jack",
+							"reference": "UT31",
+							"cost": 5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mxRofCUF7kexHMAEc",
+							"name": "Full Communion",
+							"reference": "PSI17",
+							"cost": 20,
+							"disabled": true
+						},
+						{
+							"id": "mCFVIHh02LQH2cE6d",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+								"id": "m9qu6zy-gjsxl3Jjw"
+							},
+							"name": "Blood Agent",
+							"reference": "B110,P100",
+							"cost": -40
+						},
+						{
+							"id": "mU7OlR247yC2xCmVv",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+								"id": "mVtDQj3J1f5GAAQ-J"
+							},
+							"name": "Melee Attack",
+							"reference": "B112,P103",
+							"notes": "Reach C",
+							"cost": -30
+						}
+					],
+					"calc": {
+						"points": 18
+					}
+				}
+			],
+			"calc": {
+				"points": 18
+			}
+		},
+		{
+			"id": "TQLGphs3zQSlJic3-",
+			"name": "Cell Communion (contagious)",
+			"reference": "BT166",
+			"notes": "TL12; $45000; LC1",
+			"tags": [
+				"Nanosymbionts"
+			],
+			"children": [
+				{
+					"id": "ty22-T5nLxgqg2U-_",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tnhMF2YViX6AhTHKD"
+					},
+					"name": "Telecommunication",
+					"reference": "B91,P81,PSI17",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Mental",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "m5_nn9jvYpnZoOF3H",
+							"name": "Infrared Communication",
+							"reference": "B91",
+							"cost": 10,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mF6FhJd0cPFv1e8dm",
+							"name": "Laser Communication",
+							"reference": "B91",
+							"cost": 15,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mqWrzYqlVUe6YfMB7",
+							"name": "Radio",
+							"reference": "B91",
+							"cost": 10,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mCuGJEXQnknrC53vZ",
+							"name": "Telesend",
+							"reference": "B91",
+							"cost": 30,
+							"cost_type": "points"
+						},
+						{
+							"id": "mOBRvKwjoZGIWHANT",
+							"name": "Broadcast",
+							"reference": "B91",
+							"cost": 50,
+							"disabled": true
+						},
+						{
+							"id": "mzJl_NbBGc0Op9TH3",
+							"name": "Short Wave",
+							"reference": "B91",
+							"cost": 50,
+							"disabled": true
+						},
+						{
+							"id": "m13_6JVQJzN-Z8S9j",
+							"name": "Universal",
+							"reference": "B91",
+							"cost": 50
+						},
+						{
+							"id": "mgrQueX5RhIaEdYTm",
+							"name": "Video",
+							"reference": "B91",
+							"cost": 40,
+							"disabled": true
+						},
+						{
+							"id": "mAsuwo_s1sVGvqOu8",
+							"name": "Racial",
+							"reference": "B91",
+							"cost": -20
+						},
+						{
+							"id": "m6tqwWLwBz1wGe3tQ",
+							"name": "Receive Only",
+							"reference": "B91",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "m6KmeTfFjlIvulJNi",
+							"name": "Send Only",
+							"reference": "B91",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "m8Qi-TrRBgpoxI9Wj",
+							"name": "Vague",
+							"reference": "B91",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "mh_38L31Cswdrg9uf",
+							"name": "Directional Sound",
+							"reference": "P81",
+							"cost": 5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "msuoy6LxUld3rATfs",
+							"name": "Gravity Ripple",
+							"reference": "P81",
+							"cost": 20,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mvTju2c3J5oO-Y6EW",
+							"name": "Neutrino",
+							"reference": "P81",
+							"cost": 25,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mOyodoKfkMl5PnFPn",
+							"name": "Sonar",
+							"reference": "P81",
+							"cost": 10,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mf-1qYXvwOErimTXH",
+							"name": "Burst",
+							"reference": "P81",
+							"cost": 30,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "moJ3lW7JtZ9BRGZgM",
+							"name": "FTL",
+							"reference": "P82",
+							"cost": 120,
+							"disabled": true
+						},
+						{
+							"id": "mCU2iPrqnSycgnmx1",
+							"name": "Secure",
+							"reference": "P82",
+							"cost": 20,
+							"disabled": true
+						},
+						{
+							"id": "mDWwlCfFvtU-3J5rO",
+							"name": "Sensie",
+							"reference": "P82",
+							"cost": 80,
+							"disabled": true
+						},
+						{
+							"id": "mszySdBaRkQX5Z8ah",
+							"name": "Cable Jack",
+							"reference": "UT31",
+							"cost": 5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mzIb-9vmxOI8nYgTM",
+							"name": "Full Communion",
+							"reference": "PSI17",
+							"cost": 20,
+							"disabled": true
+						},
+						{
+							"id": "m-HSUENMq4dHG5vJX",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+								"id": "m9qu6zy-gjsxl3Jjw"
+							},
+							"name": "Blood Agent",
+							"reference": "B110,P100",
+							"cost": -40
+						},
+						{
+							"id": "mZj7kIbLKc_Ggq2OP",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+								"id": "mVtDQj3J1f5GAAQ-J"
+							},
+							"name": "Melee Attack",
+							"reference": "B112,P103",
+							"notes": "Reach C",
+							"cost": -30
+						}
+					],
+					"calc": {
+						"points": 18
+					}
+				},
+				{
+					"id": "tudqu9JCZRqvOAU96",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t-ZNx5ZaorWdo5A4p"
+					},
+					"name": "Infectious Attack",
+					"reference": "B140",
+					"tags": [
+						"Disadvantage",
+						"Physical",
+						"Supernatural"
+					],
+					"base_points": -5,
+					"calc": {
+						"points": -5
+					}
+				}
+			],
+			"calc": {
+				"points": 13
+			}
+		},
+		{
+			"id": "tE5WbuPuIjFuATvI4",
+			"name": "Immunity to @Specific Disease@",
+			"reference": "BT211",
+			"tags": [
+				"Perk"
+			],
+			"base_points": 1,
+			"calc": {
+				"points": 1
+			}
+		},
+		{
+			"id": "t_NoqWLKNBgMjTgla",
+			"name": "Low Rejection Threshold",
+			"reference": "BT211",
+			"tags": [
+				"Perk"
+			],
+			"base_points": 1,
+			"calc": {
+				"points": 1
+			}
+		},
+		{
+			"id": "tcpWN_ZW2kBHtFd_-",
+			"name": "No Degeneration in Zero-G",
+			"reference": "BT211",
+			"tags": [
+				"Perk"
+			],
+			"base_points": 1,
+			"calc": {
+				"points": 1
+			}
+		},
+		{
+			"id": "tRGpIlSo089CMfK5M",
+			"name": "Pressure-Tolerant Lungs",
+			"reference": "BT211",
+			"tags": [
+				"Perk"
+			],
+			"base_points": 1,
+			"calc": {
+				"points": 1
+			}
+		},
+		{
+			"id": "tKvd6bbXhGlQVR8lm",
+			"name": "Early Maturation",
+			"reference": "BT212",
+			"tags": [
+				"Feature"
+			],
+			"can_level": true,
+			"levels": 1,
+			"calc": {
+				"points": 0
+			}
+		},
+		{
+			"id": "tLOAkXsBjj01jYAH0",
+			"name": "Low-Pressure Lungs",
+			"reference": "BT212",
+			"tags": [
+				"Feature"
+			],
+			"calc": {
+				"points": 0
+			}
+		},
+		{
+			"id": "twb6MBQOAwA8uho8X",
+			"name": "High-Pressure Lungs",
+			"reference": "BT212",
+			"tags": [
+				"Feature"
+			],
+			"calc": {
+				"points": 0
+			}
+		},
+		{
+			"id": "tYXOVImUK8rTxpM3_",
+			"name": "Allergy(@Substance@)",
+			"reference": "BT212",
+			"tags": [
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "tI21RvPkWMU8vu5MJ",
+			"name": "Nano-Fever",
+			"reference": "BT212",
+			"tags": [
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "TsERyS7fo-EFebLOQ",
+			"name": "Enhanced Muscles",
+			"reference": "BT213",
+			"container_type": "meta_trait",
+			"children": [
+				{
+					"id": "tc-Yr6_kt2XAulLeU",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t6krAE1uo6M0oDJFL"
+					},
+					"name": "Lifting ST",
+					"reference": "B65,P58",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mpr0XpwanW6hsZ8E2",
+							"name": "No Fine Manipulators",
+							"reference": "B15",
+							"cost": -40,
+							"disabled": true
+						},
+						{
+							"id": "mg09dw3EZ6IN7rh__",
+							"name": "Size",
+							"reference": "B15",
+							"cost": -10,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "m1Wm2vjw3Rv9AAA3l",
+							"name": "Super-Effort",
+							"reference": "P58",
+							"cost": 400,
+							"disabled": true
+						},
+						{
+							"id": "m_lKghYsImQC8kan2",
+							"name": "Know Your Own Strength Variant Price",
+							"reference": "PY83:18",
+							"cost": 4,
+							"cost_type": "points",
+							"affects": "levels_only",
+							"disabled": true
+						},
+						{
+							"id": "mpBQNCKY3rbGCV01-",
+							"name": "@Limb@ Grip ST",
+							"reference": "MATG28",
+							"cost": -70,
+							"disabled": true
+						},
+						{
+							"id": "m_H1yWJIRxWGQsNCL",
+							"name": "Bite ST",
+							"reference": "MATG28",
+							"cost": -70,
+							"disabled": true
+						}
+					],
+					"points_per_level": 3,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"limitation": "lifting_only",
+							"attribute": "st",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 3
+					}
+				},
+				{
+					"id": "tFKTpjIMWDMmVHCod",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t8HajX_K4BDKPuUop"
+					},
+					"name": "Striking ST",
+					"reference": "B88,P78",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mvqm4c-egGZTXDxDq",
+							"name": "No Fine Manipulators",
+							"cost": -40,
+							"disabled": true
+						},
+						{
+							"id": "m3b7UO-h3h-JSqWkY",
+							"name": "Size",
+							"cost": -10,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "m0cCvLSaQI9IYii3W",
+							"name": "Super Effort",
+							"reference": "SU24",
+							"cost": 400,
+							"disabled": true
+						},
+						{
+							"id": "mQG2_D1s7-c06CdeJ",
+							"name": "One Attack Only",
+							"reference": "P79",
+							"notes": "@Attack@",
+							"cost": -60,
+							"disabled": true
+						},
+						{
+							"id": "mUYBpmWHAMreWKpzO",
+							"name": "Know Your Own Strength Pricing Variant",
+							"reference": "PY83:18",
+							"cost": -4,
+							"cost_type": "points",
+							"affects": "levels_only",
+							"disabled": true
+						}
+					],
+					"points_per_level": 5,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"limitation": "striking_only",
+							"attribute": "st",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 5
+					}
+				}
+			],
+			"calc": {
+				"points": 8
+			}
+		},
+		{
+			"id": "TS332DBlfQey8n3VU",
+			"name": "Enhanced Reflexes",
+			"reference": "BT213",
+			"container_type": "meta_trait",
+			"children": [
+				{
+					"id": "tk6J-pR8YQF03UnWV",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tGjjVtxav9KsrG7Wx"
+					},
+					"name": "Combat Reflexes",
+					"reference": "B43",
+					"notes": "Never freeze",
+					"tags": [
+						"Advantage",
+						"Mental"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Enhanced Time Sense"
+								}
+							}
+						]
+					},
+					"base_points": 15,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "starts_with",
+								"qualifier": "fast-draw"
+							},
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "dodge",
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "parry",
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "block",
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "fright_check",
+							"amount": 2
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "on all IQ rolls to wake up or to recover from surprise or mental stun",
+							"amount": 6
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to initiative rolls for your side (+2 if you are the leader)",
+							"amount": 1
+						}
+					],
+					"calc": {
+						"points": 15
+					}
+				},
+				{
+					"id": "t4tDZZ8iL6Wdn66Xm",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tWF1J_Z0Ziz-qJ6pn"
+					},
+					"name": "Increased Basic Speed",
+					"reference": "B17",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"points_per_level": 5,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "basic_speed",
+							"amount": 0.25,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 4,
+					"calc": {
+						"points": 20
+					}
+				}
+			],
+			"calc": {
+				"points": 35
+			}
+		},
+		{
+			"id": "TluHkPSI8BnDWWEZo",
+			"name": "Bioroid",
+			"reference": "BT214",
+			"container_type": "meta_trait",
+			"children": [
+				{
+					"id": "tAgMr2EzmeXfC7Tkg",
+					"name": "Early Maturation",
+					"reference": "BT212",
+					"notes": "may be level 3-5",
+					"tags": [
+						"Feature"
+					],
+					"can_level": true,
+					"levels": 3,
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "tQqPmMDKWQQ8uP2iY",
+					"name": "Sterile",
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "tbREBHH98oA8_d6U0",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tEYEuzMtxSsWCG7uW"
+					},
+					"name": "Unusual Biochemistry",
+					"reference": "B160",
+					"tags": [
+						"Disadvantage",
+						"Physical"
+					],
+					"base_points": -5,
+					"calc": {
+						"points": -5
+					}
+				}
+			],
+			"calc": {
+				"points": -5
+			}
+		},
+		{
+			"id": "To3AVoJByLMnwXPPz",
+			"name": "Chimera",
+			"reference": "BT214",
+			"container_type": "meta_trait",
+			"children": [
+				{
+					"id": "tTpGFUz7lTlPjyWt3",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t8duh7FJvBdSs4NOb"
+					},
+					"name": "Restricted Diet (@Food@)",
+					"reference": "B151",
+					"tags": [
+						"Disadvantage",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mtvY2kjBefBxrX0Uk",
+							"name": "Substitution",
+							"reference": "B151",
+							"cost": -50
+						},
+						{
+							"id": "mv_76WUxaFt6W-plZ",
+							"name": "Very Common",
+							"reference": "B151",
+							"cost": -10,
+							"cost_type": "points"
+						},
+						{
+							"id": "mF82m0PallRSv6TUL",
+							"name": "Common",
+							"reference": "B151",
+							"cost": -20,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mh48Ye5klW0YkMmHN",
+							"name": "Occasional",
+							"reference": "B151",
+							"cost": -30,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mJwaVX8b1oIOYgWzV",
+							"name": "Rare",
+							"reference": "B151",
+							"cost": -40,
+							"cost_type": "points",
+							"disabled": true
+						}
+					],
+					"calc": {
+						"points": -5
+					}
+				},
+				{
+					"id": "tIKx8kg_F4kzztfST",
+					"name": "Sterile",
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "tvH4zQD5fc_QiQc6b",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tEYEuzMtxSsWCG7uW"
+					},
+					"name": "Unusual Biochemistry",
+					"reference": "B160",
+					"tags": [
+						"Disadvantage",
+						"Physical"
+					],
+					"base_points": -5,
+					"calc": {
+						"points": -5
+					}
+				}
+			],
+			"calc": {
+				"points": -10
+			}
+		}
+	]
+}

--- a/Library/Ultra Tech/Ultra Tech Equipment Modifiers.eqm
+++ b/Library/Ultra Tech/Ultra Tech Equipment Modifiers.eqm
@@ -146,6 +146,54 @@
 					]
 				},
 				{
+					"id": "Fq05n9n5joTw-O6wj",
+					"name": "Clothing modifiers",
+					"children": [
+						{
+							"id": "fS2hbj160gUr3w13C",
+							"name": "Varicloth",
+							"reference": "UT39",
+							"cost_type": "to_base_cost",
+							"tech_level": "9",
+							"cost": "+2 CF"
+						},
+						{
+							"id": "fEbpd-OaXfTJGsPWS",
+							"name": "Varicloth",
+							"reference": "UT39",
+							"notes": "with Responsive Fabric",
+							"cost_type": "to_base_cost",
+							"tech_level": "9",
+							"cost": "+1 CF"
+						},
+						{
+							"id": "ffYgtFc-xzY7zhAQd",
+							"name": "Buzz Fabric",
+							"reference": "UT39",
+							"cost_type": "to_base_cost",
+							"tech_level": "10",
+							"cost": "+1 CF"
+						},
+						{
+							"id": "fhrWLwDhzzZxZeIjV",
+							"name": "Buzz Fabric",
+							"reference": "UT39",
+							"notes": "for bioplastic",
+							"cost_type": "to_base_cost",
+							"tech_level": "10",
+							"cost": "+0.2 CF"
+						},
+						{
+							"id": "fLY2N6xYndg7V6SpV",
+							"name": "Responsive Fabric",
+							"reference": "UT39",
+							"cost_type": "to_base_cost",
+							"tech_level": "10",
+							"cost": "+2 CF"
+						}
+					]
+				},
+				{
 					"id": "FVq_Q2gpmaogpbxo2",
 					"name": "Computer Hardware Modifiers",
 					"notes": "Cost Factor Conversion as of LT14",
@@ -1004,6 +1052,69 @@
 							"weight_type": "to_final_weight",
 							"cost": "x0.05",
 							"weight": "x1/20"
+						}
+					]
+				},
+				{
+					"id": "F419FOxIO9HMmlQt0",
+					"name": "Clothing Modifiers",
+					"children": [
+						{
+							"id": "fmRrHIMOeO79D6_FB",
+							"name": "Varicloth",
+							"reference": "UT39",
+							"cost_type": "to_base_cost",
+							"tech_level": "9",
+							"cost": "x3"
+						},
+						{
+							"id": "fyv8rxKVfG-uwu9n3",
+							"name": "Buzz Fabric",
+							"reference": "UT39",
+							"cost_type": "to_base_cost",
+							"tech_level": "10",
+							"cost": "x2"
+						},
+						{
+							"id": "fx3b4NTFwUgr0OYCO",
+							"name": "Buzz Fabric",
+							"reference": "UT39",
+							"notes": "for bioplastic",
+							"cost_type": "to_base_cost",
+							"tech_level": "10",
+							"cost": "x1.2"
+						},
+						{
+							"id": "feDvLN9_5HH5LCr0i",
+							"name": "Responsive Fabric",
+							"reference": "UT39",
+							"cost_type": "to_base_cost",
+							"tech_level": "10",
+							"cost": "x3"
+						},
+						{
+							"id": "fFGltpTkDJBqcbBqz",
+							"name": "Responsive Varicloth",
+							"reference": "UT39",
+							"cost_type": "to_base_cost",
+							"tech_level": "10",
+							"cost": "x4"
+						},
+						{
+							"id": "f8qK_7BeUGiiwkiNd",
+							"name": "Responsive Buzz Fabric",
+							"reference": "UT39",
+							"cost_type": "to_base_cost",
+							"tech_level": "10",
+							"cost": "x4"
+						},
+						{
+							"id": "fZujKAMyC9ZZnABq2",
+							"name": "Responsive Buzz Varicloth",
+							"reference": "UT39",
+							"cost_type": "to_base_cost",
+							"tech_level": "10",
+							"cost": "x5"
 						}
 					]
 				},

--- a/Library/Ultra Tech/Ultra Tech Equipment Modifiers.eqm
+++ b/Library/Ultra Tech/Ultra Tech Equipment Modifiers.eqm
@@ -8,6 +8,44 @@
 			"disabled": true
 		},
 		{
+			"id": "F196Xi0bMeJr5p9kD",
+			"name": "Combination Gadgets",
+			"reference": "UT16",
+			"notes": "Put the constituent items inside an equipment container and apply cost modifiers to all but the most expensive, and weight modifiers to all but the heaviest",
+			"children": [
+				{
+					"id": "fte-9FKj95fCsgBZP",
+					"name": "Combination Gadget cost, one works at a time",
+					"reference": "UT16",
+					"cost_type": "to_final_cost",
+					"cost": "x0.5"
+				},
+				{
+					"id": "fZK5VWsvzMBCRHwkA",
+					"name": "Combination Gadget cost, multiple work at a time",
+					"reference": "UT16",
+					"cost_type": "to_final_cost",
+					"cost": "x0.8"
+				},
+				{
+					"id": "f8HaZ0LuUFvHUnXtt",
+					"name": "Combination Gadget weight, one works at a time",
+					"reference": "UT16",
+					"weight_type": "to_final_weight",
+					"cost": "+0",
+					"weight": "x0.5"
+				},
+				{
+					"id": "fbXG-SurLpMjqzf1Z",
+					"name": "Combination Gadget weight, multiple work at a time",
+					"reference": "UT16",
+					"weight_type": "to_final_weight",
+					"cost": "+0",
+					"weight": "x0.8"
+				}
+			]
+		},
+		{
 			"id": "F1xIyPsraY6rcgj9x",
 			"name": "Optional Cost Factors",
 			"children": [

--- a/Library/Ultra Tech/Ultra Tech Equipment.eqp
+++ b/Library/Ultra Tech/Ultra Tech Equipment.eqp
@@ -4608,7 +4608,7 @@
 			"weight": "4,000 lb",
 			"weapons": [
 				{
-					"id": "WkLQsp9gYiFkzO-bJ",
+					"id": "WhNFLOfS262mdQxu8",
 					"damage": {
 						"type": "burn, sur",
 						"base": "5dx10",
@@ -4640,6 +4640,51 @@
 					"calc": {
 						"damage": "5dx10(5) burn, sur"
 					}
+				},
+				{
+					"id": "Wz-SmwPgclwhI2rj-",
+					"damage": {
+						"type": "HT-10 aff",
+						"base": "5dx10",
+						"armor_divisor": 3
+					},
+					"strength": "160M",
+					"usage": "Omni-Blaster Stun",
+					"accuracy": "15",
+					"range": "30,000/90,000",
+					"rate_of_fire": "1",
+					"shots": "20(5)",
+					"bulk": "-10",
+					"recoil": "1",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Gunner",
+							"specialization": "Beams"
+						},
+						{
+							"type": "skill",
+							"name": "Gunner",
+							"modifier": -4
+						},
+						{
+							"type": "dx",
+							"modifier": -4
+						}
+					],
+					"hide": true,
+					"calc": {
+						"damage": "5dx10(3) HT-10 aff"
+					}
+				}
+			],
+			"modifiers": [
+				{
+					"id": "fAJ77XqB7pJ8WUJZX",
+					"name": "Omni-Blaster",
+					"notes": "note: manually unhide Omni-Blaster Stun",
+					"cost": "+100%",
+					"disabled": true
 				}
 			],
 			"quantity": 1,
@@ -4663,7 +4708,7 @@
 			"weight": "4,000 lb",
 			"weapons": [
 				{
-					"id": "WUEg3mjYEglbLy4ff",
+					"id": "Wzdr_Vlm2jNEHk_F_",
 					"damage": {
 						"type": "burn, sur",
 						"base": "5dx20",
@@ -4695,6 +4740,50 @@
 					"calc": {
 						"damage": "5dx20(5) burn, sur"
 					}
+				},
+				{
+					"id": "Ws6sBaaDvtH9kH19T",
+					"damage": {
+						"type": "HT-10 aff",
+						"armor_divisor": 3
+					},
+					"strength": "160M",
+					"usage": "Omni-Blaster Stun",
+					"accuracy": "15",
+					"range": "120,000/360,000",
+					"rate_of_fire": "1",
+					"shots": "20(5)",
+					"bulk": "-10",
+					"recoil": "1",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Gunner",
+							"specialization": "Beams"
+						},
+						{
+							"type": "skill",
+							"name": "Gunner",
+							"modifier": -4
+						},
+						{
+							"type": "dx",
+							"modifier": -4
+						}
+					],
+					"hide": true,
+					"calc": {
+						"damage": "(3) HT-10 aff"
+					}
+				}
+			],
+			"modifiers": [
+				{
+					"id": "fkP2eMZ8BLnBIS9ec",
+					"name": "Omni-Blaster",
+					"notes": "note: manually unhide Omni-Blaster Stun",
+					"cost": "+100%",
+					"disabled": true
 				}
 			],
 			"quantity": 1,
@@ -4718,7 +4807,7 @@
 			"weight": "5.6 lb",
 			"weapons": [
 				{
-					"id": "WvoDOJhLImiMLG0yY",
+					"id": "WvmDTF1vIN5M4INV1",
 					"damage": {
 						"type": "burn, sur",
 						"base": "5d",
@@ -4756,6 +4845,56 @@
 					"calc": {
 						"damage": "5d(5) burn, sur"
 					}
+				},
+				{
+					"id": "W7q3IlzDU1bZLNq7e",
+					"damage": {
+						"type": "HT-5 aff",
+						"armor_divisor": 3
+					},
+					"strength": "5†",
+					"usage": "Omni-Blaster Stun",
+					"accuracy": "10+1",
+					"range": "500/1,500",
+					"rate_of_fire": "3",
+					"shots": "17(3)",
+					"bulk": "-3",
+					"recoil": "1",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Beam Weapons",
+							"specialization": "Rifle"
+						},
+						{
+							"type": "skill",
+							"name": "Beam Weapons",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Rifle",
+							"modifier": -4
+						},
+						{
+							"type": "dx",
+							"modifier": -4
+						}
+					],
+					"hide": true,
+					"calc": {
+						"damage": "(3) HT-5 aff"
+					}
+				}
+			],
+			"modifiers": [
+				{
+					"id": "fHU3yFNpFT9gW105_",
+					"name": "Omni-Blaster",
+					"notes": "note: manually unhide Omni-Blaster Stun",
+					"cost": "+100%",
+					"disabled": true
 				}
 			],
 			"quantity": 1,
@@ -4779,7 +4918,7 @@
 			"weight": "1.6 lb",
 			"weapons": [
 				{
-					"id": "WZtHKN-OI9BtNmpNT",
+					"id": "WouV3E3GYwAURw6k4",
 					"damage": {
 						"type": "burn, sur",
 						"base": "3d",
@@ -4817,6 +4956,56 @@
 					"calc": {
 						"damage": "3d(5) burn, sur"
 					}
+				},
+				{
+					"id": "WrMfx8fvAyDEWIKeT",
+					"damage": {
+						"type": "HT-3 aff",
+						"armor_divisor": 3
+					},
+					"strength": "4",
+					"usage": "Omni-Blaster Stun",
+					"accuracy": "5",
+					"range": "300/900",
+					"rate_of_fire": "3",
+					"shots": "40(3)",
+					"bulk": "-2",
+					"recoil": "1",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Beam Weapons",
+							"specialization": "Pistol"
+						},
+						{
+							"type": "skill",
+							"name": "Beam Weapons",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Pistol",
+							"modifier": -4
+						},
+						{
+							"type": "dx",
+							"modifier": -4
+						}
+					],
+					"hide": true,
+					"calc": {
+						"damage": "(3) HT-3 aff"
+					}
+				}
+			],
+			"modifiers": [
+				{
+					"id": "f2EEQ8R0wpl4F9Yoo",
+					"name": "Omni-Blaster",
+					"notes": "note: manually unhide Omni-Blaster Stun",
+					"cost": "+100%",
+					"disabled": true
 				}
 			],
 			"quantity": 1,
@@ -4840,7 +5029,7 @@
 			"weight": "10 lb",
 			"weapons": [
 				{
-					"id": "W2g6c9TJ2p_TpReGx",
+					"id": "WvNCHvcEUSlr69mGK",
 					"damage": {
 						"type": "burn, sur",
 						"base": "6d",
@@ -4878,6 +5067,56 @@
 					"calc": {
 						"damage": "6d(5) burn, sur"
 					}
+				},
+				{
+					"id": "W70mB_HCc5Rb9D0C8",
+					"damage": {
+						"type": "HT-6 aff",
+						"armor_divisor": 3
+					},
+					"strength": "7†",
+					"usage": "Omni-Blaster Stun",
+					"accuracy": "10+2",
+					"range": "700/2,100",
+					"rate_of_fire": "3",
+					"shots": "10(3)",
+					"bulk": "-4",
+					"recoil": "1",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Beam Weapons",
+							"specialization": "Rifle"
+						},
+						{
+							"type": "skill",
+							"name": "Beam Weapons",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Rifle",
+							"modifier": -4
+						},
+						{
+							"type": "dx",
+							"modifier": -4
+						}
+					],
+					"hide": true,
+					"calc": {
+						"damage": "(3) HT-6 aff"
+					}
+				}
+			],
+			"modifiers": [
+				{
+					"id": "fppVyNACJVp3nQlH7",
+					"name": "Omni-Blaster",
+					"notes": "note: manually unhide Omni-Blaster Stun",
+					"cost": "+100%",
+					"disabled": true
 				}
 			],
 			"quantity": 1,
@@ -18558,7 +18797,7 @@
 			"weight": "20 lb",
 			"weapons": [
 				{
-					"id": "WduHXVg3794WMGKiu",
+					"id": "Wt-FXBwAXE0qZVmQH",
 					"damage": {
 						"type": "burn, sur",
 						"base": "8d",
@@ -18596,6 +18835,55 @@
 					"calc": {
 						"damage": "8d(5) burn, sur"
 					}
+				},
+				{
+					"id": "Wb1Dvgl6_3MDXiEIC",
+					"damage": {
+						"type": "HT-8 aff",
+						"armor_divisor": 3
+					},
+					"strength": "10†",
+					"usage": "Omni-Blaster Stun",
+					"accuracy": "10+4",
+					"range": "1,200/3,600",
+					"rate_of_fire": "3",
+					"shots": "20(5)",
+					"bulk": "-6",
+					"recoil": "1",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Beam Weapons",
+							"specialization": "Rifle"
+						},
+						{
+							"type": "skill",
+							"name": "Beam Weapons",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Rifle",
+							"modifier": -4
+						},
+						{
+							"type": "dx",
+							"modifier": -4
+						}
+					],
+					"calc": {
+						"damage": "(3) HT-8 aff"
+					}
+				}
+			],
+			"modifiers": [
+				{
+					"id": "foiqlX8Ng5541Irb9",
+					"name": "Omni-Blaster",
+					"notes": "note: manually unhide Omni-Blaster Stun",
+					"cost": "+100%",
+					"disabled": true
 				}
 			],
 			"quantity": 1,
@@ -18619,7 +18907,7 @@
 			"weight": "3.3 lb",
 			"weapons": [
 				{
-					"id": "WV31MqIG2RWPvBWCX",
+					"id": "WaZ3ufvxhRu996YpD",
 					"damage": {
 						"type": "burn, sur",
 						"base": "4d",
@@ -18657,6 +18945,56 @@
 					"calc": {
 						"damage": "4d(5) burn, sur"
 					}
+				},
+				{
+					"id": "WpxxbQ_RlvxEME7go",
+					"damage": {
+						"type": "HT-4 aff",
+						"armor_divisor": 3
+					},
+					"strength": "6",
+					"usage": "Omni-Blaster Stun",
+					"accuracy": "5",
+					"range": "500/1,500",
+					"rate_of_fire": "3",
+					"shots": "33(3)",
+					"bulk": "-3",
+					"recoil": "1",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Beam Weapons",
+							"specialization": "Pistol"
+						},
+						{
+							"type": "skill",
+							"name": "Beam Weapons",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Pistol",
+							"modifier": -4
+						},
+						{
+							"type": "dx",
+							"modifier": -4
+						}
+					],
+					"hide": true,
+					"calc": {
+						"damage": "(3) HT-4 aff"
+					}
+				}
+			],
+			"modifiers": [
+				{
+					"id": "fdgGRatwxO-cXEjoZ",
+					"name": "Omni-Blaster",
+					"notes": "note: manually unhide Omni-Blaster Stun",
+					"cost": "+100%",
+					"disabled": true
 				}
 			],
 			"quantity": 1,
@@ -20649,7 +20987,7 @@
 			"weight": "0.35 lb",
 			"weapons": [
 				{
-					"id": "WsxTNZPwiuA5rXT9Y",
+					"id": "WyzhwKRV_rMXfwvUY",
 					"damage": {
 						"type": "burn, sur",
 						"base": "2d",
@@ -20687,6 +21025,56 @@
 					"calc": {
 						"damage": "2d(5) burn, sur"
 					}
+				},
+				{
+					"id": "WTGGXp9wzCuGJ86xI",
+					"damage": {
+						"type": "HT-2 aff",
+						"armor_divisor": 3
+					},
+					"strength": "3",
+					"usage": "Omni-Blaster Stun",
+					"accuracy": "3",
+					"range": "130/500",
+					"rate_of_fire": "3",
+					"shots": "13(3)",
+					"bulk": "-1",
+					"recoil": "1",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Beam Weapons",
+							"specialization": "Pistol"
+						},
+						{
+							"type": "skill",
+							"name": "Beam Weapons",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Pistol",
+							"modifier": -4
+						},
+						{
+							"type": "dx",
+							"modifier": -4
+						}
+					],
+					"hide": true,
+					"calc": {
+						"damage": "(3) HT-2 aff"
+					}
+				}
+			],
+			"modifiers": [
+				{
+					"id": "f7w9YEF4vT_bzBdVy",
+					"name": "Omni-Blaster",
+					"notes": "note: manually unhide Omni-Blaster Stun",
+					"cost": "+100%",
+					"disabled": true
 				}
 			],
 			"quantity": 1,
@@ -41367,7 +41755,7 @@
 			"weight": "70 lb",
 			"weapons": [
 				{
-					"id": "Wo0rSsREitP8LR7-H",
+					"id": "W4Cgkpefx8fSmFgmB",
 					"damage": {
 						"type": "burn, sur",
 						"base": "6dx2",
@@ -41399,6 +41787,50 @@
 					"calc": {
 						"damage": "6dx2(5) burn, sur"
 					}
+				},
+				{
+					"id": "WhdBP6Ms5ATOcZa9z",
+					"damage": {
+						"type": "HT-10 aff",
+						"armor_divisor": 3
+					},
+					"strength": "18M",
+					"usage": "Omni-Blaster Stun",
+					"accuracy": "15",
+					"range": "2,800/8,400",
+					"rate_of_fire": "3",
+					"shots": "20(5)",
+					"bulk": "-10",
+					"recoil": "1",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Gunner",
+							"specialization": "Beams"
+						},
+						{
+							"type": "skill",
+							"name": "Gunner",
+							"modifier": -4
+						},
+						{
+							"type": "dx",
+							"modifier": -4
+						}
+					],
+					"hide": true,
+					"calc": {
+						"damage": "(3) HT-10 aff"
+					}
+				}
+			],
+			"modifiers": [
+				{
+					"id": "fMbmSjHd2kZ7fy-oy",
+					"name": "Omni-Blaster",
+					"notes": "note: manually unhide Omni-Blaster Stun",
+					"cost": "+100%",
+					"disabled": true
 				}
 			],
 			"quantity": 1,

--- a/Library/Ultra Tech/Ultra Tech Equipment.eqp
+++ b/Library/Ultra Tech/Ultra Tech Equipment.eqp
@@ -45318,7 +45318,7 @@
 			"id": "eT3f4c4tSQXzONaiV",
 			"description": "Space Biosuit",
 			"reference": "UT179",
-			"notes": "Flexible. DR+12 vs. piercing and cutting damage. 2C/6wk.",
+			"notes": "Flexible. 2C/6wk.",
 			"tech_level": "10",
 			"legality_class": "3",
 			"tags": [
@@ -45331,105 +45331,15 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"eye"
+						"all"
 					],
-					"amount": 3
+					"specialization": "piercing and cutting",
+					"amount": 12
 				},
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"skull"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"neck"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"torso"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"arm"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"hand"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"leg"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"foot"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"tail"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"wing"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"fin"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"brain"
+						"all"
 					],
 					"amount": 3
 				}

--- a/Library/Ultra Tech/Ultra Tech Equipment.eqp
+++ b/Library/Ultra Tech/Ultra Tech Equipment.eqp
@@ -45333,15 +45333,15 @@
 					"locations": [
 						"all"
 					],
-					"specialization": "piercing and cutting",
-					"amount": 12
+					"specialization": "corrosion, crushing and toxic",
+					"amount": -12
 				},
 				{
 					"type": "dr_bonus",
 					"locations": [
 						"all"
 					],
-					"amount": 3
+					"amount": 15
 				}
 			],
 			"quantity": 1,

--- a/Library/Ultra Tech/Ultra Tech Equipment.eqp
+++ b/Library/Ultra Tech/Ultra Tech Equipment.eqp
@@ -3942,6 +3942,9 @@
 			"description": "Biomimetic Swimsuit",
 			"reference": "UT39",
 			"tech_level": "9",
+			"tags": [
+				"Clothing"
+			],
 			"value": 100,
 			"weight": "0.2 lb",
 			"quantity": 1,
@@ -3955,6 +3958,9 @@
 			"description": "Biomimetic Swimsuit + Fins",
 			"reference": "UT39",
 			"tech_level": "9",
+			"tags": [
+				"Clothing"
+			],
 			"value": 150,
 			"weight": "0.3 lb",
 			"quantity": 1,
@@ -4439,6 +4445,9 @@
 			"description": "Bioplas Swimsuit",
 			"reference": "UT39",
 			"tech_level": "10",
+			"tags": [
+				"Clothing"
+			],
 			"value": 100,
 			"weight": "0.1 lb",
 			"quantity": 1,
@@ -4452,6 +4461,9 @@
 			"description": "Bioplas Swimsuit + Fins",
 			"reference": "UT39",
 			"tech_level": "10",
+			"tags": [
+				"Clothing"
+			],
 			"value": 150,
 			"weight": "0.2 lb",
 			"quantity": 1,
@@ -5922,6 +5934,9 @@
 			"reference": "UT40",
 			"notes": "2B/2 days.",
 			"tech_level": "11^",
+			"tags": [
+				"Clothing"
+			],
 			"value": 1000,
 			"weight": "0.5 lb",
 			"quantity": 1,
@@ -8245,6 +8260,9 @@
 			"reference": "UT39",
 			"notes": "Complexity 3. 10GB. 2B/20hr.",
 			"tech_level": "9",
+			"tags": [
+				"Clothing"
+			],
 			"value": 100,
 			"weight": "0.5 lb",
 			"quantity": 1,
@@ -8259,6 +8277,9 @@
 			"reference": "UT39",
 			"notes": "Complexity 4. 10TB. 2B/20hr.",
 			"tech_level": "10",
+			"tags": [
+				"Clothing"
+			],
 			"value": 100,
 			"weight": "0.5 lb",
 			"quantity": 1,
@@ -8273,6 +8294,9 @@
 			"reference": "UT39",
 			"notes": "Complexity 5. 10GB. 2B/20hr.",
 			"tech_level": "10",
+			"tags": [
+				"Clothing"
+			],
 			"value": 100,
 			"weight": "0.5 lb",
 			"quantity": 1,
@@ -8287,6 +8311,9 @@
 			"reference": "UT39",
 			"notes": "Complexity 5. 10PB. 2B/20hr.",
 			"tech_level": "11",
+			"tags": [
+				"Clothing"
+			],
 			"value": 100,
 			"weight": "0.5 lb",
 			"quantity": 1,
@@ -8301,6 +8328,9 @@
 			"reference": "UT39",
 			"notes": "Complexity 6. 1,000PB. 2B/20hr.",
 			"tech_level": "12",
+			"tags": [
+				"Clothing"
+			],
 			"value": 100,
 			"weight": "0.5 lb",
 			"quantity": 1,
@@ -18138,6 +18168,7 @@
 			"value": 50,
 			"weight": "3 lb",
 			"quantity": 1,
+			"equipped": true,
 			"calc": {
 				"extended_value": 50,
 				"extended_weight": "3 lb"
@@ -18154,6 +18185,7 @@
 			"value": 10,
 			"weight": "1 lb",
 			"quantity": 1,
+			"equipped": true,
 			"calc": {
 				"extended_value": 10,
 				"extended_weight": "1 lb"
@@ -22608,6 +22640,9 @@
 			"description": "Imprint Circuit",
 			"reference": "UT38",
 			"tech_level": "9",
+			"tags": [
+				"Clothing"
+			],
 			"value": 10,
 			"quantity": 1,
 			"calc": {
@@ -26941,6 +26976,9 @@
 			"reference": "UT39",
 			"tech_level": "11",
 			"legality_class": "3",
+			"tags": [
+				"Clothing"
+			],
 			"value": 40,
 			"weight": "0.25 lb",
 			"quantity": 1,
@@ -26954,6 +26992,9 @@
 			"description": "Living Suitspray",
 			"reference": "UT39",
 			"tech_level": "11",
+			"tags": [
+				"Clothing"
+			],
 			"value": 20,
 			"weight": "0.25 lb",
 			"quantity": 1,
@@ -26967,6 +27008,9 @@
 			"description": "Living Video Suitspray",
 			"reference": "UT39",
 			"tech_level": "11",
+			"tags": [
+				"Clothing"
+			],
 			"value": 40,
 			"weight": "0.25 lb",
 			"quantity": 1,
@@ -26981,6 +27025,9 @@
 			"reference": "UT39",
 			"tech_level": "11",
 			"legality_class": "3",
+			"tags": [
+				"Clothing"
+			],
 			"value": 100,
 			"weight": "0.25 lb",
 			"quantity": 1,
@@ -46809,6 +46856,9 @@
 			"description": "Suitspray",
 			"reference": "UT39",
 			"tech_level": "10",
+			"tags": [
+				"Clothing"
+			],
 			"value": 4,
 			"weight": "0.25 lb",
 			"quantity": 1,
@@ -50738,6 +50788,9 @@
 			"description": "Video Suitspray",
 			"reference": "UT39",
 			"tech_level": "10",
+			"tags": [
+				"Clothing"
+			],
 			"value": 20,
 			"weight": "0.25 lb",
 			"quantity": 1,

--- a/Library/Ultra Tech/Ultra Tech Equipment.eqp
+++ b/Library/Ultra Tech/Ultra Tech Equipment.eqp
@@ -18127,6 +18127,39 @@
 			}
 		},
 		{
+			"id": "EJckJM_hH4F4xKfwh",
+			"description": "Hand Thruster",
+			"reference": "UT231",
+			"notes": "0.1G acceleration",
+			"tech_level": "9",
+			"tags": [
+				"Expedition Gear"
+			],
+			"value": 50,
+			"weight": "3 lb",
+			"quantity": 1,
+			"calc": {
+				"extended_value": 50,
+				"extended_weight": "3 lb"
+			}
+		},
+		{
+			"id": "e1AvdwPjgAi5wr6LM",
+			"description": "Hand Thruster Cartridge",
+			"reference": "UT231",
+			"notes": "30 seconds of 0.1G acceleration",
+			"tags": [
+				"Expedition Gear"
+			],
+			"value": 10,
+			"weight": "1 lb",
+			"quantity": 1,
+			"calc": {
+				"extended_value": 10,
+				"extended_weight": "1 lb"
+			}
+		},
+		{
 			"id": "eOvo_P8j7rA5xxOgu",
 			"description": "Harvester Swarm",
 			"reference": "UT87",

--- a/Library/Ultra Tech/Ultra Tech Equipment.eqp
+++ b/Library/Ultra Tech/Ultra Tech Equipment.eqp
@@ -27333,6 +27333,60 @@
 			}
 		},
 		{
+			"id": "ePmIaLfRfhqsvCOLs",
+			"description": "Macroframe",
+			"reference": "UT22",
+			"notes": "Complexity 10. 100,000PB. External power.",
+			"tech_level": "10",
+			"legality_class": "3",
+			"tags": [
+				"Computers"
+			],
+			"value": 1000000,
+			"weight": "4,000 lb",
+			"quantity": 1,
+			"calc": {
+				"extended_value": 1000000,
+				"extended_weight": "4,000 lb"
+			}
+		},
+		{
+			"id": "eFG10kS2mWTeQ6fGV",
+			"description": "Macroframe",
+			"reference": "UT22",
+			"notes": "Complexity 11. 100,000EB. External power.",
+			"tech_level": "11",
+			"legality_class": "3",
+			"tags": [
+				"Computers"
+			],
+			"value": 1000000,
+			"weight": "4,000 lb",
+			"quantity": 1,
+			"calc": {
+				"extended_value": 1000000,
+				"extended_weight": "4,000 lb"
+			}
+		},
+		{
+			"id": "eHH00PeMx4R5RNOAF",
+			"description": "Macroframe",
+			"reference": "UT22",
+			"notes": "Complexity 8. 100,000TB. External power.",
+			"tech_level": "9",
+			"legality_class": "3",
+			"tags": [
+				"Computers"
+			],
+			"value": 1000000,
+			"weight": "4,000 lb",
+			"quantity": 1,
+			"calc": {
+				"extended_value": 1000000,
+				"extended_weight": "4,000 lb"
+			}
+		},
+		{
 			"id": "e3ndgVXcnUultfit9",
 			"description": "Magnetized Plates",
 			"reference": "UT187",
@@ -27407,6 +27461,60 @@
 			"reference": "UT22",
 			"notes": "Complexity 7. 10,000TB. External power.",
 			"tech_level": "9",
+			"legality_class": "3",
+			"tags": [
+				"Computers"
+			],
+			"value": 100000,
+			"weight": "400 lb",
+			"quantity": 1,
+			"calc": {
+				"extended_value": 100000,
+				"extended_weight": "400 lb"
+			}
+		},
+		{
+			"id": "eQMSf6E_uWngTzcIN",
+			"description": "Mainframe",
+			"reference": "UT22",
+			"notes": "Complexity 9. 10,000PB. External power.",
+			"tech_level": "10",
+			"legality_class": "3",
+			"tags": [
+				"Computers"
+			],
+			"value": 100000,
+			"weight": "400 lb",
+			"quantity": 1,
+			"calc": {
+				"extended_value": 100000,
+				"extended_weight": "400 lb"
+			}
+		},
+		{
+			"id": "eLXBbnmPJ5wGU3_xj",
+			"description": "Mainframe",
+			"reference": "UT22",
+			"notes": "Complexity 10. 10,000EB. External power.",
+			"tech_level": "11",
+			"legality_class": "3",
+			"tags": [
+				"Computers"
+			],
+			"value": 100000,
+			"weight": "400 lb",
+			"quantity": 1,
+			"calc": {
+				"extended_value": 100000,
+				"extended_weight": "400 lb"
+			}
+		},
+		{
+			"id": "e9lPNjcBMfZJ7ljNe",
+			"description": "Mainframe",
+			"reference": "UT22",
+			"notes": "Complexity 11. 10,000ZB. External power.",
+			"tech_level": "12",
 			"legality_class": "3",
 			"tags": [
 				"Computers"
@@ -29256,8 +29364,44 @@
 			"id": "eqQJB-913UymxGPyV",
 			"description": "Megacomputer",
 			"reference": "UT22",
-			"notes": "Complexity 11. 1,000,000TB. External power.",
+			"notes": "Complexity 11. 1,000,000PB. External power.",
 			"tech_level": "10",
+			"legality_class": "2",
+			"tags": [
+				"Computers"
+			],
+			"value": 10000000,
+			"weight": "40,000 lb",
+			"quantity": 1,
+			"calc": {
+				"extended_value": 10000000,
+				"extended_weight": "40,000 lb"
+			}
+		},
+		{
+			"id": "et4ieZ0d0ZCdqnf1U",
+			"description": "Megacomputer",
+			"reference": "UT22",
+			"notes": "Complexity 12. 1,000,000EB. External power.",
+			"tech_level": "11",
+			"legality_class": "2",
+			"tags": [
+				"Computers"
+			],
+			"value": 10000000,
+			"weight": "40,000 lb",
+			"quantity": 1,
+			"calc": {
+				"extended_value": 10000000,
+				"extended_weight": "40,000 lb"
+			}
+		},
+		{
+			"id": "eCfCu1PJsXlDeA_oZ",
+			"description": "Megacomputer",
+			"reference": "UT22",
+			"notes": "Complexity 13. 1,000,000ZB. External power.",
+			"tech_level": "12",
 			"legality_class": "2",
 			"tags": [
 				"Computers"
@@ -29678,6 +29822,60 @@
 			"reference": "UT22",
 			"notes": "Complexity 6. 1,000TB. External power.",
 			"tech_level": "9",
+			"legality_class": "3",
+			"tags": [
+				"Computers"
+			],
+			"value": 10000,
+			"weight": "40 lb",
+			"quantity": 1,
+			"calc": {
+				"extended_value": 10000,
+				"extended_weight": "40 lb"
+			}
+		},
+		{
+			"id": "eUU1IjCY3yuPciOCN",
+			"description": "Microframe",
+			"reference": "UT22",
+			"notes": "Complexity 8. 1,000PB. External power.",
+			"tech_level": "10",
+			"legality_class": "3",
+			"tags": [
+				"Computers"
+			],
+			"value": 10000,
+			"weight": "40 lb",
+			"quantity": 1,
+			"calc": {
+				"extended_value": 10000,
+				"extended_weight": "40 lb"
+			}
+		},
+		{
+			"id": "eDmcwfdUoKfhOq6oI",
+			"description": "Microframe",
+			"reference": "UT22",
+			"notes": "Complexity 9. 1,000EB. External power.",
+			"tech_level": "11",
+			"legality_class": "3",
+			"tags": [
+				"Computers"
+			],
+			"value": 10000,
+			"weight": "40 lb",
+			"quantity": 1,
+			"calc": {
+				"extended_value": 10000,
+				"extended_weight": "40 lb"
+			}
+		},
+		{
+			"id": "eMuqsn1Kqr5JrovHb",
+			"description": "Microframe",
+			"reference": "UT22",
+			"notes": "Complexity 10. 1,000ZB. External power.",
+			"tech_level": "12",
 			"legality_class": "3",
 			"tags": [
 				"Computers"
@@ -34780,8 +34978,42 @@
 			"id": "e2WKpO0IMVsXiTZNt",
 			"description": "Personal Computer",
 			"reference": "UT22",
-			"notes": "Complexity 7. 100TB. 2C/20hr or external power.",
+			"notes": "Complexity 7. 100PB. 2C/20hr or external power.",
 			"tech_level": "10",
+			"tags": [
+				"Computers"
+			],
+			"value": 1000,
+			"weight": "5 lb",
+			"quantity": 1,
+			"calc": {
+				"extended_value": 1000,
+				"extended_weight": "5 lb"
+			}
+		},
+		{
+			"id": "ezaCp1IvHG3JS8HOH",
+			"description": "Personal Computer",
+			"reference": "UT22",
+			"notes": "Complexity 8. 100EB. 2C/20hr or external power.",
+			"tech_level": "11",
+			"tags": [
+				"Computers"
+			],
+			"value": 1000,
+			"weight": "5 lb",
+			"quantity": 1,
+			"calc": {
+				"extended_value": 1000,
+				"extended_weight": "5 lb"
+			}
+		},
+		{
+			"id": "eqjnUfaPl1rltnPx9",
+			"description": "Personal Computer",
+			"reference": "UT22",
+			"notes": "Complexity 9. 100ZB. 2C/20hr or external power.",
+			"tech_level": "12",
 			"tags": [
 				"Computers"
 			],
@@ -42568,8 +42800,42 @@
 			"id": "exhsz08QLJ2AJRxNL",
 			"description": "Small Computer",
 			"reference": "UT22",
-			"notes": "Complexity 6. 10TB. 2B/20hr.",
+			"notes": "Complexity 6. 10PB. 2B/20hr.",
 			"tech_level": "10",
+			"tags": [
+				"Computers"
+			],
+			"value": 100,
+			"weight": "0.5 lb",
+			"quantity": 1,
+			"calc": {
+				"extended_value": 100,
+				"extended_weight": "0.5 lb"
+			}
+		},
+		{
+			"id": "e5qZTKtVs-q-xQlfS",
+			"description": "Small Computer",
+			"reference": "UT22",
+			"notes": "Complexity 7. 10EB. 2B/20hr.",
+			"tech_level": "11",
+			"tags": [
+				"Computers"
+			],
+			"value": 100,
+			"weight": "0.5 lb",
+			"quantity": 1,
+			"calc": {
+				"extended_value": 100,
+				"extended_weight": "0.5 lb"
+			}
+		},
+		{
+			"id": "ekzmk1uBDamzFHavV",
+			"description": "Small Computer",
+			"reference": "UT22",
+			"notes": "Complexity 8. 10ZB. 2B/20hr.",
+			"tech_level": "12",
 			"tags": [
 				"Computers"
 			],
@@ -48715,8 +48981,42 @@
 			"id": "eSq-F2yPGErMgrQlm",
 			"description": "Tiny Computer",
 			"reference": "UT22",
-			"notes": "Complexity 5. 1TB. 2A/20hr.",
+			"notes": "Complexity 5. 1PB. 2A/20hr.",
 			"tech_level": "10",
+			"tags": [
+				"Computers"
+			],
+			"value": 50,
+			"weight": "0.05 lb",
+			"quantity": 1,
+			"calc": {
+				"extended_value": 50,
+				"extended_weight": "0.05 lb"
+			}
+		},
+		{
+			"id": "eMGuseih1L_u1JtJS",
+			"description": "Tiny Computer",
+			"reference": "UT22",
+			"notes": "Complexity 6. 1EB. 2A/20hr.",
+			"tech_level": "11",
+			"tags": [
+				"Computers"
+			],
+			"value": 50,
+			"weight": "0.05 lb",
+			"quantity": 1,
+			"calc": {
+				"extended_value": 50,
+				"extended_weight": "0.05 lb"
+			}
+		},
+		{
+			"id": "eVQKydf8vX6eK24XI",
+			"description": "Tiny Computer",
+			"reference": "UT22",
+			"notes": "Complexity 7. 1ZB. 2A/20hr.",
+			"tech_level": "12",
 			"tags": [
 				"Computers"
 			],

--- a/Library/Ultra Tech/Ultra Tech Equipment.eqp
+++ b/Library/Ultra Tech/Ultra Tech Equipment.eqp
@@ -21960,6 +21960,27 @@
 				"Sensors and Scientific Equipment"
 			],
 			"value": 1200,
+			"features": [
+				{
+					"type": "conditional_modifier",
+					"situation": "spot hidden clues or objects with Forensics, Observation or Search",
+					"amount": 3
+				},
+				{
+					"type": "attribute_bonus",
+					"attribute": "vision",
+					"amount": 3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Tracking"
+					},
+					"amount": 3
+				}
+			],
 			"quantity": 1,
 			"calc": {
 				"extended_value": 1200,
@@ -21976,6 +21997,27 @@
 				"Sensors and Scientific Equipment"
 			],
 			"value": 1200,
+			"features": [
+				{
+					"type": "conditional_modifier",
+					"situation": "spot hidden clues or objects with Forensics, Observation or Search",
+					"amount": 3
+				},
+				{
+					"type": "attribute_bonus",
+					"attribute": "vision",
+					"amount": 3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Tracking"
+					},
+					"amount": 1
+				}
+			],
 			"quantity": 1,
 			"calc": {
 				"extended_value": 1200,
@@ -22019,6 +22061,27 @@
 			],
 			"value": 2000,
 			"weight": "0.6 lb",
+			"features": [
+				{
+					"type": "conditional_modifier",
+					"situation": "spot hidden clues or objects with Forensics, Observation or Search",
+					"amount": 3
+				},
+				{
+					"type": "attribute_bonus",
+					"attribute": "vision",
+					"amount": 3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Tracking"
+					},
+					"amount": 3
+				}
+			],
 			"quantity": 1,
 			"calc": {
 				"extended_value": 2000,
@@ -22036,6 +22099,27 @@
 			],
 			"value": 2000,
 			"weight": "0.6 lb",
+			"features": [
+				{
+					"type": "conditional_modifier",
+					"situation": "spot hidden clues or objects with Forensics, Observation or Search",
+					"amount": 3
+				},
+				{
+					"type": "attribute_bonus",
+					"attribute": "vision",
+					"amount": 3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Tracking"
+					},
+					"amount": 3
+				}
+			],
 			"quantity": 1,
 			"calc": {
 				"extended_value": 2000,
@@ -22053,6 +22137,27 @@
 			],
 			"value": 2000,
 			"weight": "0.6 lb",
+			"features": [
+				{
+					"type": "conditional_modifier",
+					"situation": "spot hidden clues or objects with Forensics, Observation or Search",
+					"amount": 3
+				},
+				{
+					"type": "attribute_bonus",
+					"attribute": "vision",
+					"amount": 3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Tracking"
+					},
+					"amount": 3
+				}
+			],
 			"quantity": 1,
 			"calc": {
 				"extended_value": 2000,
@@ -22070,6 +22175,27 @@
 			],
 			"value": 2000,
 			"weight": "0.6 lb",
+			"features": [
+				{
+					"type": "conditional_modifier",
+					"situation": "spot hidden clues or objects with Forensics, Observation or Search",
+					"amount": 3
+				},
+				{
+					"type": "attribute_bonus",
+					"attribute": "vision",
+					"amount": 3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Tracking"
+					},
+					"amount": 3
+				}
+			],
 			"quantity": 1,
 			"calc": {
 				"extended_value": 2000,
@@ -22295,6 +22421,27 @@
 			],
 			"value": 1000,
 			"weight": "0.1 lb",
+			"features": [
+				{
+					"type": "conditional_modifier",
+					"situation": "spot hidden clues or objects with Forensics, Observation or Search",
+					"amount": 3
+				},
+				{
+					"type": "attribute_bonus",
+					"attribute": "vision",
+					"amount": 3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Tracking"
+					},
+					"amount": 3
+				}
+			],
 			"quantity": 1,
 			"calc": {
 				"extended_value": 1000,
@@ -22312,6 +22459,27 @@
 			],
 			"value": 1000,
 			"weight": "0.1 lb",
+			"features": [
+				{
+					"type": "conditional_modifier",
+					"situation": "spot hidden clues or objects with Forensics, Observation or Search",
+					"amount": 3
+				},
+				{
+					"type": "attribute_bonus",
+					"attribute": "vision",
+					"amount": 3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Tracking"
+					},
+					"amount": 3
+				}
+			],
 			"quantity": 1,
 			"calc": {
 				"extended_value": 1000,
@@ -22329,6 +22497,27 @@
 			],
 			"value": 2000,
 			"weight": "0.6 lb",
+			"features": [
+				{
+					"type": "conditional_modifier",
+					"situation": "spot hidden clues or objects with Forensics, Observation or Search",
+					"amount": 3
+				},
+				{
+					"type": "attribute_bonus",
+					"attribute": "vision",
+					"amount": 3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Tracking"
+					},
+					"amount": 3
+				}
+			],
 			"quantity": 1,
 			"calc": {
 				"extended_value": 2000,
@@ -22346,6 +22535,27 @@
 			],
 			"value": 2000,
 			"weight": "0.6 lb",
+			"features": [
+				{
+					"type": "conditional_modifier",
+					"situation": "spot hidden clues or objects with Forensics, Observation or Search",
+					"amount": 3
+				},
+				{
+					"type": "attribute_bonus",
+					"attribute": "vision",
+					"amount": 3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Tracking"
+					},
+					"amount": 3
+				}
+			],
 			"quantity": 1,
 			"calc": {
 				"extended_value": 2000,
@@ -22363,6 +22573,27 @@
 			],
 			"value": 2000,
 			"weight": "0.6 lb",
+			"features": [
+				{
+					"type": "conditional_modifier",
+					"situation": "spot hidden clues or objects with Forensics, Observation or Search",
+					"amount": 3
+				},
+				{
+					"type": "attribute_bonus",
+					"attribute": "vision",
+					"amount": 3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Tracking"
+					},
+					"amount": 3
+				}
+			],
 			"quantity": 1,
 			"calc": {
 				"extended_value": 2000,
@@ -22380,6 +22611,27 @@
 			],
 			"value": 2000,
 			"weight": "0.6 lb",
+			"features": [
+				{
+					"type": "conditional_modifier",
+					"situation": "spot hidden clues or objects with Forensics, Observation or Search",
+					"amount": 3
+				},
+				{
+					"type": "attribute_bonus",
+					"attribute": "vision",
+					"amount": 3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Tracking"
+					},
+					"amount": 3
+				}
+			],
 			"quantity": 1,
 			"calc": {
 				"extended_value": 2000,

--- a/Library/Ultra Tech/Ultra Tech Equipment.eqp
+++ b/Library/Ultra Tech/Ultra Tech Equipment.eqp
@@ -151,6 +151,90 @@
 			}
 		},
 		{
+			"id": "e3Jg8var6grb3iJCY",
+			"description": "1/8\" Smart Rope",
+			"reference": "UT76",
+			"notes": "Per yard. Supports 800lbs. Can be ordered by radio to be flexible or rigid, unable to be untied.",
+			"tech_level": "11",
+			"tags": [
+				"Tools and Construction Materials"
+			],
+			"value": 0.4,
+			"weight": "0.01 lb",
+			"features": [
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Knot-Tying"
+					},
+					"amount": 3
+				}
+			],
+			"quantity": 1,
+			"calc": {
+				"extended_value": 0.4,
+				"extended_weight": "0.01 lb"
+			}
+		},
+		{
+			"id": "er8R7tAzNnD3DiV-4",
+			"description": "1/8\" Smart Rope",
+			"reference": "UT76",
+			"notes": "Per yard. Supports 1,600lbs. Can be ordered by radio to be flexible or rigid, unable to be untied.",
+			"tech_level": "12",
+			"tags": [
+				"Tools and Construction Materials"
+			],
+			"value": 0.4,
+			"weight": "0.01 lb",
+			"features": [
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Knot-Tying"
+					},
+					"amount": 3
+				}
+			],
+			"quantity": 1,
+			"calc": {
+				"extended_value": 0.4,
+				"extended_weight": "0.01 lb"
+			}
+		},
+		{
+			"id": "eeCN6UUEkvuVXponr",
+			"description": "1/8\" Smart Rope",
+			"reference": "UT76",
+			"notes": "Per yard. Supports 400lbs. Can be ordered by radio to be flexible or rigid, unable to be untied.",
+			"tech_level": "10",
+			"tags": [
+				"Tools and Construction Materials"
+			],
+			"value": 0.4,
+			"weight": "0.01 lb",
+			"features": [
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Knot-Tying"
+					},
+					"amount": 3
+				}
+			],
+			"quantity": 1,
+			"calc": {
+				"extended_value": 0.4,
+				"extended_weight": "0.01 lb"
+			}
+		},
+		{
 			"id": "ere77-AH6IPv0ZabW",
 			"description": "2-bud Bush Robot",
 			"reference": "UT86",
@@ -253,6 +337,90 @@
 			}
 		},
 		{
+			"id": "ewGj-yS99DgmGirr2",
+			"description": "3/4\" Smart Rope",
+			"reference": "UT76",
+			"notes": "Per yard. Supports 16,000lbs. Can be ordered by radio to be flexible or rigid, unable to be untied.",
+			"tech_level": "10",
+			"tags": [
+				"Tools and Construction Materials"
+			],
+			"value": 6,
+			"weight": "0.4 lb",
+			"features": [
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Knot-Tying"
+					},
+					"amount": 3
+				}
+			],
+			"quantity": 1,
+			"calc": {
+				"extended_value": 6,
+				"extended_weight": "0.4 lb"
+			}
+		},
+		{
+			"id": "ef_fAML7gbe_0qxE3",
+			"description": "3/4\" Smart Rope",
+			"reference": "UT76",
+			"notes": "Per yard. Supports 32,000lbs. Can be ordered by radio to be flexible or rigid, unable to be untied.",
+			"tech_level": "11",
+			"tags": [
+				"Tools and Construction Materials"
+			],
+			"value": 6,
+			"weight": "0.4 lb",
+			"features": [
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Knot-Tying"
+					},
+					"amount": 3
+				}
+			],
+			"quantity": 1,
+			"calc": {
+				"extended_value": 6,
+				"extended_weight": "0.4 lb"
+			}
+		},
+		{
+			"id": "efKHd6NJJtLG6vMCc",
+			"description": "3/4\" Smart Rope",
+			"reference": "UT76",
+			"notes": "Per yard. Supports 64,000lbs. Can be ordered by radio to be flexible or rigid, unable to be untied.",
+			"tech_level": "12",
+			"tags": [
+				"Tools and Construction Materials"
+			],
+			"value": 6,
+			"weight": "0.4 lb",
+			"features": [
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Knot-Tying"
+					},
+					"amount": 3
+				}
+			],
+			"quantity": 1,
+			"calc": {
+				"extended_value": 6,
+				"extended_weight": "0.4 lb"
+			}
+		},
+		{
 			"id": "eCQwpHzRQ0SGTcNrS",
 			"description": "3/8\" Rope",
 			"reference": "UT81",
@@ -321,6 +489,90 @@
 			}
 		},
 		{
+			"id": "elc7rkH2yT0DgPxKS",
+			"description": "3/8\" Smart Rope",
+			"reference": "UT76",
+			"notes": "Per yard. Supports 4,000lbs. Can be ordered by radio to be flexible or rigid, unable to be untied.",
+			"tech_level": "10",
+			"tags": [
+				"Tools and Construction Materials"
+			],
+			"value": 4,
+			"weight": "0.1 lb",
+			"features": [
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Knot-Tying"
+					},
+					"amount": 3
+				}
+			],
+			"quantity": 1,
+			"calc": {
+				"extended_value": 4,
+				"extended_weight": "0.1 lb"
+			}
+		},
+		{
+			"id": "emMhHi8btfo2lvhEJ",
+			"description": "3/8\" Smart Rope",
+			"reference": "UT76",
+			"notes": "Per yard. Supports 8,000lbs. Can be ordered by radio to be flexible or rigid, unable to be untied.",
+			"tech_level": "11",
+			"tags": [
+				"Tools and Construction Materials"
+			],
+			"value": 4,
+			"weight": "0.1 lb",
+			"features": [
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Knot-Tying"
+					},
+					"amount": 3
+				}
+			],
+			"quantity": 1,
+			"calc": {
+				"extended_value": 4,
+				"extended_weight": "0.1 lb"
+			}
+		},
+		{
+			"id": "eEbrkoDVjZV7EbWzw",
+			"description": "3/8\" Smart Rope",
+			"reference": "UT76",
+			"notes": "Per yard. Supports 16,000lbs. Can be ordered by radio to be flexible or rigid, unable to be untied.",
+			"tech_level": "12",
+			"tags": [
+				"Tools and Construction Materials"
+			],
+			"value": 4,
+			"weight": "0.1 lb",
+			"features": [
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Knot-Tying"
+					},
+					"amount": 3
+				}
+			],
+			"quantity": 1,
+			"calc": {
+				"extended_value": 4,
+				"extended_weight": "0.1 lb"
+			}
+		},
+		{
 			"id": "eVahBZ31omY03RHAi",
 			"description": "3/16\" Rope",
 			"reference": "UT81",
@@ -385,6 +637,90 @@
 			"quantity": 1,
 			"calc": {
 				"extended_value": 0.5,
+				"extended_weight": "0.025 lb"
+			}
+		},
+		{
+			"id": "eruPyJPvAPJIh0rAx",
+			"description": "3/16\" Smart Rope",
+			"reference": "UT76",
+			"notes": "Per yard. Supports 1,000lbs. Can be ordered by radio to be flexible or rigid, unable to be untied.",
+			"tech_level": "10",
+			"tags": [
+				"Tools and Construction Materials"
+			],
+			"value": 1,
+			"weight": "0.025 lb",
+			"features": [
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Knot-Tying"
+					},
+					"amount": 3
+				}
+			],
+			"quantity": 1,
+			"calc": {
+				"extended_value": 1,
+				"extended_weight": "0.025 lb"
+			}
+		},
+		{
+			"id": "e80GXy2r6Vc2kTw5i",
+			"description": "3/16\" Smart Rope",
+			"reference": "UT76",
+			"notes": "Per yard. Supports 2,000lbs. Can be ordered by radio to be flexible or rigid, unable to be untied.",
+			"tech_level": "11",
+			"tags": [
+				"Tools and Construction Materials"
+			],
+			"value": 1,
+			"weight": "0.025 lb",
+			"features": [
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Knot-Tying"
+					},
+					"amount": 3
+				}
+			],
+			"quantity": 1,
+			"calc": {
+				"extended_value": 1,
+				"extended_weight": "0.025 lb"
+			}
+		},
+		{
+			"id": "ehA0klZ2lurEAsJ8p",
+			"description": "3/16\" Smart Rope",
+			"reference": "UT76",
+			"notes": "Per yard. Supports 4,000lbs. Can be ordered by radio to be flexible or rigid, unable to be untied.",
+			"tech_level": "12",
+			"tags": [
+				"Tools and Construction Materials"
+			],
+			"value": 1,
+			"weight": "0.025 lb",
+			"features": [
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Knot-Tying"
+					},
+					"amount": 3
+				}
+			],
+			"quantity": 1,
+			"calc": {
+				"extended_value": 1,
 				"extended_weight": "0.025 lb"
 			}
 		},


### PR DESCRIPTION
I have been putting together loadouts from GURPS Loadouts: Starship Crew, and making changes in the master library as I found things missing / need fixing / could use newer features of gcs.

I was originally going to submit them all at the end, along with TL11 Starship Crew loadouts, but the current list of changes is already uncomfortably large to review.
The commits should be reasonably specific and self-contained (though the bio-tech drugs and nano are still very large)

Added new library, Bio-Tech Equipment:
* Added every drug and nanosymbiont in the drugs and nano section.
  - I've taken some creative liberty with the cost of a single dose, wherethe drug has a set schedule, but was priced by the week or month instead of by the pill, and have noted what the full schedule is in the description.

Added new library, Bio-Tech Traits:
* Added every permanent nanosymbiont
* Added perks, features, quirks and meta-traits

Added to Ultra-Tech Equipment:
* Smart Rope
* Hand Thruster
* TL11 and TL12 versions of computers

Changed in Basic Set Traits:
* Added modifiers for Hyperspectral Vision (bonus to vision, bonus to tracking skill, conditional bonus to spot hidden clues)

Changed in Ultra-Tech Equipment:
* Space Biosuit uses specialized DR instead of a note in the description, and uses the "all" location.
* Space Biosuit has reduced DR against corrosion, crushing and toxic damage, instead of piercing and cutting
  - personally I think it should be full DR only to burning and piercing, and less for everything else, in line with the rest of the bioplas armour, but there's no errata saying it should be.
* All clothing items have the "Clothing" tag
* Hyperspectral eyewear (goggles, visors, video glasses and contacts) has modifiers representing the benefits of hyperspectral vision.
* Blasters have a (disabled by default) modifier for being Omni-Blasters, and a (hidden by default) ranged weapon usage for stunning shots.

Added to Basic Set Equipment:
* Ordinary Clothes, Winter Clothes and Formal Wear for status -2 to +3
  - Low-Tech has ordinary clothing but its stats differ.

Added to Ultra-Tech Equipment Modifiers:
* Clothing modifiers (to be added to Basic Set clothing), as multipliers or additive cost factors.
* Combination Gadget modifiers (cost and weight fractional modifiers to be applied to the constituent items of a combination gadget)