### PR TITLE
Fix page references in Banestorm and Supers

### DIFF
--- a/Library/Banestorm/Classes/Entertainer.gct
+++ b/Library/Banestorm/Classes/Entertainer.gct
@@ -1193,9 +1193,14 @@
 									}
 								},
 								{
-									"id": "t3vUl--CgmEyi8K80",
+									"id": "tNKdjxF25qPBUjGem",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Banestorm/Banestorm Traits.adq",
+										"id": "tT07rcmTQWWooPN9R"
+									},
 									"name": "Code of Honor (Theatrical)",
-									"reference": "B127",
+									"reference": "BS186",
 									"tags": [
 										"Disadvantage",
 										"Mental"

--- a/Library/Supers/Templates/Archetype.gct
+++ b/Library/Supers/Templates/Archetype.gct
@@ -3364,7 +3364,7 @@
 		{
 			"id": "ntDo9Me95w7J3thWZ",
 			"text": "2000 Points - You fit the most common of all heroic patterns: amazing strength, speed, and durability, plus the ability to fly (or something close to it). You’re powerful enough to be almost immune to forcible restraint. If you’re a hero, you’re law-abiding or honorable because of your personal convictions; if you’re a villain\nor anti-hero, you’re driven by a sense of superiority to ordinary mortals.",
-			"reference": "S42"
+			"reference": "SU42"
 		}
 	]
 }

--- a/Library/Supers/Templates/Biomorph.gct
+++ b/Library/Supers/Templates/Biomorph.gct
@@ -5841,7 +5841,7 @@
 		{
 			"id": "n3fhE0QjCUv2EcZLv",
 			"text": "500 Points - You have powers based on those of other living species – usually animals, but plants, fungi, or even microorganisms are possible. Your heroic identity evokes those creatures as well. Your body may be completely human or have some anatomical peculiarities, but you don’t actually turn into another species; see Metamorph (p. 49) for that option.",
-			"reference": "S42"
+			"reference": "SU42"
 		}
 	]
 }

--- a/Library/Supers/Templates/Dreadnought.gct
+++ b/Library/Supers/Templates/Dreadnought.gct
@@ -2405,7 +2405,7 @@
 		{
 			"id": "ntrQjt3tcp02u9LSX",
 			"text": "1,000 points You’re the equivalent of a brick, but without superpowers. Instead, your enhanced strength and toughness come from technology: a suit of armor that senses, imitates, and amplifies your movements. This is far enough beyond existing technology for the suit’s abilities to be bought as advantages with gadget limitations. It’s assumed that you built it yourself, and maintain it as needed.",
-			"reference": "S42"
+			"reference": "SU45"
 		}
 	]
 }

--- a/Library/Supers/Templates/Improviser.gct
+++ b/Library/Supers/Templates/Improviser.gct
@@ -1062,7 +1062,7 @@
 		{
 			"id": "neqPCv9TqLBsiIeF2",
 			"text": "500 points You have a power that lets you do anything – or, at least, a wide range of different things. This template is built to take advantage of Modular Abilities.",
-			"reference": "S46"
+			"reference": "SU46"
 		}
 	]
 }

--- a/Library/Supers/Templates/Man Plus.gct
+++ b/Library/Supers/Templates/Man Plus.gct
@@ -857,7 +857,7 @@
 						{
 							"id": "tGqxZt4baNQ3XW0Et",
 							"name": "Perk: Skintight",
-							"reference": "S30",
+							"reference": "SU30",
 							"tags": [
 								"Physical"
 							],
@@ -2185,7 +2185,8 @@
 	"notes": [
 		{
 			"id": "n1rg4Zp0KcBnL5uBl",
-			"text": "500 points - You have the same abilities as a normal human being, but enhanced to the limit of human performance and, in some ways, beyond it. You aren’t indestructible, though, and still need to rely on external protection and defensive maneuvers to avoid lethal attacks. Your abilities may be the result of an incredibly advanced training regimen, drugs, scientific or magical enhancements, or a combination of all three. "
+			"text": "500 points - You have the same abilities as a normal human being, but enhanced to the limit of human performance and, in some ways, beyond it. You aren’t indestructible, though, and still need to rely on external protection and defensive maneuvers to avoid lethal attacks. Your abilities may be the result of an incredibly advanced training regimen, drugs, scientific or magical enhancements, or a combination of all three. ",
+			"reference": "SU47"
 		}
 	]
 }


### PR DESCRIPTION
While checking page references for GURPS Space, I noticed that some Supers templates were also using S<number> to reference pages in GURPS Supers, instead of SU<number>.

In addition, Geognome in the gcs discord mentioned finding references to Banestorm using B<number> in the Banestorm library.
I was unable to find those erroneous references, apart from the Entertainer's Code of Honor (Theatrical) using the wrong reference.