### PR TITLE
Global spelling fix "diety" to "deity"

### DIFF
--- a/Library/1shotadventures/Characters/Harry Potter and the Warlocks Tower/Kyle_George_Greyfell.gcs
+++ b/Library/1shotadventures/Characters/Harry Potter and the Warlocks Tower/Kyle_George_Greyfell.gcs
@@ -1080,7 +1080,7 @@
 				},
 				{
 					"id": "mCnPir-tlKCY8Zdtm",
-					"name": "@Who: A diety@",
+					"name": "@Who: A deity@",
 					"reference": "B72",
 					"cost": 30,
 					"cost_type": "points",

--- a/Library/1shotadventures/Characters/The Phantom Jungle/Marisa Santarelli.gcs
+++ b/Library/1shotadventures/Characters/The Phantom Jungle/Marisa Santarelli.gcs
@@ -1463,7 +1463,7 @@
 				},
 				{
 					"id": "mX-nAN56CtMfJNe6d",
-					"name": "@Who: A diety@",
+					"name": "@Who: A deity@",
 					"reference": "B72",
 					"cost": 30,
 					"cost_type": "points",

--- a/Library/Action/Action Traits.adq
+++ b/Library/Action/Action Traits.adq
@@ -4638,7 +4638,7 @@
 						},
 						{
 							"id": "m3BNcFN4v2ebvVHPK",
-							"name": "@Who: A diety@",
+							"name": "@Who: A deity@",
 							"reference": "B72",
 							"cost": 30,
 							"cost_type": "points",

--- a/Library/After the End/Templates/Doc.gct
+++ b/Library/After the End/Templates/Doc.gct
@@ -2379,7 +2379,7 @@
 										},
 										{
 											"id": "m4_CnkTQyUoUH5poo",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/After the End/Templates/Hulk.gct
+++ b/Library/After the End/Templates/Hulk.gct
@@ -2481,7 +2481,7 @@
 										},
 										{
 											"id": "mfjCEoIJ3EFCASIhY",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/After the End/Templates/Hunter.gct
+++ b/Library/After the End/Templates/Hunter.gct
@@ -1707,7 +1707,7 @@
 										},
 										{
 											"id": "mj-9m7YAflFll_dnQ",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/After the End/Templates/Nomad.gct
+++ b/Library/After the End/Templates/Nomad.gct
@@ -2063,7 +2063,7 @@
 										},
 										{
 											"id": "mLApx_UD_f6ooWRZx",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",
@@ -2460,7 +2460,7 @@
 										},
 										{
 											"id": "mLkReOgr0kH2HpMvQ",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",
@@ -2648,7 +2648,7 @@
 										},
 										{
 											"id": "mK4HEVeGaJTcPBgVo",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",
@@ -2836,7 +2836,7 @@
 										},
 										{
 											"id": "mvUGnLwG2m0kZi-dl",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/After the End/Templates/Scavenger.gct
+++ b/Library/After the End/Templates/Scavenger.gct
@@ -1856,7 +1856,7 @@
 										},
 										{
 											"id": "midAKccDnSplT-peN",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/After the End/Templates/Trader.gct
+++ b/Library/After the End/Templates/Trader.gct
@@ -2194,7 +2194,7 @@
 										},
 										{
 											"id": "myGxT0XD7X135C6MI",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",
@@ -4111,7 +4111,7 @@
 										},
 										{
 											"id": "mLpyckDIkpXUopoqm",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/After the End/Templates/Trooper.gct
+++ b/Library/After the End/Templates/Trooper.gct
@@ -2063,7 +2063,7 @@
 										},
 										{
 											"id": "mWt5x8H7ZzqmOP_5G",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Aliens/Mmm.gct
+++ b/Library/Aliens/Mmm.gct
@@ -795,7 +795,7 @@
 								},
 								{
 									"id": "m4lbRsyMI9OJJItH8",
-									"name": "@Who: A diety@",
+									"name": "@Who: A deity@",
 									"reference": "B72",
 									"cost": 30,
 									"cost_type": "points",

--- a/Library/Banestorm/Classes/Assassin.gct
+++ b/Library/Banestorm/Classes/Assassin.gct
@@ -732,7 +732,7 @@
 										},
 										{
 											"id": "mrpLBNP26aZogqEro",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Banestorm/Classes/Bard-Wizard.gct
+++ b/Library/Banestorm/Classes/Bard-Wizard.gct
@@ -804,7 +804,7 @@
 										},
 										{
 											"id": "mEQDX9hGm5xC5kQE2",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Banestorm/Classes/Bard.gct
+++ b/Library/Banestorm/Classes/Bard.gct
@@ -804,7 +804,7 @@
 										},
 										{
 											"id": "maZFGHPf8kc55U5mp",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Banestorm/Classes/Battle Wizard.gct
+++ b/Library/Banestorm/Classes/Battle Wizard.gct
@@ -359,7 +359,7 @@
 										},
 										{
 											"id": "mai-wCMXvbqSkSnDB",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Banestorm/Classes/Bounty Hunter.gct
+++ b/Library/Banestorm/Classes/Bounty Hunter.gct
@@ -810,7 +810,7 @@
 										},
 										{
 											"id": "mk9D15J6GXbqp0tHv",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Banestorm/Classes/Courtier.gct
+++ b/Library/Banestorm/Classes/Courtier.gct
@@ -1260,7 +1260,7 @@
 										},
 										{
 											"id": "mxlUHY36Y7pTuxZXL",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",
@@ -1450,7 +1450,7 @@
 										},
 										{
 											"id": "mU-QGoNv6DTLYOGNS",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Banestorm/Classes/Entertainer.gct
+++ b/Library/Banestorm/Classes/Entertainer.gct
@@ -752,7 +752,7 @@
 										},
 										{
 											"id": "mYS9toybzOfVa6_9L",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Banestorm/Classes/Freelance Wizard.gct
+++ b/Library/Banestorm/Classes/Freelance Wizard.gct
@@ -473,7 +473,7 @@
 										},
 										{
 											"id": "mufmjqty9fD-G4TbG",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Banestorm/Classes/Healer.gct
+++ b/Library/Banestorm/Classes/Healer.gct
@@ -893,7 +893,7 @@
 										},
 										{
 											"id": "mw6N-HPvkpf1ocr_A",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",
@@ -1083,7 +1083,7 @@
 										},
 										{
 											"id": "m88qCTx_CUd0rlWI_",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Banestorm/Classes/Knight-Errant.gct
+++ b/Library/Banestorm/Classes/Knight-Errant.gct
@@ -320,7 +320,7 @@
 										},
 										{
 											"id": "mYhh_-8dJYq8JXZ9P",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",
@@ -1255,7 +1255,7 @@
 								},
 								{
 									"id": "mxJvgIyGc8neUhvSq",
-									"name": "@Who: A diety@",
+									"name": "@Who: A deity@",
 									"reference": "B72",
 									"cost": 30,
 									"cost_type": "points",
@@ -1789,7 +1789,7 @@
 								},
 								{
 									"id": "mZ7bmhBRAzpbspV_I",
-									"name": "@Who: A diety@",
+									"name": "@Who: A deity@",
 									"reference": "B72",
 									"cost": 30,
 									"cost_type": "points",
@@ -2200,7 +2200,7 @@
 								},
 								{
 									"id": "mLuhufGmnaqHvETb6",
-									"name": "@Who: A diety@",
+									"name": "@Who: A deity@",
 									"reference": "B72",
 									"cost": 30,
 									"cost_type": "points",
@@ -2537,7 +2537,7 @@
 								},
 								{
 									"id": "m-uFWm-OiXi0BS9C7",
-									"name": "@Who: A diety@",
+									"name": "@Who: A deity@",
 									"reference": "B72",
 									"cost": 30,
 									"cost_type": "points",

--- a/Library/Banestorm/Classes/Mercenary.gct
+++ b/Library/Banestorm/Classes/Mercenary.gct
@@ -601,7 +601,7 @@
 										},
 										{
 											"id": "mJ4JtAAxc3JghfSKu",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Banestorm/Classes/Merchant.gct
+++ b/Library/Banestorm/Classes/Merchant.gct
@@ -694,7 +694,7 @@
 										},
 										{
 											"id": "mCreM17WLlWhVv4Sr",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Banestorm/Classes/Michaelite.gct
+++ b/Library/Banestorm/Classes/Michaelite.gct
@@ -1027,7 +1027,7 @@
 								},
 								{
 									"id": "mG9o2fOWFi6tD81qN",
-									"name": "@Who: A diety@",
+									"name": "@Who: A deity@",
 									"reference": "B72",
 									"cost": 30,
 									"cost_type": "points",

--- a/Library/Banestorm/Classes/Priest-Wizard.gct
+++ b/Library/Banestorm/Classes/Priest-Wizard.gct
@@ -518,7 +518,7 @@
 										},
 										{
 											"id": "m58_kdCv5bhKHsbYZ",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",
@@ -1552,7 +1552,7 @@
 								},
 								{
 									"id": "mQcCZb6sb508MVXaZ",
-									"name": "@Who: A diety@",
+									"name": "@Who: A deity@",
 									"reference": "B72",
 									"cost": 30,
 									"cost_type": "points",
@@ -1900,7 +1900,7 @@
 								},
 								{
 									"id": "mo4YtAvo4g_AjgikF",
-									"name": "@Who: A diety@",
+									"name": "@Who: A deity@",
 									"reference": "B72",
 									"cost": 30,
 									"cost_type": "points",

--- a/Library/Banestorm/Classes/Urban Rogue.gct
+++ b/Library/Banestorm/Classes/Urban Rogue.gct
@@ -841,7 +841,7 @@
 										},
 										{
 											"id": "mQBVxxm364odFKG9V",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Banestorm/Classes/Watchman.gct
+++ b/Library/Banestorm/Classes/Watchman.gct
@@ -739,7 +739,7 @@
 								},
 								{
 									"id": "mhN8jyWjbN1J7ZKLC",
-									"name": "@Who: A diety@",
+									"name": "@Who: A deity@",
 									"reference": "B72",
 									"cost": 30,
 									"cost_type": "points",

--- a/Library/Banestorm/Classes/Woodsman.gct
+++ b/Library/Banestorm/Classes/Woodsman.gct
@@ -586,7 +586,7 @@
 										},
 										{
 											"id": "mELS7b8S3zsSMkiCr",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -18983,7 +18983,7 @@
 				},
 				{
 					"id": "mecknYJqGcUJHT_Gd",
-					"name": "@Who: A diety@",
+					"name": "@Who: A deity@",
 					"reference": "B72",
 					"cost": 30,
 					"cost_type": "points",
@@ -27579,7 +27579,7 @@
 			"features": [
 				{
 					"type": "reaction_bonus",
-					"situation": "from followers of your diety",
+					"situation": "from followers of your deity",
 					"amount": 2
 				},
 				{

--- a/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Equipment.eqp
+++ b/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Equipment.eqp
@@ -9133,7 +9133,7 @@
 			"id": "eXBNmbYfp_PfDrjMo",
 			"description": "Holy Symbol",
 			"reference": "DFA114",
-			"notes": "@Diety@",
+			"notes": "@Deity@",
 			"tags": [
 				"Esoteric Supplies",
 				"Special Orders"
@@ -9150,7 +9150,7 @@
 			"id": "e0g5ozQZsxVJApStz",
 			"description": "Holy Symbol, Blessed",
 			"reference": "DFA114",
-			"notes": "@Diety@; Gives +1 to rolls for Exorcism, Turning, and other tests of faith, but not spells",
+			"notes": "@Deity@; Gives +1 to rolls for Exorcism, Turning, and other tests of faith, but not spells",
 			"tags": [
 				"Esoteric Supplies",
 				"Special Orders"
@@ -9167,7 +9167,7 @@
 			"id": "e6BhjsweusVMMYnAO",
 			"description": "Holy Symbol, High",
 			"reference": "DFA114",
-			"notes": "@Diety@; Gives +2 to rolls for Exorcism, Turning, and other tests of faith, but not spells",
+			"notes": "@Deity@; Gives +2 to rolls for Exorcism, Turning, and other tests of faith, but not spells",
 			"tags": [
 				"Esoteric Supplies",
 				"Special Orders"

--- a/Library/Dungeon Fantasy RPG/Loadouts/Sample Starting Equipment.gct
+++ b/Library/Dungeon Fantasy RPG/Loadouts/Sample Starting Equipment.gct
@@ -187,7 +187,7 @@
 							"id": "e89XOqyLsI3tZlbKA",
 							"description": "Holy Symbol",
 							"reference": "DFA114",
-							"notes": "@Diety@",
+							"notes": "@Deity@",
 							"tags": [
 								"Esoteric Supplies"
 							],

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 5/Divine Elements/Evil Element.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 5/Divine Elements/Evil Element.gct
@@ -418,7 +418,7 @@
 								},
 								{
 									"id": "mKBTFcB66KABtIOr4",
-									"name": "Evil Diety",
+									"name": "Evil Deity",
 									"reference": "B72",
 									"cost": 30,
 									"cost_type": "points"

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 5/Divine Elements/Good Element.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 5/Divine Elements/Good Element.gct
@@ -442,7 +442,7 @@
 								},
 								{
 									"id": "mKVEe_Lyg7Q2WrTXm",
-									"name": "Good Diety",
+									"name": "Good Deity",
 									"reference": "B72",
 									"cost": 30,
 									"cost_type": "points"

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Cleric Variants/Messenger Rogue Cleric.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Cleric Variants/Messenger Rogue Cleric.gct
@@ -1834,7 +1834,7 @@
 												},
 												{
 													"id": "mVucZHkViy0dD-HwK",
-													"name": "@Minor Diety or limited manifestation of a major deity@",
+													"name": "@Minor Deity or limited manifestation of a major deity@",
 													"reference": "B72",
 													"cost": 10,
 													"cost_type": "points"
@@ -1849,7 +1849,7 @@
 												},
 												{
 													"id": "mU7PqiBHVaao-mRhi",
-													"name": "@Minor Diety or limited manifestation of a major deity@",
+													"name": "@Minor Deity or limited manifestation of a major deity@",
 													"reference": "B72",
 													"cost": 20,
 													"cost_type": "points",
@@ -2020,7 +2020,7 @@
 												},
 												{
 													"id": "mZSeXqzXY1xi6p-B7",
-													"name": "@Minor Diety or limited manifestation of a major deity@",
+													"name": "@Minor Deity or limited manifestation of a major deity@",
 													"reference": "B72",
 													"cost": 10,
 													"cost_type": "points"
@@ -2035,7 +2035,7 @@
 												},
 												{
 													"id": "m2Ax7rhYaEwdoBwlK",
-													"name": "@Minor Diety or limited manifestation of a major deity@",
+													"name": "@Minor Deity or limited manifestation of a major deity@",
 													"reference": "B72",
 													"cost": 20,
 													"cost_type": "points",

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Messenger Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Messenger Holy Warrior.gct
@@ -987,7 +987,7 @@
 												},
 												{
 													"id": "mJfNoqabWOSwILTCU",
-													"name": "@Minor Diety or limited manifestation of a major deity@",
+													"name": "@Minor Deity or limited manifestation of a major deity@",
 													"reference": "B72",
 													"cost": 10,
 													"cost_type": "points"
@@ -1002,7 +1002,7 @@
 												},
 												{
 													"id": "mCJLUdJAZHEIwtkKl",
-													"name": "@Minor Diety or limited manifestation of a major deity@",
+													"name": "@Minor Deity or limited manifestation of a major deity@",
 													"reference": "B72",
 													"cost": 20,
 													"cost_type": "points",
@@ -1173,7 +1173,7 @@
 												},
 												{
 													"id": "m9AvoICi2Sn4b7421",
-													"name": "@Minor Diety or limited manifestation of a major deity@",
+													"name": "@Minor Deity or limited manifestation of a major deity@",
 													"reference": "B72",
 													"cost": 10,
 													"cost_type": "points"
@@ -1188,7 +1188,7 @@
 												},
 												{
 													"id": "mWWZyjapy7uPKzv0d",
-													"name": "@Minor Diety or limited manifestation of a major deity@",
+													"name": "@Minor Deity or limited manifestation of a major deity@",
 													"reference": "B72",
 													"cost": 20,
 													"cost_type": "points",

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Rogue Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Rogue Holy Warrior.gct
@@ -1633,7 +1633,7 @@
 												},
 												{
 													"id": "mdOZj6xJ5fbAL7Z-T",
-													"name": "@Minor Diety or limited manifestation of a major deity@",
+													"name": "@Minor Deity or limited manifestation of a major deity@",
 													"reference": "B72",
 													"cost": 10,
 													"cost_type": "points"
@@ -1648,7 +1648,7 @@
 												},
 												{
 													"id": "mLyZv6HMd0mTtJJh-",
-													"name": "@Minor Diety or limited manifestation of a major deity@",
+													"name": "@Minor Deity or limited manifestation of a major deity@",
 													"reference": "B72",
 													"cost": 20,
 													"cost_type": "points",
@@ -1819,7 +1819,7 @@
 												},
 												{
 													"id": "mCldaR4bwa6mQFhQN",
-													"name": "@Minor Diety or limited manifestation of a major deity@",
+													"name": "@Minor Deity or limited manifestation of a major deity@",
 													"reference": "B72",
 													"cost": 10,
 													"cost_type": "points"
@@ -1834,7 +1834,7 @@
 												},
 												{
 													"id": "mKEmf-Oji4lwOR38D",
-													"name": "@Minor Diety or limited manifestation of a major deity@",
+													"name": "@Minor Deity or limited manifestation of a major deity@",
 													"reference": "B72",
 													"cost": 20,
 													"cost_type": "points",

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 9/Classes/Shaman.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 9/Classes/Shaman.gct
@@ -462,7 +462,7 @@
 											"features": [
 												{
 													"type": "reaction_bonus",
-													"situation": "from followers of your diety",
+													"situation": "from followers of your deity",
 													"amount": 2
 												},
 												{

--- a/Library/Fantasy Folk/Elves/Profession Templates/Forest Warden.gct
+++ b/Library/Fantasy Folk/Elves/Profession Templates/Forest Warden.gct
@@ -1296,7 +1296,7 @@
 								},
 								{
 									"id": "mES93gkPLEUB4kPTc",
-									"name": "@Who: A diety@",
+									"name": "@Who: A deity@",
 									"reference": "B72",
 									"cost": 30,
 									"cost_type": "points",

--- a/Library/Fantasy Folk/Winged Folk/Profession Templates/Trader.gct
+++ b/Library/Fantasy Folk/Winged Folk/Profession Templates/Trader.gct
@@ -2378,7 +2378,7 @@
 								},
 								{
 									"id": "m_cSChGVTVnHV-mgY",
-									"name": "@Who: A diety@",
+									"name": "@Who: A deity@",
 									"reference": "B72",
 									"cost": 6,
 									"cost_type": "points",
@@ -2789,7 +2789,7 @@
 								},
 								{
 									"id": "mZoxBtX1_hlfLG0WX",
-									"name": "@Who: A diety@",
+									"name": "@Who: A deity@",
 									"reference": "B72",
 									"cost": 30,
 									"cost_type": "points",

--- a/Library/Fantasy/Classes/Enchanter.gct
+++ b/Library/Fantasy/Classes/Enchanter.gct
@@ -1041,7 +1041,7 @@
 										},
 										{
 											"id": "mVnho4N-WmMElg71W",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Fantasy/Classes/Roma Arcana/Engineer.gct
+++ b/Library/Fantasy/Classes/Roma Arcana/Engineer.gct
@@ -935,7 +935,7 @@
 										},
 										{
 											"id": "mNVr19UelJv0e-6VA",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Historical Folks/Actor.gct
+++ b/Library/Historical Folks/Actor.gct
@@ -422,7 +422,7 @@
 										},
 										{
 											"id": "mZHcGT-5se5BKNTgn",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Historical Folks/Alchemist.gct
+++ b/Library/Historical Folks/Alchemist.gct
@@ -188,7 +188,7 @@
 										},
 										{
 											"id": "mbzGeQew1gAoaX-8-",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Historical Folks/Animal Handler.gct
+++ b/Library/Historical Folks/Animal Handler.gct
@@ -423,7 +423,7 @@
 										},
 										{
 											"id": "muS7hqyMi1xM5bFOH",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Historical Folks/Writer.gct
+++ b/Library/Historical Folks/Writer.gct
@@ -241,7 +241,7 @@
 										},
 										{
 											"id": "mkY0bJMEHCHA2zdzw",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Home Brew/Characters/Caravan to Ein Arris Pregens/Girth.gcs
+++ b/Library/Home Brew/Characters/Caravan to Ein Arris Pregens/Girth.gcs
@@ -956,7 +956,7 @@
 				{
 					"id": "52fd34c4-846c-4125-a886-c0792c85a538",
 					"type": "modifier",
-					"name": "@Who: A diety@",
+					"name": "@Who: A deity@",
 					"reference": "B72",
 					"cost": 30,
 					"cost_type": "points",

--- a/Library/Home Brew/Characters/Caravan to Ein Arris Pregens/Keffiyah.gcs
+++ b/Library/Home Brew/Characters/Caravan to Ein Arris Pregens/Keffiyah.gcs
@@ -677,7 +677,7 @@
 				{
 					"id": "d8eb6dae-9ae8-4185-a5ce-5ce13c8e7fe2",
 					"type": "modifier",
-					"name": "@Who: A diety@",
+					"name": "@Who: A deity@",
 					"reference": "B72",
 					"cost": 30,
 					"cost_type": "points",

--- a/Library/Home Brew/Characters/Caravan to Ein Arris Pregens/Lariat.gcs
+++ b/Library/Home Brew/Characters/Caravan to Ein Arris Pregens/Lariat.gcs
@@ -747,7 +747,7 @@
 				{
 					"id": "d8eb6dae-9ae8-4185-a5ce-5ce13c8e7fe2",
 					"type": "modifier",
-					"name": "@Who: A diety@",
+					"name": "@Who: A deity@",
 					"reference": "B72",
 					"cost": 30,
 					"cost_type": "points",

--- a/Library/Home Brew/Characters/Caravan to Ein Arris Pregens/Manila.gcs
+++ b/Library/Home Brew/Characters/Caravan to Ein Arris Pregens/Manila.gcs
@@ -1481,7 +1481,7 @@
 				{
 					"id": "10d9944d-56b8-46ea-8694-cbe04aa7dc0c",
 					"type": "modifier",
-					"name": "@Who: A diety@",
+					"name": "@Who: A deity@",
 					"reference": "B72",
 					"cost": 30,
 					"cost_type": "points",

--- a/Library/Home Brew/Characters/Caravan to Ein Arris Pregens/Prusik.gcs
+++ b/Library/Home Brew/Characters/Caravan to Ein Arris Pregens/Prusik.gcs
@@ -723,7 +723,7 @@
 				{
 					"id": "8741171b-3bc4-4c49-876e-0116c39f7e74",
 					"type": "modifier",
-					"name": "@Who: A diety@",
+					"name": "@Who: A deity@",
 					"reference": "B72",
 					"cost": 30,
 					"cost_type": "points",

--- a/Library/Home Brew/Historical Folks Skill Sets/Skill Sets/Astronomer.gct
+++ b/Library/Home Brew/Historical Folks Skill Sets/Skill Sets/Astronomer.gct
@@ -479,7 +479,7 @@
 						{
 							"id": "10d9944d-56b8-46ea-8694-cbe04aa7dc0c",
 							"type": "modifier",
-							"name": "@Who: A diety@",
+							"name": "@Who: A deity@",
 							"reference": "B72",
 							"cost": 30,
 							"cost_type": "points",

--- a/Library/Home Brew/Historical Folks Skill Sets/Skill Sets/Noble-Consort.gct
+++ b/Library/Home Brew/Historical Folks Skill Sets/Skill Sets/Noble-Consort.gct
@@ -638,7 +638,7 @@
 						{
 							"id": "10d9944d-56b8-46ea-8694-cbe04aa7dc0c",
 							"type": "modifier",
-							"name": "@Who: A diety@",
+							"name": "@Who: A deity@",
 							"reference": "B72",
 							"cost": 30,
 							"cost_type": "points",

--- a/Library/Horror/Classes/Aristocrat.gct
+++ b/Library/Horror/Classes/Aristocrat.gct
@@ -112,7 +112,7 @@
 										},
 										{
 											"id": "mdL7OqAbffAlMCySS",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Horror/Classes/Attorney.gct
+++ b/Library/Horror/Classes/Attorney.gct
@@ -880,7 +880,7 @@
 										},
 										{
 											"id": "mRQ5csT-BMwJ5xt1g",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Horror/Classes/Criminal.gct
+++ b/Library/Horror/Classes/Criminal.gct
@@ -708,7 +708,7 @@
 										},
 										{
 											"id": "m0AHjvih5bm3Xi6m6",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Horror/Classes/Detective.gct
+++ b/Library/Horror/Classes/Detective.gct
@@ -873,7 +873,7 @@
 										},
 										{
 											"id": "mtU0lF3QPDay0AQR7",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Horror/Classes/Explorer.gct
+++ b/Library/Horror/Classes/Explorer.gct
@@ -739,7 +739,7 @@
 										},
 										{
 											"id": "mDTYWNZhrBShrAcUQ",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Horror/Classes/Journalist.gct
+++ b/Library/Horror/Classes/Journalist.gct
@@ -378,7 +378,7 @@
 										},
 										{
 											"id": "mFVV8k7VKRXRvoZMa",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Horror/Classes/Mystic Charlatan.gct
+++ b/Library/Horror/Classes/Mystic Charlatan.gct
@@ -1232,7 +1232,7 @@
 										},
 										{
 											"id": "m_NRLIXHXd9AZCvK1",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Horror/Classes/Police Officer.gct
+++ b/Library/Horror/Classes/Police Officer.gct
@@ -442,7 +442,7 @@
 										},
 										{
 											"id": "mNLbSf_MAqDb8yjET",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Lands Out of Time/Classes/Tribal Shaman.gct
+++ b/Library/Lands Out of Time/Classes/Tribal Shaman.gct
@@ -909,7 +909,7 @@
 										},
 										{
 											"id": "mZXZb4-GW1Cj_UVr0",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Monster Hunters/Classes/Champions/Psi.gct
+++ b/Library/Monster Hunters/Classes/Champions/Psi.gct
@@ -1109,7 +1109,7 @@
 										},
 										{
 											"id": "mCdJ9pCObd_c0FTIe",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Monster Hunters/Classes/Champions/Sage.gct
+++ b/Library/Monster Hunters/Classes/Champions/Sage.gct
@@ -2170,7 +2170,7 @@
 										},
 										{
 											"id": "mWJfX_GfZlTFjs1mq",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Monster Hunters/Classes/Champions/Sleuth.gct
+++ b/Library/Monster Hunters/Classes/Champions/Sleuth.gct
@@ -2679,7 +2679,7 @@
 										},
 										{
 											"id": "mx_PqGwZKhAo03Giw",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Monster Hunters/Classes/Champions/Techie.gct
+++ b/Library/Monster Hunters/Classes/Champions/Techie.gct
@@ -1844,7 +1844,7 @@
 										},
 										{
 											"id": "mvVPX0T6KF83DMYsj",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Monster Hunters/Classes/Champions/Warrior.gct
+++ b/Library/Monster Hunters/Classes/Champions/Warrior.gct
@@ -1921,7 +1921,7 @@
 										},
 										{
 											"id": "meGCofVrx_8T5VqP-",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Monster Hunters/Classes/Champions/Witch.gct
+++ b/Library/Monster Hunters/Classes/Champions/Witch.gct
@@ -1795,7 +1795,7 @@
 										},
 										{
 											"id": "mO0820rxl2J0XB41v",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Monster Hunters/Classes/Sidekicks/Brother.gct
+++ b/Library/Monster Hunters/Classes/Sidekicks/Brother.gct
@@ -1030,7 +1030,7 @@
 								},
 								{
 									"id": "mDbPCVu-yhidTbpPh",
-									"name": "@Who: A diety@",
+									"name": "@Who: A deity@",
 									"reference": "B72",
 									"cost": 30,
 									"cost_type": "points",

--- a/Library/Monster Hunters/Classes/Sidekicks/Fixer.gct
+++ b/Library/Monster Hunters/Classes/Sidekicks/Fixer.gct
@@ -697,7 +697,7 @@
 								},
 								{
 									"id": "mNK2OqfNuz6Zn-409",
-									"name": "@Who: A diety@",
+									"name": "@Who: A deity@",
 									"reference": "B72",
 									"cost": 30,
 									"cost_type": "points",

--- a/Library/Monster Hunters/Classes/Sidekicks/Geek.gct
+++ b/Library/Monster Hunters/Classes/Sidekicks/Geek.gct
@@ -2986,7 +2986,7 @@
 								},
 								{
 									"id": "m01xB8P7C_rHxqCr9",
-									"name": "@Who: A diety@",
+									"name": "@Who: A deity@",
 									"reference": "B72",
 									"cost": 30,
 									"cost_type": "points",

--- a/Library/Monster Hunters/Classes/Sidekicks/Muscle.gct
+++ b/Library/Monster Hunters/Classes/Sidekicks/Muscle.gct
@@ -1155,7 +1155,7 @@
 										},
 										{
 											"id": "m1BjzkLO0inOke9eX",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Monster Hunters/Classes/Sidekicks/Whitecoat.gct
+++ b/Library/Monster Hunters/Classes/Sidekicks/Whitecoat.gct
@@ -1033,7 +1033,7 @@
 								},
 								{
 									"id": "mDrH6CkexhqtnWgpr",
-									"name": "@Who: A diety@",
+									"name": "@Who: A deity@",
 									"reference": "B72",
 									"cost": 30,
 									"cost_type": "points",

--- a/Library/Mysteries/Classes/Defense Attorney.gct
+++ b/Library/Mysteries/Classes/Defense Attorney.gct
@@ -798,7 +798,7 @@
 								},
 								{
 									"id": "mfdJFFjamGdvaalKc",
-									"name": "@Who: A diety@",
+									"name": "@Who: A deity@",
 									"reference": "B72",
 									"cost": 30,
 									"cost_type": "points",

--- a/Library/Mysteries/Classes/Fire Marshal.gct
+++ b/Library/Mysteries/Classes/Fire Marshal.gct
@@ -407,7 +407,7 @@
 								},
 								{
 									"id": "mghZ2lGMM5odd4UwE",
-									"name": "@Who: A diety@",
+									"name": "@Who: A deity@",
 									"reference": "B72",
 									"cost": 30,
 									"cost_type": "points",

--- a/Library/Mysteries/Classes/Police Detective.gct
+++ b/Library/Mysteries/Classes/Police Detective.gct
@@ -340,7 +340,7 @@
 								},
 								{
 									"id": "mwA7CxnBv86Bb_wHY",
-									"name": "@Who: A diety@",
+									"name": "@Who: A deity@",
 									"reference": "B72",
 									"cost": 30,
 									"cost_type": "points",

--- a/Library/Mysteries/Classes/That Darn Kid.gct
+++ b/Library/Mysteries/Classes/That Darn Kid.gct
@@ -138,7 +138,7 @@
 						},
 						{
 							"id": "mq6A7zSpsWTqDjzeR",
-							"name": "@Who: A diety@",
+							"name": "@Who: A deity@",
 							"reference": "B72",
 							"cost": 30,
 							"cost_type": "points",

--- a/Library/Psionics/Classes/Celebrity.gct
+++ b/Library/Psionics/Classes/Celebrity.gct
@@ -1079,7 +1079,7 @@
 										},
 										{
 											"id": "mhKA535UfjGYEF2HS",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",
@@ -3606,7 +3606,7 @@
 										},
 										{
 											"id": "moYkHfHGvTnjnJfMy",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Psionics/Classes/Child.gct
+++ b/Library/Psionics/Classes/Child.gct
@@ -1144,7 +1144,7 @@
 										},
 										{
 											"id": "msQxpsj8H_-kR9wVO",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Psionics/Classes/Criminal.gct
+++ b/Library/Psionics/Classes/Criminal.gct
@@ -1561,7 +1561,7 @@
 										},
 										{
 											"id": "mqCN6Ksg0iR0R35M3",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",
@@ -2106,7 +2106,7 @@
 										},
 										{
 											"id": "mG1u4zZa0v_ldMVOH",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Psionics/Classes/Investigator.gct
+++ b/Library/Psionics/Classes/Investigator.gct
@@ -1133,7 +1133,7 @@
 										},
 										{
 											"id": "mpXdqbEDxcDmqVsy3",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",
@@ -1550,7 +1550,7 @@
 										},
 										{
 											"id": "mLBF83OxCIzXOul3v",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Psionics/Classes/Mythbuster.gct
+++ b/Library/Psionics/Classes/Mythbuster.gct
@@ -827,7 +827,7 @@
 										},
 										{
 											"id": "m3qP_saBJzzw9--ue",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Psionics/Classes/Secret Agent.gct
+++ b/Library/Psionics/Classes/Secret Agent.gct
@@ -294,7 +294,7 @@
 										},
 										{
 											"id": "mH8ASg6gkEga77K20",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",
@@ -1856,7 +1856,7 @@
 										},
 										{
 											"id": "mJqykkx4M1mZsCcmb",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Psionics/Classes/Soothsayer.gct
+++ b/Library/Psionics/Classes/Soothsayer.gct
@@ -1333,7 +1333,7 @@
 										},
 										{
 											"id": "mHiUJYx3RQ-kXQfMV",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Pyramid Magazine/Pyramid 112/More Skill Sets for Specialists/Religiously Ordained (Non-Supernatural).gct
+++ b/Library/Pyramid Magazine/Pyramid 112/More Skill Sets for Specialists/Religiously Ordained (Non-Supernatural).gct
@@ -402,7 +402,7 @@
 						},
 						{
 							"id": "mVN8csKF8Fv4Sf9l3",
-							"name": "@Who: A diety@",
+							"name": "@Who: A deity@",
 							"reference": "B72",
 							"cost": 30,
 							"cost_type": "points",

--- a/Library/Pyramid Magazine/Pyramid 115/Medical Professional.gct
+++ b/Library/Pyramid Magazine/Pyramid 115/Medical Professional.gct
@@ -543,7 +543,7 @@
 								},
 								{
 									"id": "mtad1zz-amwt6YJPs",
-									"name": "@Who: A diety@",
+									"name": "@Who: A deity@",
 									"reference": "B72",
 									"cost": 30,
 									"cost_type": "points",
@@ -731,7 +731,7 @@
 								},
 								{
 									"id": "m-Ef5mqlIfFpgD2Vo",
-									"name": "@Who: A diety@",
+									"name": "@Who: A deity@",
 									"reference": "B72",
 									"cost": 30,
 									"cost_type": "points",

--- a/Library/Reign of Steel Will to Live/Classes/Androids/Aniroid Ranger.gct
+++ b/Library/Reign of Steel Will to Live/Classes/Androids/Aniroid Ranger.gct
@@ -322,7 +322,7 @@
 						},
 						{
 							"id": "mYN342AotkVnqgz2E",
-							"name": "@Who: A diety@",
+							"name": "@Who: A deity@",
 							"reference": "B72",
 							"cost": 30,
 							"cost_type": "points",

--- a/Library/Reign of Steel Will to Live/Classes/Humans/Botlicker.gct
+++ b/Library/Reign of Steel Will to Live/Classes/Humans/Botlicker.gct
@@ -80,7 +80,7 @@
 						},
 						{
 							"id": "mqvi_L5ROvDogkhs4",
-							"name": "@Who: A diety@",
+							"name": "@Who: A deity@",
 							"reference": "B72",
 							"cost": 30,
 							"cost_type": "points",

--- a/Library/Reign of Steel Will to Live/Classes/Humans/Collector.gct
+++ b/Library/Reign of Steel Will to Live/Classes/Humans/Collector.gct
@@ -103,7 +103,7 @@
 						},
 						{
 							"id": "mxrWPLCovsfcdNkPy",
-							"name": "@Who: A diety@",
+							"name": "@Who: A deity@",
 							"reference": "B72",
 							"cost": 30,
 							"cost_type": "points",
@@ -291,7 +291,7 @@
 						},
 						{
 							"id": "mxmroa2Q5m8Mp3Twv",
-							"name": "@Who: A diety@",
+							"name": "@Who: A deity@",
 							"reference": "B72",
 							"cost": 30,
 							"cost_type": "points",

--- a/Library/Reign of Steel Will to Live/Classes/Humans/FBI Agent.gct
+++ b/Library/Reign of Steel Will to Live/Classes/Humans/FBI Agent.gct
@@ -359,7 +359,7 @@
 						},
 						{
 							"id": "mwBKgWoXryXj6b83N",
-							"name": "@Who: A diety@",
+							"name": "@Who: A deity@",
 							"reference": "B72",
 							"cost": 30,
 							"cost_type": "points",

--- a/Library/Reign of Steel Will to Live/Classes/Humans/Mechrider.gct
+++ b/Library/Reign of Steel Will to Live/Classes/Humans/Mechrider.gct
@@ -275,7 +275,7 @@
 						},
 						{
 							"id": "mepIJ4o2bU-OTuROf",
-							"name": "@Who: A diety@",
+							"name": "@Who: A deity@",
 							"reference": "B72",
 							"cost": 30,
 							"cost_type": "points",

--- a/Library/Reign of Steel Will to Live/Classes/Humans/Washington Chrome.gct
+++ b/Library/Reign of Steel Will to Live/Classes/Humans/Washington Chrome.gct
@@ -95,7 +95,7 @@
 						},
 						{
 							"id": "malN8R1bgpwnaCwMy",
-							"name": "@Who: A diety@",
+							"name": "@Who: A deity@",
 							"reference": "B72",
 							"cost": 30,
 							"cost_type": "points",
@@ -283,7 +283,7 @@
 						},
 						{
 							"id": "mt_NY-9_Dm9f7frzP",
-							"name": "@Who: A diety@",
+							"name": "@Who: A deity@",
 							"reference": "B72",
 							"cost": 30,
 							"cost_type": "points",

--- a/Library/Steampunk/Templates/Adventurer-Journalist.gct
+++ b/Library/Steampunk/Templates/Adventurer-Journalist.gct
@@ -938,7 +938,7 @@
 										},
 										{
 											"id": "mGkDzTjZB77237CW6",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Steampunk/Templates/Reporter.gct
+++ b/Library/Steampunk/Templates/Reporter.gct
@@ -598,7 +598,7 @@
 										},
 										{
 											"id": "mfLseDMvWGekvwvns",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Technomancer/Template - Alchemist.gct
+++ b/Library/Technomancer/Template - Alchemist.gct
@@ -300,7 +300,7 @@
 										},
 										{
 											"id": "mDrqohEmSMHPK8dZh",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",
@@ -488,7 +488,7 @@
 										},
 										{
 											"id": "mpsMI7MOwsByJ4WAJ",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Commander.gct
+++ b/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Commander.gct
@@ -1486,7 +1486,7 @@
 												},
 												{
 													"id": "mJpUe-r6e3RRlR2v_",
-													"name": "@Who: A diety@",
+													"name": "@Who: A deity@",
 													"reference": "B72",
 													"cost": 30,
 													"cost_type": "points",

--- a/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Engineer.gct
+++ b/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Engineer.gct
@@ -872,7 +872,7 @@
 												},
 												{
 													"id": "mGQ_qvBnNY6pWyxCj",
-													"name": "@Who: A diety@",
+													"name": "@Who: A deity@",
 													"reference": "B72",
 													"cost": 30,
 													"cost_type": "points",

--- a/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Helmsman.gct
+++ b/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Helmsman.gct
@@ -1033,7 +1033,7 @@
 												},
 												{
 													"id": "m27ELJcFI1EcTXliT",
-													"name": "@Who: A diety@",
+													"name": "@Who: A deity@",
 													"reference": "B72",
 													"cost": 30,
 													"cost_type": "points",

--- a/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Loadmaster.gct
+++ b/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Loadmaster.gct
@@ -975,7 +975,7 @@
 												},
 												{
 													"id": "mtE9uXnhuBKp-LqCu",
-													"name": "@Who: A diety@",
+													"name": "@Who: A deity@",
 													"reference": "B72",
 													"cost": 30,
 													"cost_type": "points",

--- a/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Medical Officer.gct
+++ b/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Medical Officer.gct
@@ -766,7 +766,7 @@
 												},
 												{
 													"id": "mLYTUJds6uSeI83PH",
-													"name": "@Who: A diety@",
+													"name": "@Who: A deity@",
 													"reference": "B72",
 													"cost": 30,
 													"cost_type": "points",

--- a/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Operations Officer.gct
+++ b/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Operations Officer.gct
@@ -1721,7 +1721,7 @@
 												},
 												{
 													"id": "mSLNnY4Z4vagfQEIN",
-													"name": "@Who: A diety@",
+													"name": "@Who: A deity@",
 													"reference": "B72",
 													"cost": 30,
 													"cost_type": "points",

--- a/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Science Officer.gct
+++ b/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Science Officer.gct
@@ -723,7 +723,7 @@
 												},
 												{
 													"id": "mTW6E5IPdHuhfDqxM",
-													"name": "@Who: A diety@",
+													"name": "@Who: A deity@",
 													"reference": "B72",
 													"cost": 30,
 													"cost_type": "points",

--- a/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Security Officer.gct
+++ b/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Security Officer.gct
@@ -803,7 +803,7 @@
 												},
 												{
 													"id": "mD_7nW8nWb0C6P6nM",
-													"name": "@Who: A diety@",
+													"name": "@Who: A deity@",
 													"reference": "B72",
 													"cost": 30,
 													"cost_type": "points",

--- a/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Steward.gct
+++ b/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Steward.gct
@@ -1254,7 +1254,7 @@
 												},
 												{
 													"id": "m4kkqH0VMQmQ66pOq",
-													"name": "@Who: A diety@",
+													"name": "@Who: A deity@",
 													"reference": "B72",
 													"cost": 30,
 													"cost_type": "points",

--- a/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Tactical Officer.gct
+++ b/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Tactical Officer.gct
@@ -908,7 +908,7 @@
 												},
 												{
 													"id": "mPihva6fU1WPi_b7-",
-													"name": "@Who: A diety@",
+													"name": "@Who: A deity@",
 													"reference": "B72",
 													"cost": 30,
 													"cost_type": "points",

--- a/Library/Traveller/Templates/Bureaucrat.gct
+++ b/Library/Traveller/Templates/Bureaucrat.gct
@@ -964,7 +964,7 @@
 										},
 										{
 											"id": "me-StE4nB0-E_C3-C",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Traveller/Templates/Capitalist.gct
+++ b/Library/Traveller/Templates/Capitalist.gct
@@ -1012,7 +1012,7 @@
 										},
 										{
 											"id": "m6cNAJkjN8iVOn6zh",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Traveller/Templates/Dilettante.gct
+++ b/Library/Traveller/Templates/Dilettante.gct
@@ -1401,7 +1401,7 @@
 										},
 										{
 											"id": "mCgTxYwnjREUPVCSg",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",

--- a/Library/Traveller/Templates/Diplomat.gct
+++ b/Library/Traveller/Templates/Diplomat.gct
@@ -1609,7 +1609,7 @@
 								},
 								{
 									"id": "mEkMGoHV2GX2bqrYG",
-									"name": "@Who: A diety@",
+									"name": "@Who: A deity@",
 									"reference": "B72",
 									"cost": 30,
 									"cost_type": "points",

--- a/Library/Traveller/Templates/Journalist.gct
+++ b/Library/Traveller/Templates/Journalist.gct
@@ -1200,7 +1200,7 @@
 								},
 								{
 									"id": "mFuZRYNt33TN5uzKS",
-									"name": "@Who: A diety@",
+									"name": "@Who: A deity@",
 									"reference": "B72",
 									"cost": 30,
 									"cost_type": "points",

--- a/Library/Traveller/Templates/Policeman.gct
+++ b/Library/Traveller/Templates/Policeman.gct
@@ -760,7 +760,7 @@
 								},
 								{
 									"id": "mqAI-UQ6Ecuv-9ZJS",
-									"name": "@Who: A diety@",
+									"name": "@Who: A deity@",
 									"reference": "B72",
 									"cost": 30,
 									"cost_type": "points",

--- a/Library/Traveller/Templates/Spy.gct
+++ b/Library/Traveller/Templates/Spy.gct
@@ -1024,7 +1024,7 @@
 								},
 								{
 									"id": "m7Z-xGYzdeEMTn0XJ",
-									"name": "@Who: A diety@",
+									"name": "@Who: A deity@",
 									"reference": "B72",
 									"cost": 30,
 									"cost_type": "points",

--- a/Library/Traveller/Templates/Zhodani - Official.gct
+++ b/Library/Traveller/Templates/Zhodani - Official.gct
@@ -852,7 +852,7 @@
 										},
 										{
 											"id": "mw0u7m0p0PJOIGQFZ",
-											"name": "@Who: A diety@",
+											"name": "@Who: A deity@",
 											"reference": "B72",
 											"cost": 30,
 											"cost_type": "points",


### PR DESCRIPTION
Just in case anyone else needs to do a global search and replace across a git tree on a Linux box (or anything else Unixy with Perl), I did this with two commands to preserve case:  

find -type f -print0|xargs -0 perl -p -i -e "s/diety/deity/g"
find -type f -print0|xargs -0 perl -p -i -e "s/Diety/Deity/g"
