### PR TITLE
Martial Arts Skills: add melee attacks to Hammer Fist

### DIFF
--- a/Library/Martial Arts/Martial Arts Skills.skl
+++ b/Library/Martial Arts/Martial Arts Skills.skl
@@ -1336,6 +1336,26 @@
 				"modifier": -1
 			},
 			"limit": 0,
+			"weapons": [
+				{
+					"id": "wtSAXknaYYGXin3Sg",
+					"damage": {
+						"type": "cr",
+						"st": "thr",
+						"base": "-2"
+					},
+					"reach": "C",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Hammer Fist"
+						}
+					],
+					"calc": {
+						"damage": "thr-2 cr"
+					}
+				}
+			],
 			"points": 1
 		},
 		{
@@ -1355,6 +1375,26 @@
 				"modifier": -1
 			},
 			"limit": 0,
+			"weapons": [
+				{
+					"id": "w4DjETUTV1byQN9C9",
+					"damage": {
+						"type": "cr",
+						"st": "thr",
+						"base": "-2"
+					},
+					"reach": "C",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Hammer Fist"
+						}
+					],
+					"calc": {
+						"damage": "thr-2 cr"
+					}
+				}
+			],
 			"points": 1
 		},
 		{


### PR DESCRIPTION
The effect of Hammer Fist is that it's a melee attack that does less damage, but has less risk of injuring the hand.

Melee attack damage for a technique can be represented in gcs, so I added it here.

Note that this may behave strangely if you have both the brawling-based Hammer Fist *and* the Karate-based one, but there's very little reason for a character to have both.