### PR TITLE
Add Chi Rations

### DIFF
--- a/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Equipment.eqp
+++ b/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Equipment.eqp
@@ -17839,6 +17839,23 @@
 			}
 		},
 		{
+			"id": "eXmS38Ykq8grUevlt",
+			"description": "Chi Rations",
+			"reference": "DFA111",
+			"notes": "One meal",
+			"tags": [
+				"Camping and Survival Gear"
+			],
+			"value": 4,
+			"weight": "0.5 lb",
+			"vtt_notes": "Chi Abilities, DFA30, \"you must pay double for rations\"",
+			"quantity": 1,
+			"calc": {
+				"extended_value": 4,
+				"extended_weight": "0.5 lb"
+			}
+		},
+		{
 			"id": "egPo_qN5SjElIh33g",
 			"description": "Reflector",
 			"reference": "DFA114",


### PR DESCRIPTION
DFA 30 Chi Abilties says people with them need to pay double for rations.  So add Chi Rations to the DFRPG equipment list.  They're just Rations with the price doubled.  These will keep Chi Abilties functioning.  Other characters can eat them too; they just provide no special benefits to them.