### PR TITLE
Ultra Tech Equipment: Add Air Tanks

### DIFF
--- a/Library/Ultra Tech/Ultra Tech Equipment.eqp
+++ b/Library/Ultra Tech/Ultra Tech Equipment.eqp
@@ -2054,6 +2054,342 @@
 			}
 		},
 		{
+			"id": "eKytBEBbkJXWj8mQ8",
+			"description": "Air Tank, Large",
+			"reference": "UT176",
+			"notes": "Holds 24 hours of air",
+			"tech_level": "9",
+			"legality_class": "4",
+			"tags": [
+				"Armor",
+				"Defenses",
+				"Environmental Gear and Suits"
+			],
+			"value": 200,
+			"weight": "10 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 200,
+				"extended_weight": "10 lb"
+			}
+		},
+		{
+			"id": "ePnOkR8SDX8z2xv38",
+			"description": "Air Tank, Large",
+			"reference": "UT176",
+			"notes": "Holds 36 hours of air",
+			"tech_level": "10",
+			"legality_class": "4",
+			"tags": [
+				"Armor",
+				"Defenses",
+				"Environmental Gear and Suits"
+			],
+			"value": 200,
+			"weight": "10 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 200,
+				"extended_weight": "10 lb"
+			}
+		},
+		{
+			"id": "eDIkQD8dFR0bUkqAu",
+			"description": "Air Tank, Large",
+			"reference": "UT176",
+			"notes": "Holds 48 hours of air",
+			"tech_level": "11",
+			"legality_class": "4",
+			"tags": [
+				"Armor",
+				"Defenses",
+				"Environmental Gear and Suits"
+			],
+			"value": 200,
+			"weight": "10 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 200,
+				"extended_weight": "10 lb"
+			}
+		},
+		{
+			"id": "emRfQB6LkHIPVx6L9",
+			"description": "Air Tank, Large",
+			"reference": "UT176",
+			"notes": "Hold 72 hours of air",
+			"tech_level": "12",
+			"legality_class": "4",
+			"tags": [
+				"Armor",
+				"Defenses",
+				"Environmental Gear and Suits"
+			],
+			"value": 200,
+			"weight": "10 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 200,
+				"extended_weight": "10 lb"
+			}
+		},
+		{
+			"id": "epWMGn2H0Zxc1gFtS",
+			"description": "Air Tank, Medium",
+			"reference": "UT176",
+			"notes": "Holds 12 hours of air",
+			"tech_level": "9",
+			"legality_class": "4",
+			"tags": [
+				"Armor",
+				"Defenses",
+				"Environmental Gear and Suits"
+			],
+			"value": 80,
+			"weight": "4 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 80,
+				"extended_weight": "4 lb"
+			}
+		},
+		{
+			"id": "ekBDpUnGLLo1r3qqQ",
+			"description": "Air Tank, Medium",
+			"reference": "UT176",
+			"notes": "Holds 18 hours of air",
+			"tech_level": "10",
+			"legality_class": "4",
+			"tags": [
+				"Armor",
+				"Defenses",
+				"Environmental Gear and Suits"
+			],
+			"value": 80,
+			"weight": "4 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 80,
+				"extended_weight": "4 lb"
+			}
+		},
+		{
+			"id": "en28SKzNAS106luAJ",
+			"description": "Air Tank, Medium",
+			"reference": "UT176",
+			"notes": "Holds 24 hours of air",
+			"tech_level": "11",
+			"legality_class": "4",
+			"tags": [
+				"Armor",
+				"Defenses",
+				"Environmental Gear and Suits"
+			],
+			"value": 80,
+			"weight": "4 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 80,
+				"extended_weight": "4 lb"
+			}
+		},
+		{
+			"id": "emaWtRsfvltUo2sB_",
+			"description": "Air Tank, Medium",
+			"reference": "UT176",
+			"notes": "Holds 36 hours of air",
+			"tech_level": "12",
+			"legality_class": "4",
+			"tags": [
+				"Armor",
+				"Defenses",
+				"Environmental Gear and Suits"
+			],
+			"value": 80,
+			"weight": "4 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 80,
+				"extended_weight": "4 lb"
+			}
+		},
+		{
+			"id": "eZMFpzJ4Pb2Mu93mp",
+			"description": "Air Tank, Mini",
+			"reference": "UT176",
+			"notes": "Holds 10 minutes of air",
+			"tech_level": "9",
+			"legality_class": "4",
+			"tags": [
+				"Armor",
+				"Defenses",
+				"Environmental Gear and Suits"
+			],
+			"value": 50,
+			"weight": "0.5 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 50,
+				"extended_weight": "0.5 lb"
+			}
+		},
+		{
+			"id": "efXVBipZTNMg16bXt",
+			"description": "Air Tank, Mini",
+			"reference": "UT176",
+			"notes": "Holds 15 minutes of air",
+			"tech_level": "10",
+			"legality_class": "4",
+			"tags": [
+				"Armor",
+				"Defenses",
+				"Environmental Gear and Suits"
+			],
+			"value": 50,
+			"weight": "0.5 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 50,
+				"extended_weight": "0.5 lb"
+			}
+		},
+		{
+			"id": "ecwrTHeX9rz6AfCTe",
+			"description": "Air Tank, Mini",
+			"reference": "UT176",
+			"notes": "Holds 20 minutes of air",
+			"tech_level": "11",
+			"legality_class": "4",
+			"tags": [
+				"Armor",
+				"Defenses",
+				"Environmental Gear and Suits"
+			],
+			"value": 50,
+			"weight": "0.5 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 50,
+				"extended_weight": "0.5 lb"
+			}
+		},
+		{
+			"id": "ekvMWhfCNI-hIrHcz",
+			"description": "Air Tank, Mini",
+			"reference": "UT176",
+			"notes": "Holds 30 minutes of air",
+			"tech_level": "12",
+			"legality_class": "4",
+			"tags": [
+				"Armor",
+				"Defenses",
+				"Environmental Gear and Suits"
+			],
+			"value": 50,
+			"weight": "0.5 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 50,
+				"extended_weight": "0.5 lb"
+			}
+		},
+		{
+			"id": "eoPX03mAKsws5oEfh",
+			"description": "Air Tank, Small",
+			"reference": "UT176",
+			"notes": "Holds 4 hours of air",
+			"tech_level": "9",
+			"legality_class": "4",
+			"tags": [
+				"Armor",
+				"Defenses",
+				"Environmental Gear and Suits"
+			],
+			"value": 60,
+			"weight": "2 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 60,
+				"extended_weight": "2 lb"
+			}
+		},
+		{
+			"id": "e5qOLyLwm8qyyMEou",
+			"description": "Air Tank, Small",
+			"reference": "UT176",
+			"notes": "Holds 6 hours of air",
+			"tech_level": "10",
+			"legality_class": "4",
+			"tags": [
+				"Armor",
+				"Defenses",
+				"Environmental Gear and Suits"
+			],
+			"value": 60,
+			"weight": "2 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 60,
+				"extended_weight": "2 lb"
+			}
+		},
+		{
+			"id": "eKLj9GlrFNav9lFEh",
+			"description": "Air Tank, Small",
+			"reference": "UT176",
+			"notes": "Holds 8 hours of air",
+			"tech_level": "11",
+			"legality_class": "4",
+			"tags": [
+				"Armor",
+				"Defenses",
+				"Environmental Gear and Suits"
+			],
+			"value": 60,
+			"weight": "2 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 60,
+				"extended_weight": "2 lb"
+			}
+		},
+		{
+			"id": "e5fxvAME3pGc_4sKH",
+			"description": "Air Tank, Small",
+			"reference": "UT176",
+			"notes": "Holds 12 hours of air",
+			"tech_level": "12",
+			"legality_class": "4",
+			"tags": [
+				"Armor",
+				"Defenses",
+				"Environmental Gear and Suits"
+			],
+			"value": 60,
+			"weight": "2 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"extended_value": 60,
+				"extended_weight": "2 lb"
+			}
+		},
+		{
 			"id": "eHiN_VltPS7Y2VUG3",
 			"description": "Air Tube",
 			"reference": "UT77",


### PR DESCRIPTION
I noticed Air Tanks were missing when FixDis asked on the discord how to add air tasks to the Air Mask.

This Pull Request adds all 4 sizes of air tank at all 4 tech levels.