### PR TITLE
Small fixes for Five Easy Pieces

### DIFF
--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Brute Warrior.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Brute Warrior.gct
@@ -879,6 +879,771 @@
 			"name": "Brute Warrior",
 			"children": [
 				{
+					"id": "SYnASDmHcZCcl3JuF",
+					"name": "At least 16 Points in Melee Weapon Skills",
+					"template_picker": {
+						"type": "points",
+						"qualifier": {
+							"compare": "at_least",
+							"qualifier": 16
+						}
+					},
+					"children": [
+						{
+							"id": "syc8HWzE-DWCymaRS",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sJWXHIqO1bo3Y5r62"
+							},
+							"name": "Axe/Mace",
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Two-Handed Axe/Mace",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Flail",
+									"modifier": -4
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "stigl1-97zF5OyYak",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "s6XXNwVPKmu2l0SjG"
+							},
+							"name": "Flail",
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/h",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -6
+								},
+								{
+									"type": "skill",
+									"name": "Axe/Mace",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Two-Handed Flail",
+									"modifier": -3
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "s9bVyzwkSlIoruOLe",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sYTrvMtG2jRQBtu_P"
+							},
+							"name": "Jitte/Sai",
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Force Sword",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Main-Gauche",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Shortsword",
+									"modifier": -3
+								},
+								{
+									"type": "dx",
+									"modifier": -5
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "sBDJaDEpGS4M4kuqe",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sGMuuC-kk-56K3Qf2"
+							},
+							"name": "Knife",
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/e",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Force Sword",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Main-Gauche",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Shortsword",
+									"modifier": -3
+								},
+								{
+									"type": "dx",
+									"modifier": -4
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "sDPtC0-vDTmRKEZ1J",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "s0tPCgdAoREgWqZIg"
+							},
+							"name": "Kusari",
+							"reference": "DFA82",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/h",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -6
+								},
+								{
+									"type": "skill",
+									"name": "Force Whip",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Monowire Whip",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Whip",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Two-Handed Flail",
+									"modifier": -4
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "snj8TmIzJQhwH3t9u",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sIPa439w__PRt4CT8"
+							},
+							"name": "Broadsword",
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Force Sword",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Rapier",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Saber",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Shortsword",
+									"modifier": -2
+								},
+								{
+									"type": "skill",
+									"name": "Two-Handed Sword",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -5
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "sqH-kH36vsSAFrhFU",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sKl5_DLlGCMU7G7zk"
+							},
+							"name": "Main-Gauche",
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Jitte/Sai",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Knife",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Rapier",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Saber",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Smallsword",
+									"modifier": -3
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "sQrujlXoM31sLcAXf",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "s2TRfOszdn6Fj48XX"
+							},
+							"name": "Polearm",
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Spear",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Staff",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Two-Handed Axe/Mace",
+									"modifier": -4
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "sLc-pVcs90mp7MfrE",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sIzhGG9-301PPDuRu"
+							},
+							"name": "Rapier",
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Broadsword",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Main-Gauche",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Saber",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Smallsword",
+									"modifier": -3
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "syzYQpGY45HyBtwfm",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "smMdtUOUAPQA6C9-Z"
+							},
+							"name": "Saber",
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Broadsword",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Shortswort",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Main-Gauche",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Rapier",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Smallsword",
+									"modifier": -3
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "senX4uaDPc_xc1FHf",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sREf0R4fH6zX2LRi2"
+							},
+							"name": "Shortsword",
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Broadsword",
+									"modifier": -2
+								},
+								{
+									"type": "skill",
+									"name": "Force Sword",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Jitte/Sai",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Knife",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Saber",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Smallsword",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Tonfa",
+									"modifier": -3
+								},
+								{
+									"type": "dx",
+									"modifier": -5
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "sMQUZsAV2FYJVgvZV",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "shd2T3Rmivpbf6QJ_"
+							},
+							"name": "Smallsword",
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Shortsword",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Main-Gauche",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Rapier",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Saber",
+									"modifier": -3
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "sylhFfo74A9DEwdaO",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sNk63TpccCvsiXKd0"
+							},
+							"name": "Spear",
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Polearm",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Staff",
+									"modifier": -2
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "szTTFNyAzWp2c-CE5",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "soilUSeitMyIlPAtg"
+							},
+							"name": "Staff",
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Polearm",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Spear",
+									"modifier": -2
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "sZvxlsyXzzcVKJUAz",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "s-qaex6gJlE3JswZv"
+							},
+							"name": "Tonfa",
+							"reference": "DFA82",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Shortsword",
+									"modifier": -3
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "s4HwUUSPAuwoLGm0h",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sRxrEmc3lfEEy4VAa"
+							},
+							"name": "Two-Handed Axe/Mace",
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Axe/Mace",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Polearm",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Two-Handed Flail",
+									"modifier": -4
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "skGgWKWCv4LN9SxZn",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "sZFEG08s5VXd1ZIMn"
+							},
+							"name": "Two-Handed Flail",
+							"reference": "DFA81",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/h",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -6
+								},
+								{
+									"type": "skill",
+									"name": "Flail",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Kusari",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Two-Handed Axe/Mace",
+									"modifier": -4
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "ssfvubUwcAoB1EAdO",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "snAFDxOB3UqelcxN5"
+							},
+							"name": "Two-Handed Sword",
+							"reference": "DFA82",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Broadsword",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Force Sword",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -5
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "sSkB5WafXTMP75mvj",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
+								"id": "s2u7PEdv1s5_cIKdV"
+							},
+							"name": "Whip",
+							"reference": "DFA82",
+							"tags": [
+								"Combat",
+								"Melee Combat",
+								"Weapon"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Force Whip",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Kusari",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Monowire Whip",
+									"modifier": -3
+								}
+							],
+							"points": 1
+						}
+					]
+				},
+				{
 					"id": "St8FQ6PUZTTeAq4UE",
 					"name": "Additional Skills",
 					"template_picker": {
@@ -1813,771 +2578,6 @@
 								"Weapon"
 							],
 							"difficulty": "dx/a",
-							"points": 1
-						}
-					]
-				},
-				{
-					"id": "SYnASDmHcZCcl3JuF",
-					"name": "At least 16 Points in Melee Weapon Skills",
-					"template_picker": {
-						"type": "points",
-						"qualifier": {
-							"compare": "at_least",
-							"qualifier": 16
-						}
-					},
-					"children": [
-						{
-							"id": "syc8HWzE-DWCymaRS",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-								"id": "sJWXHIqO1bo3Y5r62"
-							},
-							"name": "Axe/Mace",
-							"reference": "DFA81",
-							"tags": [
-								"Combat",
-								"Melee Combat",
-								"Weapon"
-							],
-							"difficulty": "dx/a",
-							"defaults": [
-								{
-									"type": "dx",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Two-Handed Axe/Mace",
-									"modifier": -3
-								},
-								{
-									"type": "skill",
-									"name": "Flail",
-									"modifier": -4
-								}
-							],
-							"points": 1
-						},
-						{
-							"id": "stigl1-97zF5OyYak",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-								"id": "s6XXNwVPKmu2l0SjG"
-							},
-							"name": "Flail",
-							"reference": "DFA81",
-							"tags": [
-								"Combat",
-								"Melee Combat",
-								"Weapon"
-							],
-							"difficulty": "dx/h",
-							"defaults": [
-								{
-									"type": "dx",
-									"modifier": -6
-								},
-								{
-									"type": "skill",
-									"name": "Axe/Mace",
-									"modifier": -4
-								},
-								{
-									"type": "skill",
-									"name": "Two-Handed Flail",
-									"modifier": -3
-								}
-							],
-							"points": 1
-						},
-						{
-							"id": "s9bVyzwkSlIoruOLe",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-								"id": "sYTrvMtG2jRQBtu_P"
-							},
-							"name": "Jitte/Sai",
-							"reference": "DFA81",
-							"tags": [
-								"Combat",
-								"Melee Combat",
-								"Weapon"
-							],
-							"difficulty": "dx/a",
-							"defaults": [
-								{
-									"type": "skill",
-									"name": "Force Sword",
-									"modifier": -4
-								},
-								{
-									"type": "skill",
-									"name": "Main-Gauche",
-									"modifier": -4
-								},
-								{
-									"type": "skill",
-									"name": "Shortsword",
-									"modifier": -3
-								},
-								{
-									"type": "dx",
-									"modifier": -5
-								}
-							],
-							"points": 1
-						},
-						{
-							"id": "sBDJaDEpGS4M4kuqe",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-								"id": "sGMuuC-kk-56K3Qf2"
-							},
-							"name": "Knife",
-							"reference": "DFA81",
-							"tags": [
-								"Combat",
-								"Melee Combat",
-								"Weapon"
-							],
-							"difficulty": "dx/e",
-							"defaults": [
-								{
-									"type": "skill",
-									"name": "Force Sword",
-									"modifier": -3
-								},
-								{
-									"type": "skill",
-									"name": "Main-Gauche",
-									"modifier": -3
-								},
-								{
-									"type": "skill",
-									"name": "Shortsword",
-									"modifier": -3
-								},
-								{
-									"type": "dx",
-									"modifier": -4
-								}
-							],
-							"points": 1
-						},
-						{
-							"id": "sDPtC0-vDTmRKEZ1J",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-								"id": "s0tPCgdAoREgWqZIg"
-							},
-							"name": "Kusari",
-							"reference": "DFA82",
-							"tags": [
-								"Combat",
-								"Melee Combat",
-								"Weapon"
-							],
-							"difficulty": "dx/h",
-							"defaults": [
-								{
-									"type": "dx",
-									"modifier": -6
-								},
-								{
-									"type": "skill",
-									"name": "Force Whip",
-									"modifier": -3
-								},
-								{
-									"type": "skill",
-									"name": "Monowire Whip",
-									"modifier": -3
-								},
-								{
-									"type": "skill",
-									"name": "Whip",
-									"modifier": -3
-								},
-								{
-									"type": "skill",
-									"name": "Two-Handed Flail",
-									"modifier": -4
-								}
-							],
-							"points": 1
-						},
-						{
-							"id": "snj8TmIzJQhwH3t9u",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-								"id": "sIPa439w__PRt4CT8"
-							},
-							"name": "Broadsword",
-							"reference": "DFA81",
-							"tags": [
-								"Combat",
-								"Melee Combat",
-								"Weapon"
-							],
-							"difficulty": "dx/a",
-							"defaults": [
-								{
-									"type": "skill",
-									"name": "Force Sword",
-									"modifier": -4
-								},
-								{
-									"type": "skill",
-									"name": "Rapier",
-									"modifier": -4
-								},
-								{
-									"type": "skill",
-									"name": "Saber",
-									"modifier": -4
-								},
-								{
-									"type": "skill",
-									"name": "Shortsword",
-									"modifier": -2
-								},
-								{
-									"type": "skill",
-									"name": "Two-Handed Sword",
-									"modifier": -4
-								},
-								{
-									"type": "dx",
-									"modifier": -5
-								}
-							],
-							"points": 1
-						},
-						{
-							"id": "sqH-kH36vsSAFrhFU",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-								"id": "sKl5_DLlGCMU7G7zk"
-							},
-							"name": "Main-Gauche",
-							"reference": "DFA81",
-							"tags": [
-								"Combat",
-								"Melee Combat",
-								"Weapon"
-							],
-							"difficulty": "dx/a",
-							"defaults": [
-								{
-									"type": "dx",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Jitte/Sai",
-									"modifier": -4
-								},
-								{
-									"type": "skill",
-									"name": "Knife",
-									"modifier": -4
-								},
-								{
-									"type": "skill",
-									"name": "Rapier",
-									"modifier": -3
-								},
-								{
-									"type": "skill",
-									"name": "Saber",
-									"modifier": -3
-								},
-								{
-									"type": "skill",
-									"name": "Smallsword",
-									"modifier": -3
-								}
-							],
-							"points": 1
-						},
-						{
-							"id": "sQrujlXoM31sLcAXf",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-								"id": "s2TRfOszdn6Fj48XX"
-							},
-							"name": "Polearm",
-							"reference": "DFA81",
-							"tags": [
-								"Combat",
-								"Melee Combat",
-								"Weapon"
-							],
-							"difficulty": "dx/a",
-							"defaults": [
-								{
-									"type": "dx",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Spear",
-									"modifier": -4
-								},
-								{
-									"type": "skill",
-									"name": "Staff",
-									"modifier": -4
-								},
-								{
-									"type": "skill",
-									"name": "Two-Handed Axe/Mace",
-									"modifier": -4
-								}
-							],
-							"points": 1
-						},
-						{
-							"id": "sLc-pVcs90mp7MfrE",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-								"id": "sIzhGG9-301PPDuRu"
-							},
-							"name": "Rapier",
-							"reference": "DFA81",
-							"tags": [
-								"Combat",
-								"Melee Combat",
-								"Weapon"
-							],
-							"difficulty": "dx/a",
-							"defaults": [
-								{
-									"type": "dx",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Broadsword",
-									"modifier": -4
-								},
-								{
-									"type": "skill",
-									"name": "Main-Gauche",
-									"modifier": -3
-								},
-								{
-									"type": "skill",
-									"name": "Saber",
-									"modifier": -3
-								},
-								{
-									"type": "skill",
-									"name": "Smallsword",
-									"modifier": -3
-								}
-							],
-							"points": 1
-						},
-						{
-							"id": "syzYQpGY45HyBtwfm",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-								"id": "smMdtUOUAPQA6C9-Z"
-							},
-							"name": "Saber",
-							"reference": "DFA81",
-							"tags": [
-								"Combat",
-								"Melee Combat",
-								"Weapon"
-							],
-							"difficulty": "dx/a",
-							"defaults": [
-								{
-									"type": "dx",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Broadsword",
-									"modifier": -4
-								},
-								{
-									"type": "skill",
-									"name": "Shortswort",
-									"modifier": -4
-								},
-								{
-									"type": "skill",
-									"name": "Main-Gauche",
-									"modifier": -3
-								},
-								{
-									"type": "skill",
-									"name": "Rapier",
-									"modifier": -3
-								},
-								{
-									"type": "skill",
-									"name": "Smallsword",
-									"modifier": -3
-								}
-							],
-							"points": 1
-						},
-						{
-							"id": "senX4uaDPc_xc1FHf",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-								"id": "sREf0R4fH6zX2LRi2"
-							},
-							"name": "Shortsword",
-							"reference": "DFA81",
-							"tags": [
-								"Combat",
-								"Melee Combat",
-								"Weapon"
-							],
-							"difficulty": "dx/a",
-							"defaults": [
-								{
-									"type": "skill",
-									"name": "Broadsword",
-									"modifier": -2
-								},
-								{
-									"type": "skill",
-									"name": "Force Sword",
-									"modifier": -4
-								},
-								{
-									"type": "skill",
-									"name": "Jitte/Sai",
-									"modifier": -3
-								},
-								{
-									"type": "skill",
-									"name": "Knife",
-									"modifier": -4
-								},
-								{
-									"type": "skill",
-									"name": "Saber",
-									"modifier": -4
-								},
-								{
-									"type": "skill",
-									"name": "Smallsword",
-									"modifier": -4
-								},
-								{
-									"type": "skill",
-									"name": "Tonfa",
-									"modifier": -3
-								},
-								{
-									"type": "dx",
-									"modifier": -5
-								}
-							],
-							"points": 1
-						},
-						{
-							"id": "sMQUZsAV2FYJVgvZV",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-								"id": "shd2T3Rmivpbf6QJ_"
-							},
-							"name": "Smallsword",
-							"reference": "DFA81",
-							"tags": [
-								"Combat",
-								"Melee Combat",
-								"Weapon"
-							],
-							"difficulty": "dx/a",
-							"defaults": [
-								{
-									"type": "dx",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Shortsword",
-									"modifier": -4
-								},
-								{
-									"type": "skill",
-									"name": "Main-Gauche",
-									"modifier": -3
-								},
-								{
-									"type": "skill",
-									"name": "Rapier",
-									"modifier": -3
-								},
-								{
-									"type": "skill",
-									"name": "Saber",
-									"modifier": -3
-								}
-							],
-							"points": 1
-						},
-						{
-							"id": "sylhFfo74A9DEwdaO",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-								"id": "sNk63TpccCvsiXKd0"
-							},
-							"name": "Spear",
-							"reference": "DFA81",
-							"tags": [
-								"Combat",
-								"Melee Combat",
-								"Weapon"
-							],
-							"difficulty": "dx/a",
-							"defaults": [
-								{
-									"type": "dx",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Polearm",
-									"modifier": -4
-								},
-								{
-									"type": "skill",
-									"name": "Staff",
-									"modifier": -2
-								}
-							],
-							"points": 1
-						},
-						{
-							"id": "szTTFNyAzWp2c-CE5",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-								"id": "soilUSeitMyIlPAtg"
-							},
-							"name": "Staff",
-							"reference": "DFA81",
-							"tags": [
-								"Combat",
-								"Melee Combat",
-								"Weapon"
-							],
-							"difficulty": "dx/a",
-							"defaults": [
-								{
-									"type": "dx",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Polearm",
-									"modifier": -4
-								},
-								{
-									"type": "skill",
-									"name": "Spear",
-									"modifier": -2
-								}
-							],
-							"points": 1
-						},
-						{
-							"id": "sZvxlsyXzzcVKJUAz",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-								"id": "s-qaex6gJlE3JswZv"
-							},
-							"name": "Tonfa",
-							"reference": "DFA82",
-							"tags": [
-								"Combat",
-								"Melee Combat",
-								"Weapon"
-							],
-							"difficulty": "dx/a",
-							"defaults": [
-								{
-									"type": "dx",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Shortsword",
-									"modifier": -3
-								}
-							],
-							"points": 1
-						},
-						{
-							"id": "s4HwUUSPAuwoLGm0h",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-								"id": "sRxrEmc3lfEEy4VAa"
-							},
-							"name": "Two-Handed Axe/Mace",
-							"reference": "DFA81",
-							"tags": [
-								"Combat",
-								"Melee Combat",
-								"Weapon"
-							],
-							"difficulty": "dx/a",
-							"defaults": [
-								{
-									"type": "dx",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Axe/Mace",
-									"modifier": -3
-								},
-								{
-									"type": "skill",
-									"name": "Polearm",
-									"modifier": -4
-								},
-								{
-									"type": "skill",
-									"name": "Two-Handed Flail",
-									"modifier": -4
-								}
-							],
-							"points": 1
-						},
-						{
-							"id": "skGgWKWCv4LN9SxZn",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-								"id": "sZFEG08s5VXd1ZIMn"
-							},
-							"name": "Two-Handed Flail",
-							"reference": "DFA81",
-							"tags": [
-								"Combat",
-								"Melee Combat",
-								"Weapon"
-							],
-							"difficulty": "dx/h",
-							"defaults": [
-								{
-									"type": "dx",
-									"modifier": -6
-								},
-								{
-									"type": "skill",
-									"name": "Flail",
-									"modifier": -3
-								},
-								{
-									"type": "skill",
-									"name": "Kusari",
-									"modifier": -4
-								},
-								{
-									"type": "skill",
-									"name": "Two-Handed Axe/Mace",
-									"modifier": -4
-								}
-							],
-							"points": 1
-						},
-						{
-							"id": "ssfvubUwcAoB1EAdO",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-								"id": "snAFDxOB3UqelcxN5"
-							},
-							"name": "Two-Handed Sword",
-							"reference": "DFA82",
-							"tags": [
-								"Combat",
-								"Melee Combat",
-								"Weapon"
-							],
-							"difficulty": "dx/a",
-							"defaults": [
-								{
-									"type": "skill",
-									"name": "Broadsword",
-									"modifier": -4
-								},
-								{
-									"type": "skill",
-									"name": "Force Sword",
-									"modifier": -4
-								},
-								{
-									"type": "dx",
-									"modifier": -5
-								}
-							],
-							"points": 1
-						},
-						{
-							"id": "sSkB5WafXTMP75mvj",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-								"id": "s2u7PEdv1s5_cIKdV"
-							},
-							"name": "Whip",
-							"reference": "DFA82",
-							"tags": [
-								"Combat",
-								"Melee Combat",
-								"Weapon"
-							],
-							"difficulty": "dx/a",
-							"defaults": [
-								{
-									"type": "dx",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Force Whip",
-									"modifier": -3
-								},
-								{
-									"type": "skill",
-									"name": "Kusari",
-									"modifier": -3
-								},
-								{
-									"type": "skill",
-									"name": "Monowire Whip",
-									"modifier": -3
-								}
-							],
 							"points": 1
 						}
 					]

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Finesse Warrior 2.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Finesse Warrior 2.gct
@@ -7519,23 +7519,6 @@
 					"points": 1
 				},
 				{
-					"id": "sJNWoHg1mXwhDmp5c",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
-						"id": "s9jNIB0FmoVgdt2ky"
-					},
-					"name": "Parry Missile-Weapons",
-					"reference": "DFA33",
-					"tags": [
-						"Combat",
-						"Melee Combat",
-						"Weapon"
-					],
-					"difficulty": "dx/h",
-					"points": 1
-				},
-				{
 					"id": "sjQIOxk2cJyoHm9RT",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",


### PR DESCRIPTION
Reorder Melee Weapons before Additional Skills in Brute Warrior. Remove Parry Missile Weapons from Finesse Warrior 2.