### PR TITLE
Add basic quirks to DFRPG Traits.

### DIFF
--- a/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq
+++ b/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq
@@ -223,6 +223,189 @@
 			}
 		},
 		{
+			"id": "tJmB4zQaqf3-cVshy",
+			"name": "@Quirk@",
+			"reference": "DFA68",
+			"tags": [
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "tanu5CGlA3VxZ-ISK",
+			"name": "Hobby (@Subject@)",
+			"reference": "DFA68",
+			"tags": [
+				"Quirk",
+				"Mental"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "tpqSHJrZERB3bRKz5",
+			"name": "@Mental Quirk@",
+			"reference": "DFA68",
+			"tags": [
+				"Quirk",
+				"Mental"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "tEl07swnu7iN4snM9",
+			"name": "@Physical Quirk@",
+			"reference": "DFA68",
+			"tags": [
+				"Quirk",
+				"Physical"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "ticN0Q6sg54QKqL53",
+			"name": "Like (@Subject@)",
+			"reference": "DFA68",
+			"tags": [
+				"Mental",
+				"Quirk",
+				"Social"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "toPfyMD2mDr7lfk1Q",
+			"name": "Dislike (@Subject@)",
+			"reference": "DFA68",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "tnM-jTSQy5XYt2a3u",
+			"name": "Habit (@Subject@)",
+			"reference": "DFA68",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "tD5y-MMRYGgB-6oXS",
+			"name": "Admiration (@Subject@)",
+			"reference": "DFA68",
+			"tags": [
+				"Mental",
+				"Quirk",
+				"Social"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "tGU6pQdbTEtWypJx7",
+			"name": "Speech Mannerism (@Subject@)",
+			"reference": "DFA68",
+			"tags": [
+				"Mental",
+				"Quirk",
+				"Social"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "toZ-5zAkPSLxZCTiF",
+			"name": "Dress Code (@Subject@)",
+			"reference": "DFA68",
+			"tags": [
+				"Mental",
+				"Quirk",
+				"Social"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "tIVsKXnkj0R0szX0r",
+			"name": "Odd Belief (@Subject@)",
+			"reference": "DFA68",
+			"tags": [
+				"Mental",
+				"Quirk",
+				"Social"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "tioXfuuD-pM6hbg-D",
+			"name": "Weak Disadvantage (@Subject@)",
+			"reference": "DFA68",
+			"tags": [
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "tWMeHPNmSscqzc_-C",
+			"name": "Trivial Disadvantage (@Subject@)",
+			"reference": "DFA68",
+			"tags": [
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "tyJBUUUWtc1jgubqj",
+			"name": "Embellishment to Disadvantage (@Subject@)",
+			"reference": "DFA68",
+			"tags": [
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
 			"id": "tEwukCyae1iQET_kA",
 			"name": "Ambidexterity",
 			"reference": "DFA47",


### PR DESCRIPTION
It's always been possible to create your own Quirks for DFRPG, or copy Quirks from other libraries like Basic Set or Power-Ups, but putting them in DFRPG helps that be self-contained, and keeps all the page number references in the DFRPG books.