### PR TITLE
Add Deflect 1 and 2 to DFRPG Equipment Modifiers for armor and shields.

### DIFF
--- a/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Equipment Modifiers.eqm
+++ b/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Equipment Modifiers.eqm
@@ -128,6 +128,42 @@
 							"cost_type": "to_final_cost",
 							"cost": "+1500",
 							"weight": "-50%"
+						},
+						{
+							"id": "fCuE8sdTC42Y0Xbkn",
+							"name": "Deflect 1",
+							"reference": "DFA118",
+							"notes": "DB +1",
+							"tags": [
+								"Magic"
+							],
+							"cost_type": "to_final_cost",
+							"cost": "+300",
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "to Dodge, Parry \u0026 Block against attacks to the arm",
+									"amount": 1
+								}
+							]
+						},
+						{
+							"id": "f2gh62m8y5p6ajCwq",
+							"name": "Deflect 2",
+							"reference": "DFA118",
+							"notes": "DB +2",
+							"tags": [
+								"Magic"
+							],
+							"cost_type": "to_final_cost",
+							"cost": "+1500",
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "to Dodge, Parry \u0026 Block against attacks to the arm",
+									"amount": 2
+								}
+							]
 						}
 					]
 				},
@@ -241,6 +277,42 @@
 							"cost_type": "to_final_cost",
 							"cost": "+3500",
 							"weight": "-50%"
+						},
+						{
+							"id": "fK5Rc61myzQU1e14R",
+							"name": "Deflect 1",
+							"reference": "DFA118",
+							"notes": "DB +1",
+							"tags": [
+								"Magic"
+							],
+							"cost_type": "to_final_cost",
+							"cost": "+700",
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "to Dodge, Parry \u0026 Block against attacks to the body",
+									"amount": 1
+								}
+							]
+						},
+						{
+							"id": "foSuCg34iZyYWxNQl",
+							"name": "Deflect 2",
+							"reference": "DFA118",
+							"notes": "DB +2",
+							"tags": [
+								"Magic"
+							],
+							"cost_type": "to_final_cost",
+							"cost": "+3500",
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "to Dodge, Parry \u0026 Block against attacks to the body",
+									"amount": 2
+								}
+							]
 						}
 					]
 				},
@@ -383,6 +455,40 @@
 							"cost_type": "to_final_cost",
 							"cost": "+500",
 							"weight": "-50%"
+						},
+						{
+							"id": "fRCRShSfTyJ8e3nl8",
+							"name": "Deflect 1",
+							"notes": "DB +1",
+							"tags": [
+								"Magic"
+							],
+							"cost_type": "to_final_cost",
+							"cost": "+100",
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "to Dodge, Parry \u0026 Block against attacks to the hand",
+									"amount": 1
+								}
+							]
+						},
+						{
+							"id": "fScuHqp30tle_NjGz",
+							"name": "Deflect 2",
+							"notes": "DB +2",
+							"tags": [
+								"Magic"
+							],
+							"cost_type": "to_final_cost",
+							"cost": "+500",
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "to Dodge, Parry \u0026 Block against attacks to the hand",
+									"amount": 2
+								}
+							]
 						}
 					]
 				},
@@ -496,6 +602,42 @@
 							"cost_type": "to_final_cost",
 							"cost": "+1000",
 							"weight": "-50%"
+						},
+						{
+							"id": "fPbEdjGm-yFhFgwsq",
+							"name": "Deflect 1",
+							"reference": "DFA118",
+							"notes": "DB +1",
+							"tags": [
+								"Magic"
+							],
+							"cost_type": "to_final_cost",
+							"cost": "+200",
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "to Dodge, Parry \u0026 Block against attacks to the head/foot",
+									"amount": 1
+								}
+							]
+						},
+						{
+							"id": "fI1C-PpM1s3fEWxw_",
+							"name": "Deflect 2",
+							"reference": "DFA118",
+							"notes": "DB +2",
+							"tags": [
+								"Magic"
+							],
+							"cost_type": "to_final_cost",
+							"cost": "+1000",
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "to Dodge, Parry \u0026 Block against attacks to the head/foot",
+									"amount": 2
+								}
+							]
 						}
 					]
 				},
@@ -707,6 +849,42 @@
 							"cost_type": "to_final_cost",
 							"cost": "+2500",
 							"weight": "-50%"
+						},
+						{
+							"id": "fTBbyXMgiIjVlOAM6",
+							"name": "Deflect 1",
+							"reference": "DFA118",
+							"notes": "DB +1",
+							"tags": [
+								"Magic"
+							],
+							"cost_type": "to_final_cost",
+							"cost": "+500",
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "to Dodge, Parry \u0026 Block against attacks to the legs",
+									"amount": 1
+								}
+							]
+						},
+						{
+							"id": "f7ZNL1BENSwZ9gHrI",
+							"name": "Deflect 2",
+							"reference": "DFA118",
+							"notes": "DB +2",
+							"tags": [
+								"Magic"
+							],
+							"cost_type": "to_final_cost",
+							"cost": "+2500",
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "to Dodge, Parry \u0026 Block against attacks to the legs",
+									"amount": 2
+								}
+							]
 						}
 					]
 				},
@@ -934,6 +1112,42 @@
 								"qualifier": "Shield"
 							},
 							"amount": 1
+						}
+					]
+				},
+				{
+					"id": "fvJhKR-Wod45ruSOt",
+					"name": "Deflect 1",
+					"reference": "DFA118",
+					"notes": "+1 DB",
+					"tags": [
+						"Magic"
+					],
+					"cost_type": "to_final_cost",
+					"cost": "+2000",
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "to Dodge, Parry \u0026 Block against attacks from the front or shield side",
+							"amount": 1
+						}
+					]
+				},
+				{
+					"id": "f8hUn8FJ6PAfCluLr",
+					"name": "Deflect 2",
+					"reference": "DFA118",
+					"notes": "+2 DB",
+					"tags": [
+						"Magic"
+					],
+					"cost_type": "to_final_cost",
+					"cost": "+10000",
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "to Dodge, Parry \u0026 Block against attacks from the front or shield side",
+							"amount": 2
 						}
 					]
 				},


### PR DESCRIPTION
These modify the cost of the shield or armor piece, and note the conditional defense bonus, but don't actually affect the dodge/block/parry levels shown for the character because the defense bonus is conditional.