### PR TITLE
Update skils and traits in Spaceship Crew templates to hold source library info

### DIFF
--- a/Library/Basic Set/Basic Set Skills.skl
+++ b/Library/Basic Set/Basic Set Skills.skl
@@ -11878,7 +11878,7 @@
 				{
 					"type": "skill",
 					"name": "Engineer",
-					"specialization": "Aerospace",
+					"specialization": "@Machine class@",
 					"modifier": -4
 				},
 				{

--- a/Library/Basic Set/Basic Set Skills.skl
+++ b/Library/Basic Set/Basic Set Skills.skl
@@ -7546,6 +7546,19 @@
 			"points": 1
 		},
 		{
+			"id": "s5xh6bANmCGbYersa",
+			"name": "Fast-Draw",
+			"reference": "B194,MA56",
+			"tags": [
+				"Combat",
+				"Ranged Combat",
+				"Weapon"
+			],
+			"specialization": "@Specialization@",
+			"difficulty": "dx/e",
+			"points": 1
+		},
+		{
 			"id": "sxpRrrGDJlHzh1VyN",
 			"name": "Fast-Draw",
 			"reference": "B194,MA56",
@@ -10225,6 +10238,24 @@
 			"points": 1
 		},
 		{
+			"id": "sn9Y6a4YbUfsQ8GxY",
+			"name": "Hazardous Materials",
+			"reference": "B199",
+			"tags": [
+				"Technical"
+			],
+			"specialization": "@Specialization@",
+			"difficulty": "iq/a",
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -5
+				}
+			],
+			"tech_level": "",
+			"points": 1
+		},
+		{
 			"id": "sivwyfAWBlyiQSQdm",
 			"name": "Hazardous Materials",
 			"reference": "B199",
@@ -11701,6 +11732,34 @@
 					"modifier": -4
 				}
 			],
+			"points": 1
+		},
+		{
+			"id": "sDKy9mOhQeiZ6fjvq",
+			"name": "Mathematics",
+			"reference": "B207",
+			"tags": [
+				"Natural Science"
+			],
+			"specialization": "@Specialization@",
+			"difficulty": "iq/h",
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Physics",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Engineer",
+					"modifier": -5
+				}
+			],
+			"tech_level": "",
 			"points": 1
 		},
 		{
@@ -14576,6 +14635,32 @@
 					"modifier": -5
 				}
 			],
+			"points": 1
+		},
+		{
+			"id": "s65U7Q64hLe7e_7UR",
+			"name": "Paleontology",
+			"reference": "B212",
+			"tags": [
+				"Humanities",
+				"Natural Science",
+				"Social Sciences"
+			],
+			"specialization": "@Specialization@",
+			"difficulty": "iq/h",
+			"defaults": [
+				{
+					"type": "skill",
+					"name": "Biology",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Paleontology",
+					"modifier": -2
+				}
+			],
+			"tech_level": "",
 			"points": 1
 		},
 		{

--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -3818,6 +3818,20 @@
 			}
 		},
 		{
+			"id": "tXJ60phAKJZOz3Pv5",
+			"name": "Compulsive Behaviour (@Activity@)",
+			"reference": "B128",
+			"tags": [
+				"Disadvantage",
+				"Mental"
+			],
+			"cr": 12,
+			"base_points": -5,
+			"calc": {
+				"points": -5
+			}
+		},
+		{
 			"id": "tapWLsuN75Unedmwn",
 			"name": "Compulsive Carousing",
 			"reference": "B128",

--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -23066,6 +23066,79 @@
 			}
 		},
 		{
+			"id": "tSSmnBdJ1f7mFMRL5",
+			"name": "Social Stigma (@Stigma@)",
+			"reference": "B155",
+			"tags": [
+				"Disadvantage",
+				"Social"
+			],
+			"modifiers": [
+				{
+					"id": "m1qBM9x_PEavPrf98",
+					"name": "Obvious from your appearance, dress or manner",
+					"use_level_from_trait": true,
+					"features": [
+						{
+							"type": "reaction_bonus",
+							"situation": "from anyone who sees you",
+							"amount": -1,
+							"per_level": true
+						}
+					],
+					"disabled": true
+				},
+				{
+					"id": "m4DMhOwPUTjfeu5J_",
+					"name": "Obvious from your speech",
+					"use_level_from_trait": true,
+					"features": [
+						{
+							"type": "reaction_bonus",
+							"situation": "from anyone who hears you speak",
+							"amount": -1,
+							"per_level": true
+						}
+					],
+					"disabled": true
+				},
+				{
+					"id": "mGWOQXKSuMPA_MG9Q",
+					"name": "Easily learned by anyone who cares to check up on you",
+					"use_level_from_trait": true,
+					"features": [
+						{
+							"type": "reaction_bonus",
+							"situation": "from anyone who cares to check up on you",
+							"amount": -1,
+							"per_level": true
+						}
+					],
+					"disabled": true
+				},
+				{
+					"id": "m6rvmjGelet0oWvKO",
+					"name": "Public Denouncement",
+					"use_level_from_trait": true,
+					"features": [
+						{
+							"type": "reaction_bonus",
+							"situation": "from everryone you meet",
+							"amount": -1,
+							"per_level": true
+						}
+					],
+					"disabled": true
+				}
+			],
+			"points_per_level": -5,
+			"can_level": true,
+			"levels": 1,
+			"calc": {
+				"points": -5
+			}
+		},
+		{
 			"id": "t7U0VbIzs6SqefwLr",
 			"name": "Social Stigma (Criminal Record)",
 			"reference": "B155",

--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -9629,14 +9629,24 @@
 		},
 		{
 			"id": "tv7bDjPB_5Noifly6",
-			"name": "Higher Purpose",
+			"name": "Higher Purpose (@Purpose@)",
 			"reference": "B59",
 			"tags": [
 				"Advantage",
 				"Exotic",
 				"Mental"
 			],
-			"base_points": 5,
+			"points_per_level": 5,
+			"features": [
+				{
+					"type": "conditional_modifier",
+					"situation": "to @circumstance the bonus applies to@",
+					"amount": 1,
+					"per_level": true
+				}
+			],
+			"can_level": true,
+			"levels": 1,
 			"calc": {
 				"points": 5
 			}

--- a/Library/Power Ups/Power Ups Traits.adq
+++ b/Library/Power Ups/Power Ups Traits.adq
@@ -2785,6 +2785,121 @@
 			}
 		},
 		{
+			"id": "tmRvpanq8GmkkkB_w",
+			"name": "Equipment Bond (@Specific Non-Combat Tool@)",
+			"reference": "PU2:9",
+			"tags": [
+				"Perk",
+				"Physical"
+			],
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "equipped_equipment",
+						"name": {
+							"compare": "is",
+							"qualifier": "@Specific Non-Combat Tool@"
+						}
+					}
+				]
+			},
+			"modifiers": [
+				{
+					"id": "MNQZLcfPSZAPXCqRV",
+					"name": "Add one:",
+					"children": [
+						{
+							"id": "mZFbP7ytANy7dt-xv",
+							"name": "As conditional modifier",
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "to all skill rolls using your @Specific Non-Combat Tool@",
+									"amount": 1
+								}
+							]
+						},
+						{
+							"id": "M6T9S5d83B1iWS9kP",
+							"name": "Add one per skill that uses this equipment",
+							"children": [
+								{
+									"id": "mG2iYR-csemEDJ0H1",
+									"name": "As skill bonus to @skill@",
+									"features": [
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "@skill@"
+											},
+											"amount": 1
+										}
+									],
+									"disabled": true
+								},
+								{
+									"id": "mAVH5pHEmq6vTtyay",
+									"name": "As skill bonus to @skill 2@",
+									"features": [
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "@skill 2@"
+											},
+											"amount": 1
+										}
+									],
+									"disabled": true
+								},
+								{
+									"id": "mj6NavxTkkxJWCrng",
+									"name": "As skill bonus to @skill 3@",
+									"features": [
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "@skill 3@"
+											},
+											"amount": 1
+										}
+									],
+									"disabled": true
+								},
+								{
+									"id": "mZZQlUak_8CYcolRB",
+									"name": "As skill bonus to @skill 4@",
+									"features": [
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "@skill 4@"
+											},
+											"amount": 1
+										}
+									],
+									"disabled": true
+								}
+							]
+						}
+					]
+				}
+			],
+			"base_points": 1,
+			"calc": {
+				"points": 1
+			}
+		},
+		{
 			"id": "tnu4tgSYh4kwdqBv2",
 			"name": "Ex-Cop",
 			"reference": "PU2:18",

--- a/Library/Space/Space Traits.adq
+++ b/Library/Space/Space Traits.adq
@@ -1,0 +1,279 @@
+{
+	"version": 5,
+	"rows": [
+		{
+			"id": "tAadxguoBdPCQMq2y",
+			"name": "Amnesia (Selective)",
+			"reference": "B123, S221",
+			"tags": [
+				"Disadvantage",
+				"Physical"
+			],
+			"base_points": -5,
+			"calc": {
+				"points": -5
+			}
+		},
+		{
+			"id": "tOiFp65jqlqQr4GWB",
+			"name": "Code of Honor (Asteroid Miner's Code)",
+			"reference": "B127, S221",
+			"notes": "Don’t jump someone else’s claim. A handshake is as good as a contract. Help other prospectors in distress.",
+			"tags": [
+				"Disadvantage",
+				"Mental"
+			],
+			"base_points": -5,
+			"calc": {
+				"points": -5
+			}
+		},
+		{
+			"id": "tDX_jutzIfMT25FNf",
+			"name": "Code of Honor (Ethical Psionic's Code)",
+			"reference": "B127, S221",
+			"notes": "Never use your powers on someone without their consent. Always help out another psi. Show restraint and self-control in front of the mundanes. Always stand up for your rights and the rights of other psis.",
+			"tags": [
+				"Disadvantage",
+				"Mental"
+			],
+			"base_points": -10,
+			"calc": {
+				"points": -10
+			}
+		},
+		{
+			"id": "tt1z2cl4UeCBv-z0y",
+			"name": "Code of Honor (Hacker's Code)",
+			"reference": "B127, S221",
+			"notes": "Never steal money. Share information. Don’t use your skills to harm people. Clever work is better than brute force.",
+			"tags": [
+				"Disadvantage",
+				"Mental"
+			],
+			"base_points": -5,
+			"calc": {
+				"points": -5
+			}
+		},
+		{
+			"id": "teNSsqOsjstajwmxn",
+			"name": "Code of Honor (Mercenary's Code)",
+			"reference": "B127, S221",
+			"notes": "A merc should look out for his buddies, take care of his gear, and fight for the honor of the unit. Obey the rules of engagement. Don’t poach on another unit’s contract. Do the job you’re hired for.",
+			"tags": [
+				"Disadvantage",
+				"Mental"
+			],
+			"base_points": -10,
+			"calc": {
+				"points": -10
+			}
+		},
+		{
+			"id": "tc3-K22Q32nUG0cWV",
+			"name": "Fragile (Tenuous)",
+			"reference": "B137, S221",
+			"tags": [
+				"Disadvantage",
+				"Exotic",
+				"Physical"
+			],
+			"base_points": -15,
+			"calc": {
+				"points": -15
+			}
+		},
+		{
+			"id": "tWB7zfEc__hxcnnkf",
+			"name": "Increased Life Support (Large)",
+			"reference": "B139, S222",
+			"tags": [
+				"Disadvantage",
+				"Exotic",
+				"Physical"
+			],
+			"points_per_level": -5,
+			"can_level": true,
+			"levels": 1,
+			"calc": {
+				"points": -5
+			}
+		},
+		{
+			"id": "thWGjZlCnelWeAvjD",
+			"name": "Radiophobia (Radiation)",
+			"reference": "B148, S222",
+			"notes": "You are terrified of invisible, deadly radiation or radioactive contamination. You must make a self-control roll to approach or touch something labeled “radioactive” or bearing the radiation trefoil, and must roll once per turn to remain near a source of radiation, even if the level isn’t harmful. You will constantly monitor the rad level in your surroundings.",
+			"tags": [
+				"Disadvantage",
+				"Mental"
+			],
+			"cr_adj": "action_penalty",
+			"cr": 12,
+			"base_points": -5,
+			"calc": {
+				"points": -5
+			}
+		},
+		{
+			"id": "to8-rdyG4Awdr7vM4",
+			"name": "Cyberphobia (Robots)",
+			"reference": "B148, S222",
+			"notes": "You are afraid of intelligent machines, or machines which act intelligent. You must make a self-control roll when encountering any seemingly sentient machine. There is a -3 penalty on the roll whenever you must entrust your life or safety to a “friendly” machine (like an autodoc or a robot pilot), and a -6 penalty when you face a hostile robot or computer intending harm. You will also react at -1 to people with cybernetic implants.",
+			"tags": [
+				"Disadvantage",
+				"Mental"
+			],
+			"cr_adj": "action_penalty",
+			"modifiers": [
+				{
+					"id": "mH6J9lBdAjLVBP0i0",
+					"name": "Sentient Machines are common",
+					"cost": 3,
+					"cost_type": "multiplier"
+				}
+			],
+			"cr": 12,
+			"base_points": -5,
+			"calc": {
+				"points": -15
+			}
+		},
+		{
+			"id": "tqjzqNtvf6849bXAG",
+			"name": "Astrophobia (Space)",
+			"reference": "B148, S222",
+			"notes": "You cannot stand being away from a real solid planet. Aboard a space station or spaceship, make a self-control roll to avoid complete panic during any stressful situation (with a penalty of -2 if you can see out a window at the time). Any time you must go outside into space wearing only a suit, a roll is required each turn to avoid panic.",
+			"tags": [
+				"Disadvantage",
+				"Mental"
+			],
+			"cr_adj": "action_penalty",
+			"modifiers": [
+				{
+					"id": "m-FHJcPLK-Kn0Miie",
+					"name": "Space travel is common",
+					"cost": 2,
+					"cost_type": "multiplier"
+				}
+			],
+			"cr": 12,
+			"base_points": -5,
+			"calc": {
+				"points": -10
+			}
+		},
+		{
+			"id": "tNDN5hNlFtMg79mPp",
+			"name": "Social Stigma (Alien)",
+			"reference": "B155, S222",
+			"notes": "Aliens are outsiders, considered funny-looking, possibly dangerous, and certainly inferior to humans.",
+			"tags": [
+				"Disadvantage",
+				"Social"
+			],
+			"base_points": -10,
+			"features": [
+				{
+					"type": "reaction_bonus",
+					"situation": "from others except your own kind",
+					"amount": -2
+				},
+				{
+					"type": "reaction_bonus",
+					"situation": "from others of your own kind in an area, profession, or situation where your minority is especially rare",
+					"amount": 2
+				}
+			],
+			"calc": {
+				"points": -10
+			}
+		},
+		{
+			"id": "tA9RbLuF_Tr6S1Zmy",
+			"name": "Social Stigma (Psionic)",
+			"reference": "B155, S222",
+			"notes": "Psionics are often considered not quite human, with abilities that make them potentially dangerous.",
+			"tags": [
+				"Disadvantage",
+				"Social"
+			],
+			"modifiers": [
+				{
+					"id": "mT7jzfVI_4nMp5W4G",
+					"name": "Psi powers require a license",
+					"cost": -5,
+					"cost_type": "points",
+					"disabled": true
+				}
+			],
+			"base_points": -10,
+			"features": [
+				{
+					"type": "reaction_bonus",
+					"situation": "from others except your own kind",
+					"amount": -2
+				},
+				{
+					"type": "reaction_bonus",
+					"situation": "from others of your own kind in an area, profession, or situation where your minority is especially rare",
+					"amount": 2
+				}
+			],
+			"calc": {
+				"points": -10
+			}
+		},
+		{
+			"id": "t2PP92iMwYdegkaiD",
+			"name": "Social Stigma (Robot)",
+			"reference": "B155, S222",
+			"tags": [
+				"Disadvantage",
+				"Social"
+			],
+			"modifiers": [
+				{
+					"id": "mJjBK5UwesKNC_b4S",
+					"name": "Free Machine",
+					"notes": "You have full legal rights",
+					"cost": 0.5,
+					"cost_type": "multiplier"
+				}
+			],
+			"base_points": -10,
+			"features": [
+				{
+					"type": "reaction_bonus",
+					"situation": "from humans",
+					"amount": -1
+				}
+			],
+			"calc": {
+				"points": -5
+			}
+		},
+		{
+			"id": "t3oswfEdRmVYp8pSh",
+			"name": "Social Stigma (Uplifted Animal)",
+			"reference": "B155, S223",
+			"notes": "You have restricted rights and privileges",
+			"tags": [
+				"Disadvantage",
+				"Social"
+			],
+			"base_points": -5,
+			"features": [
+				{
+					"type": "reaction_bonus",
+					"situation": "from humans, but not other uplifts",
+					"amount": -1
+				}
+			],
+			"calc": {
+				"points": -5
+			}
+		}
+	]
+}

--- a/Library/Supers/Templates/Archetype.gct
+++ b/Library/Supers/Templates/Archetype.gct
@@ -2337,7 +2337,7 @@
 						{
 							"id": "tYooKZX2V5W6kU_il",
 							"name": "Speed Talent",
-							"reference": "S41",
+							"reference": "SU40",
 							"tags": [
 								"Advantage",
 								"Mental",

--- a/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Commander.gct
+++ b/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Commander.gct
@@ -12,7 +12,12 @@
 					"name": "Attributes",
 					"children": [
 						{
-							"id": "tBvSMYEuLMVgM_FLY",
+							"id": "tpCsPaR6RKrdzzUlQ",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t1w1RFcFceKR2T9_e"
+							},
 							"name": "Increased Intelligence",
 							"reference": "B15",
 							"tags": [
@@ -36,7 +41,12 @@
 							}
 						},
 						{
-							"id": "teq2OhjnAfSY9poa2",
+							"id": "tLbSimXGmgqCnbH-O",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tVt3SvdGWNchJ8z4o"
+							},
 							"name": "Increased Health",
 							"reference": "B14",
 							"tags": [
@@ -60,7 +70,12 @@
 							}
 						},
 						{
-							"id": "tJpzICbTRQ0qqwegG",
+							"id": "t_8gJf3xigdzPpmcP",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tGWOSEE6SmBHACE6Y"
+							},
 							"name": "Increased Dexterity",
 							"reference": "B15",
 							"tags": [
@@ -70,7 +85,7 @@
 							],
 							"modifiers": [
 								{
-									"id": "mxdiJ_DAhHJeU-SNd",
+									"id": "mU9PrKQr0y_DdslOB",
 									"name": "No Fine Manipulators",
 									"cost": -40,
 									"disabled": true
@@ -101,7 +116,12 @@
 					"name": "Class Advantages",
 					"children": [
 						{
-							"id": "tWvfHboqmnuCExDmT",
+							"id": "thW1J1uzyx7SY_Oj5",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "trBGwkM0-bFOQUZcz"
+							},
 							"name": "Talent (Intuitive Admiral (Space))",
 							"reference": "PU3:12",
 							"tags": [
@@ -111,12 +131,45 @@
 							],
 							"modifiers": [
 								{
-									"id": "mpcd4AYBRMQrnetdf",
+									"id": "mBjHs2EG7Vf3regcj",
 									"name": "Alternative Cost",
 									"cost": -2,
 									"cost_type": "points",
 									"affects": "levels_only",
 									"disabled": true
+								},
+								{
+									"id": "MMVJmKXQQ2WPQSyex",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "mwox155NUEnekBlt2",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From anyone you serve with or command.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "mkuGkbiYdJlCVGNdj",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Bonus to initiative roll if leader",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
 								}
 							],
 							"points_per_level": 10,
@@ -234,18 +287,6 @@
 									},
 									"amount": 1,
 									"per_level": true
-								},
-								{
-									"type": "reaction_bonus",
-									"situation": "From anyone you serve with or command.",
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "conditional_modifier",
-									"situation": "Bonus to initiative roll if leader",
-									"amount": 1,
-									"per_level": true
 								}
 							],
 							"can_level": true,
@@ -255,7 +296,12 @@
 							}
 						},
 						{
-							"id": "tdCXUkel0dUUIeLc8",
+							"id": "t5HJVmzoCIdlmNxtW",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tMMQWflrKUPOkyIF9"
+							},
 							"name": "Charisma",
 							"reference": "B41",
 							"tags": [
@@ -328,7 +374,12 @@
 							"name": "30 Points chosen from",
 							"children": [
 								{
-									"id": "tEerY8t_EF3ctfx0B",
+									"id": "tN-N92deQbFdEotN7",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t55UZnC4Hxsvl7-ri"
+									},
 									"name": "Wealthy",
 									"reference": "B25",
 									"notes": "Starting wealth is 5x normal",
@@ -343,7 +394,12 @@
 									}
 								},
 								{
-									"id": "thuk_YFqJhFH3vRCy",
+									"id": "tdvi2rfkbBxU7k7vF",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tgNjs3lrycmChMxRC"
+									},
 									"name": "Very Wealthy",
 									"reference": "B25",
 									"notes": "Starting wealth is 20x normal",
@@ -358,7 +414,12 @@
 									}
 								},
 								{
-									"id": "txHpv8D3_xvoxbvry",
+									"id": "tP34G7FdV9_xeKmhM",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "trClz3uZE-XIfFJKI"
+									},
 									"name": "Unfazeable",
 									"reference": "B95",
 									"notes": "Exempt from fright checks. Reaction modifiers do not affect you.",
@@ -368,7 +429,7 @@
 									],
 									"modifiers": [
 										{
-											"id": "mpznYNnT1x9MvDT3n",
+											"id": "mlo8KhbEsS7tc_sOy",
 											"name": "Familiar Horrors",
 											"reference": "H20",
 											"cost": -50,
@@ -381,7 +442,12 @@
 									}
 								},
 								{
-									"id": "t7n1IMdo0jfDYZjzy",
+									"id": "tp8BdYt4mUADhblqE",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "t47ychA98bECqxqRM"
+									},
 									"name": "Talent (Smooth Operator)",
 									"reference": "PU3:15",
 									"tags": [
@@ -391,12 +457,45 @@
 									],
 									"modifiers": [
 										{
-											"id": "mqoqTrlTLEa21zw2_",
+											"id": "mdsP3av6URRDeI0s8",
 											"name": "Alternative Cost",
 											"cost": -2,
 											"cost_type": "points",
 											"affects": "levels_only",
 											"disabled": true
+										},
+										{
+											"id": "MxUege3ASna3sAQih",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "mhOi8hlhC7S4c736t",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From con artists, politicians, salesmen, etc. – but only if you aren’t trying to manipulate them.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "m32_5F0dkjVA55Hlr",
+													"name": "Alternative Benefit",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Bonus to resist covered skills",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
 										}
 									],
 									"points_per_level": 15,
@@ -566,18 +665,6 @@
 											},
 											"amount": 1,
 											"per_level": true
-										},
-										{
-											"type": "reaction_bonus",
-											"situation": "From con artists, politicians, salesmen, etc. – but only if you aren’t trying to manipulate them.",
-											"amount": 1,
-											"per_level": true
-										},
-										{
-											"type": "conditional_modifier",
-											"situation": "Bonus to resist covered skills",
-											"amount": 1,
-											"per_level": true
 										}
 									],
 									"can_level": true,
@@ -587,7 +674,12 @@
 									}
 								},
 								{
-									"id": "t_5PS1hPiHIqpc33B",
+									"id": "twQ7dyxJPbcoZDNAG",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "trBGwkM0-bFOQUZcz"
+									},
 									"name": "Talent (Intuitive Admiral (Space))",
 									"reference": "PU3:12",
 									"tags": [
@@ -597,12 +689,45 @@
 									],
 									"modifiers": [
 										{
-											"id": "mYhIV-bclz23f-4Xc",
+											"id": "msBFXu4s4015LDNTM",
 											"name": "Alternative Cost",
 											"cost": -2,
 											"cost_type": "points",
 											"affects": "levels_only",
 											"disabled": true
+										},
+										{
+											"id": "M7Pf0_WJY3sj7pG-i",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "mMXpn2EGyNYng1JUH",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From anyone you serve with or command.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "mn15Jm4ZfTf5iBaMA",
+													"name": "Alternative Benefit",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Bonus to initiative roll if leader",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
 										}
 									],
 									"points_per_level": 10,
@@ -720,18 +845,6 @@
 											},
 											"amount": 1,
 											"per_level": true
-										},
-										{
-											"type": "reaction_bonus",
-											"situation": "From anyone you serve with or command.",
-											"amount": 1,
-											"per_level": true
-										},
-										{
-											"type": "conditional_modifier",
-											"situation": "Bonus to initiative roll if leader",
-											"amount": 1,
-											"per_level": true
 										}
 									],
 									"can_level": true,
@@ -741,7 +854,12 @@
 									}
 								},
 								{
-									"id": "tqwGreAd4JZOBGdUO",
+									"id": "tToI2Wvzj_j3PZYmk",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tkrQLfn7UUprvkMat"
+									},
 									"name": "Talent (Explorer)",
 									"reference": "PU3:10",
 									"tags": [
@@ -751,11 +869,44 @@
 									],
 									"modifiers": [
 										{
-											"id": "mSxwiWC4k0LGBafcb",
+											"id": "mq_x6emwd6Pk-cnPl",
 											"name": "Alternative Cost",
 											"cost_type": "points",
 											"affects": "levels_only",
 											"disabled": true
+										},
+										{
+											"id": "MYyyCnI5H0uZ5f1fE",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "mCX3dJAvNjr-2w0wD",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From fellow explorers and backers.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "meAk8QOmCSV9NmbAJ",
+													"name": "Alternative Benefit",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Reduce distance and area class penalties for all skills",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
 										}
 									],
 									"points_per_level": 5,
@@ -822,18 +973,6 @@
 											},
 											"amount": 1,
 											"per_level": true
-										},
-										{
-											"type": "reaction_bonus",
-											"situation": "From fellow explorers and backers.",
-											"amount": 1,
-											"per_level": true
-										},
-										{
-											"type": "conditional_modifier",
-											"situation": "Reduce distance and area class penalties for all skills",
-											"amount": 1,
-											"per_level": true
 										}
 									],
 									"can_level": true,
@@ -843,13 +982,75 @@
 									}
 								},
 								{
-									"id": "t3a0XbzubcCcex4Me",
+									"id": "tli3Ddi0WVHa7KTv8",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tePEpgFmqM2QDb9q6"
+									},
 									"name": "Talent (Business Acumen)",
-									"reference": "B90",
+									"reference": "PU3:7",
 									"tags": [
 										"Advantage",
 										"Mental",
 										"Talent"
+									],
+									"modifiers": [
+										{
+											"id": "mdbFq9JnblbodoY1t",
+											"name": "Alternative Cost",
+											"cost": -2,
+											"cost_type": "points",
+											"affects": "levels_only",
+											"disabled": true
+										},
+										{
+											"id": "MQiqIuApTDa6G3ua6",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "m57JVqgrzyrmd8OCs",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From anyone with whom you do business.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "mf4NwHSwlGUsAFHE5",
+													"name": "Jobs and hirelings",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "To all rolls to find hirelings or jobs (pp. B517-518)",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mE-7lFs1BRHbG5sJ5",
+													"name": "Resist scams",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "To will rolls to resist others' attempts to use Influence skills to scam money.",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
+										}
 									],
 									"points_per_level": 10,
 									"features": [
@@ -932,12 +1133,6 @@
 											},
 											"amount": 1,
 											"per_level": true
-										},
-										{
-											"type": "reaction_bonus",
-											"situation": "from business partners",
-											"amount": 1,
-											"per_level": true
 										}
 									],
 									"can_level": true,
@@ -947,7 +1142,12 @@
 									}
 								},
 								{
-									"id": "t91DQWIFCkTwSHbNI",
+									"id": "t6VXZXbOfXuoHlf1R",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tHd6RZWGO9p5R91Vo"
+									},
 									"name": "Rapier Wit",
 									"reference": "B79,P70",
 									"tags": [
@@ -956,7 +1156,7 @@
 									],
 									"modifiers": [
 										{
-											"id": "mkGxvm4e8n-hkBsoE",
+											"id": "mOwcQpukw43TriDHc",
 											"name": "Words of Power",
 											"reference": "P70",
 											"cost": 100,
@@ -969,33 +1169,58 @@
 									}
 								},
 								{
-									"id": "te-ASjVHef1g8RIoZ",
+									"id": "tkKC0MaAgF3KgBzly",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tHRgrj_fBsqwVk5Gh"
+									},
 									"name": "Penetrating Voice",
-									"reference": "PU2:14",
+									"reference": "B101",
 									"tags": [
 										"Perk",
 										"Physical"
 									],
 									"base_points": 1,
+									"features": [
+										{
+											"type": "conditional_modifier",
+											"situation": "to others' Hearing roll in siturations where you want to be heard over noise",
+											"amount": 3
+										}
+									],
 									"calc": {
 										"points": 1
 									}
 								},
 								{
-									"id": "tOCl7yfgojLjaIhip",
-									"name": "License (Pilot's)",
+									"id": "twwGLNaGZxfpVHOBe",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "ts9hOD5V9mQFk64hc"
+									},
+									"name": "License (@Type@)",
 									"reference": "PU2:18",
 									"tags": [
 										"Perk",
 										"Social"
 									],
+									"replacements": {
+										"Type": "Pilot's"
+									},
 									"base_points": 1,
 									"calc": {
 										"points": 1
 									}
 								},
 								{
-									"id": "tOLuJSX_n4t8K9vcC",
+									"id": "txD7ACriUN0d3-Gyv",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tS3_80lkCglkZ8nAl"
+									},
 									"name": "Intuition",
 									"reference": "B63,P56",
 									"tags": [
@@ -1004,7 +1229,7 @@
 									],
 									"modifiers": [
 										{
-											"id": "myfB76hv8PCIQHHfR",
+											"id": "m4yf5HnwuBTbCwzig",
 											"name": "Inspired",
 											"reference": "P56",
 											"cost": 100,
@@ -1017,7 +1242,12 @@
 									}
 								},
 								{
-									"id": "tjYFBJqK3HDfCWxwR",
+									"id": "tsH4Ys3uwiqtwYnHl",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t4ANWaWCephx_yJpO"
+									},
 									"name": "Indomitable",
 									"reference": "B60",
 									"notes": "Impossible to influence through ordinary words or actions",
@@ -1031,7 +1261,41 @@
 									}
 								},
 								{
-									"id": "t0122hSVi6qeY4ySn",
+									"id": "tP7UH-HvEflkDN_wT",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Template Toolkit/Template Toolkit 3 - Starship Crew/Starship Crew Traits.adq",
+										"id": "txwHeC5OlbtuDV6Mw"
+									},
+									"name": "Higher Purpose (Save my ship!)",
+									"reference": "TT3:7,B59",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Mental"
+									],
+									"points_per_level": 5,
+									"features": [
+										{
+											"type": "conditional_modifier",
+											"situation": "to success rolls made to save the starship whenever this puts you at risk",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": 5
+									}
+								},
+								{
+									"id": "t36IbRX7C5L9nNNIs",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tzSU0oJe0L8zY5VA5"
+									},
 									"name": "Honest Face",
 									"reference": "B101",
 									"tags": [
@@ -1051,22 +1315,12 @@
 									}
 								},
 								{
-									"id": "tJ73mhSrQqcxJ9LjX",
-									"name": "Higher Purpose",
-									"reference": "B59,TT3:7",
-									"notes": "Save my ship!",
-									"tags": [
-										"Advantage",
-										"Exotic",
-										"Mental"
-									],
-									"base_points": 5,
-									"calc": {
-										"points": 5
-									}
-								},
-								{
-									"id": "tASSjpBnwEQqoLsTI",
+									"id": "tVGKlicixnw2Acjk0",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tuMfT5QpkN-4bDjWi"
+									},
 									"name": "Headhunter",
 									"reference": "PU2:13",
 									"tags": [
@@ -1083,20 +1337,33 @@
 									"name": "Everyman Advantages",
 									"children": [
 										{
-											"id": "tN8RcGDtvHmkC7Zw9",
-											"name": "Suit Familiarity (Vacc Suit)",
+											"id": "tcNNDFQp0xIfAL070",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Power Ups/Power Ups Traits.adq",
+												"id": "t3RCXCI5W-zjvxaf-"
+											},
+											"name": "Suit Familiarity (@Environment Suit skill@)",
 											"reference": "PU2:9",
 											"tags": [
 												"Perk",
 												"Physical"
 											],
+											"replacements": {
+												"Environment Suit skill": "Vacc Suit"
+											},
 											"base_points": 1,
 											"calc": {
 												"points": 1
 											}
 										},
 										{
-											"id": "tVqWyo87xGMZXDSQo",
+											"id": "tUWOHwXsPkho7eBAz",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tkiJQ7nfyi9aAdGHK"
+											},
 											"name": "Serendipity",
 											"reference": "B83,P73",
 											"tags": [
@@ -1105,17 +1372,24 @@
 											],
 											"modifiers": [
 												{
-													"id": "mhwNCxkO2x4YNHsPu",
+													"id": "mxqS4boXDLHwNHddF",
 													"name": "Wishing",
 													"reference": "P73",
 													"cost": 100,
 													"disabled": true
 												},
 												{
-													"id": "mzGoqqyUFT8HOEVVb",
+													"id": "mUNu61OZwGd3Vnmix",
 													"name": "Wishing",
 													"reference": "P73",
 													"notes": "For others only",
+													"disabled": true
+												},
+												{
+													"id": "mx3GM5UYKGxH6pKcK",
+													"name": "Game Time",
+													"reference": "P108",
+													"notes": "Uses per game week equal to its maximum possible uses per session",
 													"disabled": true
 												}
 											],
@@ -1127,8 +1401,13 @@
 											}
 										},
 										{
-											"id": "t1pJTLf3w0iUea5jp",
-											"name": "Resistant to Space Sickness",
+											"id": "tx5Zii4kmLAaNKhF6",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tJTfFdHM7YI5IZR7I"
+											},
+											"name": "Resistant",
 											"reference": "B81,P71,MA47",
 											"tags": [
 												"Advantage",
@@ -1136,7 +1415,7 @@
 											],
 											"modifiers": [
 												{
-													"id": "mijpq37Vvh8OonFa9",
+													"id": "mxVniYeGVwqr35vx3",
 													"name": "@Very Common: Metabolic Hazards, etc.@",
 													"reference": "B80",
 													"cost": 30,
@@ -1144,7 +1423,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mEHTHbSuP-yMcU25X",
+													"id": "mXWR6Z1HrWNGYvO4B",
 													"name": "@Common: Poison, Sickness, etc.@",
 													"reference": "B81",
 													"cost": 15,
@@ -1152,7 +1431,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mD3aQfGlR6L2-lObq",
+													"id": "meWHr_iVM0XSlmR9i",
 													"name": "@Occasional: Disease, Ingested Poison, etc.@",
 													"reference": "B81",
 													"cost": 10,
@@ -1160,13 +1439,17 @@
 													"disabled": true
 												},
 												{
-													"id": "m8BB3jskR20AZQPbX",
+													"id": "m9ZO8a5G7dOHtUAeC",
+													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
 													"reference": "B81",
+													"replacements": {
+														"Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.": "Space Sickness"
+													},
 													"cost": 5,
 													"cost_type": "points"
 												},
 												{
-													"id": "m4Ddr2WjFW960rwNw",
+													"id": "mm9tqXwVEy6GE8tbu",
 													"name": "Immunity",
 													"reference": "B81",
 													"cost": 1,
@@ -1174,14 +1457,14 @@
 													"disabled": true
 												},
 												{
-													"id": "m9d_w8TuqtRRmT9rw",
+													"id": "mNc52Zs91Wgdz8YQL",
 													"name": "+8 to all HT rolls to resist",
 													"reference": "B81",
 													"cost": 0.5,
 													"cost_type": "multiplier"
 												},
 												{
-													"id": "msHt5IAiSHk1mfBTu",
+													"id": "mIp-1DYeANaZcTJvU",
 													"name": "+3 to all HT rolls to resist",
 													"reference": "B81",
 													"cost": 0.33,
@@ -1195,8 +1478,13 @@
 											}
 										},
 										{
-											"id": "t67TP0zTxHh8D1G04",
-											"name": "Resistant to Space Sickness",
+											"id": "t39NuIID7k0K847Rw",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tJTfFdHM7YI5IZR7I"
+											},
+											"name": "Resistant",
 											"reference": "B81,P71,MA47",
 											"tags": [
 												"Advantage",
@@ -1204,7 +1492,7 @@
 											],
 											"modifiers": [
 												{
-													"id": "mseGJE7BF2emGqRe8",
+													"id": "mKJ-4uLJA6KmjOp6Q",
 													"name": "@Very Common: Metabolic Hazards, etc.@",
 													"reference": "B80",
 													"cost": 30,
@@ -1212,7 +1500,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mzDsiCdQZhRR0Rt1l",
+													"id": "mFe-QhrUmUjtOnlRH",
 													"name": "@Common: Poison, Sickness, etc.@",
 													"reference": "B81",
 													"cost": 15,
@@ -1220,7 +1508,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m32IIdb5xGmLxoVrP",
+													"id": "mjQHu7Qm9Xfmdve0A",
 													"name": "@Occasional: Disease, Ingested Poison, etc.@",
 													"reference": "B81",
 													"cost": 10,
@@ -1228,13 +1516,17 @@
 													"disabled": true
 												},
 												{
-													"id": "m7KXZqEqXv6sK2pxZ",
+													"id": "mYqRYE4XNCB5rrDtF",
+													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
 													"reference": "B81",
+													"replacements": {
+														"Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.": "Space Sickness"
+													},
 													"cost": 5,
 													"cost_type": "points"
 												},
 												{
-													"id": "mqIVGOKxylumBJ_ek",
+													"id": "mpYPkGC9bMLW6She0",
 													"name": "Immunity",
 													"reference": "B81",
 													"cost": 1,
@@ -1242,7 +1534,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m1DWY-QpOdcQykskL",
+													"id": "mRiLSKjfAZK-E-9jP",
 													"name": "+8 to all HT rolls to resist",
 													"reference": "B81",
 													"cost": 0.5,
@@ -1250,7 +1542,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mkDb-pR0jM5AU3zl5",
+													"id": "mP8t-T8K7KuSKmfMV",
 													"name": "+3 to all HT rolls to resist",
 													"reference": "B81",
 													"cost": 0.33,
@@ -1263,8 +1555,13 @@
 											}
 										},
 										{
-											"id": "tUz06-9WDndtoYPu-",
-											"name": "Resistant to Acceleration",
+											"id": "tddJSsDXYSFrnE3y2",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tJTfFdHM7YI5IZR7I"
+											},
+											"name": "Resistant",
 											"reference": "B81,P71,MA47",
 											"tags": [
 												"Advantage",
@@ -1272,7 +1569,7 @@
 											],
 											"modifiers": [
 												{
-													"id": "mFUoGDCXrvLbI93N8",
+													"id": "mCeWgaFZCWv8I2-2G",
 													"name": "@Very Common: Metabolic Hazards, etc.@",
 													"reference": "B80",
 													"cost": 30,
@@ -1280,7 +1577,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m9-dOaeXNxZ-cu-iQ",
+													"id": "mNraV7czz6RbKV88V",
 													"name": "@Common: Poison, Sickness, etc.@",
 													"reference": "B81",
 													"cost": 15,
@@ -1288,7 +1585,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mmK0aMJEJ5Zz6HbiS",
+													"id": "mzf3klurvE3kv3ELx",
 													"name": "@Occasional: Disease, Ingested Poison, etc.@",
 													"reference": "B81",
 													"cost": 10,
@@ -1296,13 +1593,17 @@
 													"disabled": true
 												},
 												{
-													"id": "mpZZxjPqcx0of_egE",
+													"id": "myelwhgsFRjQWQsft",
+													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
 													"reference": "B81",
+													"replacements": {
+														"Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.": "Acceleration"
+													},
 													"cost": 5,
 													"cost_type": "points"
 												},
 												{
-													"id": "mgsSeHA2LmASl9jP9",
+													"id": "mF8ucOvjZpyT8R81P",
 													"name": "Immunity",
 													"reference": "B81",
 													"cost": 1,
@@ -1310,7 +1611,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mOMRh7p8K73VbnTdH",
+													"id": "mrbNEa1s5gTxpaC9R",
 													"name": "+8 to all HT rolls to resist",
 													"reference": "B81",
 													"cost": 0.5,
@@ -1318,7 +1619,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mWETRIsRCcKE4-YS7",
+													"id": "mLflqN47c-RQVmv0r",
 													"name": "+3 to all HT rolls to resist",
 													"reference": "B81",
 													"cost": 0.33,
@@ -1331,8 +1632,13 @@
 											}
 										},
 										{
-											"id": "tqh94H8TJvILA-CZA",
-											"name": "Reputation",
+											"id": "t33riuBzFV8p5s1aA",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "ta04iFiZ_Kw0s0juj"
+											},
+											"name": "Good Reputation",
 											"reference": "B26,MA54",
 											"tags": [
 												"Advantage",
@@ -1340,7 +1646,7 @@
 											],
 											"modifiers": [
 												{
-													"id": "mfzo1WS2WfbaFUZM9",
+													"id": "mhF7JwRKluSkb2TZr",
 													"name": "People Affected",
 													"reference": "B27",
 													"notes": "Almost everyone",
@@ -1349,7 +1655,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mBL3_jNXYsNqDBSW8",
+													"id": "mZ9IZ85E9se6QiUOU",
 													"name": "People Affected",
 													"reference": "B27",
 													"notes": "Almost everyone except @large class of people@",
@@ -1358,7 +1664,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mzcFvuXOuDf6kgxS-",
+													"id": "mcSwXl0rhiSg-MR7p",
 													"name": "People Affected",
 													"reference": "B27",
 													"notes": "@Large class of people@",
@@ -1367,7 +1673,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mCynvAM_xFE5V2w6m",
+													"id": "m5yphsaQN0kaTCZwy",
 													"name": "People Affected",
 													"reference": "B27",
 													"notes": "@Small class of people@",
@@ -1376,7 +1682,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mkpQ2kvvthlv3mmA4",
+													"id": "mXG6rdQf09F0lBhAH",
 													"name": "Recognized all the time",
 													"reference": "B28",
 													"cost": 1,
@@ -1384,7 +1690,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mr0Jlj2EtsJRfpaOR",
+													"id": "mHLvGCBwAaq2chbr9",
 													"name": "Recognized sometimes",
 													"reference": "B28",
 													"notes": "10-",
@@ -1393,7 +1699,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mLJYSKaHIVEhbxsDa",
+													"id": "m_KEiXLp60YR7umOY",
 													"name": "Recognized occasionally",
 													"reference": "B28",
 													"notes": "7-",
@@ -1403,6 +1709,14 @@
 												}
 											],
 											"points_per_level": 5,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others aware of your reputation",
+													"amount": 1,
+													"per_level": true
+												}
+											],
 											"round_down": true,
 											"can_level": true,
 											"levels": 1,
@@ -1411,17 +1725,107 @@
 											}
 										},
 										{
-											"id": "tQklwGWWw3AYhB-zH",
+											"id": "toCIkqReq5H8xa3JD",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tmp8yecgaZq9TOk59"
+											},
+											"name": "@Type@ Rank",
+											"reference": "B29",
+											"tags": [
+												"Advantage",
+												"Social"
+											],
+											"replacements": {
+												"Type": "Military"
+											},
+											"modifiers": [
+												{
+													"id": "mAjMjXTUHkcsVuW5K",
+													"name": "Replaces Status",
+													"reference": "B29",
+													"cost": 5,
+													"cost_type": "points",
+													"affects": "levels_only",
+													"disabled": true
+												},
+												{
+													"id": "mW4ndKHW0sVHzGjdK",
+													"name": "Courtesy",
+													"reference": "B29",
+													"cost": -4,
+													"cost_type": "points",
+													"affects": "levels_only",
+													"disabled": true
+												}
+											],
+											"points_per_level": 5,
+											"can_level": true,
+											"levels": 1,
+											"calc": {
+												"points": 5
+											}
+										},
+										{
+											"id": "ta_ZEfM2QGA1GQ49f",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tmp8yecgaZq9TOk59"
+											},
+											"name": "@Type@ Rank",
+											"reference": "B29",
+											"tags": [
+												"Advantage",
+												"Social"
+											],
+											"replacements": {
+												"Type": "Merchant"
+											},
+											"modifiers": [
+												{
+													"id": "mk9tl0j7Ej4-YGum3",
+													"name": "Replaces Status",
+													"reference": "B29",
+													"cost": 5,
+													"cost_type": "points",
+													"affects": "levels_only",
+													"disabled": true
+												},
+												{
+													"id": "mVeUKxrrPTSz52vWH",
+													"name": "Courtesy",
+													"reference": "B29",
+													"cost": -4,
+													"cost_type": "points",
+													"affects": "levels_only",
+													"disabled": true
+												}
+											],
+											"points_per_level": 5,
+											"can_level": true,
+											"levels": 1,
+											"calc": {
+												"points": 5
+											}
+										},
+										{
+											"id": "tKYKIocENy5rCmJRL",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t6Nq6oInwkU1qbAP1"
+											},
 											"name": "Patron",
 											"reference": "B72,P65",
-											"notes": "Ship's owner or provider",
 											"tags": [
 												"Advantage",
 												"Social"
 											],
 											"modifiers": [
 												{
-													"id": "mOnmHZDiVr_VmnrNy",
+													"id": "mwqu57KXmlMfxhSdj",
 													"name": "@Who: Individual with 150% of PC's starting points@",
 													"reference": "B72",
 													"cost": 10,
@@ -1429,7 +1833,7 @@
 													"disabled": true
 												},
 												{
-													"id": "miMxYu_e1ymcameG_",
+													"id": "moNeMisXmT6a4STnf",
 													"name": "@Who: Organization with assets of at least 1000 times starting wealth@",
 													"reference": "B72",
 													"cost": 10,
@@ -1437,7 +1841,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mj1I22pyR6O8RFduL",
+													"id": "muGb2wq9-5b6EqFVv",
 													"name": "@Who: Individual with twice the PC's starting points@",
 													"reference": "B72",
 													"cost": 15,
@@ -1445,7 +1849,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mro8J2nwVavFh53Z_",
+													"id": "mLxPRUj2zym8b6si8",
 													"name": "@Who: Organization with assets of at least 10000 times starting wealth@",
 													"reference": "B72",
 													"cost": 15,
@@ -1453,7 +1857,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mGMG5tp0Ep7w6tamI",
+													"id": "muCk5xxDolqyJouFW",
 													"name": "@Who: An ultra-powerful individual@",
 													"reference": "B72",
 													"cost": 20,
@@ -1461,7 +1865,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mbojn-BGmt-uofwWH",
+													"id": "mJBlufBaNuadP2asd",
 													"name": "@Who: Organization with assets of at least 100000 times starting wealth@",
 													"reference": "B72",
 													"cost": 20,
@@ -1469,7 +1873,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mQYDCpkGq0cnFbQrC",
+													"id": "msvMBvblCK-TF3wWX",
 													"name": "@Who: Organization with assets of at least 1000000 times starting wealth@",
 													"reference": "B72",
 													"cost": 25,
@@ -1477,7 +1881,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mZjIS8W0sYVcZmJiw",
+													"id": "mTMJE5EaqxdJzEEjf",
 													"name": "@Who: A national government or giant multi-national organization@",
 													"reference": "B72",
 													"cost": 30,
@@ -1485,7 +1889,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mJpUe-r6e3RRlR2v_",
+													"id": "midGrnLtsJoo1rVqZ",
 													"name": "@Who: A deity@",
 													"reference": "B72",
 													"cost": 30,
@@ -1493,7 +1897,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mkcU108qLoc3A7W2W",
+													"id": "mmagjOqSCXg8o2ZeD",
 													"name": "Appears almost all the time",
 													"reference": "B36",
 													"notes": "15-",
@@ -1502,7 +1906,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mmBPRc3hj4KZrht5y",
+													"id": "mNc4HzOWKKEgaoqk-",
 													"name": "Appears quite often",
 													"reference": "B36",
 													"notes": "12-",
@@ -1511,7 +1915,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m_G2pIlHsye-jgVnE",
+													"id": "mLLSu65yFg6RQGuCg",
 													"name": "Appears fairly often",
 													"reference": "B36",
 													"notes": "9-",
@@ -1520,7 +1924,7 @@
 													"disabled": true
 												},
 												{
-													"id": "maxB9eBGE6v3hwy0N",
+													"id": "mtCSmzrp8X0YCkziM",
 													"name": "Appears quite rarely",
 													"reference": "B36",
 													"notes": "6-",
@@ -1529,7 +1933,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mrLBKtIQUTUpg26xu",
+													"id": "muPH2gLQ7whwFnqbO",
 													"name": "Equipment",
 													"reference": "B73",
 													"notes": "@Equipment worth no more than average starting wealth@",
@@ -1537,7 +1941,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mno1PZyZVf6DgmXP0",
+													"id": "mJKWQZmgoOMCfzzs9",
 													"name": "Equipment",
 													"reference": "B73",
 													"notes": "@Equipment worth more than average starting wealth@",
@@ -1545,14 +1949,14 @@
 													"disabled": true
 												},
 												{
-													"id": "mreZXPvtB_LTFzbvJ",
+													"id": "mpP4hQFLFLrissbr3",
 													"name": "Highly Accessible",
 													"reference": "B73",
 													"cost": 50,
 													"disabled": true
 												},
 												{
-													"id": "mIICE_viD7RICW04F",
+													"id": "mNoSd1IrQft-PFIbn",
 													"name": "Special Abilities",
 													"reference": "B73",
 													"notes": "@Extensive social or political power@",
@@ -1560,7 +1964,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mocSI6TWqWIshdOrG",
+													"id": "mvR8Cc0pe5cBviB3p",
 													"name": "Special Abilities",
 													"reference": "B73",
 													"notes": "@Magical powers in a non-magical world, higher TL equipment, grants special powers or is supernatural@",
@@ -1568,28 +1972,28 @@
 													"disabled": true
 												},
 												{
-													"id": "mb9Ehk3BG4HNGveEs",
+													"id": "m9b_Aw9MRbOHjAiSV",
 													"name": "Minimal Interventions",
 													"reference": "B73",
 													"cost": -50,
 													"disabled": true
 												},
 												{
-													"id": "m2B4AdgdzOiZiAIHr",
+													"id": "mogs0EgdNvgxbeLX7",
 													"name": "Secret",
 													"reference": "B73",
 													"cost": -50,
 													"disabled": true
 												},
 												{
-													"id": "mtvtwH0-ymaLIpRIo",
+													"id": "mmAXIpS6AwNdO5AoV",
 													"name": "Unwilling",
 													"reference": "B74",
 													"cost": -50,
 													"disabled": true
 												},
 												{
-													"id": "m067ZX0oPrSUeQrEh",
+													"id": "mmDY_EzBpYH0PTucb",
 													"name": "Favor",
 													"reference": "B55",
 													"cost": 0.2,
@@ -1602,77 +2006,12 @@
 											}
 										},
 										{
-											"id": "tVGoFuMnOtNXAsNtT",
-											"name": "Military Rank",
-											"reference": "B29",
-											"tags": [
-												"Advantage",
-												"Physical"
-											],
-											"modifiers": [
-												{
-													"id": "mP-aiWHv2NzfZmYxV",
-													"name": "Replaces Status",
-													"reference": "B29",
-													"cost": 5,
-													"cost_type": "points",
-													"affects": "levels_only",
-													"disabled": true
-												},
-												{
-													"id": "mTxifyISMv_zEatHn",
-													"name": "Courtesy",
-													"reference": "B29",
-													"cost": -4,
-													"cost_type": "points",
-													"affects": "levels_only",
-													"disabled": true
-												}
-											],
-											"points_per_level": 5,
-											"can_level": true,
-											"levels": 1,
-											"calc": {
-												"points": 5
-											}
-										},
-										{
-											"id": "t_7Da3GHcHRX689xm",
-											"name": "Merchant Rank",
-											"reference": "B29",
-											"tags": [
-												"Advantage",
-												"Physical"
-											],
-											"modifiers": [
-												{
-													"id": "mxGdaF0l6UKO8J4jm",
-													"name": "Replaces Status",
-													"reference": "B29",
-													"cost": 5,
-													"cost_type": "points",
-													"affects": "levels_only",
-													"disabled": true
-												},
-												{
-													"id": "mX3DFUTqizf1xPEz4",
-													"name": "Courtesy",
-													"reference": "B29",
-													"cost": -4,
-													"cost_type": "points",
-													"affects": "levels_only",
-													"disabled": true
-												}
-											],
-											"points_per_level": 5,
-											"can_level": true,
-											"levels": 1,
-											"calc": {
-												"points": 5
-											}
-										},
-										{
-											"id": "tc0CKRUPQ9TUOCYjU",
+											"id": "tsFYBVm-LLU1D_3dH",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tz-USDL9B_KrrVqDi"
+											},
 											"name": "Luck",
 											"reference": "B66,P59",
 											"notes": "Usable once per hour of play",
@@ -1682,14 +2021,14 @@
 											],
 											"modifiers": [
 												{
-													"id": "m9cNEK9yGW2m_orJh",
+													"id": "mU-UtBPpdz44NL7Bx",
 													"name": "Active",
 													"reference": "B66",
 													"cost": -40,
 													"disabled": true
 												},
 												{
-													"id": "mPJOu2dRf7lKbFP-B",
+													"id": "m3Q2RGxJXfzIZOiAK",
 													"name": "Aspected",
 													"reference": "B66",
 													"notes": "@Aspect@",
@@ -1697,17 +2036,24 @@
 													"disabled": true
 												},
 												{
-													"id": "mkIBpN9MopQmPo2WO",
+													"id": "mbYeAsTpJ3pChl9bC",
 													"name": "Defensive",
 													"reference": "B66",
 													"cost": -20,
 													"disabled": true
 												},
 												{
-													"id": "mDXfwNWg2_2Fb7ngk",
+													"id": "mXGPBbI0eu1RoHi6f",
 													"name": "Wishing",
 													"reference": "P59",
 													"cost": 100,
+													"disabled": true
+												},
+												{
+													"id": "mU8OJ9pgZEcwgHuHX",
+													"name": "Game Time",
+													"reference": "P108",
+													"notes": "Uses per game day equal to its maximum possible uses per real hour",
 													"disabled": true
 												}
 											],
@@ -1717,7 +2063,12 @@
 											}
 										},
 										{
-											"id": "tptxiwjZ7iCZVu4Eu",
+											"id": "tP9yV7jbMNszu7a4E",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tMxgHfzVEy_QQtlfB"
+											},
 											"name": "Less Sleep",
 											"reference": "B65",
 											"notes": "Require 1 hour/level less sleep for a full night's rest (max 4)",
@@ -1733,7 +2084,12 @@
 											}
 										},
 										{
-											"id": "tGQdITwuqHKsl1NWY",
+											"id": "txC_FzFvxyir8Ss2u",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tw1Ad0oSMw2ATM4X1"
+											},
 											"name": "Language: @Language@",
 											"reference": "B24",
 											"tags": [
@@ -1741,9 +2097,26 @@
 												"Language",
 												"Mental"
 											],
+											"prereqs": {
+												"type": "prereq_list",
+												"all": true,
+												"prereqs": [
+													{
+														"type": "trait_prereq",
+														"has": false,
+														"name": {
+															"compare": "is",
+															"qualifier": "Language Talent"
+														},
+														"level": {
+															"compare": "at_least"
+														}
+													}
+												]
+											},
 											"modifiers": [
 												{
-													"id": "mtIK-IiHNnaV8MkmC",
+													"id": "mI-_tGjrDAL9pVhIl",
 													"name": "Native",
 													"reference": "B23",
 													"cost": -6,
@@ -1751,7 +2124,7 @@
 													"disabled": true
 												},
 												{
-													"id": "moiRnTE-z2kr4ijBK",
+													"id": "muwdyC7OoP0WvNw_-",
 													"name": "Spoken",
 													"reference": "B24",
 													"notes": "None",
@@ -1759,7 +2132,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mBj_AlFXhOAH5pz-5",
+													"id": "m2QJ83qyNm4qR2cSs",
 													"name": "Spoken",
 													"reference": "B24",
 													"notes": "Broken",
@@ -1768,7 +2141,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m-SbJvmsdA_uyX4kf",
+													"id": "mid3m6WSiuU9W73lS",
 													"name": "Spoken",
 													"reference": "B24",
 													"notes": "Accented",
@@ -1776,7 +2149,7 @@
 													"cost_type": "points"
 												},
 												{
-													"id": "mCqqQ8-KrbNuLe-ef",
+													"id": "mFApXlGFVEIs743xl",
 													"name": "Spoken",
 													"reference": "B24",
 													"notes": "Native",
@@ -1785,7 +2158,7 @@
 													"disabled": true
 												},
 												{
-													"id": "my7_e9pZ8MN6opzud",
+													"id": "mrbXKCckc7ADoqqHF",
 													"name": "Written",
 													"reference": "B24",
 													"notes": "None",
@@ -1793,7 +2166,7 @@
 													"disabled": true
 												},
 												{
-													"id": "ma4pPv57FQAW09k9E",
+													"id": "myaEJV6Kof1fZ4b02",
 													"name": "Written",
 													"reference": "B24",
 													"notes": "Broken",
@@ -1802,7 +2175,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mYrU8GaV5WiMwr7lD",
+													"id": "mrS0gcQBJ5bYd4rY5",
 													"name": "Written",
 													"reference": "B24",
 													"notes": "Accented",
@@ -1810,7 +2183,7 @@
 													"cost_type": "points"
 												},
 												{
-													"id": "m-BwSmoGGiY9yxPtR",
+													"id": "mAWAjZk-jcvXM5jkR",
 													"name": "Written",
 													"reference": "B24",
 													"notes": "Native",
@@ -1824,7 +2197,12 @@
 											}
 										},
 										{
-											"id": "tUJmwE9qrMRb_hrJu",
+											"id": "tTByxA9MJ6NdB5AlN",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "txREhxV6L1SKixwe_"
+											},
 											"name": "Improved G-tolerance",
 											"reference": "B60",
 											"tags": [
@@ -1833,7 +2211,7 @@
 											],
 											"modifiers": [
 												{
-													"id": "min1xfWobQNaHAvGo",
+													"id": "mIe_gGkLp4U46XZ73",
 													"name": "0.3G",
 													"reference": "B60",
 													"cost": 5,
@@ -1841,7 +2219,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m9KK0RwHlNX8SJmdm",
+													"id": "m8Kvznx4aNMmCjK4f",
 													"name": "0.5G",
 													"reference": "B60",
 													"cost": 10,
@@ -1849,7 +2227,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mQPkE3gtZnUE_hwKe",
+													"id": "m0crlb2FTX_dIa7YI",
 													"name": "1G",
 													"reference": "B60",
 													"cost": 15,
@@ -1857,7 +2235,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mbbP0aY-wSNQk94n_",
+													"id": "mYvp-gVkyrblnyyU6",
 													"name": "5G",
 													"reference": "B60",
 													"cost": 20,
@@ -1865,7 +2243,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mA5Ix6cJn7CqWOR7Y",
+													"id": "mEKFmrtZJFtg4WMHm",
 													"name": "10G",
 													"reference": "B60",
 													"cost": 25,
@@ -1878,7 +2256,12 @@
 											}
 										},
 										{
-											"id": "ti4j0D_3hIh_uYMaS",
+											"id": "tNeZedQz0xEjQJ3vd",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t7blIRUzFpiHS_mnO"
+											},
 											"name": "Gizmo",
 											"reference": "B57,MA45",
 											"tags": [
@@ -1893,7 +2276,12 @@
 											}
 										},
 										{
-											"id": "tIBJsLpubNL_bBhku",
+											"id": "tbZEr8LS6RLyl_0kx",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tHNrjEQFQBNOgwmzK"
+											},
 											"name": "G-Experience (All)",
 											"reference": "B57",
 											"tags": [
@@ -1906,7 +2294,12 @@
 											}
 										},
 										{
-											"id": "tTsteW6AyJKCB7qWS",
+											"id": "t66jIVyt0KCz92Yu8",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tu3GuYC47Sx6bnm4k"
+											},
 											"name": "G-Experience",
 											"reference": "B57",
 											"tags": [
@@ -1921,7 +2314,12 @@
 											}
 										},
 										{
-											"id": "t4olBAVb6Ng_hZDT9",
+											"id": "tgW1gFp9zWapmRyCz",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "toTe273Ky82B6YdW5"
+											},
 											"name": "Fit",
 											"reference": "B55",
 											"notes": "Recover FP at twice the normal rate (but not FP spent for spells or psi powers)",
@@ -1942,7 +2340,12 @@
 											}
 										},
 										{
-											"id": "tdhmB_rnY2QuvXWYC",
+											"id": "tZj-v7GSAASrpYtIH",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tQa3EUrs4Hjt9gxK6"
+											},
 											"name": "Fearlessness",
 											"reference": "B55,MA44",
 											"tags": [
@@ -1979,7 +2382,12 @@
 											}
 										},
 										{
-											"id": "tJeEhmD3XRxSF4Fgj",
+											"id": "tb_2pQnKjA8QTj5gJ",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t5j2Ox4jaIV9j0rpz"
+											},
 											"name": "Deep Sleeper",
 											"reference": "B101",
 											"tags": [
@@ -1992,7 +2400,12 @@
 											}
 										},
 										{
-											"id": "tB5tA0KhV84Ri1_Wu",
+											"id": "txFgLOWFWvu-wcnE9",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tNBE3sLoyrUvAgoZ3"
+											},
 											"name": "Cybernetics",
 											"reference": "B46",
 											"tags": [
@@ -2004,7 +2417,12 @@
 											}
 										},
 										{
-											"id": "tDUItH3Bq4RXWezxH",
+											"id": "tTymK4RYn5Mo1A-Iy",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "toXBQ8q4Nek5lsLPF"
+											},
 											"name": "Cultural Familiarity (@Culture@)",
 											"reference": "B23",
 											"notes": "Do not suffer the normal -3 penalty for unfamiliarity",
@@ -2014,14 +2432,14 @@
 											],
 											"modifiers": [
 												{
-													"id": "m415JtNiuKrLA8D42",
+													"id": "mKySNDq2zWFsDVX0H",
 													"name": "Alien",
 													"cost": 1,
 													"cost_type": "points",
 													"disabled": true
 												},
 												{
-													"id": "m2kWz-gf5OVbiviO3",
+													"id": "m-aN-2ghmmaR86O-p",
 													"name": "Native",
 													"cost": -1,
 													"cost_type": "points",
@@ -2034,9 +2452,14 @@
 											}
 										},
 										{
-											"id": "tZP04ptrvmfVikrqZ",
-											"name": "Born Spacer",
-											"reference": "THSCT40",
+											"id": "td1Rkdb2A72F6Quy6",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Power Ups/Power Ups Traits.adq",
+												"id": "t3msobZZ06J7dZ8xu"
+											},
+											"name": "Talent (Born Spacer)",
+											"reference": "PU3:7",
 											"tags": [
 												"Advantage",
 												"Mental",
@@ -2044,17 +2467,60 @@
 											],
 											"modifiers": [
 												{
-													"id": "m495RPGl0A6mEntI6",
-													"name": "Alternate Benefit",
-													"notes": "@Alternate Benefit@",
-													"disabled": true
-												},
-												{
-													"id": "mEyguRKPj7HhflacX",
+													"id": "mPT5qfrXATqYGYdss",
 													"name": "Alternative Cost",
+													"cost": 1,
 													"cost_type": "points",
 													"affects": "levels_only",
 													"disabled": true
+												},
+												{
+													"id": "M1u0m2asF_cwnXydt",
+													"name": "Benefits",
+													"children": [
+														{
+															"id": "m2yewszdj24iOtVSk",
+															"name": "Reaction Bonus",
+															"use_level_from_trait": true,
+															"features": [
+																{
+																	"type": "reaction_bonus",
+																	"situation": "From professional Spacers.",
+																	"amount": 1,
+																	"per_level": true
+																}
+															]
+														},
+														{
+															"id": "mvc4QQovfwTGBzMPR",
+															"name": "Bonus to pushing off",
+															"reference": "BX350",
+															"reference_highlight": "ST/2",
+															"use_level_from_trait": true,
+															"features": [
+																{
+																	"type": "conditional_modifier",
+																	"situation": "Bonus to ST for zero G push off",
+																	"amount": 1,
+																	"per_level": true
+																}
+															],
+															"disabled": true
+														},
+														{
+															"id": "mHn16VJdb4-i-2RQF",
+															"name": "Spacecraft Familiarity",
+															"use_level_from_trait": true,
+															"features": [
+																{
+																	"type": "conditional_modifier",
+																	"situation": "Counteracts Familiarity for spacecraft.",
+																	"amount": 1
+																}
+															],
+															"disabled": true
+														}
+													]
 												}
 											],
 											"points_per_level": 5,
@@ -2086,6 +2552,10 @@
 														"compare": "is",
 														"qualifier": "Navigation"
 													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "Space"
+													},
 													"amount": 1,
 													"per_level": true
 												},
@@ -2097,8 +2567,36 @@
 														"qualifier": "Piloting"
 													},
 													"specialization": {
-														"compare": "contains",
-														"qualifier": "Spacecraft"
+														"compare": "is",
+														"qualifier": "High-Performance Spacecraft"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Piloting"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "Low-Performance Spacecraft"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Piloting"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "Aerospace"
 													},
 													"amount": 1,
 													"per_level": true
@@ -2122,12 +2620,6 @@
 													},
 													"amount": 1,
 													"per_level": true
-												},
-												{
-													"type": "reaction_bonus",
-													"situation": "Professional Spacers",
-													"amount": 1,
-													"per_level": true
 												}
 											],
 											"can_level": true,
@@ -2137,41 +2629,21 @@
 											}
 										},
 										{
-											"id": "tA5FfnzrT08VFHf1d",
-											"name": "Alien Friend",
-											"reference": "S220",
+											"id": "t6MZ_CMDicHfjqdyP",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Power Ups/Power Ups Traits.adq",
+												"id": "tcCw979nTBoztowCU"
+											},
+											"name": "Talent (Alien Friend)",
+											"reference": "PU3:6",
 											"tags": [
 												"Advantage",
 												"Mental",
 												"Talent"
 											],
-											"modifiers": [
-												{
-													"id": "m5i5DX7txlzgHqdxr",
-													"name": "Alternate Benefit",
-													"notes": "@Alternate Benefit@",
-													"disabled": true
-												},
-												{
-													"id": "m38UWuh4AdjQ-1Zvz",
-													"name": "Alternative Cost",
-													"cost_type": "points",
-													"affects": "levels_only",
-													"disabled": true
-												}
-											],
 											"points_per_level": 5,
 											"features": [
-												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "Anthropology"
-													},
-													"amount": 1,
-													"per_level": true
-												},
 												{
 													"type": "skill_bonus",
 													"selection_type": "skills_with_name",
@@ -2189,6 +2661,24 @@
 														"compare": "is",
 														"qualifier": "Expert Skill"
 													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "Xenology"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Anthropology"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "@Alien@"
+													},
 													"amount": 1,
 													"per_level": true
 												},
@@ -2198,6 +2688,10 @@
 													"name": {
 														"compare": "is",
 														"qualifier": "History"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "@Alien@"
 													},
 													"amount": 1,
 													"per_level": true
@@ -2209,12 +2703,16 @@
 														"compare": "is",
 														"qualifier": "Psychology"
 													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "@Alien@"
+													},
 													"amount": 1,
 													"per_level": true
 												},
 												{
 													"type": "reaction_bonus",
-													"situation": "Aliens",
+													"situation": "From aliens.",
 													"amount": 1,
 													"per_level": true
 												}
@@ -2226,7 +2724,12 @@
 											}
 										},
 										{
-											"id": "toPKRIEpvkZN1lpUf",
+											"id": "tYxa2sVYIHLjneXWp",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tM6z7Mx6e2V4VvUR4"
+											},
 											"name": "Absolute Direction",
 											"reference": "B34",
 											"tags": [
@@ -2236,14 +2739,14 @@
 											],
 											"modifiers": [
 												{
-													"id": "mx1YbwjCZNk_n0cyh",
+													"id": "mML-2NczGpyvwbEDE",
 													"name": "Requires signal",
 													"reference": "B34",
 													"cost": -20,
 													"disabled": true
 												},
 												{
-													"id": "m5Wv930qR8EwTdXUc",
+													"id": "m2pL_qfKLsUSpiw8f",
 													"name": "3D Spatial Sense",
 													"reference": "B34",
 													"cost": 5,
@@ -2366,7 +2869,12 @@
 									}
 								},
 								{
-									"id": "tTXMENhAySC-WjwMu",
+									"id": "tjzvTzg4hnhlAR1k7",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tdEOEbc8ltxyQNFJj"
+									},
 									"name": "Comfortable Wealth",
 									"reference": "B25",
 									"notes": "Starting wealth is twice normal",
@@ -2381,7 +2889,12 @@
 									}
 								},
 								{
-									"id": "tQ0izLzeg5-zyXRK6",
+									"id": "thW4KFoAGe7Nyf1e5",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tMMQWflrKUPOkyIF9"
+									},
 									"name": "Charisma",
 									"reference": "B41",
 									"tags": [
@@ -2450,7 +2963,12 @@
 									}
 								},
 								{
-									"id": "tbzxxitnZDEFWRT2V",
+									"id": "tlVK_fnZufzFTEydr",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tdlCZw4YB4T7QkOnj"
+									},
 									"name": "Appearance",
 									"reference": "B21",
 									"tags": [
@@ -2459,7 +2977,7 @@
 									],
 									"modifiers": [
 										{
-											"id": "mIucyMmYxZC0H9UBV",
+											"id": "m6IUx1Hgt91CIA5fH",
 											"name": "Attractive",
 											"reference": "B21",
 											"cost": 4,
@@ -2474,14 +2992,14 @@
 											"disabled": true
 										},
 										{
-											"id": "mU9JkrdaXMEFqKTsp",
+											"id": "m2zulSJPMIeM5qoJH",
 											"name": "Average",
 											"reference": "B21",
 											"cost_type": "points",
 											"disabled": true
 										},
 										{
-											"id": "mCeikxr9VONgUtrfL",
+											"id": "mTK2JLq3aOO1sc6JA",
 											"name": "Beautiful",
 											"reference": "B21",
 											"cost": 12,
@@ -2496,7 +3014,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mPPXkcJZpLym7pEa2",
+											"id": "mgQXfukhbp9Yq5TnK",
 											"name": "Beautiful (Androgynous)",
 											"reference": "B21",
 											"cost": 12,
@@ -2511,7 +3029,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mG6dFeC5_Z9E_EFwN",
+											"id": "m0AwxIvSbaW7lxxd_",
 											"name": "Beautiful (Impressive)",
 											"reference": "B21",
 											"cost": 12,
@@ -2526,7 +3044,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mkloH9qNT4N8HHnYn",
+											"id": "mSYs0rTzsAvCK1-SY",
 											"name": "Handsome",
 											"reference": "B21",
 											"cost": 12,
@@ -2541,7 +3059,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mqnPIX9RXoatBgPZE",
+											"id": "ma6L1fPPDBhI_yANU",
 											"name": "Handsome (Androgynous)",
 											"reference": "B21",
 											"cost": 12,
@@ -2556,7 +3074,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mMzFKUAMqOzK1Pfam",
+											"id": "m57Xe1oLo1Kgwlc9k",
 											"name": "Handsome (Impressive)",
 											"reference": "B21",
 											"cost": 12,
@@ -2571,12 +3089,21 @@
 											"disabled": true
 										},
 										{
-											"id": "mgp3AOeVrY6TkeSC5",
+											"id": "mUjXuC111rVIOYjv1",
 											"name": "Hideous",
-											"reference": "B21",
+											"reference": "B21,B202",
 											"cost": -16,
 											"cost_type": "points",
 											"features": [
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Intimidation"
+													},
+													"amount": 2
+												},
 												{
 													"type": "reaction_bonus",
 													"situation": "from others",
@@ -2586,12 +3113,21 @@
 											"disabled": true
 										},
 										{
-											"id": "msFeHa4YVKtZahhtz",
+											"id": "mOJKRBt-GGZXAlJPN",
 											"name": "Horrific",
-											"reference": "B21",
+											"reference": "B21,B202",
 											"cost": -24,
 											"cost_type": "points",
 											"features": [
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Intimidation"
+													},
+													"amount": 4
+												},
 												{
 													"type": "reaction_bonus",
 													"situation": "from others",
@@ -2601,19 +3137,28 @@
 											"disabled": true
 										},
 										{
-											"id": "mtBqMDw_r_f1y2gEO",
+											"id": "m3wbFE3dLEBIC_h0T",
 											"name": "Impressive",
 											"reference": "B21",
 											"cost_type": "points",
 											"disabled": true
 										},
 										{
-											"id": "mQei23xIcFdWJsgOj",
+											"id": "m_IsfcBYBBPO0_bP0",
 											"name": "Monstrous",
-											"reference": "B21",
+											"reference": "B21,B202",
 											"cost": -20,
 											"cost_type": "points",
 											"features": [
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Intimidation"
+													},
+													"amount": 3
+												},
 												{
 													"type": "reaction_bonus",
 													"situation": "from others",
@@ -2623,7 +3168,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mVPwWXhQZ4XtufIdl",
+											"id": "maOwP-SrtkHBqksPy",
 											"name": "Off-the-Shelf Looks",
 											"reference": "B21",
 											"notes": "Halves the usual reaction bonus - adjust manually",
@@ -2631,7 +3176,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mb-nlZ59ti6Yvkbns",
+											"id": "mRRnO0bCwDUH2cJSU",
 											"name": "Transcendent",
 											"reference": "B21",
 											"cost": 20,
@@ -2646,7 +3191,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mi26vkRF5UPWaBb7j",
+											"id": "m0tEYgHiImTT6h6cR",
 											"name": "Transcendent (Androgynous)",
 											"reference": "B21",
 											"cost": 20,
@@ -2661,7 +3206,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mXTCBZceyGYjczQlO",
+											"id": "mi6JJRNDLUltpn-vZ",
 											"name": "Transcendent (Impressive)",
 											"reference": "B21",
 											"cost": 20,
@@ -2676,7 +3221,7 @@
 											"disabled": true
 										},
 										{
-											"id": "m11ryNwu0xmagXNRf",
+											"id": "m1_VCmzYoM72ROEtS",
 											"name": "Ugly",
 											"reference": "B21",
 											"cost": -8,
@@ -2691,7 +3236,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mndoAyZmaCBrcuBgj",
+											"id": "mOxDX22JFJKoNnv8f",
 											"name": "Unattractive",
 											"reference": "B21",
 											"cost": -4,
@@ -2706,14 +3251,14 @@
 											"disabled": true
 										},
 										{
-											"id": "mH-M_c3lz4VJAUFtd",
+											"id": "mvCadDCUOYGMH1x1e",
 											"name": "Universal",
 											"reference": "B21",
 											"cost": 25,
 											"disabled": true
 										},
 										{
-											"id": "mDnZSYApPfISyNmpD",
+											"id": "mcX34F26HZ0xSMsWp",
 											"name": "Very Beautiful",
 											"reference": "B21",
 											"cost": 16,
@@ -2728,7 +3273,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mWFJPmSmPjVFrTkhA",
+											"id": "mNx6hrF5gsQdcWiQD",
 											"name": "Very Beautiful (Androgynous)",
 											"reference": "B21",
 											"cost": 16,
@@ -2743,7 +3288,7 @@
 											"disabled": true
 										},
 										{
-											"id": "m2bdZ4WuLSd75QIvG",
+											"id": "mR9FIfI6w5APaYp31",
 											"name": "Very Beautiful (Impressive)",
 											"reference": "B21",
 											"cost": 16,
@@ -2758,7 +3303,7 @@
 											"disabled": true
 										},
 										{
-											"id": "muvsvAphCKMRxNpr9",
+											"id": "m3EcObnozegTRd9zj",
 											"name": "Very Handsome",
 											"reference": "B21",
 											"cost": 16,
@@ -2773,7 +3318,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mG5vNX7BDqFvDoEIV",
+											"id": "mSYPrUOYV46ThINDO",
 											"name": "Very Handsome (Androgynous)",
 											"reference": "B21",
 											"cost": 16,
@@ -2788,7 +3333,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mxRC7djW-PxJdJW_Z",
+											"id": "mt7hQdx__prH6bT67",
 											"name": "Very Handsome (Impressive)",
 											"reference": "B21",
 											"cost": 16,
@@ -2808,16 +3353,21 @@
 									}
 								},
 								{
-									"id": "tnfE9HeSrSH4CLv9a",
+									"id": "thKx0KF3CCxqCc4rl",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tmp8yecgaZq9TOk59"
+									},
 									"name": "@Type@ Rank",
 									"reference": "B29",
 									"tags": [
 										"Advantage",
-										"Physical"
+										"Social"
 									],
 									"modifiers": [
 										{
-											"id": "mdtgjLEuhyLirAiLb",
+											"id": "mAvowBzShWr6KcFA2",
 											"name": "Replaces Status",
 											"reference": "B29",
 											"cost": 5,
@@ -2826,7 +3376,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mBSnyE4zDFt4HCR-Q",
+											"id": "mFK6xo5K-UsKx3her",
 											"name": "Courtesy",
 											"reference": "B29",
 											"cost": -4,
@@ -2846,7 +3396,12 @@
 									"name": "Better attributes",
 									"children": [
 										{
-											"id": "tbXKsNDnxOKdC92nO",
+											"id": "t4rPMh5JioDdSJmE2",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tGWOSEE6SmBHACE6Y"
+											},
 											"name": "Increased Dexterity",
 											"reference": "B15",
 											"tags": [
@@ -2856,7 +3411,7 @@
 											],
 											"modifiers": [
 												{
-													"id": "md__l7PwQATaI-GBf",
+													"id": "m8bciL_JJ_oXFMjns",
 													"name": "No Fine Manipulators",
 													"cost": -40,
 													"disabled": true
@@ -2878,7 +3433,12 @@
 											}
 										},
 										{
-											"id": "tCso7zYUwYEgolE6Z",
+											"id": "t8w3ixDhXzdzLG5Tf",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tVt3SvdGWNchJ8z4o"
+											},
 											"name": "Increased Health",
 											"reference": "B14",
 											"tags": [
@@ -2902,7 +3462,12 @@
 											}
 										},
 										{
-											"id": "teWzxwflr359K6g2H",
+											"id": "tZ-fbvNDqeAxQ16iM",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t1w1RFcFceKR2T9_e"
+											},
 											"name": "Increased Intelligence",
 											"reference": "B15",
 											"tags": [
@@ -2926,7 +3491,12 @@
 											}
 										},
 										{
-											"id": "tpnNoP-wsOoaS3b5J",
+											"id": "tE7MpEbyGqRuqPDyU",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tqha9GlDBU9P-Wg-6"
+											},
 											"name": "Increased Strength",
 											"reference": "B14",
 											"tags": [
@@ -2936,14 +3506,14 @@
 											],
 											"modifiers": [
 												{
-													"id": "mOZcUu5cwQH7wRXNl",
+													"id": "ma-k0LpgRrvIdnAgJ",
 													"name": "No Fine Manipulators",
 													"reference": "B15",
 													"cost": -40,
 													"disabled": true
 												},
 												{
-													"id": "m8KZjmU6Qb1VzjECs",
+													"id": "mj07azkeguRCZMcPq",
 													"name": "Size",
 													"reference": "B15",
 													"cost": -10,
@@ -2951,7 +3521,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mqSr9ejhfzcrUUx78",
+													"id": "mXOs4ZQqP_F4nH1zL",
 													"name": "Super-Effort",
 													"reference": "SU24",
 													"cost": 300,
@@ -2997,7 +3567,12 @@
 							"name": "-40 Points chosen from",
 							"children": [
 								{
-									"id": "tQM_PdXAUxd9a3io9",
+									"id": "tD62LooVEtq4K21xU",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tu0KYjUBLw84B4gKc"
+									},
 									"name": "Trickster",
 									"reference": "B159",
 									"notes": "Make a self-control roll each day. If you fail, you must try to trick a dangerous subject: a skilled warrior, a dangerous monster, a whole group of reasonably competent opponents, etc. If you resist, you get a cumulative -1 per day to your self-control roll until you finally fail a roll!",
@@ -3012,7 +3587,12 @@
 									}
 								},
 								{
-									"id": "t3KVB-8vz7-JwZ0ka",
+									"id": "t1EgHFzpKblUXwFLv",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t4gqkFmqABx7dLjkS"
+									},
 									"name": "Stubbornness",
 									"reference": "B157",
 									"tags": [
@@ -3032,7 +3612,12 @@
 									}
 								},
 								{
-									"id": "tNVLXqx-AaB3XiYqC",
+									"id": "t4_418UnxSFpHM1jZ",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tw81RysAzky-yjNYN"
+									},
 									"name": "Selfless",
 									"reference": "B153",
 									"notes": "You must make a self-control roll to put your needs – even survival – before those of someone else.",
@@ -3047,7 +3632,12 @@
 									}
 								},
 								{
-									"id": "t7BKs5bh8OS0T6Qd6",
+									"id": "t9S9kngj7K7Nbuy-a",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tYdqy1uPSGI8VqvLV"
+									},
 									"name": "Selfish",
 									"reference": "B153",
 									"notes": "Make a self-control roll whenever you experience a clear social slight or “snub.” On a failure, you lash out at the offending party just as if you had Bad Temper.",
@@ -3069,7 +3659,12 @@
 									}
 								},
 								{
-									"id": "tgLwW6TdDyYCIO_Ur",
+									"id": "toBolo1eBPGwbaPG4",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tPbL1_rekOzkM86wz"
+									},
 									"name": "Overconfidence",
 									"reference": "B148",
 									"notes": "You must make a self-control roll any time the GM feels you show an unreasonable degree of caution. If you fail, you must go ahead as though you were able to handle the situation!",
@@ -3096,7 +3691,12 @@
 									}
 								},
 								{
-									"id": "tCsHNFL3AZpQWdDiA",
+									"id": "tW797LczbhvfHEJk7",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tNNZgqAtiUMQ_dZs6"
+									},
 									"name": "Jealousy",
 									"reference": "B140",
 									"tags": [
@@ -3116,7 +3716,12 @@
 									}
 								},
 								{
-									"id": "tzjcPp2hqNpnWTEip",
+									"id": "tbmiYR-7p5QyF8gRh",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tUHvsAnxBrL6XEzEn"
+									},
 									"name": "Guilt Complex",
 									"reference": "B137",
 									"tags": [
@@ -3129,7 +3734,12 @@
 									}
 								},
 								{
-									"id": "tpJVvEssBFjyhaFST",
+									"id": "to75dfR6Tss-Vmot5",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tvF5dIQf3Jrwb_KXv"
+									},
 									"name": "Greed",
 									"reference": "B137",
 									"notes": "Make a self-control roll any time riches are offered – as payment for fair work, gains from adventure, spoils of crime, or just bait. If you fail, you do whatever it takes to get the payoff.",
@@ -3151,7 +3761,12 @@
 									],
 									"children": [
 										{
-											"id": "tVH2iNKkU4q53Jg_s",
+											"id": "tYBf1jlGo-yPDc4jK",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tX9XXLPFBvyQSpA4k"
+											},
 											"name": "Xenophilia",
 											"reference": "B162",
 											"tags": [
@@ -3165,7 +3780,12 @@
 											}
 										},
 										{
-											"id": "tByLHW1x7XQhQE-Ci",
+											"id": "tYwD_XqfNBuXcAvx6",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t8I0xw1Lj1_222aEN"
+											},
 											"name": "Workaholic",
 											"reference": "B162",
 											"tags": [
@@ -3178,7 +3798,12 @@
 											}
 										},
 										{
-											"id": "tGlwERGKChv0AQnVb",
+											"id": "tIVg_Odo-TwBFlrOj",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t7U0VbIzs6SqefwLr"
+											},
 											"name": "Social Stigma (Criminal Record)",
 											"reference": "B155",
 											"tags": [
@@ -3198,7 +3823,12 @@
 											}
 										},
 										{
-											"id": "tnkcQccP77KgCWvZ6",
+											"id": "tO99sf4l1xWY2Bh6g",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "thSMVzJ590v7gAD8d"
+											},
 											"name": "Pacifism: Self-Defense Only",
 											"reference": "B148",
 											"notes": "You only fight to defend yourself or those in your care, using only as much force as necessary (no pre-emptive strikes allowed!). You must do your best to discourage others from starting fights.",
@@ -3208,7 +3838,7 @@
 											],
 											"modifiers": [
 												{
-													"id": "m1c6ngjgJcqw7y93j",
+													"id": "m2f3s3XzhMhPCg3OT",
 													"name": "Species-Specific",
 													"reference": "UT32",
 													"cost": -80,
@@ -3221,7 +3851,12 @@
 											}
 										},
 										{
-											"id": "t64xteCwRDWlqcJwy",
+											"id": "tfN1qtflvsScMXqFK",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tV_f_75HmwzWOPhuu"
+											},
 											"name": "Pacifism: Reluctant Killer",
 											"reference": "B148",
 											"notes": "You are psychologically unprepared to kill people. Whenever you make a deadly attack (e.g., with a knife or a gun) against an obvious person whose face is visible to you, you are at -4 to hit and may not Aim. If you cannot see the foe’s face (due to a mask, darkness, or distance, or because you attacked from behind), the penalty is only -2, save in close combat. You have no penalty to attack a vehicle (even an occupied one), an opponent you do not believe is a person (including things with Horrific or Monstrous appearance), or a target you can’t actually see (e.g., a set of map coordinates or a blip on a radar screen). If you kill a recognizable person, the effect on you is the same as for Pacifism: Cannot Kill. You have no problem with your allies killing; you may even supply ammo, loaded weapons, and encouragement! You just can’t do the killing yourself.",
@@ -3231,7 +3866,7 @@
 											],
 											"modifiers": [
 												{
-													"id": "m-itK1_ku0Tz30oa2",
+													"id": "m7sJ5VjUnVaZMpHtN",
 													"name": "Species-Specific",
 													"reference": "UT32",
 													"cost": -80,
@@ -3244,7 +3879,12 @@
 											}
 										},
 										{
-											"id": "t9k0Hpq-yOy794qJZ",
+											"id": "tmU4Hl7sgsICQra9F",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "th9TK1Jmqg8uKe6SC"
+											},
 											"name": "Pacifism: Cannot Harm Innocents",
 											"reference": "B148",
 											"notes": "You may fight – you may even start fights – but you may only use deadly force on a foe that is attempting to do you serious harm. Capture is not “serious harm” unless you are already under penalty of death or have a Code of Honor that would require suicide if captured. You never intentionally do anything that causes, or even threatens to cause, injury to the uninvolved – particularly if they are “ordinary folks.”",
@@ -3254,7 +3894,7 @@
 											],
 											"modifiers": [
 												{
-													"id": "mvFJZJm1uN1nVbtHF",
+													"id": "m5xeVw5w339pP1rzl",
 													"name": "Species-Specific",
 													"reference": "UT32",
 													"cost": -80,
@@ -3267,7 +3907,12 @@
 											}
 										},
 										{
-											"id": "tMrsctKyn4I_bGCJI",
+											"id": "taaOJk9P9c7Yot-yp",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tSiOKuvTJkqJhuRrI"
+											},
 											"name": "Lecherousness",
 											"reference": "B142",
 											"notes": "Make a self-control roll whenever you have more than the briefest contact with an appealing member of the sex you find attractive, at -5 if this person is Handsome/Beautiful, or at -10 if Very Handsome/Very Beautiful. If you fail, you must make a “pass” using whatever wiles and skills you can bring to bear.",
@@ -3282,23 +3927,31 @@
 											}
 										},
 										{
-											"id": "te9C6aDApURyOym4k",
-											"name": "Intolerance (@Rival civilization or species@)",
+											"id": "tjNA5rq_I9mX4n071",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "ttHkLI9zwzfeOIEZc"
+											},
+											"name": "Intolerance (@Class, Ethnicity, Nationality, Religion, Sex, or Species@)",
 											"reference": "B140",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
+											"replacements": {
+												"Class, Ethnicity, Nationality, Religion, Sex, or Species": "Rival civilization or species"
+											},
 											"modifiers": [
 												{
-													"id": "meOY7cOtPBHn0EBrM",
+													"id": "mcax0Fv9h2zjyJ4A9",
 													"name": "Scope: Common",
 													"reference": "B140",
 													"cost": -5,
 													"cost_type": "points"
 												},
 												{
-													"id": "mRMnlMp_2CpDQY1ss",
+													"id": "mRf58IITTGcuPrQAK",
 													"name": "Scope: Occasional",
 													"reference": "B140",
 													"cost": -2,
@@ -3306,7 +3959,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mgeFYuJ7zEcNErg5m",
+													"id": "mXkdZ767Ymi3mjFVV",
 													"name": "Scope: Rare",
 													"reference": "B140",
 													"cost": -1,
@@ -3314,7 +3967,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mwI1OPUF290-G3kLT",
+													"id": "mKbUyP65v7rR6FRah",
 													"name": "Scope: Anyone unlike you",
 													"reference": "B140",
 													"cost": -10,
@@ -3334,7 +3987,12 @@
 											}
 										},
 										{
-											"id": "tbbirmbJ6-XasiBgR",
+											"id": "tYolrbZxnV2KGFukp",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t7pCgXTVkswkTjOZO"
+											},
 											"name": "Honesty",
 											"reference": "B138",
 											"notes": "Make a self-control roll when faced with the “need” to break unreasonable laws; if you fail, you must obey the law, whatever the consequences. If you manage to resist your urges and break the law, make a second self-control roll afterward. If you fail, you must turn yourself in to the authorities!",
@@ -3349,7 +4007,12 @@
 											}
 										},
 										{
-											"id": "t3ZmekWD71T1o84tP",
+											"id": "tj1QXy3b9RpBm8j5k",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t5bwP6TnS4cX-zM8L"
+											},
 											"name": "Enemy (@Who@)",
 											"reference": "B135",
 											"tags": [
@@ -3358,7 +4021,7 @@
 											],
 											"modifiers": [
 												{
-													"id": "mhrb8ZiRE04DlhnZB",
+													"id": "mo74gzXtTHHeYa63m",
 													"name": "Weak Individual",
 													"reference": "B135",
 													"notes": "50% of your starting points",
@@ -3367,7 +4030,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mOow9hMqSd5EZRnn7",
+													"id": "mheluHbYPVuwiYFMB",
 													"name": "Equal Individual",
 													"reference": "B135",
 													"notes": "100% of your starting points",
@@ -3376,7 +4039,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mhk8YichITfiGggpG",
+													"id": "m-RFsgb4m_hK-PbC9",
 													"name": "Powerful Individual",
 													"reference": "B135",
 													"notes": "\u003e150% of your starting points",
@@ -3385,7 +4048,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mlg4EZJLLkXaAZgAS",
+													"id": "miBI3XB5RHWq3lRVm",
 													"name": "Weak Group",
 													"reference": "B135",
 													"cost": -10,
@@ -3393,7 +4056,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mp9PryLCzI9vCbyYZ",
+													"id": "mb_yjujJfdJboEJsr",
 													"name": "Medium Group",
 													"reference": "B135",
 													"cost": -20,
@@ -3401,7 +4064,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mkdEfK1SFNigDr5Wm",
+													"id": "mNyJLXCpzZNnBXQGD",
 													"name": "Appears almost all the time",
 													"reference": "B36",
 													"notes": "15-",
@@ -3410,7 +4073,7 @@
 													"disabled": true
 												},
 												{
-													"id": "muLUb9pXIimpsYCK0",
+													"id": "mnBhfyiRTaODzxTVt",
 													"name": "Appears quite often",
 													"reference": "B36",
 													"notes": "12-",
@@ -3419,7 +4082,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mkmaZiO4XUz-oCNgv",
+													"id": "mlSh5jj2KQCd5-m22",
 													"name": "Appears fairly often",
 													"reference": "B36",
 													"notes": "9-",
@@ -3428,7 +4091,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mqyBJUP-NTnV4DzkC",
+													"id": "murdroeecprGKmPTo",
 													"name": "Appears quite rarely",
 													"reference": "B36",
 													"notes": "6-",
@@ -3437,7 +4100,7 @@
 													"disabled": true
 												},
 												{
-													"id": "movPCzQDTF1DBe6vX",
+													"id": "mNH9gzpbUvvQxcMD7",
 													"name": "Large/Powerful Group",
 													"reference": "B135",
 													"cost": -30,
@@ -3445,7 +4108,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mVH1oxIzgY_Ppsbuc",
+													"id": "mvwZb8sJgZD20qSm2",
 													"name": "Utterly Formidable Group",
 													"reference": "B135",
 													"cost": -40,
@@ -3453,7 +4116,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mhLXid9jxhIWRj1jb",
+													"id": "mPf3a6HBNS3YnzzYC",
 													"name": "Unknown",
 													"reference": "B135",
 													"cost": -5,
@@ -3461,14 +4124,14 @@
 													"disabled": true
 												},
 												{
-													"id": "mgyWR_fyJK8vKknDG",
+													"id": "mzdnv3CAwM6GpDkQe",
 													"name": "Evil Twin",
 													"reference": "B135",
 													"cost_type": "points",
 													"disabled": true
 												},
 												{
-													"id": "m5iqpgWIZM4rpx9Wt",
+													"id": "mO0fj_5vFSud5tRvt",
 													"name": "Evil Twin",
 													"reference": "B135",
 													"notes": "More skilled or extra abilities",
@@ -3477,7 +4140,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mO-nV-a44rwtvHFcL",
+													"id": "mkMJ1fuBgHUegYZ3w",
 													"name": "Evil Twin",
 													"reference": "B135",
 													"notes": "More skilled and extra abilities",
@@ -3486,7 +4149,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m3dTIDta28JIl1qtV",
+													"id": "mI49P6xCtQdFLZpQO",
 													"name": "Watcher",
 													"reference": "B135",
 													"cost": 0.25,
@@ -3494,7 +4157,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mus8sl0F_0BIQinzA",
+													"id": "mhxaZSS1MyfG2_KsK",
 													"name": "Rival",
 													"reference": "B135",
 													"cost": 0.5,
@@ -3502,7 +4165,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mC_iJG69UmOIsFG3f",
+													"id": "mHsgAAOQvGDcMjlvl",
 													"name": "Hunter",
 													"reference": "B135",
 													"cost": 1,
@@ -3515,58 +4178,65 @@
 											}
 										},
 										{
-											"id": "tpmjQW_agWGOWTqmE",
-											"name": "Duty (To ship's owner or provider)",
+											"id": "tbuEIhsul5Sq1wAkk",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t1HUGl4o498iCyvrw"
+											},
+											"name": "Duty (@Duty@)",
 											"reference": "B133",
 											"tags": [
 												"Disadvantage",
 												"Social"
 											],
+											"replacements": {
+												"Duty": "To ship's owner or provider"
+											},
 											"modifiers": [
 												{
-													"id": "miE6y6nZv2MENruWi",
+													"id": "mAEPmJj2byaEmwlok",
 													"name": "FR: 6",
 													"cost": -2,
 													"cost_type": "points",
 													"disabled": true
 												},
 												{
-													"id": "mco9_AtRCBLSRd_WK",
+													"id": "mTKugDxvipu8G7fKU",
 													"name": "FR: 9",
 													"cost": -5,
 													"cost_type": "points",
 													"disabled": true
 												},
 												{
-													"id": "mIFNfGdAVW49nCm1h",
+													"id": "mVWIYYm5zDXmXMDD1",
 													"name": "FR: 12",
 													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
+													"cost_type": "points"
 												},
 												{
-													"id": "mxuv2xdBh6JzrYOjh",
+													"id": "miJ4Gr_SaMCESnVc_",
 													"name": "FR: 15",
 													"cost": -15,
 													"cost_type": "points",
 													"disabled": true
 												},
 												{
-													"id": "mVjkfFMPT0y9g9k9m",
+													"id": "mc0fEZqWUoukSa7F4",
 													"name": "Extremely Hazardous",
 													"cost": -5,
 													"cost_type": "points",
 													"disabled": true
 												},
 												{
-													"id": "mfolehlHT5N4TXf7w",
+													"id": "mgnQGubLznFMNIdkN",
 													"name": "Involuntary",
 													"cost": -5,
 													"cost_type": "points",
 													"disabled": true
 												},
 												{
-													"id": "m7QS_oVVSbDR8vRai",
+													"id": "mEvOZ9JvCmQ982uQi",
 													"name": "Nonhazardous",
 													"cost": 5,
 													"cost_type": "points",
@@ -3574,62 +4244,69 @@
 												}
 											],
 											"calc": {
-												"points": 0
+												"points": -10
 											}
 										},
 										{
-											"id": "tTrZHhQuvL_qTuRFg",
-											"name": "Duty (To ship's owner or provider)",
+											"id": "tS-GVBN_UoYIMgtJn",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t1HUGl4o498iCyvrw"
+											},
+											"name": "Duty (@Duty@)",
 											"reference": "B133",
 											"tags": [
 												"Disadvantage",
 												"Social"
 											],
+											"replacements": {
+												"Duty": "To ship's owner or provider"
+											},
 											"modifiers": [
 												{
-													"id": "mK0tn_oCKWX_n7paA",
+													"id": "moadoVDc4dQFdwP97",
 													"name": "FR: 6",
 													"cost": -2,
 													"cost_type": "points",
 													"disabled": true
 												},
 												{
-													"id": "mxSRW_24HXtQuulJb",
+													"id": "mV7yWrKuG2aq9CgXj",
 													"name": "FR: 9",
 													"cost": -5,
 													"cost_type": "points",
 													"disabled": true
 												},
 												{
-													"id": "m_WCQjUr1xh9wHZ44",
+													"id": "mt3NFvIZfV7yvl7tm",
 													"name": "FR: 12",
 													"cost": -10,
 													"cost_type": "points",
 													"disabled": true
 												},
 												{
-													"id": "mlCww7tbiAblGHkiD",
+													"id": "m7G32rJnWnPoip03s",
 													"name": "FR: 15",
 													"cost": -15,
-													"cost_type": "points",
-													"disabled": true
+													"cost_type": "points"
 												},
 												{
-													"id": "mMSZSGsW4kYxl44oE",
+													"id": "meIu0pxlVpYBKMW5I",
 													"name": "Extremely Hazardous",
 													"cost": -5,
 													"cost_type": "points",
 													"disabled": true
 												},
 												{
-													"id": "maE5jun2IR3Yp-mDg",
+													"id": "mxBSXfZd1LUNzf159",
 													"name": "Involuntary",
 													"cost": -5,
 													"cost_type": "points",
 													"disabled": true
 												},
 												{
-													"id": "mD32fNkDylN7vogUK",
+													"id": "m-dICH3SygmVWdr7e",
 													"name": "Nonhazardous",
 													"cost": 5,
 													"cost_type": "points",
@@ -3637,11 +4314,16 @@
 												}
 											],
 											"calc": {
-												"points": 0
+												"points": -15
 											}
 										},
 										{
-											"id": "tbEGr_ghOrBIYQaRh",
+											"id": "tZz0gtod4IrQm23tI",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tXFf9MSQ3FMT2psO8"
+											},
 											"name": "Demophobia (Crowds)",
 											"reference": "B149",
 											"notes": "Any group of over a dozen people sets off this fear unless they are all well known to you. The self-control roll is at -1 for over 25 people, -2 for a crowd of 100 or more, -3 for 1,000, -4 for 10,000, and so on.",
@@ -3657,7 +4339,12 @@
 											}
 										},
 										{
-											"id": "tHTwXR5j7JeIRyZL9",
+											"id": "tSjf96LHu8sDfLmV4",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tK4QdVZYxGAd4cqr_"
+											},
 											"name": "Compulsive Gambling",
 											"reference": "B128",
 											"tags": [
@@ -3671,7 +4358,12 @@
 											}
 										},
 										{
-											"id": "tq9AWgxRJi3Vli-SR",
+											"id": "tRk-4KGntPq2IEkV9",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tapWLsuN75Unedmwn"
+											},
 											"name": "Compulsive Carousing",
 											"reference": "B128",
 											"tags": [
@@ -3697,7 +4389,12 @@
 											}
 										},
 										{
-											"id": "tTLIVt-sytdKi35Ld",
+											"id": "t2QxsWNeaHBx8EB8S",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "txSrmgLB0M36uR802"
+											},
 											"name": "Code of Honor (Soldier's)",
 											"reference": "B127",
 											"notes": "An officer should be tough but fair, lead from the front, and look out for his men; an enlisted man should look out for his buddies and take care of his kit. Every soldier should be willing to fight and die for the honor of his unit, service, and country; follow orders; obey the “rules of war”; treat an honorable enemy with respect (a dishonorable enemy deserves a bullet); and wear the uniform with pride.",
@@ -3711,7 +4408,31 @@
 											}
 										},
 										{
-											"id": "tc170EWLQwnKaH-R_",
+											"id": "tphgXjLvQy7OpVgvL",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Space/Space Traits.adq",
+												"id": "teNSsqOsjstajwmxn"
+											},
+											"name": "Code of Honor (Mercenary's Code)",
+											"reference": "B127, S221",
+											"notes": "A merc should look out for his buddies, take care of his gear, and fight for the honor of the unit. Obey the rules of engagement. Don’t poach on another unit’s contract. Do the job you’re hired for.",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"base_points": -10,
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "t7W8lFGnWho61Oqtw",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tqq24I9NJrLajsURv"
+											},
 											"name": "Code of Honor (Pirate's)",
 											"reference": "B127",
 											"notes": "Always avenge an insult, regardless of the danger; your buddy’s foe is your own; never attack a fellow crewman or buddy except in a fair, open duel.",
@@ -3725,21 +4446,42 @@
 											}
 										},
 										{
-											"id": "tIFFTt0GtslGrDtEN",
-											"name": "Code of Honor (Mercanary's)",
-											"reference": "S221",
-											"notes": "A merc should look out for his buddies, take care of his gear, and fight for the honor of the unit. Obey the rule's of engagement. Don't poach on another unit's contract. Do the job you're hired for.",
+											"id": "tx-rJpIidVPlGrlHB",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t4KGpV0KBExr-fEb2"
+											},
+											"name": "Gregarious",
+											"reference": "B126",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
 											"base_points": -10,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "to others",
+													"amount": 4
+												},
+												{
+													"type": "conditional_modifier",
+													"situation": "to IQ-based skills when alone, or only -1 if in a group of 4 or less",
+													"amount": -2
+												}
+											],
 											"calc": {
 												"points": -10
 											}
 										},
 										{
-											"id": "tKZc-GcPlGCgLHAHJ",
+											"id": "tbFNQxIHr_EoSOobT",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tzBDG0xUlT_dh7FuY"
+											},
 											"name": "Chummy",
 											"reference": "B126",
 											"tags": [
@@ -3764,7 +4506,12 @@
 											}
 										},
 										{
-											"id": "t_eJ3fq6KZs_CAbAp",
+											"id": "tRyjAT2RBr31F2CAN",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "taFPI7E0PJwXbS5nL"
+											},
 											"name": "Agoraphobia (Open Spaces)",
 											"reference": "B150",
 											"notes": "You are uncomfortable whenever you are outside, and actually become frightened when there are no walls within 50 feet.",
@@ -3781,11 +4528,16 @@
 										}
 									],
 									"calc": {
-										"points": -145
+										"points": -180
 									}
 								},
 								{
-									"id": "tKVQToXMbtMsu3Yc5",
+									"id": "tTvCT_asSrOpUYtj3",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tNHz23N7hxglFkVlr"
+									},
 									"name": "Debt",
 									"reference": "B26",
 									"tags": [
@@ -3801,17 +4553,17 @@
 								}
 							],
 							"calc": {
-								"points": -211
+								"points": -246
 							}
 						}
 					],
 					"calc": {
-						"points": -211
+						"points": -246
 					}
 				}
 			],
 			"calc": {
-				"points": 260
+				"points": 225
 			}
 		},
 		{
@@ -3824,7 +4576,12 @@
 					"name": "Legendary",
 					"children": [
 						{
-							"id": "t54sCZuMGvXZXVLsy",
+							"id": "tNexegrzSCqGvb-b0",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t1w1RFcFceKR2T9_e"
+							},
 							"name": "Increased Intelligence",
 							"reference": "B15",
 							"tags": [
@@ -3848,7 +4605,12 @@
 							}
 						},
 						{
-							"id": "tGY3P9BAu1q5iCFPJ",
+							"id": "tYzwfMk9kFjja2Wra",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tGWOSEE6SmBHACE6Y"
+							},
 							"name": "Increased Dexterity",
 							"reference": "B15",
 							"tags": [
@@ -3858,7 +4620,7 @@
 							],
 							"modifiers": [
 								{
-									"id": "mhqD5LTmvrk4tGH3i",
+									"id": "mH8Hk4_QRF7RE_Wtg",
 									"name": "No Fine Manipulators",
 									"cost": -40,
 									"disabled": true
@@ -3880,7 +4642,12 @@
 							}
 						},
 						{
-							"id": "t5w9-eyyypa2CJUaP",
+							"id": "tsNHtZE8AnB1X7nSE",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "trBGwkM0-bFOQUZcz"
+							},
 							"name": "Talent (Intuitive Admiral (Space))",
 							"reference": "PU3:12",
 							"tags": [
@@ -3890,12 +4657,45 @@
 							],
 							"modifiers": [
 								{
-									"id": "m9uuandR3G4ThEKi-",
+									"id": "m1XSLQ1Cu22vVoZ1I",
 									"name": "Alternative Cost",
 									"cost": -2,
 									"cost_type": "points",
 									"affects": "levels_only",
 									"disabled": true
+								},
+								{
+									"id": "MftjSEHL6FYyV95Zi",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "mc1aC4FRuddJVrmiA",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From anyone you serve with or command.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "mpSCz2WAUyDJUiMq5",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Bonus to initiative roll if leader",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
 								}
 							],
 							"points_per_level": 10,
@@ -4013,18 +4813,6 @@
 									},
 									"amount": 1,
 									"per_level": true
-								},
-								{
-									"type": "reaction_bonus",
-									"situation": "From anyone you serve with or command.",
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "conditional_modifier",
-									"situation": "Bonus to initiative roll if leader",
-									"amount": 1,
-									"per_level": true
 								}
 							],
 							"can_level": true,
@@ -4043,7 +4831,12 @@
 					"name": "Multi-Role",
 					"children": [
 						{
-							"id": "ttqPP4emFT_NHRK70",
+							"id": "tyNFXIW9wty1EqKMy",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t1w1RFcFceKR2T9_e"
+							},
 							"name": "Increased Intelligence",
 							"reference": "B15",
 							"tags": [
@@ -4067,7 +4860,12 @@
 							}
 						},
 						{
-							"id": "tnJJaI9ps_Xnnar9T",
+							"id": "tc_3OodN128_jK6FI",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "trBGwkM0-bFOQUZcz"
+							},
 							"name": "Talent (Intuitive Admiral (Space))",
 							"reference": "PU3:12",
 							"tags": [
@@ -4077,12 +4875,45 @@
 							],
 							"modifiers": [
 								{
-									"id": "mNKUO47T1u1-RHm0_",
+									"id": "mSnC_0YCetN5d-Vu9",
 									"name": "Alternative Cost",
 									"cost": -2,
 									"cost_type": "points",
 									"affects": "levels_only",
 									"disabled": true
+								},
+								{
+									"id": "MULyABr-h_j8-CeIW",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "mn-CYPqu28ScFwVMB",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From anyone you serve with or command.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "mkT-n0IkZKu1NHkJR",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Bonus to initiative roll if leader",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
 								}
 							],
 							"points_per_level": 10,
@@ -4200,18 +5031,6 @@
 									},
 									"amount": 1,
 									"per_level": true
-								},
-								{
-									"type": "reaction_bonus",
-									"situation": "From anyone you serve with or command.",
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "conditional_modifier",
-									"situation": "Bonus to initiative roll if leader",
-									"amount": 1,
-									"per_level": true
 								}
 							],
 							"can_level": true,
@@ -4221,7 +5040,12 @@
 							}
 						},
 						{
-							"id": "tviPn3l5N2O1mQz8K",
+							"id": "tWlGvOSzUtuZ30lo7",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tMMQWflrKUPOkyIF9"
+							},
 							"name": "Charisma",
 							"reference": "B41",
 							"tags": [
@@ -4311,7 +5135,12 @@
 					"name": "Primary Skills",
 					"children": [
 						{
-							"id": "szRt-IoheIC56zYOV",
+							"id": "siZgBBwDfW09TgC5i",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sSxGnNPMXyZpZKoFZ"
+							},
 							"name": "Leadership",
 							"reference": "B204",
 							"tags": [
@@ -4328,7 +5157,12 @@
 							"points": 2
 						},
 						{
-							"id": "sRGB1OUXtUzZGckP3",
+							"id": "sHtonNcJ1qb_lG1yb",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sR_M_d1acCzYenF_A"
+							},
 							"name": "Shiphandling",
 							"reference": "B220",
 							"tags": [
@@ -4397,7 +5231,12 @@
 							"points": 8
 						},
 						{
-							"id": "sIs1Lr4yDb5yNZ67F",
+							"id": "sA2C6xmsIlrlvQo8T",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "s9IHT34mK8yfSB7d_"
+							},
 							"name": "Spacer",
 							"reference": "B185",
 							"tags": [
@@ -4420,7 +5259,12 @@
 					"name": "Secondary Skills",
 					"children": [
 						{
-							"id": "swh9jSX9Rye1fgM4T",
+							"id": "sGxYBPSGhM1lueBiH",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sn-AqOk3ggCs7fqIQ"
+							},
 							"name": "Administration",
 							"reference": "B174",
 							"tags": [
@@ -4442,7 +5286,12 @@
 							"points": 2
 						},
 						{
-							"id": "slYhinc0shzZtjRYn",
+							"id": "sk-m7kdY7XLAhsYRL",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "swXuff1DBhSQbTqy1"
+							},
 							"name": "Electronics Operation",
 							"reference": "B189",
 							"tags": [
@@ -4477,7 +5326,12 @@
 							"points": 2
 						},
 						{
-							"id": "so5SwVi9GXhqhFsqe",
+							"id": "s9FTotmrfvOM8dXm_",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sluTeYhSTpIbVNfA5"
+							},
 							"name": "Electronics Operation",
 							"reference": "B189",
 							"tags": [
@@ -4512,7 +5366,12 @@
 							"points": 2
 						},
 						{
-							"id": "siyt-IGXVyB-wHwY9",
+							"id": "sLrbrMhzSF7OC_bC0",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "s7kVwKFERTuMYO3O8"
+							},
 							"name": "Free Fall",
 							"reference": "B197",
 							"tags": [
@@ -4532,7 +5391,12 @@
 							"points": 4
 						},
 						{
-							"id": "s8bF45DM3heohVZPS",
+							"id": "sZSJAyVON94Ev88b0",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "shChZ7cQ-SIe7JKo6"
+							},
 							"name": "Navigation",
 							"reference": "B211",
 							"tags": [
@@ -4541,7 +5405,10 @@
 								"Technical",
 								"Vehicle"
 							],
-							"specialization": "@FTL@",
+							"replacements": {
+								"Environment": "@FTL@"
+							},
+							"specialization": "@Environment@",
 							"difficulty": "iq/a",
 							"defaults": [
 								{
@@ -4566,7 +5433,12 @@
 							"points": 2
 						},
 						{
-							"id": "sqLeUIJFxB0UI1Zj6",
+							"id": "shO0o8QdCe1iJ7ruS",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sZZ8IZK6yPuxwffjd"
+							},
 							"name": "Navigation",
 							"reference": "B211",
 							"tags": [
@@ -4600,13 +5472,21 @@
 							"points": 2
 						},
 						{
-							"id": "sfck9Bcc9R8yY-DzY",
+							"id": "sKDVc6HTzS52C-YjV",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sQE2t0-gMM5-4KgPb"
+							},
 							"name": "Piloting",
 							"reference": "B214",
 							"tags": [
 								"Vehicle"
 							],
-							"specialization": "@Main@",
+							"replacements": {
+								"Flying vehicle class": "@Main@"
+							},
+							"specialization": "@Flying vehicle class@",
 							"difficulty": "dx/a",
 							"defaults": [
 								{
@@ -4629,13 +5509,21 @@
 							"points": 4
 						},
 						{
-							"id": "sN3dayNTr4gI2oll4",
+							"id": "selYRJNi7CchZXmzA",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sQE2t0-gMM5-4KgPb"
+							},
 							"name": "Piloting",
 							"reference": "B214",
 							"tags": [
 								"Vehicle"
 							],
-							"specialization": "@Secondary@",
+							"replacements": {
+								"Flying vehicle class": "@Secondary@"
+							},
+							"specialization": "@Flying vehicle class@",
 							"difficulty": "dx/a",
 							"defaults": [
 								{
@@ -4658,7 +5546,12 @@
 							"points": 4
 						},
 						{
-							"id": "swa6p8t1zNdA2jcXx",
+							"id": "sZ4VGU6M-1ft-jjK6",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "svZCidrvq9QTwwV3-"
+							},
 							"name": "Strategy",
 							"reference": "B222",
 							"tags": [
@@ -4694,7 +5587,12 @@
 							"name": "Two of",
 							"children": [
 								{
-									"id": "sSn5ijNxpxRqK7s36",
+									"id": "s8KzI7WdNCA26y9C7",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sIegIM7jx4oMnRMm2"
+									},
 									"name": "Detect Lies",
 									"reference": "B187",
 									"tags": [
@@ -4722,7 +5620,12 @@
 									"points": 2
 								},
 								{
-									"id": "s2eKqDqqIgUGX6dGJ",
+									"id": "spE9cRQ-NjNsTn5XA",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "s8j6tcaNxXkF89Xbt"
+									},
 									"name": "Diplomacy",
 									"reference": "B187",
 									"tags": [
@@ -4745,7 +5648,12 @@
 									"points": 2
 								},
 								{
-									"id": "sJBGQWi9F51yWm_72",
+									"id": "srpHSQSCt43jRwvSN",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "shun-iitiwyWbrGcF"
+									},
 									"name": "Intimidation",
 									"reference": "B202",
 									"tags": [
@@ -4771,7 +5679,12 @@
 							]
 						},
 						{
-							"id": "sJsKatVZ20CEbRkel",
+							"id": "sZTM_vA1F7048udJ6",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sAmDzPjf0rKZ6I5G1"
+							},
 							"name": "Vacc Suit",
 							"reference": "B192",
 							"tags": [
@@ -4813,7 +5726,12 @@
 							"name": "10 Points chosen from",
 							"children": [
 								{
-									"id": "sayc1r9ozuN37oMt0",
+									"id": "sLyAZUDmH6Ug1Ovlv",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "siUwhUBcqrDAPgud8"
+									},
 									"name": "Artillery",
 									"reference": "B178",
 									"tags": [
@@ -4833,7 +5751,12 @@
 									"points": 1
 								},
 								{
-									"id": "soBuotyuPxvXmWgyU",
+									"id": "s7eQJsoL2XcEa5gMk",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sUOQKAH8IaMhpxk1o"
+									},
 									"name": "Electronics Operation",
 									"reference": "B189",
 									"tags": [
@@ -4872,7 +5795,12 @@
 									"name": "Everyman Skills",
 									"children": [
 										{
-											"id": "s6NXOaZ6Nexp2WeOm",
+											"id": "s0LWerRloPEvf_X9u",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sTXDrqXH0sT2NSD_b"
+											},
 											"name": "Area Knowledge",
 											"reference": "B176",
 											"notes": "Location of the capitals of interplanetary states and the homeworlds of major races; general awareness of all major races; knowledge of individuals of Status 8; general understanding of relations between interplanetary states",
@@ -4893,7 +5821,12 @@
 											"points": 1
 										},
 										{
-											"id": "sF4hqscXfJI-NiP4k",
+											"id": "sMN7zJWk7EAshziFw",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "s-Ckyxw5PmHIvbZab"
+											},
 											"name": "Area Knowledge",
 											"reference": "B176",
 											"notes": "Location of major planets; familiarity with all known races (but not necessarily expertise); knowledge of people of Status 7+; general understanding of the economic and political situation",
@@ -4901,13 +5834,9 @@
 												"Everyman",
 												"Knowledge"
 											],
-											"specialization": "@Interplanetary State@; Lived there",
+											"specialization": "@Interplanetary State@",
 											"difficulty": "iq/e",
 											"defaults": [
-												{
-													"type": "iq",
-													"modifier": -4
-												},
 												{
 													"type": "skill",
 													"name": "Geography",
@@ -4918,7 +5847,12 @@
 											"points": 1
 										},
 										{
-											"id": "sKmW9UteqRNTQZWHl",
+											"id": "sGmv4XyDfHJkRZXLQ",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "strhX4LEdd46xgmIS"
+											},
 											"name": "Area Knowledge",
 											"reference": "B176",
 											"notes": "Location of its major cities and important sites; awareness of its major customs, ethnic groups, and languages (but not necessarily expertise); names of folk of Status 7+; and a general understanding of the economic and political situation",
@@ -4926,13 +5860,9 @@
 												"Everyman",
 												"Knowledge"
 											],
-											"specialization": "@Planet@; Lived there",
+											"specialization": "@Planet@",
 											"difficulty": "iq/e",
 											"defaults": [
-												{
-													"type": "iq",
-													"modifier": -4
-												},
 												{
 													"type": "skill",
 													"name": "Geography",
@@ -4943,7 +5873,12 @@
 											"points": 1
 										},
 										{
-											"id": "saASP36xeFexSDbyi",
+											"id": "skBP9vq-k6tg7ssfg",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sBJgeWUs81Ifhob4Z"
+											},
 											"name": "Beam Weapons",
 											"reference": "B179",
 											"tags": [
@@ -4974,7 +5909,12 @@
 											"points": 1
 										},
 										{
-											"id": "s-8gBjsAZeQqRZJfC",
+											"id": "sO0pHKff80IB_6KlA",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sOp4wssAMtUc1ukJI"
+											},
 											"name": "Body Language",
 											"reference": "B181",
 											"tags": [
@@ -4998,10 +5938,14 @@
 											"points": 1
 										},
 										{
-											"id": "sO8k1C_Dy9XK3jdsF",
+											"id": "sm3LdAkS-eTwxQpIX",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sziMa9_9xTvR2iiqx"
+											},
 											"name": "Body Sense",
 											"reference": "B181",
-											"notes": "For settings with matter transmission",
 											"tags": [
 												"Athletic"
 											],
@@ -5020,7 +5964,12 @@
 											"points": 1
 										},
 										{
-											"id": "sNCSioonThmI6wDIJ",
+											"id": "saIT2iOAHxxLiKZJv",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "shtDdl5thrvKSnJHf"
+											},
 											"name": "Brawling",
 											"reference": "B182,MA55",
 											"tags": [
@@ -5048,7 +5997,12 @@
 											"points": 1
 										},
 										{
-											"id": "sWFaAoaXyYMNiZM-B",
+											"id": "sBiDFId0UHz999bi5",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "si-upI7A5RgdO0cjC"
+											},
 											"name": "Carousing",
 											"reference": "B183",
 											"tags": [
@@ -5066,7 +6020,12 @@
 											"points": 1
 										},
 										{
-											"id": "sewWXrJjxWRxk4zfo",
+											"id": "sW4efOp-iUA6Ojc2t",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sWFtA7Gvclq4aL-Yb"
+											},
 											"name": "Current Affairs",
 											"reference": "B186",
 											"tags": [
@@ -5097,7 +6056,12 @@
 											"points": 1
 										},
 										{
-											"id": "sJ4yq3-IPgmJ4dNzO",
+											"id": "s8clj3vdJHEUNy9dg",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "s9mV--3lpIfXO7N6Z"
+											},
 											"name": "First Aid",
 											"reference": "B195",
 											"tags": [
@@ -5128,7 +6092,12 @@
 											"points": 1
 										},
 										{
-											"id": "skEpu40IYb1b2ga19",
+											"id": "sbChJr1xnnqji4592",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sWB9ypJAq43MF3O0n"
+											},
 											"name": "Gambling",
 											"reference": "B197",
 											"tags": [
@@ -5152,7 +6121,12 @@
 											"points": 1
 										},
 										{
-											"id": "sa0n1E-vyq-DpGUU6",
+											"id": "sdnspkHTjTBEqNY_S",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "syfSQ9N8yETqQbhFK"
+											},
 											"name": "Games",
 											"reference": "B197,MA57",
 											"tags": [
@@ -5169,7 +6143,12 @@
 											"points": 1
 										},
 										{
-											"id": "scFCzWYwrXs71zz74",
+											"id": "seN3N4_mBV52lcm7p",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sGz21GskAlJXL1hYP"
+											},
 											"name": "Gesture",
 											"reference": "B198",
 											"tags": [
@@ -5185,7 +6164,12 @@
 											"points": 1
 										},
 										{
-											"id": "s0g1sAV-XDp2a8UcH",
+											"id": "seYGRKBohqUGNvMAW",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sT5htbz4-Mr0PFCk7"
+											},
 											"name": "Guns",
 											"reference": "B198",
 											"tags": [
@@ -5210,7 +6194,12 @@
 											"points": 1
 										},
 										{
-											"id": "s-jmUAHj_caGN73mq",
+											"id": "sX-AwPBqR-FyEZfMZ",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sOtPessbzkRjGaQPR"
+											},
 											"name": "Hobby Skill",
 											"reference": "B200,MA57",
 											"tags": [
@@ -5227,7 +6216,12 @@
 											"points": 1
 										},
 										{
-											"id": "sDpAhgW0dMyM6xm6l",
+											"id": "szwQpR4a4_G3Yx-rR",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sDLf4crz0sGRjVDFi"
+											},
 											"name": "Hobby Skill",
 											"reference": "B200,MA57",
 											"tags": [
@@ -5244,7 +6238,12 @@
 											"points": 1
 										},
 										{
-											"id": "s9_zP-6FN2wY5UT6p",
+											"id": "s1DlEnN8YGr5bj12x",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sfZrwMVUibhbtdssl"
+											},
 											"name": "Housekeeping",
 											"reference": "B200",
 											"tags": [
@@ -5260,7 +6259,12 @@
 											"points": 1
 										},
 										{
-											"id": "sbpkN0czMETjXYoS7",
+											"id": "sKpsIK_Jz-tAlQ5tH",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sdl9m7gHE7hlMX0AX"
+											},
 											"name": "Lip Reading",
 											"reference": "B205",
 											"tags": [
@@ -5276,7 +6280,12 @@
 											"points": 1
 										},
 										{
-											"id": "sGdcVCTiJ11eT8wEE",
+											"id": "sNbSd7owWVmxS7Y0B",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sx1CDkGBR830IZrmz"
+											},
 											"name": "Professional Skill",
 											"reference": "B215",
 											"tags": [
@@ -5293,7 +6302,12 @@
 											"points": 1
 										},
 										{
-											"id": "sFU5k46xrJ85H6s5V",
+											"id": "s1xPEAaxK_9vL7Yqy",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sBec-o4Z7gPpbg2f9"
+											},
 											"name": "Professional Skill",
 											"reference": "B215",
 											"tags": [
@@ -5310,7 +6324,12 @@
 											"points": 1
 										},
 										{
-											"id": "ssja07tnQPzb1OBMT",
+											"id": "sG057BtRDAQuDAWIT",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "smxkcngH5Kz54yeN3"
+											},
 											"name": "Sports",
 											"reference": "B222,MA59",
 											"tags": [
@@ -5327,7 +6346,12 @@
 											"points": 1
 										},
 										{
-											"id": "sRBQOUbXHnD6HE43k",
+											"id": "sRvh9pcr3sBzLO2UO",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "smTUpMWJGqPeT1KER"
+											},
 											"name": "Streetwise",
 											"reference": "B223",
 											"tags": [
@@ -5348,7 +6372,12 @@
 									]
 								},
 								{
-									"id": "sqaPcCyYxeKaC3wI_",
+									"id": "sGvyTPFqlSMOrwi3_",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "s88gTPKTH8WGPQqDI"
+									},
 									"name": "Expert Skill",
 									"reference": "B193,MA56",
 									"tags": [
@@ -5361,7 +6390,12 @@
 									"points": 1
 								},
 								{
-									"id": "sP2ZtcCGw9JRj1jjZ",
+									"id": "spTVmLUVZ3tsvRmPv",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "s7zUqAO5PEC5JKk_W"
+									},
 									"name": "Fast-Talk",
 									"reference": "B195",
 									"tags": [
@@ -5385,7 +6419,12 @@
 									"points": 1
 								},
 								{
-									"id": "soas0cRsfgOzqKG7A",
+									"id": "srlytaSnXjMTrE00x",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "snZtm1wwlLIeerPuO"
+									},
 									"name": "Gunner",
 									"reference": "B198",
 									"tags": [
@@ -5410,7 +6449,12 @@
 									"points": 1
 								},
 								{
-									"id": "snPGQLIbRE4yZMXlL",
+									"id": "sFRbAXl_-QRKTl8ux",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sPyZ0zxFI-Kygrzie"
+									},
 									"name": "Intelligence Analysis",
 									"reference": "B201",
 									"tags": [
@@ -5434,7 +6478,12 @@
 									"points": 1
 								},
 								{
-									"id": "sHZ6o6DJqBXXY7_qR",
+									"id": "sYNk5dqgfSuPVQUXX",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "shHyf3H441PtZMBlJ"
+									},
 									"name": "Merchant",
 									"reference": "B209",
 									"tags": [
@@ -5461,7 +6510,12 @@
 									"points": 1
 								},
 								{
-									"id": "s9pQZzlEpdozmzxxN",
+									"id": "s5d_7oXu340UiMZ5d",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "s4WxUyOWPwvLxBypO"
+									},
 									"name": "Savoir-Faire",
 									"reference": "B218,MA59",
 									"tags": [
@@ -5486,7 +6540,12 @@
 									"points": 1
 								},
 								{
-									"id": "swaawIFC6igko_Mj3",
+									"id": "s_kLHSHKP37F-t2be",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sPTlfb6j7JYiJ2sdx"
+									},
 									"name": "Savoir-Faire",
 									"reference": "B218,MA59",
 									"tags": [
@@ -5505,7 +6564,12 @@
 									"points": 1
 								},
 								{
-									"id": "s5mDJbEcz06ts6RRK",
+									"id": "s9cADiEQeRzdcWMBT",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sgWf_qVqI7HrPQUo7"
+									},
 									"name": "Tactics",
 									"reference": "B224,MA60",
 									"tags": [
@@ -5529,7 +6593,12 @@
 							]
 						},
 						{
-							"id": "sTPCx0TKr8PlasW4-",
+							"id": "sDVFgvv57jizzx4hU",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "ssHhRG7LH-Ma3YDnH"
+							},
 							"name": "Computer Operation",
 							"reference": "B184",
 							"tags": [
@@ -5561,13 +6630,21 @@
 					"name": "Multi-Role",
 					"children": [
 						{
-							"id": "s1H2q08ba5-XnrcTI",
+							"id": "sP22-mbfOx6pSjY8I",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sQE2t0-gMM5-4KgPb"
+							},
 							"name": "Piloting",
 							"reference": "B214",
 							"tags": [
 								"Vehicle"
 							],
-							"specialization": "@Main@",
+							"replacements": {
+								"Flying vehicle class": "@Main@"
+							},
+							"specialization": "@Flying vehicle class@",
 							"difficulty": "dx/a",
 							"defaults": [
 								{
@@ -5590,13 +6667,21 @@
 							"points": 2
 						},
 						{
-							"id": "sCaR5r1eB4wFd4aUZ",
+							"id": "s_IVmvuC1qSj76k7A",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sQE2t0-gMM5-4KgPb"
+							},
 							"name": "Piloting",
 							"reference": "B214",
 							"tags": [
 								"Vehicle"
 							],
-							"specialization": "@Secondary@",
+							"replacements": {
+								"Flying vehicle class": "@Secondary@"
+							},
+							"specialization": "@Flying vehicle class@",
 							"difficulty": "dx/a",
 							"defaults": [
 								{
@@ -5619,7 +6704,12 @@
 							"points": 2
 						},
 						{
-							"id": "sRdBuwZTveYGpXgAN",
+							"id": "sE0tNlFCvVNRImCAz",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sSxGnNPMXyZpZKoFZ"
+							},
 							"name": "Leadership",
 							"reference": "B204",
 							"tags": [
@@ -5636,7 +6726,12 @@
 							"points": 1
 						},
 						{
-							"id": "sENZpk_Pnzrbubkc5",
+							"id": "seMIvgr-EdkhRjGBV",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sn-AqOk3ggCs7fqIQ"
+							},
 							"name": "Administration",
 							"reference": "B174",
 							"tags": [
@@ -5658,7 +6753,12 @@
 							"points": 2
 						},
 						{
-							"id": "scSpvgLz02El2NIU_",
+							"id": "sHJEwjeH3SgWnrRau",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "shChZ7cQ-SIe7JKo6"
+							},
 							"name": "Navigation",
 							"reference": "B211",
 							"tags": [
@@ -5667,7 +6767,10 @@
 								"Technical",
 								"Vehicle"
 							],
-							"specialization": "@FTL@",
+							"replacements": {
+								"Environment": "@FTL@"
+							},
+							"specialization": "@Environment@",
 							"difficulty": "iq/a",
 							"defaults": [
 								{
@@ -5692,7 +6795,12 @@
 							"points": 2
 						},
 						{
-							"id": "siddv1oho7UmenvAb",
+							"id": "sC3zzZMu1jzvPAxy-",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sZZ8IZK6yPuxwffjd"
+							},
 							"name": "Navigation",
 							"reference": "B211",
 							"tags": [
@@ -5726,7 +6834,12 @@
 							"points": 2
 						},
 						{
-							"id": "sMZ6fOBuL-jkdaPG3",
+							"id": "sJN7NOlIoOOpI_oHb",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sR_M_d1acCzYenF_A"
+							},
 							"name": "Shiphandling",
 							"reference": "B220",
 							"tags": [

--- a/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Engineer.gct
+++ b/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Engineer.gct
@@ -12,7 +12,12 @@
 					"name": "Attributes",
 					"children": [
 						{
-							"id": "txeR21r0ucHme1xJl",
+							"id": "tWDlHh1jvb8AiAaAZ",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tGWOSEE6SmBHACE6Y"
+							},
 							"name": "Increased Dexterity",
 							"reference": "B15",
 							"tags": [
@@ -22,7 +27,7 @@
 							],
 							"modifiers": [
 								{
-									"id": "mQa1W0oz-RkspBWXp",
+									"id": "mHUDcIzq7Ohv4RROi",
 									"name": "No Fine Manipulators",
 									"cost": -40,
 									"disabled": true
@@ -44,7 +49,12 @@
 							}
 						},
 						{
-							"id": "t80jj6bl7ZCVh1f45",
+							"id": "tpFaHrZum8q6-8K5c",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t1w1RFcFceKR2T9_e"
+							},
 							"name": "Increased Intelligence",
 							"reference": "B15",
 							"tags": [
@@ -68,7 +78,12 @@
 							}
 						},
 						{
-							"id": "tcA2p70yNJolmngLf",
+							"id": "tpGUdwuHPMaN1WjFl",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tVt3SvdGWNchJ8z4o"
+							},
 							"name": "Increased Health",
 							"reference": "B14",
 							"tags": [
@@ -101,7 +116,12 @@
 					"name": "Class Advantages",
 					"children": [
 						{
-							"id": "tUHNkZwJ2gccXQFMD",
+							"id": "tBebN6m8VOTx8KuDM",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "tsNQlDAw4VudwHU0N"
+							},
 							"name": "Talent (Artificer)",
 							"reference": "PU3:6",
 							"tags": [
@@ -111,12 +131,45 @@
 							],
 							"modifiers": [
 								{
-									"id": "mK6w7xQLzaRtdwHHu",
+									"id": "mfIHCgAKmTdc1kLhz",
 									"name": "Alternative Cost",
 									"cost": -1,
 									"cost_type": "points",
 									"affects": "levels_only",
 									"disabled": true
+								},
+								{
+									"id": "MSDcL8oYe1jQ9UhrZ",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "m0AjRldlfu_9YtI49",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From employers.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "m6EaC1XhlmLiJYKnA",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Eliminate -1/level to a skill with success on another to improvise tools; Apply to Enigmatic Device Table rolls and other unskilled tech rolls.",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
 								}
 							],
 							"points_per_level": 10,
@@ -210,18 +263,6 @@
 									},
 									"amount": 1,
 									"per_level": true
-								},
-								{
-									"type": "reaction_bonus",
-									"situation": "From employers.",
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "conditional_modifier",
-									"situation": "Eliminate -1/level to a skill with success on another to improvise tools; Apply to Enigmatic Device Table rolls and other unskilled tech rolls.",
-									"amount": 1,
-									"per_level": true
 								}
 							],
 							"can_level": true,
@@ -231,7 +272,12 @@
 							}
 						},
 						{
-							"id": "tbRVT1eaf4B8KwmFl",
+							"id": "t_aXKtaO39ZAHHrcn",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tDPqnU1ciDF13F4kZ"
+							},
 							"name": "Versatile",
 							"reference": "B96",
 							"tags": [
@@ -259,7 +305,12 @@
 									"name": "Better Attributes",
 									"children": [
 										{
-											"id": "tRx5_2kBCP3Xh3i8o",
+											"id": "tC7tN-DOHoDT21Lj5",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tGWOSEE6SmBHACE6Y"
+											},
 											"name": "Increased Dexterity",
 											"reference": "B15",
 											"tags": [
@@ -269,7 +320,7 @@
 											],
 											"modifiers": [
 												{
-													"id": "mL3_X-YXKf77AJQVB",
+													"id": "mwBjFt8G5-_8XLkME",
 													"name": "No Fine Manipulators",
 													"cost": -40,
 													"disabled": true
@@ -291,7 +342,12 @@
 											}
 										},
 										{
-											"id": "td0huLZvQMQkjBiPN",
+											"id": "tP5H_eu3XvbRXUHbZ",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tVt3SvdGWNchJ8z4o"
+											},
 											"name": "Increased Health",
 											"reference": "B14",
 											"tags": [
@@ -315,7 +371,12 @@
 											}
 										},
 										{
-											"id": "tJkO55-BCe9NsC2bY",
+											"id": "tR29DGBIMkYRkIfG8",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t1w1RFcFceKR2T9_e"
+											},
 											"name": "Increased Intelligence",
 											"reference": "B15",
 											"tags": [
@@ -339,7 +400,12 @@
 											}
 										},
 										{
-											"id": "taWXRSQXEbM4pive1",
+											"id": "t-ERogdwN44qNKUxp",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tqha9GlDBU9P-Wg-6"
+											},
 											"name": "Increased Strength",
 											"reference": "B14",
 											"tags": [
@@ -349,14 +415,14 @@
 											],
 											"modifiers": [
 												{
-													"id": "mfjoy71EWLZXl4XHA",
+													"id": "mkOkpB6uHljJb4-V2",
 													"name": "No Fine Manipulators",
 													"reference": "B15",
 													"cost": -40,
 													"disabled": true
 												},
 												{
-													"id": "mZxs7_U0Uh3-1r4WK",
+													"id": "mmm2ykFfaLVxoI544",
 													"name": "Size",
 													"reference": "B15",
 													"cost": -10,
@@ -364,7 +430,7 @@
 													"disabled": true
 												},
 												{
-													"id": "moyUXzwatcPMFGarG",
+													"id": "mlcYNB7m1r1E0cW5S",
 													"name": "Super-Effort",
 													"reference": "SU24",
 													"cost": 300,
@@ -392,24 +458,37 @@
 									}
 								},
 								{
-									"id": "TZsDvgAJjKGVwQ1xs",
+									"id": "TctVAtvhaV87NBO61",
 									"name": "Everyman Advantages",
 									"children": [
 										{
-											"id": "tUpH0xIdFfGyVFJqC",
-											"name": "Suit Familiarity (Vacc Suit)",
+											"id": "tXvVh4T47S7lapEls",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Power Ups/Power Ups Traits.adq",
+												"id": "t3RCXCI5W-zjvxaf-"
+											},
+											"name": "Suit Familiarity (@Environment Suit skill@)",
 											"reference": "PU2:9",
 											"tags": [
 												"Perk",
 												"Physical"
 											],
+											"replacements": {
+												"Environment Suit skill": "Vacc Suit"
+											},
 											"base_points": 1,
 											"calc": {
 												"points": 1
 											}
 										},
 										{
-											"id": "tjWI9CLxvhsAJ1_ap",
+											"id": "tjDNWsHHvPzBUzFSG",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tkiJQ7nfyi9aAdGHK"
+											},
 											"name": "Serendipity",
 											"reference": "B83,P73",
 											"tags": [
@@ -418,17 +497,24 @@
 											],
 											"modifiers": [
 												{
-													"id": "mKWKTnR2Orv_LtVbT",
+													"id": "mkOPaOCvNE9bIA0kw",
 													"name": "Wishing",
 													"reference": "P73",
 													"cost": 100,
 													"disabled": true
 												},
 												{
-													"id": "mMqjektPMSBCHrEgq",
+													"id": "m2aR05AZWMb7kWn4M",
 													"name": "Wishing",
 													"reference": "P73",
 													"notes": "For others only",
+													"disabled": true
+												},
+												{
+													"id": "mgp09ZDknAF0eEnG7",
+													"name": "Game Time",
+													"reference": "P108",
+													"notes": "Uses per game week equal to its maximum possible uses per session",
 													"disabled": true
 												}
 											],
@@ -440,8 +526,13 @@
 											}
 										},
 										{
-											"id": "tuESSQd8cpEx5OF29",
-											"name": "Resistant to Acceleration",
+											"id": "ti2rf0UF47PH04q1X",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tJTfFdHM7YI5IZR7I"
+											},
+											"name": "Resistant",
 											"reference": "B81,P71,MA47",
 											"tags": [
 												"Advantage",
@@ -449,7 +540,7 @@
 											],
 											"modifiers": [
 												{
-													"id": "m5VYBSbXpp-_ZoaHC",
+													"id": "mcWuziyibbkmbN-Wt",
 													"name": "@Very Common: Metabolic Hazards, etc.@",
 													"reference": "B80",
 													"cost": 30,
@@ -457,7 +548,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mNEJOkHtjzD9G6OO0",
+													"id": "mF-2N0uWUR4N01Eej",
 													"name": "@Common: Poison, Sickness, etc.@",
 													"reference": "B81",
 													"cost": 15,
@@ -465,7 +556,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mC729xuRmOFHqPJ_7",
+													"id": "mOXXhfvXVS18D1308",
 													"name": "@Occasional: Disease, Ingested Poison, etc.@",
 													"reference": "B81",
 													"cost": 10,
@@ -473,14 +564,17 @@
 													"disabled": true
 												},
 												{
-													"id": "mc7uZY3482qRkMi_1",
+													"id": "m75SP0VkGrqk-yHBb",
 													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
 													"reference": "B81",
+													"replacements": {
+														"Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.": "Space Sickness"
+													},
 													"cost": 5,
 													"cost_type": "points"
 												},
 												{
-													"id": "mn8QMbtvYPJ099sBW",
+													"id": "m-JJh9BrpIfblNoae",
 													"name": "Immunity",
 													"reference": "B81",
 													"cost": 1,
@@ -488,152 +582,14 @@
 													"disabled": true
 												},
 												{
-													"id": "mjrY3Dl8y0tl6i1uO",
-													"name": "+8 to all HT rolls to resist",
-													"reference": "B81",
-													"cost": 0.5,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "msJociCe-76O2Fhis",
-													"name": "+3 to all HT rolls to resist",
-													"reference": "B81",
-													"cost": 0.33,
-													"cost_type": "multiplier"
-												}
-											],
-											"round_down": true,
-											"calc": {
-												"points": 1
-											}
-										},
-										{
-											"id": "tHSL31Tm07Nii5NZi",
-											"name": "Resistant to Space Sickness",
-											"reference": "B81,P71,MA47",
-											"tags": [
-												"Advantage",
-												"Physical"
-											],
-											"modifiers": [
-												{
-													"id": "mGpqmnUys5-2Q5AXI",
-													"name": "@Very Common: Metabolic Hazards, etc.@",
-													"reference": "B80",
-													"cost": 30,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m6DI1rAcXM3aRKJ32",
-													"name": "@Common: Poison, Sickness, etc.@",
-													"reference": "B81",
-													"cost": 15,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m_xYIhQzG8sEmge28",
-													"name": "@Occasional: Disease, Ingested Poison, etc.@",
-													"reference": "B81",
-													"cost": 10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mxBlkNvba3PCs4_5Y",
-													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
-													"reference": "B81",
-													"cost": 5,
-													"cost_type": "points"
-												},
-												{
-													"id": "mU9Rw-REgAgaHV8hs",
-													"name": "Immunity",
-													"reference": "B81",
-													"cost": 1,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mGVGiBZAyksZSu0uX",
-													"name": "+8 to all HT rolls to resist",
-													"reference": "B81",
-													"cost": 0.5,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mPo7aUzguENjIDBDM",
-													"name": "+3 to all HT rolls to resist",
-													"reference": "B81",
-													"cost": 0.33,
-													"cost_type": "multiplier"
-												}
-											],
-											"round_down": true,
-											"calc": {
-												"points": 1
-											}
-										},
-										{
-											"id": "tgcbS3XMvHhSGzEp3",
-											"name": "Resistant to Space Sickness",
-											"reference": "B81,P71,MA47",
-											"tags": [
-												"Advantage",
-												"Physical"
-											],
-											"modifiers": [
-												{
-													"id": "mvNS_c2J9l8o1EIIX",
-													"name": "@Very Common: Metabolic Hazards, etc.@",
-													"reference": "B80",
-													"cost": 30,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mSFQ9idT1kKt011-i",
-													"name": "@Common: Poison, Sickness, etc.@",
-													"reference": "B81",
-													"cost": 15,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mwbxrj26VaoemEH1u",
-													"name": "@Occasional: Disease, Ingested Poison, etc.@",
-													"reference": "B81",
-													"cost": 10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mLXH-7CiIcNdwqojB",
-													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
-													"reference": "B81",
-													"cost": 5,
-													"cost_type": "points"
-												},
-												{
-													"id": "mluXZoclUMTkyT_uZ",
-													"name": "Immunity",
-													"reference": "B81",
-													"cost": 1,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mJ9jNrdXIiuNyitl3",
+													"id": "mNSpymh7f99STMl2I",
 													"name": "+8 to all HT rolls to resist",
 													"reference": "B81",
 													"cost": 0.5,
 													"cost_type": "multiplier"
 												},
 												{
-													"id": "mmnQPUvB7_0GMjNK1",
+													"id": "mnlmYmOfEwymi2jQD",
 													"name": "+3 to all HT rolls to resist",
 													"reference": "B81",
 													"cost": 0.33,
@@ -647,8 +603,167 @@
 											}
 										},
 										{
-											"id": "tUPqijPHCA4qq-md7",
-											"name": "Reputation",
+											"id": "tKtgOvQcDS9R7aIFV",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tJTfFdHM7YI5IZR7I"
+											},
+											"name": "Resistant",
+											"reference": "B81,P71,MA47",
+											"tags": [
+												"Advantage",
+												"Physical"
+											],
+											"modifiers": [
+												{
+													"id": "m3NLOO7AYs5yvl2U7",
+													"name": "@Very Common: Metabolic Hazards, etc.@",
+													"reference": "B80",
+													"cost": 30,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mZFa9ClAhKDXSB-IG",
+													"name": "@Common: Poison, Sickness, etc.@",
+													"reference": "B81",
+													"cost": 15,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mhEvGnen_o2WDhTNA",
+													"name": "@Occasional: Disease, Ingested Poison, etc.@",
+													"reference": "B81",
+													"cost": 10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mjzbZtm-u78eNyQ5o",
+													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+													"reference": "B81",
+													"replacements": {
+														"Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.": "Space Sickness"
+													},
+													"cost": 5,
+													"cost_type": "points"
+												},
+												{
+													"id": "mWOIQPOpWHnzubaci",
+													"name": "Immunity",
+													"reference": "B81",
+													"cost": 1,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mjlNB-RNkQ_GVAsI2",
+													"name": "+8 to all HT rolls to resist",
+													"reference": "B81",
+													"cost": 0.5,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mWqvR8LNCN3VBvRsx",
+													"name": "+3 to all HT rolls to resist",
+													"reference": "B81",
+													"cost": 0.33,
+													"cost_type": "multiplier"
+												}
+											],
+											"round_down": true,
+											"calc": {
+												"points": 1
+											}
+										},
+										{
+											"id": "ttttfvWrLt9UVyDE0",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tJTfFdHM7YI5IZR7I"
+											},
+											"name": "Resistant",
+											"reference": "B81,P71,MA47",
+											"tags": [
+												"Advantage",
+												"Physical"
+											],
+											"modifiers": [
+												{
+													"id": "mnpTW_3ba1_vCTH3B",
+													"name": "@Very Common: Metabolic Hazards, etc.@",
+													"reference": "B80",
+													"cost": 30,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mORvdmttEMoKbYcIg",
+													"name": "@Common: Poison, Sickness, etc.@",
+													"reference": "B81",
+													"cost": 15,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mAC-6qe1VrU-AnXO1",
+													"name": "@Occasional: Disease, Ingested Poison, etc.@",
+													"reference": "B81",
+													"cost": 10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mVg1gsaIyDTdF8sEq",
+													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+													"reference": "B81",
+													"replacements": {
+														"Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.": "Acceleration"
+													},
+													"cost": 5,
+													"cost_type": "points"
+												},
+												{
+													"id": "m2--MTghWwkTeRpif",
+													"name": "Immunity",
+													"reference": "B81",
+													"cost": 1,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mW2Yo5L33qsHmCwWg",
+													"name": "+8 to all HT rolls to resist",
+													"reference": "B81",
+													"cost": 0.5,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mBbokpm3e_H8GkVYa",
+													"name": "+3 to all HT rolls to resist",
+													"reference": "B81",
+													"cost": 0.33,
+													"cost_type": "multiplier"
+												}
+											],
+											"round_down": true,
+											"calc": {
+												"points": 1
+											}
+										},
+										{
+											"id": "tcbyYwLVl-rQnq2_z",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "ta04iFiZ_Kw0s0juj"
+											},
+											"name": "Good Reputation",
 											"reference": "B26,MA54",
 											"tags": [
 												"Advantage",
@@ -656,7 +771,7 @@
 											],
 											"modifiers": [
 												{
-													"id": "m0oy5og8sghrllXl6",
+													"id": "mNES_oUXMfaylVQCn",
 													"name": "People Affected",
 													"reference": "B27",
 													"notes": "Almost everyone",
@@ -665,7 +780,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mqBhYFoYL8f4jqvy8",
+													"id": "mbpvKF2m3Yx8aq3Yy",
 													"name": "People Affected",
 													"reference": "B27",
 													"notes": "Almost everyone except @large class of people@",
@@ -674,7 +789,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mZDPvTQ8iNIozDYyH",
+													"id": "mX62QUqWGl81DZ74l",
 													"name": "People Affected",
 													"reference": "B27",
 													"notes": "@Large class of people@",
@@ -683,7 +798,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mOFsIwx5uHb9yxmx4",
+													"id": "m7sUJdjEM6fLt5P0Q",
 													"name": "People Affected",
 													"reference": "B27",
 													"notes": "@Small class of people@",
@@ -692,7 +807,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mzL47ULNAeWOgILqk",
+													"id": "mjXqYfVi7cl75xAa8",
 													"name": "Recognized all the time",
 													"reference": "B28",
 													"cost": 1,
@@ -700,7 +815,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mWtaj7Ln5v99zSFJi",
+													"id": "mUzsLBwGtSg9LKQ2l",
 													"name": "Recognized sometimes",
 													"reference": "B28",
 													"notes": "10-",
@@ -709,7 +824,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mrMvnmFTCSS2_oK5C",
+													"id": "mbkdLh472gtqK95G4",
 													"name": "Recognized occasionally",
 													"reference": "B28",
 													"notes": "7-",
@@ -719,6 +834,14 @@
 												}
 											],
 											"points_per_level": 5,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others aware of your reputation",
+													"amount": 1,
+													"per_level": true
+												}
+											],
 											"round_down": true,
 											"can_level": true,
 											"levels": 1,
@@ -727,16 +850,24 @@
 											}
 										},
 										{
-											"id": "tB3ySSMXa9RkMBNLZ",
-											"name": "Military Rank",
+											"id": "tD_u4z_B20urlmyo5",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tmp8yecgaZq9TOk59"
+											},
+											"name": "@Type@ Rank",
 											"reference": "B29",
 											"tags": [
 												"Advantage",
-												"Physical"
+												"Social"
 											],
+											"replacements": {
+												"Type": "Military"
+											},
 											"modifiers": [
 												{
-													"id": "mqcVsY5V2dxjEJJvu",
+													"id": "mHhsMZmMVWVJJZwjM",
 													"name": "Replaces Status",
 													"reference": "B29",
 													"cost": 5,
@@ -745,7 +876,7 @@
 													"disabled": true
 												},
 												{
-													"id": "makOjMFBXzNmxol14",
+													"id": "mw-oD6Ag7TtslbYTx",
 													"name": "Courtesy",
 													"reference": "B29",
 													"cost": -4,
@@ -762,16 +893,24 @@
 											}
 										},
 										{
-											"id": "tR3Ii4wR60d09WfNy",
-											"name": "Merchant Rank",
+											"id": "t9Rxtx5B0Ujt4Ci5C",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tmp8yecgaZq9TOk59"
+											},
+											"name": "@Type@ Rank",
 											"reference": "B29",
 											"tags": [
 												"Advantage",
-												"Physical"
+												"Social"
 											],
+											"replacements": {
+												"Type": "Merchant"
+											},
 											"modifiers": [
 												{
-													"id": "mp78iLsJykMHtKgY9",
+													"id": "mXOlQe-UseO8Oa9sZ",
 													"name": "Replaces Status",
 													"reference": "B29",
 													"cost": 5,
@@ -780,7 +919,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mQQtsMrQSPhwDM-DJ",
+													"id": "mmNRjAPSbhm8IFxbM",
 													"name": "Courtesy",
 													"reference": "B29",
 													"cost": -4,
@@ -797,17 +936,21 @@
 											}
 										},
 										{
-											"id": "tupXa0KNYUYnEoQBi",
+											"id": "tkPz51oOTxYiEBPQj",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t6Nq6oInwkU1qbAP1"
+											},
 											"name": "Patron",
 											"reference": "B72,P65",
-											"notes": "Ship's owner or provider",
 											"tags": [
 												"Advantage",
 												"Social"
 											],
 											"modifiers": [
 												{
-													"id": "m3e-dEDICST6l4swG",
+													"id": "mRB6PGT4hGCFKtyF-",
 													"name": "@Who: Individual with 150% of PC's starting points@",
 													"reference": "B72",
 													"cost": 10,
@@ -815,7 +958,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m6jUbYHCB-ThugiP0",
+													"id": "mKWuZsMOLE5c5s7TO",
 													"name": "@Who: Organization with assets of at least 1000 times starting wealth@",
 													"reference": "B72",
 													"cost": 10,
@@ -823,7 +966,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mnWrNmCOBh8z8IOo6",
+													"id": "mW9-iK0Iwqn-wwJ2A",
 													"name": "@Who: Individual with twice the PC's starting points@",
 													"reference": "B72",
 													"cost": 15,
@@ -831,7 +974,7 @@
 													"disabled": true
 												},
 												{
-													"id": "moVRpCyUveDhPfKq4",
+													"id": "m4ZSHSbHslmcsEcPB",
 													"name": "@Who: Organization with assets of at least 10000 times starting wealth@",
 													"reference": "B72",
 													"cost": 15,
@@ -839,7 +982,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m3RSl1vHNnfSfqHHY",
+													"id": "m1vTn2KMJpqJrrCeR",
 													"name": "@Who: An ultra-powerful individual@",
 													"reference": "B72",
 													"cost": 20,
@@ -847,7 +990,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m9s29abghJdQKvX7r",
+													"id": "m35mT5naT4kEdEM-m",
 													"name": "@Who: Organization with assets of at least 100000 times starting wealth@",
 													"reference": "B72",
 													"cost": 20,
@@ -855,7 +998,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mLdKhKgiqHPOWxnYh",
+													"id": "mLJvpp6xKTYk7fJDi",
 													"name": "@Who: Organization with assets of at least 1000000 times starting wealth@",
 													"reference": "B72",
 													"cost": 25,
@@ -863,7 +1006,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mXqNg29vn9lJ9L2yu",
+													"id": "mzMmRih5s_hgI6zEc",
 													"name": "@Who: A national government or giant multi-national organization@",
 													"reference": "B72",
 													"cost": 30,
@@ -871,7 +1014,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mGQ_qvBnNY6pWyxCj",
+													"id": "m1kMRkfR_ukUCFVNq",
 													"name": "@Who: A deity@",
 													"reference": "B72",
 													"cost": 30,
@@ -879,7 +1022,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mODgC5nf1Ek43JMWj",
+													"id": "meHeURjg4CF5Zz8qh",
 													"name": "Appears almost all the time",
 													"reference": "B36",
 													"notes": "15-",
@@ -888,7 +1031,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mB2Fe5tA1j5i-8KVW",
+													"id": "mXfclVRispGUOg00m",
 													"name": "Appears quite often",
 													"reference": "B36",
 													"notes": "12-",
@@ -897,7 +1040,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mvN4s4SGjz0frkwIX",
+													"id": "mbJ69FfQtMnEh93b6",
 													"name": "Appears fairly often",
 													"reference": "B36",
 													"notes": "9-",
@@ -906,7 +1049,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m993PWlptqDMWDvzC",
+													"id": "m2mPkcsXw9YKpMrCg",
 													"name": "Appears quite rarely",
 													"reference": "B36",
 													"notes": "6-",
@@ -915,7 +1058,7 @@
 													"disabled": true
 												},
 												{
-													"id": "ml-RjtJJC9RiIViEk",
+													"id": "mikRySutUG5Nlgkji",
 													"name": "Equipment",
 													"reference": "B73",
 													"notes": "@Equipment worth no more than average starting wealth@",
@@ -923,7 +1066,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mhHSZQJk_5ICNoZFB",
+													"id": "m4KgdYVUl2CWdhDRz",
 													"name": "Equipment",
 													"reference": "B73",
 													"notes": "@Equipment worth more than average starting wealth@",
@@ -931,14 +1074,14 @@
 													"disabled": true
 												},
 												{
-													"id": "m5n1DSFtFWD-A4Ok2",
+													"id": "mbyfZHYDPZ5XgVEmq",
 													"name": "Highly Accessible",
 													"reference": "B73",
 													"cost": 50,
 													"disabled": true
 												},
 												{
-													"id": "m47FO_zOK8sK2tkF5",
+													"id": "mhEkQrlCJY7SIS6Xd",
 													"name": "Special Abilities",
 													"reference": "B73",
 													"notes": "@Extensive social or political power@",
@@ -946,7 +1089,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mLDd3qaqQwo6Zl7_3",
+													"id": "mdlOf98OIzix3I2kw",
 													"name": "Special Abilities",
 													"reference": "B73",
 													"notes": "@Magical powers in a non-magical world, higher TL equipment, grants special powers or is supernatural@",
@@ -954,28 +1097,28 @@
 													"disabled": true
 												},
 												{
-													"id": "moBuhZsTaZXtNedvB",
+													"id": "mxiI2PABLUVC_Pa3J",
 													"name": "Minimal Interventions",
 													"reference": "B73",
 													"cost": -50,
 													"disabled": true
 												},
 												{
-													"id": "mDWiS2CVLygiK3_wq",
+													"id": "mlN1g-ldL-7b7RALG",
 													"name": "Secret",
 													"reference": "B73",
 													"cost": -50,
 													"disabled": true
 												},
 												{
-													"id": "mBgTzs4LeHM7c4Wxf",
+													"id": "mFSgraCFNhm4hPW_4",
 													"name": "Unwilling",
 													"reference": "B74",
 													"cost": -50,
 													"disabled": true
 												},
 												{
-													"id": "mUmeUWe7bTuWeqZ7h",
+													"id": "mBV4-Wz95G5WabEqI",
 													"name": "Favor",
 													"reference": "B55",
 													"cost": 0.2,
@@ -988,7 +1131,12 @@
 											}
 										},
 										{
-											"id": "tDeys3Px83czCg2hf",
+											"id": "tEOkD3zl0V8CXVYDk",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tz-USDL9B_KrrVqDi"
+											},
 											"name": "Luck",
 											"reference": "B66,P59",
 											"notes": "Usable once per hour of play",
@@ -998,14 +1146,14 @@
 											],
 											"modifiers": [
 												{
-													"id": "m48AEYfdN_lzC9lHb",
+													"id": "mv8FyaQbyMNVDV4Zu",
 													"name": "Active",
 													"reference": "B66",
 													"cost": -40,
 													"disabled": true
 												},
 												{
-													"id": "mF-V00ijnb2oibUQi",
+													"id": "mqJim9L-DBH1i-Vcr",
 													"name": "Aspected",
 													"reference": "B66",
 													"notes": "@Aspect@",
@@ -1013,17 +1161,24 @@
 													"disabled": true
 												},
 												{
-													"id": "mfjOZvS5_QvhUQ7r_",
+													"id": "mhcShyj9icq-KG10D",
 													"name": "Defensive",
 													"reference": "B66",
 													"cost": -20,
 													"disabled": true
 												},
 												{
-													"id": "maJgumoUSaYQdJiC5",
+													"id": "m2A1Jh-7xVS6kYEFA",
 													"name": "Wishing",
 													"reference": "P59",
 													"cost": 100,
+													"disabled": true
+												},
+												{
+													"id": "mhL4wTy_NK8MVZUuH",
+													"name": "Game Time",
+													"reference": "P108",
+													"notes": "Uses per game day equal to its maximum possible uses per real hour",
 													"disabled": true
 												}
 											],
@@ -1033,7 +1188,12 @@
 											}
 										},
 										{
-											"id": "toROjb3DtGxjSuXiu",
+											"id": "tF4uRA0ho3bs6ZtZx",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tMxgHfzVEy_QQtlfB"
+											},
 											"name": "Less Sleep",
 											"reference": "B65",
 											"notes": "Require 1 hour/level less sleep for a full night's rest (max 4)",
@@ -1049,7 +1209,12 @@
 											}
 										},
 										{
-											"id": "t9qrWhEiiPcsVC27H",
+											"id": "tOqGpZolWcWaSxAIN",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tw1Ad0oSMw2ATM4X1"
+											},
 											"name": "Language: @Language@",
 											"reference": "B24",
 											"tags": [
@@ -1057,9 +1222,26 @@
 												"Language",
 												"Mental"
 											],
+											"prereqs": {
+												"type": "prereq_list",
+												"all": true,
+												"prereqs": [
+													{
+														"type": "trait_prereq",
+														"has": false,
+														"name": {
+															"compare": "is",
+															"qualifier": "Language Talent"
+														},
+														"level": {
+															"compare": "at_least"
+														}
+													}
+												]
+											},
 											"modifiers": [
 												{
-													"id": "mdmQHzab8NFYYmJZb",
+													"id": "mPdmrQtUSQL_QX6W3",
 													"name": "Native",
 													"reference": "B23",
 													"cost": -6,
@@ -1067,7 +1249,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mlJjCcAv2Dwn3li9n",
+													"id": "m7WiqTiyRkJ6GBnLg",
 													"name": "Spoken",
 													"reference": "B24",
 													"notes": "None",
@@ -1075,7 +1257,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mu79wlThNRbYDDOfc",
+													"id": "mesh3QUPbeqRAirsd",
 													"name": "Spoken",
 													"reference": "B24",
 													"notes": "Broken",
@@ -1084,7 +1266,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m5mcovqji8gxacdaz",
+													"id": "m3Eicl8Au3gsKNl0k",
 													"name": "Spoken",
 													"reference": "B24",
 													"notes": "Accented",
@@ -1092,7 +1274,7 @@
 													"cost_type": "points"
 												},
 												{
-													"id": "mYyE2BweUqgjPiyUS",
+													"id": "mW-JZmjydWlKbsVjN",
 													"name": "Spoken",
 													"reference": "B24",
 													"notes": "Native",
@@ -1101,7 +1283,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mWfd0O5QJd8iJJgEg",
+													"id": "mv9WC3WExDUITMxqm",
 													"name": "Written",
 													"reference": "B24",
 													"notes": "None",
@@ -1109,7 +1291,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mOVvjA6p6VgVsjQw6",
+													"id": "mMJgjj8_41VsT7Dck",
 													"name": "Written",
 													"reference": "B24",
 													"notes": "Broken",
@@ -1118,7 +1300,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m-psXT8L740M2IfCv",
+													"id": "mboUPZAB2SsCOL34E",
 													"name": "Written",
 													"reference": "B24",
 													"notes": "Accented",
@@ -1126,7 +1308,7 @@
 													"cost_type": "points"
 												},
 												{
-													"id": "m1OXvNQPXWap4HEKp",
+													"id": "mBJqGAzNfg5v7hIdL",
 													"name": "Written",
 													"reference": "B24",
 													"notes": "Native",
@@ -1140,7 +1322,12 @@
 											}
 										},
 										{
-											"id": "tcSY4enw9c5p8W5s-",
+											"id": "tLoFlvkoouactuqqi",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "txREhxV6L1SKixwe_"
+											},
 											"name": "Improved G-tolerance",
 											"reference": "B60",
 											"tags": [
@@ -1149,7 +1336,7 @@
 											],
 											"modifiers": [
 												{
-													"id": "m9EucJEz0-qzXdil6",
+													"id": "m9YE3cTUSFO1RRVTx",
 													"name": "0.3G",
 													"reference": "B60",
 													"cost": 5,
@@ -1157,7 +1344,7 @@
 													"disabled": true
 												},
 												{
-													"id": "msYqFOwIXOFoWa6-K",
+													"id": "mJ2JGaZWesZPKmxFK",
 													"name": "0.5G",
 													"reference": "B60",
 													"cost": 10,
@@ -1165,7 +1352,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mFOt1bqSW8zpMPoci",
+													"id": "mnRb2fk9ETDBp_DKn",
 													"name": "1G",
 													"reference": "B60",
 													"cost": 15,
@@ -1173,7 +1360,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mW3tLsDah73-3eApc",
+													"id": "my316x9KGzbAdqpoW",
 													"name": "5G",
 													"reference": "B60",
 													"cost": 20,
@@ -1181,7 +1368,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mfKLHw5iaT2EMEpAO",
+													"id": "muB73lsHOQ8zGZ00h",
 													"name": "10G",
 													"reference": "B60",
 													"cost": 25,
@@ -1194,7 +1381,12 @@
 											}
 										},
 										{
-											"id": "tduAjv-wJc5tBzGd_",
+											"id": "tplb0xzo6iMiX4Pec",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t7blIRUzFpiHS_mnO"
+											},
 											"name": "Gizmo",
 											"reference": "B57,MA45",
 											"tags": [
@@ -1209,7 +1401,12 @@
 											}
 										},
 										{
-											"id": "twHfgaAwEWoXs-qgr",
+											"id": "tFBgh8WW476tCnxfc",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tHNrjEQFQBNOgwmzK"
+											},
 											"name": "G-Experience (All)",
 											"reference": "B57",
 											"tags": [
@@ -1222,7 +1419,12 @@
 											}
 										},
 										{
-											"id": "tqVuh0XrZIGC6ftJr",
+											"id": "tu11r01mDDWWA1WrR",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tu3GuYC47Sx6bnm4k"
+											},
 											"name": "G-Experience",
 											"reference": "B57",
 											"tags": [
@@ -1237,7 +1439,12 @@
 											}
 										},
 										{
-											"id": "tG2voadDJxy6XJoAL",
+											"id": "tfjALPEwhl5luLZJk",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "toTe273Ky82B6YdW5"
+											},
 											"name": "Fit",
 											"reference": "B55",
 											"notes": "Recover FP at twice the normal rate (but not FP spent for spells or psi powers)",
@@ -1258,7 +1465,12 @@
 											}
 										},
 										{
-											"id": "t9asZTdKdeDketUFm",
+											"id": "tgTbX-dKzxvKR9HGT",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tQa3EUrs4Hjt9gxK6"
+											},
 											"name": "Fearlessness",
 											"reference": "B55,MA44",
 											"tags": [
@@ -1295,7 +1507,12 @@
 											}
 										},
 										{
-											"id": "tU61-szTo2cw_3xWA",
+											"id": "tUWp9SIT2CD0gBF70",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t5j2Ox4jaIV9j0rpz"
+											},
 											"name": "Deep Sleeper",
 											"reference": "B101",
 											"tags": [
@@ -1308,7 +1525,12 @@
 											}
 										},
 										{
-											"id": "t6HsPYizI3zTHqUhq",
+											"id": "t5iGpRrfy0qPQnm5v",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tNBE3sLoyrUvAgoZ3"
+											},
 											"name": "Cybernetics",
 											"reference": "B46",
 											"tags": [
@@ -1320,7 +1542,12 @@
 											}
 										},
 										{
-											"id": "ttpnKMo6ewMO0GjhJ",
+											"id": "tUSXzuFkwbhTU1_Dw",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "toXBQ8q4Nek5lsLPF"
+											},
 											"name": "Cultural Familiarity (@Culture@)",
 											"reference": "B23",
 											"notes": "Do not suffer the normal -3 penalty for unfamiliarity",
@@ -1330,14 +1557,14 @@
 											],
 											"modifiers": [
 												{
-													"id": "mCmVZpMl7vbDJnqtu",
+													"id": "mScWPll6FoW1VOExp",
 													"name": "Alien",
 													"cost": 1,
 													"cost_type": "points",
 													"disabled": true
 												},
 												{
-													"id": "miVHN1BXrlvqVKORY",
+													"id": "mMltjDqAvTtFoZzL7",
 													"name": "Native",
 													"cost": -1,
 													"cost_type": "points",
@@ -1350,9 +1577,14 @@
 											}
 										},
 										{
-											"id": "tcc0B0iwHA8jsBW8h",
-											"name": "Alien Friend",
-											"reference": "S220",
+											"id": "tWxdprhdy7ddVlFMi",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Power Ups/Power Ups Traits.adq",
+												"id": "t3msobZZ06J7dZ8xu"
+											},
+											"name": "Talent (Born Spacer)",
+											"reference": "PU3:7",
 											"tags": [
 												"Advantage",
 												"Mental",
@@ -1360,106 +1592,60 @@
 											],
 											"modifiers": [
 												{
-													"id": "mY4p1aHfy1eEiBFqu",
-													"name": "Alternate Benefit",
-													"notes": "@Alternate Benefit@",
-													"disabled": true
-												},
-												{
-													"id": "mZ5ogwtLs-LHgCkFh",
+													"id": "mvJ2Eejii6oCdM-Uz",
 													"name": "Alternative Cost",
+													"cost": 1,
 													"cost_type": "points",
 													"affects": "levels_only",
 													"disabled": true
-												}
-											],
-											"points_per_level": 5,
-											"features": [
-												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "Anthropology"
-													},
-													"amount": 1,
-													"per_level": true
 												},
 												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "Diplomacy"
-													},
-													"amount": 1,
-													"per_level": true
-												},
-												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "Expert Skill"
-													},
-													"amount": 1,
-													"per_level": true
-												},
-												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "History"
-													},
-													"amount": 1,
-													"per_level": true
-												},
-												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "Psychology"
-													},
-													"amount": 1,
-													"per_level": true
-												},
-												{
-													"type": "reaction_bonus",
-													"situation": "Aliens",
-													"amount": 1,
-													"per_level": true
-												}
-											],
-											"can_level": true,
-											"levels": 1,
-											"calc": {
-												"points": 5
-											}
-										},
-										{
-											"id": "tsGr0tdCznDJ-uoBH",
-											"name": "Born Spacer",
-											"reference": "THSCT40",
-											"tags": [
-												"Advantage",
-												"Mental",
-												"Talent"
-											],
-											"modifiers": [
-												{
-													"id": "mp4DA88lAbPvqSwjR",
-													"name": "Alternate Benefit",
-													"notes": "@Alternate Benefit@",
-													"disabled": true
-												},
-												{
-													"id": "mYVUgviZKbijfU9qK",
-													"name": "Alternative Cost",
-													"cost_type": "points",
-													"affects": "levels_only",
-													"disabled": true
+													"id": "MWoH6iDNemFX7nRlP",
+													"name": "Benefits",
+													"children": [
+														{
+															"id": "mGmeI3o7Yc0yNIYHn",
+															"name": "Reaction Bonus",
+															"use_level_from_trait": true,
+															"features": [
+																{
+																	"type": "reaction_bonus",
+																	"situation": "From professional Spacers.",
+																	"amount": 1,
+																	"per_level": true
+																}
+															]
+														},
+														{
+															"id": "mLI8O0YH_7jMehd1B",
+															"name": "Bonus to pushing off",
+															"reference": "BX350",
+															"reference_highlight": "ST/2",
+															"use_level_from_trait": true,
+															"features": [
+																{
+																	"type": "conditional_modifier",
+																	"situation": "Bonus to ST for zero G push off",
+																	"amount": 1,
+																	"per_level": true
+																}
+															],
+															"disabled": true
+														},
+														{
+															"id": "mmRiMmtG5BA8IorOi",
+															"name": "Spacecraft Familiarity",
+															"use_level_from_trait": true,
+															"features": [
+																{
+																	"type": "conditional_modifier",
+																	"situation": "Counteracts Familiarity for spacecraft.",
+																	"amount": 1
+																}
+															],
+															"disabled": true
+														}
+													]
 												}
 											],
 											"points_per_level": 5,
@@ -1491,6 +1677,10 @@
 														"compare": "is",
 														"qualifier": "Navigation"
 													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "Space"
+													},
 													"amount": 1,
 													"per_level": true
 												},
@@ -1502,8 +1692,36 @@
 														"qualifier": "Piloting"
 													},
 													"specialization": {
-														"compare": "contains",
-														"qualifier": "Spacecraft"
+														"compare": "is",
+														"qualifier": "High-Performance Spacecraft"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Piloting"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "Low-Performance Spacecraft"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Piloting"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "Aerospace"
 													},
 													"amount": 1,
 													"per_level": true
@@ -1527,10 +1745,99 @@
 													},
 													"amount": 1,
 													"per_level": true
+												}
+											],
+											"can_level": true,
+											"levels": 1,
+											"calc": {
+												"points": 5
+											}
+										},
+										{
+											"id": "tAuKsARPHHqAT2fHT",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Power Ups/Power Ups Traits.adq",
+												"id": "tcCw979nTBoztowCU"
+											},
+											"name": "Talent (Alien Friend)",
+											"reference": "PU3:6",
+											"tags": [
+												"Advantage",
+												"Mental",
+												"Talent"
+											],
+											"points_per_level": 5,
+											"features": [
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Diplomacy"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Expert Skill"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "Xenology"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Anthropology"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "@Alien@"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "History"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "@Alien@"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Psychology"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "@Alien@"
+													},
+													"amount": 1,
+													"per_level": true
 												},
 												{
 													"type": "reaction_bonus",
-													"situation": "Professional Spacers",
+													"situation": "From aliens.",
 													"amount": 1,
 													"per_level": true
 												}
@@ -1542,7 +1849,12 @@
 											}
 										},
 										{
-											"id": "tuUWQMqTOeUtnAPsk",
+											"id": "tpg3zRUZdm9VR42DX",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tM6z7Mx6e2V4VvUR4"
+											},
 											"name": "Absolute Direction",
 											"reference": "B34",
 											"tags": [
@@ -1552,14 +1864,14 @@
 											],
 											"modifiers": [
 												{
-													"id": "mFiYbU0xpK1BJ5RN3",
+													"id": "mdBdLYjXV4CWqNWds",
 													"name": "Requires signal",
 													"reference": "B34",
 													"cost": -20,
 													"disabled": true
 												},
 												{
-													"id": "mFIfabzZev62BIC3X",
+													"id": "mTUjcHpvFOZaLliMj",
 													"name": "3D Spatial Sense",
 													"reference": "B34",
 													"cost": 5,
@@ -1682,7 +1994,12 @@
 									}
 								},
 								{
-									"id": "tob15276Wx2M6bB9n",
+									"id": "tJGhVZEAkd_sdIYGL",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tsNQlDAw4VudwHU0N"
+									},
 									"name": "Talent (Artificer)",
 									"reference": "PU3:6",
 									"tags": [
@@ -1692,12 +2009,45 @@
 									],
 									"modifiers": [
 										{
-											"id": "mKXHBgomdv6VmkgDP",
+											"id": "mGjOQSRXCFyRlXpGD",
 											"name": "Alternative Cost",
 											"cost": -1,
 											"cost_type": "points",
 											"affects": "levels_only",
 											"disabled": true
+										},
+										{
+											"id": "M9UHU2Epyw98KnC4d",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "msy73HWi0cXF_PNMo",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From employers.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "mLoHPCM6q0PlUXBxc",
+													"name": "Alternative Benefit",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Eliminate -1/level to a skill with success on another to improvise tools; Apply to Enigmatic Device Table rolls and other unskilled tech rolls.",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
 										}
 									],
 									"points_per_level": 10,
@@ -1791,18 +2141,6 @@
 											},
 											"amount": 1,
 											"per_level": true
-										},
-										{
-											"type": "reaction_bonus",
-											"situation": "From employers.",
-											"amount": 1,
-											"per_level": true
-										},
-										{
-											"type": "conditional_modifier",
-											"situation": "Eliminate -1/level to a skill with success on another to improvise tools; Apply to Enigmatic Device Table rolls and other unskilled tech rolls.",
-											"amount": 1,
-											"per_level": true
 										}
 									],
 									"can_level": true,
@@ -1812,7 +2150,12 @@
 									}
 								},
 								{
-									"id": "t6O2BH5nOyZ-_Me0_",
+									"id": "t6ZYA2Nu3YH5bKoml",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tW-eAzIKBWa5Yc9cI"
+									},
 									"name": "Eidetic Memory",
 									"reference": "B51",
 									"tags": [
@@ -1821,7 +2164,35 @@
 									],
 									"modifiers": [
 										{
-											"id": "mw3BZf9H8WrWB6o2F",
+											"id": "mpFrooHrm8hXFf85u",
+											"name": "Photographic",
+											"reference": "B51",
+											"cost": 5,
+											"cost_type": "points",
+											"disabled": true
+										}
+									],
+									"base_points": 5,
+									"calc": {
+										"points": 5
+									}
+								},
+								{
+									"id": "t43VyIlu7TXd7Gh-N",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tW-eAzIKBWa5Yc9cI"
+									},
+									"name": "Eidetic Memory",
+									"reference": "B51",
+									"tags": [
+										"Advantage",
+										"Mental"
+									],
+									"modifiers": [
+										{
+											"id": "mnIO7m9X1axagFaKx",
 											"name": "Photographic",
 											"reference": "B51",
 											"cost": 5,
@@ -1834,12 +2205,122 @@
 									}
 								},
 								{
-									"id": "tIGIwXHsGjprO2S0Q",
-									"name": "Equipment Bond (Tools)",
+									"id": "tCvyMtW_xj6a8ebpS",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tmRvpanq8GmkkkB_w"
+									},
+									"name": "Equipment Bond (@Specific Non-Combat Tool@)",
 									"reference": "PU2:9",
 									"tags": [
 										"Perk",
 										"Physical"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "equipped_equipment",
+												"name": {
+													"compare": "is",
+													"qualifier": "@Specific Non-Combat Tool@"
+												}
+											}
+										]
+									},
+									"replacements": {
+										"Specific Non-Combat Tool": "@Tools@"
+									},
+									"modifiers": [
+										{
+											"id": "MOMn30gFIQXHmoHmC",
+											"name": "Add one:",
+											"children": [
+												{
+													"id": "mKDLXYiqeMrkvBvfS",
+													"name": "As conditional modifier",
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "to all skill rolls using your @Specific Non-Combat Tool@",
+															"amount": 1
+														}
+													]
+												},
+												{
+													"id": "M_MLRTGSNjbMbqsaC",
+													"name": "Add one per skill that uses this equipment",
+													"children": [
+														{
+															"id": "mKFWMjsd_2W3LXu-w",
+															"name": "As skill bonus to @skill@",
+															"features": [
+																{
+																	"type": "skill_bonus",
+																	"selection_type": "skills_with_name",
+																	"name": {
+																		"compare": "is",
+																		"qualifier": "@skill@"
+																	},
+																	"amount": 1
+																}
+															],
+															"disabled": true
+														},
+														{
+															"id": "m0_dEqQ7eaJnuxfjG",
+															"name": "As skill bonus to @skill 2@",
+															"features": [
+																{
+																	"type": "skill_bonus",
+																	"selection_type": "skills_with_name",
+																	"name": {
+																		"compare": "is",
+																		"qualifier": "@skill 2@"
+																	},
+																	"amount": 1
+																}
+															],
+															"disabled": true
+														},
+														{
+															"id": "mZWY_XcIW0PuLQqNv",
+															"name": "As skill bonus to @skill 3@",
+															"features": [
+																{
+																	"type": "skill_bonus",
+																	"selection_type": "skills_with_name",
+																	"name": {
+																		"compare": "is",
+																		"qualifier": "@skill 3@"
+																	},
+																	"amount": 1
+																}
+															],
+															"disabled": true
+														},
+														{
+															"id": "ms8LOfYk3iAcOma-L",
+															"name": "As skill bonus to @skill 4@",
+															"features": [
+																{
+																	"type": "skill_bonus",
+																	"selection_type": "skills_with_name",
+																	"name": {
+																		"compare": "is",
+																		"qualifier": "@skill 4@"
+																	},
+																	"amount": 1
+																}
+															],
+															"disabled": true
+														}
+													]
+												}
+											]
+										}
 									],
 									"base_points": 1,
 									"calc": {
@@ -1847,7 +2328,12 @@
 									}
 								},
 								{
-									"id": "t_2Wo2o5vyKGHnGWa",
+									"id": "thdsfnJFrIcznufdi",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "ta7LDTJnsrxUu_hpV"
+									},
 									"name": "Flexibility",
 									"reference": "B56,MA44",
 									"tags": [
@@ -1894,7 +2380,12 @@
 									}
 								},
 								{
-									"id": "tGQ6XNxit6P8wfq9W",
+									"id": "tU1TpWyNsNSsZh6N6",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t8o1i_S4Xtjzg7gxR"
+									},
 									"name": "Flexibility (Double-Jointed)",
 									"reference": "B56",
 									"tags": [
@@ -1941,7 +2432,12 @@
 									}
 								},
 								{
-									"id": "tdFRTPHQu_zlHTBnW",
+									"id": "tevNHwZEr6r7rhKCW",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t5mke7RFjA2ZT0KRA"
+									},
 									"name": "Gadgeteer",
 									"reference": "B57",
 									"tags": [
@@ -1950,7 +2446,7 @@
 									],
 									"modifiers": [
 										{
-											"id": "m-Mx95Gwe_TS_P--N",
+											"id": "mAdJd_cDVIdLiSMur",
 											"name": "Quick",
 											"reference": "B57",
 											"cost": 25,
@@ -1964,7 +2460,12 @@
 									}
 								},
 								{
-									"id": "tEPk9XI3RifMyxTXE",
+									"id": "tetl4p1OuJBdJsUoI",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t7blIRUzFpiHS_mnO"
+									},
 									"name": "Gizmo",
 									"reference": "B57,MA45",
 									"tags": [
@@ -1979,7 +2480,12 @@
 									}
 								},
 								{
-									"id": "tLATeAIEN0_qAeuyh",
+									"id": "tdG73OT_nonRcwltI",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tY_8UkOBvzKIAgGGQ"
+									},
 									"name": "High Manual Dexterity",
 									"reference": "B59",
 									"tags": [
@@ -2106,22 +2612,41 @@
 									}
 								},
 								{
-									"id": "tGkvxo1b097RwXQKC",
-									"name": "Higher Purpose",
-									"reference": "B59,TT3:7",
-									"notes": "Save my ship!",
+									"id": "tO0Mn91Dau3wR0ZLf",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Template Toolkit/Template Toolkit 3 - Starship Crew/Starship Crew Traits.adq",
+										"id": "txwHeC5OlbtuDV6Mw"
+									},
+									"name": "Higher Purpose (Save my ship!)",
+									"reference": "TT3:7,B59",
 									"tags": [
 										"Advantage",
 										"Exotic",
 										"Mental"
 									],
-									"base_points": 5,
+									"points_per_level": 5,
+									"features": [
+										{
+											"type": "conditional_modifier",
+											"situation": "to success rolls made to save the starship whenever this puts you at risk",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
 									"calc": {
 										"points": 5
 									}
 								},
 								{
-									"id": "tN-Ex-eVojRcGktSQ",
+									"id": "tuOL6CD3WHUscYoE-",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tUzmcuTXRq35xQ-rB"
+									},
 									"name": "Single-Minded",
 									"reference": "B85",
 									"tags": [
@@ -2147,12 +2672,12 @@
 								}
 							],
 							"calc": {
-								"points": 312
+								"points": 317
 							}
 						}
 					],
 					"calc": {
-						"points": 347
+						"points": 352
 					}
 				},
 				{
@@ -2164,14 +2689,56 @@
 							"name": "-40 Points chosen from",
 							"children": [
 								{
-									"id": "T5rgHZ3CWOrkgyfoX",
+									"id": "TBT9LdHXoPJ90E8cG",
 									"name": "Everyman Disadvantages",
 									"tags": [
 										"Disadvantage"
 									],
 									"children": [
 										{
-											"id": "t-7bQTYpHtyf8RO2L",
+											"id": "t1GxGmbOiebHzqbzl",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tX9XXLPFBvyQSpA4k"
+											},
+											"name": "Xenophilia",
+											"reference": "B162",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"cr": 12,
+											"base_points": -10,
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "tK0N3KIEoegksuViC",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t8I0xw1Lj1_222aEN"
+											},
+											"name": "Workaholic",
+											"reference": "B162",
+											"tags": [
+												"Disadvantage",
+												"Physical"
+											],
+											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										},
+										{
+											"id": "tS3EiJbLzQBzi4R5T",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t7U0VbIzs6SqefwLr"
+											},
 											"name": "Social Stigma (Criminal Record)",
 											"reference": "B155",
 											"tags": [
@@ -2191,23 +2758,162 @@
 											}
 										},
 										{
-											"id": "tFYy_JRECFbHOKTjE",
-											"name": "Chummy",
-											"reference": "B126",
+											"id": "ti7Wt6-Tip70l61zZ",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "thSMVzJ590v7gAD8d"
+											},
+											"name": "Pacifism: Self-Defense Only",
+											"reference": "B148",
+											"notes": "You only fight to defend yourself or those in your care, using only as much force as necessary (no pre-emptive strikes allowed!). You must do your best to discourage others from starting fights.",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
+											"modifiers": [
+												{
+													"id": "m1dI_ModQRkg-esIN",
+													"name": "Species-Specific",
+													"reference": "UT32",
+													"cost": -80,
+													"disabled": true
+												}
+											],
+											"base_points": -15,
+											"calc": {
+												"points": -15
+											}
+										},
+										{
+											"id": "tENx4s4-zQKYRhkv9",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tV_f_75HmwzWOPhuu"
+											},
+											"name": "Pacifism: Reluctant Killer",
+											"reference": "B148",
+											"notes": "You are psychologically unprepared to kill people. Whenever you make a deadly attack (e.g., with a knife or a gun) against an obvious person whose face is visible to you, you are at -4 to hit and may not Aim. If you cannot see the foe’s face (due to a mask, darkness, or distance, or because you attacked from behind), the penalty is only -2, save in close combat. You have no penalty to attack a vehicle (even an occupied one), an opponent you do not believe is a person (including things with Horrific or Monstrous appearance), or a target you can’t actually see (e.g., a set of map coordinates or a blip on a radar screen). If you kill a recognizable person, the effect on you is the same as for Pacifism: Cannot Kill. You have no problem with your allies killing; you may even supply ammo, loaded weapons, and encouragement! You just can’t do the killing yourself.",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"modifiers": [
+												{
+													"id": "mdeTAIx_lbl4MpkMq",
+													"name": "Species-Specific",
+													"reference": "UT32",
+													"cost": -80,
+													"disabled": true
+												}
+											],
 											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										},
+										{
+											"id": "tMD2k_ULyAXT_hzK1",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "th9TK1Jmqg8uKe6SC"
+											},
+											"name": "Pacifism: Cannot Harm Innocents",
+											"reference": "B148",
+											"notes": "You may fight – you may even start fights – but you may only use deadly force on a foe that is attempting to do you serious harm. Capture is not “serious harm” unless you are already under penalty of death or have a Code of Honor that would require suicide if captured. You never intentionally do anything that causes, or even threatens to cause, injury to the uninvolved – particularly if they are “ordinary folks.”",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"modifiers": [
+												{
+													"id": "mvsAgf_sHm0cBmuMF",
+													"name": "Species-Specific",
+													"reference": "UT32",
+													"cost": -80,
+													"disabled": true
+												}
+											],
+											"base_points": -10,
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "tTMitQwXFcLGRYdnv",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tSiOKuvTJkqJhuRrI"
+											},
+											"name": "Lecherousness",
+											"reference": "B142",
+											"notes": "Make a self-control roll whenever you have more than the briefest contact with an appealing member of the sex you find attractive, at -5 if this person is Handsome/Beautiful, or at -10 if Very Handsome/Very Beautiful. If you fail, you must make a “pass” using whatever wiles and skills you can bring to bear.",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"cr": 12,
+											"base_points": -15,
+											"calc": {
+												"points": -15
+											}
+										},
+										{
+											"id": "t2G6yq8xlMEK3H1El",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "ttHkLI9zwzfeOIEZc"
+											},
+											"name": "Intolerance (@Class, Ethnicity, Nationality, Religion, Sex, or Species@)",
+											"reference": "B140",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"replacements": {
+												"Class, Ethnicity, Nationality, Religion, Sex, or Species": "Rival civilization or species"
+											},
+											"modifiers": [
+												{
+													"id": "mDyR2oUqQ2yImP3Bt",
+													"name": "Scope: Common",
+													"reference": "B140",
+													"cost": -5,
+													"cost_type": "points"
+												},
+												{
+													"id": "m4byHC4AVtLQW8pLW",
+													"name": "Scope: Occasional",
+													"reference": "B140",
+													"cost": -2,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m9FkeubgAxLkigJmJ",
+													"name": "Scope: Rare",
+													"reference": "B140",
+													"cost": -1,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m_aMk7unUh7dvy6pc",
+													"name": "Scope: Anyone unlike you",
+													"reference": "B140",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												}
+											],
 											"features": [
 												{
 													"type": "reaction_bonus",
-													"situation": "to others",
-													"amount": 2
-												},
-												{
-													"type": "conditional_modifier",
-													"situation": "to IQ-based skills when alone",
+													"situation": "from victims of your intolerance (may be as much as -5, at GM's discretion)",
 													"amount": -1
 												}
 											],
@@ -2216,49 +2922,383 @@
 											}
 										},
 										{
-											"id": "t-FhfeEBi2gOJWOsb",
-											"name": "Code of Honor (Mercanary's)",
-											"reference": "S221",
-											"notes": "A merc should look out for his buddies, take care of his gear, and fight for the honor of the unit. Obey the rule's of engagement. Don't poach on another unit's contract. Do the job you're hired for.",
+											"id": "tVSf9htQR2cjHxzL7",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t7pCgXTVkswkTjOZO"
+											},
+											"name": "Honesty",
+											"reference": "B138",
+											"notes": "Make a self-control roll when faced with the “need” to break unreasonable laws; if you fail, you must obey the law, whatever the consequences. If you manage to resist your urges and break the law, make a second self-control roll afterward. If you fail, you must turn yourself in to the authorities!",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
+											"cr": 12,
 											"base_points": -10,
 											"calc": {
 												"points": -10
 											}
 										},
 										{
-											"id": "thxfjFDDubo4vHXyG",
-											"name": "Code of Honor (Pirate's)",
-											"reference": "B127",
-											"notes": "Always avenge an insult, regardless of the danger; your buddy’s foe is your own; never attack a fellow crewman or buddy except in a fair, open duel.",
+											"id": "txwfMw1pcToPv3cUJ",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t5bwP6TnS4cX-zM8L"
+											},
+											"name": "Enemy (@Who@)",
+											"reference": "B135",
+											"tags": [
+												"Disadvantage",
+												"Social"
+											],
+											"modifiers": [
+												{
+													"id": "myYR6wcDZIVNtW9_B",
+													"name": "Weak Individual",
+													"reference": "B135",
+													"notes": "50% of your starting points",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "miCEc-sQ_S8pJ3IH8",
+													"name": "Equal Individual",
+													"reference": "B135",
+													"notes": "100% of your starting points",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mHlSHiEs5NnRS4w2D",
+													"name": "Powerful Individual",
+													"reference": "B135",
+													"notes": "\u003e150% of your starting points",
+													"cost": -20,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mzenZc7VYIyT_iOEV",
+													"name": "Weak Group",
+													"reference": "B135",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mX0E0WpehL9ZUAQBg",
+													"name": "Medium Group",
+													"reference": "B135",
+													"cost": -20,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mK51AqsjhWqnLNfSG",
+													"name": "Appears almost all the time",
+													"reference": "B36",
+													"notes": "15-",
+													"cost": 3,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mZTDLJe5Rw7oEgxoi",
+													"name": "Appears quite often",
+													"reference": "B36",
+													"notes": "12-",
+													"cost": 2,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mjMnqvPwP7-KsHO6u",
+													"name": "Appears fairly often",
+													"reference": "B36",
+													"notes": "9-",
+													"cost": 1,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mELbgm3pCwEAX9il3",
+													"name": "Appears quite rarely",
+													"reference": "B36",
+													"notes": "6-",
+													"cost": 0.5,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mEvNeZoCIo-vLu0kA",
+													"name": "Large/Powerful Group",
+													"reference": "B135",
+													"cost": -30,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mI8hMqKwQzFRuxsKO",
+													"name": "Utterly Formidable Group",
+													"reference": "B135",
+													"cost": -40,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mrTQw8WddoBTd4zOH",
+													"name": "Unknown",
+													"reference": "B135",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mv3pcoO46z4aYAGSL",
+													"name": "Evil Twin",
+													"reference": "B135",
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m_Z4trJ09t0_O4IQx",
+													"name": "Evil Twin",
+													"reference": "B135",
+													"notes": "More skilled or extra abilities",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m8vNn0lrqCsTqXc2E",
+													"name": "Evil Twin",
+													"reference": "B135",
+													"notes": "More skilled and extra abilities",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mQLRR88-GIW0Q2YMa",
+													"name": "Watcher",
+													"reference": "B135",
+													"cost": 0.25,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mei7Z_STUvL56o2ZL",
+													"name": "Rival",
+													"reference": "B135",
+													"cost": 0.5,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mcCEm4HdTYIpBavtf",
+													"name": "Hunter",
+													"reference": "B135",
+													"cost": 1,
+													"cost_type": "multiplier",
+													"disabled": true
+												}
+											],
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "ti6NKppttWmZN81S4",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t1HUGl4o498iCyvrw"
+											},
+											"name": "Duty (@Duty@)",
+											"reference": "B133",
+											"tags": [
+												"Disadvantage",
+												"Social"
+											],
+											"replacements": {
+												"Duty": "To ship's owner or provider"
+											},
+											"modifiers": [
+												{
+													"id": "mPIaTUEvklrMkTU2S",
+													"name": "FR: 6",
+													"cost": -2,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mrx2PtBQi6USkPiLi",
+													"name": "FR: 9",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mLYWWicZ4pJMXaB2r",
+													"name": "FR: 12",
+													"cost": -10,
+													"cost_type": "points"
+												},
+												{
+													"id": "m0Y7Du8JmH5ZTVRkF",
+													"name": "FR: 15",
+													"cost": -15,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mBMgsRtZ2zvPF_Sch",
+													"name": "Extremely Hazardous",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mpe9Ca6ZWmwRI52Mt",
+													"name": "Involuntary",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mhoh8nl1ebCN5BgB8",
+													"name": "Nonhazardous",
+													"cost": 5,
+													"cost_type": "points",
+													"disabled": true
+												}
+											],
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "t0wVNeEk9LWPm4_s6",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t1HUGl4o498iCyvrw"
+											},
+											"name": "Duty (@Duty@)",
+											"reference": "B133",
+											"tags": [
+												"Disadvantage",
+												"Social"
+											],
+											"replacements": {
+												"Duty": "To ship's owner or provider"
+											},
+											"modifiers": [
+												{
+													"id": "mP29nok_VR0XaACkc",
+													"name": "FR: 6",
+													"cost": -2,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mPWelWjlX56VFx-Q7",
+													"name": "FR: 9",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mjdDRV0a1c9-HE8o9",
+													"name": "FR: 12",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mXjTZVlOTcn7HSPvz",
+													"name": "FR: 15",
+													"cost": -15,
+													"cost_type": "points"
+												},
+												{
+													"id": "mnDES25l0Ovk8iDrw",
+													"name": "Extremely Hazardous",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mX5-AmExU1l9ov_Zx",
+													"name": "Involuntary",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mhw1TpQrvmmEvr7hO",
+													"name": "Nonhazardous",
+													"cost": 5,
+													"cost_type": "points",
+													"disabled": true
+												}
+											],
+											"calc": {
+												"points": -15
+											}
+										},
+										{
+											"id": "tZaPDZk0lTG3qlGCe",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tXFf9MSQ3FMT2psO8"
+											},
+											"name": "Demophobia (Crowds)",
+											"reference": "B149",
+											"notes": "Any group of over a dozen people sets off this fear unless they are all well known to you. The self-control roll is at -1 for over 25 people, -2 for a crowd of 100 or more, -3 for 1,000, -4 for 10,000, and so on.",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
+											"cr_adj": "action_penalty",
+											"cr": 12,
+											"base_points": -15,
+											"calc": {
+												"points": -15
+											}
+										},
+										{
+											"id": "tZORLwmQ7FiMJ6pCU",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tK4QdVZYxGAd4cqr_"
+											},
+											"name": "Compulsive Gambling",
+											"reference": "B128",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"cr": 12,
 											"base_points": -5,
 											"calc": {
 												"points": -5
 											}
 										},
 										{
-											"id": "tDAfQslhF3U9mO8l4",
-											"name": "Code of Honor (Soldier's)",
-											"reference": "B127",
-											"notes": "An officer should be tough but fair, lead from the front, and look out for his men; an enlisted man should look out for his buddies and take care of his kit. Every soldier should be willing to fight and die for the honor of his unit, service, and country; follow orders; obey the “rules of war”; treat an honorable enemy with respect (a dishonorable enemy deserves a bullet); and wear the uniform with pride.",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"base_points": -10,
-											"calc": {
-												"points": -10
-											}
-										},
-										{
-											"id": "tlWs_SbjIKidIJE8y",
+											"id": "thcFQsnCYZ68pSv2v",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tapWLsuN75Unedmwn"
+											},
 											"name": "Compulsive Carousing",
 											"reference": "B128",
 											"tags": [
@@ -2284,308 +3324,115 @@
 											}
 										},
 										{
-											"id": "tGLEHeq-SYeQ7ZS0o",
-											"name": "Compulsive Gambling",
-											"reference": "B128",
+											"id": "takWJJFsKDKGwtI6D",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "txSrmgLB0M36uR802"
+											},
+											"name": "Code of Honor (Soldier's)",
+											"reference": "B127",
+											"notes": "An officer should be tough but fair, lead from the front, and look out for his men; an enlisted man should look out for his buddies and take care of his kit. Every soldier should be willing to fight and die for the honor of his unit, service, and country; follow orders; obey the “rules of war”; treat an honorable enemy with respect (a dishonorable enemy deserves a bullet); and wear the uniform with pride.",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
-											"cr": 12,
-											"base_points": -5,
-											"calc": {
-												"points": -5
-											}
-										},
-										{
-											"id": "tyESOjL-hV7TG_OYb",
-											"name": "Duty (To ship's owner or provider)",
-											"reference": "B133",
-											"tags": [
-												"Disadvantage",
-												"Social"
-											],
-											"modifiers": [
-												{
-													"id": "mQh77AOJWuS7Zy9Ec",
-													"name": "FR: 6",
-													"cost": -2,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mpWzFL84CoV15w8FQ",
-													"name": "FR: 9",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "myTkNuUjk27rQD-j_",
-													"name": "FR: 12",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m0lcW0McfpnnoIPUx",
-													"name": "FR: 15",
-													"cost": -15,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mpuNm7PIsSi1rxtHI",
-													"name": "Extremely Hazardous",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mGyZl8T5RHGscdV4g",
-													"name": "Involuntary",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mZ1Mkz__cbw9-bTbG",
-													"name": "Nonhazardous",
-													"cost": 5,
-													"cost_type": "points",
-													"disabled": true
-												}
-											],
-											"calc": {
-												"points": 0
-											}
-										},
-										{
-											"id": "tSjiyVqpEdkSkaXOs",
-											"name": "Enemy (@Who@)",
-											"reference": "B135",
-											"tags": [
-												"Disadvantage",
-												"Social"
-											],
-											"modifiers": [
-												{
-													"id": "mBhSWZdx5csWAsXFT",
-													"name": "Weak Individual",
-													"reference": "B135",
-													"notes": "50% of your starting points",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mEXmXuAWAJl4Mqb1s",
-													"name": "Equal Individual",
-													"reference": "B135",
-													"notes": "100% of your starting points",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mPAphU6gGTN2zQSlr",
-													"name": "Powerful Individual",
-													"reference": "B135",
-													"notes": "\u003e150% of your starting points",
-													"cost": -20,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mtbU7sGkrse8ehZSN",
-													"name": "Weak Group",
-													"reference": "B135",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mfW_CO4gRcQjd0bzW",
-													"name": "Medium Group",
-													"reference": "B135",
-													"cost": -20,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mM_Xuh6nw7vGvtBMu",
-													"name": "Appears almost all the time",
-													"reference": "B36",
-													"notes": "15-",
-													"cost": 3,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mwolkmrZh97vZp8SL",
-													"name": "Appears quite often",
-													"reference": "B36",
-													"notes": "12-",
-													"cost": 2,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mFUEEWT7jKtMELcM4",
-													"name": "Appears fairly often",
-													"reference": "B36",
-													"notes": "9-",
-													"cost": 1,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "ma0pgptpWlkrr5sdo",
-													"name": "Appears quite rarely",
-													"reference": "B36",
-													"notes": "6-",
-													"cost": 0.5,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "m6_8XMGHJb5J2q4lj",
-													"name": "Large/Powerful Group",
-													"reference": "B135",
-													"cost": -30,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m5nCFopI7eoR8rwBZ",
-													"name": "Utterly Formidable Group",
-													"reference": "B135",
-													"cost": -40,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mHfvN-WlfVXABrggt",
-													"name": "Unknown",
-													"reference": "B135",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mBvOgfqd1GCZOw3uN",
-													"name": "Evil Twin",
-													"reference": "B135",
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mY5WmUpS0uRJIFfcB",
-													"name": "Evil Twin",
-													"reference": "B135",
-													"notes": "More skilled or extra abilities",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m-PAj_TL1GaqipM_F",
-													"name": "Evil Twin",
-													"reference": "B135",
-													"notes": "More skilled and extra abilities",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mvYBjVfald0meiQWw",
-													"name": "Watcher",
-													"reference": "B135",
-													"cost": 0.25,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "moRFaj5A8se432JI1",
-													"name": "Rival",
-													"reference": "B135",
-													"cost": 0.5,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mKCVIkxu3JeSgdqFf",
-													"name": "Hunter",
-													"reference": "B135",
-													"cost": 1,
-													"cost_type": "multiplier",
-													"disabled": true
-												}
-											],
-											"calc": {
-												"points": 0
-											}
-										},
-										{
-											"id": "tre30SxPBjSKvC5-S",
-											"name": "Honesty",
-											"reference": "B138",
-											"notes": "Make a self-control roll when faced with the “need” to break unreasonable laws; if you fail, you must obey the law, whatever the consequences. If you manage to resist your urges and break the law, make a second self-control roll afterward. If you fail, you must turn yourself in to the authorities!",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"cr": 12,
 											"base_points": -10,
 											"calc": {
 												"points": -10
 											}
 										},
 										{
-											"id": "tStjBAAT4zB8S0XYJ",
-											"name": "Intolerance (@Rival civilization or species@)",
-											"reference": "B140",
+											"id": "tt5X6LsrR4B0Rwrqg",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Space/Space Traits.adq",
+												"id": "teNSsqOsjstajwmxn"
+											},
+											"name": "Code of Honor (Mercenary's Code)",
+											"reference": "B127, S221",
+											"notes": "A merc should look out for his buddies, take care of his gear, and fight for the honor of the unit. Obey the rules of engagement. Don’t poach on another unit’s contract. Do the job you’re hired for.",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
-											"modifiers": [
-												{
-													"id": "mEFQit41oKvsbzoUt",
-													"name": "Scope: Common",
-													"reference": "B140",
-													"cost": -5,
-													"cost_type": "points"
-												},
-												{
-													"id": "mWmCasJMMvksLovJ9",
-													"name": "Scope: Occasional",
-													"reference": "B140",
-													"cost": -2,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mglkrMf27KkY5u1Hb",
-													"name": "Scope: Rare",
-													"reference": "B140",
-													"cost": -1,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mhjaLfh12VniHr9Cn",
-													"name": "Scope: Anyone unlike you",
-													"reference": "B140",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												}
+											"base_points": -10,
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "twgHRjtsRP4nj8Een",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tqq24I9NJrLajsURv"
+											},
+											"name": "Code of Honor (Pirate's)",
+											"reference": "B127",
+											"notes": "Always avenge an insult, regardless of the danger; your buddy’s foe is your own; never attack a fellow crewman or buddy except in a fair, open duel.",
+											"tags": [
+												"Disadvantage",
+												"Mental"
 											],
+											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										},
+										{
+											"id": "ttQ-0tBkSmVvRfXbK",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t4KGpV0KBExr-fEb2"
+											},
+											"name": "Gregarious",
+											"reference": "B126",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"base_points": -10,
 											"features": [
 												{
 													"type": "reaction_bonus",
-													"situation": "from victims of your intolerance (may be as much as -5, at GM's discretion)",
+													"situation": "to others",
+													"amount": 4
+												},
+												{
+													"type": "conditional_modifier",
+													"situation": "to IQ-based skills when alone, or only -1 if in a group of 4 or less",
+													"amount": -2
+												}
+											],
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "t5C9uOKt-QmZ_v__n",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tzBDG0xUlT_dh7FuY"
+											},
+											"name": "Chummy",
+											"reference": "B126",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"base_points": -5,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "to others",
+													"amount": 2
+												},
+												{
+													"type": "conditional_modifier",
+													"situation": "to IQ-based skills when alone",
 													"amount": -1
 												}
 											],
@@ -2594,91 +3441,12 @@
 											}
 										},
 										{
-											"id": "t3ijKz36wdr6GYXcj",
-											"name": "Lecherousness",
-											"reference": "B142",
-											"notes": "Make a self-control roll whenever you have more than the briefest contact with an appealing member of the sex you find attractive, at -5 if this person is Handsome/Beautiful, or at -10 if Very Handsome/Very Beautiful. If you fail, you must make a “pass” using whatever wiles and skills you can bring to bear.",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"cr": 12,
-											"base_points": -15,
-											"calc": {
-												"points": -15
-											}
-										},
-										{
-											"id": "tZqgBYGXFvDEoOgx_",
-											"name": "Pacifism: Reluctant Killer",
-											"reference": "B148",
-											"notes": "You are psychologically unprepared to kill people. Whenever you make a deadly attack (e.g., with a knife or a gun) against an obvious person whose face is visible to you, you are at -4 to hit and may not Aim. If you cannot see the foe’s face (due to a mask, darkness, or distance, or because you attacked from behind), the penalty is only -2, save in close combat. You have no penalty to attack a vehicle (even an occupied one), an opponent you do not believe is a person (including things with Horrific or Monstrous appearance), or a target you can’t actually see (e.g., a set of map coordinates or a blip on a radar screen). If you kill a recognizable person, the effect on you is the same as for Pacifism: Cannot Kill. You have no problem with your allies killing; you may even supply ammo, loaded weapons, and encouragement! You just can’t do the killing yourself.",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"modifiers": [
-												{
-													"id": "mzlr45l-35E5DuiJZ",
-													"name": "Species-Specific",
-													"reference": "UT32",
-													"cost": -80,
-													"disabled": true
-												}
-											],
-											"base_points": -5,
-											"calc": {
-												"points": -5
-											}
-										},
-										{
-											"id": "tc0hrzaKuPYvthcG2",
-											"name": "Pacifism: Self-Defense Only",
-											"reference": "B148",
-											"notes": "You only fight to defend yourself or those in your care, using only as much force as necessary (no pre-emptive strikes allowed!). You must do your best to discourage others from starting fights.",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"modifiers": [
-												{
-													"id": "m6fFoCRfnLAJQxCU6",
-													"name": "Species-Specific",
-													"reference": "UT32",
-													"cost": -80,
-													"disabled": true
-												}
-											],
-											"base_points": -15,
-											"calc": {
-												"points": -15
-											}
-										},
-										{
-											"id": "t71dCWcUkGMfOo97K",
-											"name": "Pacifism: Cannot Harm Innocents",
-											"reference": "B148",
-											"notes": "You may fight – you may even start fights – but you may only use deadly force on a foe that is attempting to do you serious harm. Capture is not “serious harm” unless you are already under penalty of death or have a Code of Honor that would require suicide if captured. You never intentionally do anything that causes, or even threatens to cause, injury to the uninvolved – particularly if they are “ordinary folks.”",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"modifiers": [
-												{
-													"id": "mo0_yYVmVkibfRN7B",
-													"name": "Species-Specific",
-													"reference": "UT32",
-													"cost": -80,
-													"disabled": true
-												}
-											],
-											"base_points": -10,
-											"calc": {
-												"points": -10
-											}
-										},
-										{
-											"id": "tcQoFmX3Pxn9GnMQF",
+											"id": "t-FRtYKrWha7Sa6v7",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "taFPI7E0PJwXbS5nL"
+											},
 											"name": "Agoraphobia (Open Spaces)",
 											"reference": "B150",
 											"notes": "You are uncomfortable whenever you are outside, and actually become frightened when there are no walls within 50 feet.",
@@ -2692,120 +3460,19 @@
 											"calc": {
 												"points": -10
 											}
-										},
-										{
-											"id": "t1JRDfj-e285f45R_",
-											"name": "Demophobia (Crowds)",
-											"reference": "B149",
-											"notes": "Any group of over a dozen people sets off this fear unless they are all well known to you. The self-control roll is at -1 for over 25 people, -2 for a crowd of 100 or more, -3 for 1,000, -4 for 10,000, and so on.",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"cr_adj": "action_penalty",
-											"cr": 12,
-											"base_points": -15,
-											"calc": {
-												"points": -15
-											}
-										},
-										{
-											"id": "tx0i1BCt-LIhI5U3g",
-											"name": "Duty (To ship's owner or provider)",
-											"reference": "B133",
-											"tags": [
-												"Disadvantage",
-												"Social"
-											],
-											"modifiers": [
-												{
-													"id": "mxTSAhYyjmYqtDmEY",
-													"name": "FR: 6",
-													"cost": -2,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m2mrz2fzRHoLd7TaZ",
-													"name": "FR: 9",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m0hUp4PPGUuKfWcEc",
-													"name": "FR: 12",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m4GGWaZp2i1pzSIsl",
-													"name": "FR: 15",
-													"cost": -15,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "meIKam150oMWuEAO3",
-													"name": "Extremely Hazardous",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "moP442iDcqmb86kLC",
-													"name": "Involuntary",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m1LStxGLDtSU33PZ4",
-													"name": "Nonhazardous",
-													"cost": 5,
-													"cost_type": "points",
-													"disabled": true
-												}
-											],
-											"calc": {
-												"points": 0
-											}
-										},
-										{
-											"id": "tRYEIIY7VNpsFOjcP",
-											"name": "Workaholic",
-											"reference": "B162",
-											"tags": [
-												"Disadvantage",
-												"Physical"
-											],
-											"base_points": -5,
-											"calc": {
-												"points": -5
-											}
-										},
-										{
-											"id": "tbLIWZTwDLBdEOoHh",
-											"name": "Xenophilia",
-											"reference": "B162",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"cr": 12,
-											"base_points": -10,
-											"calc": {
-												"points": -10
-											}
 										}
 									],
 									"calc": {
-										"points": -145
+										"points": -180
 									}
 								},
 								{
-									"id": "tgZ5IvrNfUcvFgx1f",
+									"id": "tN8M8rKQDbz2sdJfN",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t5Qs23yaRu3D4T_hM"
+									},
 									"name": "Attentive",
 									"reference": "B163",
 									"tags": [
@@ -2825,7 +3492,12 @@
 									}
 								},
 								{
-									"id": "tRCzG9Hve-FvFTt7r",
+									"id": "trXXTLiYQ_YFynHlq",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tnrtPQ0mWF4k75plo"
+									},
 									"name": "Bad Temper",
 									"reference": "B124",
 									"tags": [
@@ -2839,13 +3511,21 @@
 									}
 								},
 								{
-									"id": "tkq2MOhLcVllcAfbt",
-									"name": "Compulsive Tinkering",
-									"reference": "B129",
+									"id": "tLcwdvwoIf-tyYmsj",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tXJ60phAKJZOz3Pv5"
+									},
+									"name": "Compulsive Behaviour (@Activity@)",
+									"reference": "B128",
 									"tags": [
 										"Disadvantage",
 										"Mental"
 									],
+									"replacements": {
+										"Activity": "Tinkering"
+									},
 									"cr": 12,
 									"base_points": -5,
 									"calc": {
@@ -2853,7 +3533,12 @@
 									}
 								},
 								{
-									"id": "t9G9hPkBN3hynqkYQ",
+									"id": "tvK2phc4UhkdPToJW",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tPbL1_rekOzkM86wz"
+									},
 									"name": "Overconfidence",
 									"reference": "B148",
 									"notes": "You must make a self-control roll any time the GM feels you show an unreasonable degree of caution. If you fail, you must go ahead as though you were able to handle the situation!",
@@ -2880,7 +3565,12 @@
 									}
 								},
 								{
-									"id": "tdketrjWvRiJC4oAQ",
+									"id": "tsfmAIbNNZCOhHv1j",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t4gqkFmqABx7dLjkS"
+									},
 									"name": "Stubbornness",
 									"reference": "B157",
 									"tags": [
@@ -2901,17 +3591,17 @@
 								}
 							],
 							"calc": {
-								"points": -171
+								"points": -206
 							}
 						}
 					],
 					"calc": {
-						"points": -171
+						"points": -206
 					}
 				}
 			],
 			"calc": {
-				"points": 266
+				"points": 236
 			}
 		},
 		{
@@ -2924,7 +3614,12 @@
 					"name": "Multi-Role",
 					"children": [
 						{
-							"id": "t3D0PmhEhNUCW1HR8",
+							"id": "tYfXstUjW2i8rc7Fo",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t1w1RFcFceKR2T9_e"
+							},
 							"name": "Increased Intelligence",
 							"reference": "B15",
 							"tags": [
@@ -2948,7 +3643,12 @@
 							}
 						},
 						{
-							"id": "tOeTXRcwg6Q_t0MVz",
+							"id": "tET2fMNtqz1qJPbhb",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "tsNQlDAw4VudwHU0N"
+							},
 							"name": "Talent (Artificer)",
 							"reference": "PU3:6",
 							"tags": [
@@ -2958,12 +3658,45 @@
 							],
 							"modifiers": [
 								{
-									"id": "mv8gYOhk31W9FApDe",
+									"id": "mRKp-zKRcZ7bVttD1",
 									"name": "Alternative Cost",
 									"cost": -1,
 									"cost_type": "points",
 									"affects": "levels_only",
 									"disabled": true
+								},
+								{
+									"id": "M_BGYPruVnNY1RnW9",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "mXDvJ_y00jSbQChm1",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From employers.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "ml78ScPhaCV9X2_KN",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Eliminate -1/level to a skill with success on another to improvise tools; Apply to Enigmatic Device Table rolls and other unskilled tech rolls.",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
 								}
 							],
 							"points_per_level": 10,
@@ -3057,18 +3790,6 @@
 									},
 									"amount": 1,
 									"per_level": true
-								},
-								{
-									"type": "reaction_bonus",
-									"situation": "From employers.",
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "conditional_modifier",
-									"situation": "Eliminate -1/level to a skill with success on another to improvise tools; Apply to Enigmatic Device Table rolls and other unskilled tech rolls.",
-									"amount": 1,
-									"per_level": true
 								}
 							],
 							"can_level": true,
@@ -3087,7 +3808,12 @@
 					"name": "Legendary",
 					"children": [
 						{
-							"id": "tbvzrVj6C3TCFK2NS",
+							"id": "tfGo8dNeOYLdObEng",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t1w1RFcFceKR2T9_e"
+							},
 							"name": "Increased Intelligence",
 							"reference": "B15",
 							"tags": [
@@ -3111,7 +3837,12 @@
 							}
 						},
 						{
-							"id": "tBwLsZPljxeg22Q3s",
+							"id": "t3UwdHujcSvj2ZfKW",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "tsNQlDAw4VudwHU0N"
+							},
 							"name": "Talent (Artificer)",
 							"reference": "PU3:6",
 							"tags": [
@@ -3121,12 +3852,45 @@
 							],
 							"modifiers": [
 								{
-									"id": "mzSPu8rrKdY49jb8e",
+									"id": "mnhgAcGY6dSj4PWhR",
 									"name": "Alternative Cost",
 									"cost": -1,
 									"cost_type": "points",
 									"affects": "levels_only",
 									"disabled": true
+								},
+								{
+									"id": "MJg6rBHZ9KOoteHld",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "mtxV5Z-8xldAXtyng",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From employers.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "m8n3LMZZTHcY1SrwP",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Eliminate -1/level to a skill with success on another to improvise tools; Apply to Enigmatic Device Table rolls and other unskilled tech rolls.",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
 								}
 							],
 							"points_per_level": 10,
@@ -3218,18 +3982,6 @@
 										"compare": "is",
 										"qualifier": "smith"
 									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "reaction_bonus",
-									"situation": "From employers.",
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "conditional_modifier",
-									"situation": "Eliminate -1/level to a skill with success on another to improvise tools; Apply to Enigmatic Device Table rolls and other unskilled tech rolls.",
 									"amount": 1,
 									"per_level": true
 								}
@@ -3262,7 +4014,12 @@
 					"name": "Primary Skills",
 					"children": [
 						{
-							"id": "sRbpi7dH7GhMSpnVg",
+							"id": "sMUaONx1ZGg9BSpjh",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "scAysIf1hcMnIL0Ca"
+							},
 							"name": "Electrician",
 							"reference": "B189",
 							"tags": [
@@ -3286,7 +4043,12 @@
 							"points": 1
 						},
 						{
-							"id": "slOl-uGkPmCOh9rT4",
+							"id": "syFeIO3rsLDEljykd",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "smQb4vkfHH6Aaczt2"
+							},
 							"name": "Electronics Repair",
 							"reference": "B190",
 							"tags": [
@@ -3322,7 +4084,12 @@
 							"points": 1
 						},
 						{
-							"id": "sbGxCo_0NNWUbWgQx",
+							"id": "sqYeafpd61sQdI_Rz",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sfGjvfoOWTcgmqI06"
+							},
 							"name": "Electronics Repair",
 							"reference": "B190",
 							"tags": [
@@ -3358,14 +4125,22 @@
 							"points": 1
 						},
 						{
-							"id": "sqK8A8tlUYP0gNgBF",
+							"id": "s5cVa_qBIf7VGaJUg",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sjiPOdZOS0Ve3xMhr"
+							},
 							"name": "Mechanic",
 							"reference": "B207",
 							"tags": [
 								"Maintenance",
 								"Repair"
 							],
-							"specialization": "@FTL Motive System Type@",
+							"replacements": {
+								"Machine class": "@FTL Motive System Type@"
+							},
+							"specialization": "@Machine class@",
 							"difficulty": "iq/a",
 							"defaults": [
 								{
@@ -3375,7 +4150,7 @@
 								{
 									"type": "skill",
 									"name": "Engineer",
-									"specialization": "Aerospace",
+									"specialization": "@Machine class@",
 									"modifier": -4
 								},
 								{
@@ -3393,14 +4168,22 @@
 							"points": 1
 						},
 						{
-							"id": "sRPqJc7pGV2rHUn3B",
+							"id": "sOzrI3JKDKOx9FbpB",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sjiPOdZOS0Ve3xMhr"
+							},
 							"name": "Mechanic",
 							"reference": "B207",
 							"tags": [
 								"Maintenance",
 								"Repair"
 							],
-							"specialization": "@Power Plant Type@",
+							"replacements": {
+								"Machine class": "@Power Plant Type@"
+							},
+							"specialization": "@Machine class@",
 							"difficulty": "iq/a",
 							"defaults": [
 								{
@@ -3410,7 +4193,7 @@
 								{
 									"type": "skill",
 									"name": "Engineer",
-									"specialization": "Aerospace",
+									"specialization": "@Machine class@",
 									"modifier": -4
 								},
 								{
@@ -3428,14 +4211,22 @@
 							"points": 1
 						},
 						{
-							"id": "sDWCkQkePU0GAwttl",
+							"id": "sTprWb4km4tD5escJ",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sjiPOdZOS0Ve3xMhr"
+							},
 							"name": "Mechanic",
 							"reference": "B207",
 							"tags": [
 								"Maintenance",
 								"Repair"
 							],
-							"specialization": "@STL Motive System Type@",
+							"replacements": {
+								"Machine class": "@STL Motive System Type@"
+							},
+							"specialization": "@Machine class@",
 							"difficulty": "iq/a",
 							"defaults": [
 								{
@@ -3445,42 +4236,7 @@
 								{
 									"type": "skill",
 									"name": "Engineer",
-									"specialization": "Aerospace",
-									"modifier": -4
-								},
-								{
-									"type": "skill",
-									"name": "Machinist",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Mechanic",
-									"modifier": -4
-								}
-							],
-							"tech_level": "",
-							"points": 1
-						},
-						{
-							"id": "swzoB2_5-0upr6Wka",
-							"name": "Mechanic",
-							"reference": "B207",
-							"tags": [
-								"Maintenance",
-								"Repair"
-							],
-							"specialization": "@Vehicle Type@",
-							"difficulty": "iq/a",
-							"defaults": [
-								{
-									"type": "iq",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Engineer",
-									"specialization": "Aerospace",
+									"specialization": "@Machine class@",
 									"modifier": -4
 								},
 								{
@@ -3500,22 +4256,70 @@
 					]
 				},
 				{
+					"id": "s63PF0RlL5HhD04Vb",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Skills.skl",
+						"id": "ssHhRG7LH-Ma3YDnH"
+					},
+					"name": "Computer Operation",
+					"reference": "B184",
+					"tags": [
+						"Everyman",
+						"Scholarly",
+						"Technical"
+					],
+					"difficulty": "iq/e",
+					"defaults": [
+						{
+							"type": "iq",
+							"modifier": -4
+						}
+					],
+					"tech_level": "",
+					"points": 1
+				},
+				{
 					"id": "SEeOTWgYy_xOaKWg5",
 					"name": "Secondary Skills",
 					"children": [
 						{
-							"id": "s7kySeDeXrLxQhbFZ",
-							"name": "Computer Operation",
-							"reference": "B184",
+							"id": "svLFbjDAqoXpXcZFI",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sjiPOdZOS0Ve3xMhr"
+							},
+							"name": "Mechanic",
+							"reference": "B207",
 							"tags": [
-								"Everyman",
-								"Scholarly",
-								"Technical"
+								"Maintenance",
+								"Repair"
 							],
-							"difficulty": "iq/e",
+							"replacements": {
+								"Machine class": "@Vehicle Type@"
+							},
+							"specialization": "@Machine class@",
+							"difficulty": "iq/a",
 							"defaults": [
 								{
 									"type": "iq",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Engineer",
+									"specialization": "@Machine class@",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Machinist",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Mechanic",
 									"modifier": -4
 								}
 							],
@@ -3523,7 +4327,12 @@
 							"points": 1
 						},
 						{
-							"id": "sDEWxfSbHb5Iv-EbT",
+							"id": "s740lvY7OFH0lkcnD",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "srZiLf_ZzsCdOM31Y"
+							},
 							"name": "Engineer",
 							"reference": "B190",
 							"tags": [
@@ -3567,7 +4376,12 @@
 							"points": 1
 						},
 						{
-							"id": "srSqyypZDOefMzROW",
+							"id": "s5xcT_3vsmHn0VAKD",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sQ2Nj_TqMYKV7skUF"
+							},
 							"name": "Scrounging",
 							"reference": "B218",
 							"tags": [
@@ -3581,10 +4395,15 @@
 									"modifier": -4
 								}
 							],
-							"points": 1
+							"points": 2
 						},
 						{
-							"id": "src6HCJTQ2EcsZ65F",
+							"id": "skkJe-2fBNq7120wY",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "s9IHT34mK8yfSB7d_"
+							},
 							"name": "Spacer",
 							"reference": "B185",
 							"tags": [
@@ -3605,7 +4424,12 @@
 							"name": "Six of",
 							"children": [
 								{
-									"id": "sGcodnO8hkPw1qBen",
+									"id": "sy65aXpC9MqOTHh1_",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "s_sZinIoG3OeLxjPX"
+									},
 									"name": "Armoury",
 									"reference": "B178",
 									"tags": [
@@ -3613,7 +4437,7 @@
 										"Military",
 										"Repair"
 									],
-									"specialization": "@Force Shields, Heavy Weapons, or Vehicular Armor@",
+									"specialization": "Force Shields",
 									"difficulty": "iq/a",
 									"defaults": [
 										{
@@ -3623,7 +4447,7 @@
 										{
 											"type": "skill",
 											"name": "Engineer",
-											"specialization": "Battlesuits",
+											"specialization": "Force Shields",
 											"modifier": -4
 										}
 									],
@@ -3631,14 +4455,84 @@
 									"points": 1
 								},
 								{
-									"id": "sCmhETK9wr1DvtZ8b",
+									"id": "szRRjexhS7BE4aViv",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "siSKgRr1MizPF9IrU"
+									},
+									"name": "Armoury",
+									"reference": "B178",
+									"tags": [
+										"Maintenance",
+										"Military",
+										"Repair"
+									],
+									"specialization": "Heavy Weapons",
+									"difficulty": "iq/a",
+									"defaults": [
+										{
+											"type": "iq",
+											"modifier": -5
+										},
+										{
+											"type": "skill",
+											"name": "Engineer",
+											"specialization": "Heavy Weapons",
+											"modifier": -4
+										}
+									],
+									"tech_level": "",
+									"points": 1
+								},
+								{
+									"id": "sGsgjKa-EjrXw8gud",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sF2gsndOW8j3EX1CG"
+									},
+									"name": "Armoury",
+									"reference": "B178",
+									"tags": [
+										"Maintenance",
+										"Military",
+										"Repair"
+									],
+									"specialization": "Vehicular Armor",
+									"difficulty": "iq/a",
+									"defaults": [
+										{
+											"type": "iq",
+											"modifier": -5
+										},
+										{
+											"type": "skill",
+											"name": "Engineer",
+											"specialization": "Vehicular Armor",
+											"modifier": -4
+										}
+									],
+									"tech_level": "",
+									"points": 1
+								},
+								{
+									"id": "sjSW9vZLkNplKA4rG",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sYwZvSMZ9tfHES4z7"
+									},
 									"name": "Electronics Repair",
 									"reference": "B190",
 									"tags": [
 										"Maintenance",
 										"Repair"
 									],
-									"specialization": "@any other@",
+									"replacements": {
+										"Electronics type": "@any other@"
+									},
+									"specialization": "@Electronics type@",
 									"difficulty": "iq/a",
 									"defaults": [
 										{
@@ -3667,7 +4561,12 @@
 									"points": 1
 								},
 								{
-									"id": "sMIBXSC4sjh562hQk",
+									"id": "s9lYKfLYPAjIP06SX",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "s_KN_9-Qka4xk40ns"
+									},
 									"name": "Machinist",
 									"reference": "B206",
 									"tags": [
@@ -3690,14 +4589,22 @@
 									"points": 1
 								},
 								{
-									"id": "sDcAI0LVtDtKEQ0HI",
+									"id": "sZkIsFI90jsEowxSZ",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sjiPOdZOS0Ve3xMhr"
+									},
 									"name": "Mechanic",
 									"reference": "B207",
 									"tags": [
 										"Maintenance",
 										"Repair"
 									],
-									"specialization": "@Any other@",
+									"replacements": {
+										"Machine class": "@any other@"
+									},
+									"specialization": "@Machine class@",
 									"difficulty": "iq/a",
 									"defaults": [
 										{
@@ -3707,7 +4614,7 @@
 										{
 											"type": "skill",
 											"name": "Engineer",
-											"specialization": "Aerospace",
+											"specialization": "@Machine class@",
 											"modifier": -4
 										},
 										{
@@ -3725,7 +4632,12 @@
 									"points": 1
 								},
 								{
-									"id": "sBQeZrXIn9TBXWqDm",
+									"id": "sWoPFU7wUdXNnHwby",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sUOQKAH8IaMhpxk1o"
+									},
 									"name": "Electronics Operation",
 									"reference": "B189",
 									"tags": [
@@ -3760,7 +4672,12 @@
 									"points": 1
 								},
 								{
-									"id": "spywLJ7d4nCLOc8O2",
+									"id": "shuiyPbQLguhP6xJ1",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "s_QPsaG-MtZBFWSgN"
+									},
 									"name": "Engineer",
 									"reference": "B190",
 									"tags": [
@@ -3768,7 +4685,10 @@
 										"Engineer",
 										"Invention"
 									],
-									"specialization": "@any other@",
+									"replacements": {
+										"Field of expertise": "@any other@"
+									},
+									"specialization": "@Field of expertise@",
 									"difficulty": "iq/h",
 									"defaults": [
 										{
@@ -3812,7 +4732,12 @@
 					"name": "Background Skills",
 					"children": [
 						{
-							"id": "s2me35JDSEHVTEcMR",
+							"id": "s1yRvCFvdk5uinoIU",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sBY-R7Xmf64T7WzZ4"
+							},
 							"name": "Computer Programming",
 							"reference": "B184",
 							"tags": [
@@ -3821,10 +4746,15 @@
 							],
 							"difficulty": "iq/h",
 							"tech_level": "",
-							"points": 1
+							"points": 2
 						},
 						{
-							"id": "so2sLY3gMrLgrKRVR",
+							"id": "sc-R91aXRDaTwJKuR",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "s7kVwKFERTuMYO3O8"
+							},
 							"name": "Free Fall",
 							"reference": "B197",
 							"tags": [
@@ -3841,10 +4771,15 @@
 									"modifier": -5
 								}
 							],
-							"points": 1
+							"points": 2
 						},
 						{
-							"id": "slKuFjNIKofd2P9XE",
+							"id": "sEpD86J85Jh1CYm4K",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sAmDzPjf0rKZ6I5G1"
+							},
 							"name": "Vacc Suit",
 							"reference": "B192",
 							"tags": [
@@ -3873,10 +4808,15 @@
 								}
 							],
 							"tech_level": "",
-							"points": 1
+							"points": 2
 						},
 						{
-							"id": "sIzPh4u6HbvG-7ggs",
+							"id": "sPpTr81Cw_jPd4P1v",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sGgBbCTe-AwY1nu3W"
+							},
 							"name": "Mathematics",
 							"reference": "B207",
 							"tags": [
@@ -3908,11 +4848,16 @@
 							"name": "10 Points chosen from",
 							"children": [
 								{
-									"id": "S6e-s5PHeo0gQD1JY",
+									"id": "SXfshaFyGNSnhj1rO",
 									"name": "Everyman Skills",
 									"children": [
 										{
-											"id": "ssJvJwd93kvSNBMpY",
+											"id": "sAZH0DEzWfVJ50biq",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sTXDrqXH0sT2NSD_b"
+											},
 											"name": "Area Knowledge",
 											"reference": "B176",
 											"notes": "Location of the capitals of interplanetary states and the homeworlds of major races; general awareness of all major races; knowledge of individuals of Status 8; general understanding of relations between interplanetary states",
@@ -3933,7 +4878,12 @@
 											"points": 1
 										},
 										{
-											"id": "sjpzkADmWSPUWiknV",
+											"id": "s_td01pEyWm2Jv_JN",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "s-Ckyxw5PmHIvbZab"
+											},
 											"name": "Area Knowledge",
 											"reference": "B176",
 											"notes": "Location of major planets; familiarity with all known races (but not necessarily expertise); knowledge of people of Status 7+; general understanding of the economic and political situation",
@@ -3941,13 +4891,9 @@
 												"Everyman",
 												"Knowledge"
 											],
-											"specialization": "@Interplanetary State@; Lived there",
+											"specialization": "@Interplanetary State@",
 											"difficulty": "iq/e",
 											"defaults": [
-												{
-													"type": "iq",
-													"modifier": -4
-												},
 												{
 													"type": "skill",
 													"name": "Geography",
@@ -3958,7 +4904,12 @@
 											"points": 1
 										},
 										{
-											"id": "s4eL7dYM0bTjjsvcy",
+											"id": "syPLprNnGJ4dFFjZF",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "strhX4LEdd46xgmIS"
+											},
 											"name": "Area Knowledge",
 											"reference": "B176",
 											"notes": "Location of its major cities and important sites; awareness of its major customs, ethnic groups, and languages (but not necessarily expertise); names of folk of Status 7+; and a general understanding of the economic and political situation",
@@ -3966,13 +4917,9 @@
 												"Everyman",
 												"Knowledge"
 											],
-											"specialization": "@Planet@; Lived there",
+											"specialization": "@Planet@",
 											"difficulty": "iq/e",
 											"defaults": [
-												{
-													"type": "iq",
-													"modifier": -4
-												},
 												{
 													"type": "skill",
 													"name": "Geography",
@@ -3983,7 +4930,12 @@
 											"points": 1
 										},
 										{
-											"id": "sq8RMYPZYGIytv0QF",
+											"id": "sL4vbLjP-o2LEfiQl",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sBJgeWUs81Ifhob4Z"
+											},
 											"name": "Beam Weapons",
 											"reference": "B179",
 											"tags": [
@@ -4014,7 +4966,12 @@
 											"points": 1
 										},
 										{
-											"id": "spFUxkFWLZphw29OL",
+											"id": "sUPKpBm7Y8bj3bJ8J",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sOp4wssAMtUc1ukJI"
+											},
 											"name": "Body Language",
 											"reference": "B181",
 											"tags": [
@@ -4038,10 +4995,14 @@
 											"points": 1
 										},
 										{
-											"id": "slajc2ezbf1fRHiOk",
+											"id": "sMT8fJ8SS_0p4r02G",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sziMa9_9xTvR2iiqx"
+											},
 											"name": "Body Sense",
 											"reference": "B181",
-											"notes": "For settings with matter transmission",
 											"tags": [
 												"Athletic"
 											],
@@ -4060,7 +5021,12 @@
 											"points": 1
 										},
 										{
-											"id": "sEwB9KoOi1Brup1jP",
+											"id": "sHhjR0o5BtnqNEYEh",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "shtDdl5thrvKSnJHf"
+											},
 											"name": "Brawling",
 											"reference": "B182,MA55",
 											"tags": [
@@ -4088,7 +5054,12 @@
 											"points": 1
 										},
 										{
-											"id": "s4i_0CDH_JKhjrN6_",
+											"id": "s7dcqNxHVAHGJ2-X0",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "si-upI7A5RgdO0cjC"
+											},
 											"name": "Carousing",
 											"reference": "B183",
 											"tags": [
@@ -4106,7 +5077,12 @@
 											"points": 1
 										},
 										{
-											"id": "s90ZEBZQgm3qmWanr",
+											"id": "s670lROKHb_lNJcch",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sWFtA7Gvclq4aL-Yb"
+											},
 											"name": "Current Affairs",
 											"reference": "B186",
 											"tags": [
@@ -4137,7 +5113,12 @@
 											"points": 1
 										},
 										{
-											"id": "sdsXJzUpfOtiF70VL",
+											"id": "sGM7kaEQLDri9cF2g",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "s9mV--3lpIfXO7N6Z"
+											},
 											"name": "First Aid",
 											"reference": "B195",
 											"tags": [
@@ -4168,7 +5149,12 @@
 											"points": 1
 										},
 										{
-											"id": "s-KDzg7JAPA5TILcr",
+											"id": "sX-x00pOM-NqCPIiK",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sWB9ypJAq43MF3O0n"
+											},
 											"name": "Gambling",
 											"reference": "B197",
 											"tags": [
@@ -4192,7 +5178,12 @@
 											"points": 1
 										},
 										{
-											"id": "sElpKU59gMkwxg9p3",
+											"id": "sxB-PN6ndIqT1CE3p",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "syfSQ9N8yETqQbhFK"
+											},
 											"name": "Games",
 											"reference": "B197,MA57",
 											"tags": [
@@ -4209,7 +5200,12 @@
 											"points": 1
 										},
 										{
-											"id": "sJ_vhCaAyAcNwWIbN",
+											"id": "sYaHJNjUWb4_D88Da",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sGz21GskAlJXL1hYP"
+											},
 											"name": "Gesture",
 											"reference": "B198",
 											"tags": [
@@ -4225,7 +5221,12 @@
 											"points": 1
 										},
 										{
-											"id": "slh0iM8zAXyMgOmcn",
+											"id": "s1n1OpFM0wsuqN5Dc",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sT5htbz4-Mr0PFCk7"
+											},
 											"name": "Guns",
 											"reference": "B198",
 											"tags": [
@@ -4250,7 +5251,12 @@
 											"points": 1
 										},
 										{
-											"id": "sfCs5l9VLHuOep6Ul",
+											"id": "s4XeUIjfrmwBfwn6Y",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sOtPessbzkRjGaQPR"
+											},
 											"name": "Hobby Skill",
 											"reference": "B200,MA57",
 											"tags": [
@@ -4267,7 +5273,12 @@
 											"points": 1
 										},
 										{
-											"id": "snpsO4BWEJds0_BkA",
+											"id": "sKY6pn-C6c37PucPA",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sDLf4crz0sGRjVDFi"
+											},
 											"name": "Hobby Skill",
 											"reference": "B200,MA57",
 											"tags": [
@@ -4284,7 +5295,12 @@
 											"points": 1
 										},
 										{
-											"id": "sJ7O-Nyu6ejY0gU9d",
+											"id": "sUbqqh2mAOyXh3FfU",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sfZrwMVUibhbtdssl"
+											},
 											"name": "Housekeeping",
 											"reference": "B200",
 											"tags": [
@@ -4300,7 +5316,12 @@
 											"points": 1
 										},
 										{
-											"id": "sxmcVgz_Bpa3PQ3iZ",
+											"id": "sIEmlL7dIA--fYfNt",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sdl9m7gHE7hlMX0AX"
+											},
 											"name": "Lip Reading",
 											"reference": "B205",
 											"tags": [
@@ -4316,7 +5337,12 @@
 											"points": 1
 										},
 										{
-											"id": "sw2jSxKDmChWtgaMH",
+											"id": "sVbvvYGtGsSuY1eXg",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sx1CDkGBR830IZrmz"
+											},
 											"name": "Professional Skill",
 											"reference": "B215",
 											"tags": [
@@ -4333,7 +5359,12 @@
 											"points": 1
 										},
 										{
-											"id": "sVN0I-BQs1I--Qys1",
+											"id": "s1ZsrT6VV8y8yvkuN",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sBec-o4Z7gPpbg2f9"
+											},
 											"name": "Professional Skill",
 											"reference": "B215",
 											"tags": [
@@ -4350,7 +5381,12 @@
 											"points": 1
 										},
 										{
-											"id": "skcl6KjD4ECH_dBxE",
+											"id": "sUdK6t2SBkwlyuX8e",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "smxkcngH5Kz54yeN3"
+											},
 											"name": "Sports",
 											"reference": "B222,MA59",
 											"tags": [
@@ -4367,7 +5403,12 @@
 											"points": 1
 										},
 										{
-											"id": "sAjVp_3GbKeEbXHCS",
+											"id": "s3Ys4sq-e_upbi4A6",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "smTUpMWJGqPeT1KER"
+											},
 											"name": "Streetwise",
 											"reference": "B223",
 											"tags": [
@@ -4402,7 +5443,12 @@
 					"name": "Multi-Role",
 					"children": [
 						{
-							"id": "s09zLW_nb23GyvuXa",
+							"id": "sXu34ak3PrYuBAuUF",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "scAysIf1hcMnIL0Ca"
+							},
 							"name": "Electrician",
 							"reference": "B189",
 							"tags": [
@@ -4426,7 +5472,12 @@
 							"points": 1
 						},
 						{
-							"id": "sLD-kG2mzy9dratvb",
+							"id": "sHJ5hxXnVvhNDUNUA",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "smQb4vkfHH6Aaczt2"
+							},
 							"name": "Electronics Repair",
 							"reference": "B190",
 							"tags": [
@@ -4462,11 +5513,17 @@
 							"points": 1
 						},
 						{
-							"id": "sn-mBcay2jO_O59yv",
-							"name": "Electronics Operation",
-							"reference": "B189",
+							"id": "so5HRwMGO0zBj50Kt",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sfGjvfoOWTcgmqI06"
+							},
+							"name": "Electronics Repair",
+							"reference": "B190",
 							"tags": [
-								"Technical"
+								"Maintenance",
+								"Repair"
 							],
 							"specialization": "Sensors",
 							"difficulty": "iq/a",
@@ -4477,19 +5534,19 @@
 								},
 								{
 									"type": "skill",
-									"name": "Electronics Repair",
+									"name": "Electronics Operation",
 									"specialization": "Sensors",
-									"modifier": -5
+									"modifier": -3
 								},
 								{
 									"type": "skill",
 									"name": "Engineer",
 									"specialization": "Electronics",
-									"modifier": -5
+									"modifier": -3
 								},
 								{
 									"type": "skill",
-									"name": "Electronics Operation",
+									"name": "Electronics Repair",
 									"modifier": -4
 								}
 							],
@@ -4497,14 +5554,22 @@
 							"points": 1
 						},
 						{
-							"id": "s1pUbh85YRWoCzysU",
+							"id": "sZ_3slPFEuzDtl2HO",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sjiPOdZOS0Ve3xMhr"
+							},
 							"name": "Mechanic",
 							"reference": "B207",
 							"tags": [
 								"Maintenance",
 								"Repair"
 							],
-							"specialization": "@FTL Motive System Type@",
+							"replacements": {
+								"Machine class": "@FTL Motive System Type@"
+							},
+							"specialization": "@Machine class@",
 							"difficulty": "iq/a",
 							"defaults": [
 								{
@@ -4514,7 +5579,7 @@
 								{
 									"type": "skill",
 									"name": "Engineer",
-									"specialization": "Aerospace",
+									"specialization": "@Machine class@",
 									"modifier": -4
 								},
 								{
@@ -4532,14 +5597,22 @@
 							"points": 1
 						},
 						{
-							"id": "s-JhLBRLy_S8q_bfD",
+							"id": "so_j9sCg6D7LVny29",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sjiPOdZOS0Ve3xMhr"
+							},
 							"name": "Mechanic",
 							"reference": "B207",
 							"tags": [
 								"Maintenance",
 								"Repair"
 							],
-							"specialization": "@Power Plant Type@",
+							"replacements": {
+								"Machine class": "@Power Plant Type@"
+							},
+							"specialization": "@Machine class@",
 							"difficulty": "iq/a",
 							"defaults": [
 								{
@@ -4549,7 +5622,7 @@
 								{
 									"type": "skill",
 									"name": "Engineer",
-									"specialization": "Aerospace",
+									"specialization": "@Machine class@",
 									"modifier": -4
 								},
 								{
@@ -4567,14 +5640,22 @@
 							"points": 1
 						},
 						{
-							"id": "sH1ZpDfE08ng0_WfR",
+							"id": "s0xahiXGuBKhszaLy",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sjiPOdZOS0Ve3xMhr"
+							},
 							"name": "Mechanic",
 							"reference": "B207",
 							"tags": [
 								"Maintenance",
 								"Repair"
 							],
-							"specialization": "@STL Motive System Type@",
+							"replacements": {
+								"Machine class": "@STL Motive System Type@"
+							},
+							"specialization": "@Machine class@",
 							"difficulty": "iq/a",
 							"defaults": [
 								{
@@ -4584,7 +5665,7 @@
 								{
 									"type": "skill",
 									"name": "Engineer",
-									"specialization": "Aerospace",
+									"specialization": "@Machine class@",
 									"modifier": -4
 								},
 								{
@@ -4602,14 +5683,22 @@
 							"points": 1
 						},
 						{
-							"id": "s5cmNEKEabhIsmtV2",
+							"id": "sVg7gDzxV-7c-feOo",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sjiPOdZOS0Ve3xMhr"
+							},
 							"name": "Mechanic",
 							"reference": "B207",
 							"tags": [
 								"Maintenance",
 								"Repair"
 							],
-							"specialization": "@Vehicle Type@",
+							"replacements": {
+								"Machine class": "@Vehicle Type@"
+							},
+							"specialization": "@Machine class@",
 							"difficulty": "iq/a",
 							"defaults": [
 								{
@@ -4619,7 +5708,7 @@
 								{
 									"type": "skill",
 									"name": "Engineer",
-									"specialization": "Aerospace",
+									"specialization": "@Machine class@",
 									"modifier": -4
 								},
 								{
@@ -4641,7 +5730,12 @@
 							"name": "Three of",
 							"children": [
 								{
-									"id": "syD2iD8f-GxVXpgfS",
+									"id": "sIH_0fqxBCftLk7MG",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "s_sZinIoG3OeLxjPX"
+									},
 									"name": "Armoury",
 									"reference": "B178",
 									"tags": [
@@ -4649,7 +5743,7 @@
 										"Military",
 										"Repair"
 									],
-									"specialization": "@Force Shields, Heavy Weapons, or Vehicular Armor@",
+									"specialization": "Force Shields",
 									"difficulty": "iq/a",
 									"defaults": [
 										{
@@ -4659,7 +5753,7 @@
 										{
 											"type": "skill",
 											"name": "Engineer",
-											"specialization": "Battlesuits",
+											"specialization": "Force Shields",
 											"modifier": -4
 										}
 									],
@@ -4667,13 +5761,20 @@
 									"points": 1
 								},
 								{
-									"id": "sSHSdxNiIuhpVPYmQ",
-									"name": "Electronics Operation",
-									"reference": "B189",
+									"id": "sbK7wOC1YE5Bvzk1b",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "siSKgRr1MizPF9IrU"
+									},
+									"name": "Armoury",
+									"reference": "B178",
 									"tags": [
-										"Technical"
+										"Maintenance",
+										"Military",
+										"Repair"
 									],
-									"specialization": "@Any other@",
+									"specialization": "Heavy Weapons",
 									"difficulty": "iq/a",
 									"defaults": [
 										{
@@ -4682,27 +5783,52 @@
 										},
 										{
 											"type": "skill",
-											"name": "Electronics Operation",
-											"modifier": -4
-										},
-										{
-											"type": "skill",
-											"name": "Electronics Repair",
-											"specialization": "Communications",
-											"modifier": -5
-										},
-										{
-											"type": "skill",
 											"name": "Engineer",
-											"specialization": "Electronics",
-											"modifier": -5
+											"specialization": "Heavy Weapons",
+											"modifier": -4
 										}
 									],
 									"tech_level": "",
 									"points": 1
 								},
 								{
-									"id": "sxJv4le11ibP1IXJ0",
+									"id": "szNXyvElWoOS9i08p",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sF2gsndOW8j3EX1CG"
+									},
+									"name": "Armoury",
+									"reference": "B178",
+									"tags": [
+										"Maintenance",
+										"Military",
+										"Repair"
+									],
+									"specialization": "Vehicular Armor",
+									"difficulty": "iq/a",
+									"defaults": [
+										{
+											"type": "iq",
+											"modifier": -5
+										},
+										{
+											"type": "skill",
+											"name": "Engineer",
+											"specialization": "Vehicular Armor",
+											"modifier": -4
+										}
+									],
+									"tech_level": "",
+									"points": 1
+								},
+								{
+									"id": "sDrDmP0DrRIpjNDSC",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "s_KN_9-Qka4xk40ns"
+									},
 									"name": "Machinist",
 									"reference": "B206",
 									"tags": [
@@ -4725,14 +5851,22 @@
 									"points": 1
 								},
 								{
-									"id": "shQguo_aGgEorHLmW",
+									"id": "s7xTPIKwmr7IqMao7",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sjiPOdZOS0Ve3xMhr"
+									},
 									"name": "Mechanic",
 									"reference": "B207",
 									"tags": [
 										"Maintenance",
 										"Repair"
 									],
-									"specialization": "@Any other@",
+									"replacements": {
+										"Machine class": "@any other@"
+									},
+									"specialization": "@Machine class@",
 									"difficulty": "iq/a",
 									"defaults": [
 										{
@@ -4742,7 +5876,7 @@
 										{
 											"type": "skill",
 											"name": "Engineer",
-											"specialization": "Aerospace",
+											"specialization": "@Machine class@",
 											"modifier": -4
 										},
 										{
@@ -4754,6 +5888,46 @@
 											"type": "skill",
 											"name": "Mechanic",
 											"modifier": -4
+										}
+									],
+									"tech_level": "",
+									"points": 1
+								},
+								{
+									"id": "sE9hA2nNqffKmf9Q5",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sUOQKAH8IaMhpxk1o"
+									},
+									"name": "Electronics Operation",
+									"reference": "B189",
+									"tags": [
+										"Technical"
+									],
+									"specialization": "@Electronics type@",
+									"difficulty": "iq/a",
+									"defaults": [
+										{
+											"type": "iq",
+											"modifier": -5
+										},
+										{
+											"type": "skill",
+											"name": "Electronics Operation",
+											"modifier": -4
+										},
+										{
+											"type": "skill",
+											"name": "Electronics Repair",
+											"specialization": "Communications",
+											"modifier": -5
+										},
+										{
+											"type": "skill",
+											"name": "Engineer",
+											"specialization": "Electronics",
+											"modifier": -5
 										}
 									],
 									"tech_level": "",

--- a/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Helmsman.gct
+++ b/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Helmsman.gct
@@ -12,7 +12,12 @@
 					"name": "Attributes",
 					"children": [
 						{
-							"id": "trzoKOCdZi0gSLL-Q",
+							"id": "tfZF5djWo-uEh4KOp",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tGWOSEE6SmBHACE6Y"
+							},
 							"name": "Increased Dexterity",
 							"reference": "B15",
 							"tags": [
@@ -22,7 +27,7 @@
 							],
 							"modifiers": [
 								{
-									"id": "mNCeFCdP3kzqaI6ZH",
+									"id": "mBfRBFzcNKpzePhYU",
 									"name": "No Fine Manipulators",
 									"cost": -40,
 									"disabled": true
@@ -44,7 +49,12 @@
 							}
 						},
 						{
-							"id": "tXZWbB7HQC4T4oIwb",
+							"id": "tijLGC8UhdUyJ7u0x",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t1w1RFcFceKR2T9_e"
+							},
 							"name": "Increased Intelligence",
 							"reference": "B15",
 							"tags": [
@@ -68,7 +78,12 @@
 							}
 						},
 						{
-							"id": "tUYzC_plAFFxeH81z",
+							"id": "tKdSL-GMyUn0RoEaD",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tVt3SvdGWNchJ8z4o"
+							},
 							"name": "Increased Health",
 							"reference": "B14",
 							"tags": [
@@ -101,7 +116,12 @@
 					"name": "Secondary Characteristics",
 					"children": [
 						{
-							"id": "t2xaaCSGbiWpPT9e6",
+							"id": "tF6TRoLpi8mPARnsC",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tWF1J_Z0Ziz-qJ6pn"
+							},
 							"name": "Increased Basic Speed",
 							"reference": "B17",
 							"tags": [
@@ -134,7 +154,12 @@
 					"name": "Class Advantages",
 					"children": [
 						{
-							"id": "tdSSF5MCVNaoFlIic",
+							"id": "tfVH7R7kotScQ31DF",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tM6z7Mx6e2V4VvUR4"
+							},
 							"name": "Absolute Direction",
 							"reference": "B34",
 							"tags": [
@@ -144,14 +169,14 @@
 							],
 							"modifiers": [
 								{
-									"id": "mdGCyuvBIb9GCiXfk",
+									"id": "mC7mIyoxMkVe7wMtU",
 									"name": "Requires signal",
 									"reference": "B34",
 									"cost": -20,
 									"disabled": true
 								},
 								{
-									"id": "m85SnEJIlxASH30Wn",
+									"id": "msp1wBvq0gaW2WrZ5",
 									"name": "3D Spatial Sense",
 									"reference": "B34",
 									"cost": 5,
@@ -269,13 +294,53 @@
 							}
 						},
 						{
-							"id": "tROUll3tXfo_rkpRn",
+							"id": "tLUvnHoQOp2vQrz-C",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "tHPdAVdz9JvulCeVU"
+							},
 							"name": "Talent (Hot Pilot)",
 							"reference": "PU3:11",
 							"tags": [
 								"Advantage",
 								"Mental",
 								"Talent"
+							],
+							"modifiers": [
+								{
+									"id": "MjmefO5v3RZ3a8pph",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "m5Vtiqm7MZUaU_JBN",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From other Pilots.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "mFeBif7o_Eipz2yIm",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Reduce penalties for unfamiliar systems of vehicles you have Piloting skill for",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
+								}
 							],
 							"points_per_level": 5,
 							"features": [
@@ -326,18 +391,6 @@
 									},
 									"amount": 1,
 									"per_level": true
-								},
-								{
-									"type": "reaction_bonus",
-									"situation": "From other Pilots.",
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "conditional_modifier",
-									"situation": "Reduce penalties for unfamiliar systems of vehicles you have Piloting skill for",
-									"amount": 1,
-									"per_level": true
 								}
 							],
 							"can_level": true,
@@ -347,8 +400,13 @@
 							}
 						},
 						{
-							"id": "te72jMPoJXsu3Bxtq",
-							"name": "Resistant to Acceleration",
+							"id": "tbQ2smZRTXG89K7VA",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tJTfFdHM7YI5IZR7I"
+							},
+							"name": "Resistant",
 							"reference": "B81,P71,MA47",
 							"tags": [
 								"Advantage",
@@ -356,7 +414,7 @@
 							],
 							"modifiers": [
 								{
-									"id": "m91VDxQKlBeV7-oiD",
+									"id": "mvAgbSc03rw6a8lHy",
 									"name": "@Very Common: Metabolic Hazards, etc.@",
 									"reference": "B80",
 									"cost": 30,
@@ -364,7 +422,7 @@
 									"disabled": true
 								},
 								{
-									"id": "mY9J5-dSS_iTSIiNH",
+									"id": "mwA864TSLFMfQWwl8",
 									"name": "@Common: Poison, Sickness, etc.@",
 									"reference": "B81",
 									"cost": 15,
@@ -372,7 +430,7 @@
 									"disabled": true
 								},
 								{
-									"id": "mjqZLiAw9OCgdNASG",
+									"id": "mNo4dx3aFQn3K6bTE",
 									"name": "@Occasional: Disease, Ingested Poison, etc.@",
 									"reference": "B81",
 									"cost": 10,
@@ -380,13 +438,17 @@
 									"disabled": true
 								},
 								{
-									"id": "mm19QuNGwzBC5zRxt",
+									"id": "mNNIrjc5Hw4zKcnWQ",
+									"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
 									"reference": "B81",
+									"replacements": {
+										"Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.": "Acceleration"
+									},
 									"cost": 5,
 									"cost_type": "points"
 								},
 								{
-									"id": "mDKvbVPG_7FuC0qgy",
+									"id": "mAmBgbBtsOlFmzhAB",
 									"name": "Immunity",
 									"reference": "B81",
 									"cost": 1,
@@ -394,14 +456,14 @@
 									"disabled": true
 								},
 								{
-									"id": "m1IjyrjfbMxG-q7RI",
+									"id": "mu_OeFSI62IXFOfF8",
 									"name": "+8 to all HT rolls to resist",
 									"reference": "B81",
 									"cost": 0.5,
 									"cost_type": "multiplier"
 								},
 								{
-									"id": "mnlJ8tkIQqqbuVko4",
+									"id": "mgEt8sXE4VkefJpwC",
 									"name": "+3 to all HT rolls to resist",
 									"reference": "B81",
 									"cost": 0.33,
@@ -423,7 +485,12 @@
 									"name": "Better attributes",
 									"children": [
 										{
-											"id": "th6cz5dIjIimoE9-M",
+											"id": "t3G6N2RhgLcs0ShJQ",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tGWOSEE6SmBHACE6Y"
+											},
 											"name": "Increased Dexterity",
 											"reference": "B15",
 											"tags": [
@@ -433,7 +500,7 @@
 											],
 											"modifiers": [
 												{
-													"id": "mzm2SMkUPnQzxQJBF",
+													"id": "mzTpj6WWfJiizoxyd",
 													"name": "No Fine Manipulators",
 													"cost": -40,
 													"disabled": true
@@ -455,7 +522,12 @@
 											}
 										},
 										{
-											"id": "t81KuUApMhiFW1Mxy",
+											"id": "td482SyzeRxBybv5I",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tVt3SvdGWNchJ8z4o"
+											},
 											"name": "Increased Health",
 											"reference": "B14",
 											"tags": [
@@ -479,7 +551,12 @@
 											}
 										},
 										{
-											"id": "tGbt4r4_uoRfdNL3Q",
+											"id": "tqP6DVa_pJ6bdzXCD",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t1w1RFcFceKR2T9_e"
+											},
 											"name": "Increased Intelligence",
 											"reference": "B15",
 											"tags": [
@@ -503,7 +580,12 @@
 											}
 										},
 										{
-											"id": "t7F_8mA1Ah784NOhh",
+											"id": "tAu1PtkqAAdSrLKEf",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tqha9GlDBU9P-Wg-6"
+											},
 											"name": "Increased Strength",
 											"reference": "B14",
 											"tags": [
@@ -513,14 +595,14 @@
 											],
 											"modifiers": [
 												{
-													"id": "meUg_vko1Wc8uY-qc",
+													"id": "mloCZ7SL-pDvzkV5D",
 													"name": "No Fine Manipulators",
 													"reference": "B15",
 													"cost": -40,
 													"disabled": true
 												},
 												{
-													"id": "mFdbqB4P_OhiLn47w",
+													"id": "mPBOSL6JYCrPyUSVL",
 													"name": "Size",
 													"reference": "B15",
 													"cost": -10,
@@ -528,7 +610,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mKSztSwN07ysTpvCA",
+													"id": "mEa40vdaKMdQJ5-wB",
 													"name": "Super-Effort",
 													"reference": "SU24",
 													"cost": 300,
@@ -556,24 +638,37 @@
 									}
 								},
 								{
-									"id": "TEP32XQme5eUc4m9l",
+									"id": "TpbK9MS5WWAsen_Gn",
 									"name": "Everyman Advantages",
 									"children": [
 										{
-											"id": "teZ3ffABtuGLFoVa9",
-											"name": "Suit Familiarity (Vacc Suit)",
+											"id": "tdUTrOvd61FSHN7UU",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Power Ups/Power Ups Traits.adq",
+												"id": "t3RCXCI5W-zjvxaf-"
+											},
+											"name": "Suit Familiarity (@Environment Suit skill@)",
 											"reference": "PU2:9",
 											"tags": [
 												"Perk",
 												"Physical"
 											],
+											"replacements": {
+												"Environment Suit skill": "Vacc Suit"
+											},
 											"base_points": 1,
 											"calc": {
 												"points": 1
 											}
 										},
 										{
-											"id": "tBsGrvztHbkaIIK7w",
+											"id": "tYr7F6MU_c25PJISI",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tkiJQ7nfyi9aAdGHK"
+											},
 											"name": "Serendipity",
 											"reference": "B83,P73",
 											"tags": [
@@ -582,17 +677,24 @@
 											],
 											"modifiers": [
 												{
-													"id": "mP91mevpEkggbyrGf",
+													"id": "mAibi6nfbuCimpCSK",
 													"name": "Wishing",
 													"reference": "P73",
 													"cost": 100,
 													"disabled": true
 												},
 												{
-													"id": "m9T2bq_JHQHWdZ0Fl",
+													"id": "m_RuX6pZhKYiNwrek",
 													"name": "Wishing",
 													"reference": "P73",
 													"notes": "For others only",
+													"disabled": true
+												},
+												{
+													"id": "mguaT56IDUjfUUqOd",
+													"name": "Game Time",
+													"reference": "P108",
+													"notes": "Uses per game week equal to its maximum possible uses per session",
 													"disabled": true
 												}
 											],
@@ -604,8 +706,13 @@
 											}
 										},
 										{
-											"id": "t7FF08eKfa5BwgkzS",
-											"name": "Resistant to Acceleration",
+											"id": "t7TMgg5qAlolHPazq",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tJTfFdHM7YI5IZR7I"
+											},
+											"name": "Resistant",
 											"reference": "B81,P71,MA47",
 											"tags": [
 												"Advantage",
@@ -613,7 +720,7 @@
 											],
 											"modifiers": [
 												{
-													"id": "mXkG100G2AO1VNppS",
+													"id": "mjbZ_vV61ah-mTwAG",
 													"name": "@Very Common: Metabolic Hazards, etc.@",
 													"reference": "B80",
 													"cost": 30,
@@ -621,7 +728,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mAxMBI3nOFgK0EjHh",
+													"id": "mQoUzihz0w4NDzjyG",
 													"name": "@Common: Poison, Sickness, etc.@",
 													"reference": "B81",
 													"cost": 15,
@@ -629,7 +736,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mD5bV_rdF1-b1H3sr",
+													"id": "mTesOT-b9Zpw8UyKB",
 													"name": "@Occasional: Disease, Ingested Poison, etc.@",
 													"reference": "B81",
 													"cost": 10,
@@ -637,13 +744,17 @@
 													"disabled": true
 												},
 												{
-													"id": "mqEQLYyp-ryHZmTg8",
+													"id": "mu0Al5fknVzusG-uF",
+													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
 													"reference": "B81",
+													"replacements": {
+														"Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.": "Space Sickness"
+													},
 													"cost": 5,
 													"cost_type": "points"
 												},
 												{
-													"id": "mefAcq51E0UE05adB",
+													"id": "mwKIfUyadaXoBnmF_",
 													"name": "Immunity",
 													"reference": "B81",
 													"cost": 1,
@@ -651,150 +762,14 @@
 													"disabled": true
 												},
 												{
-													"id": "mZmq--UkXz1TIl5l3",
-													"name": "+8 to all HT rolls to resist",
-													"reference": "B81",
-													"cost": 0.5,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mgd__X8RShmFPKHHV",
-													"name": "+3 to all HT rolls to resist",
-													"reference": "B81",
-													"cost": 0.33,
-													"cost_type": "multiplier"
-												}
-											],
-											"round_down": true,
-											"calc": {
-												"points": 1
-											}
-										},
-										{
-											"id": "tnu0J_6bNiyosLjRM",
-											"name": "Resistant to Space Sickness",
-											"reference": "B81,P71,MA47",
-											"tags": [
-												"Advantage",
-												"Physical"
-											],
-											"modifiers": [
-												{
-													"id": "m8oh0v4NhFSHnSCcW",
-													"name": "@Very Common: Metabolic Hazards, etc.@",
-													"reference": "B80",
-													"cost": 30,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mD15AEHi7QEluZnk8",
-													"name": "@Common: Poison, Sickness, etc.@",
-													"reference": "B81",
-													"cost": 15,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mb_XF7M9--7fvh9fo",
-													"name": "@Occasional: Disease, Ingested Poison, etc.@",
-													"reference": "B81",
-													"cost": 10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m5CHHbYyQp3s2--Gg",
-													"reference": "B81",
-													"cost": 5,
-													"cost_type": "points"
-												},
-												{
-													"id": "mig8ZPZgquDUXnjg9",
-													"name": "Immunity",
-													"reference": "B81",
-													"cost": 1,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mrOd8P2jEzNXYLYat",
-													"name": "+8 to all HT rolls to resist",
-													"reference": "B81",
-													"cost": 0.5,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mb06_8gMuShXu3BM1",
-													"name": "+3 to all HT rolls to resist",
-													"reference": "B81",
-													"cost": 0.33,
-													"cost_type": "multiplier"
-												}
-											],
-											"round_down": true,
-											"calc": {
-												"points": 1
-											}
-										},
-										{
-											"id": "t0N-jRpJqFrQ7iLAM",
-											"name": "Resistant to Space Sickness",
-											"reference": "B81,P71,MA47",
-											"tags": [
-												"Advantage",
-												"Physical"
-											],
-											"modifiers": [
-												{
-													"id": "m6eN98Z4X4cpjpYPR",
-													"name": "@Very Common: Metabolic Hazards, etc.@",
-													"reference": "B80",
-													"cost": 30,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m_Mz9OwuTj5WWucs-",
-													"name": "@Common: Poison, Sickness, etc.@",
-													"reference": "B81",
-													"cost": 15,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mnDdBDdesz43B82BQ",
-													"name": "@Occasional: Disease, Ingested Poison, etc.@",
-													"reference": "B81",
-													"cost": 10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mF0vWNAtWkgZizp6s",
-													"reference": "B81",
-													"cost": 5,
-													"cost_type": "points"
-												},
-												{
-													"id": "mWXPWNe6YA7WYVxeW",
-													"name": "Immunity",
-													"reference": "B81",
-													"cost": 1,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mLRn-YwrVqlfdxgXi",
+													"id": "mmWEFLFpYM8v13bKX",
 													"name": "+8 to all HT rolls to resist",
 													"reference": "B81",
 													"cost": 0.5,
 													"cost_type": "multiplier"
 												},
 												{
-													"id": "mHyC4nHVZMDGuBWbe",
+													"id": "mflezF9-sjdqKDNoU",
 													"name": "+3 to all HT rolls to resist",
 													"reference": "B81",
 													"cost": 0.33,
@@ -808,8 +783,167 @@
 											}
 										},
 										{
-											"id": "tDmAjgIwedVbiq23r",
-											"name": "Reputation",
+											"id": "t1E7v6vzLq5nq8pDy",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tJTfFdHM7YI5IZR7I"
+											},
+											"name": "Resistant",
+											"reference": "B81,P71,MA47",
+											"tags": [
+												"Advantage",
+												"Physical"
+											],
+											"modifiers": [
+												{
+													"id": "mGw8zURF2HAyIXdYO",
+													"name": "@Very Common: Metabolic Hazards, etc.@",
+													"reference": "B80",
+													"cost": 30,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m859BcjQpUVRQcHky",
+													"name": "@Common: Poison, Sickness, etc.@",
+													"reference": "B81",
+													"cost": 15,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mXyPU6DA9macwJQQn",
+													"name": "@Occasional: Disease, Ingested Poison, etc.@",
+													"reference": "B81",
+													"cost": 10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mCbMFRCuSTQ60B4vT",
+													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+													"reference": "B81",
+													"replacements": {
+														"Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.": "Space Sickness"
+													},
+													"cost": 5,
+													"cost_type": "points"
+												},
+												{
+													"id": "m3MThPpNvSYRSpt-H",
+													"name": "Immunity",
+													"reference": "B81",
+													"cost": 1,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mx8nJ0vj4eyo_JgfR",
+													"name": "+8 to all HT rolls to resist",
+													"reference": "B81",
+													"cost": 0.5,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mu3oHvrMrBKyupkVC",
+													"name": "+3 to all HT rolls to resist",
+													"reference": "B81",
+													"cost": 0.33,
+													"cost_type": "multiplier"
+												}
+											],
+											"round_down": true,
+											"calc": {
+												"points": 1
+											}
+										},
+										{
+											"id": "td8QdLTr_pnFsZiZ7",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tJTfFdHM7YI5IZR7I"
+											},
+											"name": "Resistant",
+											"reference": "B81,P71,MA47",
+											"tags": [
+												"Advantage",
+												"Physical"
+											],
+											"modifiers": [
+												{
+													"id": "mR_KUxX3WS39v4XND",
+													"name": "@Very Common: Metabolic Hazards, etc.@",
+													"reference": "B80",
+													"cost": 30,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mrcrktPeRflNNyVlX",
+													"name": "@Common: Poison, Sickness, etc.@",
+													"reference": "B81",
+													"cost": 15,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mq3FV4JgvLoqg_xRN",
+													"name": "@Occasional: Disease, Ingested Poison, etc.@",
+													"reference": "B81",
+													"cost": 10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "ms7kEffwCgoFSgKih",
+													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+													"reference": "B81",
+													"replacements": {
+														"Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.": "Acceleration"
+													},
+													"cost": 5,
+													"cost_type": "points"
+												},
+												{
+													"id": "mNQHFclBjWQ5iE8L9",
+													"name": "Immunity",
+													"reference": "B81",
+													"cost": 1,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mJv-OIIts0PRta_MJ",
+													"name": "+8 to all HT rolls to resist",
+													"reference": "B81",
+													"cost": 0.5,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mHDvO0Apgq6pqG9yS",
+													"name": "+3 to all HT rolls to resist",
+													"reference": "B81",
+													"cost": 0.33,
+													"cost_type": "multiplier"
+												}
+											],
+											"round_down": true,
+											"calc": {
+												"points": 1
+											}
+										},
+										{
+											"id": "tBu6nCP0GfiTfYTLd",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "ta04iFiZ_Kw0s0juj"
+											},
+											"name": "Good Reputation",
 											"reference": "B26,MA54",
 											"tags": [
 												"Advantage",
@@ -817,7 +951,7 @@
 											],
 											"modifiers": [
 												{
-													"id": "mFVB6qSACk4Nl17dU",
+													"id": "mMCxdQJCIpAS5rjWk",
 													"name": "People Affected",
 													"reference": "B27",
 													"notes": "Almost everyone",
@@ -826,7 +960,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mJ1iQyith83E5V96X",
+													"id": "muekgF3Hm6CTmxiGR",
 													"name": "People Affected",
 													"reference": "B27",
 													"notes": "Almost everyone except @large class of people@",
@@ -835,7 +969,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mgd5ksmX07YE-Qn53",
+													"id": "mH40-pyENg2DS9kZg",
 													"name": "People Affected",
 													"reference": "B27",
 													"notes": "@Large class of people@",
@@ -844,7 +978,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mDThOsd6y4dYgaRl5",
+													"id": "mrcPmlb3C2xBJ0u9m",
 													"name": "People Affected",
 													"reference": "B27",
 													"notes": "@Small class of people@",
@@ -853,7 +987,7 @@
 													"disabled": true
 												},
 												{
-													"id": "ms-9pJ9mCqGHheHFU",
+													"id": "mmJvMtr1AHRS1IRPc",
 													"name": "Recognized all the time",
 													"reference": "B28",
 													"cost": 1,
@@ -861,7 +995,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mDO9ERDpsFSZd5lL_",
+													"id": "mG4ehbL4WE5Y89LGr",
 													"name": "Recognized sometimes",
 													"reference": "B28",
 													"notes": "10-",
@@ -870,7 +1004,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m7qbhYCJD88KNhqbm",
+													"id": "mqiOdz2ybRvNVmhfr",
 													"name": "Recognized occasionally",
 													"reference": "B28",
 													"notes": "7-",
@@ -880,6 +1014,14 @@
 												}
 											],
 											"points_per_level": 5,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others aware of your reputation",
+													"amount": 1,
+													"per_level": true
+												}
+											],
 											"round_down": true,
 											"can_level": true,
 											"levels": 1,
@@ -888,16 +1030,24 @@
 											}
 										},
 										{
-											"id": "tm1DRArnEiC87oo3k",
-											"name": "Military Rank",
+											"id": "tZ1qsVI9Z0zI14sww",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tmp8yecgaZq9TOk59"
+											},
+											"name": "@Type@ Rank",
 											"reference": "B29",
 											"tags": [
 												"Advantage",
-												"Physical"
+												"Social"
 											],
+											"replacements": {
+												"Type": "Military"
+											},
 											"modifiers": [
 												{
-													"id": "m-rg_V9-VVPkZzM3X",
+													"id": "mvN7vmjXqTB46xLJw",
 													"name": "Replaces Status",
 													"reference": "B29",
 													"cost": 5,
@@ -906,7 +1056,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mCQ9mX__ujMuYQv4E",
+													"id": "mqBd5woFwLQdlNPkL",
 													"name": "Courtesy",
 													"reference": "B29",
 													"cost": -4,
@@ -923,16 +1073,24 @@
 											}
 										},
 										{
-											"id": "t2dpektV9LgknQPbT",
-											"name": "Merchant Rank",
+											"id": "ti3vgtXquCRYVf4fP",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tmp8yecgaZq9TOk59"
+											},
+											"name": "@Type@ Rank",
 											"reference": "B29",
 											"tags": [
 												"Advantage",
-												"Physical"
+												"Social"
 											],
+											"replacements": {
+												"Type": "Merchant"
+											},
 											"modifiers": [
 												{
-													"id": "mhLGuB6NJN_jyI8wL",
+													"id": "mWJJNfZiSVAchSxIV",
 													"name": "Replaces Status",
 													"reference": "B29",
 													"cost": 5,
@@ -941,7 +1099,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mSdk2b4Xal33MGApM",
+													"id": "mL35BSbWgTK6x3Xl_",
 													"name": "Courtesy",
 													"reference": "B29",
 													"cost": -4,
@@ -958,17 +1116,21 @@
 											}
 										},
 										{
-											"id": "trBzUSh5xf_Xwrzn9",
+											"id": "tQPjYgHyK3yucS2DB",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t6Nq6oInwkU1qbAP1"
+											},
 											"name": "Patron",
 											"reference": "B72,P65",
-											"notes": "Ship's owner or provider",
 											"tags": [
 												"Advantage",
 												"Social"
 											],
 											"modifiers": [
 												{
-													"id": "mw1RHNX0Z9SUMEkO1",
+													"id": "mDFkHxQEloD6NMBaH",
 													"name": "@Who: Individual with 150% of PC's starting points@",
 													"reference": "B72",
 													"cost": 10,
@@ -976,7 +1138,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m1FQ9Z4lUnJSnrFLn",
+													"id": "mXFjf0w9mV7UdQVud",
 													"name": "@Who: Organization with assets of at least 1000 times starting wealth@",
 													"reference": "B72",
 													"cost": 10,
@@ -984,7 +1146,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mO-lsyVw88-fEXYBg",
+													"id": "m8LlfoTiyCIPyOh5Z",
 													"name": "@Who: Individual with twice the PC's starting points@",
 													"reference": "B72",
 													"cost": 15,
@@ -992,7 +1154,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mJTtOqELWTDcYOfJc",
+													"id": "m8ZPrVEDCqbacIrN5",
 													"name": "@Who: Organization with assets of at least 10000 times starting wealth@",
 													"reference": "B72",
 													"cost": 15,
@@ -1000,7 +1162,7 @@
 													"disabled": true
 												},
 												{
-													"id": "ml8-sNH2T1i4L8c1W",
+													"id": "mNQ_bwQo_ZrTCIT-y",
 													"name": "@Who: An ultra-powerful individual@",
 													"reference": "B72",
 													"cost": 20,
@@ -1008,7 +1170,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mdIBtRxyt7di32J6q",
+													"id": "muN4rK9EefLgsTAR_",
 													"name": "@Who: Organization with assets of at least 100000 times starting wealth@",
 													"reference": "B72",
 													"cost": 20,
@@ -1016,7 +1178,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mY03dkd2qpdrdN95s",
+													"id": "mQtR3CnQrsfcfPliV",
 													"name": "@Who: Organization with assets of at least 1000000 times starting wealth@",
 													"reference": "B72",
 													"cost": 25,
@@ -1024,7 +1186,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mmqVgVadT1vhGxsFV",
+													"id": "m_KizwVMEMF-w_8Nf",
 													"name": "@Who: A national government or giant multi-national organization@",
 													"reference": "B72",
 													"cost": 30,
@@ -1032,7 +1194,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m27ELJcFI1EcTXliT",
+													"id": "mZ8KsqeYHp_Ax4i9q",
 													"name": "@Who: A deity@",
 													"reference": "B72",
 													"cost": 30,
@@ -1040,7 +1202,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mL1NRIS8vDsdR9tfy",
+													"id": "mx2zD4q_dvkYkc7AP",
 													"name": "Appears almost all the time",
 													"reference": "B36",
 													"notes": "15-",
@@ -1049,7 +1211,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mOkeHMjUomMAJ8dlc",
+													"id": "mlDII9ShUzzlIFFlr",
 													"name": "Appears quite often",
 													"reference": "B36",
 													"notes": "12-",
@@ -1058,7 +1220,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mdSb1IND_7Z8Gbbxo",
+													"id": "myp_DFu-5r87f1Vk6",
 													"name": "Appears fairly often",
 													"reference": "B36",
 													"notes": "9-",
@@ -1067,7 +1229,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mSNaw_EWCPCx-2lv6",
+													"id": "mskFSna9i9P3YFKke",
 													"name": "Appears quite rarely",
 													"reference": "B36",
 													"notes": "6-",
@@ -1076,7 +1238,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mvx3UgjRvp0d8mPO3",
+													"id": "m_mDCdSCMI7IXf9hZ",
 													"name": "Equipment",
 													"reference": "B73",
 													"notes": "@Equipment worth no more than average starting wealth@",
@@ -1084,7 +1246,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mjDDQztX9Vn0ZD0z8",
+													"id": "m2s60aHikI7Gzx_D3",
 													"name": "Equipment",
 													"reference": "B73",
 													"notes": "@Equipment worth more than average starting wealth@",
@@ -1092,14 +1254,14 @@
 													"disabled": true
 												},
 												{
-													"id": "mTu73XqJ4l6bWdZTr",
+													"id": "mf3RaOR-nuqARi-pw",
 													"name": "Highly Accessible",
 													"reference": "B73",
 													"cost": 50,
 													"disabled": true
 												},
 												{
-													"id": "mP4nwEU9zE9uFvxhF",
+													"id": "mB7OZreV7qKjf_7cY",
 													"name": "Special Abilities",
 													"reference": "B73",
 													"notes": "@Extensive social or political power@",
@@ -1107,7 +1269,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m5x--UMq_HV9ISeYa",
+													"id": "mbmGvmFS2h7ulJa6J",
 													"name": "Special Abilities",
 													"reference": "B73",
 													"notes": "@Magical powers in a non-magical world, higher TL equipment, grants special powers or is supernatural@",
@@ -1115,28 +1277,28 @@
 													"disabled": true
 												},
 												{
-													"id": "moXzqiSVwwmvzNdMP",
+													"id": "mLga0BEz9usTW6_tt",
 													"name": "Minimal Interventions",
 													"reference": "B73",
 													"cost": -50,
 													"disabled": true
 												},
 												{
-													"id": "mn5fDr_eD0rYhcJYg",
+													"id": "meIblrp2EqCvRsH2q",
 													"name": "Secret",
 													"reference": "B73",
 													"cost": -50,
 													"disabled": true
 												},
 												{
-													"id": "m9PHQVftutwv2l8-6",
+													"id": "mHvkbzxaXvELv_aoD",
 													"name": "Unwilling",
 													"reference": "B74",
 													"cost": -50,
 													"disabled": true
 												},
 												{
-													"id": "mF2sTIntoPRXLuVt1",
+													"id": "m0tZX699E0dyZsrr1",
 													"name": "Favor",
 													"reference": "B55",
 													"cost": 0.2,
@@ -1149,7 +1311,12 @@
 											}
 										},
 										{
-											"id": "t_mX_b4Mx2vl4bJT9",
+											"id": "tKgo_PCry20NFvmgq",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tz-USDL9B_KrrVqDi"
+											},
 											"name": "Luck",
 											"reference": "B66,P59",
 											"notes": "Usable once per hour of play",
@@ -1159,14 +1326,14 @@
 											],
 											"modifiers": [
 												{
-													"id": "mvy3yg_4IHNDx00Y2",
+													"id": "mnwK0ouJ2pzxt_XQH",
 													"name": "Active",
 													"reference": "B66",
 													"cost": -40,
 													"disabled": true
 												},
 												{
-													"id": "mtWvn_7_l7Geyld3J",
+													"id": "mX1S-NviLv63Z5aCG",
 													"name": "Aspected",
 													"reference": "B66",
 													"notes": "@Aspect@",
@@ -1174,17 +1341,24 @@
 													"disabled": true
 												},
 												{
-													"id": "mFib4-Wl7p6ZCYxtO",
+													"id": "m0cmv10soEk-E4D-S",
 													"name": "Defensive",
 													"reference": "B66",
 													"cost": -20,
 													"disabled": true
 												},
 												{
-													"id": "m9nR6ZpyRyu4dHMHE",
+													"id": "m1eOxzqZ3chEjoc1N",
 													"name": "Wishing",
 													"reference": "P59",
 													"cost": 100,
+													"disabled": true
+												},
+												{
+													"id": "mj8pX1wpXPpWcLAq4",
+													"name": "Game Time",
+													"reference": "P108",
+													"notes": "Uses per game day equal to its maximum possible uses per real hour",
 													"disabled": true
 												}
 											],
@@ -1194,7 +1368,12 @@
 											}
 										},
 										{
-											"id": "tgM9D03uj5gCpeHKW",
+											"id": "ttyO9DbgRRXDG7vB_",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tMxgHfzVEy_QQtlfB"
+											},
 											"name": "Less Sleep",
 											"reference": "B65",
 											"notes": "Require 1 hour/level less sleep for a full night's rest (max 4)",
@@ -1210,7 +1389,12 @@
 											}
 										},
 										{
-											"id": "t8u6CsXIcvnQPMHnn",
+											"id": "tzkwC7wsZr7i0Q6Hd",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tw1Ad0oSMw2ATM4X1"
+											},
 											"name": "Language: @Language@",
 											"reference": "B24",
 											"tags": [
@@ -1218,9 +1402,26 @@
 												"Language",
 												"Mental"
 											],
+											"prereqs": {
+												"type": "prereq_list",
+												"all": true,
+												"prereqs": [
+													{
+														"type": "trait_prereq",
+														"has": false,
+														"name": {
+															"compare": "is",
+															"qualifier": "Language Talent"
+														},
+														"level": {
+															"compare": "at_least"
+														}
+													}
+												]
+											},
 											"modifiers": [
 												{
-													"id": "mVVIRNgu2jOJyAKoj",
+													"id": "m76PkMxieIuQtFVgr",
 													"name": "Native",
 													"reference": "B23",
 													"cost": -6,
@@ -1228,7 +1429,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m89WvXJh7MGnfBfG1",
+													"id": "mIc6ztUbKelBuiIE4",
 													"name": "Spoken",
 													"reference": "B24",
 													"notes": "None",
@@ -1236,7 +1437,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mA-hBArgvaVNdA_7Z",
+													"id": "m0HFllh62b9fMbB9g",
 													"name": "Spoken",
 													"reference": "B24",
 													"notes": "Broken",
@@ -1245,7 +1446,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mgkswTqbSrdvezCGh",
+													"id": "m8seMFMbVclP7YJrf",
 													"name": "Spoken",
 													"reference": "B24",
 													"notes": "Accented",
@@ -1253,7 +1454,7 @@
 													"cost_type": "points"
 												},
 												{
-													"id": "m2hcCnqtAM9voMLYv",
+													"id": "mAW3dmXy2nhG3jGr_",
 													"name": "Spoken",
 													"reference": "B24",
 													"notes": "Native",
@@ -1262,7 +1463,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mI_mS-zsfnLDeKjDM",
+													"id": "mEzDvXDhzq12wbfw-",
 													"name": "Written",
 													"reference": "B24",
 													"notes": "None",
@@ -1270,7 +1471,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mpx1i6ETueegs9qLP",
+													"id": "m1C5aiWlINVkHRRug",
 													"name": "Written",
 													"reference": "B24",
 													"notes": "Broken",
@@ -1279,7 +1480,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mLq26PIpjzLEZPtq6",
+													"id": "mqbPStB8LxDm2rls6",
 													"name": "Written",
 													"reference": "B24",
 													"notes": "Accented",
@@ -1287,7 +1488,7 @@
 													"cost_type": "points"
 												},
 												{
-													"id": "mPx67GN9bM2-x7xPW",
+													"id": "mAByBxfl1aZdN_CUR",
 													"name": "Written",
 													"reference": "B24",
 													"notes": "Native",
@@ -1301,7 +1502,12 @@
 											}
 										},
 										{
-											"id": "t_eBku-Z1OSDW3B7r",
+											"id": "t862q8vAPwbOuNIcT",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "txREhxV6L1SKixwe_"
+											},
 											"name": "Improved G-tolerance",
 											"reference": "B60",
 											"tags": [
@@ -1310,7 +1516,7 @@
 											],
 											"modifiers": [
 												{
-													"id": "mKYgETlRlsNyYhjjL",
+													"id": "mvbhU20bdWmBLFv1r",
 													"name": "0.3G",
 													"reference": "B60",
 													"cost": 5,
@@ -1318,7 +1524,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mKhVo7PvVfc1-xPNx",
+													"id": "mDDx8s1TWWH7fczU4",
 													"name": "0.5G",
 													"reference": "B60",
 													"cost": 10,
@@ -1326,7 +1532,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mL28SdWwjh-mZz72L",
+													"id": "m5OLLsoxe9Af_zyKq",
 													"name": "1G",
 													"reference": "B60",
 													"cost": 15,
@@ -1334,7 +1540,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m4eOhi1fZEdudhRb8",
+													"id": "mXDAKGdaL0dQjaQa6",
 													"name": "5G",
 													"reference": "B60",
 													"cost": 20,
@@ -1342,7 +1548,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m2mbKhKw4tZBxvxcn",
+													"id": "mXtS1k3m8uZ7Qj_Vz",
 													"name": "10G",
 													"reference": "B60",
 													"cost": 25,
@@ -1355,7 +1561,12 @@
 											}
 										},
 										{
-											"id": "tIx-OkOQKOZfhIJHw",
+											"id": "tq_2gNsbMuMzKoBAb",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t7blIRUzFpiHS_mnO"
+											},
 											"name": "Gizmo",
 											"reference": "B57,MA45",
 											"tags": [
@@ -1370,7 +1581,12 @@
 											}
 										},
 										{
-											"id": "tUvPpPnVwje9mMrnB",
+											"id": "t8EszUHGbB7qPqVmJ",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tHNrjEQFQBNOgwmzK"
+											},
 											"name": "G-Experience (All)",
 											"reference": "B57",
 											"tags": [
@@ -1383,7 +1599,12 @@
 											}
 										},
 										{
-											"id": "t_n7mdGXRuMCCZCv_",
+											"id": "t_ORjq9BLc5o0P1vg",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tu3GuYC47Sx6bnm4k"
+											},
 											"name": "G-Experience",
 											"reference": "B57",
 											"tags": [
@@ -1398,7 +1619,12 @@
 											}
 										},
 										{
-											"id": "tUE5LIiJO-s-wy259",
+											"id": "tg71lywe2BWDadphi",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "toTe273Ky82B6YdW5"
+											},
 											"name": "Fit",
 											"reference": "B55",
 											"notes": "Recover FP at twice the normal rate (but not FP spent for spells or psi powers)",
@@ -1419,7 +1645,12 @@
 											}
 										},
 										{
-											"id": "tTb_KGRWAaJ7pdA18",
+											"id": "t6yImjZC9qLP3SqMx",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tQa3EUrs4Hjt9gxK6"
+											},
 											"name": "Fearlessness",
 											"reference": "B55,MA44",
 											"tags": [
@@ -1456,7 +1687,12 @@
 											}
 										},
 										{
-											"id": "tMYviWkIlZmF2JiNp",
+											"id": "tJUWZSslzywkEvyfQ",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t5j2Ox4jaIV9j0rpz"
+											},
 											"name": "Deep Sleeper",
 											"reference": "B101",
 											"tags": [
@@ -1469,7 +1705,12 @@
 											}
 										},
 										{
-											"id": "tRkV8-x1NLQsDA_um",
+											"id": "tGYeLZ_cZMWlu4Xdf",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tNBE3sLoyrUvAgoZ3"
+											},
 											"name": "Cybernetics",
 											"reference": "B46",
 											"tags": [
@@ -1481,7 +1722,12 @@
 											}
 										},
 										{
-											"id": "tyTcoRuXLY91DJNA3",
+											"id": "t0Y8ypAFm6AykPvaG",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "toXBQ8q4Nek5lsLPF"
+											},
 											"name": "Cultural Familiarity (@Culture@)",
 											"reference": "B23",
 											"notes": "Do not suffer the normal -3 penalty for unfamiliarity",
@@ -1491,14 +1737,14 @@
 											],
 											"modifiers": [
 												{
-													"id": "mkgscqWhqmuPx3VQi",
+													"id": "mUj9Xi0eGTc8_eRWa",
 													"name": "Alien",
 													"cost": 1,
 													"cost_type": "points",
 													"disabled": true
 												},
 												{
-													"id": "m6_XLOx77UH2S3jVF",
+													"id": "m8iUAY_Hj-5z7_chI",
 													"name": "Native",
 													"cost": -1,
 													"cost_type": "points",
@@ -1511,9 +1757,14 @@
 											}
 										},
 										{
-											"id": "tBYQ-Q20ykvlH8tT9",
-											"name": "Alien Friend",
-											"reference": "S220",
+											"id": "tFaMNmUIplCfTU_Gn",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Power Ups/Power Ups Traits.adq",
+												"id": "t3msobZZ06J7dZ8xu"
+											},
+											"name": "Talent (Born Spacer)",
+											"reference": "PU3:7",
 											"tags": [
 												"Advantage",
 												"Mental",
@@ -1521,106 +1772,60 @@
 											],
 											"modifiers": [
 												{
-													"id": "mNpu1qZtK1sDOxt-4",
-													"name": "Alternate Benefit",
-													"notes": "@Alternate Benefit@",
-													"disabled": true
-												},
-												{
-													"id": "m8U8aS5tIiHg73mJa",
+													"id": "mi0AsHioA9aPZoLnb",
 													"name": "Alternative Cost",
+													"cost": 1,
 													"cost_type": "points",
 													"affects": "levels_only",
 													"disabled": true
-												}
-											],
-											"points_per_level": 5,
-											"features": [
-												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "Anthropology"
-													},
-													"amount": 1,
-													"per_level": true
 												},
 												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "Diplomacy"
-													},
-													"amount": 1,
-													"per_level": true
-												},
-												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "Expert Skill"
-													},
-													"amount": 1,
-													"per_level": true
-												},
-												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "History"
-													},
-													"amount": 1,
-													"per_level": true
-												},
-												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "Psychology"
-													},
-													"amount": 1,
-													"per_level": true
-												},
-												{
-													"type": "reaction_bonus",
-													"situation": "Aliens",
-													"amount": 1,
-													"per_level": true
-												}
-											],
-											"can_level": true,
-											"levels": 1,
-											"calc": {
-												"points": 5
-											}
-										},
-										{
-											"id": "tJjCJfHuBqwVLPoZe",
-											"name": "Born Spacer",
-											"reference": "THSCT40",
-											"tags": [
-												"Advantage",
-												"Mental",
-												"Talent"
-											],
-											"modifiers": [
-												{
-													"id": "mHm2QXgzCQ_w8dcQV",
-													"name": "Alternate Benefit",
-													"notes": "@Alternate Benefit@",
-													"disabled": true
-												},
-												{
-													"id": "modhrXWa-jDV2-Wpd",
-													"name": "Alternative Cost",
-													"cost_type": "points",
-													"affects": "levels_only",
-													"disabled": true
+													"id": "Mw5A5VWsHZCAqOIMq",
+													"name": "Benefits",
+													"children": [
+														{
+															"id": "m6fxrWUKp_LxUESV3",
+															"name": "Reaction Bonus",
+															"use_level_from_trait": true,
+															"features": [
+																{
+																	"type": "reaction_bonus",
+																	"situation": "From professional Spacers.",
+																	"amount": 1,
+																	"per_level": true
+																}
+															]
+														},
+														{
+															"id": "mUIMLNQY34qo-ql9b",
+															"name": "Bonus to pushing off",
+															"reference": "BX350",
+															"reference_highlight": "ST/2",
+															"use_level_from_trait": true,
+															"features": [
+																{
+																	"type": "conditional_modifier",
+																	"situation": "Bonus to ST for zero G push off",
+																	"amount": 1,
+																	"per_level": true
+																}
+															],
+															"disabled": true
+														},
+														{
+															"id": "mmteved_3uMHURUIf",
+															"name": "Spacecraft Familiarity",
+															"use_level_from_trait": true,
+															"features": [
+																{
+																	"type": "conditional_modifier",
+																	"situation": "Counteracts Familiarity for spacecraft.",
+																	"amount": 1
+																}
+															],
+															"disabled": true
+														}
+													]
 												}
 											],
 											"points_per_level": 5,
@@ -1652,6 +1857,10 @@
 														"compare": "is",
 														"qualifier": "Navigation"
 													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "Space"
+													},
 													"amount": 1,
 													"per_level": true
 												},
@@ -1663,8 +1872,36 @@
 														"qualifier": "Piloting"
 													},
 													"specialization": {
-														"compare": "contains",
-														"qualifier": "Spacecraft"
+														"compare": "is",
+														"qualifier": "High-Performance Spacecraft"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Piloting"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "Low-Performance Spacecraft"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Piloting"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "Aerospace"
 													},
 													"amount": 1,
 													"per_level": true
@@ -1688,10 +1925,99 @@
 													},
 													"amount": 1,
 													"per_level": true
+												}
+											],
+											"can_level": true,
+											"levels": 1,
+											"calc": {
+												"points": 5
+											}
+										},
+										{
+											"id": "txyTZF2vf0fjIQpAD",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Power Ups/Power Ups Traits.adq",
+												"id": "tcCw979nTBoztowCU"
+											},
+											"name": "Talent (Alien Friend)",
+											"reference": "PU3:6",
+											"tags": [
+												"Advantage",
+												"Mental",
+												"Talent"
+											],
+											"points_per_level": 5,
+											"features": [
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Diplomacy"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Expert Skill"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "Xenology"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Anthropology"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "@Alien@"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "History"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "@Alien@"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Psychology"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "@Alien@"
+													},
+													"amount": 1,
+													"per_level": true
 												},
 												{
 													"type": "reaction_bonus",
-													"situation": "Professional Spacers",
+													"situation": "From aliens.",
 													"amount": 1,
 													"per_level": true
 												}
@@ -1703,7 +2029,12 @@
 											}
 										},
 										{
-											"id": "tzgOzITroqk4q1Iuq",
+											"id": "tKj_dXEJ7olbodkOu",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tM6z7Mx6e2V4VvUR4"
+											},
 											"name": "Absolute Direction",
 											"reference": "B34",
 											"tags": [
@@ -1713,14 +2044,14 @@
 											],
 											"modifiers": [
 												{
-													"id": "mKR2S_8aQ3fsYbU9U",
+													"id": "mE8d3eeo_RhokW-AA",
 													"name": "Requires signal",
 													"reference": "B34",
 													"cost": -20,
 													"disabled": true
 												},
 												{
-													"id": "mJySWTJjlyZIKK3VZ",
+													"id": "mxbfOeGf_0wCI2hdR",
 													"name": "3D Spatial Sense",
 													"reference": "B34",
 													"cost": 5,
@@ -1843,7 +2174,12 @@
 									}
 								},
 								{
-									"id": "tXjdZfTZoiVjHXbxb",
+									"id": "tTC1ZbWnFgh9jbjqE",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tkdGzhkqoMAQbknEc"
+									},
 									"name": "Acute Vision",
 									"reference": "B35",
 									"tags": [
@@ -1866,7 +2202,12 @@
 									}
 								},
 								{
-									"id": "t0pn_SOqMllrnd89j",
+									"id": "tiJ1K7JZg0OziLc2O",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tGjjVtxav9KsrG7Wx"
+									},
 									"name": "Combat Reflexes",
 									"reference": "B43",
 									"notes": "Never freeze",
@@ -1935,7 +2276,12 @@
 									}
 								},
 								{
-									"id": "tFvKDZF9cBfXiwEkX",
+									"id": "tVZMsEvkXDbfj70AD",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tO0G2kcresS1YZ_KE"
+									},
 									"name": "Daredevil",
 									"reference": "B47",
 									"tags": [
@@ -1955,15 +2301,27 @@
 									}
 								},
 								{
-									"id": "tZcUlowezoaE_sGZ7",
-									"name": "Enhanced Dodge (Piloting)",
-									"reference": "TT3:5",
-									"notes": "not auto calculated by VTT",
+									"id": "tacASwrZOyElh38c-",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Template Toolkit/Template Toolkit 3 - Starship Crew/Starship Crew Traits.adq",
+										"id": "ty6xQhthuc1s_qAW6"
+									},
+									"name": "Enhanced Dodge (@Piloting Skill@)",
+									"reference": "TT3:5, B51",
 									"tags": [
 										"Advantage",
 										"Mental"
 									],
 									"points_per_level": 5,
+									"features": [
+										{
+											"type": "conditional_modifier",
+											"situation": "to vehicular dodges with @Piloting Skill@",
+											"amount": 1,
+											"per_level": true
+										}
+									],
 									"can_level": true,
 									"levels": 1,
 									"calc": {
@@ -1971,7 +2329,12 @@
 									}
 								},
 								{
-									"id": "t-9vw-ZEDwqpr1jgq",
+									"id": "t6O37NUONZKnWAWt4",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tkrQLfn7UUprvkMat"
+									},
 									"name": "Talent (Explorer)",
 									"reference": "PU3:10",
 									"tags": [
@@ -1981,11 +2344,44 @@
 									],
 									"modifiers": [
 										{
-											"id": "mh_H8vBeQu2K6BSHV",
+											"id": "mc3jBRVssZ-nvuGAk",
 											"name": "Alternative Cost",
 											"cost_type": "points",
 											"affects": "levels_only",
 											"disabled": true
+										},
+										{
+											"id": "MDNfaz5UoA6rv9YjW",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "mKxIG5LwseYz472Vk",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From fellow explorers and backers.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "mdUpyycX277uELU2d",
+													"name": "Alternative Benefit",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Reduce distance and area class penalties for all skills",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
 										}
 									],
 									"points_per_level": 5,
@@ -2052,18 +2448,6 @@
 											},
 											"amount": 1,
 											"per_level": true
-										},
-										{
-											"type": "reaction_bonus",
-											"situation": "From fellow explorers and backers.",
-											"amount": 1,
-											"per_level": true
-										},
-										{
-											"type": "conditional_modifier",
-											"situation": "Reduce distance and area class penalties for all skills",
-											"amount": 1,
-											"per_level": true
 										}
 									],
 									"can_level": true,
@@ -2073,13 +2457,53 @@
 									}
 								},
 								{
-									"id": "t3S0K7-gk3os1kwQ1",
+									"id": "tV0aFiPx0XTFdIMy9",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tHPdAVdz9JvulCeVU"
+									},
 									"name": "Talent (Hot Pilot)",
 									"reference": "PU3:11",
 									"tags": [
 										"Advantage",
 										"Mental",
 										"Talent"
+									],
+									"modifiers": [
+										{
+											"id": "MZoF575uuJHpCgXRy",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "m8_XhS4y7sWTl-0_R",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From other Pilots.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "m71NQPWt9IIpvathQ",
+													"name": "Alternative Benefit",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Reduce penalties for unfamiliar systems of vehicles you have Piloting skill for",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
+										}
 									],
 									"points_per_level": 5,
 									"features": [
@@ -2130,18 +2554,6 @@
 											},
 											"amount": 1,
 											"per_level": true
-										},
-										{
-											"type": "reaction_bonus",
-											"situation": "From other Pilots.",
-											"amount": 1,
-											"per_level": true
-										},
-										{
-											"type": "conditional_modifier",
-											"situation": "Reduce penalties for unfamiliar systems of vehicles you have Piloting skill for",
-											"amount": 1,
-											"per_level": true
 										}
 									],
 									"can_level": true,
@@ -2151,7 +2563,12 @@
 									}
 								},
 								{
-									"id": "tjgO4-ROB54BAXKz7",
+									"id": "t0GB7g8Iw68P5d1kV",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tq6b1t_pc4X18GAWi"
+									},
 									"name": "Lightning Calculator",
 									"reference": "B66",
 									"tags": [
@@ -2160,7 +2577,7 @@
 									],
 									"modifiers": [
 										{
-											"id": "msa7AH6wl3tGolL9U",
+											"id": "mb10mbvvie9t8ht3f",
 											"name": "Intuitive Mathematician",
 											"reference": "B66",
 											"cost": 3,
@@ -2173,20 +2590,33 @@
 									}
 								},
 								{
-									"id": "t9pqyjH3meAY_5orO",
-									"name": "License (Pilot's)",
+									"id": "tTrvWt3CrXEfk3s9L",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "ts9hOD5V9mQFk64hc"
+									},
+									"name": "License (@Type@)",
 									"reference": "PU2:18",
 									"tags": [
 										"Perk",
 										"Social"
 									],
+									"replacements": {
+										"Type": "Pilot's"
+									},
 									"base_points": 1,
 									"calc": {
 										"points": 1
 									}
 								},
 								{
-									"id": "teOK0tvOqhOEvwhyO",
+									"id": "tt1pPYtsfKXj7bdZK",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t2uxXuNNQjGUAFAd0"
+									},
 									"name": "Perfect Balance",
 									"reference": "B74",
 									"tags": [
@@ -2195,6 +2625,16 @@
 									],
 									"base_points": 15,
 									"features": [
+										{
+											"type": "conditional_modifier",
+											"situation": "on DX and DX-based skill rolls to keep your feet or avoid being knocked down in combat",
+											"amount": 4
+										},
+										{
+											"type": "conditional_modifier",
+											"situation": "on all rolls to keep your feet if the surface is wet, slippery or unstable",
+											"amount": 6
+										},
 										{
 											"type": "skill_bonus",
 											"selection_type": "skills_with_name",
@@ -2218,6 +2658,24 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
+												"qualifier": "aerobatics"
+											},
+											"amount": 1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "aquabatics"
+											},
+											"amount": 1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
 												"qualifier": "climbing"
 											},
 											"amount": 1
@@ -2228,7 +2686,12 @@
 									}
 								},
 								{
-									"id": "tidXODB0bt-Nu5Air",
+									"id": "tBML84jrfWbHWzOYF",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "trClz3uZE-XIfFJKI"
+									},
 									"name": "Unfazeable",
 									"reference": "B95",
 									"notes": "Exempt from fright checks. Reaction modifiers do not affect you.",
@@ -2238,7 +2701,7 @@
 									],
 									"modifiers": [
 										{
-											"id": "m7G3MFTmhwx36PLq8",
+											"id": "mJl4a9bxlAElBFgHv",
 											"name": "Familiar Horrors",
 											"reference": "H20",
 											"cost": -50,
@@ -2269,14 +2732,56 @@
 							"name": "-40 Points chosen from",
 							"children": [
 								{
-									"id": "TwZ3wCm349AQjPsfP",
+									"id": "TSarOsYNlnuLkIla2",
 									"name": "Everyman Disadvantages",
 									"tags": [
 										"Disadvantage"
 									],
 									"children": [
 										{
-											"id": "tg37NhGsEcDc4-fZo",
+											"id": "t4K0kaNhFSQG8CiKl",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tX9XXLPFBvyQSpA4k"
+											},
+											"name": "Xenophilia",
+											"reference": "B162",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"cr": 12,
+											"base_points": -10,
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "t9F6kWtRQ3IkKtWGM",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t8I0xw1Lj1_222aEN"
+											},
+											"name": "Workaholic",
+											"reference": "B162",
+											"tags": [
+												"Disadvantage",
+												"Physical"
+											],
+											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										},
+										{
+											"id": "tGs5XD6QdZY9Lb-c-",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t7U0VbIzs6SqefwLr"
+											},
 											"name": "Social Stigma (Criminal Record)",
 											"reference": "B155",
 											"tags": [
@@ -2296,23 +2801,162 @@
 											}
 										},
 										{
-											"id": "tFVjClYPTKU8MD2VM",
-											"name": "Chummy",
-											"reference": "B126",
+											"id": "tncA5j2vF80Tu0tay",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "thSMVzJ590v7gAD8d"
+											},
+											"name": "Pacifism: Self-Defense Only",
+											"reference": "B148",
+											"notes": "You only fight to defend yourself or those in your care, using only as much force as necessary (no pre-emptive strikes allowed!). You must do your best to discourage others from starting fights.",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
+											"modifiers": [
+												{
+													"id": "mzpGf331xfAQMzJCJ",
+													"name": "Species-Specific",
+													"reference": "UT32",
+													"cost": -80,
+													"disabled": true
+												}
+											],
+											"base_points": -15,
+											"calc": {
+												"points": -15
+											}
+										},
+										{
+											"id": "tSVRHjRnbDn4Wxxhg",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tV_f_75HmwzWOPhuu"
+											},
+											"name": "Pacifism: Reluctant Killer",
+											"reference": "B148",
+											"notes": "You are psychologically unprepared to kill people. Whenever you make a deadly attack (e.g., with a knife or a gun) against an obvious person whose face is visible to you, you are at -4 to hit and may not Aim. If you cannot see the foe’s face (due to a mask, darkness, or distance, or because you attacked from behind), the penalty is only -2, save in close combat. You have no penalty to attack a vehicle (even an occupied one), an opponent you do not believe is a person (including things with Horrific or Monstrous appearance), or a target you can’t actually see (e.g., a set of map coordinates or a blip on a radar screen). If you kill a recognizable person, the effect on you is the same as for Pacifism: Cannot Kill. You have no problem with your allies killing; you may even supply ammo, loaded weapons, and encouragement! You just can’t do the killing yourself.",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"modifiers": [
+												{
+													"id": "mmscu2dDMCbiG3rZ2",
+													"name": "Species-Specific",
+													"reference": "UT32",
+													"cost": -80,
+													"disabled": true
+												}
+											],
 											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										},
+										{
+											"id": "tZ8v4OihKq3bNEsSO",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "th9TK1Jmqg8uKe6SC"
+											},
+											"name": "Pacifism: Cannot Harm Innocents",
+											"reference": "B148",
+											"notes": "You may fight – you may even start fights – but you may only use deadly force on a foe that is attempting to do you serious harm. Capture is not “serious harm” unless you are already under penalty of death or have a Code of Honor that would require suicide if captured. You never intentionally do anything that causes, or even threatens to cause, injury to the uninvolved – particularly if they are “ordinary folks.”",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"modifiers": [
+												{
+													"id": "mM6ZzZaIRUPlw440s",
+													"name": "Species-Specific",
+													"reference": "UT32",
+													"cost": -80,
+													"disabled": true
+												}
+											],
+											"base_points": -10,
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "tVHQoZy4XFTFiomuA",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tSiOKuvTJkqJhuRrI"
+											},
+											"name": "Lecherousness",
+											"reference": "B142",
+											"notes": "Make a self-control roll whenever you have more than the briefest contact with an appealing member of the sex you find attractive, at -5 if this person is Handsome/Beautiful, or at -10 if Very Handsome/Very Beautiful. If you fail, you must make a “pass” using whatever wiles and skills you can bring to bear.",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"cr": 12,
+											"base_points": -15,
+											"calc": {
+												"points": -15
+											}
+										},
+										{
+											"id": "tGkey73Ftiazfciqm",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "ttHkLI9zwzfeOIEZc"
+											},
+											"name": "Intolerance (@Class, Ethnicity, Nationality, Religion, Sex, or Species@)",
+											"reference": "B140",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"replacements": {
+												"Class, Ethnicity, Nationality, Religion, Sex, or Species": "Rival civilization or species"
+											},
+											"modifiers": [
+												{
+													"id": "myC47et1lmvc9fKsz",
+													"name": "Scope: Common",
+													"reference": "B140",
+													"cost": -5,
+													"cost_type": "points"
+												},
+												{
+													"id": "monsDT2Dr0Nb4M8h5",
+													"name": "Scope: Occasional",
+													"reference": "B140",
+													"cost": -2,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "meHOKwvThefpxPXoK",
+													"name": "Scope: Rare",
+													"reference": "B140",
+													"cost": -1,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m-9so3E3312Rws1P2",
+													"name": "Scope: Anyone unlike you",
+													"reference": "B140",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												}
+											],
 											"features": [
 												{
 													"type": "reaction_bonus",
-													"situation": "to others",
-													"amount": 2
-												},
-												{
-													"type": "conditional_modifier",
-													"situation": "to IQ-based skills when alone",
+													"situation": "from victims of your intolerance (may be as much as -5, at GM's discretion)",
 													"amount": -1
 												}
 											],
@@ -2321,49 +2965,383 @@
 											}
 										},
 										{
-											"id": "tVO4vg5rnzKc4PPB1",
-											"name": "Code of Honor (Mercanary's)",
-											"reference": "S221",
-											"notes": "A merc should look out for his buddies, take care of his gear, and fight for the honor of the unit. Obey the rule's of engagement. Don't poach on another unit's contract. Do the job you're hired for.",
+											"id": "teBpAWhp7EQ1fWevI",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t7pCgXTVkswkTjOZO"
+											},
+											"name": "Honesty",
+											"reference": "B138",
+											"notes": "Make a self-control roll when faced with the “need” to break unreasonable laws; if you fail, you must obey the law, whatever the consequences. If you manage to resist your urges and break the law, make a second self-control roll afterward. If you fail, you must turn yourself in to the authorities!",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
+											"cr": 12,
 											"base_points": -10,
 											"calc": {
 												"points": -10
 											}
 										},
 										{
-											"id": "tqDtMKMsyk1zFUjJm",
-											"name": "Code of Honor (Pirate's)",
-											"reference": "B127",
-											"notes": "Always avenge an insult, regardless of the danger; your buddy’s foe is your own; never attack a fellow crewman or buddy except in a fair, open duel.",
+											"id": "ttM8QOAsmyVrNfi15",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t5bwP6TnS4cX-zM8L"
+											},
+											"name": "Enemy (@Who@)",
+											"reference": "B135",
+											"tags": [
+												"Disadvantage",
+												"Social"
+											],
+											"modifiers": [
+												{
+													"id": "mMqTZhUBq3m_-WYl9",
+													"name": "Weak Individual",
+													"reference": "B135",
+													"notes": "50% of your starting points",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "md0uXNPITEwrEfKbl",
+													"name": "Equal Individual",
+													"reference": "B135",
+													"notes": "100% of your starting points",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mMHtl3uZgXwWqxJ_q",
+													"name": "Powerful Individual",
+													"reference": "B135",
+													"notes": "\u003e150% of your starting points",
+													"cost": -20,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mhzpkkz8sPpfVjgoT",
+													"name": "Weak Group",
+													"reference": "B135",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mPz3o7bGOvoaNBd8o",
+													"name": "Medium Group",
+													"reference": "B135",
+													"cost": -20,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m6Ds_rP58bI6NXkdX",
+													"name": "Appears almost all the time",
+													"reference": "B36",
+													"notes": "15-",
+													"cost": 3,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mFQ3vIv4Xk0vGvhXX",
+													"name": "Appears quite often",
+													"reference": "B36",
+													"notes": "12-",
+													"cost": 2,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mII8trDX0jO3sTJTk",
+													"name": "Appears fairly often",
+													"reference": "B36",
+													"notes": "9-",
+													"cost": 1,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "miAQJ6mCgCbCbfaYm",
+													"name": "Appears quite rarely",
+													"reference": "B36",
+													"notes": "6-",
+													"cost": 0.5,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mVqmUlqzmef9Adb9Z",
+													"name": "Large/Powerful Group",
+													"reference": "B135",
+													"cost": -30,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mDnVDk53iblq_SO_q",
+													"name": "Utterly Formidable Group",
+													"reference": "B135",
+													"cost": -40,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mBWi2lGyhhcKN7Y98",
+													"name": "Unknown",
+													"reference": "B135",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mp5viHZqSVjmyPliY",
+													"name": "Evil Twin",
+													"reference": "B135",
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mHlLzN2sVHPuM6UQD",
+													"name": "Evil Twin",
+													"reference": "B135",
+													"notes": "More skilled or extra abilities",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m_jsTfSE5mwJdpFA9",
+													"name": "Evil Twin",
+													"reference": "B135",
+													"notes": "More skilled and extra abilities",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mMMRtxvR9fANzMFFQ",
+													"name": "Watcher",
+													"reference": "B135",
+													"cost": 0.25,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mAHn3lrFjSjbD4D1C",
+													"name": "Rival",
+													"reference": "B135",
+													"cost": 0.5,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mkInteqyeCNYFBMZ8",
+													"name": "Hunter",
+													"reference": "B135",
+													"cost": 1,
+													"cost_type": "multiplier",
+													"disabled": true
+												}
+											],
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "tQBulZ7zTLAIqRfKU",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t1HUGl4o498iCyvrw"
+											},
+											"name": "Duty (@Duty@)",
+											"reference": "B133",
+											"tags": [
+												"Disadvantage",
+												"Social"
+											],
+											"replacements": {
+												"Duty": "To ship's owner or provider"
+											},
+											"modifiers": [
+												{
+													"id": "m8cGmLtGicawWjJ3d",
+													"name": "FR: 6",
+													"cost": -2,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mWqS6xR0M28PbL8K_",
+													"name": "FR: 9",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mI7wv6hkU8vrA-f7Q",
+													"name": "FR: 12",
+													"cost": -10,
+													"cost_type": "points"
+												},
+												{
+													"id": "mH3_go41nss8hzfHm",
+													"name": "FR: 15",
+													"cost": -15,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mRDtxuv8Tv1OcpF2K",
+													"name": "Extremely Hazardous",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mxt_-_X9x2O1WEe2u",
+													"name": "Involuntary",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "md-tl4AszT37mxuD6",
+													"name": "Nonhazardous",
+													"cost": 5,
+													"cost_type": "points",
+													"disabled": true
+												}
+											],
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "t2U3youtelgDnY4R2",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t1HUGl4o498iCyvrw"
+											},
+											"name": "Duty (@Duty@)",
+											"reference": "B133",
+											"tags": [
+												"Disadvantage",
+												"Social"
+											],
+											"replacements": {
+												"Duty": "To ship's owner or provider"
+											},
+											"modifiers": [
+												{
+													"id": "mYk4LFUUPZmdHoK3d",
+													"name": "FR: 6",
+													"cost": -2,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m8L6dsiyXlBHP05lf",
+													"name": "FR: 9",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mJ8hy-lL-x7ts1kEx",
+													"name": "FR: 12",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mdMLJhQ8WUTIkKlkR",
+													"name": "FR: 15",
+													"cost": -15,
+													"cost_type": "points"
+												},
+												{
+													"id": "mfu2_ZobCbAzLNJhG",
+													"name": "Extremely Hazardous",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m1eHTPsXtOdU12pEA",
+													"name": "Involuntary",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mfh7_Iiv4GPvqSO_u",
+													"name": "Nonhazardous",
+													"cost": 5,
+													"cost_type": "points",
+													"disabled": true
+												}
+											],
+											"calc": {
+												"points": -15
+											}
+										},
+										{
+											"id": "t1oRzzZ04x8hoLZSy",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tXFf9MSQ3FMT2psO8"
+											},
+											"name": "Demophobia (Crowds)",
+											"reference": "B149",
+											"notes": "Any group of over a dozen people sets off this fear unless they are all well known to you. The self-control roll is at -1 for over 25 people, -2 for a crowd of 100 or more, -3 for 1,000, -4 for 10,000, and so on.",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
+											"cr_adj": "action_penalty",
+											"cr": 12,
+											"base_points": -15,
+											"calc": {
+												"points": -15
+											}
+										},
+										{
+											"id": "tFEl-8pPKETzsFHAc",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tK4QdVZYxGAd4cqr_"
+											},
+											"name": "Compulsive Gambling",
+											"reference": "B128",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"cr": 12,
 											"base_points": -5,
 											"calc": {
 												"points": -5
 											}
 										},
 										{
-											"id": "tXpEYaJGG_q_FQg4C",
-											"name": "Code of Honor (Soldier's)",
-											"reference": "B127",
-											"notes": "An officer should be tough but fair, lead from the front, and look out for his men; an enlisted man should look out for his buddies and take care of his kit. Every soldier should be willing to fight and die for the honor of his unit, service, and country; follow orders; obey the “rules of war”; treat an honorable enemy with respect (a dishonorable enemy deserves a bullet); and wear the uniform with pride.",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"base_points": -10,
-											"calc": {
-												"points": -10
-											}
-										},
-										{
-											"id": "t1tjwmv8rOWw7jMon",
+											"id": "t5WmBDEOUrqfWkZcP",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tapWLsuN75Unedmwn"
+											},
 											"name": "Compulsive Carousing",
 											"reference": "B128",
 											"tags": [
@@ -2389,308 +3367,115 @@
 											}
 										},
 										{
-											"id": "toAFUtUTanWmeodLs",
-											"name": "Compulsive Gambling",
-											"reference": "B128",
+											"id": "tmXpjYTAMMmVsDFlK",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "txSrmgLB0M36uR802"
+											},
+											"name": "Code of Honor (Soldier's)",
+											"reference": "B127",
+											"notes": "An officer should be tough but fair, lead from the front, and look out for his men; an enlisted man should look out for his buddies and take care of his kit. Every soldier should be willing to fight and die for the honor of his unit, service, and country; follow orders; obey the “rules of war”; treat an honorable enemy with respect (a dishonorable enemy deserves a bullet); and wear the uniform with pride.",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
-											"cr": 12,
-											"base_points": -5,
-											"calc": {
-												"points": -5
-											}
-										},
-										{
-											"id": "t8GMuNpFtnyPmLSUD",
-											"name": "Duty (To ship's owner or provider)",
-											"reference": "B133",
-											"tags": [
-												"Disadvantage",
-												"Social"
-											],
-											"modifiers": [
-												{
-													"id": "mRqe5E1pyxkTemBqT",
-													"name": "FR: 6",
-													"cost": -2,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mQH9bdCDN5AeAVtON",
-													"name": "FR: 9",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mfetxKPsTihuHhixl",
-													"name": "FR: 12",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m6AGnzVX8DJBpd_jf",
-													"name": "FR: 15",
-													"cost": -15,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "msmRyHXhXzBoGJEYn",
-													"name": "Extremely Hazardous",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m_md6D5ib7DUqE5Ik",
-													"name": "Involuntary",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mwdf-owig66M3qF5e",
-													"name": "Nonhazardous",
-													"cost": 5,
-													"cost_type": "points",
-													"disabled": true
-												}
-											],
-											"calc": {
-												"points": 0
-											}
-										},
-										{
-											"id": "tJabVRQSyf3w8u2oR",
-											"name": "Enemy (@Who@)",
-											"reference": "B135",
-											"tags": [
-												"Disadvantage",
-												"Social"
-											],
-											"modifiers": [
-												{
-													"id": "mk7qTxZZznG3qInKo",
-													"name": "Weak Individual",
-													"reference": "B135",
-													"notes": "50% of your starting points",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mMRBmhqPq2H4rj44n",
-													"name": "Equal Individual",
-													"reference": "B135",
-													"notes": "100% of your starting points",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mK66cf-4_1MIT2Rs0",
-													"name": "Powerful Individual",
-													"reference": "B135",
-													"notes": "\u003e150% of your starting points",
-													"cost": -20,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mQp4PVH5L9jUlpiC9",
-													"name": "Weak Group",
-													"reference": "B135",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m-gKlXpnHqR8dozOQ",
-													"name": "Medium Group",
-													"reference": "B135",
-													"cost": -20,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m2iRr4oT5qxzBZms3",
-													"name": "Appears almost all the time",
-													"reference": "B36",
-													"notes": "15-",
-													"cost": 3,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "me8TuDsouziDp1hw0",
-													"name": "Appears quite often",
-													"reference": "B36",
-													"notes": "12-",
-													"cost": 2,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mD1DCjArl3LBfwSSI",
-													"name": "Appears fairly often",
-													"reference": "B36",
-													"notes": "9-",
-													"cost": 1,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "m-vfoaQXXFfjygyC5",
-													"name": "Appears quite rarely",
-													"reference": "B36",
-													"notes": "6-",
-													"cost": 0.5,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mR_jV1iRceLtZzlO6",
-													"name": "Large/Powerful Group",
-													"reference": "B135",
-													"cost": -30,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mA_9LmbEVsnicG3kW",
-													"name": "Utterly Formidable Group",
-													"reference": "B135",
-													"cost": -40,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mrrQBPVFgKnLSdats",
-													"name": "Unknown",
-													"reference": "B135",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mGavT65SCHSixFQ7M",
-													"name": "Evil Twin",
-													"reference": "B135",
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mpkeCSOf-_K8uhxBd",
-													"name": "Evil Twin",
-													"reference": "B135",
-													"notes": "More skilled or extra abilities",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mybK5_7oBJ7btyi6A",
-													"name": "Evil Twin",
-													"reference": "B135",
-													"notes": "More skilled and extra abilities",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m_HloipEQcxD_MZdN",
-													"name": "Watcher",
-													"reference": "B135",
-													"cost": 0.25,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mHeqfBM8siCWgGPdO",
-													"name": "Rival",
-													"reference": "B135",
-													"cost": 0.5,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mfDme5MO_6Ku6CWTK",
-													"name": "Hunter",
-													"reference": "B135",
-													"cost": 1,
-													"cost_type": "multiplier",
-													"disabled": true
-												}
-											],
-											"calc": {
-												"points": 0
-											}
-										},
-										{
-											"id": "t246l5VoSuW7jjf1d",
-											"name": "Honesty",
-											"reference": "B138",
-											"notes": "Make a self-control roll when faced with the “need” to break unreasonable laws; if you fail, you must obey the law, whatever the consequences. If you manage to resist your urges and break the law, make a second self-control roll afterward. If you fail, you must turn yourself in to the authorities!",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"cr": 12,
 											"base_points": -10,
 											"calc": {
 												"points": -10
 											}
 										},
 										{
-											"id": "trF9sU6khGLxsAQ9n",
-											"name": "Intolerance (@Rival civilization or species@)",
-											"reference": "B140",
+											"id": "tJ5cgcn7yiuAVylHE",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Space/Space Traits.adq",
+												"id": "teNSsqOsjstajwmxn"
+											},
+											"name": "Code of Honor (Mercenary's Code)",
+											"reference": "B127, S221",
+											"notes": "A merc should look out for his buddies, take care of his gear, and fight for the honor of the unit. Obey the rules of engagement. Don’t poach on another unit’s contract. Do the job you’re hired for.",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
-											"modifiers": [
-												{
-													"id": "mE7HznsHMnw6q4QBL",
-													"name": "Scope: Common",
-													"reference": "B140",
-													"cost": -5,
-													"cost_type": "points"
-												},
-												{
-													"id": "ma_DMewxzDogEK07l",
-													"name": "Scope: Occasional",
-													"reference": "B140",
-													"cost": -2,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mJupL0daKPAgrCs7Z",
-													"name": "Scope: Rare",
-													"reference": "B140",
-													"cost": -1,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mQ2D4WylqMMninfAo",
-													"name": "Scope: Anyone unlike you",
-													"reference": "B140",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												}
+											"base_points": -10,
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "tCTfKHrUrdkU9sqLg",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tqq24I9NJrLajsURv"
+											},
+											"name": "Code of Honor (Pirate's)",
+											"reference": "B127",
+											"notes": "Always avenge an insult, regardless of the danger; your buddy’s foe is your own; never attack a fellow crewman or buddy except in a fair, open duel.",
+											"tags": [
+												"Disadvantage",
+												"Mental"
 											],
+											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										},
+										{
+											"id": "tcKHv3YjoJffuy-vb",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t4KGpV0KBExr-fEb2"
+											},
+											"name": "Gregarious",
+											"reference": "B126",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"base_points": -10,
 											"features": [
 												{
 													"type": "reaction_bonus",
-													"situation": "from victims of your intolerance (may be as much as -5, at GM's discretion)",
+													"situation": "to others",
+													"amount": 4
+												},
+												{
+													"type": "conditional_modifier",
+													"situation": "to IQ-based skills when alone, or only -1 if in a group of 4 or less",
+													"amount": -2
+												}
+											],
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "tsNKCv1QWxNTIPkx2",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tzBDG0xUlT_dh7FuY"
+											},
+											"name": "Chummy",
+											"reference": "B126",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"base_points": -5,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "to others",
+													"amount": 2
+												},
+												{
+													"type": "conditional_modifier",
+													"situation": "to IQ-based skills when alone",
 													"amount": -1
 												}
 											],
@@ -2699,91 +3484,12 @@
 											}
 										},
 										{
-											"id": "tM6QSNf7IupFf5KEg",
-											"name": "Lecherousness",
-											"reference": "B142",
-											"notes": "Make a self-control roll whenever you have more than the briefest contact with an appealing member of the sex you find attractive, at -5 if this person is Handsome/Beautiful, or at -10 if Very Handsome/Very Beautiful. If you fail, you must make a “pass” using whatever wiles and skills you can bring to bear.",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"cr": 12,
-											"base_points": -15,
-											"calc": {
-												"points": -15
-											}
-										},
-										{
-											"id": "tvbd6yyCCiMwT2Lwf",
-											"name": "Pacifism: Reluctant Killer",
-											"reference": "B148",
-											"notes": "You are psychologically unprepared to kill people. Whenever you make a deadly attack (e.g., with a knife or a gun) against an obvious person whose face is visible to you, you are at -4 to hit and may not Aim. If you cannot see the foe’s face (due to a mask, darkness, or distance, or because you attacked from behind), the penalty is only -2, save in close combat. You have no penalty to attack a vehicle (even an occupied one), an opponent you do not believe is a person (including things with Horrific or Monstrous appearance), or a target you can’t actually see (e.g., a set of map coordinates or a blip on a radar screen). If you kill a recognizable person, the effect on you is the same as for Pacifism: Cannot Kill. You have no problem with your allies killing; you may even supply ammo, loaded weapons, and encouragement! You just can’t do the killing yourself.",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"modifiers": [
-												{
-													"id": "mXj0DfCVbw7ZAsFLw",
-													"name": "Species-Specific",
-													"reference": "UT32",
-													"cost": -80,
-													"disabled": true
-												}
-											],
-											"base_points": -5,
-											"calc": {
-												"points": -5
-											}
-										},
-										{
-											"id": "twwudeulH3TSt8qRK",
-											"name": "Pacifism: Self-Defense Only",
-											"reference": "B148",
-											"notes": "You only fight to defend yourself or those in your care, using only as much force as necessary (no pre-emptive strikes allowed!). You must do your best to discourage others from starting fights.",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"modifiers": [
-												{
-													"id": "mGd8vmStklokh9zO8",
-													"name": "Species-Specific",
-													"reference": "UT32",
-													"cost": -80,
-													"disabled": true
-												}
-											],
-											"base_points": -15,
-											"calc": {
-												"points": -15
-											}
-										},
-										{
-											"id": "tzju8NPIc3RuWPE7T",
-											"name": "Pacifism: Cannot Harm Innocents",
-											"reference": "B148",
-											"notes": "You may fight – you may even start fights – but you may only use deadly force on a foe that is attempting to do you serious harm. Capture is not “serious harm” unless you are already under penalty of death or have a Code of Honor that would require suicide if captured. You never intentionally do anything that causes, or even threatens to cause, injury to the uninvolved – particularly if they are “ordinary folks.”",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"modifiers": [
-												{
-													"id": "mypCyHq5lqJLk1Jg0",
-													"name": "Species-Specific",
-													"reference": "UT32",
-													"cost": -80,
-													"disabled": true
-												}
-											],
-											"base_points": -10,
-											"calc": {
-												"points": -10
-											}
-										},
-										{
-											"id": "t64UvJmTRR4seNeC_",
+											"id": "tQUvxk6dC55gs0us-",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "taFPI7E0PJwXbS5nL"
+											},
 											"name": "Agoraphobia (Open Spaces)",
 											"reference": "B150",
 											"notes": "You are uncomfortable whenever you are outside, and actually become frightened when there are no walls within 50 feet.",
@@ -2797,120 +3503,19 @@
 											"calc": {
 												"points": -10
 											}
-										},
-										{
-											"id": "tNA1pGYJ1nPD6_a06",
-											"name": "Demophobia (Crowds)",
-											"reference": "B149",
-											"notes": "Any group of over a dozen people sets off this fear unless they are all well known to you. The self-control roll is at -1 for over 25 people, -2 for a crowd of 100 or more, -3 for 1,000, -4 for 10,000, and so on.",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"cr_adj": "action_penalty",
-											"cr": 12,
-											"base_points": -15,
-											"calc": {
-												"points": -15
-											}
-										},
-										{
-											"id": "tEwCu-tsmNhQGy3Hm",
-											"name": "Duty (To ship's owner or provider)",
-											"reference": "B133",
-											"tags": [
-												"Disadvantage",
-												"Social"
-											],
-											"modifiers": [
-												{
-													"id": "mg0qfARGL4zK06EBG",
-													"name": "FR: 6",
-													"cost": -2,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mTXLSCXAwMh9e5REl",
-													"name": "FR: 9",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m53Fo5g8XJcIRkW4G",
-													"name": "FR: 12",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mr2GE-J3mt1bwB1ie",
-													"name": "FR: 15",
-													"cost": -15,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mgmFqQUTrTLcj9m8g",
-													"name": "Extremely Hazardous",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mFMcUyr2b4Om8FbHU",
-													"name": "Involuntary",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mC85t5YPiG25JvX8y",
-													"name": "Nonhazardous",
-													"cost": 5,
-													"cost_type": "points",
-													"disabled": true
-												}
-											],
-											"calc": {
-												"points": 0
-											}
-										},
-										{
-											"id": "tZFxUZCdNXUW288aY",
-											"name": "Workaholic",
-											"reference": "B162",
-											"tags": [
-												"Disadvantage",
-												"Physical"
-											],
-											"base_points": -5,
-											"calc": {
-												"points": -5
-											}
-										},
-										{
-											"id": "t4l5qHzj2gjc7UI35",
-											"name": "Xenophilia",
-											"reference": "B162",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"cr": 12,
-											"base_points": -10,
-											"calc": {
-												"points": -10
-											}
 										}
 									],
 									"calc": {
-										"points": -145
+										"points": -180
 									}
 								},
 								{
-									"id": "t9jcZI7-q0EBE_Vzy",
+									"id": "tg8kVvHUdImfcwd6u",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tV06LED8bg9xJGF3c"
+									},
 									"name": "Impulsiveness",
 									"reference": "B139",
 									"notes": "Make a self-control roll whenever it would be wise to wait and ponder. If you fail, you must act",
@@ -2925,7 +3530,12 @@
 									}
 								},
 								{
-									"id": "tZr5BEzzdAYzir7sd",
+									"id": "tF8fJQFokbG8UNpEp",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tNNZgqAtiUMQ_dZs6"
+									},
 									"name": "Jealousy",
 									"reference": "B140",
 									"tags": [
@@ -2945,7 +3555,12 @@
 									}
 								},
 								{
-									"id": "t_q6OPNtI36D18Mhc",
+									"id": "t1DjXKGUbdKeY_hjj",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "td7zQlyInlQxbhJsD"
+									},
 									"name": "On the Edge",
 									"reference": "B146",
 									"notes": "Make a self-control roll whenever you face a life-threatening situation: piloting a burning vehicle, staring down an entire street gang while armed only with a toothbrush, etc. If you fail, you may not back down from the challenge – but you may roll again after every success roll or reaction roll relating to the situation. In combat, make a self-control roll every time you take your turn. If you fail, you must make an All-Out attack or engage in some other kind of near-insane, suicidal behavior.",
@@ -2967,7 +3582,12 @@
 									}
 								},
 								{
-									"id": "tRsgLH1fXISGMuRqE",
+									"id": "t9X7Bks99r5HwfND9",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tPbL1_rekOzkM86wz"
+									},
 									"name": "Overconfidence",
 									"reference": "B148",
 									"notes": "You must make a self-control roll any time the GM feels you show an unreasonable degree of caution. If you fail, you must go ahead as though you were able to handle the situation!",
@@ -2995,17 +3615,17 @@
 								}
 							],
 							"calc": {
-								"points": -185
+								"points": -220
 							}
 						}
 					],
 					"calc": {
-						"points": -185
+						"points": -220
 					}
 				}
 			],
 			"calc": {
-				"points": 216
+				"points": 181
 			}
 		},
 		{
@@ -3018,7 +3638,12 @@
 					"name": "Multi-Role",
 					"children": [
 						{
-							"id": "txKnw1_-M5tNpLYMQ",
+							"id": "t4kvPwiWU_JNz4gAM",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tGWOSEE6SmBHACE6Y"
+							},
 							"name": "Increased Dexterity",
 							"reference": "B15",
 							"tags": [
@@ -3028,7 +3653,7 @@
 							],
 							"modifiers": [
 								{
-									"id": "mQHPfynUODA6ZdOFe",
+									"id": "mBJAIRasW91f0flrS",
 									"name": "No Fine Manipulators",
 									"cost": -40,
 									"disabled": true
@@ -3050,85 +3675,12 @@
 							}
 						},
 						{
-							"id": "tGs35E6eGI1ST4Llw",
-							"name": "Talent (Hot Pilot)",
-							"reference": "PU3:11",
-							"tags": [
-								"Advantage",
-								"Mental",
-								"Talent"
-							],
-							"points_per_level": 5,
-							"features": [
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Gunner"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Navigation"
-									},
-									"specialization": {
-										"compare": "is",
-										"qualifier": "Air"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Navigation"
-									},
-									"specialization": {
-										"compare": "is",
-										"qualifier": "Space"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Piloting"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "reaction_bonus",
-									"situation": "From other Pilots.",
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "conditional_modifier",
-									"situation": "Reduce penalties for unfamiliar systems of vehicles you have Piloting skill for",
-									"amount": 1,
-									"per_level": true
-								}
-							],
-							"can_level": true,
-							"levels": 2,
-							"calc": {
-								"points": 10
-							}
-						},
-						{
-							"id": "tF3hPcXuD7dx3FjCY",
+							"id": "tvFpdwsApQxhdCYh_",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tM6z7Mx6e2V4VvUR4"
+							},
 							"name": "Absolute Direction",
 							"reference": "B34",
 							"tags": [
@@ -3138,14 +3690,14 @@
 							],
 							"modifiers": [
 								{
-									"id": "mWUAAToU3YKaByac2",
+									"id": "m7JIQ00La5UIbgc-t",
 									"name": "Requires signal",
 									"reference": "B34",
 									"cost": -20,
 									"disabled": true
 								},
 								{
-									"id": "mZVCsOBIr3GSabeZ_",
+									"id": "m931wYfImOwLk2Iof",
 									"name": "3D Spatial Sense",
 									"reference": "B34",
 									"cost": 5,
@@ -3261,80 +3813,55 @@
 							"calc": {
 								"points": 10
 							}
-						}
-					],
-					"calc": {
-						"points": 40
-					}
-				},
-				{
-					"id": "TiKgfgtbBUmC1O2FM",
-					"name": "Legendary",
-					"children": [
-						{
-							"id": "tw1yeMgmStcOZByz_",
-							"name": "Increased Dexterity",
-							"reference": "B15",
-							"tags": [
-								"Advantage",
-								"Attribute",
-								"Physical"
-							],
-							"modifiers": [
-								{
-									"id": "mcEeFt7nMwA6JttMK",
-									"name": "No Fine Manipulators",
-									"cost": -40,
-									"disabled": true
-								}
-							],
-							"points_per_level": 20,
-							"features": [
-								{
-									"type": "attribute_bonus",
-									"attribute": "dx",
-									"amount": 1,
-									"per_level": true
-								}
-							],
-							"can_level": true,
-							"levels": 1,
-							"calc": {
-								"points": 20
-							}
 						},
 						{
-							"id": "t6f7nWLI2j457wEfU",
-							"name": "Increased Intelligence",
-							"reference": "B15",
-							"tags": [
-								"Advantage",
-								"Attribute",
-								"Mental"
-							],
-							"points_per_level": 20,
-							"features": [
-								{
-									"type": "attribute_bonus",
-									"attribute": "iq",
-									"amount": 1,
-									"per_level": true
-								}
-							],
-							"can_level": true,
-							"levels": 1,
-							"calc": {
-								"points": 20
-							}
-						},
-						{
-							"id": "tb3k7kcuiNByjarYp",
+							"id": "tkSSxD1MMnx16cIBT",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "tHPdAVdz9JvulCeVU"
+							},
 							"name": "Talent (Hot Pilot)",
 							"reference": "PU3:11",
 							"tags": [
 								"Advantage",
 								"Mental",
 								"Talent"
+							],
+							"modifiers": [
+								{
+									"id": "MRyz9jzebZFWzG4pr",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "mwuw3rNOesk2a9ljL",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From other Pilots.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "m9hbqyk0jIj4k0z9b",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Reduce penalties for unfamiliar systems of vehicles you have Piloting skill for",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
+								}
 							],
 							"points_per_level": 5,
 							"features": [
@@ -3385,16 +3912,185 @@
 									},
 									"amount": 1,
 									"per_level": true
-								},
+								}
+							],
+							"can_level": true,
+							"levels": 2,
+							"calc": {
+								"points": 10
+							}
+						}
+					],
+					"calc": {
+						"points": 40
+					}
+				},
+				{
+					"id": "TiKgfgtbBUmC1O2FM",
+					"name": "Legendary",
+					"children": [
+						{
+							"id": "tz7ECBnNZHVkiPtsy",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tGWOSEE6SmBHACE6Y"
+							},
+							"name": "Increased Dexterity",
+							"reference": "B15",
+							"tags": [
+								"Advantage",
+								"Attribute",
+								"Physical"
+							],
+							"modifiers": [
 								{
-									"type": "reaction_bonus",
-									"situation": "From other Pilots.",
+									"id": "mKkFak9MCeELhxB5c",
+									"name": "No Fine Manipulators",
+									"cost": -40,
+									"disabled": true
+								}
+							],
+							"points_per_level": 20,
+							"features": [
+								{
+									"type": "attribute_bonus",
+									"attribute": "dx",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"levels": 1,
+							"calc": {
+								"points": 20
+							}
+						},
+						{
+							"id": "t9OVVtQcHLuX37bhO",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t1w1RFcFceKR2T9_e"
+							},
+							"name": "Increased Intelligence",
+							"reference": "B15",
+							"tags": [
+								"Advantage",
+								"Attribute",
+								"Mental"
+							],
+							"points_per_level": 20,
+							"features": [
+								{
+									"type": "attribute_bonus",
+									"attribute": "iq",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"levels": 1,
+							"calc": {
+								"points": 20
+							}
+						},
+						{
+							"id": "tmQMMxq5Ul--Va7g0",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "tHPdAVdz9JvulCeVU"
+							},
+							"name": "Talent (Hot Pilot)",
+							"reference": "PU3:11",
+							"tags": [
+								"Advantage",
+								"Mental",
+								"Talent"
+							],
+							"modifiers": [
+								{
+									"id": "MuSWqiXSfW6EG5RXK",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "mFqZinaxfTMXiDTQV",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From other Pilots.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "mo7HxDzqAf-CeMG5w",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Reduce penalties for unfamiliar systems of vehicles you have Piloting skill for",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
+								}
+							],
+							"points_per_level": 5,
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Gunner"
+									},
 									"amount": 1,
 									"per_level": true
 								},
 								{
-									"type": "conditional_modifier",
-									"situation": "Reduce penalties for unfamiliar systems of vehicles you have Piloting skill for",
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Navigation"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "Air"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Navigation"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "Space"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Piloting"
+									},
 									"amount": 1,
 									"per_level": true
 								}
@@ -3427,7 +4123,12 @@
 					"name": "Primary Skills",
 					"children": [
 						{
-							"id": "sxBQLUsA243xg5mOW",
+							"id": "sX57aRw-96z3g_0SU",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "shChZ7cQ-SIe7JKo6"
+							},
 							"name": "Navigation",
 							"reference": "B211",
 							"tags": [
@@ -3436,7 +4137,10 @@
 								"Technical",
 								"Vehicle"
 							],
-							"specialization": "@FTL@",
+							"replacements": {
+								"Environment": "@FTL@"
+							},
+							"specialization": "@Environment@",
 							"difficulty": "iq/a",
 							"defaults": [
 								{
@@ -3461,7 +4165,12 @@
 							"points": 4
 						},
 						{
-							"id": "slYVcFdWZlsIb0AKJ",
+							"id": "sRe3mCBr5Inj4cMgT",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sZZ8IZK6yPuxwffjd"
+							},
 							"name": "Navigation",
 							"reference": "B211",
 							"tags": [
@@ -3495,13 +4204,21 @@
 							"points": 1
 						},
 						{
-							"id": "sv6x3l-0J3fqAAZvw",
+							"id": "sRie02EW7Ctesl03c",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sQE2t0-gMM5-4KgPb"
+							},
 							"name": "Piloting",
 							"reference": "B214",
 							"tags": [
 								"Vehicle"
 							],
-							"specialization": "@Main@",
+							"replacements": {
+								"Flying vehicle class": "@Main@"
+							},
+							"specialization": "@Flying vehicle class@",
 							"difficulty": "dx/a",
 							"defaults": [
 								{
@@ -3524,13 +4241,21 @@
 							"points": 2
 						},
 						{
-							"id": "syX95O_crqMJRSg8f",
+							"id": "s0jbjBA_PK91w2tZU",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sQE2t0-gMM5-4KgPb"
+							},
 							"name": "Piloting",
 							"reference": "B214",
 							"tags": [
 								"Vehicle"
 							],
-							"specialization": "@Secondary@",
+							"replacements": {
+								"Flying vehicle class": "@Secondary@"
+							},
+							"specialization": "@Flying vehicle class@",
 							"difficulty": "dx/a",
 							"defaults": [
 								{
@@ -3559,28 +4284,70 @@
 					"name": "Secondary Skills",
 					"children": [
 						{
-							"id": "sygIkjnXaAc2QA_gE",
-							"name": "Area Knowledge",
-							"reference": "B176",
-							"notes": "Location of major planets; familiarity with all known races (but not necessarily expertise); knowledge of people of Status 7+; general understanding of the economic and political situation",
-							"tags": [
-								"Everyman",
-								"Knowledge"
-							],
-							"specialization": "@interplanetary State or Galaxy@",
-							"difficulty": "iq/e",
-							"defaults": [
+							"id": "Sq01vnfhtQh2jHEi_",
+							"name": "One of:",
+							"children": [
 								{
-									"type": "skill",
-									"name": "Geography",
-									"specialization": "@Specialty@",
-									"modifier": -3
+									"id": "sZoHCXxgykNjMnixL",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "s-Ckyxw5PmHIvbZab"
+									},
+									"name": "Area Knowledge",
+									"reference": "B176",
+									"notes": "Location of major planets; familiarity with all known races (but not necessarily expertise); knowledge of people of Status 7+; general understanding of the economic and political situation",
+									"tags": [
+										"Everyman",
+										"Knowledge"
+									],
+									"specialization": "@Interplanetary State@",
+									"difficulty": "iq/e",
+									"defaults": [
+										{
+											"type": "skill",
+											"name": "Geography",
+											"specialization": "@Specialty@",
+											"modifier": -3
+										}
+									],
+									"points": 2
+								},
+								{
+									"id": "syhvvz9W5I7bXpmwa",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sTXDrqXH0sT2NSD_b"
+									},
+									"name": "Area Knowledge",
+									"reference": "B176",
+									"notes": "Location of the capitals of interplanetary states and the homeworlds of major races; general awareness of all major races; knowledge of individuals of Status 8; general understanding of relations between interplanetary states",
+									"tags": [
+										"Everyman",
+										"Knowledge"
+									],
+									"specialization": "@Galaxy@",
+									"difficulty": "iq/e",
+									"defaults": [
+										{
+											"type": "skill",
+											"name": "Geography",
+											"specialization": "@Specialty@",
+											"modifier": -3
+										}
+									],
+									"points": 2
 								}
-							],
-							"points": 2
+							]
 						},
 						{
-							"id": "sMptzHIOcYgi3QR9S",
+							"id": "s8zdDVec13bCntUym",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sB28HTR_MZyXLP90w"
+							},
 							"name": "Cartography",
 							"reference": "B183",
 							"tags": [
@@ -3616,7 +4383,12 @@
 							"points": 4
 						},
 						{
-							"id": "s9tTI7D2iOCIbm7FV",
+							"id": "sUfV1Dn5QnyThZt1w",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sluTeYhSTpIbVNfA5"
+							},
 							"name": "Electronics Operation",
 							"reference": "B189",
 							"tags": [
@@ -3651,7 +4423,12 @@
 							"points": 4
 						},
 						{
-							"id": "s7f1vVN-h2pkeicxC",
+							"id": "sV0lAuu2-oScX1FTo",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sbcabbj7Zf2iurxxA"
+							},
 							"name": "Astronomy",
 							"reference": "B179",
 							"tags": [
@@ -3686,7 +4463,12 @@
 							"points": 4
 						},
 						{
-							"id": "s_vFoI_GOK_o9BYi4",
+							"id": "sp2Y7_KsxseD8UWzB",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sR_M_d1acCzYenF_A"
+							},
 							"name": "Shiphandling",
 							"reference": "B220",
 							"tags": [
@@ -3761,7 +4543,12 @@
 					"name": "Background Skills",
 					"children": [
 						{
-							"id": "sGibTdpKWR3oyWeg4",
+							"id": "sogt-U7fE8iU6Rn-q",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "ssHhRG7LH-Ma3YDnH"
+							},
 							"name": "Computer Operation",
 							"reference": "B184",
 							"tags": [
@@ -3780,7 +4567,12 @@
 							"points": 1
 						},
 						{
-							"id": "srK7J1y3rlcpQDPpA",
+							"id": "sEjELLQDSDg6PeaYN",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "s7kVwKFERTuMYO3O8"
+							},
 							"name": "Free Fall",
 							"reference": "B197",
 							"tags": [
@@ -3800,7 +4592,12 @@
 							"points": 1
 						},
 						{
-							"id": "s3Anf1bD-HWRj0YIU",
+							"id": "soSSiaPdY7M9h64TY",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sSxGnNPMXyZpZKoFZ"
+							},
 							"name": "Leadership",
 							"reference": "B204",
 							"tags": [
@@ -3817,7 +4614,12 @@
 							"points": 1
 						},
 						{
-							"id": "sBkwBdZAHyaGhC_QP",
+							"id": "s1VnN5WdfuP7qp_b5",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "s9IHT34mK8yfSB7d_"
+							},
 							"name": "Spacer",
 							"reference": "B185",
 							"tags": [
@@ -3834,7 +4636,12 @@
 							"points": 1
 						},
 						{
-							"id": "stbLWI_-89K_t2-0J",
+							"id": "srK5jDIFtyn4v5ZPc",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sAmDzPjf0rKZ6I5G1"
+							},
 							"name": "Vacc Suit",
 							"reference": "B192",
 							"tags": [
@@ -3870,11 +4677,94 @@
 							"name": "10 Points chosen from",
 							"children": [
 								{
-									"id": "SQI54B7Ulze0XJfTz",
+									"id": "SgM4bBiBArPmussVh",
 									"name": "Everyman Skills",
 									"children": [
 										{
-											"id": "sgGKsUOLLhnSYzCJN",
+											"id": "ssUn4eO2n85wAQ8dy",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sTXDrqXH0sT2NSD_b"
+											},
+											"name": "Area Knowledge",
+											"reference": "B176",
+											"notes": "Location of the capitals of interplanetary states and the homeworlds of major races; general awareness of all major races; knowledge of individuals of Status 8; general understanding of relations between interplanetary states",
+											"tags": [
+												"Everyman",
+												"Knowledge"
+											],
+											"specialization": "@Galaxy@",
+											"difficulty": "iq/e",
+											"defaults": [
+												{
+													"type": "skill",
+													"name": "Geography",
+													"specialization": "@Specialty@",
+													"modifier": -3
+												}
+											],
+											"points": 1
+										},
+										{
+											"id": "sploY1gdoZVizl0H0",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "s-Ckyxw5PmHIvbZab"
+											},
+											"name": "Area Knowledge",
+											"reference": "B176",
+											"notes": "Location of major planets; familiarity with all known races (but not necessarily expertise); knowledge of people of Status 7+; general understanding of the economic and political situation",
+											"tags": [
+												"Everyman",
+												"Knowledge"
+											],
+											"specialization": "@Interplanetary State@",
+											"difficulty": "iq/e",
+											"defaults": [
+												{
+													"type": "skill",
+													"name": "Geography",
+													"specialization": "@Specialty@",
+													"modifier": -3
+												}
+											],
+											"points": 1
+										},
+										{
+											"id": "snIiB738l9MM8AQNa",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "strhX4LEdd46xgmIS"
+											},
+											"name": "Area Knowledge",
+											"reference": "B176",
+											"notes": "Location of its major cities and important sites; awareness of its major customs, ethnic groups, and languages (but not necessarily expertise); names of folk of Status 7+; and a general understanding of the economic and political situation",
+											"tags": [
+												"Everyman",
+												"Knowledge"
+											],
+											"specialization": "@Planet@",
+											"difficulty": "iq/e",
+											"defaults": [
+												{
+													"type": "skill",
+													"name": "Geography",
+													"specialization": "@Specialty@",
+													"modifier": -3
+												}
+											],
+											"points": 1
+										},
+										{
+											"id": "sFMgf5k7E2FrRKE-Y",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sBJgeWUs81Ifhob4Z"
+											},
 											"name": "Beam Weapons",
 											"reference": "B179",
 											"tags": [
@@ -3905,7 +4795,67 @@
 											"points": 1
 										},
 										{
-											"id": "sA7Tbhk09fr6X54xP",
+											"id": "sGDIt9Hzd6aLnJPL6",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sOp4wssAMtUc1ukJI"
+											},
+											"name": "Body Language",
+											"reference": "B181",
+											"tags": [
+												"Police",
+												"Social",
+												"Spy"
+											],
+											"difficulty": "per/a",
+											"defaults": [
+												{
+													"type": "skill",
+													"name": "Detect Lies",
+													"modifier": -4
+												},
+												{
+													"type": "skill",
+													"name": "Psychology",
+													"modifier": -4
+												}
+											],
+											"points": 1
+										},
+										{
+											"id": "sYy1jRuAWwQzlKoi2",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sziMa9_9xTvR2iiqx"
+											},
+											"name": "Body Sense",
+											"reference": "B181",
+											"tags": [
+												"Athletic"
+											],
+											"difficulty": "dx/h",
+											"defaults": [
+												{
+													"type": "dx",
+													"modifier": -6
+												},
+												{
+													"type": "skill",
+													"name": "Acrobatics",
+													"modifier": -3
+												}
+											],
+											"points": 1
+										},
+										{
+											"id": "sKgmdmAtMW4jWGJiV",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "shtDdl5thrvKSnJHf"
+											},
 											"name": "Brawling",
 											"reference": "B182,MA55",
 											"tags": [
@@ -3933,210 +4883,35 @@
 											"points": 1
 										},
 										{
-											"id": "sHD0IVQ_mbB5fDr-h",
-											"name": "Guns",
-											"reference": "B198",
+											"id": "sNAu152wdQ9cpKNfF",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "si-upI7A5RgdO0cjC"
+											},
+											"name": "Carousing",
+											"reference": "B183",
 											"tags": [
-												"Combat",
-												"Ranged Combat",
-												"Weapon"
+												"Criminal",
+												"Social",
+												"Street"
 											],
-											"specialization": "@Gun class@",
-											"difficulty": "dx/e",
+											"difficulty": "ht/e",
 											"defaults": [
 												{
-													"type": "dx",
-													"modifier": -4
-												},
-												{
-													"type": "skill",
-													"name": "Guns",
-													"modifier": -4
-												}
-											],
-											"tech_level": "",
-											"points": 1
-										},
-										{
-											"id": "sdmHh6xChxspI1gUf",
-											"name": "Sports",
-											"reference": "B222,MA59",
-											"tags": [
-												"Athletic"
-											],
-											"specialization": "@Speciality@",
-											"difficulty": "dx/a",
-											"defaults": [
-												{
-													"type": "dx",
-													"modifier": -5
-												}
-											],
-											"points": 1
-										},
-										{
-											"id": "s_tZGRUnoQ2t0ehn-",
-											"name": "Body Sense",
-											"reference": "B181",
-											"notes": "For settings with matter transmission",
-											"tags": [
-												"Athletic"
-											],
-											"difficulty": "dx/h",
-											"defaults": [
-												{
-													"type": "dx",
-													"modifier": -6
-												},
-												{
-													"type": "skill",
-													"name": "Acrobatics",
-													"modifier": -3
-												}
-											],
-											"points": 1
-										},
-										{
-											"id": "suWtr6maeAHRJIA_-",
-											"name": "Hobby Skill",
-											"reference": "B200,MA57",
-											"tags": [
-												"Knowledge"
-											],
-											"specialization": "@Mental Hobby@",
-											"difficulty": "iq/e",
-											"defaults": [
-												{
-													"type": "iq",
+													"type": "ht",
 													"modifier": -4
 												}
 											],
 											"points": 1
 										},
 										{
-											"id": "sn19J9FQ4X1jNWlob",
-											"name": "Hobby Skill",
-											"reference": "B200,MA57",
-											"tags": [
-												"Knowledge"
-											],
-											"specialization": "@Physical Hobby@",
-											"difficulty": "dx/e",
-											"defaults": [
-												{
-													"type": "dx",
-													"modifier": -4
-												}
-											],
-											"points": 1
-										},
-										{
-											"id": "ssfmSO2-3WVJof9KI",
-											"name": "Professional Skill",
-											"reference": "B215",
-											"tags": [
-												"Knowledge"
-											],
-											"specialization": "@Mental Skill@",
-											"difficulty": "iq/a",
-											"defaults": [
-												{
-													"type": "iq",
-													"modifier": -5
-												}
-											],
-											"points": 1
-										},
-										{
-											"id": "sXw2GjpQScblTY3kP",
-											"name": "Professional Skill",
-											"reference": "B215",
-											"tags": [
-												"Knowledge"
-											],
-											"specialization": "@Physical Skill@",
-											"difficulty": "dx/a",
-											"defaults": [
-												{
-													"type": "dx",
-													"modifier": -5
-												}
-											],
-											"points": 1
-										},
-										{
-											"id": "sa7w2agZkqgYNU_4M",
-											"name": "Area Knowledge",
-											"reference": "B176",
-											"notes": "Location of the capitals of interplanetary states and the homeworlds of major races; general awareness of all major races; knowledge of individuals of Status 8; general understanding of relations between interplanetary states",
-											"tags": [
-												"Everyman",
-												"Knowledge"
-											],
-											"specialization": "@Galaxy@",
-											"difficulty": "iq/e",
-											"defaults": [
-												{
-													"type": "skill",
-													"name": "Geography",
-													"specialization": "@Specialty@",
-													"modifier": -3
-												}
-											],
-											"points": 1
-										},
-										{
-											"id": "s2-180CkA9w557PmG",
-											"name": "Area Knowledge",
-											"reference": "B176",
-											"notes": "Location of major planets; familiarity with all known races (but not necessarily expertise); knowledge of people of Status 7+; general understanding of the economic and political situation",
-											"tags": [
-												"Everyman",
-												"Knowledge"
-											],
-											"specialization": "@Interplanetary State@; Lived there",
-											"difficulty": "iq/e",
-											"defaults": [
-												{
-													"type": "iq",
-													"modifier": -4
-												},
-												{
-													"type": "skill",
-													"name": "Geography",
-													"specialization": "@Specialty@",
-													"modifier": -3
-												}
-											],
-											"points": 1
-										},
-										{
-											"id": "shgRkH51A88gloqIK",
-											"name": "Area Knowledge",
-											"reference": "B176",
-											"notes": "Location of its major cities and important sites; awareness of its major customs, ethnic groups, and languages (but not necessarily expertise); names of folk of Status 7+; and a general understanding of the economic and political situation",
-											"tags": [
-												"Everyman",
-												"Knowledge"
-											],
-											"specialization": "@Planet@; Lived there",
-											"difficulty": "iq/e",
-											"defaults": [
-												{
-													"type": "iq",
-													"modifier": -4
-												},
-												{
-													"type": "skill",
-													"name": "Geography",
-													"specialization": "@Specialty@",
-													"modifier": -3
-												}
-											],
-											"points": 1
-										},
-										{
-											"id": "s-MGh7hNPGL8_oiAp",
+											"id": "sba4HfxXhmLFFfbhq",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sWFtA7Gvclq4aL-Yb"
+											},
 											"name": "Current Affairs",
 											"reference": "B186",
 											"tags": [
@@ -4167,7 +4942,12 @@
 											"points": 1
 										},
 										{
-											"id": "ss65p4H874iWsGCA1",
+											"id": "sdQi2VYXg-u6NJoOH",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "s9mV--3lpIfXO7N6Z"
+											},
 											"name": "First Aid",
 											"reference": "B195",
 											"tags": [
@@ -4198,56 +4978,12 @@
 											"points": 1
 										},
 										{
-											"id": "sxzHvLf5TNmZ7FMBr",
-											"name": "Games",
-											"reference": "B197,MA57",
-											"tags": [
-												"Knowledge"
-											],
-											"specialization": "@Specialty@",
-											"difficulty": "iq/e",
-											"defaults": [
-												{
-													"type": "iq",
-													"modifier": -4
-												}
-											],
-											"points": 1
-										},
-										{
-											"id": "sr_ifTL7XoJT2wmn1",
-											"name": "Gesture",
-											"reference": "B198",
-											"tags": [
-												"Social"
-											],
-											"difficulty": "iq/e",
-											"defaults": [
-												{
-													"type": "iq",
-													"modifier": -4
-												}
-											],
-											"points": 1
-										},
-										{
-											"id": "syJ3ynWV1VG1X301a",
-											"name": "Housekeeping",
-											"reference": "B200",
-											"tags": [
-												"Everyman"
-											],
-											"difficulty": "iq/e",
-											"defaults": [
-												{
-													"type": "iq",
-													"modifier": -4
-												}
-											],
-											"points": 1
-										},
-										{
-											"id": "se5D-GlBISZQZsIMy",
+											"id": "snwHRy5Hm0LAPDWCl",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sWB9ypJAq43MF3O0n"
+											},
 											"name": "Gambling",
 											"reference": "B197",
 											"tags": [
@@ -4271,7 +5007,237 @@
 											"points": 1
 										},
 										{
-											"id": "sKeRqVQS-9im7b0Et",
+											"id": "squgdLgTVq-x8-1uQ",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "syfSQ9N8yETqQbhFK"
+											},
+											"name": "Games",
+											"reference": "B197,MA57",
+											"tags": [
+												"Knowledge"
+											],
+											"specialization": "@Specialty@",
+											"difficulty": "iq/e",
+											"defaults": [
+												{
+													"type": "iq",
+													"modifier": -4
+												}
+											],
+											"points": 1
+										},
+										{
+											"id": "sg5JnwSYkhuXYfGpE",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sGz21GskAlJXL1hYP"
+											},
+											"name": "Gesture",
+											"reference": "B198",
+											"tags": [
+												"Social"
+											],
+											"difficulty": "iq/e",
+											"defaults": [
+												{
+													"type": "iq",
+													"modifier": -4
+												}
+											],
+											"points": 1
+										},
+										{
+											"id": "sai_3uer_57kFYnCQ",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sT5htbz4-Mr0PFCk7"
+											},
+											"name": "Guns",
+											"reference": "B198",
+											"tags": [
+												"Combat",
+												"Ranged Combat",
+												"Weapon"
+											],
+											"specialization": "@Gun class@",
+											"difficulty": "dx/e",
+											"defaults": [
+												{
+													"type": "dx",
+													"modifier": -4
+												},
+												{
+													"type": "skill",
+													"name": "Guns",
+													"modifier": -4
+												}
+											],
+											"tech_level": "",
+											"points": 1
+										},
+										{
+											"id": "sUyY3flmzsmiz_dW9",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sOtPessbzkRjGaQPR"
+											},
+											"name": "Hobby Skill",
+											"reference": "B200,MA57",
+											"tags": [
+												"Knowledge"
+											],
+											"specialization": "@Mental Hobby@",
+											"difficulty": "iq/e",
+											"defaults": [
+												{
+													"type": "iq",
+													"modifier": -4
+												}
+											],
+											"points": 1
+										},
+										{
+											"id": "s616PpQLyZritiyRH",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sDLf4crz0sGRjVDFi"
+											},
+											"name": "Hobby Skill",
+											"reference": "B200,MA57",
+											"tags": [
+												"Knowledge"
+											],
+											"specialization": "@Physical Hobby@",
+											"difficulty": "dx/e",
+											"defaults": [
+												{
+													"type": "dx",
+													"modifier": -4
+												}
+											],
+											"points": 1
+										},
+										{
+											"id": "sD1QVgFRi6JSncZvI",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sfZrwMVUibhbtdssl"
+											},
+											"name": "Housekeeping",
+											"reference": "B200",
+											"tags": [
+												"Everyman"
+											],
+											"difficulty": "iq/e",
+											"defaults": [
+												{
+													"type": "iq",
+													"modifier": -4
+												}
+											],
+											"points": 1
+										},
+										{
+											"id": "s97Ut574nyhod7vWV",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sdl9m7gHE7hlMX0AX"
+											},
+											"name": "Lip Reading",
+											"reference": "B205",
+											"tags": [
+												"Spy"
+											],
+											"difficulty": "per/a",
+											"defaults": [
+												{
+													"type": "per",
+													"modifier": -10
+												}
+											],
+											"points": 1
+										},
+										{
+											"id": "sc57ObxtbkohnGMuS",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sx1CDkGBR830IZrmz"
+											},
+											"name": "Professional Skill",
+											"reference": "B215",
+											"tags": [
+												"Knowledge"
+											],
+											"specialization": "@Mental Skill@",
+											"difficulty": "iq/a",
+											"defaults": [
+												{
+													"type": "iq",
+													"modifier": -5
+												}
+											],
+											"points": 1
+										},
+										{
+											"id": "sa062Ag_RBSiz_lKw",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sBec-o4Z7gPpbg2f9"
+											},
+											"name": "Professional Skill",
+											"reference": "B215",
+											"tags": [
+												"Knowledge"
+											],
+											"specialization": "@Physical Skill@",
+											"difficulty": "dx/a",
+											"defaults": [
+												{
+													"type": "dx",
+													"modifier": -5
+												}
+											],
+											"points": 1
+										},
+										{
+											"id": "s6ktjH8jB_uH7U3r3",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "smxkcngH5Kz54yeN3"
+											},
+											"name": "Sports",
+											"reference": "B222,MA59",
+											"tags": [
+												"Athletic"
+											],
+											"specialization": "@Speciality@",
+											"difficulty": "dx/a",
+											"defaults": [
+												{
+													"type": "dx",
+													"modifier": -5
+												}
+											],
+											"points": 1
+										},
+										{
+											"id": "sz4lLn4PmAYbxYf8o",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "smTUpMWJGqPeT1KER"
+											},
 											"name": "Streetwise",
 											"reference": "B223",
 											"tags": [
@@ -4288,69 +5254,16 @@
 												}
 											],
 											"points": 1
-										},
-										{
-											"id": "s1gKKHffs_QSja4V0",
-											"name": "Carousing",
-											"reference": "B183",
-											"tags": [
-												"Criminal",
-												"Social",
-												"Street"
-											],
-											"difficulty": "ht/e",
-											"defaults": [
-												{
-													"type": "ht",
-													"modifier": -4
-												}
-											],
-											"points": 1
-										},
-										{
-											"id": "sca_xuGlnwYC7cgYa",
-											"name": "Body Language",
-											"reference": "B181",
-											"tags": [
-												"Police",
-												"Social",
-												"Spy"
-											],
-											"difficulty": "per/a",
-											"defaults": [
-												{
-													"type": "skill",
-													"name": "Detect Lies",
-													"modifier": -4
-												},
-												{
-													"type": "skill",
-													"name": "Psychology",
-													"modifier": -4
-												}
-											],
-											"points": 1
-										},
-										{
-											"id": "sJTaXtcgncGYxEDF6",
-											"name": "Lip Reading",
-											"reference": "B205",
-											"tags": [
-												"Spy"
-											],
-											"difficulty": "per/a",
-											"defaults": [
-												{
-													"type": "per",
-													"modifier": -10
-												}
-											],
-											"points": 1
 										}
 									]
 								},
 								{
-									"id": "sWDs1gk1N60CHp7rF",
+									"id": "sCPE0FHshUjPydHip",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "snZtm1wwlLIeerPuO"
+									},
 									"name": "Gunner",
 									"reference": "B198",
 									"tags": [
@@ -4375,13 +5288,21 @@
 									"points": 1
 								},
 								{
-									"id": "sCy2qaXalivULmvCU",
+									"id": "s6V_lejqILtT6Iv_r",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sQE2t0-gMM5-4KgPb"
+									},
 									"name": "Piloting",
 									"reference": "B214",
 									"tags": [
 										"Vehicle"
 									],
-									"specialization": "@Any other@",
+									"replacements": {
+										"Flying vehicle class": "@Any other@"
+									},
+									"specialization": "@Flying vehicle class@",
 									"difficulty": "dx/a",
 									"defaults": [
 										{
@@ -4404,7 +5325,12 @@
 									"points": 1
 								},
 								{
-									"id": "sZ7NEfvmGQM3_XlL0",
+									"id": "sRIcBjZCNGic1sqiV",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "siUwhUBcqrDAPgud8"
+									},
 									"name": "Artillery",
 									"reference": "B178",
 									"tags": [
@@ -4424,13 +5350,21 @@
 									"points": 1
 								},
 								{
-									"id": "supSt7kzoGjrcOCuh",
+									"id": "sqjXzzJ5GNtFp-bCD",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sUOQKAH8IaMhpxk1o"
+									},
 									"name": "Electronics Operation",
 									"reference": "B189",
 									"tags": [
 										"Technical"
 									],
-									"specialization": "@Any other@",
+									"replacements": {
+										"Electronics type": "@Any other@"
+									},
+									"specialization": "@Electronics type@",
 									"difficulty": "iq/a",
 									"defaults": [
 										{
@@ -4459,7 +5393,12 @@
 									"points": 1
 								},
 								{
-									"id": "sTAY4o0nxvdboyyOp",
+									"id": "sekWDJShiid8He7z4",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "svZCidrvq9QTwwV3-"
+									},
 									"name": "Strategy",
 									"reference": "B222",
 									"tags": [
@@ -4491,7 +5430,12 @@
 									"points": 1
 								},
 								{
-									"id": "s_2m4ZlMT4ueXZFsg",
+									"id": "svTNRcPX-i2OTt7kX",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sgWf_qVqI7HrPQUo7"
+									},
 									"name": "Tactics",
 									"reference": "B224,MA60",
 									"tags": [
@@ -4528,28 +5472,70 @@
 					"name": "Multi-Role",
 					"children": [
 						{
-							"id": "sH5iJ4t_lR5NA-wRk",
-							"name": "Area Knowledge",
-							"reference": "B176",
-							"notes": "Location of the capitals of interplanetary states and the homeworlds of major races; general awareness of all major races; knowledge of individuals of Status 8; general understanding of relations between interplanetary states",
-							"tags": [
-								"Everyman",
-								"Knowledge"
-							],
-							"specialization": "@Galaxy@",
-							"difficulty": "iq/e",
-							"defaults": [
+							"id": "SbqB6HvHM9FoR-Kge",
+							"name": "One of:",
+							"children": [
 								{
-									"type": "skill",
-									"name": "Geography",
-									"specialization": "@Specialty@",
-									"modifier": -3
+									"id": "seYSemOPkaao3N34T",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "s-Ckyxw5PmHIvbZab"
+									},
+									"name": "Area Knowledge",
+									"reference": "B176",
+									"notes": "Location of major planets; familiarity with all known races (but not necessarily expertise); knowledge of people of Status 7+; general understanding of the economic and political situation",
+									"tags": [
+										"Everyman",
+										"Knowledge"
+									],
+									"specialization": "@Interplanetary State@",
+									"difficulty": "iq/e",
+									"defaults": [
+										{
+											"type": "skill",
+											"name": "Geography",
+											"specialization": "@Specialty@",
+											"modifier": -3
+										}
+									],
+									"points": 1
+								},
+								{
+									"id": "szEIljG27iEO__9xy",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sTXDrqXH0sT2NSD_b"
+									},
+									"name": "Area Knowledge",
+									"reference": "B176",
+									"notes": "Location of the capitals of interplanetary states and the homeworlds of major races; general awareness of all major races; knowledge of individuals of Status 8; general understanding of relations between interplanetary states",
+									"tags": [
+										"Everyman",
+										"Knowledge"
+									],
+									"specialization": "@Galaxy@",
+									"difficulty": "iq/e",
+									"defaults": [
+										{
+											"type": "skill",
+											"name": "Geography",
+											"specialization": "@Specialty@",
+											"modifier": -3
+										}
+									],
+									"points": 1
 								}
-							],
-							"points": 1
+							]
 						},
 						{
-							"id": "sWsGoyv4qGh0Ya8Vp",
+							"id": "saMk6-C-RBSAAcNLe",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sbcabbj7Zf2iurxxA"
+							},
 							"name": "Astronomy",
 							"reference": "B179",
 							"tags": [
@@ -4584,7 +5570,12 @@
 							"points": 2
 						},
 						{
-							"id": "sFOas3_a55lMM2bqo",
+							"id": "s5HHvWxGodO_7ZZbR",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sB28HTR_MZyXLP90w"
+							},
 							"name": "Cartography",
 							"reference": "B183",
 							"tags": [
@@ -4620,7 +5611,12 @@
 							"points": 2
 						},
 						{
-							"id": "s8D5x8dzCWKWwVJZ0",
+							"id": "sEX1TDjP2CD-b8b1z",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "shChZ7cQ-SIe7JKo6"
+							},
 							"name": "Navigation",
 							"reference": "B211",
 							"tags": [
@@ -4629,7 +5625,10 @@
 								"Technical",
 								"Vehicle"
 							],
-							"specialization": "@FTL@",
+							"replacements": {
+								"Environment": "@FTL@"
+							},
+							"specialization": "@Environment@",
 							"difficulty": "iq/a",
 							"defaults": [
 								{
@@ -4654,7 +5653,12 @@
 							"points": 2
 						},
 						{
-							"id": "schPCKT-zM8U4KcxT",
+							"id": "s_G9NYHnQP3DWOBrQ",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sZZ8IZK6yPuxwffjd"
+							},
 							"name": "Navigation",
 							"reference": "B211",
 							"tags": [
@@ -4688,13 +5692,21 @@
 							"points": 1
 						},
 						{
-							"id": "sKspjMHG1t2KWgwgw",
+							"id": "sUGDarwdje7U3HQG5",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sQE2t0-gMM5-4KgPb"
+							},
 							"name": "Piloting",
 							"reference": "B214",
 							"tags": [
 								"Vehicle"
 							],
-							"specialization": "@Main@",
+							"replacements": {
+								"Flying vehicle class": "@Main@"
+							},
+							"specialization": "@Flying vehicle class@",
 							"difficulty": "dx/a",
 							"defaults": [
 								{
@@ -4717,13 +5729,21 @@
 							"points": 1
 						},
 						{
-							"id": "sVZ595BofIKGPi2LK",
+							"id": "sgc6N-L-7SVQu99tw",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sQE2t0-gMM5-4KgPb"
+							},
 							"name": "Piloting",
 							"reference": "B214",
 							"tags": [
 								"Vehicle"
 							],
-							"specialization": "@Secondary@",
+							"replacements": {
+								"Flying vehicle class": "@Secondary@"
+							},
+							"specialization": "@Flying vehicle class@",
 							"difficulty": "dx/a",
 							"defaults": [
 								{

--- a/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Loadmaster.gct
+++ b/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Loadmaster.gct
@@ -12,7 +12,12 @@
 					"name": "Attributes",
 					"children": [
 						{
-							"id": "t4Qiq8xFOnT7J4RLh",
+							"id": "tOpdxMlEs0lYtu29J",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tqha9GlDBU9P-Wg-6"
+							},
 							"name": "Increased Strength",
 							"reference": "B14",
 							"tags": [
@@ -22,14 +27,14 @@
 							],
 							"modifiers": [
 								{
-									"id": "mpSd3EzFx60pzhxa8",
+									"id": "myUL8m5mCwonjnHYw",
 									"name": "No Fine Manipulators",
 									"reference": "B15",
 									"cost": -40,
 									"disabled": true
 								},
 								{
-									"id": "mP8TfTlKSRQA9RkF1",
+									"id": "mczQ0xsVMV7Ehm8bF",
 									"name": "Size",
 									"reference": "B15",
 									"cost": -10,
@@ -37,7 +42,7 @@
 									"disabled": true
 								},
 								{
-									"id": "mnAh4HLcxj-T-jkK3",
+									"id": "mZKL4VHFQ_3Rek3ml",
 									"name": "Super-Effort",
 									"reference": "SU24",
 									"cost": 300,
@@ -60,7 +65,12 @@
 							}
 						},
 						{
-							"id": "tb2Og9dI_-DKh9VoE",
+							"id": "tNpRSngQt54cl1Fyg",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tGWOSEE6SmBHACE6Y"
+							},
 							"name": "Increased Dexterity",
 							"reference": "B15",
 							"tags": [
@@ -70,7 +80,7 @@
 							],
 							"modifiers": [
 								{
-									"id": "ml3eXRB9hhed07qYE",
+									"id": "m3XGWouYnTuwT-L1y",
 									"name": "No Fine Manipulators",
 									"cost": -40,
 									"disabled": true
@@ -92,7 +102,12 @@
 							}
 						},
 						{
-							"id": "tbfX1t1hQCnvPEndE",
+							"id": "tKIMiCa6tI02VFFg7",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t1w1RFcFceKR2T9_e"
+							},
 							"name": "Increased Intelligence",
 							"reference": "B15",
 							"tags": [
@@ -116,7 +131,12 @@
 							}
 						},
 						{
-							"id": "tV7sf1UWLnqaVBj-m",
+							"id": "t4i3DgmLyy6U_yNYJ",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tVt3SvdGWNchJ8z4o"
+							},
 							"name": "Increased Health",
 							"reference": "B14",
 							"tags": [
@@ -149,7 +169,12 @@
 					"name": "Class Advantages",
 					"children": [
 						{
-							"id": "t8_wB4L1G12jQB5P9",
+							"id": "t31Zh30mzAI7-P2ua",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "t3msobZZ06J7dZ8xu"
+							},
 							"name": "Talent (Born Spacer)",
 							"reference": "PU3:7",
 							"tags": [
@@ -159,12 +184,60 @@
 							],
 							"modifiers": [
 								{
-									"id": "mS3phEmCyGA5UvtV1",
+									"id": "mQ1arMOVVX5m6YP2f",
 									"name": "Alternative Cost",
 									"cost": 1,
 									"cost_type": "points",
 									"affects": "levels_only",
 									"disabled": true
+								},
+								{
+									"id": "MOsKpgfy3MmaErIFA",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "mh3he2yPVQtDjD8RC",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From professional Spacers.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "mTNwjlk54Q1hby5wd",
+											"name": "Bonus to pushing off",
+											"reference": "BX350",
+											"reference_highlight": "ST/2",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Bonus to ST for zero G push off",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "meMHypn5jBngUPMkn",
+											"name": "Spacecraft Familiarity",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Counteracts Familiarity for spacecraft.",
+													"amount": 1
+												}
+											],
+											"disabled": true
+										}
+									]
 								}
 							],
 							"points_per_level": 5,
@@ -264,18 +337,6 @@
 									},
 									"amount": 1,
 									"per_level": true
-								},
-								{
-									"type": "reaction_bonus",
-									"situation": "From professional Spacers.",
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "conditional_modifier",
-									"situation": "Bonus to ST for zero G push off.  Reduce penalty for unfamiliar spacecraft.",
-									"amount": 1,
-									"per_level": true
 								}
 							],
 							"can_level": true,
@@ -285,7 +346,12 @@
 							}
 						},
 						{
-							"id": "t1Le0lcoAhsZU0_TR",
+							"id": "t_tqKuWrXSFimx7fv",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tJTfFdHM7YI5IZR7I"
+							},
 							"name": "Resistant",
 							"reference": "B81,P71,MA47",
 							"tags": [
@@ -294,7 +360,7 @@
 							],
 							"modifiers": [
 								{
-									"id": "m26FYekxcQGzY1-aX",
+									"id": "mGHWVj11akTNCnomr",
 									"name": "@Very Common: Metabolic Hazards, etc.@",
 									"reference": "B80",
 									"cost": 30,
@@ -302,7 +368,7 @@
 									"disabled": true
 								},
 								{
-									"id": "mfBojJUqZ4rlAcyUJ",
+									"id": "m6XEBiCDacSUVtMh0",
 									"name": "@Common: Poison, Sickness, etc.@",
 									"reference": "B81",
 									"cost": 15,
@@ -310,7 +376,7 @@
 									"disabled": true
 								},
 								{
-									"id": "mEIfS4ykTvcuwMvxp",
+									"id": "mqKd7eEnHjLAVZrJv",
 									"name": "@Occasional: Disease, Ingested Poison, etc.@",
 									"reference": "B81",
 									"cost": 10,
@@ -318,14 +384,17 @@
 									"disabled": true
 								},
 								{
-									"id": "mIbvfTHlGC1pq1PhB",
-									"name": "Space Sickness",
+									"id": "mFDDJOCIuwKPi4nTw",
+									"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
 									"reference": "B81",
+									"replacements": {
+										"Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.": "Space Sickness"
+									},
 									"cost": 5,
 									"cost_type": "points"
 								},
 								{
-									"id": "mEx1znSjOKXW2fQku",
+									"id": "mgOgG3VfbYUADxOMp",
 									"name": "Immunity",
 									"reference": "B81",
 									"cost": 1,
@@ -333,7 +402,7 @@
 									"disabled": true
 								},
 								{
-									"id": "mCaMqjFVZxub0Rw4D",
+									"id": "mH0XB3tZp2pg0XxcD",
 									"name": "+8 to all HT rolls to resist",
 									"reference": "B81",
 									"cost": 0.5,
@@ -341,7 +410,7 @@
 									"disabled": true
 								},
 								{
-									"id": "mjfx8JaTRNOpNwhvI",
+									"id": "m2eh4E1nfyzDrd9HW",
 									"name": "+3 to all HT rolls to resist",
 									"reference": "B81",
 									"cost": 0.33,
@@ -362,7 +431,12 @@
 									"name": "Better Attributes",
 									"children": [
 										{
-											"id": "t8J9IF7o3nKsIBglr",
+											"id": "toLaxjp1V1YsZ9LbC",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tGWOSEE6SmBHACE6Y"
+											},
 											"name": "Increased Dexterity",
 											"reference": "B15",
 											"tags": [
@@ -372,7 +446,7 @@
 											],
 											"modifiers": [
 												{
-													"id": "mQAiA8O6TnlcF_-bl",
+													"id": "mTUamhBjypT-YEeno",
 													"name": "No Fine Manipulators",
 													"cost": -40,
 													"disabled": true
@@ -394,7 +468,12 @@
 											}
 										},
 										{
-											"id": "tSKiC3tkIAz-K-AfZ",
+											"id": "tJP9NQWdwDQ4PHmzR",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tVt3SvdGWNchJ8z4o"
+											},
 											"name": "Increased Health",
 											"reference": "B14",
 											"tags": [
@@ -418,7 +497,12 @@
 											}
 										},
 										{
-											"id": "ty8HQQiiu1AgprRoM",
+											"id": "t1mqn5iDCsLNWzbZR",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t1w1RFcFceKR2T9_e"
+											},
 											"name": "Increased Intelligence",
 											"reference": "B15",
 											"tags": [
@@ -442,7 +526,12 @@
 											}
 										},
 										{
-											"id": "tyDMc8ouyiPU7_v_4",
+											"id": "ti4CZV_7r1U7Rreat",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tqha9GlDBU9P-Wg-6"
+											},
 											"name": "Increased Strength",
 											"reference": "B14",
 											"tags": [
@@ -452,14 +541,14 @@
 											],
 											"modifiers": [
 												{
-													"id": "m-FTIZ6Xp91uGVvsB",
+													"id": "mHJu-o3qpluCRrrHL",
 													"name": "No Fine Manipulators",
 													"reference": "B15",
 													"cost": -40,
 													"disabled": true
 												},
 												{
-													"id": "mGsFQBM3iIscy-ja2",
+													"id": "maTNtGktNQAhfY6E2",
 													"name": "Size",
 													"reference": "B15",
 													"cost": -10,
@@ -467,7 +556,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mSuvNJ9TLlYBqjCWR",
+													"id": "mSwV-KvgjObyVCzT6",
 													"name": "Super-Effort",
 													"reference": "SU24",
 													"cost": 300,
@@ -495,24 +584,37 @@
 									}
 								},
 								{
-									"id": "TsQWCdJHIqhlLObLN",
+									"id": "TWn0MjYNHilN9OsCJ",
 									"name": "Everyman Advantages",
 									"children": [
 										{
-											"id": "thmKDnS00P9h1DrHt",
-											"name": "Suit Familiarity (Vacc Suit)",
+											"id": "tTrhYUEfc1D_5rgYS",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Power Ups/Power Ups Traits.adq",
+												"id": "t3RCXCI5W-zjvxaf-"
+											},
+											"name": "Suit Familiarity (@Environment Suit skill@)",
 											"reference": "PU2:9",
 											"tags": [
 												"Perk",
 												"Physical"
 											],
+											"replacements": {
+												"Environment Suit skill": "Vacc Suit"
+											},
 											"base_points": 1,
 											"calc": {
 												"points": 1
 											}
 										},
 										{
-											"id": "tTkRBWLnVu__h0VJl",
+											"id": "tY5xKy8O11eb3z2Qr",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tkiJQ7nfyi9aAdGHK"
+											},
 											"name": "Serendipity",
 											"reference": "B83,P73",
 											"tags": [
@@ -521,17 +623,24 @@
 											],
 											"modifiers": [
 												{
-													"id": "mStG9FQ5H3kPWklYd",
+													"id": "mWA8KEb2HE2eLleG8",
 													"name": "Wishing",
 													"reference": "P73",
 													"cost": 100,
 													"disabled": true
 												},
 												{
-													"id": "mQ6M-gt8tp9sjSh60",
+													"id": "mGoGdK6PGosmzn3e9",
 													"name": "Wishing",
 													"reference": "P73",
 													"notes": "For others only",
+													"disabled": true
+												},
+												{
+													"id": "mXqDqhK6wsSXnNlEc",
+													"name": "Game Time",
+													"reference": "P108",
+													"notes": "Uses per game week equal to its maximum possible uses per session",
 													"disabled": true
 												}
 											],
@@ -543,8 +652,13 @@
 											}
 										},
 										{
-											"id": "tmYsnMQmKrnRsZGIl",
-											"name": "Resistant to Acceleration",
+											"id": "t2d8QOF6mHLkl9LP0",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tJTfFdHM7YI5IZR7I"
+											},
+											"name": "Resistant",
 											"reference": "B81,P71,MA47",
 											"tags": [
 												"Advantage",
@@ -552,7 +666,7 @@
 											],
 											"modifiers": [
 												{
-													"id": "myDvqiy9WbW1oyo6v",
+													"id": "mWHDK2XGay3P1G3UF",
 													"name": "@Very Common: Metabolic Hazards, etc.@",
 													"reference": "B80",
 													"cost": 30,
@@ -560,7 +674,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mTriy4RXK7GkuiAmO",
+													"id": "mIXZF8zoW9-CtrsaN",
 													"name": "@Common: Poison, Sickness, etc.@",
 													"reference": "B81",
 													"cost": 15,
@@ -568,7 +682,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mUA2RzOsjY2-NcSLh",
+													"id": "ms8WqgYPAZE7sP01s",
 													"name": "@Occasional: Disease, Ingested Poison, etc.@",
 													"reference": "B81",
 													"cost": 10,
@@ -576,14 +690,17 @@
 													"disabled": true
 												},
 												{
-													"id": "mlLNQwhaILfGJXcjq",
+													"id": "mjysshUNqxIkL-ORq",
 													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
 													"reference": "B81",
+													"replacements": {
+														"Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.": "Space Sickness"
+													},
 													"cost": 5,
 													"cost_type": "points"
 												},
 												{
-													"id": "mAL52X-xfDNy2e1BR",
+													"id": "mIQe4E8gX09VU9K-u",
 													"name": "Immunity",
 													"reference": "B81",
 													"cost": 1,
@@ -591,152 +708,14 @@
 													"disabled": true
 												},
 												{
-													"id": "ml5B-R8zU9y7tWrX8",
-													"name": "+8 to all HT rolls to resist",
-													"reference": "B81",
-													"cost": 0.5,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mWs4UferSTRLQamT3",
-													"name": "+3 to all HT rolls to resist",
-													"reference": "B81",
-													"cost": 0.33,
-													"cost_type": "multiplier"
-												}
-											],
-											"round_down": true,
-											"calc": {
-												"points": 1
-											}
-										},
-										{
-											"id": "tffppn8dj6DGB89ub",
-											"name": "Resistant to Space Sickness",
-											"reference": "B81,P71,MA47",
-											"tags": [
-												"Advantage",
-												"Physical"
-											],
-											"modifiers": [
-												{
-													"id": "mZWmGXVYsxOHKWQPR",
-													"name": "@Very Common: Metabolic Hazards, etc.@",
-													"reference": "B80",
-													"cost": 30,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m1SDnAsnkF88Zk8Gb",
-													"name": "@Common: Poison, Sickness, etc.@",
-													"reference": "B81",
-													"cost": 15,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mzJf9pe3-ZvfhuJS3",
-													"name": "@Occasional: Disease, Ingested Poison, etc.@",
-													"reference": "B81",
-													"cost": 10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mMjgDZontWplyYHAL",
-													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
-													"reference": "B81",
-													"cost": 5,
-													"cost_type": "points"
-												},
-												{
-													"id": "mBVtOA6X0GQmjmO06",
-													"name": "Immunity",
-													"reference": "B81",
-													"cost": 1,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "m3OHS9CNfS1Er-I4m",
-													"name": "+8 to all HT rolls to resist",
-													"reference": "B81",
-													"cost": 0.5,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mNVIfRIcYSH3lW0xc",
-													"name": "+3 to all HT rolls to resist",
-													"reference": "B81",
-													"cost": 0.33,
-													"cost_type": "multiplier"
-												}
-											],
-											"round_down": true,
-											"calc": {
-												"points": 1
-											}
-										},
-										{
-											"id": "tOsDVJC1JaRAYjJl0",
-											"name": "Resistant to Space Sickness",
-											"reference": "B81,P71,MA47",
-											"tags": [
-												"Advantage",
-												"Physical"
-											],
-											"modifiers": [
-												{
-													"id": "meOGsep8zdQC0AYAb",
-													"name": "@Very Common: Metabolic Hazards, etc.@",
-													"reference": "B80",
-													"cost": 30,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mGEjfkfD8SItrAY1C",
-													"name": "@Common: Poison, Sickness, etc.@",
-													"reference": "B81",
-													"cost": 15,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m01VrxaU3MY13YOST",
-													"name": "@Occasional: Disease, Ingested Poison, etc.@",
-													"reference": "B81",
-													"cost": 10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mYMPNTS_HHmlr2_iz",
-													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
-													"reference": "B81",
-													"cost": 5,
-													"cost_type": "points"
-												},
-												{
-													"id": "mlYpwgMSugGVnOmxT",
-													"name": "Immunity",
-													"reference": "B81",
-													"cost": 1,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "m-2tkQJrqvU8pXXN-",
+													"id": "mKJKUAinEWWqK5KfA",
 													"name": "+8 to all HT rolls to resist",
 													"reference": "B81",
 													"cost": 0.5,
 													"cost_type": "multiplier"
 												},
 												{
-													"id": "mW3Rq_zQpeAg_Tuq8",
+													"id": "mQ4sOhoBfrbHFla0g",
 													"name": "+3 to all HT rolls to resist",
 													"reference": "B81",
 													"cost": 0.33,
@@ -750,8 +729,167 @@
 											}
 										},
 										{
-											"id": "toCeD6qw_i9ZqDL6Z",
-											"name": "Reputation",
+											"id": "tOOz-m3wzknwc1y_-",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tJTfFdHM7YI5IZR7I"
+											},
+											"name": "Resistant",
+											"reference": "B81,P71,MA47",
+											"tags": [
+												"Advantage",
+												"Physical"
+											],
+											"modifiers": [
+												{
+													"id": "m_ShXi-GIJj1j42ib",
+													"name": "@Very Common: Metabolic Hazards, etc.@",
+													"reference": "B80",
+													"cost": 30,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mfMWETvw3Go8C_1o0",
+													"name": "@Common: Poison, Sickness, etc.@",
+													"reference": "B81",
+													"cost": 15,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mO1w0drfOXd1z7g6B",
+													"name": "@Occasional: Disease, Ingested Poison, etc.@",
+													"reference": "B81",
+													"cost": 10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mUHj2p_1WaMJBTmgG",
+													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+													"reference": "B81",
+													"replacements": {
+														"Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.": "Space Sickness"
+													},
+													"cost": 5,
+													"cost_type": "points"
+												},
+												{
+													"id": "mFccVKlyU2JRTVeya",
+													"name": "Immunity",
+													"reference": "B81",
+													"cost": 1,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mlkpOdWopApn_Xbft",
+													"name": "+8 to all HT rolls to resist",
+													"reference": "B81",
+													"cost": 0.5,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mHlGRRZ5xxthmTjla",
+													"name": "+3 to all HT rolls to resist",
+													"reference": "B81",
+													"cost": 0.33,
+													"cost_type": "multiplier"
+												}
+											],
+											"round_down": true,
+											"calc": {
+												"points": 1
+											}
+										},
+										{
+											"id": "tsnE6H9motwXg-DVt",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tJTfFdHM7YI5IZR7I"
+											},
+											"name": "Resistant",
+											"reference": "B81,P71,MA47",
+											"tags": [
+												"Advantage",
+												"Physical"
+											],
+											"modifiers": [
+												{
+													"id": "mUxqcqZ6uH_dZF08x",
+													"name": "@Very Common: Metabolic Hazards, etc.@",
+													"reference": "B80",
+													"cost": 30,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mMGWxt_88YEzghkOe",
+													"name": "@Common: Poison, Sickness, etc.@",
+													"reference": "B81",
+													"cost": 15,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mGKgnxsFa4186xNSP",
+													"name": "@Occasional: Disease, Ingested Poison, etc.@",
+													"reference": "B81",
+													"cost": 10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mk-Db1qJkzd_C_eUC",
+													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+													"reference": "B81",
+													"replacements": {
+														"Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.": "Acceleration"
+													},
+													"cost": 5,
+													"cost_type": "points"
+												},
+												{
+													"id": "mgYbuHB8Z6guxvcWT",
+													"name": "Immunity",
+													"reference": "B81",
+													"cost": 1,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mO4_Q9gGF7QBDYDm8",
+													"name": "+8 to all HT rolls to resist",
+													"reference": "B81",
+													"cost": 0.5,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mvYf0zl0L_dOTS5-y",
+													"name": "+3 to all HT rolls to resist",
+													"reference": "B81",
+													"cost": 0.33,
+													"cost_type": "multiplier"
+												}
+											],
+											"round_down": true,
+											"calc": {
+												"points": 1
+											}
+										},
+										{
+											"id": "tdlnuosVDhoqvAcx0",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "ta04iFiZ_Kw0s0juj"
+											},
+											"name": "Good Reputation",
 											"reference": "B26,MA54",
 											"tags": [
 												"Advantage",
@@ -759,7 +897,7 @@
 											],
 											"modifiers": [
 												{
-													"id": "mE0PcnmJRBVafgPao",
+													"id": "mV-VAGI53dE-uT3sM",
 													"name": "People Affected",
 													"reference": "B27",
 													"notes": "Almost everyone",
@@ -768,7 +906,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mZZuGFHfvrrn1bNfH",
+													"id": "mrm0I6Z34kW-PbUJ_",
 													"name": "People Affected",
 													"reference": "B27",
 													"notes": "Almost everyone except @large class of people@",
@@ -777,7 +915,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mpU-EzMM01efZNAX2",
+													"id": "mQMBgvgbKre-FVjCz",
 													"name": "People Affected",
 													"reference": "B27",
 													"notes": "@Large class of people@",
@@ -786,7 +924,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m8VGClxMpNgtxXtpy",
+													"id": "m8gg_9WecuiEsFZaj",
 													"name": "People Affected",
 													"reference": "B27",
 													"notes": "@Small class of people@",
@@ -795,7 +933,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mN8Ra3fcWpDLoZhWr",
+													"id": "m6mf5ZCDKwbOYmOcv",
 													"name": "Recognized all the time",
 													"reference": "B28",
 													"cost": 1,
@@ -803,7 +941,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m8pHP2GD7WyD6fSVE",
+													"id": "mtpAFfJXP3KUapgR6",
 													"name": "Recognized sometimes",
 													"reference": "B28",
 													"notes": "10-",
@@ -812,7 +950,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mAd1fTBbAVp2qLJS8",
+													"id": "m5AaD-JIYlezkrTNN",
 													"name": "Recognized occasionally",
 													"reference": "B28",
 													"notes": "7-",
@@ -822,6 +960,14 @@
 												}
 											],
 											"points_per_level": 5,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others aware of your reputation",
+													"amount": 1,
+													"per_level": true
+												}
+											],
 											"round_down": true,
 											"can_level": true,
 											"levels": 1,
@@ -830,16 +976,24 @@
 											}
 										},
 										{
-											"id": "tZn6NU27VMnGT1flU",
-											"name": "Military Rank",
+											"id": "tn37NcLVzYDDxOyYK",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tmp8yecgaZq9TOk59"
+											},
+											"name": "@Type@ Rank",
 											"reference": "B29",
 											"tags": [
 												"Advantage",
-												"Physical"
+												"Social"
 											],
+											"replacements": {
+												"Type": "Military"
+											},
 											"modifiers": [
 												{
-													"id": "mu8MbD5qWM6s8oQkD",
+													"id": "mMmQX-fqWQuSAlbo4",
 													"name": "Replaces Status",
 													"reference": "B29",
 													"cost": 5,
@@ -848,7 +1002,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mXqaf7rZIZrOUSJox",
+													"id": "m1-T_Z7VhR0_uZVCc",
 													"name": "Courtesy",
 													"reference": "B29",
 													"cost": -4,
@@ -865,16 +1019,24 @@
 											}
 										},
 										{
-											"id": "tTq1GTR48gyvIQsxH",
-											"name": "Merchant Rank",
+											"id": "tJLbFSas5TR3rMO70",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tmp8yecgaZq9TOk59"
+											},
+											"name": "@Type@ Rank",
 											"reference": "B29",
 											"tags": [
 												"Advantage",
-												"Physical"
+												"Social"
 											],
+											"replacements": {
+												"Type": "Merchant"
+											},
 											"modifiers": [
 												{
-													"id": "mo7RMaHNOk9P_6btO",
+													"id": "mLhmHyxWHd2rr-S28",
 													"name": "Replaces Status",
 													"reference": "B29",
 													"cost": 5,
@@ -883,7 +1045,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m6DdEiceEqECeKIvR",
+													"id": "meTZ3JujiXG9sz2Vk",
 													"name": "Courtesy",
 													"reference": "B29",
 													"cost": -4,
@@ -900,17 +1062,21 @@
 											}
 										},
 										{
-											"id": "tCAqfn4DH_eHqmnZp",
+											"id": "tisqnrkyv4UDNa0U1",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t6Nq6oInwkU1qbAP1"
+											},
 											"name": "Patron",
 											"reference": "B72,P65",
-											"notes": "Ship's owner or provider",
 											"tags": [
 												"Advantage",
 												"Social"
 											],
 											"modifiers": [
 												{
-													"id": "mqGA9tP_bIKQwteSV",
+													"id": "miCq-ovxLq7KmUTxD",
 													"name": "@Who: Individual with 150% of PC's starting points@",
 													"reference": "B72",
 													"cost": 10,
@@ -918,7 +1084,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mEraf6BXg9aPoqNkK",
+													"id": "mqLVrbh6s6pgaWmCf",
 													"name": "@Who: Organization with assets of at least 1000 times starting wealth@",
 													"reference": "B72",
 													"cost": 10,
@@ -926,7 +1092,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m88vhDoVdvRH-XFfe",
+													"id": "mLowQSs6lSRZMVnCl",
 													"name": "@Who: Individual with twice the PC's starting points@",
 													"reference": "B72",
 													"cost": 15,
@@ -934,7 +1100,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mIkCjw-e2_APstOJJ",
+													"id": "mF7rOzjY14gH3ZiTc",
 													"name": "@Who: Organization with assets of at least 10000 times starting wealth@",
 													"reference": "B72",
 													"cost": 15,
@@ -942,7 +1108,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mv8hWz0tyq91r91pe",
+													"id": "mR9E2VQwjBaiVVR2f",
 													"name": "@Who: An ultra-powerful individual@",
 													"reference": "B72",
 													"cost": 20,
@@ -950,7 +1116,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mKGSXlWRB61ryEhqn",
+													"id": "mYoLOEWYTS9yKNrLE",
 													"name": "@Who: Organization with assets of at least 100000 times starting wealth@",
 													"reference": "B72",
 													"cost": 20,
@@ -958,7 +1124,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mrYJaH1Yw_XnULAw4",
+													"id": "mt2sj3-w9CDuX10wq",
 													"name": "@Who: Organization with assets of at least 1000000 times starting wealth@",
 													"reference": "B72",
 													"cost": 25,
@@ -966,7 +1132,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mS7nIClYzDyTksQH6",
+													"id": "mLENFmq8Zauo9ksbS",
 													"name": "@Who: A national government or giant multi-national organization@",
 													"reference": "B72",
 													"cost": 30,
@@ -974,7 +1140,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mtE9uXnhuBKp-LqCu",
+													"id": "mZnaHSRjmUCh-UAnv",
 													"name": "@Who: A deity@",
 													"reference": "B72",
 													"cost": 30,
@@ -982,7 +1148,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mVyL-VBWYuT20I_A9",
+													"id": "m68gVa3lAmSkU6rve",
 													"name": "Appears almost all the time",
 													"reference": "B36",
 													"notes": "15-",
@@ -991,7 +1157,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m5ZsfWzVVyK0oNlm2",
+													"id": "mgmGPpbEOJzvTsWe1",
 													"name": "Appears quite often",
 													"reference": "B36",
 													"notes": "12-",
@@ -1000,7 +1166,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m5x_4B8z-H4RnoEkY",
+													"id": "m8qisGQ3I7WNudP_M",
 													"name": "Appears fairly often",
 													"reference": "B36",
 													"notes": "9-",
@@ -1009,7 +1175,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m_KoIGHqB3rFXR15k",
+													"id": "md4t1cw0hSrOm-VRc",
 													"name": "Appears quite rarely",
 													"reference": "B36",
 													"notes": "6-",
@@ -1018,7 +1184,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m2iNM9bao6PnQw34K",
+													"id": "mMpbGl-QDr79b8ixL",
 													"name": "Equipment",
 													"reference": "B73",
 													"notes": "@Equipment worth no more than average starting wealth@",
@@ -1026,7 +1192,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mB2SKi33JF-QxX61d",
+													"id": "mYDWS5Brj7gPLEadi",
 													"name": "Equipment",
 													"reference": "B73",
 													"notes": "@Equipment worth more than average starting wealth@",
@@ -1034,14 +1200,14 @@
 													"disabled": true
 												},
 												{
-													"id": "mhsnkSMEvsw_N1e0o",
+													"id": "me160PBbXqC6llrqn",
 													"name": "Highly Accessible",
 													"reference": "B73",
 													"cost": 50,
 													"disabled": true
 												},
 												{
-													"id": "mcwvP2VNYgyulbzZ1",
+													"id": "mEYGYoxh4Ef4HgJy-",
 													"name": "Special Abilities",
 													"reference": "B73",
 													"notes": "@Extensive social or political power@",
@@ -1049,7 +1215,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mO2kY3a4Kbp3yZjWG",
+													"id": "m_MuEjFZAirCfWGqZ",
 													"name": "Special Abilities",
 													"reference": "B73",
 													"notes": "@Magical powers in a non-magical world, higher TL equipment, grants special powers or is supernatural@",
@@ -1057,28 +1223,28 @@
 													"disabled": true
 												},
 												{
-													"id": "mktwN8kE_YcjccwpM",
+													"id": "m8akFbNYdsfJOcG3-",
 													"name": "Minimal Interventions",
 													"reference": "B73",
 													"cost": -50,
 													"disabled": true
 												},
 												{
-													"id": "mhPUt5hypjv2FhtSo",
+													"id": "mlEIlLvylnn4dcYBk",
 													"name": "Secret",
 													"reference": "B73",
 													"cost": -50,
 													"disabled": true
 												},
 												{
-													"id": "mrf8qr04R3x2ux3ED",
+													"id": "mfSY3N1hM46e6LV0l",
 													"name": "Unwilling",
 													"reference": "B74",
 													"cost": -50,
 													"disabled": true
 												},
 												{
-													"id": "mQxCx90F_iInRTOdl",
+													"id": "mzEUfLOZ71YOZRUi7",
 													"name": "Favor",
 													"reference": "B55",
 													"cost": 0.2,
@@ -1091,7 +1257,12 @@
 											}
 										},
 										{
-											"id": "tHpvE5s3JoL1u4tzh",
+											"id": "t-z1NuJSASvCOnesz",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tz-USDL9B_KrrVqDi"
+											},
 											"name": "Luck",
 											"reference": "B66,P59",
 											"notes": "Usable once per hour of play",
@@ -1101,14 +1272,14 @@
 											],
 											"modifiers": [
 												{
-													"id": "mYGLaOEFqZzjWhG84",
+													"id": "mlBmZDTiJWAq8_GtE",
 													"name": "Active",
 													"reference": "B66",
 													"cost": -40,
 													"disabled": true
 												},
 												{
-													"id": "mLLQky_wcCQD9yzBD",
+													"id": "m18Yop-5QpIQT4j1n",
 													"name": "Aspected",
 													"reference": "B66",
 													"notes": "@Aspect@",
@@ -1116,17 +1287,24 @@
 													"disabled": true
 												},
 												{
-													"id": "moEMUE022G_f-4o3z",
+													"id": "m_Z7vSChe74TY69pp",
 													"name": "Defensive",
 													"reference": "B66",
 													"cost": -20,
 													"disabled": true
 												},
 												{
-													"id": "mGIpapczYBnHOjyu0",
+													"id": "mkS9dQ0mLZNy_3u1O",
 													"name": "Wishing",
 													"reference": "P59",
 													"cost": 100,
+													"disabled": true
+												},
+												{
+													"id": "mYTMp1gMLhAEZ8giG",
+													"name": "Game Time",
+													"reference": "P108",
+													"notes": "Uses per game day equal to its maximum possible uses per real hour",
 													"disabled": true
 												}
 											],
@@ -1136,7 +1314,12 @@
 											}
 										},
 										{
-											"id": "ty13ppp8cY94XBr77",
+											"id": "ty3acKzt07LcF0e73",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tMxgHfzVEy_QQtlfB"
+											},
 											"name": "Less Sleep",
 											"reference": "B65",
 											"notes": "Require 1 hour/level less sleep for a full night's rest (max 4)",
@@ -1152,7 +1335,12 @@
 											}
 										},
 										{
-											"id": "trbO9YAfsPTIOCe_w",
+											"id": "te-bcr9GxEky4YyxA",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tw1Ad0oSMw2ATM4X1"
+											},
 											"name": "Language: @Language@",
 											"reference": "B24",
 											"tags": [
@@ -1160,9 +1348,26 @@
 												"Language",
 												"Mental"
 											],
+											"prereqs": {
+												"type": "prereq_list",
+												"all": true,
+												"prereqs": [
+													{
+														"type": "trait_prereq",
+														"has": false,
+														"name": {
+															"compare": "is",
+															"qualifier": "Language Talent"
+														},
+														"level": {
+															"compare": "at_least"
+														}
+													}
+												]
+											},
 											"modifiers": [
 												{
-													"id": "m7gWHlErHvbRnoGzw",
+													"id": "mm81G4-m0YK9MHfTS",
 													"name": "Native",
 													"reference": "B23",
 													"cost": -6,
@@ -1170,7 +1375,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mQVJS0iC5Hke6reH-",
+													"id": "m8Y_NRPg2iHhc4qtR",
 													"name": "Spoken",
 													"reference": "B24",
 													"notes": "None",
@@ -1178,7 +1383,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mCTkAJ_ZLAU5Gguac",
+													"id": "mjwl4_6zs44r36qKO",
 													"name": "Spoken",
 													"reference": "B24",
 													"notes": "Broken",
@@ -1187,7 +1392,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mhcns6ZR-nV8OA4pG",
+													"id": "mOaEOOV-hM8cEI___",
 													"name": "Spoken",
 													"reference": "B24",
 													"notes": "Accented",
@@ -1195,7 +1400,7 @@
 													"cost_type": "points"
 												},
 												{
-													"id": "m86vo_GpqR_Iqbyel",
+													"id": "maY7JXCFoW20XfaS4",
 													"name": "Spoken",
 													"reference": "B24",
 													"notes": "Native",
@@ -1204,7 +1409,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mTj1Vz4FGcm_KtgMR",
+													"id": "mhzGmKXlTp0WXY5Ug",
 													"name": "Written",
 													"reference": "B24",
 													"notes": "None",
@@ -1212,7 +1417,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m8Z6P_mZs6FwuQBhj",
+													"id": "mw80xdvVC1YZ0O7pF",
 													"name": "Written",
 													"reference": "B24",
 													"notes": "Broken",
@@ -1221,7 +1426,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mkXfV9er4Y9LRvRlk",
+													"id": "mPA9vrjcoIWuRcB9i",
 													"name": "Written",
 													"reference": "B24",
 													"notes": "Accented",
@@ -1229,7 +1434,7 @@
 													"cost_type": "points"
 												},
 												{
-													"id": "mh4AJ_K9hOHDcT_05",
+													"id": "mEjNk9csyq_is08TS",
 													"name": "Written",
 													"reference": "B24",
 													"notes": "Native",
@@ -1243,7 +1448,12 @@
 											}
 										},
 										{
-											"id": "tJ1MSEuAPhAzcwUqX",
+											"id": "tTNLpxx3pH3BXu91B",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "txREhxV6L1SKixwe_"
+											},
 											"name": "Improved G-tolerance",
 											"reference": "B60",
 											"tags": [
@@ -1252,7 +1462,7 @@
 											],
 											"modifiers": [
 												{
-													"id": "mc4ITuY4y9yPJyJec",
+													"id": "mqGASeiRmV3tikKvz",
 													"name": "0.3G",
 													"reference": "B60",
 													"cost": 5,
@@ -1260,7 +1470,7 @@
 													"disabled": true
 												},
 												{
-													"id": "md8C2AeekkD7GkdMb",
+													"id": "m7jvZ3dVObCnUFsxP",
 													"name": "0.5G",
 													"reference": "B60",
 													"cost": 10,
@@ -1268,7 +1478,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mX666FpAGfjADt7fv",
+													"id": "mjmVfe23t1JgXQG3d",
 													"name": "1G",
 													"reference": "B60",
 													"cost": 15,
@@ -1276,7 +1486,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mbQGzvphZdMF9FJe8",
+													"id": "mmxo4INhX6bCpr771",
 													"name": "5G",
 													"reference": "B60",
 													"cost": 20,
@@ -1284,7 +1494,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mYb9C3mtR7S77u3zn",
+													"id": "mPbLnPoeWPCC5UESm",
 													"name": "10G",
 													"reference": "B60",
 													"cost": 25,
@@ -1297,7 +1507,12 @@
 											}
 										},
 										{
-											"id": "tUBIL1RtiIWsRiFwE",
+											"id": "tzl-HgRMKFkIF_Rvv",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t7blIRUzFpiHS_mnO"
+											},
 											"name": "Gizmo",
 											"reference": "B57,MA45",
 											"tags": [
@@ -1312,7 +1527,12 @@
 											}
 										},
 										{
-											"id": "tgDWPrZTymSsQ9j-w",
+											"id": "tKv1e5Ry1k0ICENW4",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tHNrjEQFQBNOgwmzK"
+											},
 											"name": "G-Experience (All)",
 											"reference": "B57",
 											"tags": [
@@ -1325,7 +1545,12 @@
 											}
 										},
 										{
-											"id": "tGySH49nu-bUBXm_K",
+											"id": "tcNCpyIf_pvqSehuV",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tu3GuYC47Sx6bnm4k"
+											},
 											"name": "G-Experience",
 											"reference": "B57",
 											"tags": [
@@ -1340,7 +1565,12 @@
 											}
 										},
 										{
-											"id": "tYGCAeFhPRBUR1TIz",
+											"id": "tfEeMpJcHkXlPvS-L",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "toTe273Ky82B6YdW5"
+											},
 											"name": "Fit",
 											"reference": "B55",
 											"notes": "Recover FP at twice the normal rate (but not FP spent for spells or psi powers)",
@@ -1361,7 +1591,12 @@
 											}
 										},
 										{
-											"id": "tFo6UASKt7VWxBXpv",
+											"id": "ts411geTO9r8kfORB",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tQa3EUrs4Hjt9gxK6"
+											},
 											"name": "Fearlessness",
 											"reference": "B55,MA44",
 											"tags": [
@@ -1398,7 +1633,12 @@
 											}
 										},
 										{
-											"id": "tpWJ_0KRIQDHg-1m6",
+											"id": "tj-e96gSxcAFLNmlQ",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t5j2Ox4jaIV9j0rpz"
+											},
 											"name": "Deep Sleeper",
 											"reference": "B101",
 											"tags": [
@@ -1411,7 +1651,12 @@
 											}
 										},
 										{
-											"id": "tajqkFj0wCP0HFo_x",
+											"id": "tSuE3bBHIrn9MPNx_",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tNBE3sLoyrUvAgoZ3"
+											},
 											"name": "Cybernetics",
 											"reference": "B46",
 											"tags": [
@@ -1423,7 +1668,12 @@
 											}
 										},
 										{
-											"id": "t5gV5sx8qiEfZqDAY",
+											"id": "tB95c5kp1vBqyTZSi",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "toXBQ8q4Nek5lsLPF"
+											},
 											"name": "Cultural Familiarity (@Culture@)",
 											"reference": "B23",
 											"notes": "Do not suffer the normal -3 penalty for unfamiliarity",
@@ -1433,14 +1683,14 @@
 											],
 											"modifiers": [
 												{
-													"id": "mR1UAK28hSwGVJcew",
+													"id": "mLo_CmdFDW-e9x5Np",
 													"name": "Alien",
 													"cost": 1,
 													"cost_type": "points",
 													"disabled": true
 												},
 												{
-													"id": "mAsjIgcbAbnR_68GQ",
+													"id": "mBVYw9bKduVaexsR_",
 													"name": "Native",
 													"cost": -1,
 													"cost_type": "points",
@@ -1453,9 +1703,14 @@
 											}
 										},
 										{
-											"id": "ti65Hj0S0BS71Kq8w",
-											"name": "Alien Friend",
-											"reference": "S220",
+											"id": "toj5hEEnwilqmXCd9",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Power Ups/Power Ups Traits.adq",
+												"id": "t3msobZZ06J7dZ8xu"
+											},
+											"name": "Talent (Born Spacer)",
+											"reference": "PU3:7",
 											"tags": [
 												"Advantage",
 												"Mental",
@@ -1463,106 +1718,60 @@
 											],
 											"modifiers": [
 												{
-													"id": "mnwDjpul-4Gglqyxa",
-													"name": "Alternate Benefit",
-													"notes": "@Alternate Benefit@",
-													"disabled": true
-												},
-												{
-													"id": "mQKAz8qC8Tji340JC",
+													"id": "mSw2RFdUo6WdKJ44Y",
 													"name": "Alternative Cost",
+													"cost": 1,
 													"cost_type": "points",
 													"affects": "levels_only",
 													"disabled": true
-												}
-											],
-											"points_per_level": 5,
-											"features": [
-												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "Anthropology"
-													},
-													"amount": 1,
-													"per_level": true
 												},
 												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "Diplomacy"
-													},
-													"amount": 1,
-													"per_level": true
-												},
-												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "Expert Skill"
-													},
-													"amount": 1,
-													"per_level": true
-												},
-												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "History"
-													},
-													"amount": 1,
-													"per_level": true
-												},
-												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "Psychology"
-													},
-													"amount": 1,
-													"per_level": true
-												},
-												{
-													"type": "reaction_bonus",
-													"situation": "Aliens",
-													"amount": 1,
-													"per_level": true
-												}
-											],
-											"can_level": true,
-											"levels": 1,
-											"calc": {
-												"points": 5
-											}
-										},
-										{
-											"id": "tiH6aIYD5877LdxFg",
-											"name": "Born Spacer",
-											"reference": "THSCT40",
-											"tags": [
-												"Advantage",
-												"Mental",
-												"Talent"
-											],
-											"modifiers": [
-												{
-													"id": "mnGW1N03lWCbZK2mm",
-													"name": "Alternate Benefit",
-													"notes": "@Alternate Benefit@",
-													"disabled": true
-												},
-												{
-													"id": "mIUC0vseXhCsFLorF",
-													"name": "Alternative Cost",
-													"cost_type": "points",
-													"affects": "levels_only",
-													"disabled": true
+													"id": "My8vssSd6MfE_cJkh",
+													"name": "Benefits",
+													"children": [
+														{
+															"id": "mi7GCwX3UOyiRV1od",
+															"name": "Reaction Bonus",
+															"use_level_from_trait": true,
+															"features": [
+																{
+																	"type": "reaction_bonus",
+																	"situation": "From professional Spacers.",
+																	"amount": 1,
+																	"per_level": true
+																}
+															]
+														},
+														{
+															"id": "m6NSxGtLJiC2qjJfE",
+															"name": "Bonus to pushing off",
+															"reference": "BX350",
+															"reference_highlight": "ST/2",
+															"use_level_from_trait": true,
+															"features": [
+																{
+																	"type": "conditional_modifier",
+																	"situation": "Bonus to ST for zero G push off",
+																	"amount": 1,
+																	"per_level": true
+																}
+															],
+															"disabled": true
+														},
+														{
+															"id": "mEHBdia7jxAOzpxED",
+															"name": "Spacecraft Familiarity",
+															"use_level_from_trait": true,
+															"features": [
+																{
+																	"type": "conditional_modifier",
+																	"situation": "Counteracts Familiarity for spacecraft.",
+																	"amount": 1
+																}
+															],
+															"disabled": true
+														}
+													]
 												}
 											],
 											"points_per_level": 5,
@@ -1594,6 +1803,10 @@
 														"compare": "is",
 														"qualifier": "Navigation"
 													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "Space"
+													},
 													"amount": 1,
 													"per_level": true
 												},
@@ -1605,8 +1818,36 @@
 														"qualifier": "Piloting"
 													},
 													"specialization": {
-														"compare": "contains",
-														"qualifier": "Spacecraft"
+														"compare": "is",
+														"qualifier": "High-Performance Spacecraft"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Piloting"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "Low-Performance Spacecraft"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Piloting"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "Aerospace"
 													},
 													"amount": 1,
 													"per_level": true
@@ -1630,10 +1871,99 @@
 													},
 													"amount": 1,
 													"per_level": true
+												}
+											],
+											"can_level": true,
+											"levels": 1,
+											"calc": {
+												"points": 5
+											}
+										},
+										{
+											"id": "ttSyZ8m-vR56YCN8i",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Power Ups/Power Ups Traits.adq",
+												"id": "tcCw979nTBoztowCU"
+											},
+											"name": "Talent (Alien Friend)",
+											"reference": "PU3:6",
+											"tags": [
+												"Advantage",
+												"Mental",
+												"Talent"
+											],
+											"points_per_level": 5,
+											"features": [
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Diplomacy"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Expert Skill"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "Xenology"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Anthropology"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "@Alien@"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "History"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "@Alien@"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Psychology"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "@Alien@"
+													},
+													"amount": 1,
+													"per_level": true
 												},
 												{
 													"type": "reaction_bonus",
-													"situation": "Professional Spacers",
+													"situation": "From aliens.",
 													"amount": 1,
 													"per_level": true
 												}
@@ -1645,7 +1975,12 @@
 											}
 										},
 										{
-											"id": "tO8pH4tVA4jqQz1qf",
+											"id": "t5cJYUlL70u_VgC4i",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tM6z7Mx6e2V4VvUR4"
+											},
 											"name": "Absolute Direction",
 											"reference": "B34",
 											"tags": [
@@ -1655,14 +1990,14 @@
 											],
 											"modifiers": [
 												{
-													"id": "mc1AZSlrTkcDPNSOL",
+													"id": "mcJNzU_woPcxwV6fE",
 													"name": "Requires signal",
 													"reference": "B34",
 													"cost": -20,
 													"disabled": true
 												},
 												{
-													"id": "mlT_y6NrHH7BWsfN2",
+													"id": "m8PxTXlBld2pCu3J_",
 													"name": "3D Spatial Sense",
 													"reference": "B34",
 													"cost": 5,
@@ -1785,7 +2120,12 @@
 									}
 								},
 								{
-									"id": "t4rFK8qhy2TQr1SOB",
+									"id": "twLwYpzvDGFi0dAbL",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "t3msobZZ06J7dZ8xu"
+									},
 									"name": "Talent (Born Spacer)",
 									"reference": "PU3:7",
 									"tags": [
@@ -1795,12 +2135,60 @@
 									],
 									"modifiers": [
 										{
-											"id": "mgN2Kbz6iLq7yj4TA",
+											"id": "mlw4eI2ZvFVd7O1_p",
 											"name": "Alternative Cost",
 											"cost": 1,
 											"cost_type": "points",
 											"affects": "levels_only",
 											"disabled": true
+										},
+										{
+											"id": "MgspuBZ1ajPFuZ5PU",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "mM9Y6Hxh9JwEOtkfj",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From professional Spacers.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "mWfusn2xf1RQt779m",
+													"name": "Bonus to pushing off",
+													"reference": "BX350",
+													"reference_highlight": "ST/2",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Bonus to ST for zero G push off",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mUckg6QTriOPz7K-r",
+													"name": "Spacecraft Familiarity",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Counteracts Familiarity for spacecraft.",
+															"amount": 1
+														}
+													],
+													"disabled": true
+												}
+											]
 										}
 									],
 									"points_per_level": 5,
@@ -1900,18 +2288,6 @@
 											},
 											"amount": 1,
 											"per_level": true
-										},
-										{
-											"type": "reaction_bonus",
-											"situation": "From professional Spacers.",
-											"amount": 1,
-											"per_level": true
-										},
-										{
-											"type": "conditional_modifier",
-											"situation": "Bonus to ST for zero G push off.  Reduce penalty for unfamiliar spacecraft.",
-											"amount": 1,
-											"per_level": true
 										}
 									],
 									"can_level": true,
@@ -1921,7 +2297,12 @@
 									}
 								},
 								{
-									"id": "twjOSSRy7rYLM73uj",
+									"id": "tbFVvUQKAtUEMp5v0",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tqSO2a00yPEs8sCn3"
+									},
 									"name": "Common Sense",
 									"reference": "B43,P45",
 									"tags": [
@@ -1930,7 +2311,7 @@
 									],
 									"modifiers": [
 										{
-											"id": "mbg6qQu-qrhJCeRKS",
+											"id": "m45PJRFroqyPU1fdY",
 											"name": "Concious",
 											"reference": "P45",
 											"cost": 50,
@@ -1943,7 +2324,12 @@
 									}
 								},
 								{
-									"id": "tq-qFv81y3u0gT3d0",
+									"id": "tx0EZtf4V8EwRVRZ4",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t7blIRUzFpiHS_mnO"
+									},
 									"name": "Gizmo",
 									"reference": "B57,MA45",
 									"tags": [
@@ -1958,7 +2344,12 @@
 									}
 								},
 								{
-									"id": "t1gAu4x8OJ9_b0kB8",
+									"id": "tvuKuFDg8wPYnLLQ1",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "txSLRSX9nxLwQkE2n"
+									},
 									"name": "Hard to Kill",
 									"reference": "B58",
 									"tags": [
@@ -1981,7 +2372,12 @@
 									}
 								},
 								{
-									"id": "t33XY2x4KgTZsTnqa",
+									"id": "tAYPbmz4igKKd1xR9",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "teRggYn926_I1YeWO"
+									},
 									"name": "High Pain Threshold",
 									"reference": "B59",
 									"notes": "Never suffer shock penalties when injured",
@@ -2007,7 +2403,12 @@
 									}
 								},
 								{
-									"id": "t0WTu6ij1XaW8h4Ps",
+									"id": "tq5L-7nYw6ZcG2Pax",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tk0ZKpvgqpE35AZcM"
+									},
 									"name": "Night Vision",
 									"reference": "B71,P87",
 									"tags": [
@@ -2022,7 +2423,12 @@
 									}
 								},
 								{
-									"id": "t79U8oTvENiST-Szd",
+									"id": "t2mOgw73oIkB-9Op4",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t2uxXuNNQjGUAFAd0"
+									},
 									"name": "Perfect Balance",
 									"reference": "B74",
 									"tags": [
@@ -2031,6 +2437,16 @@
 									],
 									"base_points": 15,
 									"features": [
+										{
+											"type": "conditional_modifier",
+											"situation": "on DX and DX-based skill rolls to keep your feet or avoid being knocked down in combat",
+											"amount": 4
+										},
+										{
+											"type": "conditional_modifier",
+											"situation": "on all rolls to keep your feet if the surface is wet, slippery or unstable",
+											"amount": 6
+										},
 										{
 											"type": "skill_bonus",
 											"selection_type": "skills_with_name",
@@ -2054,6 +2470,24 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
+												"qualifier": "aerobatics"
+											},
+											"amount": 1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "aquabatics"
+											},
+											"amount": 1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
 												"qualifier": "climbing"
 											},
 											"amount": 1
@@ -2064,7 +2498,12 @@
 									}
 								},
 								{
-									"id": "tZxDP64FD-tx2Qkj4",
+									"id": "t4fUdpQbHiN1k4Kws",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "trMfToThYl9fEmPdt"
+									},
 									"name": "Rapid Healing",
 									"reference": "B79",
 									"tags": [
@@ -2099,7 +2538,12 @@
 									}
 								},
 								{
-									"id": "tEiqlQdsz8cNpd5ws",
+									"id": "tFwJzI53455DVE2_y",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tAonFRmR-RtLdMP8e"
+									},
 									"name": "Very Rapid Healing",
 									"reference": "B79",
 									"notes": "When you roll to recover lost HP, a successful HT roll means you heal 2 HP, not 1",
@@ -2135,7 +2579,12 @@
 									}
 								},
 								{
-									"id": "tA7RhhI-fDV_EoF3C",
+									"id": "tCH-Wd3hLGn6qIWeK",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "touwUIFalnae02BUl"
+									},
 									"name": "Temperature Tolerance",
 									"reference": "B93",
 									"tags": [
@@ -2150,7 +2599,12 @@
 									}
 								},
 								{
-									"id": "tMhyQADGBwJRPbA9h",
+									"id": "tH1loD11YrsSrkYdH",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "trClz3uZE-XIfFJKI"
+									},
 									"name": "Unfazeable",
 									"reference": "B95",
 									"notes": "Exempt from fright checks. Reaction modifiers do not affect you.",
@@ -2160,7 +2614,7 @@
 									],
 									"modifiers": [
 										{
-											"id": "m-CMke7429Gtrc3Is",
+											"id": "m8T4He1UYi6awGO0-",
 											"name": "Familiar Horrors",
 											"reference": "H20",
 											"cost": -50,
@@ -2173,7 +2627,12 @@
 									}
 								},
 								{
-									"id": "tJTnYlf05ZRATqY6e",
+									"id": "tgui6_UkplZb0cG7i",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tOQfp3YosDgO4S3yI"
+									},
 									"name": "Very Fit",
 									"reference": "B55",
 									"notes": "Recover FP at twice the normal rate; lose FP at half the normal rate (in both cases, not FP spent for spells or psi powers)",
@@ -2212,14 +2671,56 @@
 							"name": "-40 Points chosen from",
 							"children": [
 								{
-									"id": "TagD1-BW-EkvoHpBV",
+									"id": "TPKrClvGK3lt5YoEg",
 									"name": "Everyman Disadvantages",
 									"tags": [
 										"Disadvantage"
 									],
 									"children": [
 										{
-											"id": "tSm0yEcakUr98BTBi",
+											"id": "tMt1Hc7DZrfnPThH9",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tX9XXLPFBvyQSpA4k"
+											},
+											"name": "Xenophilia",
+											"reference": "B162",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"cr": 12,
+											"base_points": -10,
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "tO1s1CqpC_S-qir3c",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t8I0xw1Lj1_222aEN"
+											},
+											"name": "Workaholic",
+											"reference": "B162",
+											"tags": [
+												"Disadvantage",
+												"Physical"
+											],
+											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										},
+										{
+											"id": "tCB1Hq1k6psBzqBWm",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t7U0VbIzs6SqefwLr"
+											},
 											"name": "Social Stigma (Criminal Record)",
 											"reference": "B155",
 											"tags": [
@@ -2239,23 +2740,162 @@
 											}
 										},
 										{
-											"id": "tuNx676seDXYjjf_B",
-											"name": "Chummy",
-											"reference": "B126",
+											"id": "tD6z1wjxDE7STbomA",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "thSMVzJ590v7gAD8d"
+											},
+											"name": "Pacifism: Self-Defense Only",
+											"reference": "B148",
+											"notes": "You only fight to defend yourself or those in your care, using only as much force as necessary (no pre-emptive strikes allowed!). You must do your best to discourage others from starting fights.",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
+											"modifiers": [
+												{
+													"id": "mF6jnx12J-L_enBfi",
+													"name": "Species-Specific",
+													"reference": "UT32",
+													"cost": -80,
+													"disabled": true
+												}
+											],
+											"base_points": -15,
+											"calc": {
+												"points": -15
+											}
+										},
+										{
+											"id": "tV73Ojv296DDq5Rfr",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tV_f_75HmwzWOPhuu"
+											},
+											"name": "Pacifism: Reluctant Killer",
+											"reference": "B148",
+											"notes": "You are psychologically unprepared to kill people. Whenever you make a deadly attack (e.g., with a knife or a gun) against an obvious person whose face is visible to you, you are at -4 to hit and may not Aim. If you cannot see the foe’s face (due to a mask, darkness, or distance, or because you attacked from behind), the penalty is only -2, save in close combat. You have no penalty to attack a vehicle (even an occupied one), an opponent you do not believe is a person (including things with Horrific or Monstrous appearance), or a target you can’t actually see (e.g., a set of map coordinates or a blip on a radar screen). If you kill a recognizable person, the effect on you is the same as for Pacifism: Cannot Kill. You have no problem with your allies killing; you may even supply ammo, loaded weapons, and encouragement! You just can’t do the killing yourself.",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"modifiers": [
+												{
+													"id": "mEyie1zqW5b04sCMR",
+													"name": "Species-Specific",
+													"reference": "UT32",
+													"cost": -80,
+													"disabled": true
+												}
+											],
 											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										},
+										{
+											"id": "tMXN_KjMLS8_ywpDc",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "th9TK1Jmqg8uKe6SC"
+											},
+											"name": "Pacifism: Cannot Harm Innocents",
+											"reference": "B148",
+											"notes": "You may fight – you may even start fights – but you may only use deadly force on a foe that is attempting to do you serious harm. Capture is not “serious harm” unless you are already under penalty of death or have a Code of Honor that would require suicide if captured. You never intentionally do anything that causes, or even threatens to cause, injury to the uninvolved – particularly if they are “ordinary folks.”",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"modifiers": [
+												{
+													"id": "mVhWR7HAWlLO2tnjc",
+													"name": "Species-Specific",
+													"reference": "UT32",
+													"cost": -80,
+													"disabled": true
+												}
+											],
+											"base_points": -10,
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "tm6hxpapKT7CcTmQL",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tSiOKuvTJkqJhuRrI"
+											},
+											"name": "Lecherousness",
+											"reference": "B142",
+											"notes": "Make a self-control roll whenever you have more than the briefest contact with an appealing member of the sex you find attractive, at -5 if this person is Handsome/Beautiful, or at -10 if Very Handsome/Very Beautiful. If you fail, you must make a “pass” using whatever wiles and skills you can bring to bear.",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"cr": 12,
+											"base_points": -15,
+											"calc": {
+												"points": -15
+											}
+										},
+										{
+											"id": "t7in0ElYA37eSPd45",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "ttHkLI9zwzfeOIEZc"
+											},
+											"name": "Intolerance (@Class, Ethnicity, Nationality, Religion, Sex, or Species@)",
+											"reference": "B140",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"replacements": {
+												"Class, Ethnicity, Nationality, Religion, Sex, or Species": "Rival civilization or species"
+											},
+											"modifiers": [
+												{
+													"id": "mW7A8vxWnvVa7e-YI",
+													"name": "Scope: Common",
+													"reference": "B140",
+													"cost": -5,
+													"cost_type": "points"
+												},
+												{
+													"id": "mRhRdsuBTNnpzKST3",
+													"name": "Scope: Occasional",
+													"reference": "B140",
+													"cost": -2,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "my7chfss9EbdVTuqK",
+													"name": "Scope: Rare",
+													"reference": "B140",
+													"cost": -1,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "me6M8-1mX1BoZv3Nx",
+													"name": "Scope: Anyone unlike you",
+													"reference": "B140",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												}
+											],
 											"features": [
 												{
 													"type": "reaction_bonus",
-													"situation": "to others",
-													"amount": 2
-												},
-												{
-													"type": "conditional_modifier",
-													"situation": "to IQ-based skills when alone",
+													"situation": "from victims of your intolerance (may be as much as -5, at GM's discretion)",
 													"amount": -1
 												}
 											],
@@ -2264,49 +2904,383 @@
 											}
 										},
 										{
-											"id": "tlpqlL0O-97eK87Ek",
-											"name": "Code of Honor (Mercanary's)",
-											"reference": "S221",
-											"notes": "A merc should look out for his buddies, take care of his gear, and fight for the honor of the unit. Obey the rule's of engagement. Don't poach on another unit's contract. Do the job you're hired for.",
+											"id": "t-JtfieEXbPgtLMNA",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t7pCgXTVkswkTjOZO"
+											},
+											"name": "Honesty",
+											"reference": "B138",
+											"notes": "Make a self-control roll when faced with the “need” to break unreasonable laws; if you fail, you must obey the law, whatever the consequences. If you manage to resist your urges and break the law, make a second self-control roll afterward. If you fail, you must turn yourself in to the authorities!",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
+											"cr": 12,
 											"base_points": -10,
 											"calc": {
 												"points": -10
 											}
 										},
 										{
-											"id": "toO0sm6Qjgk4Hfv0I",
-											"name": "Code of Honor (Pirate's)",
-											"reference": "B127",
-											"notes": "Always avenge an insult, regardless of the danger; your buddy’s foe is your own; never attack a fellow crewman or buddy except in a fair, open duel.",
+											"id": "txBNnZ-moiARrwUtM",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t5bwP6TnS4cX-zM8L"
+											},
+											"name": "Enemy (@Who@)",
+											"reference": "B135",
+											"tags": [
+												"Disadvantage",
+												"Social"
+											],
+											"modifiers": [
+												{
+													"id": "mx41UK7-CczEXgLnl",
+													"name": "Weak Individual",
+													"reference": "B135",
+													"notes": "50% of your starting points",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m6yrRLttMcUtjjU-D",
+													"name": "Equal Individual",
+													"reference": "B135",
+													"notes": "100% of your starting points",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m0489tmXoxkFLLK24",
+													"name": "Powerful Individual",
+													"reference": "B135",
+													"notes": "\u003e150% of your starting points",
+													"cost": -20,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mx52OAF0qZvy4ULUC",
+													"name": "Weak Group",
+													"reference": "B135",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mAnz_RbVunsmk3xRj",
+													"name": "Medium Group",
+													"reference": "B135",
+													"cost": -20,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mqQ8K1jQaPq2tQJZy",
+													"name": "Appears almost all the time",
+													"reference": "B36",
+													"notes": "15-",
+													"cost": 3,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mI__BmEPTTjEL0S47",
+													"name": "Appears quite often",
+													"reference": "B36",
+													"notes": "12-",
+													"cost": 2,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mewCSx_tsGqQHsRG8",
+													"name": "Appears fairly often",
+													"reference": "B36",
+													"notes": "9-",
+													"cost": 1,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "m-z-tDoeMh_3eO76_",
+													"name": "Appears quite rarely",
+													"reference": "B36",
+													"notes": "6-",
+													"cost": 0.5,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mRP0rUCD3zMlrKRRT",
+													"name": "Large/Powerful Group",
+													"reference": "B135",
+													"cost": -30,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m06Ev8OCtTtymQ46e",
+													"name": "Utterly Formidable Group",
+													"reference": "B135",
+													"cost": -40,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mx9fCpjyhMuAHFhec",
+													"name": "Unknown",
+													"reference": "B135",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m73JdWRp3x8bam-yh",
+													"name": "Evil Twin",
+													"reference": "B135",
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mgAKtAMA8Bauegrs6",
+													"name": "Evil Twin",
+													"reference": "B135",
+													"notes": "More skilled or extra abilities",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mZMKV1HVxZrF81FRe",
+													"name": "Evil Twin",
+													"reference": "B135",
+													"notes": "More skilled and extra abilities",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m0t-hHW4IcYd5lDfW",
+													"name": "Watcher",
+													"reference": "B135",
+													"cost": 0.25,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "m8KIwbY0YDnK3O3V7",
+													"name": "Rival",
+													"reference": "B135",
+													"cost": 0.5,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mpAr-WBfWfzLN0qkG",
+													"name": "Hunter",
+													"reference": "B135",
+													"cost": 1,
+													"cost_type": "multiplier",
+													"disabled": true
+												}
+											],
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "t06nbbi6rstbZRTTz",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t1HUGl4o498iCyvrw"
+											},
+											"name": "Duty (@Duty@)",
+											"reference": "B133",
+											"tags": [
+												"Disadvantage",
+												"Social"
+											],
+											"replacements": {
+												"Duty": "To ship's owner or provider"
+											},
+											"modifiers": [
+												{
+													"id": "mZF4uxCjBZ_Rk2B8z",
+													"name": "FR: 6",
+													"cost": -2,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mmTOb5wV2-7snYo3g",
+													"name": "FR: 9",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "moMiwyzrNwjvplWzI",
+													"name": "FR: 12",
+													"cost": -10,
+													"cost_type": "points"
+												},
+												{
+													"id": "m-t9ysoVXryVAC4jR",
+													"name": "FR: 15",
+													"cost": -15,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mhtTJxl8bhA5bHrhH",
+													"name": "Extremely Hazardous",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mKFaiSx5hnP6CNYli",
+													"name": "Involuntary",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mdA37zYiCwWh-AZVJ",
+													"name": "Nonhazardous",
+													"cost": 5,
+													"cost_type": "points",
+													"disabled": true
+												}
+											],
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "tkl0JglzgAHZsY24r",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t1HUGl4o498iCyvrw"
+											},
+											"name": "Duty (@Duty@)",
+											"reference": "B133",
+											"tags": [
+												"Disadvantage",
+												"Social"
+											],
+											"replacements": {
+												"Duty": "To ship's owner or provider"
+											},
+											"modifiers": [
+												{
+													"id": "mCiMRfAT57Hhsf8ZW",
+													"name": "FR: 6",
+													"cost": -2,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mMc1K9rwSIkaaXXg7",
+													"name": "FR: 9",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mi7T1nVk-za3pcgpt",
+													"name": "FR: 12",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mymUsIiO9s4fl7ERc",
+													"name": "FR: 15",
+													"cost": -15,
+													"cost_type": "points"
+												},
+												{
+													"id": "mNyx1htj4wJpPWQIe",
+													"name": "Extremely Hazardous",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mNlcTctbcoXf-grTJ",
+													"name": "Involuntary",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m3WuBF3eEajOdqL0B",
+													"name": "Nonhazardous",
+													"cost": 5,
+													"cost_type": "points",
+													"disabled": true
+												}
+											],
+											"calc": {
+												"points": -15
+											}
+										},
+										{
+											"id": "tv9TzRhF4F0lazU3p",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tXFf9MSQ3FMT2psO8"
+											},
+											"name": "Demophobia (Crowds)",
+											"reference": "B149",
+											"notes": "Any group of over a dozen people sets off this fear unless they are all well known to you. The self-control roll is at -1 for over 25 people, -2 for a crowd of 100 or more, -3 for 1,000, -4 for 10,000, and so on.",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
+											"cr_adj": "action_penalty",
+											"cr": 12,
+											"base_points": -15,
+											"calc": {
+												"points": -15
+											}
+										},
+										{
+											"id": "tai59E_NeG7GtBK4m",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tK4QdVZYxGAd4cqr_"
+											},
+											"name": "Compulsive Gambling",
+											"reference": "B128",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"cr": 12,
 											"base_points": -5,
 											"calc": {
 												"points": -5
 											}
 										},
 										{
-											"id": "tmTiEt9O0nDmFFRW0",
-											"name": "Code of Honor (Soldier's)",
-											"reference": "B127",
-											"notes": "An officer should be tough but fair, lead from the front, and look out for his men; an enlisted man should look out for his buddies and take care of his kit. Every soldier should be willing to fight and die for the honor of his unit, service, and country; follow orders; obey the “rules of war”; treat an honorable enemy with respect (a dishonorable enemy deserves a bullet); and wear the uniform with pride.",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"base_points": -10,
-											"calc": {
-												"points": -10
-											}
-										},
-										{
-											"id": "tH1Dftn-LSCWb60C6",
+											"id": "tjA0ddGi0HLLkxg_0",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tapWLsuN75Unedmwn"
+											},
 											"name": "Compulsive Carousing",
 											"reference": "B128",
 											"tags": [
@@ -2332,308 +3306,115 @@
 											}
 										},
 										{
-											"id": "tzJJU9M9alAckvv97",
-											"name": "Compulsive Gambling",
-											"reference": "B128",
+											"id": "tfcfrUVLqPUeDBPwy",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "txSrmgLB0M36uR802"
+											},
+											"name": "Code of Honor (Soldier's)",
+											"reference": "B127",
+											"notes": "An officer should be tough but fair, lead from the front, and look out for his men; an enlisted man should look out for his buddies and take care of his kit. Every soldier should be willing to fight and die for the honor of his unit, service, and country; follow orders; obey the “rules of war”; treat an honorable enemy with respect (a dishonorable enemy deserves a bullet); and wear the uniform with pride.",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
-											"cr": 12,
-											"base_points": -5,
-											"calc": {
-												"points": -5
-											}
-										},
-										{
-											"id": "tzwdG4uzJ1BGxT6Y-",
-											"name": "Duty (To ship's owner or provider)",
-											"reference": "B133",
-											"tags": [
-												"Disadvantage",
-												"Social"
-											],
-											"modifiers": [
-												{
-													"id": "mN0SqvEdYW7od9uQY",
-													"name": "FR: 6",
-													"cost": -2,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mNyRoL5Tq72aEtfoo",
-													"name": "FR: 9",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m1c0nTDTTCYmZPm5d",
-													"name": "FR: 12",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mwenKvvZdDM5dWoqS",
-													"name": "FR: 15",
-													"cost": -15,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m_8yXbVIeT_TpkJBx",
-													"name": "Extremely Hazardous",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mTYEY3qFnRolAdJXK",
-													"name": "Involuntary",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "maN9Mubb_uvIG9CMI",
-													"name": "Nonhazardous",
-													"cost": 5,
-													"cost_type": "points",
-													"disabled": true
-												}
-											],
-											"calc": {
-												"points": 0
-											}
-										},
-										{
-											"id": "tkHF6a5BURogv5lF6",
-											"name": "Enemy (@Who@)",
-											"reference": "B135",
-											"tags": [
-												"Disadvantage",
-												"Social"
-											],
-											"modifiers": [
-												{
-													"id": "mOepbSz4l-pxu1iBr",
-													"name": "Weak Individual",
-													"reference": "B135",
-													"notes": "50% of your starting points",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mXmzZwAplrWXdC-FS",
-													"name": "Equal Individual",
-													"reference": "B135",
-													"notes": "100% of your starting points",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mGYbSOFQLRVDTcwa6",
-													"name": "Powerful Individual",
-													"reference": "B135",
-													"notes": "\u003e150% of your starting points",
-													"cost": -20,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m9d4mzbDYZRelpUXE",
-													"name": "Weak Group",
-													"reference": "B135",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mySsgLXjpObE8v_m8",
-													"name": "Medium Group",
-													"reference": "B135",
-													"cost": -20,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mpEAgNpsTSN0LQC7L",
-													"name": "Appears almost all the time",
-													"reference": "B36",
-													"notes": "15-",
-													"cost": 3,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "m4SZ4kMiL391Fc9W6",
-													"name": "Appears quite often",
-													"reference": "B36",
-													"notes": "12-",
-													"cost": 2,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "m_g8D1IXwj5U62mFX",
-													"name": "Appears fairly often",
-													"reference": "B36",
-													"notes": "9-",
-													"cost": 1,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "muAqv9N-Wyg6XC8Yc",
-													"name": "Appears quite rarely",
-													"reference": "B36",
-													"notes": "6-",
-													"cost": 0.5,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mREWKNpZ9b2c5wDw4",
-													"name": "Large/Powerful Group",
-													"reference": "B135",
-													"cost": -30,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mnAGRlbUGwFTm2n2H",
-													"name": "Utterly Formidable Group",
-													"reference": "B135",
-													"cost": -40,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mgTXJIgAK0il_Fhg-",
-													"name": "Unknown",
-													"reference": "B135",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mkRV2vg4pcCXrAjWe",
-													"name": "Evil Twin",
-													"reference": "B135",
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mhhOaKJDiJ_3qgnq5",
-													"name": "Evil Twin",
-													"reference": "B135",
-													"notes": "More skilled or extra abilities",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mfO-brU6ohuyT0C3F",
-													"name": "Evil Twin",
-													"reference": "B135",
-													"notes": "More skilled and extra abilities",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mgx06MpBvWqYA4shR",
-													"name": "Watcher",
-													"reference": "B135",
-													"cost": 0.25,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "m2wY25iw_ah8QQdqd",
-													"name": "Rival",
-													"reference": "B135",
-													"cost": 0.5,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mJoels094rRKlu7DV",
-													"name": "Hunter",
-													"reference": "B135",
-													"cost": 1,
-													"cost_type": "multiplier",
-													"disabled": true
-												}
-											],
-											"calc": {
-												"points": 0
-											}
-										},
-										{
-											"id": "tis-30z2tH53VSYRt",
-											"name": "Honesty",
-											"reference": "B138",
-											"notes": "Make a self-control roll when faced with the “need” to break unreasonable laws; if you fail, you must obey the law, whatever the consequences. If you manage to resist your urges and break the law, make a second self-control roll afterward. If you fail, you must turn yourself in to the authorities!",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"cr": 12,
 											"base_points": -10,
 											"calc": {
 												"points": -10
 											}
 										},
 										{
-											"id": "tBOKuYIMu5RBsnR87",
-											"name": "Intolerance (@Rival civilization or species@)",
-											"reference": "B140",
+											"id": "t447_rKBe8-ExcY5c",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Space/Space Traits.adq",
+												"id": "teNSsqOsjstajwmxn"
+											},
+											"name": "Code of Honor (Mercenary's Code)",
+											"reference": "B127, S221",
+											"notes": "A merc should look out for his buddies, take care of his gear, and fight for the honor of the unit. Obey the rules of engagement. Don’t poach on another unit’s contract. Do the job you’re hired for.",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
-											"modifiers": [
-												{
-													"id": "moF-AITWrIqqZscJ0",
-													"name": "Scope: Common",
-													"reference": "B140",
-													"cost": -5,
-													"cost_type": "points"
-												},
-												{
-													"id": "mnwucxW8qbykk-8p_",
-													"name": "Scope: Occasional",
-													"reference": "B140",
-													"cost": -2,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mQj7YB07_m5i8TkkQ",
-													"name": "Scope: Rare",
-													"reference": "B140",
-													"cost": -1,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mRt08Bd2C1o09IqTl",
-													"name": "Scope: Anyone unlike you",
-													"reference": "B140",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												}
+											"base_points": -10,
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "tPJG1-GCT6t3yE326",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tqq24I9NJrLajsURv"
+											},
+											"name": "Code of Honor (Pirate's)",
+											"reference": "B127",
+											"notes": "Always avenge an insult, regardless of the danger; your buddy’s foe is your own; never attack a fellow crewman or buddy except in a fair, open duel.",
+											"tags": [
+												"Disadvantage",
+												"Mental"
 											],
+											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										},
+										{
+											"id": "tAAfGKKJzQvAQhuRU",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t4KGpV0KBExr-fEb2"
+											},
+											"name": "Gregarious",
+											"reference": "B126",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"base_points": -10,
 											"features": [
 												{
 													"type": "reaction_bonus",
-													"situation": "from victims of your intolerance (may be as much as -5, at GM's discretion)",
+													"situation": "to others",
+													"amount": 4
+												},
+												{
+													"type": "conditional_modifier",
+													"situation": "to IQ-based skills when alone, or only -1 if in a group of 4 or less",
+													"amount": -2
+												}
+											],
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "tTKslIAl-YK2Je0rZ",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tzBDG0xUlT_dh7FuY"
+											},
+											"name": "Chummy",
+											"reference": "B126",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"base_points": -5,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "to others",
+													"amount": 2
+												},
+												{
+													"type": "conditional_modifier",
+													"situation": "to IQ-based skills when alone",
 													"amount": -1
 												}
 											],
@@ -2642,91 +3423,12 @@
 											}
 										},
 										{
-											"id": "ttHy1xrgo_byled_D",
-											"name": "Lecherousness",
-											"reference": "B142",
-											"notes": "Make a self-control roll whenever you have more than the briefest contact with an appealing member of the sex you find attractive, at -5 if this person is Handsome/Beautiful, or at -10 if Very Handsome/Very Beautiful. If you fail, you must make a “pass” using whatever wiles and skills you can bring to bear.",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"cr": 12,
-											"base_points": -15,
-											"calc": {
-												"points": -15
-											}
-										},
-										{
-											"id": "tvqj1eU0MPH-CuBK_",
-											"name": "Pacifism: Reluctant Killer",
-											"reference": "B148",
-											"notes": "You are psychologically unprepared to kill people. Whenever you make a deadly attack (e.g., with a knife or a gun) against an obvious person whose face is visible to you, you are at -4 to hit and may not Aim. If you cannot see the foe’s face (due to a mask, darkness, or distance, or because you attacked from behind), the penalty is only -2, save in close combat. You have no penalty to attack a vehicle (even an occupied one), an opponent you do not believe is a person (including things with Horrific or Monstrous appearance), or a target you can’t actually see (e.g., a set of map coordinates or a blip on a radar screen). If you kill a recognizable person, the effect on you is the same as for Pacifism: Cannot Kill. You have no problem with your allies killing; you may even supply ammo, loaded weapons, and encouragement! You just can’t do the killing yourself.",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"modifiers": [
-												{
-													"id": "mrgdMC4uwS5yJNtJE",
-													"name": "Species-Specific",
-													"reference": "UT32",
-													"cost": -80,
-													"disabled": true
-												}
-											],
-											"base_points": -5,
-											"calc": {
-												"points": -5
-											}
-										},
-										{
-											"id": "tkBDQ1BeTcBiP8JnP",
-											"name": "Pacifism: Self-Defense Only",
-											"reference": "B148",
-											"notes": "You only fight to defend yourself or those in your care, using only as much force as necessary (no pre-emptive strikes allowed!). You must do your best to discourage others from starting fights.",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"modifiers": [
-												{
-													"id": "mVPhQa4of1eG00518",
-													"name": "Species-Specific",
-													"reference": "UT32",
-													"cost": -80,
-													"disabled": true
-												}
-											],
-											"base_points": -15,
-											"calc": {
-												"points": -15
-											}
-										},
-										{
-											"id": "tSlsbzMxkUXwaWDho",
-											"name": "Pacifism: Cannot Harm Innocents",
-											"reference": "B148",
-											"notes": "You may fight – you may even start fights – but you may only use deadly force on a foe that is attempting to do you serious harm. Capture is not “serious harm” unless you are already under penalty of death or have a Code of Honor that would require suicide if captured. You never intentionally do anything that causes, or even threatens to cause, injury to the uninvolved – particularly if they are “ordinary folks.”",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"modifiers": [
-												{
-													"id": "m-piNyujKZ2dpzshY",
-													"name": "Species-Specific",
-													"reference": "UT32",
-													"cost": -80,
-													"disabled": true
-												}
-											],
-											"base_points": -10,
-											"calc": {
-												"points": -10
-											}
-										},
-										{
-											"id": "tO33_9jTU7iUWeG6J",
+											"id": "t1sH8KmiGxoZcmLyg",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "taFPI7E0PJwXbS5nL"
+											},
 											"name": "Agoraphobia (Open Spaces)",
 											"reference": "B150",
 											"notes": "You are uncomfortable whenever you are outside, and actually become frightened when there are no walls within 50 feet.",
@@ -2740,120 +3442,19 @@
 											"calc": {
 												"points": -10
 											}
-										},
-										{
-											"id": "tUv3tEPBRszUqAbDE",
-											"name": "Demophobia (Crowds)",
-											"reference": "B149",
-											"notes": "Any group of over a dozen people sets off this fear unless they are all well known to you. The self-control roll is at -1 for over 25 people, -2 for a crowd of 100 or more, -3 for 1,000, -4 for 10,000, and so on.",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"cr_adj": "action_penalty",
-											"cr": 12,
-											"base_points": -15,
-											"calc": {
-												"points": -15
-											}
-										},
-										{
-											"id": "tTGYjYKtWHhNotY8q",
-											"name": "Duty (To ship's owner or provider)",
-											"reference": "B133",
-											"tags": [
-												"Disadvantage",
-												"Social"
-											],
-											"modifiers": [
-												{
-													"id": "mghD6JAx954RC6uqh",
-													"name": "FR: 6",
-													"cost": -2,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mVfxQIJUpMfzMA4_6",
-													"name": "FR: 9",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mrFBdoaBy0UpUp3Nq",
-													"name": "FR: 12",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m6SNmKUxjOXuj8hnW",
-													"name": "FR: 15",
-													"cost": -15,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mCX_6jsw_gnGqBu-a",
-													"name": "Extremely Hazardous",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mGd9VtVzugX4bQRNM",
-													"name": "Involuntary",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mZH76OO9HAbq6Som-",
-													"name": "Nonhazardous",
-													"cost": 5,
-													"cost_type": "points",
-													"disabled": true
-												}
-											],
-											"calc": {
-												"points": 0
-											}
-										},
-										{
-											"id": "t_BIkOMcs6T9UiAS7",
-											"name": "Workaholic",
-											"reference": "B162",
-											"tags": [
-												"Disadvantage",
-												"Physical"
-											],
-											"base_points": -5,
-											"calc": {
-												"points": -5
-											}
-										},
-										{
-											"id": "tdN9nBNxO4ly2Ohuq",
-											"name": "Xenophilia",
-											"reference": "B162",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"cr": 12,
-											"base_points": -10,
-											"calc": {
-												"points": -10
-											}
 										}
 									],
 									"calc": {
-										"points": -145
+										"points": -180
 									}
 								},
 								{
-									"id": "tsoNzc6K4OmqGglQP",
+									"id": "tJVmYLIgGIf-WyHRs",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t-ZuUbg_LrqZ1hi6c"
+									},
 									"name": "Careful",
 									"reference": "B163",
 									"tags": [
@@ -2866,7 +3467,12 @@
 									}
 								},
 								{
-									"id": "tz6JjIZtbeeq22hK5",
+									"id": "tyoi9ekc2rDU5fpP0",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t7pDegQEavl5neK-Z"
+									},
 									"name": "Hard of Hearing",
 									"reference": "B138",
 									"tags": [
@@ -2891,12 +3497,17 @@
 									}
 								},
 								{
-									"id": "tO-QDc-WCstwK0xMF",
+									"id": "t3rvmi6HnvF9G1MXL",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tAFhfFoZosiPCFUhy"
+									},
 									"name": "No Sense of Humor",
 									"reference": "B146",
 									"tags": [
 										"Disadvantage",
-										"Physical"
+										"Mental"
 									],
 									"base_points": -10,
 									"features": [
@@ -2911,7 +3522,12 @@
 									}
 								},
 								{
-									"id": "tPIbzm38qLWp1y4Ko",
+									"id": "tRXEFkj10yxiJx8yF",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tPbL1_rekOzkM86wz"
+									},
 									"name": "Overconfidence",
 									"reference": "B148",
 									"notes": "You must make a self-control roll any time the GM feels you show an unreasonable degree of caution. If you fail, you must go ahead as though you were able to handle the situation!",
@@ -2938,7 +3554,12 @@
 									}
 								},
 								{
-									"id": "tAL3XA366t2x07PHE",
+									"id": "tAUBjLblRH0_ul_BO",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t4gqkFmqABx7dLjkS"
+									},
 									"name": "Stubbornness",
 									"reference": "B157",
 									"tags": [
@@ -2959,17 +3580,17 @@
 								}
 							],
 							"calc": {
-								"points": -176
+								"points": -211
 							}
 						}
 					],
 					"calc": {
-						"points": -176
+						"points": -211
 					}
 				}
 			],
 			"calc": {
-				"points": 249
+				"points": 214
 			}
 		},
 		{
@@ -2982,7 +3603,12 @@
 					"name": "Multi-Role",
 					"children": [
 						{
-							"id": "tJ5uuvVrM-0qr8Pxe",
+							"id": "tgOoE4vK1oKEP7bpB",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tqha9GlDBU9P-Wg-6"
+							},
 							"name": "Increased Strength",
 							"reference": "B14",
 							"tags": [
@@ -2992,14 +3618,14 @@
 							],
 							"modifiers": [
 								{
-									"id": "mAw0WkYTCmAnFsu78",
+									"id": "mFhLCSzfPh_zwCPCO",
 									"name": "No Fine Manipulators",
 									"reference": "B15",
 									"cost": -40,
 									"disabled": true
 								},
 								{
-									"id": "m7Krjm4TmChp-gAJG",
+									"id": "mc_7W2E3hE7t5wrPq",
 									"name": "Size",
 									"reference": "B15",
 									"cost": -10,
@@ -3007,7 +3633,7 @@
 									"disabled": true
 								},
 								{
-									"id": "m0CGLdUntjfzB6Lff",
+									"id": "msnSxZpDT6mVmkKyv",
 									"name": "Super-Effort",
 									"reference": "SU24",
 									"cost": 300,
@@ -3030,7 +3656,41 @@
 							}
 						},
 						{
-							"id": "tXyKUuzhNib3yw295",
+							"id": "tJUq2GfrnvI8IV3Gg",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tVt3SvdGWNchJ8z4o"
+							},
+							"name": "Increased Health",
+							"reference": "B14",
+							"tags": [
+								"Advantage",
+								"Attribute",
+								"Physical"
+							],
+							"points_per_level": 10,
+							"features": [
+								{
+									"type": "attribute_bonus",
+									"attribute": "ht",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"levels": 1,
+							"calc": {
+								"points": 10
+							}
+						},
+						{
+							"id": "tDFKXfb165YtnKLIz",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "t3msobZZ06J7dZ8xu"
+							},
 							"name": "Talent (Born Spacer)",
 							"reference": "PU3:7",
 							"tags": [
@@ -3040,12 +3700,60 @@
 							],
 							"modifiers": [
 								{
-									"id": "mrZxR59csewo-zI-a",
+									"id": "mEeJRhmJsuP1ADK1V",
 									"name": "Alternative Cost",
 									"cost": 1,
 									"cost_type": "points",
 									"affects": "levels_only",
 									"disabled": true
+								},
+								{
+									"id": "MzNhmFffSuBf2u37A",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "mhgWv87UBnvAP7PS1",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From professional Spacers.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "mSbKr2nLdvbwe0hiR",
+											"name": "Bonus to pushing off",
+											"reference": "BX350",
+											"reference_highlight": "ST/2",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Bonus to ST for zero G push off",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "m_NVL1L0eGXQsbaAZ",
+											"name": "Spacecraft Familiarity",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Counteracts Familiarity for spacecraft.",
+													"amount": 1
+												}
+											],
+											"disabled": true
+										}
+									]
 								}
 							],
 							"points_per_level": 5,
@@ -3143,18 +3851,6 @@
 										"compare": "is",
 										"qualifier": "Vacc Suit"
 									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "reaction_bonus",
-									"situation": "From professional Spacers.",
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "conditional_modifier",
-									"situation": "Bonus to ST for zero G push off.  Reduce penalty for unfamiliar spacecraft.",
 									"amount": 1,
 									"per_level": true
 								}
@@ -3167,7 +3863,7 @@
 						}
 					],
 					"calc": {
-						"points": 20
+						"points": 30
 					}
 				},
 				{
@@ -3175,7 +3871,12 @@
 					"name": "Legenday",
 					"children": [
 						{
-							"id": "tkkifv2bmf5n3oBGX",
+							"id": "tY6j0rGZVdI5UMzrr",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "t3msobZZ06J7dZ8xu"
+							},
 							"name": "Talent (Born Spacer)",
 							"reference": "PU3:7",
 							"tags": [
@@ -3185,12 +3886,60 @@
 							],
 							"modifiers": [
 								{
-									"id": "may7zv61Gm3e3CP0M",
+									"id": "mJ-KQQKPQiBInBZq_",
 									"name": "Alternative Cost",
 									"cost": 1,
 									"cost_type": "points",
 									"affects": "levels_only",
 									"disabled": true
+								},
+								{
+									"id": "Mt_LsjqqIMc2ZcljD",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "mdvke4bV2OsgFytok",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From professional Spacers.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "mk6kq8pC4Ow_Fhg4v",
+											"name": "Bonus to pushing off",
+											"reference": "BX350",
+											"reference_highlight": "ST/2",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Bonus to ST for zero G push off",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "msebJ-oH_XrlIjmQn",
+											"name": "Spacecraft Familiarity",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Counteracts Familiarity for spacecraft.",
+													"amount": 1
+												}
+											],
+											"disabled": true
+										}
+									]
 								}
 							],
 							"points_per_level": 5,
@@ -3288,18 +4037,6 @@
 										"compare": "is",
 										"qualifier": "Vacc Suit"
 									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "reaction_bonus",
-									"situation": "From professional Spacers.",
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "conditional_modifier",
-									"situation": "Bonus to ST for zero G push off.  Reduce penalty for unfamiliar spacecraft.",
 									"amount": 1,
 									"per_level": true
 								}
@@ -3315,7 +4052,12 @@
 							"name": "40 Points chosen from",
 							"children": [
 								{
-									"id": "tsYJlA55_7nNA19__",
+									"id": "tahSydbxUTEzdbZ7T",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tqha9GlDBU9P-Wg-6"
+									},
 									"name": "Increased Strength",
 									"reference": "B14",
 									"tags": [
@@ -3325,14 +4067,14 @@
 									],
 									"modifiers": [
 										{
-											"id": "mL5aGQR20vMAz7ZQH",
+											"id": "mQPF8A0zRmVbZliog",
 											"name": "No Fine Manipulators",
 											"reference": "B15",
 											"cost": -40,
 											"disabled": true
 										},
 										{
-											"id": "mXJncQJPN8DLr8jUF",
+											"id": "m1b8w3wvKVG48TZWk",
 											"name": "Size",
 											"reference": "B15",
 											"cost": -10,
@@ -3340,7 +4082,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mu6c2LKJ9mdpR32IK",
+											"id": "mkCChhOcsCihGSEfS",
 											"name": "Super-Effort",
 											"reference": "SU24",
 											"cost": 300,
@@ -3363,7 +4105,12 @@
 									}
 								},
 								{
-									"id": "tovCZtT-QCMuXmU-l",
+									"id": "tdgandfdy7dTwg04z",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tGWOSEE6SmBHACE6Y"
+									},
 									"name": "Increased Dexterity",
 									"reference": "B15",
 									"tags": [
@@ -3373,7 +4120,7 @@
 									],
 									"modifiers": [
 										{
-											"id": "mbay8YB9F9Wvxg9lS",
+											"id": "mA82ckB8P9xZphU1Z",
 											"name": "No Fine Manipulators",
 											"cost": -40,
 											"disabled": true
@@ -3395,7 +4142,12 @@
 									}
 								},
 								{
-									"id": "t_Xs2tDu4MnAWapkT",
+									"id": "tvnZOidLbfhHiF_7D",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tVt3SvdGWNchJ8z4o"
+									},
 									"name": "Increased Health",
 									"reference": "B14",
 									"tags": [
@@ -3419,7 +4171,12 @@
 									}
 								},
 								{
-									"id": "tF2CK6wR32xKqfWZ3",
+									"id": "tI5eb3X-6lTz2dm2N",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tM6z7Mx6e2V4VvUR4"
+									},
 									"name": "Absolute Direction",
 									"reference": "B34",
 									"tags": [
@@ -3429,14 +4186,14 @@
 									],
 									"modifiers": [
 										{
-											"id": "mD_QDtY0-VQ33zy7-",
+											"id": "m60uKIJqKk9l1s6AU",
 											"name": "Requires signal",
 											"reference": "B34",
 											"cost": -20,
 											"disabled": true
 										},
 										{
-											"id": "mtSdSAFMz5MCKx3az",
+											"id": "mJBAE1mwMUre9t8Bl",
 											"name": "3D Spatial Sense",
 											"reference": "B34",
 											"cost": 5,
@@ -3554,7 +4311,12 @@
 									}
 								},
 								{
-									"id": "tLHHXewQ2dOmH-3-Y",
+									"id": "tPagy7fholoGoLCEm",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tq2NvaQrWXxqG_wLn"
+									},
 									"name": "Deep Sleeper",
 									"reference": "PU2:13",
 									"tags": [
@@ -3567,7 +4329,148 @@
 									}
 								},
 								{
-									"id": "tsDX1ZDM9cqGTDCGP",
+									"id": "t2qJLSQv9K0w5tAJO",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tu3GuYC47Sx6bnm4k"
+									},
+									"name": "G-Experience",
+									"reference": "B57",
+									"tags": [
+										"Advantage",
+										"Mental"
+									],
+									"points_per_level": 1,
+									"can_level": true,
+									"levels": 10,
+									"calc": {
+										"points": 10
+									}
+								},
+								{
+									"id": "tJGZXsknDnRi-Bvko",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "txREhxV6L1SKixwe_"
+									},
+									"name": "Improved G-tolerance",
+									"reference": "B60",
+									"tags": [
+										"Advantage",
+										"Physical"
+									],
+									"modifiers": [
+										{
+											"id": "mr7BdBiHAmzQ-DMLT",
+											"name": "0.3G",
+											"reference": "B60",
+											"cost": 5,
+											"cost_type": "points"
+										},
+										{
+											"id": "mix-TRdBbysDLkQwa",
+											"name": "0.5G",
+											"reference": "B60",
+											"cost": 10,
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "m1DMJ_5AP836QIG9v",
+											"name": "1G",
+											"reference": "B60",
+											"cost": 15,
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "mmv8LNa_N0Rlac_zv",
+											"name": "5G",
+											"reference": "B60",
+											"cost": 20,
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "mJ__LDBBuJ-AlnoOy",
+											"name": "10G",
+											"reference": "B60",
+											"cost": 25,
+											"cost_type": "points",
+											"disabled": true
+										}
+									],
+									"calc": {
+										"points": 5
+									}
+								},
+								{
+									"id": "tZiOALFvDfEnS_5ev",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "txREhxV6L1SKixwe_"
+									},
+									"name": "Improved G-tolerance",
+									"reference": "B60",
+									"tags": [
+										"Advantage",
+										"Physical"
+									],
+									"modifiers": [
+										{
+											"id": "mBD9JdjhDA0eg5XVM",
+											"name": "0.3G",
+											"reference": "B60",
+											"cost": 5,
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "maIVEz2cutfQ4qII6",
+											"name": "0.5G",
+											"reference": "B60",
+											"cost": 10,
+											"cost_type": "points"
+										},
+										{
+											"id": "m1dcJImby68AP4MRs",
+											"name": "1G",
+											"reference": "B60",
+											"cost": 15,
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "mK5S-k2PHI-goFU-a",
+											"name": "5G",
+											"reference": "B60",
+											"cost": 20,
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "mjnEOsC2U5Jz-7JB2",
+											"name": "10G",
+											"reference": "B60",
+											"cost": 25,
+											"cost_type": "points",
+											"disabled": true
+										}
+									],
+									"calc": {
+										"points": 10
+									}
+								},
+								{
+									"id": "tnU8scYl_na03f82R",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tJTfFdHM7YI5IZR7I"
+									},
 									"name": "Resistant",
 									"reference": "B81,P71,MA47",
 									"tags": [
@@ -3576,7 +4479,7 @@
 									],
 									"modifiers": [
 										{
-											"id": "mzwgogm8uHh1Xpule",
+											"id": "m_4bEGBfenK7TtqJm",
 											"name": "@Very Common: Metabolic Hazards, etc.@",
 											"reference": "B80",
 											"cost": 30,
@@ -3584,7 +4487,7 @@
 											"disabled": true
 										},
 										{
-											"id": "m1TBMl4c3JSLiEZL7",
+											"id": "mTV_QMzjo25yIe9QW",
 											"name": "@Common: Poison, Sickness, etc.@",
 											"reference": "B81",
 											"cost": 15,
@@ -3592,7 +4495,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mZUZybIpCqCQp8ww8",
+											"id": "m_UHQBR0Zoe-060Ao",
 											"name": "@Occasional: Disease, Ingested Poison, etc.@",
 											"reference": "B81",
 											"cost": 10,
@@ -3600,14 +4503,17 @@
 											"disabled": true
 										},
 										{
-											"id": "ma3EaKawFFsODZoMp",
-											"name": "Acceleration",
+											"id": "m4BoCcl31SoUDvfng",
+											"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
 											"reference": "B81",
+											"replacements": {
+												"Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.": "Acceleration"
+											},
 											"cost": 5,
 											"cost_type": "points"
 										},
 										{
-											"id": "mW5FQ9lmpgK9O7kRZ",
+											"id": "m2rVAbemVC0ZqGTYO",
 											"name": "Immunity",
 											"reference": "B81",
 											"cost": 1,
@@ -3615,7 +4521,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mwLVSQkJ_tN_WGHdT",
+											"id": "mkxAeWTqP9xC3EkSq",
 											"name": "+8 to all HT rolls to resist",
 											"reference": "B81",
 											"cost": 0.5,
@@ -3623,7 +4529,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mRXLKQIz6_tuWtflD",
+											"id": "m_5fXYC2GQEO377_S",
 											"name": "+3 to all HT rolls to resist",
 											"reference": "B81",
 											"cost": 0.33,
@@ -3636,7 +4542,12 @@
 									}
 								},
 								{
-									"id": "tz2yUxSnGh0sz8O7o",
+									"id": "t5xxpuYm8R-kb2b7S",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "touwUIFalnae02BUl"
+									},
 									"name": "Temperature Tolerance",
 									"reference": "B93",
 									"tags": [
@@ -3651,7 +4562,12 @@
 									}
 								},
 								{
-									"id": "t0v8Sj3MlYYxs9tAK",
+									"id": "t5JUQjfwlJm5UF_6M",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "toTe273Ky82B6YdW5"
+									},
 									"name": "Fit",
 									"reference": "B55",
 									"notes": "Recover FP at twice the normal rate (but not FP spent for spells or psi powers)",
@@ -3672,7 +4588,12 @@
 									}
 								},
 								{
-									"id": "tPoco7IUjsFFyDecv",
+									"id": "tDsPW1SLYTri20FDJ",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tOQfp3YosDgO4S3yI"
+									},
 									"name": "Very Fit",
 									"reference": "B55",
 									"notes": "Recover FP at twice the normal rate; lose FP at half the normal rate (in both cases, not FP spent for spells or psi powers)",
@@ -3693,7 +4614,12 @@
 									}
 								},
 								{
-									"id": "ttyYLNJ57SbJaD7Bd",
+									"id": "tuKESQqeVfWW4RHaF",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tJTfFdHM7YI5IZR7I"
+									},
 									"name": "Resistant",
 									"reference": "B81,P71,MA47",
 									"tags": [
@@ -3702,7 +4628,7 @@
 									],
 									"modifiers": [
 										{
-											"id": "mSx5EPU81Md70qg4G",
+											"id": "mnP6Xc1_2JJ-UCYlO",
 											"name": "@Very Common: Metabolic Hazards, etc.@",
 											"reference": "B80",
 											"cost": 30,
@@ -3710,7 +4636,7 @@
 											"disabled": true
 										},
 										{
-											"id": "maYHXqirs3e7cQSL2",
+											"id": "mcFmcZWHDrBSjK7HN",
 											"name": "@Common: Poison, Sickness, etc.@",
 											"reference": "B81",
 											"cost": 15,
@@ -3718,7 +4644,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mT93IGqmgZvveSdag",
+											"id": "m3xvAN3tq1DPyNuEe",
 											"name": "@Occasional: Disease, Ingested Poison, etc.@",
 											"reference": "B81",
 											"cost": 10,
@@ -3726,14 +4652,17 @@
 											"disabled": true
 										},
 										{
-											"id": "mMIfrY892OAvmbQjH",
-											"name": "Space Sickness",
+											"id": "mYJJen6-gYXy2gqo7",
+											"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
 											"reference": "B81",
+											"replacements": {
+												"Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.": "Space Sickness"
+											},
 											"cost": 5,
 											"cost_type": "points"
 										},
 										{
-											"id": "m1sTw48ztA1ADyMnW",
+											"id": "mb6QTdOYUSL3OL759",
 											"name": "Immunity",
 											"reference": "B81",
 											"cost": 1,
@@ -3741,14 +4670,14 @@
 											"disabled": true
 										},
 										{
-											"id": "mrRP1R26sOQ_89o7p",
+											"id": "mq8ItCnX4_v-l8wDw",
 											"name": "+8 to all HT rolls to resist",
 											"reference": "B81",
 											"cost": 0.5,
 											"cost_type": "multiplier"
 										},
 										{
-											"id": "mIr1E4TAo8JLz4y0S",
+											"id": "mQzSMYMLRxDr6wLxK",
 											"name": "+3 to all HT rolls to resist",
 											"reference": "B81",
 											"cost": 0.33,
@@ -3760,88 +4689,20 @@
 									"calc": {
 										"points": 2
 									}
-								},
-								{
-									"id": "teV0VGMCl5xuXGQR5",
-									"name": "G-Experience",
-									"reference": "B57",
-									"tags": [
-										"Advantage",
-										"Mental"
-									],
-									"points_per_level": 1,
-									"can_level": true,
-									"levels": 10,
-									"calc": {
-										"points": 10
-									}
-								},
-								{
-									"id": "tfHmaSWPuujoF5FuL",
-									"name": "Improved G-tolerance",
-									"reference": "B60",
-									"tags": [
-										"Advantage",
-										"Physical"
-									],
-									"modifiers": [
-										{
-											"id": "mbgaM6_JTJUU1LYj9",
-											"name": "0.3G",
-											"reference": "B60",
-											"cost": 5,
-											"cost_type": "points",
-											"disabled": true
-										},
-										{
-											"id": "mjwRn3O8aDYZcWjlj",
-											"name": "0.5G",
-											"reference": "B60",
-											"cost": 10,
-											"cost_type": "points"
-										},
-										{
-											"id": "mTBPWGotZBGTqsw1E",
-											"name": "1G",
-											"reference": "B60",
-											"cost": 15,
-											"cost_type": "points",
-											"disabled": true
-										},
-										{
-											"id": "mtz1TvpHuuubD-ah0",
-											"name": "5G",
-											"reference": "B60",
-											"cost": 20,
-											"cost_type": "points",
-											"disabled": true
-										},
-										{
-											"id": "mhXX1k9ksc7b2DzJg",
-											"name": "10G",
-											"reference": "B60",
-											"cost": 25,
-											"cost_type": "points",
-											"disabled": true
-										}
-									],
-									"calc": {
-										"points": 10
-									}
 								}
 							],
 							"calc": {
-								"points": 176
+								"points": 181
 							}
 						}
 					],
 					"calc": {
-						"points": 186
+						"points": 191
 					}
 				}
 			],
 			"calc": {
-				"points": 206
+				"points": 221
 			}
 		}
 	],
@@ -3856,7 +4717,12 @@
 					"name": "Primary Skills",
 					"children": [
 						{
-							"id": "s09JkoaBtsjAo4_Es",
+							"id": "sIcBi-ydU7zQwF9KW",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "s7kVwKFERTuMYO3O8"
+							},
 							"name": "Free Fall",
 							"reference": "B197",
 							"tags": [
@@ -3876,7 +4742,12 @@
 							"points": 2
 						},
 						{
-							"id": "sgi7bkkQMKz2Gsyzh",
+							"id": "sNVxtWSxus7t4xxwx",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sVspKJvpEaYNHFmRo"
+							},
 							"name": "Freight Handling",
 							"reference": "B197",
 							"tags": [
@@ -3894,7 +4765,12 @@
 							"points": 12
 						},
 						{
-							"id": "sg9-aljqSPrfjcbaq",
+							"id": "scOYD-T9yIw3JuaZ_",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "s9IHT34mK8yfSB7d_"
+							},
 							"name": "Spacer",
 							"reference": "B185",
 							"tags": [
@@ -3911,7 +4787,12 @@
 							"points": 2
 						},
 						{
-							"id": "sQvSK6nK32mwTbhZK",
+							"id": "sVLFwThxuI4afzNFh",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sAmDzPjf0rKZ6I5G1"
+							},
 							"name": "Vacc Suit",
 							"reference": "B192",
 							"tags": [
@@ -3949,7 +4830,12 @@
 					"name": "Secondary Skills",
 					"children": [
 						{
-							"id": "sHyVzOzbBLzP-gQiC",
+							"id": "sPor1nuQnyaUeQvjm",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sxSlxLiSgB95HINP_"
+							},
 							"name": "Forced Entry",
 							"reference": "B196",
 							"tags": [
@@ -3962,7 +4848,12 @@
 							"points": 1
 						},
 						{
-							"id": "srXAUn0-32DeacrbJ",
+							"id": "sGZHUzidF15LA_Hy4",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sENfGTCKokQN0N4PF"
+							},
 							"name": "Climbing",
 							"reference": "B183",
 							"tags": [
@@ -3983,7 +4874,12 @@
 							"points": 2
 						},
 						{
-							"id": "s6sRSvrnCjpsDKFem",
+							"id": "siREr4S0R7hID_f8i",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "s9mV--3lpIfXO7N6Z"
+							},
 							"name": "First Aid",
 							"reference": "B195",
 							"tags": [
@@ -4014,7 +4910,12 @@
 							"points": 2
 						},
 						{
-							"id": "sLmbidXxx0ZmiTiy9",
+							"id": "s3tWdo32BGVN_Cy5S",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sGz21GskAlJXL1hYP"
+							},
 							"name": "Gesture",
 							"reference": "B198",
 							"tags": [
@@ -4030,7 +4931,12 @@
 							"points": 2
 						},
 						{
-							"id": "sC8iMhidMxvkn9msK",
+							"id": "s9v3X1ozq_7Ph24Li",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sQ2Nj_TqMYKV7skUF"
+							},
 							"name": "Scrounging",
 							"reference": "B218",
 							"tags": [
@@ -4051,7 +4957,12 @@
 							"name": "Four of",
 							"children": [
 								{
-									"id": "sK846qSe2dUjZOZvT",
+									"id": "sXimWZFZLXslUINfY",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "siupVKFgi0pYYp4oa"
+									},
 									"name": "Battlesuit",
 									"reference": "B192",
 									"tags": [
@@ -4084,7 +4995,12 @@
 									"points": 4
 								},
 								{
-									"id": "s8F0UYlCLcyZdywfA",
+									"id": "sxBdu-pGWizGRCMMW",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sOp4wssAMtUc1ukJI"
+									},
 									"name": "Body Language",
 									"reference": "B181",
 									"tags": [
@@ -4108,7 +5024,12 @@
 									"points": 4
 								},
 								{
-									"id": "se0mihUMzJpNmpuDM",
+									"id": "sHSwZMTR1nj1uip5B",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sUOQKAH8IaMhpxk1o"
+									},
 									"name": "Electronics Operation",
 									"reference": "B189",
 									"tags": [
@@ -4143,13 +5064,18 @@
 									"points": 4
 								},
 								{
-									"id": "sAueMI8Qot02WW8Fw",
+									"id": "sy6OEASSWzGzn2pKU",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sn9Y6a4YbUfsQ8GxY"
+									},
 									"name": "Hazardous Materials",
 									"reference": "B199",
 									"tags": [
 										"Technical"
 									],
-									"specialization": "@Specailty@",
+									"specialization": "@Specialization@",
 									"difficulty": "iq/a",
 									"defaults": [
 										{
@@ -4161,7 +5087,12 @@
 									"points": 4
 								},
 								{
-									"id": "sEq-coepR_y0WrE4I",
+									"id": "s4F3cUCScOkTIzDQA",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "s_KN_9-Qka4xk40ns"
+									},
 									"name": "Machinist",
 									"reference": "B206",
 									"tags": [
@@ -4184,14 +5115,22 @@
 									"points": 4
 								},
 								{
-									"id": "sJ-lpFqXLuErUAvE-",
+									"id": "sc4y7u2z3581h2LeC",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sjiPOdZOS0Ve3xMhr"
+									},
 									"name": "Mechanic",
 									"reference": "B207",
 									"tags": [
 										"Maintenance",
 										"Repair"
 									],
-									"specialization": "@Life Support, or Vehicle Type@",
+									"replacements": {
+										"Machine class": "@Life Support, or Vehicle Type@"
+									},
+									"specialization": "@Machine class@",
 									"difficulty": "iq/a",
 									"defaults": [
 										{
@@ -4201,7 +5140,7 @@
 										{
 											"type": "skill",
 											"name": "Engineer",
-											"specialization": "Aerospace",
+											"specialization": "@Machine class@",
 											"modifier": -4
 										},
 										{
@@ -4219,7 +5158,12 @@
 									"points": 4
 								},
 								{
-									"id": "siiQ9KfTlcvV-MhKG",
+									"id": "s7BWjASYq99Dk_U3z",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "swYZeCAKyU5w-2tzd"
+									},
 									"name": "Smuggling",
 									"reference": "B221",
 									"tags": [
@@ -4237,7 +5181,12 @@
 									"points": 4
 								},
 								{
-									"id": "sT-ERB27E5MsSIa1e",
+									"id": "sQ52U3W60LPn8ZdnK",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "suO1r-jJlrd15U-GJ"
+									},
 									"name": "Lifting",
 									"reference": "B205",
 									"tags": [
@@ -4247,7 +5196,12 @@
 									"points": 4
 								},
 								{
-									"id": "s4Iiu5ursSCp54Ycg",
+									"id": "sj8tOqtqog46pyxvF",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sdl9m7gHE7hlMX0AX"
+									},
 									"name": "Lip Reading",
 									"reference": "B205",
 									"tags": [
@@ -4263,7 +5217,12 @@
 									"points": 4
 								},
 								{
-									"id": "sLpm9bZ_l2qFVZnaG",
+									"id": "sRv0z8a1PTwSCD2EF",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sW_dr_6QZxz1zrODT"
+									},
 									"name": "Search",
 									"reference": "B219",
 									"tags": [
@@ -4293,7 +5252,12 @@
 					"name": "Background Skills",
 					"children": [
 						{
-							"id": "sIWM-vlNxc3zbEk5w",
+							"id": "s0ZtUfW8Ox0WA7ePy",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "ssHhRG7LH-Ma3YDnH"
+							},
 							"name": "Computer Operation",
 							"reference": "B184",
 							"tags": [
@@ -4316,11 +5280,16 @@
 							"name": "10 Points chosen from",
 							"children": [
 								{
-									"id": "SNiB4Zus_RIr5sVzy",
+									"id": "SGr8cYNL1M4xTjIxu",
 									"name": "Everyman Skills",
 									"children": [
 										{
-											"id": "sMFemaXGdXUxDUEmm",
+											"id": "s1uyK6gfaifOcsa_J",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sTXDrqXH0sT2NSD_b"
+											},
 											"name": "Area Knowledge",
 											"reference": "B176",
 											"notes": "Location of the capitals of interplanetary states and the homeworlds of major races; general awareness of all major races; knowledge of individuals of Status 8; general understanding of relations between interplanetary states",
@@ -4341,7 +5310,12 @@
 											"points": 1
 										},
 										{
-											"id": "s2ZfBVAQftlGB8T0d",
+											"id": "stsDEzAe0EhtF18ak",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "s-Ckyxw5PmHIvbZab"
+											},
 											"name": "Area Knowledge",
 											"reference": "B176",
 											"notes": "Location of major planets; familiarity with all known races (but not necessarily expertise); knowledge of people of Status 7+; general understanding of the economic and political situation",
@@ -4349,13 +5323,9 @@
 												"Everyman",
 												"Knowledge"
 											],
-											"specialization": "@Interplanetary State@; Lived there",
+											"specialization": "@Interplanetary State@",
 											"difficulty": "iq/e",
 											"defaults": [
-												{
-													"type": "iq",
-													"modifier": -4
-												},
 												{
 													"type": "skill",
 													"name": "Geography",
@@ -4366,7 +5336,12 @@
 											"points": 1
 										},
 										{
-											"id": "sVPXiekJfVczyKwkI",
+											"id": "sa0-5m5MA7Lj-p9ts",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "strhX4LEdd46xgmIS"
+											},
 											"name": "Area Knowledge",
 											"reference": "B176",
 											"notes": "Location of its major cities and important sites; awareness of its major customs, ethnic groups, and languages (but not necessarily expertise); names of folk of Status 7+; and a general understanding of the economic and political situation",
@@ -4374,13 +5349,9 @@
 												"Everyman",
 												"Knowledge"
 											],
-											"specialization": "@Planet@; Lived there",
+											"specialization": "@Planet@",
 											"difficulty": "iq/e",
 											"defaults": [
-												{
-													"type": "iq",
-													"modifier": -4
-												},
 												{
 													"type": "skill",
 													"name": "Geography",
@@ -4391,7 +5362,12 @@
 											"points": 1
 										},
 										{
-											"id": "sUWnFz6Ud9c13wf9h",
+											"id": "sqiIi3VQSCh4NoW_G",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sBJgeWUs81Ifhob4Z"
+											},
 											"name": "Beam Weapons",
 											"reference": "B179",
 											"tags": [
@@ -4422,7 +5398,12 @@
 											"points": 1
 										},
 										{
-											"id": "snA7s112SEkzT-so3",
+											"id": "siULq9ThP2NPsbz4P",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sOp4wssAMtUc1ukJI"
+											},
 											"name": "Body Language",
 											"reference": "B181",
 											"tags": [
@@ -4446,10 +5427,14 @@
 											"points": 1
 										},
 										{
-											"id": "s8mCXPlZPEX8zdbIg",
+											"id": "sKhL_bqgmjCHFQp6B",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sziMa9_9xTvR2iiqx"
+											},
 											"name": "Body Sense",
 											"reference": "B181",
-											"notes": "For settings with matter transmission",
 											"tags": [
 												"Athletic"
 											],
@@ -4468,7 +5453,12 @@
 											"points": 1
 										},
 										{
-											"id": "s0q0S2ZKJo-71FWRW",
+											"id": "s0xeaaNnmIifStEvN",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "shtDdl5thrvKSnJHf"
+											},
 											"name": "Brawling",
 											"reference": "B182,MA55",
 											"tags": [
@@ -4496,7 +5486,12 @@
 											"points": 1
 										},
 										{
-											"id": "sPnUPiGHPG8xcZdGT",
+											"id": "sYFSKH6hxPKSf2Vhm",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "si-upI7A5RgdO0cjC"
+											},
 											"name": "Carousing",
 											"reference": "B183",
 											"tags": [
@@ -4514,7 +5509,12 @@
 											"points": 1
 										},
 										{
-											"id": "s-7LRvlLOzVTO8vM7",
+											"id": "sXKe06BEJn7c1esm9",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sWFtA7Gvclq4aL-Yb"
+											},
 											"name": "Current Affairs",
 											"reference": "B186",
 											"tags": [
@@ -4545,7 +5545,12 @@
 											"points": 1
 										},
 										{
-											"id": "sZV8QCzURXK5OcTpx",
+											"id": "s1djUeThJo_0ng7UH",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "s9mV--3lpIfXO7N6Z"
+											},
 											"name": "First Aid",
 											"reference": "B195",
 											"tags": [
@@ -4576,7 +5581,12 @@
 											"points": 1
 										},
 										{
-											"id": "spfRmzJa7vOPTnGz8",
+											"id": "s_0E8dIDK0-FxbqUy",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sWB9ypJAq43MF3O0n"
+											},
 											"name": "Gambling",
 											"reference": "B197",
 											"tags": [
@@ -4600,7 +5610,12 @@
 											"points": 1
 										},
 										{
-											"id": "sMDOzSYNvtHVh7qug",
+											"id": "sKgNkA9G4XoIe7K0l",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "syfSQ9N8yETqQbhFK"
+											},
 											"name": "Games",
 											"reference": "B197,MA57",
 											"tags": [
@@ -4617,7 +5632,12 @@
 											"points": 1
 										},
 										{
-											"id": "sOaOSzoQlB-4efu7K",
+											"id": "sU4ld1t6ALXhT-KiH",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sGz21GskAlJXL1hYP"
+											},
 											"name": "Gesture",
 											"reference": "B198",
 											"tags": [
@@ -4633,7 +5653,12 @@
 											"points": 1
 										},
 										{
-											"id": "sPHtBGQgcmc18AUD_",
+											"id": "sHxBRWSatASewc_9A",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sT5htbz4-Mr0PFCk7"
+											},
 											"name": "Guns",
 											"reference": "B198",
 											"tags": [
@@ -4658,7 +5683,12 @@
 											"points": 1
 										},
 										{
-											"id": "sVPh6r53c7RJd6Tjt",
+											"id": "s7B8G9z5Hc4EzpYy-",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sOtPessbzkRjGaQPR"
+											},
 											"name": "Hobby Skill",
 											"reference": "B200,MA57",
 											"tags": [
@@ -4675,7 +5705,12 @@
 											"points": 1
 										},
 										{
-											"id": "s0Amlb-PWivgTqppR",
+											"id": "s-UjuKxlAcNNkCShZ",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sDLf4crz0sGRjVDFi"
+											},
 											"name": "Hobby Skill",
 											"reference": "B200,MA57",
 											"tags": [
@@ -4692,7 +5727,12 @@
 											"points": 1
 										},
 										{
-											"id": "s-6Ei6Elf6jJqc3l_",
+											"id": "skMQB64-mkUpZeDhO",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sfZrwMVUibhbtdssl"
+											},
 											"name": "Housekeeping",
 											"reference": "B200",
 											"tags": [
@@ -4708,7 +5748,12 @@
 											"points": 1
 										},
 										{
-											"id": "sVN3wbwWb5q51MOs5",
+											"id": "sS5eD4LyrvPxNITIV",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sdl9m7gHE7hlMX0AX"
+											},
 											"name": "Lip Reading",
 											"reference": "B205",
 											"tags": [
@@ -4724,7 +5769,12 @@
 											"points": 1
 										},
 										{
-											"id": "sE_vuQpxEN2Gt45PB",
+											"id": "swuoQBy2HTbPqCMrT",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sx1CDkGBR830IZrmz"
+											},
 											"name": "Professional Skill",
 											"reference": "B215",
 											"tags": [
@@ -4741,7 +5791,12 @@
 											"points": 1
 										},
 										{
-											"id": "sx9-5Nm0uA38y11os",
+											"id": "swr5JwW2uNpOAKoHE",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sBec-o4Z7gPpbg2f9"
+											},
 											"name": "Professional Skill",
 											"reference": "B215",
 											"tags": [
@@ -4758,7 +5813,12 @@
 											"points": 1
 										},
 										{
-											"id": "sTdF9w5dW2v1Z8oTd",
+											"id": "sm4TzzymOfeHzJXmv",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "smxkcngH5Kz54yeN3"
+											},
 											"name": "Sports",
 											"reference": "B222,MA59",
 											"tags": [
@@ -4775,7 +5835,12 @@
 											"points": 1
 										},
 										{
-											"id": "ss2WWFluOCGR4KQnH",
+											"id": "sFOWZGLHAkbbejqpw",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "smTUpMWJGqPeT1KER"
+											},
 											"name": "Streetwise",
 											"reference": "B223",
 											"tags": [
@@ -4811,7 +5876,12 @@
 					"name": "Multi-Role",
 					"children": [
 						{
-							"id": "sR5GUceWzsKAYvI7e",
+							"id": "sJoR4tfdJ9Nl3eb89",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sVspKJvpEaYNHFmRo"
+							},
 							"name": "Freight Handling",
 							"reference": "B197",
 							"tags": [
@@ -4833,7 +5903,12 @@
 							"name": "8 Points spent on improving Free Fall, Spacer, or Vacc Suit, or to add",
 							"children": [
 								{
-									"id": "svDlYRpcF7SJ0uPSs",
+									"id": "scoZyLH81x5Vs7izN",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sxSlxLiSgB95HINP_"
+									},
 									"name": "Forced Entry",
 									"reference": "B196",
 									"tags": [
@@ -4846,7 +5921,12 @@
 									"points": 1
 								},
 								{
-									"id": "s_opd0zKCQRiBpNlh",
+									"id": "sPF3zLdNlzOwLpKJU",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "siupVKFgi0pYYp4oa"
+									},
 									"name": "Battlesuit",
 									"reference": "B192",
 									"tags": [
@@ -4879,7 +5959,12 @@
 									"points": 2
 								},
 								{
-									"id": "sdcWJtKeeLsxrC24k",
+									"id": "stJDubEm8ag4nkHCM",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sENfGTCKokQN0N4PF"
+									},
 									"name": "Climbing",
 									"reference": "B183",
 									"tags": [
@@ -4900,7 +5985,12 @@
 									"points": 2
 								},
 								{
-									"id": "sqs0Cg9ioLNrcraDo",
+									"id": "ssYTL0rLZjsNp2C1z",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "s9mV--3lpIfXO7N6Z"
+									},
 									"name": "First Aid",
 									"reference": "B195",
 									"tags": [
@@ -4931,7 +6021,12 @@
 									"points": 1
 								},
 								{
-									"id": "sGPaUYewrvvEej0aE",
+									"id": "sLbNzsCGOF7CwbAtz",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sGz21GskAlJXL1hYP"
+									},
 									"name": "Gesture",
 									"reference": "B198",
 									"tags": [
@@ -4947,7 +6042,12 @@
 									"points": 1
 								},
 								{
-									"id": "shjhEXDXRjRYamMfx",
+									"id": "sZFCtueYU_1tcsyzY",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sUOQKAH8IaMhpxk1o"
+									},
 									"name": "Electronics Operation",
 									"reference": "B189",
 									"tags": [
@@ -4982,13 +6082,18 @@
 									"points": 2
 								},
 								{
-									"id": "sUkEMtekx90DUG1Zj",
+									"id": "s__19CfdOeUxIxQfg",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sn9Y6a4YbUfsQ8GxY"
+									},
 									"name": "Hazardous Materials",
 									"reference": "B199",
 									"tags": [
 										"Technical"
 									],
-									"specialization": "@Specialty@",
+									"specialization": "@Specialization@",
 									"difficulty": "iq/a",
 									"defaults": [
 										{
@@ -5000,7 +6105,12 @@
 									"points": 2
 								},
 								{
-									"id": "seWfgf9vmty3mgs3H",
+									"id": "sLLzbQFP4UHkwE8ht",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "s_KN_9-Qka4xk40ns"
+									},
 									"name": "Machinist",
 									"reference": "B206",
 									"tags": [
@@ -5023,14 +6133,22 @@
 									"points": 2
 								},
 								{
-									"id": "sUejUVjDzbjgTEjHE",
+									"id": "s5VqDxlWvBQQofdDy",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sjiPOdZOS0Ve3xMhr"
+									},
 									"name": "Mechanic",
 									"reference": "B207",
 									"tags": [
 										"Maintenance",
 										"Repair"
 									],
-									"specialization": "@Life Support or Vehicle Type@",
+									"replacements": {
+										"Machine class": "@Life Support, or Vehicle Type@"
+									},
+									"specialization": "@Machine class@",
 									"difficulty": "iq/a",
 									"defaults": [
 										{
@@ -5040,7 +6158,7 @@
 										{
 											"type": "skill",
 											"name": "Engineer",
-											"specialization": "Aerospace",
+											"specialization": "@Machine class@",
 											"modifier": -4
 										},
 										{
@@ -5058,7 +6176,12 @@
 									"points": 2
 								},
 								{
-									"id": "sLIso9UdHyHK1KZZ0",
+									"id": "sv7tTYrVU-ZdK_u5K",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "swYZeCAKyU5w-2tzd"
+									},
 									"name": "Smuggling",
 									"reference": "B221",
 									"tags": [
@@ -5076,7 +6199,12 @@
 									"points": 2
 								},
 								{
-									"id": "sx3pljKzRZJ4FvRbR",
+									"id": "sqlDjJdwSZM7WPFEM",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "suO1r-jJlrd15U-GJ"
+									},
 									"name": "Lifting",
 									"reference": "B205",
 									"tags": [
@@ -5086,7 +6214,12 @@
 									"points": 2
 								},
 								{
-									"id": "sg7bgFonpSilBAimL",
+									"id": "sPuG0YPzEFXZVVRgN",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sQ2Nj_TqMYKV7skUF"
+									},
 									"name": "Scrounging",
 									"reference": "B218",
 									"tags": [
@@ -5103,7 +6236,12 @@
 									"points": 2
 								},
 								{
-									"id": "sLXBrjkHmtxBCyJbe",
+									"id": "srXILydW0FP_om1Ku",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sOp4wssAMtUc1ukJI"
+									},
 									"name": "Body Language",
 									"reference": "B181",
 									"tags": [
@@ -5127,7 +6265,12 @@
 									"points": 2
 								},
 								{
-									"id": "sfXb9-A_77loPRUPM",
+									"id": "sdJmIUAztOCMElzaE",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sdl9m7gHE7hlMX0AX"
+									},
 									"name": "Lip Reading",
 									"reference": "B205",
 									"tags": [
@@ -5143,7 +6286,12 @@
 									"points": 2
 								},
 								{
-									"id": "sc-ULmyndflJzUz6i",
+									"id": "srtxr-tj-TxOQX7_a",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sW_dr_6QZxz1zrODT"
+									},
 									"name": "Search",
 									"reference": "B219",
 									"tags": [

--- a/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Medical Officer.gct
+++ b/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Medical Officer.gct
@@ -12,7 +12,12 @@
 					"name": "Attributes",
 					"children": [
 						{
-							"id": "tgeVLHLAJEr49OFeo",
+							"id": "t1QI_VJULIFo9Icj4",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tGWOSEE6SmBHACE6Y"
+							},
 							"name": "Increased Dexterity",
 							"reference": "B15",
 							"tags": [
@@ -22,7 +27,7 @@
 							],
 							"modifiers": [
 								{
-									"id": "macFw1VMHYk27QkvF",
+									"id": "me1NXgw84hid1lHPd",
 									"name": "No Fine Manipulators",
 									"cost": -40,
 									"disabled": true
@@ -44,7 +49,12 @@
 							}
 						},
 						{
-							"id": "tAmmW158RA9WSjItz",
+							"id": "t4c9LvT5zuxGhPc6a",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t1w1RFcFceKR2T9_e"
+							},
 							"name": "Increased Intelligence",
 							"reference": "B15",
 							"tags": [
@@ -68,7 +78,12 @@
 							}
 						},
 						{
-							"id": "thsvP7chYOGup0Hps",
+							"id": "tp6oE2OGWVmWKD-_3",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tVt3SvdGWNchJ8z4o"
+							},
 							"name": "Increased Health",
 							"reference": "B14",
 							"tags": [
@@ -101,7 +116,12 @@
 					"name": "Class Advantages",
 					"children": [
 						{
-							"id": "tGitoYEfv1MimpD9H",
+							"id": "tCGJXls4KEQXT8gMS",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "ttd4Q71sdt2GT6xKv"
+							},
 							"name": "Talent (Healer)",
 							"reference": "PU3:11",
 							"notes": "Modern",
@@ -134,12 +154,45 @@
 							},
 							"modifiers": [
 								{
-									"id": "mEP6ueTDMZ4r_JIkJ",
+									"id": "mZ1KxTxMeYHQ1Lnf7",
 									"name": "Alternative Cost",
 									"cost": 1,
 									"cost_type": "points",
 									"affects": "levels_only",
 									"disabled": true
+								},
+								{
+									"id": "M3QEAKp5ZL_Ma3AG5",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "makMhYIxefAarGG1a",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From patients.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "msGs8l4YIGbbWnSr9",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Bonus to HT rolls for a specific patient and condition if treated full time.",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
 								}
 							],
 							"points_per_level": 10,
@@ -261,18 +314,6 @@
 									},
 									"amount": 1,
 									"per_level": true
-								},
-								{
-									"type": "reaction_bonus",
-									"situation": "From patients.",
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "conditional_modifier",
-									"situation": "Bonus to HT rolls for a specific patient and condition if treated full time.",
-									"amount": 1,
-									"per_level": true
 								}
 							],
 							"can_level": true,
@@ -286,24 +327,37 @@
 							"name": "30 Points chosen from",
 							"children": [
 								{
-									"id": "T2B4tHSUIJjLGM8lj",
+									"id": "TKfhpvXZjQN_1W2J2",
 									"name": "Everyman Advantages",
 									"children": [
 										{
-											"id": "tJ_b_KMO6GjkaqQlr",
-											"name": "Suit Familiarity (Vacc Suit)",
+											"id": "teRq-rnouj5rS7Bwk",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Power Ups/Power Ups Traits.adq",
+												"id": "t3RCXCI5W-zjvxaf-"
+											},
+											"name": "Suit Familiarity (@Environment Suit skill@)",
 											"reference": "PU2:9",
 											"tags": [
 												"Perk",
 												"Physical"
 											],
+											"replacements": {
+												"Environment Suit skill": "Vacc Suit"
+											},
 											"base_points": 1,
 											"calc": {
 												"points": 1
 											}
 										},
 										{
-											"id": "tIrEg-er2yBwxh9bO",
+											"id": "tfUBxtBNypzGbBFxj",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tkiJQ7nfyi9aAdGHK"
+											},
 											"name": "Serendipity",
 											"reference": "B83,P73",
 											"tags": [
@@ -312,17 +366,24 @@
 											],
 											"modifiers": [
 												{
-													"id": "m9oqrmUZhvvcy1gwX",
+													"id": "mWviUEpX-Zkj8Oo1r",
 													"name": "Wishing",
 													"reference": "P73",
 													"cost": 100,
 													"disabled": true
 												},
 												{
-													"id": "mD7ZKMMLbgYLyHkY_",
+													"id": "mzCBbi0VYFYng_7VI",
 													"name": "Wishing",
 													"reference": "P73",
 													"notes": "For others only",
+													"disabled": true
+												},
+												{
+													"id": "mux99S6X-Bvr2LFY9",
+													"name": "Game Time",
+													"reference": "P108",
+													"notes": "Uses per game week equal to its maximum possible uses per session",
 													"disabled": true
 												}
 											],
@@ -334,8 +395,13 @@
 											}
 										},
 										{
-											"id": "tykTCnWGsarax7HT7",
-											"name": "Resistant to Acceleration",
+											"id": "taNOuJ_th5Mtx3Hzj",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tJTfFdHM7YI5IZR7I"
+											},
+											"name": "Resistant",
 											"reference": "B81,P71,MA47",
 											"tags": [
 												"Advantage",
@@ -343,7 +409,7 @@
 											],
 											"modifiers": [
 												{
-													"id": "mGaBwO_tndHzJwG04",
+													"id": "mOf6StWWoiQIG-3Sb",
 													"name": "@Very Common: Metabolic Hazards, etc.@",
 													"reference": "B80",
 													"cost": 30,
@@ -351,7 +417,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mlUgA5JyN9lczMzrB",
+													"id": "mjSfMEGA9I2eL17z2",
 													"name": "@Common: Poison, Sickness, etc.@",
 													"reference": "B81",
 													"cost": 15,
@@ -359,7 +425,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mr709UL2o12I_6oT_",
+													"id": "mlRCOtt9SPf7k7DlM",
 													"name": "@Occasional: Disease, Ingested Poison, etc.@",
 													"reference": "B81",
 													"cost": 10,
@@ -367,14 +433,17 @@
 													"disabled": true
 												},
 												{
-													"id": "mdwtWvvVK-e50NBtq",
+													"id": "m52dNUND3RRrGzhvB",
 													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
 													"reference": "B81",
+													"replacements": {
+														"Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.": "Space Sickness"
+													},
 													"cost": 5,
 													"cost_type": "points"
 												},
 												{
-													"id": "m4otW9vXFebpzcEJ1",
+													"id": "mZNziAL4BHZjxtsys",
 													"name": "Immunity",
 													"reference": "B81",
 													"cost": 1,
@@ -382,152 +451,14 @@
 													"disabled": true
 												},
 												{
-													"id": "mw74BzXMCxq8hULyW",
-													"name": "+8 to all HT rolls to resist",
-													"reference": "B81",
-													"cost": 0.5,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mNBIgh-Bo95Yv7Ize",
-													"name": "+3 to all HT rolls to resist",
-													"reference": "B81",
-													"cost": 0.33,
-													"cost_type": "multiplier"
-												}
-											],
-											"round_down": true,
-											"calc": {
-												"points": 1
-											}
-										},
-										{
-											"id": "tX6y5unmS3ZEfdd_a",
-											"name": "Resistant to Space Sickness",
-											"reference": "B81,P71,MA47",
-											"tags": [
-												"Advantage",
-												"Physical"
-											],
-											"modifiers": [
-												{
-													"id": "mTL0DuHdfoLCfG8Rk",
-													"name": "@Very Common: Metabolic Hazards, etc.@",
-													"reference": "B80",
-													"cost": 30,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mah_WqsD2ISMFZqnN",
-													"name": "@Common: Poison, Sickness, etc.@",
-													"reference": "B81",
-													"cost": 15,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m6TJOwLIqf3xKxAJg",
-													"name": "@Occasional: Disease, Ingested Poison, etc.@",
-													"reference": "B81",
-													"cost": 10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mURb4_WozWWSEMGql",
-													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
-													"reference": "B81",
-													"cost": 5,
-													"cost_type": "points"
-												},
-												{
-													"id": "m_5I3h_2bC36II9hw",
-													"name": "Immunity",
-													"reference": "B81",
-													"cost": 1,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mEcXk2PJ9h6ciCu0v",
-													"name": "+8 to all HT rolls to resist",
-													"reference": "B81",
-													"cost": 0.5,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mCIGock8JbOaeMw9T",
-													"name": "+3 to all HT rolls to resist",
-													"reference": "B81",
-													"cost": 0.33,
-													"cost_type": "multiplier"
-												}
-											],
-											"round_down": true,
-											"calc": {
-												"points": 1
-											}
-										},
-										{
-											"id": "twd43AAQatsjNM8CE",
-											"name": "Resistant to Space Sickness",
-											"reference": "B81,P71,MA47",
-											"tags": [
-												"Advantage",
-												"Physical"
-											],
-											"modifiers": [
-												{
-													"id": "mAmUdL8zfykRrazEk",
-													"name": "@Very Common: Metabolic Hazards, etc.@",
-													"reference": "B80",
-													"cost": 30,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m7q3S4eAYZKPrXMCm",
-													"name": "@Common: Poison, Sickness, etc.@",
-													"reference": "B81",
-													"cost": 15,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mrp_sgsP31CaNy5lc",
-													"name": "@Occasional: Disease, Ingested Poison, etc.@",
-													"reference": "B81",
-													"cost": 10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m73jc-6T7FAtVbXfv",
-													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
-													"reference": "B81",
-													"cost": 5,
-													"cost_type": "points"
-												},
-												{
-													"id": "mtzYtyKE_QMV46cDJ",
-													"name": "Immunity",
-													"reference": "B81",
-													"cost": 1,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mrTb-gAv56xLSqwg2",
+													"id": "mv-tTFmrTe-FmIwYH",
 													"name": "+8 to all HT rolls to resist",
 													"reference": "B81",
 													"cost": 0.5,
 													"cost_type": "multiplier"
 												},
 												{
-													"id": "myso5ZoWTAY-Dg1er",
+													"id": "mQiigrt6s9p451ZLl",
 													"name": "+3 to all HT rolls to resist",
 													"reference": "B81",
 													"cost": 0.33,
@@ -541,8 +472,167 @@
 											}
 										},
 										{
-											"id": "tKFkBOmi_cb8v0B6X",
-											"name": "Reputation",
+											"id": "tjTW4yfexHF8prfpO",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tJTfFdHM7YI5IZR7I"
+											},
+											"name": "Resistant",
+											"reference": "B81,P71,MA47",
+											"tags": [
+												"Advantage",
+												"Physical"
+											],
+											"modifiers": [
+												{
+													"id": "mCIbtH4oVczi8DhCF",
+													"name": "@Very Common: Metabolic Hazards, etc.@",
+													"reference": "B80",
+													"cost": 30,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mGQtwuKfRJmdB8sit",
+													"name": "@Common: Poison, Sickness, etc.@",
+													"reference": "B81",
+													"cost": 15,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m9rFVoejcKhXiOr3k",
+													"name": "@Occasional: Disease, Ingested Poison, etc.@",
+													"reference": "B81",
+													"cost": 10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mNXdGF9WdoaZsbGBr",
+													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+													"reference": "B81",
+													"replacements": {
+														"Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.": "Space Sickness"
+													},
+													"cost": 5,
+													"cost_type": "points"
+												},
+												{
+													"id": "mJHiwg3Bs1wbhipnq",
+													"name": "Immunity",
+													"reference": "B81",
+													"cost": 1,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mhqrlxjnQWXis0XU2",
+													"name": "+8 to all HT rolls to resist",
+													"reference": "B81",
+													"cost": 0.5,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mmJQgG4PosD8Ndn1o",
+													"name": "+3 to all HT rolls to resist",
+													"reference": "B81",
+													"cost": 0.33,
+													"cost_type": "multiplier"
+												}
+											],
+											"round_down": true,
+											"calc": {
+												"points": 1
+											}
+										},
+										{
+											"id": "tngXyIaUn8iT2M0ch",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tJTfFdHM7YI5IZR7I"
+											},
+											"name": "Resistant",
+											"reference": "B81,P71,MA47",
+											"tags": [
+												"Advantage",
+												"Physical"
+											],
+											"modifiers": [
+												{
+													"id": "mSnBpckcyXPYQV3jQ",
+													"name": "@Very Common: Metabolic Hazards, etc.@",
+													"reference": "B80",
+													"cost": 30,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mAajZ5eUrTz96voS6",
+													"name": "@Common: Poison, Sickness, etc.@",
+													"reference": "B81",
+													"cost": 15,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mNVV6EujPUlk47FeU",
+													"name": "@Occasional: Disease, Ingested Poison, etc.@",
+													"reference": "B81",
+													"cost": 10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m0EhHUhIdJy1ThvKR",
+													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+													"reference": "B81",
+													"replacements": {
+														"Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.": "Acceleration"
+													},
+													"cost": 5,
+													"cost_type": "points"
+												},
+												{
+													"id": "m_eIkicOXKN8Mm-6f",
+													"name": "Immunity",
+													"reference": "B81",
+													"cost": 1,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mwR3pDWzJ8E1SPI47",
+													"name": "+8 to all HT rolls to resist",
+													"reference": "B81",
+													"cost": 0.5,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mcaq2TIKHmgK8kIeQ",
+													"name": "+3 to all HT rolls to resist",
+													"reference": "B81",
+													"cost": 0.33,
+													"cost_type": "multiplier"
+												}
+											],
+											"round_down": true,
+											"calc": {
+												"points": 1
+											}
+										},
+										{
+											"id": "tOeoPa_WlMhHjoE1S",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "ta04iFiZ_Kw0s0juj"
+											},
+											"name": "Good Reputation",
 											"reference": "B26,MA54",
 											"tags": [
 												"Advantage",
@@ -550,7 +640,7 @@
 											],
 											"modifiers": [
 												{
-													"id": "m6jLfCc7wNDITbBSh",
+													"id": "mYW4k2iCt2VJrkx51",
 													"name": "People Affected",
 													"reference": "B27",
 													"notes": "Almost everyone",
@@ -559,7 +649,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mS26RuwKqZ7H9jqe8",
+													"id": "mPFvpbbHPO6gMFjoJ",
 													"name": "People Affected",
 													"reference": "B27",
 													"notes": "Almost everyone except @large class of people@",
@@ -568,7 +658,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mW0MatW0QqMokX_3_",
+													"id": "m67pXHpkrwNvtPxKU",
 													"name": "People Affected",
 													"reference": "B27",
 													"notes": "@Large class of people@",
@@ -577,7 +667,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m7h2SQZc6fggxxkND",
+													"id": "mejYOH04ocNBT9ZvY",
 													"name": "People Affected",
 													"reference": "B27",
 													"notes": "@Small class of people@",
@@ -586,7 +676,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mDxaFPMMtaKvFTV-7",
+													"id": "mzkBrRwpCaBUZRdoM",
 													"name": "Recognized all the time",
 													"reference": "B28",
 													"cost": 1,
@@ -594,7 +684,7 @@
 													"disabled": true
 												},
 												{
-													"id": "muNFndr2PG_gakAu9",
+													"id": "mKPgBpe7UbHYqK-Ep",
 													"name": "Recognized sometimes",
 													"reference": "B28",
 													"notes": "10-",
@@ -603,7 +693,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m0anFyY3MPZ1mF3Lu",
+													"id": "mKFlgdLTwz5NSncLJ",
 													"name": "Recognized occasionally",
 													"reference": "B28",
 													"notes": "7-",
@@ -613,6 +703,14 @@
 												}
 											],
 											"points_per_level": 5,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others aware of your reputation",
+													"amount": 1,
+													"per_level": true
+												}
+											],
 											"round_down": true,
 											"can_level": true,
 											"levels": 1,
@@ -621,16 +719,24 @@
 											}
 										},
 										{
-											"id": "tjagwi1FADBspkLZt",
-											"name": "Military Rank",
+											"id": "tVBsyB9UuWtZ-2uuU",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tmp8yecgaZq9TOk59"
+											},
+											"name": "@Type@ Rank",
 											"reference": "B29",
 											"tags": [
 												"Advantage",
-												"Physical"
+												"Social"
 											],
+											"replacements": {
+												"Type": "Military"
+											},
 											"modifiers": [
 												{
-													"id": "msSEEx2ir3S5f7q9h",
+													"id": "mEoScH_HPxk9wFQJF",
 													"name": "Replaces Status",
 													"reference": "B29",
 													"cost": 5,
@@ -639,7 +745,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mKuoGaKBVcAKnOtMX",
+													"id": "magg5wWuMCANtRpb8",
 													"name": "Courtesy",
 													"reference": "B29",
 													"cost": -4,
@@ -656,16 +762,24 @@
 											}
 										},
 										{
-											"id": "t2RHnKkNqDrxcq2CV",
-											"name": "Merchant Rank",
+											"id": "tNShuFChzRpW8m0T4",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tmp8yecgaZq9TOk59"
+											},
+											"name": "@Type@ Rank",
 											"reference": "B29",
 											"tags": [
 												"Advantage",
-												"Physical"
+												"Social"
 											],
+											"replacements": {
+												"Type": "Merchant"
+											},
 											"modifiers": [
 												{
-													"id": "mVdvx8G7qE_3TdNh4",
+													"id": "md9ykDREBRBMuC2zs",
 													"name": "Replaces Status",
 													"reference": "B29",
 													"cost": 5,
@@ -674,7 +788,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mzcNC2bJYYtz70OyR",
+													"id": "mBx3KpVyQyC1jHhHp",
 													"name": "Courtesy",
 													"reference": "B29",
 													"cost": -4,
@@ -691,17 +805,21 @@
 											}
 										},
 										{
-											"id": "t0iauZpAx0oJGTsoh",
+											"id": "tGIFSYFPsIK-DePak",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t6Nq6oInwkU1qbAP1"
+											},
 											"name": "Patron",
 											"reference": "B72,P65",
-											"notes": "Ship's owner or provider",
 											"tags": [
 												"Advantage",
 												"Social"
 											],
 											"modifiers": [
 												{
-													"id": "mjktHpurXHbseNYz7",
+													"id": "m_MxPOPlmHai0BfnY",
 													"name": "@Who: Individual with 150% of PC's starting points@",
 													"reference": "B72",
 													"cost": 10,
@@ -709,7 +827,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mqMbmKry66s86FSfZ",
+													"id": "myc68WueMHTlsTMDC",
 													"name": "@Who: Organization with assets of at least 1000 times starting wealth@",
 													"reference": "B72",
 													"cost": 10,
@@ -717,7 +835,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mgo_9DN-U8RTgNTHl",
+													"id": "mupdTSHNm_tXs86-I",
 													"name": "@Who: Individual with twice the PC's starting points@",
 													"reference": "B72",
 													"cost": 15,
@@ -725,7 +843,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mCOglOeXyVc2ThB7X",
+													"id": "mopqdfLKXEOc59S21",
 													"name": "@Who: Organization with assets of at least 10000 times starting wealth@",
 													"reference": "B72",
 													"cost": 15,
@@ -733,7 +851,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m4kcaMNUXnkS6dOyo",
+													"id": "mVl3gtEIb_n3RUX2Y",
 													"name": "@Who: An ultra-powerful individual@",
 													"reference": "B72",
 													"cost": 20,
@@ -741,7 +859,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mnSEyBX4ZJcSpm94o",
+													"id": "mGfq_0-l55NtVc07M",
 													"name": "@Who: Organization with assets of at least 100000 times starting wealth@",
 													"reference": "B72",
 													"cost": 20,
@@ -749,7 +867,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m6SkLBJ02Lhpo2nCD",
+													"id": "mQZChDP1fgx4iZIyv",
 													"name": "@Who: Organization with assets of at least 1000000 times starting wealth@",
 													"reference": "B72",
 													"cost": 25,
@@ -757,7 +875,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mXNEU60ihzMMMyKLt",
+													"id": "mpX_6Uu1rGVVxWbBc",
 													"name": "@Who: A national government or giant multi-national organization@",
 													"reference": "B72",
 													"cost": 30,
@@ -765,7 +883,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mLYTUJds6uSeI83PH",
+													"id": "mvL9eT4LBfvy3oYAQ",
 													"name": "@Who: A deity@",
 													"reference": "B72",
 													"cost": 30,
@@ -773,7 +891,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mmUnJRb-JPR9v2UM5",
+													"id": "mXuw3Hoy1ufA0EBrr",
 													"name": "Appears almost all the time",
 													"reference": "B36",
 													"notes": "15-",
@@ -782,7 +900,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mLITs2XFDB5p-GYDW",
+													"id": "m-mxDC4-Us9c7_aj3",
 													"name": "Appears quite often",
 													"reference": "B36",
 													"notes": "12-",
@@ -791,7 +909,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mVqXItjYUfdKrRlG-",
+													"id": "m-n6YQFongCHKQuqK",
 													"name": "Appears fairly often",
 													"reference": "B36",
 													"notes": "9-",
@@ -800,7 +918,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mn0XtrFByCXseNKfr",
+													"id": "m_X-IZU7zYUAh8zLM",
 													"name": "Appears quite rarely",
 													"reference": "B36",
 													"notes": "6-",
@@ -809,7 +927,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mQyaScXthg3oRtMR6",
+													"id": "ma_Y8CBiZUftOP1UY",
 													"name": "Equipment",
 													"reference": "B73",
 													"notes": "@Equipment worth no more than average starting wealth@",
@@ -817,7 +935,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mH1_gy3RWLRNkzdtp",
+													"id": "mpGJG5dfO47ZjqZzr",
 													"name": "Equipment",
 													"reference": "B73",
 													"notes": "@Equipment worth more than average starting wealth@",
@@ -825,14 +943,14 @@
 													"disabled": true
 												},
 												{
-													"id": "mr0m5PfL7HZuQWC3D",
+													"id": "maZYzY0LxgvlMyNKR",
 													"name": "Highly Accessible",
 													"reference": "B73",
 													"cost": 50,
 													"disabled": true
 												},
 												{
-													"id": "mWVLW1WXVkrfupN4D",
+													"id": "mIkKR03alY4R97rBe",
 													"name": "Special Abilities",
 													"reference": "B73",
 													"notes": "@Extensive social or political power@",
@@ -840,7 +958,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mFO68ciAs_wpYOSn6",
+													"id": "m0fjXiUCwnHr8Obpz",
 													"name": "Special Abilities",
 													"reference": "B73",
 													"notes": "@Magical powers in a non-magical world, higher TL equipment, grants special powers or is supernatural@",
@@ -848,28 +966,28 @@
 													"disabled": true
 												},
 												{
-													"id": "mV959snC7LrVM8lIk",
+													"id": "mKTQatfZl4949RAWE",
 													"name": "Minimal Interventions",
 													"reference": "B73",
 													"cost": -50,
 													"disabled": true
 												},
 												{
-													"id": "mqidy1y9bLKzLsGT-",
+													"id": "mNhJD5QtaBuUiqCTk",
 													"name": "Secret",
 													"reference": "B73",
 													"cost": -50,
 													"disabled": true
 												},
 												{
-													"id": "mg-rHQaW5p3P-AV-F",
+													"id": "mEhAlPm8ZLlopUgPS",
 													"name": "Unwilling",
 													"reference": "B74",
 													"cost": -50,
 													"disabled": true
 												},
 												{
-													"id": "miUGs1u88UROiIRbn",
+													"id": "mvGbEgDWlytY5btjd",
 													"name": "Favor",
 													"reference": "B55",
 													"cost": 0.2,
@@ -882,7 +1000,12 @@
 											}
 										},
 										{
-											"id": "tiFJvofPLUbDnNMVE",
+											"id": "tYpS5JIXC8rCy_bvH",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tz-USDL9B_KrrVqDi"
+											},
 											"name": "Luck",
 											"reference": "B66,P59",
 											"notes": "Usable once per hour of play",
@@ -892,14 +1015,14 @@
 											],
 											"modifiers": [
 												{
-													"id": "mN8FmZ5_njQlsiIXt",
+													"id": "mC2aWj9nq4NCJi24n",
 													"name": "Active",
 													"reference": "B66",
 													"cost": -40,
 													"disabled": true
 												},
 												{
-													"id": "mtOKT6cFCEctD5yqd",
+													"id": "m_9g-E127VLC25uBn",
 													"name": "Aspected",
 													"reference": "B66",
 													"notes": "@Aspect@",
@@ -907,17 +1030,24 @@
 													"disabled": true
 												},
 												{
-													"id": "mnl7kyWgk4tg85i9i",
+													"id": "mUUuF-eXb3mEiuiq2",
 													"name": "Defensive",
 													"reference": "B66",
 													"cost": -20,
 													"disabled": true
 												},
 												{
-													"id": "m-cvu-5diYIZ8xH5X",
+													"id": "mEqsR8ZRzp__udgjk",
 													"name": "Wishing",
 													"reference": "P59",
 													"cost": 100,
+													"disabled": true
+												},
+												{
+													"id": "m7881agJBAxtwV3m2",
+													"name": "Game Time",
+													"reference": "P108",
+													"notes": "Uses per game day equal to its maximum possible uses per real hour",
 													"disabled": true
 												}
 											],
@@ -927,7 +1057,12 @@
 											}
 										},
 										{
-											"id": "tLn-xdSECAP7VsyoZ",
+											"id": "teMcKOIJpHO2ebXu8",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tMxgHfzVEy_QQtlfB"
+											},
 											"name": "Less Sleep",
 											"reference": "B65",
 											"notes": "Require 1 hour/level less sleep for a full night's rest (max 4)",
@@ -943,7 +1078,12 @@
 											}
 										},
 										{
-											"id": "tyjB-C3MF3txh8b8R",
+											"id": "th1ghfTBT4nv7Lly_",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tw1Ad0oSMw2ATM4X1"
+											},
 											"name": "Language: @Language@",
 											"reference": "B24",
 											"tags": [
@@ -951,9 +1091,26 @@
 												"Language",
 												"Mental"
 											],
+											"prereqs": {
+												"type": "prereq_list",
+												"all": true,
+												"prereqs": [
+													{
+														"type": "trait_prereq",
+														"has": false,
+														"name": {
+															"compare": "is",
+															"qualifier": "Language Talent"
+														},
+														"level": {
+															"compare": "at_least"
+														}
+													}
+												]
+											},
 											"modifiers": [
 												{
-													"id": "mi_bH_X-DIToy7ju2",
+													"id": "mXC4H9GjeOrUbiGrP",
 													"name": "Native",
 													"reference": "B23",
 													"cost": -6,
@@ -961,7 +1118,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mdEd05izTLWUnN0Gn",
+													"id": "mcx-5sf4RA5BxYgH1",
 													"name": "Spoken",
 													"reference": "B24",
 													"notes": "None",
@@ -969,7 +1126,7 @@
 													"disabled": true
 												},
 												{
-													"id": "myjKjeskRAxQBkRik",
+													"id": "meLcxbGIHQGHEm5rC",
 													"name": "Spoken",
 													"reference": "B24",
 													"notes": "Broken",
@@ -978,7 +1135,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mp8pvVKTqJvVq9Gp3",
+													"id": "mCNFrUcsU0ABSiUVm",
 													"name": "Spoken",
 													"reference": "B24",
 													"notes": "Accented",
@@ -986,7 +1143,7 @@
 													"cost_type": "points"
 												},
 												{
-													"id": "mMtEVQfweVfX0bgVB",
+													"id": "mpphVvCxYwqlrxI_F",
 													"name": "Spoken",
 													"reference": "B24",
 													"notes": "Native",
@@ -995,7 +1152,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m_uadVAQla_B2OWa5",
+													"id": "mNfFpk8ICvJrCg4R3",
 													"name": "Written",
 													"reference": "B24",
 													"notes": "None",
@@ -1003,7 +1160,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m_RGAoADtc_e56Cf5",
+													"id": "m11uu3a6p4ZGHbxNu",
 													"name": "Written",
 													"reference": "B24",
 													"notes": "Broken",
@@ -1012,7 +1169,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mEYZjFG0m9LK_JIsU",
+													"id": "mzHLKXbQsPWQZY7ZB",
 													"name": "Written",
 													"reference": "B24",
 													"notes": "Accented",
@@ -1020,7 +1177,7 @@
 													"cost_type": "points"
 												},
 												{
-													"id": "mFNmkn7f61WodKeAF",
+													"id": "m0rPqC815fF1PpHPb",
 													"name": "Written",
 													"reference": "B24",
 													"notes": "Native",
@@ -1034,7 +1191,12 @@
 											}
 										},
 										{
-											"id": "tPiGyIsLxP1irkWCK",
+											"id": "t7E-1xWP5Wz9wMz_z",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "txREhxV6L1SKixwe_"
+											},
 											"name": "Improved G-tolerance",
 											"reference": "B60",
 											"tags": [
@@ -1043,7 +1205,7 @@
 											],
 											"modifiers": [
 												{
-													"id": "mQodMTi-9WulpfGMn",
+													"id": "msVjyRfC8SD8Qgw6i",
 													"name": "0.3G",
 													"reference": "B60",
 													"cost": 5,
@@ -1051,7 +1213,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mYX_Qz13-T7JQkoZ9",
+													"id": "m4Z1vAxKZ_kbx3Ads",
 													"name": "0.5G",
 													"reference": "B60",
 													"cost": 10,
@@ -1059,7 +1221,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mSRsCQxC4qppn1x3K",
+													"id": "m_K-H7FfjQCY69tDK",
 													"name": "1G",
 													"reference": "B60",
 													"cost": 15,
@@ -1067,7 +1229,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mlzQcru5CO-zaO362",
+													"id": "meLQbMPThH3Jobldt",
 													"name": "5G",
 													"reference": "B60",
 													"cost": 20,
@@ -1075,7 +1237,7 @@
 													"disabled": true
 												},
 												{
-													"id": "msfYkytDggeTi66Uh",
+													"id": "mk0Gex8Zq9cL1s4gd",
 													"name": "10G",
 													"reference": "B60",
 													"cost": 25,
@@ -1088,7 +1250,12 @@
 											}
 										},
 										{
-											"id": "tnyKyeeDrwK8w8Fph",
+											"id": "t1K4K2q8CHPcjdd_Y",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t7blIRUzFpiHS_mnO"
+											},
 											"name": "Gizmo",
 											"reference": "B57,MA45",
 											"tags": [
@@ -1103,7 +1270,12 @@
 											}
 										},
 										{
-											"id": "tT0IBOTJFsxPod8Om",
+											"id": "tnjDnaL3K-YomLhOf",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tHNrjEQFQBNOgwmzK"
+											},
 											"name": "G-Experience (All)",
 											"reference": "B57",
 											"tags": [
@@ -1116,7 +1288,12 @@
 											}
 										},
 										{
-											"id": "tYfgMyNIjf4tUdgqc",
+											"id": "tsJDAOH3Ztxwg0HyR",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tu3GuYC47Sx6bnm4k"
+											},
 											"name": "G-Experience",
 											"reference": "B57",
 											"tags": [
@@ -1131,7 +1308,12 @@
 											}
 										},
 										{
-											"id": "tCAMFp-C2XFQwT29I",
+											"id": "toVDm7Xt-jkQmiLvY",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "toTe273Ky82B6YdW5"
+											},
 											"name": "Fit",
 											"reference": "B55",
 											"notes": "Recover FP at twice the normal rate (but not FP spent for spells or psi powers)",
@@ -1152,7 +1334,12 @@
 											}
 										},
 										{
-											"id": "t1c8Yo8L-8E-nQvJH",
+											"id": "t1MZuCSqJiqyXGFOA",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tQa3EUrs4Hjt9gxK6"
+											},
 											"name": "Fearlessness",
 											"reference": "B55,MA44",
 											"tags": [
@@ -1189,7 +1376,12 @@
 											}
 										},
 										{
-											"id": "tkOkphyn-bS2sSSaG",
+											"id": "tuH2Ixqe12VJdcDbq",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t5j2Ox4jaIV9j0rpz"
+											},
 											"name": "Deep Sleeper",
 											"reference": "B101",
 											"tags": [
@@ -1202,7 +1394,12 @@
 											}
 										},
 										{
-											"id": "tQP18BJk36cSmi2dS",
+											"id": "tWtdCRHsVEHu-BBL3",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tNBE3sLoyrUvAgoZ3"
+											},
 											"name": "Cybernetics",
 											"reference": "B46",
 											"tags": [
@@ -1214,7 +1411,12 @@
 											}
 										},
 										{
-											"id": "t6fH2V20v0TXCQ2Xf",
+											"id": "tNjV2rW0rtOguxwWc",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "toXBQ8q4Nek5lsLPF"
+											},
 											"name": "Cultural Familiarity (@Culture@)",
 											"reference": "B23",
 											"notes": "Do not suffer the normal -3 penalty for unfamiliarity",
@@ -1224,14 +1426,14 @@
 											],
 											"modifiers": [
 												{
-													"id": "m7ELRAh28xADVaAud",
+													"id": "m_x35wNX98BQbTs6X",
 													"name": "Alien",
 													"cost": 1,
 													"cost_type": "points",
 													"disabled": true
 												},
 												{
-													"id": "m62xytc5bbDZBgqfa",
+													"id": "mp92iJC_8ijqafeXd",
 													"name": "Native",
 													"cost": -1,
 													"cost_type": "points",
@@ -1244,9 +1446,14 @@
 											}
 										},
 										{
-											"id": "tkPweeywlzSbzeyx9",
-											"name": "Alien Friend",
-											"reference": "S220",
+											"id": "tyMkpMo0TKTyBEZ7S",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Power Ups/Power Ups Traits.adq",
+												"id": "t3msobZZ06J7dZ8xu"
+											},
+											"name": "Talent (Born Spacer)",
+											"reference": "PU3:7",
 											"tags": [
 												"Advantage",
 												"Mental",
@@ -1254,106 +1461,60 @@
 											],
 											"modifiers": [
 												{
-													"id": "m6KJhM2iG69bFoDFC",
-													"name": "Alternate Benefit",
-													"notes": "@Alternate Benefit@",
-													"disabled": true
-												},
-												{
-													"id": "mSral9jvDxnxncwns",
+													"id": "mFYDKpO9GFoDFQ31N",
 													"name": "Alternative Cost",
+													"cost": 1,
 													"cost_type": "points",
 													"affects": "levels_only",
 													"disabled": true
-												}
-											],
-											"points_per_level": 5,
-											"features": [
-												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "Anthropology"
-													},
-													"amount": 1,
-													"per_level": true
 												},
 												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "Diplomacy"
-													},
-													"amount": 1,
-													"per_level": true
-												},
-												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "Expert Skill"
-													},
-													"amount": 1,
-													"per_level": true
-												},
-												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "History"
-													},
-													"amount": 1,
-													"per_level": true
-												},
-												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "Psychology"
-													},
-													"amount": 1,
-													"per_level": true
-												},
-												{
-													"type": "reaction_bonus",
-													"situation": "Aliens",
-													"amount": 1,
-													"per_level": true
-												}
-											],
-											"can_level": true,
-											"levels": 1,
-											"calc": {
-												"points": 5
-											}
-										},
-										{
-											"id": "tvHDY21XYusGYZ2Ji",
-											"name": "Born Spacer",
-											"reference": "THSCT40",
-											"tags": [
-												"Advantage",
-												"Mental",
-												"Talent"
-											],
-											"modifiers": [
-												{
-													"id": "m6ilsStDXYUHk5AgM",
-													"name": "Alternate Benefit",
-													"notes": "@Alternate Benefit@",
-													"disabled": true
-												},
-												{
-													"id": "mlXg1CMMgJQL_RdUc",
-													"name": "Alternative Cost",
-													"cost_type": "points",
-													"affects": "levels_only",
-													"disabled": true
+													"id": "Mjt5zXkOaFCq50FCb",
+													"name": "Benefits",
+													"children": [
+														{
+															"id": "mosuCLJz46ytY1GjR",
+															"name": "Reaction Bonus",
+															"use_level_from_trait": true,
+															"features": [
+																{
+																	"type": "reaction_bonus",
+																	"situation": "From professional Spacers.",
+																	"amount": 1,
+																	"per_level": true
+																}
+															]
+														},
+														{
+															"id": "mC_Zu9GRiTwOgE0-h",
+															"name": "Bonus to pushing off",
+															"reference": "BX350",
+															"reference_highlight": "ST/2",
+															"use_level_from_trait": true,
+															"features": [
+																{
+																	"type": "conditional_modifier",
+																	"situation": "Bonus to ST for zero G push off",
+																	"amount": 1,
+																	"per_level": true
+																}
+															],
+															"disabled": true
+														},
+														{
+															"id": "m9riQ1phmCj6r8W1P",
+															"name": "Spacecraft Familiarity",
+															"use_level_from_trait": true,
+															"features": [
+																{
+																	"type": "conditional_modifier",
+																	"situation": "Counteracts Familiarity for spacecraft.",
+																	"amount": 1
+																}
+															],
+															"disabled": true
+														}
+													]
 												}
 											],
 											"points_per_level": 5,
@@ -1385,6 +1546,10 @@
 														"compare": "is",
 														"qualifier": "Navigation"
 													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "Space"
+													},
 													"amount": 1,
 													"per_level": true
 												},
@@ -1396,8 +1561,36 @@
 														"qualifier": "Piloting"
 													},
 													"specialization": {
-														"compare": "contains",
-														"qualifier": "Spacecraft"
+														"compare": "is",
+														"qualifier": "High-Performance Spacecraft"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Piloting"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "Low-Performance Spacecraft"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Piloting"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "Aerospace"
 													},
 													"amount": 1,
 													"per_level": true
@@ -1421,10 +1614,99 @@
 													},
 													"amount": 1,
 													"per_level": true
+												}
+											],
+											"can_level": true,
+											"levels": 1,
+											"calc": {
+												"points": 5
+											}
+										},
+										{
+											"id": "tls3rqpksk_sF3cBF",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Power Ups/Power Ups Traits.adq",
+												"id": "tcCw979nTBoztowCU"
+											},
+											"name": "Talent (Alien Friend)",
+											"reference": "PU3:6",
+											"tags": [
+												"Advantage",
+												"Mental",
+												"Talent"
+											],
+											"points_per_level": 5,
+											"features": [
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Diplomacy"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Expert Skill"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "Xenology"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Anthropology"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "@Alien@"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "History"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "@Alien@"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Psychology"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "@Alien@"
+													},
+													"amount": 1,
+													"per_level": true
 												},
 												{
 													"type": "reaction_bonus",
-													"situation": "Professional Spacers",
+													"situation": "From aliens.",
 													"amount": 1,
 													"per_level": true
 												}
@@ -1436,7 +1718,12 @@
 											}
 										},
 										{
-											"id": "tSVcveH7OzC2K2nWI",
+											"id": "tJPjygABhpYtNjy8V",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tM6z7Mx6e2V4VvUR4"
+											},
 											"name": "Absolute Direction",
 											"reference": "B34",
 											"tags": [
@@ -1446,14 +1733,14 @@
 											],
 											"modifiers": [
 												{
-													"id": "mHjKwLdmg_JH2Et2J",
+													"id": "mYPNzAE_mS2ZmVLi3",
 													"name": "Requires signal",
 													"reference": "B34",
 													"cost": -20,
 													"disabled": true
 												},
 												{
-													"id": "mzLm7xFr_x7SVoa7L",
+													"id": "mIsj_UtRlgmkP582e",
 													"name": "3D Spatial Sense",
 													"reference": "B34",
 													"cost": 5,
@@ -1576,7 +1863,12 @@
 									}
 								},
 								{
-									"id": "txRZAUFexfMZ6H5l-",
+									"id": "tyOxcZARgzfZsmjjG",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tqSO2a00yPEs8sCn3"
+									},
 									"name": "Common Sense",
 									"reference": "B43,P45",
 									"tags": [
@@ -1585,7 +1877,7 @@
 									],
 									"modifiers": [
 										{
-											"id": "m0SUY8sPoCYn7E37R",
+											"id": "mHioeUzZSahrWQ-7K",
 											"name": "Concious",
 											"reference": "P45",
 											"cost": 50,
@@ -1598,7 +1890,12 @@
 									}
 								},
 								{
-									"id": "tkSfORmYnNLnaylYH",
+									"id": "tBVsw3xxX0tbOiqQd",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t7blIRUzFpiHS_mnO"
+									},
 									"name": "Gizmo",
 									"reference": "B57,MA45",
 									"tags": [
@@ -1613,7 +1910,12 @@
 									}
 								},
 								{
-									"id": "tGa0opPXVQ3xCrAMN",
+									"id": "tmHg0Q08g2Ex4tkTM",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "ttd4Q71sdt2GT6xKv"
+									},
 									"name": "Talent (Healer)",
 									"reference": "PU3:11",
 									"notes": "Modern",
@@ -1646,12 +1948,45 @@
 									},
 									"modifiers": [
 										{
-											"id": "m46YyIkmlWjB6_IDn",
+											"id": "mKvw8vzsdRSn-c9Ql",
 											"name": "Alternative Cost",
 											"cost": 1,
 											"cost_type": "points",
 											"affects": "levels_only",
 											"disabled": true
+										},
+										{
+											"id": "MMLdgpKtBROfEXNj3",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "mEEp08tA9ZmfHC3jd",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From patients.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "mPvYwXiveQHIxv1vO",
+													"name": "Alternative Benefit",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Bonus to HT rolls for a specific patient and condition if treated full time.",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
 										}
 									],
 									"points_per_level": 10,
@@ -1773,18 +2108,6 @@
 											},
 											"amount": 1,
 											"per_level": true
-										},
-										{
-											"type": "reaction_bonus",
-											"situation": "From patients.",
-											"amount": 1,
-											"per_level": true
-										},
-										{
-											"type": "conditional_modifier",
-											"situation": "Bonus to HT rolls for a specific patient and condition if treated full time.",
-											"amount": 1,
-											"per_level": true
 										}
 									],
 									"can_level": true,
@@ -1794,7 +2117,12 @@
 									}
 								},
 								{
-									"id": "tZYdKVEjoDQ1xJdwV",
+									"id": "tgd3KWbiGcEC2dMqQ",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tY_8UkOBvzKIAgGGQ"
+									},
 									"name": "High Manual Dexterity",
 									"reference": "B59",
 									"tags": [
@@ -1921,35 +2249,62 @@
 									}
 								},
 								{
-									"id": "tKu3pTLcMoOeunvtE",
-									"name": "Higher Purpose",
-									"reference": "B59,TT3:7",
-									"notes": "Medic!",
+									"id": "tFLnxRFMM_8AzUK62",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Template Toolkit/Template Toolkit 3 - Starship Crew/Starship Crew Traits.adq",
+										"id": "t6EG4LOMfRtVLO4OD"
+									},
+									"name": "Higher Purpose (Medic!)",
+									"reference": "TT3:7,B59",
 									"tags": [
 										"Advantage",
 										"Exotic",
 										"Mental"
 									],
-									"base_points": 5,
+									"points_per_level": 5,
+									"features": [
+										{
+											"type": "conditional_modifier",
+											"situation": "to success rolls made to aid injured crew or passengers whenever this puts you at risk",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
 									"calc": {
 										"points": 5
 									}
 								},
 								{
-									"id": "ti0YgnBCZ3nHtLjo0",
-									"name": "License (Medical)",
+									"id": "tcufr8fla3dqJ9bd9",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "ts9hOD5V9mQFk64hc"
+									},
+									"name": "License (@Type@)",
 									"reference": "PU2:18",
 									"tags": [
 										"Perk",
 										"Social"
 									],
+									"replacements": {
+										"Type": "Medical"
+									},
 									"base_points": 1,
 									"calc": {
 										"points": 1
 									}
 								},
 								{
-									"id": "tkiYjB3mDbOAg7rn-",
+									"id": "tReCYvpFvr-FgzIBI",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tJTfFdHM7YI5IZR7I"
+									},
 									"name": "Resistant",
 									"reference": "B81,P71,MA47",
 									"tags": [
@@ -1958,7 +2313,7 @@
 									],
 									"modifiers": [
 										{
-											"id": "mJIkTYYokOOY4DtJ6",
+											"id": "mxrkHmGPCZhsC6xhu",
 											"name": "@Very Common: Metabolic Hazards, etc.@",
 											"reference": "B80",
 											"cost": 30,
@@ -1966,7 +2321,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mFTAbhxK9OXB0WA0u",
+											"id": "mcLAcWD74iOkDMBY4",
 											"name": "@Common: Poison, Sickness, etc.@",
 											"reference": "B81",
 											"cost": 15,
@@ -1974,14 +2329,17 @@
 											"disabled": true
 										},
 										{
-											"id": "mbIUozRXp5X945Jae",
-											"name": "Disease",
+											"id": "mz9MmclUGbJ9sZfSz",
+											"name": "@Occasional: Disease, Ingested Poison, etc.@",
 											"reference": "B81",
+											"replacements": {
+												"Occasional: Disease, Ingested Poison, etc.": "Disease"
+											},
 											"cost": 10,
 											"cost_type": "points"
 										},
 										{
-											"id": "mzMcBrzuMlpvj2nYf",
+											"id": "m0eLvPODIorZyOKRJ",
 											"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
 											"reference": "B81",
 											"cost": 5,
@@ -1989,7 +2347,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mEKvru6XgOjzYMgud",
+											"id": "muv1E8KD8sOk8pF6I",
 											"name": "Immunity",
 											"reference": "B81",
 											"cost": 1,
@@ -1997,14 +2355,91 @@
 											"disabled": true
 										},
 										{
-											"id": "mg_5DcHtFq2tCqxHt",
+											"id": "m6TxMaiB-0X0BOXVK",
+											"name": "+8 to all HT rolls to resist",
+											"reference": "B81",
+											"cost": 0.5,
+											"cost_type": "multiplier",
+											"disabled": true
+										},
+										{
+											"id": "mf4eSGtoWPpWTE_uu",
+											"name": "+3 to all HT rolls to resist",
+											"reference": "B81",
+											"cost": 0.33,
+											"cost_type": "multiplier"
+										}
+									],
+									"round_down": true,
+									"calc": {
+										"points": 3
+									}
+								},
+								{
+									"id": "t1j8TH-wDYS2KyrZq",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tJTfFdHM7YI5IZR7I"
+									},
+									"name": "Resistant",
+									"reference": "B81,P71,MA47",
+									"tags": [
+										"Advantage",
+										"Physical"
+									],
+									"modifiers": [
+										{
+											"id": "m9XIrDbCtuu0DdfEa",
+											"name": "@Very Common: Metabolic Hazards, etc.@",
+											"reference": "B80",
+											"cost": 30,
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "mGPsA_DFwviHf_jYm",
+											"name": "@Common: Poison, Sickness, etc.@",
+											"reference": "B81",
+											"cost": 15,
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "mdUxQkWQRtNmOmqCy",
+											"name": "@Occasional: Disease, Ingested Poison, etc.@",
+											"reference": "B81",
+											"replacements": {
+												"Occasional: Disease, Ingested Poison, etc.": "Disease"
+											},
+											"cost": 10,
+											"cost_type": "points"
+										},
+										{
+											"id": "md7UmlazWoasWk859",
+											"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+											"reference": "B81",
+											"cost": 5,
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "mrypAO9w877RC-SAI",
+											"name": "Immunity",
+											"reference": "B81",
+											"cost": 1,
+											"cost_type": "multiplier",
+											"disabled": true
+										},
+										{
+											"id": "mWcCn1g4u7L83t6Rp",
 											"name": "+8 to all HT rolls to resist",
 											"reference": "B81",
 											"cost": 0.5,
 											"cost_type": "multiplier"
 										},
 										{
-											"id": "mDV5oeQf_nxeT5ePy",
+											"id": "mcBMgv09C1oc0hXHh",
 											"name": "+3 to all HT rolls to resist",
 											"reference": "B81",
 											"cost": 0.33,
@@ -2018,7 +2453,12 @@
 									}
 								},
 								{
-									"id": "tc5bdtfKAztrTlQoX",
+									"id": "t00tRAJhh5PqOarfL",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t24PEm7VuLQlQZbMN"
+									},
 									"name": "Empathy (Sensitive)",
 									"reference": "B51",
 									"tags": [
@@ -2027,7 +2467,7 @@
 									],
 									"modifiers": [
 										{
-											"id": "mFlJgPr0K8LoTh4qH",
+											"id": "mT-A-avjLz6dRM9VT",
 											"name": "Remote",
 											"reference": "P48",
 											"cost": 50,
@@ -2069,7 +2509,12 @@
 									}
 								},
 								{
-									"id": "tmxJxt2vdDI2YvvEO",
+									"id": "taThRY80FlkE4ms2V",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "txfWfYkxkkcwmLAS4"
+									},
 									"name": "Empathy",
 									"reference": "B51,P48",
 									"tags": [
@@ -2078,7 +2523,7 @@
 									],
 									"modifiers": [
 										{
-											"id": "mqFaypmRT43LsUAJD",
+											"id": "me-pff63IsNHnRE_Q",
 											"name": "Remote",
 											"reference": "P48",
 											"cost": 50,
@@ -2121,12 +2566,12 @@
 								}
 							],
 							"calc": {
-								"points": 187
+								"points": 190
 							}
 						}
 					],
 					"calc": {
-						"points": 217
+						"points": 220
 					}
 				},
 				{
@@ -2138,14 +2583,56 @@
 							"name": "-40 Points chosen from",
 							"children": [
 								{
-									"id": "TA2esXTeG7e0jv7qt",
+									"id": "TP7B9SI6Suaz_c5Yy",
 									"name": "Everyman Disadvantages",
 									"tags": [
 										"Disadvantage"
 									],
 									"children": [
 										{
-											"id": "tlQbgO53Mf76QJ6-N",
+											"id": "tzI86FOgBys1NmVni",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tX9XXLPFBvyQSpA4k"
+											},
+											"name": "Xenophilia",
+											"reference": "B162",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"cr": 12,
+											"base_points": -10,
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "tTXPRxWkzV4r5vRMY",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t8I0xw1Lj1_222aEN"
+											},
+											"name": "Workaholic",
+											"reference": "B162",
+											"tags": [
+												"Disadvantage",
+												"Physical"
+											],
+											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										},
+										{
+											"id": "tpV17WqNRNlEcJTag",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t7U0VbIzs6SqefwLr"
+											},
 											"name": "Social Stigma (Criminal Record)",
 											"reference": "B155",
 											"tags": [
@@ -2165,23 +2652,162 @@
 											}
 										},
 										{
-											"id": "tJmgbt2bw2Lrnrl3I",
-											"name": "Chummy",
-											"reference": "B126",
+											"id": "t-i4Om_Wbpp6L3luw",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "thSMVzJ590v7gAD8d"
+											},
+											"name": "Pacifism: Self-Defense Only",
+											"reference": "B148",
+											"notes": "You only fight to defend yourself or those in your care, using only as much force as necessary (no pre-emptive strikes allowed!). You must do your best to discourage others from starting fights.",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
+											"modifiers": [
+												{
+													"id": "mD8uVhw-WTlMShkBj",
+													"name": "Species-Specific",
+													"reference": "UT32",
+													"cost": -80,
+													"disabled": true
+												}
+											],
+											"base_points": -15,
+											"calc": {
+												"points": -15
+											}
+										},
+										{
+											"id": "tJZr7-kg9-egfAA2X",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tV_f_75HmwzWOPhuu"
+											},
+											"name": "Pacifism: Reluctant Killer",
+											"reference": "B148",
+											"notes": "You are psychologically unprepared to kill people. Whenever you make a deadly attack (e.g., with a knife or a gun) against an obvious person whose face is visible to you, you are at -4 to hit and may not Aim. If you cannot see the foe’s face (due to a mask, darkness, or distance, or because you attacked from behind), the penalty is only -2, save in close combat. You have no penalty to attack a vehicle (even an occupied one), an opponent you do not believe is a person (including things with Horrific or Monstrous appearance), or a target you can’t actually see (e.g., a set of map coordinates or a blip on a radar screen). If you kill a recognizable person, the effect on you is the same as for Pacifism: Cannot Kill. You have no problem with your allies killing; you may even supply ammo, loaded weapons, and encouragement! You just can’t do the killing yourself.",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"modifiers": [
+												{
+													"id": "ma7VLExV4Nm1t2utE",
+													"name": "Species-Specific",
+													"reference": "UT32",
+													"cost": -80,
+													"disabled": true
+												}
+											],
 											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										},
+										{
+											"id": "ty_JMrLgTX2D57hWi",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "th9TK1Jmqg8uKe6SC"
+											},
+											"name": "Pacifism: Cannot Harm Innocents",
+											"reference": "B148",
+											"notes": "You may fight – you may even start fights – but you may only use deadly force on a foe that is attempting to do you serious harm. Capture is not “serious harm” unless you are already under penalty of death or have a Code of Honor that would require suicide if captured. You never intentionally do anything that causes, or even threatens to cause, injury to the uninvolved – particularly if they are “ordinary folks.”",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"modifiers": [
+												{
+													"id": "mEOX4ys3JPeYU21Tj",
+													"name": "Species-Specific",
+													"reference": "UT32",
+													"cost": -80,
+													"disabled": true
+												}
+											],
+											"base_points": -10,
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "tuHL1YjzZBoS7guRp",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tSiOKuvTJkqJhuRrI"
+											},
+											"name": "Lecherousness",
+											"reference": "B142",
+											"notes": "Make a self-control roll whenever you have more than the briefest contact with an appealing member of the sex you find attractive, at -5 if this person is Handsome/Beautiful, or at -10 if Very Handsome/Very Beautiful. If you fail, you must make a “pass” using whatever wiles and skills you can bring to bear.",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"cr": 12,
+											"base_points": -15,
+											"calc": {
+												"points": -15
+											}
+										},
+										{
+											"id": "tv1QPRvM1hK5lPKuM",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "ttHkLI9zwzfeOIEZc"
+											},
+											"name": "Intolerance (@Class, Ethnicity, Nationality, Religion, Sex, or Species@)",
+											"reference": "B140",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"replacements": {
+												"Class, Ethnicity, Nationality, Religion, Sex, or Species": "Rival civilization or species"
+											},
+											"modifiers": [
+												{
+													"id": "m8BzARmLU9YTwe4_R",
+													"name": "Scope: Common",
+													"reference": "B140",
+													"cost": -5,
+													"cost_type": "points"
+												},
+												{
+													"id": "mMFKcEXCHlOJUY4ov",
+													"name": "Scope: Occasional",
+													"reference": "B140",
+													"cost": -2,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m96Tgq5SvB98Oxq8c",
+													"name": "Scope: Rare",
+													"reference": "B140",
+													"cost": -1,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mvCOOzpobL5xM5XRe",
+													"name": "Scope: Anyone unlike you",
+													"reference": "B140",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												}
+											],
 											"features": [
 												{
 													"type": "reaction_bonus",
-													"situation": "to others",
-													"amount": 2
-												},
-												{
-													"type": "conditional_modifier",
-													"situation": "to IQ-based skills when alone",
+													"situation": "from victims of your intolerance (may be as much as -5, at GM's discretion)",
 													"amount": -1
 												}
 											],
@@ -2190,49 +2816,383 @@
 											}
 										},
 										{
-											"id": "tGqbFYMG3UMyZ4CM-",
-											"name": "Code of Honor (Mercanary's)",
-											"reference": "S221",
-											"notes": "A merc should look out for his buddies, take care of his gear, and fight for the honor of the unit. Obey the rule's of engagement. Don't poach on another unit's contract. Do the job you're hired for.",
+											"id": "tT0QASLX07EF9lTLk",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t7pCgXTVkswkTjOZO"
+											},
+											"name": "Honesty",
+											"reference": "B138",
+											"notes": "Make a self-control roll when faced with the “need” to break unreasonable laws; if you fail, you must obey the law, whatever the consequences. If you manage to resist your urges and break the law, make a second self-control roll afterward. If you fail, you must turn yourself in to the authorities!",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
+											"cr": 12,
 											"base_points": -10,
 											"calc": {
 												"points": -10
 											}
 										},
 										{
-											"id": "tlqtuGtcqOQ2V1Ux9",
-											"name": "Code of Honor (Pirate's)",
-											"reference": "B127",
-											"notes": "Always avenge an insult, regardless of the danger; your buddy’s foe is your own; never attack a fellow crewman or buddy except in a fair, open duel.",
+											"id": "trsZ2Zc7D5NK67NQP",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t5bwP6TnS4cX-zM8L"
+											},
+											"name": "Enemy (@Who@)",
+											"reference": "B135",
+											"tags": [
+												"Disadvantage",
+												"Social"
+											],
+											"modifiers": [
+												{
+													"id": "m1uqbmSF4XPadh6ct",
+													"name": "Weak Individual",
+													"reference": "B135",
+													"notes": "50% of your starting points",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mq2IaHTU5nWySQr_m",
+													"name": "Equal Individual",
+													"reference": "B135",
+													"notes": "100% of your starting points",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mMA3IA0ZLVXv3F3qB",
+													"name": "Powerful Individual",
+													"reference": "B135",
+													"notes": "\u003e150% of your starting points",
+													"cost": -20,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "muWf3KElf6YClR5Mc",
+													"name": "Weak Group",
+													"reference": "B135",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m4sFGqodTeLtkoORR",
+													"name": "Medium Group",
+													"reference": "B135",
+													"cost": -20,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "meOsEqsWx2wMZCkMx",
+													"name": "Appears almost all the time",
+													"reference": "B36",
+													"notes": "15-",
+													"cost": 3,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mEdyAe9G1r8dH1F29",
+													"name": "Appears quite often",
+													"reference": "B36",
+													"notes": "12-",
+													"cost": 2,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "m6avZMdTKvD0Hnr4I",
+													"name": "Appears fairly often",
+													"reference": "B36",
+													"notes": "9-",
+													"cost": 1,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mgD9jEz2Tm5yqQEUE",
+													"name": "Appears quite rarely",
+													"reference": "B36",
+													"notes": "6-",
+													"cost": 0.5,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mKg7WAzJwYVZzUQCm",
+													"name": "Large/Powerful Group",
+													"reference": "B135",
+													"cost": -30,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m8ITbG6YOmeRJHWHk",
+													"name": "Utterly Formidable Group",
+													"reference": "B135",
+													"cost": -40,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mPA6jBVJ7-asOdcmV",
+													"name": "Unknown",
+													"reference": "B135",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "moZL6yvdvwf15YuTm",
+													"name": "Evil Twin",
+													"reference": "B135",
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mjiIJekxOvwoV814h",
+													"name": "Evil Twin",
+													"reference": "B135",
+													"notes": "More skilled or extra abilities",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mV0vjlXEbQNuTp1mm",
+													"name": "Evil Twin",
+													"reference": "B135",
+													"notes": "More skilled and extra abilities",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mDqiF2KJBvzZacgqc",
+													"name": "Watcher",
+													"reference": "B135",
+													"cost": 0.25,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mPvsj4I6AwtUg-ImP",
+													"name": "Rival",
+													"reference": "B135",
+													"cost": 0.5,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mGlW0YwRrPPEsX8vg",
+													"name": "Hunter",
+													"reference": "B135",
+													"cost": 1,
+													"cost_type": "multiplier",
+													"disabled": true
+												}
+											],
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "tU93BpsWd87tXQoG4",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t1HUGl4o498iCyvrw"
+											},
+											"name": "Duty (@Duty@)",
+											"reference": "B133",
+											"tags": [
+												"Disadvantage",
+												"Social"
+											],
+											"replacements": {
+												"Duty": "To ship's owner or provider"
+											},
+											"modifiers": [
+												{
+													"id": "mqPbBzktkRvUQhKS4",
+													"name": "FR: 6",
+													"cost": -2,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mc28kHHdl2bC-9jas",
+													"name": "FR: 9",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "msHKyNJnqPJLv7t_W",
+													"name": "FR: 12",
+													"cost": -10,
+													"cost_type": "points"
+												},
+												{
+													"id": "msDg-TEv5JFPahd7c",
+													"name": "FR: 15",
+													"cost": -15,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m6cttDrUq1LDCj_Wu",
+													"name": "Extremely Hazardous",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m2hXo5s80zwmYT0kE",
+													"name": "Involuntary",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mMnLPQIBBmwkcBnfD",
+													"name": "Nonhazardous",
+													"cost": 5,
+													"cost_type": "points",
+													"disabled": true
+												}
+											],
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "tPL7aOcy-1kkf1qq1",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t1HUGl4o498iCyvrw"
+											},
+											"name": "Duty (@Duty@)",
+											"reference": "B133",
+											"tags": [
+												"Disadvantage",
+												"Social"
+											],
+											"replacements": {
+												"Duty": "To ship's owner or provider"
+											},
+											"modifiers": [
+												{
+													"id": "m96MdAAES9GpApzoC",
+													"name": "FR: 6",
+													"cost": -2,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mGKucdvSNl5tMycOk",
+													"name": "FR: 9",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m7KyeizQmennJcHFR",
+													"name": "FR: 12",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mb_dFRZraclwj0XNh",
+													"name": "FR: 15",
+													"cost": -15,
+													"cost_type": "points"
+												},
+												{
+													"id": "m9kJ_EK_Xl3xE9UMU",
+													"name": "Extremely Hazardous",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mLdHSMwdTz6zaEhWQ",
+													"name": "Involuntary",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mNdYr40hJI6UMdxt6",
+													"name": "Nonhazardous",
+													"cost": 5,
+													"cost_type": "points",
+													"disabled": true
+												}
+											],
+											"calc": {
+												"points": -15
+											}
+										},
+										{
+											"id": "t-4sWpkSiKyhffX-I",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tXFf9MSQ3FMT2psO8"
+											},
+											"name": "Demophobia (Crowds)",
+											"reference": "B149",
+											"notes": "Any group of over a dozen people sets off this fear unless they are all well known to you. The self-control roll is at -1 for over 25 people, -2 for a crowd of 100 or more, -3 for 1,000, -4 for 10,000, and so on.",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
+											"cr_adj": "action_penalty",
+											"cr": 12,
+											"base_points": -15,
+											"calc": {
+												"points": -15
+											}
+										},
+										{
+											"id": "tSMZ4ahPb9GQ1M5oL",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tK4QdVZYxGAd4cqr_"
+											},
+											"name": "Compulsive Gambling",
+											"reference": "B128",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"cr": 12,
 											"base_points": -5,
 											"calc": {
 												"points": -5
 											}
 										},
 										{
-											"id": "t3TKGWeuogPRm2IHa",
-											"name": "Code of Honor (Soldier's)",
-											"reference": "B127",
-											"notes": "An officer should be tough but fair, lead from the front, and look out for his men; an enlisted man should look out for his buddies and take care of his kit. Every soldier should be willing to fight and die for the honor of his unit, service, and country; follow orders; obey the “rules of war”; treat an honorable enemy with respect (a dishonorable enemy deserves a bullet); and wear the uniform with pride.",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"base_points": -10,
-											"calc": {
-												"points": -10
-											}
-										},
-										{
-											"id": "tIddJDeXlHOFA_LBm",
+											"id": "tkT_J4xCKgvdh7nRY",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tapWLsuN75Unedmwn"
+											},
 											"name": "Compulsive Carousing",
 											"reference": "B128",
 											"tags": [
@@ -2258,308 +3218,115 @@
 											}
 										},
 										{
-											"id": "t3QTeH3wqFztNwNPi",
-											"name": "Compulsive Gambling",
-											"reference": "B128",
+											"id": "tUNC5OZCynydiMB4I",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "txSrmgLB0M36uR802"
+											},
+											"name": "Code of Honor (Soldier's)",
+											"reference": "B127",
+											"notes": "An officer should be tough but fair, lead from the front, and look out for his men; an enlisted man should look out for his buddies and take care of his kit. Every soldier should be willing to fight and die for the honor of his unit, service, and country; follow orders; obey the “rules of war”; treat an honorable enemy with respect (a dishonorable enemy deserves a bullet); and wear the uniform with pride.",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
-											"cr": 12,
-											"base_points": -5,
-											"calc": {
-												"points": -5
-											}
-										},
-										{
-											"id": "teZKgZrv3PVDeQcp2",
-											"name": "Duty (To ship's owner or provider)",
-											"reference": "B133",
-											"tags": [
-												"Disadvantage",
-												"Social"
-											],
-											"modifiers": [
-												{
-													"id": "mAN7Aybt5_Sqqvnk8",
-													"name": "FR: 6",
-													"cost": -2,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mh8DSUcbxSMjNhcpa",
-													"name": "FR: 9",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mG9alY30nWhYIksB0",
-													"name": "FR: 12",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mh2uZSuo-10ERTujU",
-													"name": "FR: 15",
-													"cost": -15,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mAP84xS4XH7UWLd6L",
-													"name": "Extremely Hazardous",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m9YhPGTjEWXjazLMQ",
-													"name": "Involuntary",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m591D0Mru1gIAGvMA",
-													"name": "Nonhazardous",
-													"cost": 5,
-													"cost_type": "points",
-													"disabled": true
-												}
-											],
-											"calc": {
-												"points": 0
-											}
-										},
-										{
-											"id": "t99n27vtfE7oofiUD",
-											"name": "Enemy (@Who@)",
-											"reference": "B135",
-											"tags": [
-												"Disadvantage",
-												"Social"
-											],
-											"modifiers": [
-												{
-													"id": "mz9Ppjel63NuPIUu4",
-													"name": "Weak Individual",
-													"reference": "B135",
-													"notes": "50% of your starting points",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m4QJyYCqWvX1ALbgM",
-													"name": "Equal Individual",
-													"reference": "B135",
-													"notes": "100% of your starting points",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mn6pTY-12X_98l-1w",
-													"name": "Powerful Individual",
-													"reference": "B135",
-													"notes": "\u003e150% of your starting points",
-													"cost": -20,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m5XZFUCAV0S7L2RuW",
-													"name": "Weak Group",
-													"reference": "B135",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mnSA5ky5kZqgM60zu",
-													"name": "Medium Group",
-													"reference": "B135",
-													"cost": -20,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mCGswZe5EEgcyG0vN",
-													"name": "Appears almost all the time",
-													"reference": "B36",
-													"notes": "15-",
-													"cost": 3,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mk0Bx5c1Ekbu4AAJb",
-													"name": "Appears quite often",
-													"reference": "B36",
-													"notes": "12-",
-													"cost": 2,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mf3882f1PSEnmFjIn",
-													"name": "Appears fairly often",
-													"reference": "B36",
-													"notes": "9-",
-													"cost": 1,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "m9ruTAzvfLAXSQ9hr",
-													"name": "Appears quite rarely",
-													"reference": "B36",
-													"notes": "6-",
-													"cost": 0.5,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mIda6ml2ECH09-lYE",
-													"name": "Large/Powerful Group",
-													"reference": "B135",
-													"cost": -30,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mzxkScAJfgy5MLNC4",
-													"name": "Utterly Formidable Group",
-													"reference": "B135",
-													"cost": -40,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mMH9zz8KNdt2C-PWu",
-													"name": "Unknown",
-													"reference": "B135",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "moPolSYW0M-nX0Gpf",
-													"name": "Evil Twin",
-													"reference": "B135",
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mHScMcGrpi_Ahmoqf",
-													"name": "Evil Twin",
-													"reference": "B135",
-													"notes": "More skilled or extra abilities",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mLe0J3emHPI-68O1t",
-													"name": "Evil Twin",
-													"reference": "B135",
-													"notes": "More skilled and extra abilities",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "moDv79WIFTVUy_iCE",
-													"name": "Watcher",
-													"reference": "B135",
-													"cost": 0.25,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "marKzHrMYweE0RER9",
-													"name": "Rival",
-													"reference": "B135",
-													"cost": 0.5,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "m4GhKJrTz7tdCZTOm",
-													"name": "Hunter",
-													"reference": "B135",
-													"cost": 1,
-													"cost_type": "multiplier",
-													"disabled": true
-												}
-											],
-											"calc": {
-												"points": 0
-											}
-										},
-										{
-											"id": "tKHHjtLFf1eCH8idZ",
-											"name": "Honesty",
-											"reference": "B138",
-											"notes": "Make a self-control roll when faced with the “need” to break unreasonable laws; if you fail, you must obey the law, whatever the consequences. If you manage to resist your urges and break the law, make a second self-control roll afterward. If you fail, you must turn yourself in to the authorities!",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"cr": 12,
 											"base_points": -10,
 											"calc": {
 												"points": -10
 											}
 										},
 										{
-											"id": "tSYjQMTQiyipvh3Yr",
-											"name": "Intolerance (@Rival civilization or species@)",
-											"reference": "B140",
+											"id": "txBAm-8bhytWsfga-",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Space/Space Traits.adq",
+												"id": "teNSsqOsjstajwmxn"
+											},
+											"name": "Code of Honor (Mercenary's Code)",
+											"reference": "B127, S221",
+											"notes": "A merc should look out for his buddies, take care of his gear, and fight for the honor of the unit. Obey the rules of engagement. Don’t poach on another unit’s contract. Do the job you’re hired for.",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
-											"modifiers": [
-												{
-													"id": "mP6mBsqB6RkpKGw38",
-													"name": "Scope: Common",
-													"reference": "B140",
-													"cost": -5,
-													"cost_type": "points"
-												},
-												{
-													"id": "mHPdIzFW5GQ3eVzse",
-													"name": "Scope: Occasional",
-													"reference": "B140",
-													"cost": -2,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mCazq4hBNJ3Zz5Rwp",
-													"name": "Scope: Rare",
-													"reference": "B140",
-													"cost": -1,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mpZiAAsQaabe_sh3o",
-													"name": "Scope: Anyone unlike you",
-													"reference": "B140",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												}
+											"base_points": -10,
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "tMTyWQ6yWjeAtu4Qg",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tqq24I9NJrLajsURv"
+											},
+											"name": "Code of Honor (Pirate's)",
+											"reference": "B127",
+											"notes": "Always avenge an insult, regardless of the danger; your buddy’s foe is your own; never attack a fellow crewman or buddy except in a fair, open duel.",
+											"tags": [
+												"Disadvantage",
+												"Mental"
 											],
+											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										},
+										{
+											"id": "tZOaLtfxDVq6bIkZ_",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t4KGpV0KBExr-fEb2"
+											},
+											"name": "Gregarious",
+											"reference": "B126",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"base_points": -10,
 											"features": [
 												{
 													"type": "reaction_bonus",
-													"situation": "from victims of your intolerance (may be as much as -5, at GM's discretion)",
+													"situation": "to others",
+													"amount": 4
+												},
+												{
+													"type": "conditional_modifier",
+													"situation": "to IQ-based skills when alone, or only -1 if in a group of 4 or less",
+													"amount": -2
+												}
+											],
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "t9KpefpGiMPiQ8Eho",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tzBDG0xUlT_dh7FuY"
+											},
+											"name": "Chummy",
+											"reference": "B126",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"base_points": -5,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "to others",
+													"amount": 2
+												},
+												{
+													"type": "conditional_modifier",
+													"situation": "to IQ-based skills when alone",
 													"amount": -1
 												}
 											],
@@ -2568,91 +3335,12 @@
 											}
 										},
 										{
-											"id": "tSN8G_nvcF8AXq7jd",
-											"name": "Lecherousness",
-											"reference": "B142",
-											"notes": "Make a self-control roll whenever you have more than the briefest contact with an appealing member of the sex you find attractive, at -5 if this person is Handsome/Beautiful, or at -10 if Very Handsome/Very Beautiful. If you fail, you must make a “pass” using whatever wiles and skills you can bring to bear.",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"cr": 12,
-											"base_points": -15,
-											"calc": {
-												"points": -15
-											}
-										},
-										{
-											"id": "toFtUBLn3oDqwK9rr",
-											"name": "Pacifism: Reluctant Killer",
-											"reference": "B148",
-											"notes": "You are psychologically unprepared to kill people. Whenever you make a deadly attack (e.g., with a knife or a gun) against an obvious person whose face is visible to you, you are at -4 to hit and may not Aim. If you cannot see the foe’s face (due to a mask, darkness, or distance, or because you attacked from behind), the penalty is only -2, save in close combat. You have no penalty to attack a vehicle (even an occupied one), an opponent you do not believe is a person (including things with Horrific or Monstrous appearance), or a target you can’t actually see (e.g., a set of map coordinates or a blip on a radar screen). If you kill a recognizable person, the effect on you is the same as for Pacifism: Cannot Kill. You have no problem with your allies killing; you may even supply ammo, loaded weapons, and encouragement! You just can’t do the killing yourself.",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"modifiers": [
-												{
-													"id": "mTOpdfOPyRSTPZxII",
-													"name": "Species-Specific",
-													"reference": "UT32",
-													"cost": -80,
-													"disabled": true
-												}
-											],
-											"base_points": -5,
-											"calc": {
-												"points": -5
-											}
-										},
-										{
-											"id": "t2ggCZY9jzq8p2p5v",
-											"name": "Pacifism: Self-Defense Only",
-											"reference": "B148",
-											"notes": "You only fight to defend yourself or those in your care, using only as much force as necessary (no pre-emptive strikes allowed!). You must do your best to discourage others from starting fights.",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"modifiers": [
-												{
-													"id": "mvUppBrTzhO8SlZvY",
-													"name": "Species-Specific",
-													"reference": "UT32",
-													"cost": -80,
-													"disabled": true
-												}
-											],
-											"base_points": -15,
-											"calc": {
-												"points": -15
-											}
-										},
-										{
-											"id": "tOk-w--6qXaDpwEOj",
-											"name": "Pacifism: Cannot Harm Innocents",
-											"reference": "B148",
-											"notes": "You may fight – you may even start fights – but you may only use deadly force on a foe that is attempting to do you serious harm. Capture is not “serious harm” unless you are already under penalty of death or have a Code of Honor that would require suicide if captured. You never intentionally do anything that causes, or even threatens to cause, injury to the uninvolved – particularly if they are “ordinary folks.”",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"modifiers": [
-												{
-													"id": "maGTTpEaozs-XKpMt",
-													"name": "Species-Specific",
-													"reference": "UT32",
-													"cost": -80,
-													"disabled": true
-												}
-											],
-											"base_points": -10,
-											"calc": {
-												"points": -10
-											}
-										},
-										{
-											"id": "tF5bkfQ3sMC6pL3dQ",
+											"id": "t5WAJXfkpz9UhvMug",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "taFPI7E0PJwXbS5nL"
+											},
 											"name": "Agoraphobia (Open Spaces)",
 											"reference": "B150",
 											"notes": "You are uncomfortable whenever you are outside, and actually become frightened when there are no walls within 50 feet.",
@@ -2666,120 +3354,19 @@
 											"calc": {
 												"points": -10
 											}
-										},
-										{
-											"id": "tZXTlKRE4cCbpQxWu",
-											"name": "Demophobia (Crowds)",
-											"reference": "B149",
-											"notes": "Any group of over a dozen people sets off this fear unless they are all well known to you. The self-control roll is at -1 for over 25 people, -2 for a crowd of 100 or more, -3 for 1,000, -4 for 10,000, and so on.",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"cr_adj": "action_penalty",
-											"cr": 12,
-											"base_points": -15,
-											"calc": {
-												"points": -15
-											}
-										},
-										{
-											"id": "tjbDdKswMprutfGiZ",
-											"name": "Duty (To ship's owner or provider)",
-											"reference": "B133",
-											"tags": [
-												"Disadvantage",
-												"Social"
-											],
-											"modifiers": [
-												{
-													"id": "meLFrIbIVYCBHAeZb",
-													"name": "FR: 6",
-													"cost": -2,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m4I3pf6_wgHW9bXAF",
-													"name": "FR: 9",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mBXCRqQ-MvOVKuUcn",
-													"name": "FR: 12",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "maJz6iwz_zPfARgt3",
-													"name": "FR: 15",
-													"cost": -15,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "moJyTKOKVzvJWp1JX",
-													"name": "Extremely Hazardous",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mlDy8NxjyA0YvUCXX",
-													"name": "Involuntary",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mC8nR7WlaJzO27Vbj",
-													"name": "Nonhazardous",
-													"cost": 5,
-													"cost_type": "points",
-													"disabled": true
-												}
-											],
-											"calc": {
-												"points": 0
-											}
-										},
-										{
-											"id": "tmda4WbtMTh1_cbyI",
-											"name": "Workaholic",
-											"reference": "B162",
-											"tags": [
-												"Disadvantage",
-												"Physical"
-											],
-											"base_points": -5,
-											"calc": {
-												"points": -5
-											}
-										},
-										{
-											"id": "tn4seQCEHsaBwe7or",
-											"name": "Xenophilia",
-											"reference": "B162",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"cr": 12,
-											"base_points": -10,
-											"calc": {
-												"points": -10
-											}
 										}
 									],
 									"calc": {
-										"points": -145
+										"points": -180
 									}
 								},
 								{
-									"id": "tnNk3BAfRHo6he6pe",
+									"id": "tgYkaMsIn0VoRe4Cv",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t5Qs23yaRu3D4T_hM"
+									},
 									"name": "Attentive",
 									"reference": "B163",
 									"tags": [
@@ -2799,7 +3386,12 @@
 									}
 								},
 								{
-									"id": "tgyuKPg4LKHrcpcT-",
+									"id": "tnp2yiR4mUwxpawUd",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t-ZuUbg_LrqZ1hi6c"
+									},
 									"name": "Careful",
 									"reference": "B163",
 									"tags": [
@@ -2812,7 +3404,12 @@
 									}
 								},
 								{
-									"id": "tvIqpH_HFdUCO8EgO",
+									"id": "tpWOtLUMzzMslnrmP",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tNG1o64IqmaaNJPg1"
+									},
 									"name": "Charitable",
 									"reference": "B125",
 									"notes": "Make a self-control roll in any situation where you could render aid or are specifically asked for help, but should resist the urge",
@@ -2827,8 +3424,13 @@
 									}
 								},
 								{
-									"id": "tJsDG8nA4BfSRAVCb",
-									"name": "Code of Honor (Hippocratic Oath)",
+									"id": "tjldk86KjlqFAbfA8",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tW3e4OJTtFNNveAgo"
+									},
+									"name": "Code of Honor (Professional)",
 									"reference": "B127",
 									"notes": "Adhere to the ethics of your profession; always do your job to the best of your ability; support your guild, union, or professional association.",
 									"tags": [
@@ -2841,7 +3443,12 @@
 									}
 								},
 								{
-									"id": "t6HyreR3qRrLSCiE8",
+									"id": "tvLqwQ-kjXvf5VxuQ",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t2O8gMxbRPpAWLej9"
+									},
 									"name": "Curious",
 									"reference": "B129",
 									"notes": "Make a self-control roll when presented with an interesting item or situation",
@@ -2856,7 +3463,12 @@
 									}
 								},
 								{
-									"id": "t7yuoCg2E90XLJ3rF",
+									"id": "tj0CzduJu9JHvkpJj",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tUHvsAnxBrL6XEzEn"
+									},
 									"name": "Guilt Complex",
 									"reference": "B137",
 									"tags": [
@@ -2869,7 +3481,12 @@
 									}
 								},
 								{
-									"id": "tGfO0YlZKCTenRLQy",
+									"id": "tQZSmzoASjdJ2Cq2U",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tUl2tCfZVgRF9QWYx"
+									},
 									"name": "Pacifism: Cannot Kill",
 									"reference": "B148",
 									"notes": "You may fight – you may even start fights – but you may never do anything that seems likely to kill another. This includes abandoning a wounded foe to die “on his own”! You must do your best to keep your companions from killing, too. If you do kill someone (or feel responsible for a death), you immediately suffer a nervous breakdown. Roll 3d and be totally morose and useless for that many days. During this time, you must make a Will roll to offer any sort of violence toward anyone, for any reason.",
@@ -2879,7 +3496,7 @@
 									],
 									"modifiers": [
 										{
-											"id": "mzOs1xtKMJ2dijQqs",
+											"id": "mj-1lqG6u018sZJFN",
 											"name": "Species-Specific",
 											"reference": "UT32",
 											"cost": -80,
@@ -2892,7 +3509,12 @@
 									}
 								},
 								{
-									"id": "teXmMYBMxX5OHOSaE",
+									"id": "tP7uBYGTNhVPBSLX0",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tYggvuZw_KmnKdpZ0"
+									},
 									"name": "Mysophobia (Dirt)",
 									"reference": "B149",
 									"notes": "You are deathly afraid of infection, or just of dirt and filth. Make a self-control roll when you must do something that might get you dirty. Roll at -5 to eat any unaccustomed food. You should act as “finicky” as possible.",
@@ -2908,7 +3530,12 @@
 									}
 								},
 								{
-									"id": "t68BStly1kDoKzhVS",
+									"id": "tvZADTkz92DkGYWrg",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tcLpFfSmbHHdHy5Yd"
+									},
 									"name": "Post-Combat Shakes",
 									"reference": "B150",
 									"notes": "Make a self-control roll at the end of any battle. If you fail, roll 3d, add the amount by which you failed your self-control roll, and look up the result on the Fright Check Table.",
@@ -2923,7 +3550,12 @@
 									}
 								},
 								{
-									"id": "t-ZYyCDlRGM0pJQaw",
+									"id": "tnI-7OZhjiX_PkGxW",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tw81RysAzky-yjNYN"
+									},
 									"name": "Selfless",
 									"reference": "B153",
 									"notes": "You must make a self-control roll to put your needs – even survival – before those of someone else.",
@@ -2938,37 +3570,105 @@
 									}
 								},
 								{
-									"id": "tLWYz-BtQPAQh9-UW",
-									"name": "Social Stigma (License Revoked)",
+									"id": "tKFqmNE98jv4RnxzF",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tSSmnBdJ1f7mFMRL5"
+									},
+									"name": "Social Stigma (@Stigma@)",
 									"reference": "B155",
 									"tags": [
 										"Disadvantage",
 										"Social"
 									],
-									"base_points": -5,
-									"features": [
+									"replacements": {
+										"Stigma": "License Revoked"
+									},
+									"modifiers": [
 										{
-											"type": "reaction_bonus",
-											"situation": "from non-criminals who learn of your Criminal Record. Police, judges, vigilantes, and other law-and-order types react at -2",
-											"amount": -1
+											"id": "m0HC0-ac3jgHcPqb1",
+											"name": "Obvious from your appearance, dress or manner",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from anyone who sees you",
+													"amount": -1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "m89GUW2pteqq2i1j4",
+											"name": "Obvious from your speech",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from anyone who hears you speak",
+													"amount": -1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mRLYOfLYPrmjWdDMd",
+											"name": "Easily learned by anyone who cares to check up on you",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from anyone who cares to check up on you",
+													"amount": -1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "m-elAsaPPHR8RIQyV",
+											"name": "Public Denouncement",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from everryone you meet",
+													"amount": -1,
+													"per_level": true
+												}
+											],
+											"disabled": true
 										}
 									],
+									"points_per_level": -5,
+									"can_level": true,
+									"levels": 1,
 									"calc": {
 										"points": -5
 									}
 								},
 								{
-									"id": "tN0H6lszk-o9DrZGM",
+									"id": "tlreJBHcJ2RdfThZp",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t5R0c_iujWXeXusIu"
+									},
 									"name": "Vow",
 									"reference": "B161",
-									"notes": "Refuse no request for medical aid",
+									"notes": "@Subject@",
 									"tags": [
 										"Disadvantage",
-										"Physical"
+										"Mental"
 									],
+									"replacements": {
+										"Subject": "Refuse no request for medical aid"
+									},
 									"modifiers": [
 										{
-											"id": "mLaex4ORQFb8Cwu4i",
+											"id": "mWRBf1OFzjkrkpJVy",
 											"name": "Minor",
 											"reference": "B161",
 											"cost": -5,
@@ -2976,14 +3676,14 @@
 											"disabled": true
 										},
 										{
-											"id": "m0OY-4DmRKIpPBOY-",
+											"id": "mADRcqCoF-QzFyiUx",
 											"name": "Major",
 											"reference": "B161",
 											"cost": -10,
 											"cost_type": "points"
 										},
 										{
-											"id": "mj4eVwHgwjyAJtQOU",
+											"id": "mkAsc9H-qe7fM7P5T",
 											"name": "Great",
 											"reference": "B161",
 											"cost": -15,
@@ -2992,22 +3692,23 @@
 										}
 									],
 									"calc": {
-										"points": -10
+										"points": -10,
+										"resolved_notes": "Refuse no request for medical aid"
 									}
 								}
 							],
 							"calc": {
-								"points": -227
+								"points": -262
 							}
 						}
 					],
 					"calc": {
-						"points": -227
+						"points": -262
 					}
 				}
 			],
 			"calc": {
-				"points": 80
+				"points": 48
 			}
 		},
 		{
@@ -3020,7 +3721,12 @@
 					"name": "Multi-Role",
 					"children": [
 						{
-							"id": "tjU1nOmmEsHnmzj2h",
+							"id": "tn3GsbuLThxPsCMAD",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t1w1RFcFceKR2T9_e"
+							},
 							"name": "Increased Intelligence",
 							"reference": "B15",
 							"tags": [
@@ -3044,7 +3750,12 @@
 							}
 						},
 						{
-							"id": "tTMvOOHKJXAmionwj",
+							"id": "tp0avwdhWvDhg93Qg",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "ttd4Q71sdt2GT6xKv"
+							},
 							"name": "Talent (Healer)",
 							"reference": "PU3:11",
 							"notes": "Modern",
@@ -3077,12 +3788,45 @@
 							},
 							"modifiers": [
 								{
-									"id": "mfRFgsurEOBdwNGUF",
+									"id": "mWUkjkeVl2L-uKkKW",
 									"name": "Alternative Cost",
 									"cost": 1,
 									"cost_type": "points",
 									"affects": "levels_only",
 									"disabled": true
+								},
+								{
+									"id": "MQn5iK6eK8_aOCesK",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "mN4ieWfD_kXOfsvlR",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From patients.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "mP93HDUl4XoQDl1Wz",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Bonus to HT rolls for a specific patient and condition if treated full time.",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
 								}
 							],
 							"points_per_level": 10,
@@ -3204,18 +3948,6 @@
 									},
 									"amount": 1,
 									"per_level": true
-								},
-								{
-									"type": "reaction_bonus",
-									"situation": "From patients.",
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "conditional_modifier",
-									"situation": "Bonus to HT rolls for a specific patient and condition if treated full time.",
-									"amount": 1,
-									"per_level": true
 								}
 							],
 							"can_level": true,
@@ -3234,7 +3966,12 @@
 					"name": "Legendary",
 					"children": [
 						{
-							"id": "t1Zt1w9NfraBARbIk",
+							"id": "tq3X1jRMJZ_44EdZX",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t1w1RFcFceKR2T9_e"
+							},
 							"name": "Increased Intelligence",
 							"reference": "B15",
 							"tags": [
@@ -3258,7 +3995,12 @@
 							}
 						},
 						{
-							"id": "tqOyy9dvWRkwvvEho",
+							"id": "tw-cWg7rCKJKAfeOE",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "ttd4Q71sdt2GT6xKv"
+							},
 							"name": "Talent (Healer)",
 							"reference": "PU3:11",
 							"notes": "Modern",
@@ -3291,12 +4033,45 @@
 							},
 							"modifiers": [
 								{
-									"id": "mF4xdn0oelTV4xQzF",
+									"id": "mdj0UZ_9SrL29bUmz",
 									"name": "Alternative Cost",
 									"cost": 1,
 									"cost_type": "points",
 									"affects": "levels_only",
 									"disabled": true
+								},
+								{
+									"id": "MIEYZZ1t1Y5kh7_7I",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "mkjm9pK7I7A92hI8s",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From patients.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "mR9uwXdTxVB2bupFA",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Bonus to HT rolls for a specific patient and condition if treated full time.",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
 								}
 							],
 							"points_per_level": 10,
@@ -3416,18 +4191,6 @@
 										"compare": "is",
 										"qualifier": "Epidemiology"
 									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "reaction_bonus",
-									"situation": "From patients.",
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "conditional_modifier",
-									"situation": "Bonus to HT rolls for a specific patient and condition if treated full time.",
 									"amount": 1,
 									"per_level": true
 								}
@@ -3460,7 +4223,12 @@
 					"name": "Primary Skills",
 					"children": [
 						{
-							"id": "sJllY52S3siKUqIQ0",
+							"id": "sDhvyXm3_HZtP2dlJ",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sdjyVxpBGLKKkBeCm"
+							},
 							"name": "Diagnosis",
 							"reference": "B187",
 							"tags": [
@@ -3492,7 +4260,12 @@
 							"points": 2
 						},
 						{
-							"id": "sEL8LXg5iujI_FSDG",
+							"id": "s9ItE69TO9OIlapSb",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sVSxt6kQGDV8RpNKB"
+							},
 							"name": "Physician",
 							"reference": "B213",
 							"tags": [
@@ -3519,7 +4292,12 @@
 							"points": 2
 						},
 						{
-							"id": "sP_QqxXy0U12sWc86",
+							"id": "sPKREKHNQz7nE2DUa",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sjU9kn3jTX-_5Q5p5"
+							},
 							"name": "Psychology",
 							"reference": "B216",
 							"tags": [
@@ -3541,7 +4319,12 @@
 							"points": 2
 						},
 						{
-							"id": "sn3hnpwiqc8CAqQL-",
+							"id": "sEwG-rCdCU8R0Ne8G",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sgrDrFiOdLC9njqnC"
+							},
 							"name": "Surgery",
 							"reference": "B223",
 							"tags": [
@@ -3602,7 +4385,12 @@
 					"name": "Secondary Skills",
 					"children": [
 						{
-							"id": "sieNcqSCxW5-2L6CD",
+							"id": "sy1A6UoG3oJB5tqrz",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sKTF4zU6WcKytEDRW"
+							},
 							"name": "Electronics Operation",
 							"reference": "B189",
 							"tags": [
@@ -3638,14 +4426,22 @@
 							"points": 4
 						},
 						{
-							"id": "sJlL890tMq72Ab9R1",
+							"id": "s7FoGQolU2JGqqgXu",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sjiPOdZOS0Ve3xMhr"
+							},
 							"name": "Mechanic",
 							"reference": "B207",
 							"tags": [
 								"Maintenance",
 								"Repair"
 							],
-							"specialization": "Life Support",
+							"replacements": {
+								"Machine class": "Life Support"
+							},
+							"specialization": "@Machine class@",
 							"difficulty": "iq/a",
 							"defaults": [
 								{
@@ -3655,7 +4451,7 @@
 								{
 									"type": "skill",
 									"name": "Engineer",
-									"specialization": "Aerospace",
+									"specialization": "@Machine class@",
 									"modifier": -4
 								},
 								{
@@ -3673,7 +4469,12 @@
 							"points": 2
 						},
 						{
-							"id": "sekNjmtCnvjd6hK4S",
+							"id": "sZmkV6lHfQK9dp9UK",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "secK3UkDUOcuXpmed"
+							},
 							"name": "Pharmacy",
 							"reference": "B213",
 							"tags": [
@@ -3703,7 +4504,12 @@
 							"points": 1
 						},
 						{
-							"id": "sdZa4ruN-0RYDHUAR",
+							"id": "sl2CGC4Va_hN58FK3",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sPfyz7_V73fxlVXOS"
+							},
 							"name": "Physiology",
 							"reference": "B213",
 							"tags": [
@@ -3741,7 +4547,12 @@
 							"name": "Three of",
 							"children": [
 								{
-									"id": "sd0EU3MK_niVLuN6y",
+									"id": "sOtswGeMoq7Sc_99b",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "swjwM4R_hmkH-UXlB"
+									},
 									"name": "NBC Suit",
 									"reference": "B192",
 									"tags": [
@@ -3774,7 +4585,12 @@
 									"points": 2
 								},
 								{
-									"id": "sbvYqQeLDU8Od6r5x",
+									"id": "s1tF1ZB_Xpn6GpwbW",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sn9Y6a4YbUfsQ8GxY"
+									},
 									"name": "Hazardous Materials",
 									"reference": "B199",
 									"tags": [
@@ -3792,7 +4608,12 @@
 									"points": 2
 								},
 								{
-									"id": "szJ2ausWpaLnJmhuO",
+									"id": "ssifj7Mhm2o7vO7ky",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "stFawUEv8gxldDoiC"
+									},
 									"name": "Research",
 									"reference": "B217",
 									"tags": [
@@ -3885,7 +4706,42 @@
 									"points": 2
 								},
 								{
-									"id": "sR8X-AN1zkRpw1dCo",
+									"id": "s5wuFIfuX6M0RGx2F",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sSnvf-r4ViMOrA_5y"
+									},
+									"name": "Bioengineering",
+									"reference": "B180",
+									"tags": [
+										"Design",
+										"Invention"
+									],
+									"specialization": "@Specialty@",
+									"difficulty": "iq/h",
+									"defaults": [
+										{
+											"type": "skill",
+											"name": "Biology",
+											"modifier": -5
+										},
+										{
+											"type": "skill",
+											"name": "Bioengineering",
+											"modifier": -4
+										}
+									],
+									"tech_level": "",
+									"points": 2
+								},
+								{
+									"id": "s2RCloeZ_IEAWcJpe",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sVG21oGW_ok1qdXIS"
+									},
 									"name": "Expert Skill",
 									"reference": "B193,MA56",
 									"tags": [
@@ -3899,7 +4755,12 @@
 									"points": 2
 								},
 								{
-									"id": "suFJyivjgce9e2iUn",
+									"id": "s-FtcIEOt5v_ykjhX",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sqKieRudf_Tp4-T6T"
+									},
 									"name": "Expert Skill",
 									"reference": "B193,MA56",
 									"tags": [
@@ -3913,7 +4774,12 @@
 									"points": 2
 								},
 								{
-									"id": "soM2OWelK-raqTNrf",
+									"id": "sn785227gluKtY_u9",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sVa9gXF-NnYK9vQkh"
+									},
 									"name": "Poisons",
 									"reference": "B214",
 									"tags": [
@@ -3948,7 +4814,12 @@
 									"points": 2
 								},
 								{
-									"id": "s4Dqjj0Z2K8polEE9",
+									"id": "svqSjxpNf5F7tvUrZ",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sb6LoqgrQgzKvzHH2"
+									},
 									"name": "Biology",
 									"reference": "B180",
 									"tags": [
@@ -3980,7 +4851,12 @@
 					"name": "Background Skills",
 					"children": [
 						{
-							"id": "sq77jwKrvx9Bq1YUe",
+							"id": "sdnZ7TvPlnWmxVp9r",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "ssHhRG7LH-Ma3YDnH"
+							},
 							"name": "Computer Operation",
 							"reference": "B184",
 							"tags": [
@@ -3999,7 +4875,12 @@
 							"points": 1
 						},
 						{
-							"id": "sbninq9PcrFm0uhWP",
+							"id": "sv6E2-vWsTBiV9qg7",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "s7kVwKFERTuMYO3O8"
+							},
 							"name": "Free Fall",
 							"reference": "B197",
 							"tags": [
@@ -4016,10 +4897,15 @@
 									"modifier": -5
 								}
 							],
-							"points": 1
+							"points": 2
 						},
 						{
-							"id": "saVe0uVXPo06aYKDw",
+							"id": "sUi-bfJn587UXqXlw",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "s9IHT34mK8yfSB7d_"
+							},
 							"name": "Spacer",
 							"reference": "B185",
 							"tags": [
@@ -4036,7 +4922,12 @@
 							"points": 1
 						},
 						{
-							"id": "sw2gDHnRonlqyRBOe",
+							"id": "s3fetAy2_JK-FfXSJ",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sAmDzPjf0rKZ6I5G1"
+							},
 							"name": "Vacc Suit",
 							"reference": "B192",
 							"tags": [
@@ -4072,11 +4963,16 @@
 							"name": "10 Points chosen from",
 							"children": [
 								{
-									"id": "ScJHXYDTsL7mudgoF",
+									"id": "SgWD3cKhaOxWFHMaL",
 									"name": "Everyman Skills",
 									"children": [
 										{
-											"id": "seXERvKc4gF1vb9Wp",
+											"id": "sC1Xlt16rQtjpB4Ww",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sTXDrqXH0sT2NSD_b"
+											},
 											"name": "Area Knowledge",
 											"reference": "B176",
 											"notes": "Location of the capitals of interplanetary states and the homeworlds of major races; general awareness of all major races; knowledge of individuals of Status 8; general understanding of relations between interplanetary states",
@@ -4097,7 +4993,12 @@
 											"points": 1
 										},
 										{
-											"id": "s4Zyxxd3J2LOva29j",
+											"id": "satHaz_yHCNExijJ_",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "s-Ckyxw5PmHIvbZab"
+											},
 											"name": "Area Knowledge",
 											"reference": "B176",
 											"notes": "Location of major planets; familiarity with all known races (but not necessarily expertise); knowledge of people of Status 7+; general understanding of the economic and political situation",
@@ -4105,13 +5006,9 @@
 												"Everyman",
 												"Knowledge"
 											],
-											"specialization": "@Interplanetary State@; Lived there",
+											"specialization": "@Interplanetary State@",
 											"difficulty": "iq/e",
 											"defaults": [
-												{
-													"type": "iq",
-													"modifier": -4
-												},
 												{
 													"type": "skill",
 													"name": "Geography",
@@ -4122,7 +5019,12 @@
 											"points": 1
 										},
 										{
-											"id": "sdi1mY4WD4zPB6Bw2",
+											"id": "sdm2UTkkCCaLrcSfx",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "strhX4LEdd46xgmIS"
+											},
 											"name": "Area Knowledge",
 											"reference": "B176",
 											"notes": "Location of its major cities and important sites; awareness of its major customs, ethnic groups, and languages (but not necessarily expertise); names of folk of Status 7+; and a general understanding of the economic and political situation",
@@ -4130,13 +5032,9 @@
 												"Everyman",
 												"Knowledge"
 											],
-											"specialization": "@Planet@; Lived there",
+											"specialization": "@Planet@",
 											"difficulty": "iq/e",
 											"defaults": [
-												{
-													"type": "iq",
-													"modifier": -4
-												},
 												{
 													"type": "skill",
 													"name": "Geography",
@@ -4147,7 +5045,12 @@
 											"points": 1
 										},
 										{
-											"id": "sv32P2xzpaShqDxjv",
+											"id": "sgYoSQNdTraUtrMW1",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sBJgeWUs81Ifhob4Z"
+											},
 											"name": "Beam Weapons",
 											"reference": "B179",
 											"tags": [
@@ -4178,7 +5081,12 @@
 											"points": 1
 										},
 										{
-											"id": "s0nKh0VMBk_PODW_G",
+											"id": "sKP0yx0eByOh9Xvq4",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sOp4wssAMtUc1ukJI"
+											},
 											"name": "Body Language",
 											"reference": "B181",
 											"tags": [
@@ -4202,10 +5110,14 @@
 											"points": 1
 										},
 										{
-											"id": "sAG9Gn7c3Y8c1_tvP",
+											"id": "scfOZZQre4ZgUqqrV",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sziMa9_9xTvR2iiqx"
+											},
 											"name": "Body Sense",
 											"reference": "B181",
-											"notes": "For settings with matter transmission",
 											"tags": [
 												"Athletic"
 											],
@@ -4224,7 +5136,12 @@
 											"points": 1
 										},
 										{
-											"id": "s6n7uXfF2_-N2gmNh",
+											"id": "sgzgMWUCbVuxypfRL",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "shtDdl5thrvKSnJHf"
+											},
 											"name": "Brawling",
 											"reference": "B182,MA55",
 											"tags": [
@@ -4252,7 +5169,12 @@
 											"points": 1
 										},
 										{
-											"id": "sin0k-UtjPXeuU3e-",
+											"id": "sidVTTlnQYKqYemza",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "si-upI7A5RgdO0cjC"
+											},
 											"name": "Carousing",
 											"reference": "B183",
 											"tags": [
@@ -4270,7 +5192,12 @@
 											"points": 1
 										},
 										{
-											"id": "spCWkUTjKu2LBnKK1",
+											"id": "sdi-MSVQdPs11uelo",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sWFtA7Gvclq4aL-Yb"
+											},
 											"name": "Current Affairs",
 											"reference": "B186",
 											"tags": [
@@ -4301,7 +5228,12 @@
 											"points": 1
 										},
 										{
-											"id": "sdkivSz2f7ueKQk7L",
+											"id": "sCeUd5JWIYsYkUkZM",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "s9mV--3lpIfXO7N6Z"
+											},
 											"name": "First Aid",
 											"reference": "B195",
 											"tags": [
@@ -4332,7 +5264,12 @@
 											"points": 1
 										},
 										{
-											"id": "sTeqDiwyH7zGqTavC",
+											"id": "saeCT1L9jxAg9jwRJ",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sWB9ypJAq43MF3O0n"
+											},
 											"name": "Gambling",
 											"reference": "B197",
 											"tags": [
@@ -4356,7 +5293,12 @@
 											"points": 1
 										},
 										{
-											"id": "sFsPBWJfsBdI7oUGT",
+											"id": "sl2ECERvdrVd3_Frf",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "syfSQ9N8yETqQbhFK"
+											},
 											"name": "Games",
 											"reference": "B197,MA57",
 											"tags": [
@@ -4373,7 +5315,12 @@
 											"points": 1
 										},
 										{
-											"id": "svoDoUShzCb7Z9mfO",
+											"id": "s3MYMph911XyHdztD",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sGz21GskAlJXL1hYP"
+											},
 											"name": "Gesture",
 											"reference": "B198",
 											"tags": [
@@ -4389,7 +5336,12 @@
 											"points": 1
 										},
 										{
-											"id": "sPuTIFQ81UeEPSFQq",
+											"id": "sVKR7mDJbIA_5ifaP",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sT5htbz4-Mr0PFCk7"
+											},
 											"name": "Guns",
 											"reference": "B198",
 											"tags": [
@@ -4414,7 +5366,12 @@
 											"points": 1
 										},
 										{
-											"id": "sKapjMCPHPJuLLlv8",
+											"id": "sDv4CA8jQzC2p50pg",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sOtPessbzkRjGaQPR"
+											},
 											"name": "Hobby Skill",
 											"reference": "B200,MA57",
 											"tags": [
@@ -4431,7 +5388,12 @@
 											"points": 1
 										},
 										{
-											"id": "s2aDxSyZZFtBbDKoB",
+											"id": "sTsLFPkJrPv7arNJ2",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sDLf4crz0sGRjVDFi"
+											},
 											"name": "Hobby Skill",
 											"reference": "B200,MA57",
 											"tags": [
@@ -4448,7 +5410,12 @@
 											"points": 1
 										},
 										{
-											"id": "svfrR9Fl-QKSiC2JA",
+											"id": "sREJNjWOpMB8XNX8T",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sfZrwMVUibhbtdssl"
+											},
 											"name": "Housekeeping",
 											"reference": "B200",
 											"tags": [
@@ -4464,7 +5431,12 @@
 											"points": 1
 										},
 										{
-											"id": "sIXETxHGQb5TQIsqw",
+											"id": "sUlJKNECQrrgltOV0",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sdl9m7gHE7hlMX0AX"
+											},
 											"name": "Lip Reading",
 											"reference": "B205",
 											"tags": [
@@ -4480,7 +5452,12 @@
 											"points": 1
 										},
 										{
-											"id": "sqgTEhYyAxBFDVGLO",
+											"id": "s8474oMS2dBBjEiE6",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sx1CDkGBR830IZrmz"
+											},
 											"name": "Professional Skill",
 											"reference": "B215",
 											"tags": [
@@ -4497,7 +5474,12 @@
 											"points": 1
 										},
 										{
-											"id": "s_8eLyRyGG1G-bTYO",
+											"id": "s8UIXemOH4hjA_IfV",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sBec-o4Z7gPpbg2f9"
+											},
 											"name": "Professional Skill",
 											"reference": "B215",
 											"tags": [
@@ -4514,7 +5496,12 @@
 											"points": 1
 										},
 										{
-											"id": "sLRdu9sfS4CruHAk9",
+											"id": "sBMUHfwW1_sxoVN-g",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "smxkcngH5Kz54yeN3"
+											},
 											"name": "Sports",
 											"reference": "B222,MA59",
 											"tags": [
@@ -4531,7 +5518,12 @@
 											"points": 1
 										},
 										{
-											"id": "sM3CfDBMCm-xbkvTt",
+											"id": "sgzulmOk5J8NLoQyZ",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "smTUpMWJGqPeT1KER"
+											},
 											"name": "Streetwise",
 											"reference": "B223",
 											"tags": [
@@ -4567,7 +5559,12 @@
 					"name": "Multi-Role",
 					"children": [
 						{
-							"id": "sjVk0p8dX0UFI8DCa",
+							"id": "sxXkBAi06VLG-glbd",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sKTF4zU6WcKytEDRW"
+							},
 							"name": "Electronics Operation",
 							"reference": "B189",
 							"tags": [
@@ -4603,14 +5600,22 @@
 							"points": 1
 						},
 						{
-							"id": "s__PWIBmGNmUbz1rP",
+							"id": "spyc_L3MGimMD2JF3",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sjiPOdZOS0Ve3xMhr"
+							},
 							"name": "Mechanic",
 							"reference": "B207",
 							"tags": [
 								"Maintenance",
 								"Repair"
 							],
-							"specialization": "Life Support",
+							"replacements": {
+								"Machine class": "Life Support"
+							},
+							"specialization": "@Machine class@",
 							"difficulty": "iq/a",
 							"defaults": [
 								{
@@ -4620,7 +5625,7 @@
 								{
 									"type": "skill",
 									"name": "Engineer",
-									"specialization": "Aerospace",
+									"specialization": "@Machine class@",
 									"modifier": -4
 								},
 								{
@@ -4638,7 +5643,12 @@
 							"points": 1
 						},
 						{
-							"id": "skOZBKTlhRz7JQ9fN",
+							"id": "sCYhw2VMRrPLdJzg7",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sdjyVxpBGLKKkBeCm"
+							},
 							"name": "Diagnosis",
 							"reference": "B187",
 							"tags": [
@@ -4670,7 +5680,12 @@
 							"points": 4
 						},
 						{
-							"id": "sLnUc46d7bwi0ZD-4",
+							"id": "sPF3n8iR2VaPbdmQa",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sVSxt6kQGDV8RpNKB"
+							},
 							"name": "Physician",
 							"reference": "B213",
 							"tags": [
@@ -4697,7 +5712,12 @@
 							"points": 4
 						},
 						{
-							"id": "s9YasWI9PsZqF35JQ",
+							"id": "sE0378bxcNj2dF5PO",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "secK3UkDUOcuXpmed"
+							},
 							"name": "Pharmacy",
 							"reference": "B213",
 							"tags": [
@@ -4727,7 +5747,12 @@
 							"points": 2
 						},
 						{
-							"id": "s7XyNL1kUKB4rCDy7",
+							"id": "seYNuozoRP2I0mPvJ",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sPfyz7_V73fxlVXOS"
+							},
 							"name": "Physiology",
 							"reference": "B213",
 							"tags": [
@@ -4761,7 +5786,12 @@
 							"points": 2
 						},
 						{
-							"id": "s0Vr0af_0WF2v4zBn",
+							"id": "s-CHDOBudP5-oasWy",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sjU9kn3jTX-_5Q5p5"
+							},
 							"name": "Psychology",
 							"reference": "B216",
 							"tags": [
@@ -4783,7 +5813,12 @@
 							"points": 2
 						},
 						{
-							"id": "sdPes1tX2cB-yQQAn",
+							"id": "sNBxneP_JeGM_Rwth",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sgrDrFiOdLC9njqnC"
+							},
 							"name": "Surgery",
 							"reference": "B223",
 							"tags": [

--- a/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Omnicompetent.gct
+++ b/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Omnicompetent.gct
@@ -1,0 +1,117 @@
+{
+	"version": 5,
+	"id": "BBugx7Cocfp7IzzAJ",
+	"traits": [
+		{
+			"id": "TI-fjmOl1ypSm24AT",
+			"name": "Omnicompetent",
+			"reference": "TT3:11",
+			"children": [
+				{
+					"id": "tru_rkFACbMcbn12S",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Power Ups/Power Ups Traits.adq",
+						"id": "t9xtkYUx0xMrWAdxY"
+					},
+					"name": "Talent (Jack of All Trades)",
+					"reference": "PU3:11",
+					"notes": "Bonus to all defaults from attributes",
+					"tags": [
+						"Advantage",
+						"Mental",
+						"Talent"
+					],
+					"points_per_level": 10,
+					"can_level": true,
+					"levels": 3,
+					"calc": {
+						"points": 30
+					}
+				},
+				{
+					"id": "tf3Ol552X3hnIkeI7",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tg6F-Wf29f6BFE1oD"
+					},
+					"name": "Wild Talent",
+					"reference": "B99,P89,MA49",
+					"tags": [
+						"Advantage",
+						"Mental",
+						"Supernatural"
+					],
+					"modifiers": [
+						{
+							"id": "mXoh571IGvqF5xG5M",
+							"name": "Retention",
+							"reference": "B99",
+							"cost": 25,
+							"disabled": true
+						},
+						{
+							"id": "mwKfA6IaGlYQEEdCZ",
+							"name": "Emergencies Only",
+							"reference": "B100",
+							"cost": -30,
+							"disabled": true
+						},
+						{
+							"id": "mgb1nJYx1160oGpLN",
+							"name": "Focused",
+							"reference": "B99",
+							"notes": "@Type: Mental, Physical, Magical or Chi@",
+							"cost": -20,
+							"disabled": true
+						},
+						{
+							"id": "m49nsQGZam5A86J6K",
+							"name": "Wild Ability",
+							"reference": "P90",
+							"cost": 50,
+							"disabled": true
+						},
+						{
+							"id": "mTQMDnNwMUZ_-iXrQ",
+							"name": "External",
+							"reference": "P90",
+							"cost": -20,
+							"disabled": true
+						},
+						{
+							"id": "mZw1hi15wf2N2iTr6",
+							"name": "No Advantage Requirements",
+							"reference": "DF4:8",
+							"cost": 50,
+							"disabled": true
+						},
+						{
+							"id": "mpuNjekVHppIjur_X",
+							"name": "Game Time",
+							"reference": "P108",
+							"notes": "Uses per game week equal to its maximum possible uses per session",
+							"disabled": true
+						}
+					],
+					"points_per_level": 20,
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 20
+					}
+				}
+			],
+			"calc": {
+				"points": 50
+			}
+		}
+	],
+	"notes": [
+		{
+			"id": "ng8FOflpJloBlMtLo",
+			"text": "Add Versatile [5] to advantage options, if missing"
+		}
+	]
+}

--- a/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Operations Officer.gct
+++ b/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Operations Officer.gct
@@ -12,7 +12,12 @@
 					"name": "Attributes",
 					"children": [
 						{
-							"id": "tykh0xBAHGOuQyikQ",
+							"id": "tblZmL6G4p-bqNH1_",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t1w1RFcFceKR2T9_e"
+							},
 							"name": "Increased Intelligence",
 							"reference": "B15",
 							"tags": [
@@ -36,7 +41,12 @@
 							}
 						},
 						{
-							"id": "teiGdPQjweeePijgh",
+							"id": "tNdOgYU0yIhLbo8a9",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tVt3SvdGWNchJ8z4o"
+							},
 							"name": "Increased Health",
 							"reference": "B14",
 							"tags": [
@@ -73,14 +83,56 @@
 							"name": "-40 Points chosen from",
 							"children": [
 								{
-									"id": "TBglCbIxTB3JXcTki",
+									"id": "TWBy5Y8qs3yz6CF1j",
 									"name": "Everyman Disadvantages",
 									"tags": [
 										"Disadvantage"
 									],
 									"children": [
 										{
-											"id": "tm2kgo8U-vJZACaPM",
+											"id": "tRmXDkiULe8jHsIat",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tX9XXLPFBvyQSpA4k"
+											},
+											"name": "Xenophilia",
+											"reference": "B162",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"cr": 12,
+											"base_points": -10,
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "t4xLCNnYG0MEkaJs_",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t8I0xw1Lj1_222aEN"
+											},
+											"name": "Workaholic",
+											"reference": "B162",
+											"tags": [
+												"Disadvantage",
+												"Physical"
+											],
+											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										},
+										{
+											"id": "tJVEUgWKqr2yES3eB",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t7U0VbIzs6SqefwLr"
+											},
 											"name": "Social Stigma (Criminal Record)",
 											"reference": "B155",
 											"tags": [
@@ -100,23 +152,162 @@
 											}
 										},
 										{
-											"id": "tdFBo6XdE0ICU3vY_",
-											"name": "Chummy",
-											"reference": "B126",
+											"id": "tvqvKpewz1--WSkUZ",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "thSMVzJ590v7gAD8d"
+											},
+											"name": "Pacifism: Self-Defense Only",
+											"reference": "B148",
+											"notes": "You only fight to defend yourself or those in your care, using only as much force as necessary (no pre-emptive strikes allowed!). You must do your best to discourage others from starting fights.",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
+											"modifiers": [
+												{
+													"id": "ml4eZ3p4nmHO8h_IH",
+													"name": "Species-Specific",
+													"reference": "UT32",
+													"cost": -80,
+													"disabled": true
+												}
+											],
+											"base_points": -15,
+											"calc": {
+												"points": -15
+											}
+										},
+										{
+											"id": "tMzbdeW0aBQo8XPNw",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tV_f_75HmwzWOPhuu"
+											},
+											"name": "Pacifism: Reluctant Killer",
+											"reference": "B148",
+											"notes": "You are psychologically unprepared to kill people. Whenever you make a deadly attack (e.g., with a knife or a gun) against an obvious person whose face is visible to you, you are at -4 to hit and may not Aim. If you cannot see the foe’s face (due to a mask, darkness, or distance, or because you attacked from behind), the penalty is only -2, save in close combat. You have no penalty to attack a vehicle (even an occupied one), an opponent you do not believe is a person (including things with Horrific or Monstrous appearance), or a target you can’t actually see (e.g., a set of map coordinates or a blip on a radar screen). If you kill a recognizable person, the effect on you is the same as for Pacifism: Cannot Kill. You have no problem with your allies killing; you may even supply ammo, loaded weapons, and encouragement! You just can’t do the killing yourself.",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"modifiers": [
+												{
+													"id": "maG6HPR66NCF5ffA5",
+													"name": "Species-Specific",
+													"reference": "UT32",
+													"cost": -80,
+													"disabled": true
+												}
+											],
 											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										},
+										{
+											"id": "teIvOG5H0OuZV0raR",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "th9TK1Jmqg8uKe6SC"
+											},
+											"name": "Pacifism: Cannot Harm Innocents",
+											"reference": "B148",
+											"notes": "You may fight – you may even start fights – but you may only use deadly force on a foe that is attempting to do you serious harm. Capture is not “serious harm” unless you are already under penalty of death or have a Code of Honor that would require suicide if captured. You never intentionally do anything that causes, or even threatens to cause, injury to the uninvolved – particularly if they are “ordinary folks.”",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"modifiers": [
+												{
+													"id": "mC5OyqAPLvTPtp2nj",
+													"name": "Species-Specific",
+													"reference": "UT32",
+													"cost": -80,
+													"disabled": true
+												}
+											],
+											"base_points": -10,
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "t32w1KAc9lwg89SIj",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tSiOKuvTJkqJhuRrI"
+											},
+											"name": "Lecherousness",
+											"reference": "B142",
+											"notes": "Make a self-control roll whenever you have more than the briefest contact with an appealing member of the sex you find attractive, at -5 if this person is Handsome/Beautiful, or at -10 if Very Handsome/Very Beautiful. If you fail, you must make a “pass” using whatever wiles and skills you can bring to bear.",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"cr": 12,
+											"base_points": -15,
+											"calc": {
+												"points": -15
+											}
+										},
+										{
+											"id": "t9sJIRHYUCqviODRd",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "ttHkLI9zwzfeOIEZc"
+											},
+											"name": "Intolerance (@Class, Ethnicity, Nationality, Religion, Sex, or Species@)",
+											"reference": "B140",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"replacements": {
+												"Class, Ethnicity, Nationality, Religion, Sex, or Species": "Rival civilization or species"
+											},
+											"modifiers": [
+												{
+													"id": "mDTZhdgRcAfl8aJfj",
+													"name": "Scope: Common",
+													"reference": "B140",
+													"cost": -5,
+													"cost_type": "points"
+												},
+												{
+													"id": "mrkRD0NtBX7G03v3V",
+													"name": "Scope: Occasional",
+													"reference": "B140",
+													"cost": -2,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mWUfS-xrGc70ov9UM",
+													"name": "Scope: Rare",
+													"reference": "B140",
+													"cost": -1,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mifKMFk-Bn660utgi",
+													"name": "Scope: Anyone unlike you",
+													"reference": "B140",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												}
+											],
 											"features": [
 												{
 													"type": "reaction_bonus",
-													"situation": "to others",
-													"amount": 2
-												},
-												{
-													"type": "conditional_modifier",
-													"situation": "to IQ-based skills when alone",
+													"situation": "from victims of your intolerance (may be as much as -5, at GM's discretion)",
 													"amount": -1
 												}
 											],
@@ -125,49 +316,383 @@
 											}
 										},
 										{
-											"id": "tGb8AUwJuRjLNo1hQ",
-											"name": "Code of Honor (Mercanary's)",
-											"reference": "S221",
-											"notes": "A merc should look out for his buddies, take care of his gear, and fight for the honor of the unit. Obey the rule's of engagement. Don't poach on another unit's contract. Do the job you're hired for.",
+											"id": "tagZob0ttzBPgzQsR",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t7pCgXTVkswkTjOZO"
+											},
+											"name": "Honesty",
+											"reference": "B138",
+											"notes": "Make a self-control roll when faced with the “need” to break unreasonable laws; if you fail, you must obey the law, whatever the consequences. If you manage to resist your urges and break the law, make a second self-control roll afterward. If you fail, you must turn yourself in to the authorities!",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
+											"cr": 12,
 											"base_points": -10,
 											"calc": {
 												"points": -10
 											}
 										},
 										{
-											"id": "tlYjmZkyvWMlim4dc",
-											"name": "Code of Honor (Pirate's)",
-											"reference": "B127",
-											"notes": "Always avenge an insult, regardless of the danger; your buddy’s foe is your own; never attack a fellow crewman or buddy except in a fair, open duel.",
+											"id": "tkGmujjP6GLDScfO7",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t5bwP6TnS4cX-zM8L"
+											},
+											"name": "Enemy (@Who@)",
+											"reference": "B135",
+											"tags": [
+												"Disadvantage",
+												"Social"
+											],
+											"modifiers": [
+												{
+													"id": "mhr3NCzlUcFjdMQMH",
+													"name": "Weak Individual",
+													"reference": "B135",
+													"notes": "50% of your starting points",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mLyPv-7GR9vlZyyv5",
+													"name": "Equal Individual",
+													"reference": "B135",
+													"notes": "100% of your starting points",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mjtJjZY5jQTCc5NlM",
+													"name": "Powerful Individual",
+													"reference": "B135",
+													"notes": "\u003e150% of your starting points",
+													"cost": -20,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m5Z3i-IyEuq09jHlF",
+													"name": "Weak Group",
+													"reference": "B135",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mCxanZ2Zt3HldWbW5",
+													"name": "Medium Group",
+													"reference": "B135",
+													"cost": -20,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mBqvbnUeVijkVez24",
+													"name": "Appears almost all the time",
+													"reference": "B36",
+													"notes": "15-",
+													"cost": 3,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "m1Hm9IxgnaB_V7gzS",
+													"name": "Appears quite often",
+													"reference": "B36",
+													"notes": "12-",
+													"cost": 2,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mLtVZLrGQ8m-D9Ez6",
+													"name": "Appears fairly often",
+													"reference": "B36",
+													"notes": "9-",
+													"cost": 1,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mJ4DETjYWrXShApFJ",
+													"name": "Appears quite rarely",
+													"reference": "B36",
+													"notes": "6-",
+													"cost": 0.5,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mIPMjaqVEVA7e70uI",
+													"name": "Large/Powerful Group",
+													"reference": "B135",
+													"cost": -30,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mHYryJYCOxqjW3wAS",
+													"name": "Utterly Formidable Group",
+													"reference": "B135",
+													"cost": -40,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mbItCWO9WThDUej56",
+													"name": "Unknown",
+													"reference": "B135",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mgdNbVcgsSYxzaVdD",
+													"name": "Evil Twin",
+													"reference": "B135",
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mbTsMB12j9saRGJQy",
+													"name": "Evil Twin",
+													"reference": "B135",
+													"notes": "More skilled or extra abilities",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m1fekwmkOxcFOdjc_",
+													"name": "Evil Twin",
+													"reference": "B135",
+													"notes": "More skilled and extra abilities",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m5VFRT416gHFjWnIo",
+													"name": "Watcher",
+													"reference": "B135",
+													"cost": 0.25,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mRieTrvMTh5HCYagc",
+													"name": "Rival",
+													"reference": "B135",
+													"cost": 0.5,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mGukxxQf37c2zf5ob",
+													"name": "Hunter",
+													"reference": "B135",
+													"cost": 1,
+													"cost_type": "multiplier",
+													"disabled": true
+												}
+											],
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "tlftbWNfJzFYjCD2H",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t1HUGl4o498iCyvrw"
+											},
+											"name": "Duty (@Duty@)",
+											"reference": "B133",
+											"tags": [
+												"Disadvantage",
+												"Social"
+											],
+											"replacements": {
+												"Duty": "To ship's owner or provider"
+											},
+											"modifiers": [
+												{
+													"id": "m-KYTpZAiRpAYi2rC",
+													"name": "FR: 6",
+													"cost": -2,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mZ6VFvnPsoWCARdX7",
+													"name": "FR: 9",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mP-0Nlttidh7HnoA4",
+													"name": "FR: 12",
+													"cost": -10,
+													"cost_type": "points"
+												},
+												{
+													"id": "mG9q4Qyk1aJKcD_U0",
+													"name": "FR: 15",
+													"cost": -15,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mJ57MAAIyRTGde4OL",
+													"name": "Extremely Hazardous",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mO3AtCum2T_roE5pg",
+													"name": "Involuntary",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mxm7jdwchsPMwoFUy",
+													"name": "Nonhazardous",
+													"cost": 5,
+													"cost_type": "points",
+													"disabled": true
+												}
+											],
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "tyzhTPTmNVHo2D1Kh",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t1HUGl4o498iCyvrw"
+											},
+											"name": "Duty (@Duty@)",
+											"reference": "B133",
+											"tags": [
+												"Disadvantage",
+												"Social"
+											],
+											"replacements": {
+												"Duty": "To ship's owner or provider"
+											},
+											"modifiers": [
+												{
+													"id": "mLpuAW1_OMSVjCw1b",
+													"name": "FR: 6",
+													"cost": -2,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mUzeLpJtMxccHztlY",
+													"name": "FR: 9",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m99JBCrMwP5P1HPmN",
+													"name": "FR: 12",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mgvX2Gry7rjDeapKo",
+													"name": "FR: 15",
+													"cost": -15,
+													"cost_type": "points"
+												},
+												{
+													"id": "mh43QtzT98DSI-ygj",
+													"name": "Extremely Hazardous",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mS1rXBFQUEJVXm2ku",
+													"name": "Involuntary",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mpcYTQrJS6Jxayy9s",
+													"name": "Nonhazardous",
+													"cost": 5,
+													"cost_type": "points",
+													"disabled": true
+												}
+											],
+											"calc": {
+												"points": -15
+											}
+										},
+										{
+											"id": "tcCXN7nAVboPePNVK",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tXFf9MSQ3FMT2psO8"
+											},
+											"name": "Demophobia (Crowds)",
+											"reference": "B149",
+											"notes": "Any group of over a dozen people sets off this fear unless they are all well known to you. The self-control roll is at -1 for over 25 people, -2 for a crowd of 100 or more, -3 for 1,000, -4 for 10,000, and so on.",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
+											"cr_adj": "action_penalty",
+											"cr": 12,
+											"base_points": -15,
+											"calc": {
+												"points": -15
+											}
+										},
+										{
+											"id": "t70UYQEHIj0dhaoZ1",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tK4QdVZYxGAd4cqr_"
+											},
+											"name": "Compulsive Gambling",
+											"reference": "B128",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"cr": 12,
 											"base_points": -5,
 											"calc": {
 												"points": -5
 											}
 										},
 										{
-											"id": "tRC91_7v0fyA9dMdv",
-											"name": "Code of Honor (Soldier's)",
-											"reference": "B127",
-											"notes": "An officer should be tough but fair, lead from the front, and look out for his men; an enlisted man should look out for his buddies and take care of his kit. Every soldier should be willing to fight and die for the honor of his unit, service, and country; follow orders; obey the “rules of war”; treat an honorable enemy with respect (a dishonorable enemy deserves a bullet); and wear the uniform with pride.",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"base_points": -10,
-											"calc": {
-												"points": -10
-											}
-										},
-										{
-											"id": "t7ukKaPNv1BorDRNp",
+											"id": "tBqlVD-1aYHlZgsSC",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tapWLsuN75Unedmwn"
+											},
 											"name": "Compulsive Carousing",
 											"reference": "B128",
 											"tags": [
@@ -193,308 +718,115 @@
 											}
 										},
 										{
-											"id": "t-T0lSjZEs1yaqube",
-											"name": "Compulsive Gambling",
-											"reference": "B128",
+											"id": "tIiagwe5CYbp4Xre1",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "txSrmgLB0M36uR802"
+											},
+											"name": "Code of Honor (Soldier's)",
+											"reference": "B127",
+											"notes": "An officer should be tough but fair, lead from the front, and look out for his men; an enlisted man should look out for his buddies and take care of his kit. Every soldier should be willing to fight and die for the honor of his unit, service, and country; follow orders; obey the “rules of war”; treat an honorable enemy with respect (a dishonorable enemy deserves a bullet); and wear the uniform with pride.",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
-											"cr": 12,
-											"base_points": -5,
-											"calc": {
-												"points": -5
-											}
-										},
-										{
-											"id": "ti3RiRtq9nPK0v5io",
-											"name": "Duty (To ship's owner or provider)",
-											"reference": "B133",
-											"tags": [
-												"Disadvantage",
-												"Social"
-											],
-											"modifiers": [
-												{
-													"id": "m-M38BS96FPqWBL6K",
-													"name": "FR: 6",
-													"cost": -2,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m_fqYiMzf3E9ut0cq",
-													"name": "FR: 9",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mRkdDNt56TAJDf6Xf",
-													"name": "FR: 12",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mZUfvNjT21aTPq5Kf",
-													"name": "FR: 15",
-													"cost": -15,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mohgSDT2XiCJbDHvW",
-													"name": "Extremely Hazardous",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mWQTg_CK4GvX7bynM",
-													"name": "Involuntary",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mzduH1ETssoYd2JfF",
-													"name": "Nonhazardous",
-													"cost": 5,
-													"cost_type": "points",
-													"disabled": true
-												}
-											],
-											"calc": {
-												"points": 0
-											}
-										},
-										{
-											"id": "teu-awNkggtA0FKKe",
-											"name": "Enemy (@Who@)",
-											"reference": "B135",
-											"tags": [
-												"Disadvantage",
-												"Social"
-											],
-											"modifiers": [
-												{
-													"id": "mliM3_PGP10hDaszb",
-													"name": "Weak Individual",
-													"reference": "B135",
-													"notes": "50% of your starting points",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mtg63e0R3hyXqz2Y8",
-													"name": "Equal Individual",
-													"reference": "B135",
-													"notes": "100% of your starting points",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "moUPCixldnSnQ4sFy",
-													"name": "Powerful Individual",
-													"reference": "B135",
-													"notes": "\u003e150% of your starting points",
-													"cost": -20,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mVdgmSzxpl8w1iAZL",
-													"name": "Weak Group",
-													"reference": "B135",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m7K7ppgsQcLmdQqPa",
-													"name": "Medium Group",
-													"reference": "B135",
-													"cost": -20,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mNc4Vpucxp4IAiGnM",
-													"name": "Appears almost all the time",
-													"reference": "B36",
-													"notes": "15-",
-													"cost": 3,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mCsWio0sDvApTR8AY",
-													"name": "Appears quite often",
-													"reference": "B36",
-													"notes": "12-",
-													"cost": 2,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "m9H2DoLwr1bWvnGqv",
-													"name": "Appears fairly often",
-													"reference": "B36",
-													"notes": "9-",
-													"cost": 1,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mGnUyDeQZ74b1ApRl",
-													"name": "Appears quite rarely",
-													"reference": "B36",
-													"notes": "6-",
-													"cost": 0.5,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mY4gkES-VunvNYtQW",
-													"name": "Large/Powerful Group",
-													"reference": "B135",
-													"cost": -30,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m-IyePRxHhUX7x357",
-													"name": "Utterly Formidable Group",
-													"reference": "B135",
-													"cost": -40,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mqnvqNwbWdZ7XECM-",
-													"name": "Unknown",
-													"reference": "B135",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m8kmqa8ikghNtO4cW",
-													"name": "Evil Twin",
-													"reference": "B135",
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m1O2l3MIxRxkEp9DG",
-													"name": "Evil Twin",
-													"reference": "B135",
-													"notes": "More skilled or extra abilities",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mjQCsKrw3awm8p197",
-													"name": "Evil Twin",
-													"reference": "B135",
-													"notes": "More skilled and extra abilities",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mHwRv9WzT1U62asOL",
-													"name": "Watcher",
-													"reference": "B135",
-													"cost": 0.25,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mr9glD9hRHq-4mjQf",
-													"name": "Rival",
-													"reference": "B135",
-													"cost": 0.5,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mi1T4bQ-MzqpID3aw",
-													"name": "Hunter",
-													"reference": "B135",
-													"cost": 1,
-													"cost_type": "multiplier",
-													"disabled": true
-												}
-											],
-											"calc": {
-												"points": 0
-											}
-										},
-										{
-											"id": "tm2Xi51HXRAXBqfyM",
-											"name": "Honesty",
-											"reference": "B138",
-											"notes": "Make a self-control roll when faced with the “need” to break unreasonable laws; if you fail, you must obey the law, whatever the consequences. If you manage to resist your urges and break the law, make a second self-control roll afterward. If you fail, you must turn yourself in to the authorities!",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"cr": 12,
 											"base_points": -10,
 											"calc": {
 												"points": -10
 											}
 										},
 										{
-											"id": "t0X3bNW2JBGYoHFEa",
-											"name": "Intolerance (@Rival civilization or species@)",
-											"reference": "B140",
+											"id": "tTrjnQ-XoMbdIB7Of",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Space/Space Traits.adq",
+												"id": "teNSsqOsjstajwmxn"
+											},
+											"name": "Code of Honor (Mercenary's Code)",
+											"reference": "B127, S221",
+											"notes": "A merc should look out for his buddies, take care of his gear, and fight for the honor of the unit. Obey the rules of engagement. Don’t poach on another unit’s contract. Do the job you’re hired for.",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
-											"modifiers": [
-												{
-													"id": "mffove01EwK1vrOLV",
-													"name": "Scope: Common",
-													"reference": "B140",
-													"cost": -5,
-													"cost_type": "points"
-												},
-												{
-													"id": "m7fedkTqyCwAmkZQ-",
-													"name": "Scope: Occasional",
-													"reference": "B140",
-													"cost": -2,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mGePI6uzoXz-PMxB6",
-													"name": "Scope: Rare",
-													"reference": "B140",
-													"cost": -1,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mv3LID5H4hrxYw1Lu",
-													"name": "Scope: Anyone unlike you",
-													"reference": "B140",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												}
+											"base_points": -10,
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "t4nHylCMmkpy7Kvrm",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tqq24I9NJrLajsURv"
+											},
+											"name": "Code of Honor (Pirate's)",
+											"reference": "B127",
+											"notes": "Always avenge an insult, regardless of the danger; your buddy’s foe is your own; never attack a fellow crewman or buddy except in a fair, open duel.",
+											"tags": [
+												"Disadvantage",
+												"Mental"
 											],
+											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										},
+										{
+											"id": "tM5XvMY67360gSM0x",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t4KGpV0KBExr-fEb2"
+											},
+											"name": "Gregarious",
+											"reference": "B126",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"base_points": -10,
 											"features": [
 												{
 													"type": "reaction_bonus",
-													"situation": "from victims of your intolerance (may be as much as -5, at GM's discretion)",
+													"situation": "to others",
+													"amount": 4
+												},
+												{
+													"type": "conditional_modifier",
+													"situation": "to IQ-based skills when alone, or only -1 if in a group of 4 or less",
+													"amount": -2
+												}
+											],
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "tcETgKoIEOnANXJxY",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tzBDG0xUlT_dh7FuY"
+											},
+											"name": "Chummy",
+											"reference": "B126",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"base_points": -5,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "to others",
+													"amount": 2
+												},
+												{
+													"type": "conditional_modifier",
+													"situation": "to IQ-based skills when alone",
 													"amount": -1
 												}
 											],
@@ -503,91 +835,12 @@
 											}
 										},
 										{
-											"id": "tPkXqTwBJaQmPX4RZ",
-											"name": "Lecherousness",
-											"reference": "B142",
-											"notes": "Make a self-control roll whenever you have more than the briefest contact with an appealing member of the sex you find attractive, at -5 if this person is Handsome/Beautiful, or at -10 if Very Handsome/Very Beautiful. If you fail, you must make a “pass” using whatever wiles and skills you can bring to bear.",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"cr": 12,
-											"base_points": -15,
-											"calc": {
-												"points": -15
-											}
-										},
-										{
-											"id": "tnB1V2OAEsRJNyRjx",
-											"name": "Pacifism: Reluctant Killer",
-											"reference": "B148",
-											"notes": "You are psychologically unprepared to kill people. Whenever you make a deadly attack (e.g., with a knife or a gun) against an obvious person whose face is visible to you, you are at -4 to hit and may not Aim. If you cannot see the foe’s face (due to a mask, darkness, or distance, or because you attacked from behind), the penalty is only -2, save in close combat. You have no penalty to attack a vehicle (even an occupied one), an opponent you do not believe is a person (including things with Horrific or Monstrous appearance), or a target you can’t actually see (e.g., a set of map coordinates or a blip on a radar screen). If you kill a recognizable person, the effect on you is the same as for Pacifism: Cannot Kill. You have no problem with your allies killing; you may even supply ammo, loaded weapons, and encouragement! You just can’t do the killing yourself.",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"modifiers": [
-												{
-													"id": "m2UhCY-9NpzH2IlLJ",
-													"name": "Species-Specific",
-													"reference": "UT32",
-													"cost": -80,
-													"disabled": true
-												}
-											],
-											"base_points": -5,
-											"calc": {
-												"points": -5
-											}
-										},
-										{
-											"id": "tzxfSfIJPwh5OWIb1",
-											"name": "Pacifism: Self-Defense Only",
-											"reference": "B148",
-											"notes": "You only fight to defend yourself or those in your care, using only as much force as necessary (no pre-emptive strikes allowed!). You must do your best to discourage others from starting fights.",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"modifiers": [
-												{
-													"id": "mL5pZGZpn-Gq2c5a1",
-													"name": "Species-Specific",
-													"reference": "UT32",
-													"cost": -80,
-													"disabled": true
-												}
-											],
-											"base_points": -15,
-											"calc": {
-												"points": -15
-											}
-										},
-										{
-											"id": "t4FPJZaL3Hklj-PXu",
-											"name": "Pacifism: Cannot Harm Innocents",
-											"reference": "B148",
-											"notes": "You may fight – you may even start fights – but you may only use deadly force on a foe that is attempting to do you serious harm. Capture is not “serious harm” unless you are already under penalty of death or have a Code of Honor that would require suicide if captured. You never intentionally do anything that causes, or even threatens to cause, injury to the uninvolved – particularly if they are “ordinary folks.”",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"modifiers": [
-												{
-													"id": "mSN9N2otzloCT305X",
-													"name": "Species-Specific",
-													"reference": "UT32",
-													"cost": -80,
-													"disabled": true
-												}
-											],
-											"base_points": -10,
-											"calc": {
-												"points": -10
-											}
-										},
-										{
-											"id": "tE9SdK-vFVRH1C_br",
+											"id": "tgsEJcTSjjwwt_D8s",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "taFPI7E0PJwXbS5nL"
+											},
 											"name": "Agoraphobia (Open Spaces)",
 											"reference": "B150",
 											"notes": "You are uncomfortable whenever you are outside, and actually become frightened when there are no walls within 50 feet.",
@@ -601,116 +854,10 @@
 											"calc": {
 												"points": -10
 											}
-										},
-										{
-											"id": "t_mVV8mYEZ2Dg7uJm",
-											"name": "Demophobia (Crowds)",
-											"reference": "B149",
-											"notes": "Any group of over a dozen people sets off this fear unless they are all well known to you. The self-control roll is at -1 for over 25 people, -2 for a crowd of 100 or more, -3 for 1,000, -4 for 10,000, and so on.",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"cr_adj": "action_penalty",
-											"cr": 12,
-											"base_points": -15,
-											"calc": {
-												"points": -15
-											}
-										},
-										{
-											"id": "ttEdMGDJobRf86zwO",
-											"name": "Duty (To ship's owner or provider)",
-											"reference": "B133",
-											"tags": [
-												"Disadvantage",
-												"Social"
-											],
-											"modifiers": [
-												{
-													"id": "meIS4QJEiUf2H2DkA",
-													"name": "FR: 6",
-													"cost": -2,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mU9ML2pJqfni6op5m",
-													"name": "FR: 9",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m4IMCiXAwsJMxqy-g",
-													"name": "FR: 12",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mIBGfHMTEDClS4Q7Q",
-													"name": "FR: 15",
-													"cost": -15,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "maJATfd9mbmEpTvm9",
-													"name": "Extremely Hazardous",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mlKVtXIP-yLIHnqRA",
-													"name": "Involuntary",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mcLL1m49aewFpzbVU",
-													"name": "Nonhazardous",
-													"cost": 5,
-													"cost_type": "points",
-													"disabled": true
-												}
-											],
-											"calc": {
-												"points": 0
-											}
-										},
-										{
-											"id": "tC36SsrrwmxLrJDEd",
-											"name": "Workaholic",
-											"reference": "B162",
-											"tags": [
-												"Disadvantage",
-												"Physical"
-											],
-											"base_points": -5,
-											"calc": {
-												"points": -5
-											}
-										},
-										{
-											"id": "tQ4XJgwrokXG_1099",
-											"name": "Xenophilia",
-											"reference": "B162",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"cr": 12,
-											"base_points": -10,
-											"calc": {
-												"points": -10
-											}
 										}
 									],
 									"calc": {
-										"points": -145
+										"points": -180
 									}
 								},
 								{
@@ -797,7 +944,121 @@
 									}
 								},
 								{
-									"id": "t8BRn77R4WmIpBuF8",
+									"id": "to4Tt7uYMxbc9gWDQ",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tC7vHppsCtZue1RiC"
+									},
+									"name": "Addiction (@Substance@)",
+									"reference": "B122",
+									"tags": [
+										"Disadvantage",
+										"Mental",
+										"Physical"
+									],
+									"replacements": {
+										"Substance": "VR"
+									},
+									"modifiers": [
+										{
+											"id": "M1_FKs9VKAUZ1bCj6",
+											"name": "Legality Modifiers",
+											"children": [
+												{
+													"id": "mbPjF0T9p1Vjz7lPs",
+													"name": "Illegal",
+													"reference": "B122",
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "misuNBF4z_QtxMJQb",
+													"name": "Legal",
+													"reference": "B122",
+													"cost": 5,
+													"cost_type": "points"
+												}
+											]
+										},
+										{
+											"id": "MQ_k290LoL3DHKI3Y",
+											"name": "Cost Modifiers",
+											"children": [
+												{
+													"id": "mzrez2X-ME6ngkitF",
+													"name": "Cheap",
+													"reference": "B122",
+													"cost": -5,
+													"cost_type": "points"
+												},
+												{
+													"id": "mYeZgXC14h-XUa0c1",
+													"name": "Expensive",
+													"reference": "B122",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m-atJvGhxBhEueW80",
+													"name": "Very Expensive",
+													"reference": "B122",
+													"cost": -20,
+													"cost_type": "points",
+													"disabled": true
+												}
+											]
+										},
+										{
+											"id": "Mh726Qb0n3dfNBubL",
+											"name": "Effect Modifiers",
+											"children": [
+												{
+													"id": "mDrvgXpGjTICPAn6g",
+													"name": "Highly Addictive (-5 on withdrawal roll)",
+													"reference": "B122",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mB9YohWlklFR09gCA",
+													"name": "Totally Addictive (-10 on withdrawal roll)",
+													"reference": "B122",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mEOLyoR804pLxGFSh",
+													"name": "Hallucinogenic",
+													"reference": "B122",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mGB7Qj9rMiT4VjKEU",
+													"name": "Incapacitating",
+													"reference": "B122",
+													"cost": -10,
+													"cost_type": "points"
+												}
+											]
+										}
+									],
+									"calc": {
+										"points": -10
+									}
+								},
+								{
+									"id": "to2bGsIv3uGhyMfn6",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "ttlpxHmhTlHZvLehl"
+									},
 									"name": "Clueless",
 									"reference": "B126",
 									"tags": [
@@ -817,7 +1078,7 @@
 										},
 										{
 											"type": "reaction_bonus",
-											"situation": "from others",
+											"situation": "from others aware of your clueless nature",
 											"amount": -2
 										},
 										{
@@ -831,9 +1092,14 @@
 									}
 								},
 								{
-									"id": "t8SzAMiES8lxCDvPz",
-									"name": "Code of Honor (Hacker)",
-									"reference": "B127,S221",
+									"id": "tCwmc155GY0XUxyvZ",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Space/Space Traits.adq",
+										"id": "tt1z2cl4UeCBv-z0y"
+									},
+									"name": "Code of Honor (Hacker's Code)",
+									"reference": "B127, S221",
 									"notes": "Never steal money. Share information. Don’t use your skills to harm people. Clever work is better than brute force.",
 									"tags": [
 										"Disadvantage",
@@ -845,7 +1111,12 @@
 									}
 								},
 								{
-									"id": "tW9pTIPduyZEYLh3k",
+									"id": "tupdeamiww6I8BDFq",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t2O8gMxbRPpAWLej9"
+									},
 									"name": "Curious",
 									"reference": "B129",
 									"notes": "Make a self-control roll when presented with an interesting item or situation",
@@ -860,7 +1131,12 @@
 									}
 								},
 								{
-									"id": "tMwWToc2Uctq1ylEv",
+									"id": "tHmmTB8NB_1v5a_d2",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tYNyLy2IqVVc5zHut"
+									},
 									"name": "Oblivious",
 									"reference": "B146",
 									"tags": [
@@ -934,7 +1210,12 @@
 									}
 								},
 								{
-									"id": "tzpWA3MkiT98_8flj",
+									"id": "tim0WUbISJPe7SbFY",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "twYBwZGOG4EPwmpOx"
+									},
 									"name": "Slow Riser",
 									"reference": "B155",
 									"tags": [
@@ -964,7 +1245,12 @@
 									}
 								},
 								{
-									"id": "toTAe6WQNWniKy_l7",
+									"id": "t-hP6YTGkHlx2fY02",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "trz9QJbCgpzx7SYZt"
+									},
 									"name": "Squeamish",
 									"reference": "B156",
 									"tags": [
@@ -979,12 +1265,12 @@
 								}
 							],
 							"calc": {
-								"points": -195
+								"points": -240
 							}
 						}
 					],
 					"calc": {
-						"points": -195
+						"points": -240
 					}
 				},
 				{
@@ -992,13 +1278,53 @@
 					"name": "Class Advantages",
 					"children": [
 						{
-							"id": "t6u902OEcmm4lRHMb",
+							"id": "tS-nE5plontblEuBx",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "tqoCYR-O1ke1yxxex"
+							},
 							"name": "Talent (Circuit Sense)",
 							"reference": "PU3:8",
 							"tags": [
 								"Advantage",
 								"Mental",
 								"Talent"
+							],
+							"modifiers": [
+								{
+									"id": "MgGVkz2Yl2EKYesL1",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "mITOiXI80KSGufmYg",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From anyone for whom you use your skills.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "m5VBl_AMUX7utBPS1",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Less-severe penalties from Familiarity (p. B169) – which can run to -10 in certain cases (see p. B189) – when using any skill to operate unfamiliar gear that runs on electricity.",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
+								}
 							],
 							"points_per_level": 5,
 							"features": [
@@ -1041,18 +1367,6 @@
 									},
 									"amount": 1,
 									"per_level": true
-								},
-								{
-									"type": "reaction_bonus",
-									"situation": "From anyone for whom you use your skills.",
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "conditional_modifier",
-									"situation": "Less-severe penalties from Familiarity (p. B169) – which can run to -10 in certain cases (see p. B189) – when using any skill to operate unfamiliar gear that runs on electricity.",
-									"amount": 1,
-									"per_level": true
 								}
 							],
 							"can_level": true,
@@ -1062,85 +1376,20 @@
 							}
 						},
 						{
-							"id": "tERlnelvnVaWBjya3",
-							"name": "Compartmentalized Mind",
-							"reference": "B43,PSI13",
+							"id": "tMBKvoNKBs8sHZ1W1",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Template Toolkit/Template Toolkit 3 - Starship Crew/Starship Crew Traits.adq",
+								"id": "thmdPLVO-wMIpvPf6"
+							},
+							"name": "Compartmentalized Mind (Multi-Tasking)",
+							"reference": "TT3:5, B43",
+							"notes": "Reduces the number of mundane tasks you're doing at the same time by this level when assessing multi-tasking penalties.",
 							"tags": [
 								"Advantage",
-								"Exotic",
 								"Mental"
 							],
-							"modifiers": [
-								{
-									"id": "mU9pTqZXplM5tYYRV",
-									"name": "Massively Parallel",
-									"reference": "SU26",
-									"cost": 20,
-									"disabled": true
-								},
-								{
-									"id": "mBHmOf9Xf9v_WZVP6",
-									"name": "Controls",
-									"reference": "B43",
-									"cost": -25,
-									"cost_type": "points",
-									"affects": "base_only",
-									"disabled": true
-								},
-								{
-									"id": "mA0cNJf791lR7L6rW",
-									"name": "Dedicated Controls",
-									"reference": "B43",
-									"cost": -40,
-									"cost_type": "points",
-									"affects": "base_only",
-									"disabled": true
-								},
-								{
-									"id": "m1s-aIsNMorSVYI3a",
-									"name": "Limited, One Ability",
-									"reference": "PSI13",
-									"notes": "@Ability@",
-									"cost": -30,
-									"disabled": true
-								},
-								{
-									"id": "mws02hOZW6gtFqeX0",
-									"name": "Limited, One Power",
-									"reference": "PSI13",
-									"notes": "@Power@",
-									"cost": -20,
-									"disabled": true
-								},
-								{
-									"id": "moFbjwjhov9GuUaBw",
-									"name": "Mental Separation Only",
-									"reference": "PSI13",
-									"cost": -80,
-									"disabled": true
-								},
-								{
-									"id": "mduB9NZjskpSH_9-c",
-									"name": "Mentalism",
-									"reference": "PSI14",
-									"cost": -10,
-									"disabled": true
-								},
-								{
-									"id": "mm7CSyQgF6_qpAfm7",
-									"name": "No Mental Separation",
-									"reference": "PSI14",
-									"cost": -20,
-									"disabled": true
-								},
-								{
-									"id": "ms90vOEUp6UHfdaBQ",
-									"name": "Multi-Tasking",
-									"reference": "TT3:5",
-									"cost": -50
-								}
-							],
-							"points_per_level": 50,
+							"points_per_level": 25,
 							"can_level": true,
 							"levels": 1,
 							"calc": {
@@ -1148,7 +1397,12 @@
 							}
 						},
 						{
-							"id": "tVB7XjX-zalmSf_vu",
+							"id": "tOQmh3Bf11HBpLQXW",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tw1Ad0oSMw2ATM4X1"
+							},
 							"name": "Language: @Language@",
 							"reference": "B24",
 							"tags": [
@@ -1156,9 +1410,26 @@
 								"Language",
 								"Mental"
 							],
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Language Talent"
+										},
+										"level": {
+											"compare": "at_least"
+										}
+									}
+								]
+							},
 							"modifiers": [
 								{
-									"id": "mn_3KMllNJzAxA81d",
+									"id": "meDkr3X96acadbJ_2",
 									"name": "Native",
 									"reference": "B23",
 									"cost": -6,
@@ -1166,7 +1437,7 @@
 									"disabled": true
 								},
 								{
-									"id": "mmTZmyAdHcqT3A5UD",
+									"id": "mYs-IvHDEDC0PcvJD",
 									"name": "Spoken",
 									"reference": "B24",
 									"notes": "None",
@@ -1174,7 +1445,7 @@
 									"disabled": true
 								},
 								{
-									"id": "mkVs_QN8jCLjQxeue",
+									"id": "magWkuwxLyIWY-2qa",
 									"name": "Spoken",
 									"reference": "B24",
 									"notes": "Broken",
@@ -1183,15 +1454,16 @@
 									"disabled": true
 								},
 								{
-									"id": "m_46kYOTCibzh-ZD8",
+									"id": "mGOG3oY1hq_ty5tZ4",
 									"name": "Spoken",
 									"reference": "B24",
 									"notes": "Accented",
 									"cost": 2,
-									"cost_type": "points"
+									"cost_type": "points",
+									"disabled": true
 								},
 								{
-									"id": "mMcoZbAutXV9UZCJs",
+									"id": "m1Z2uKe3OUV47dVtD",
 									"name": "Spoken",
 									"reference": "B24",
 									"notes": "Native",
@@ -1199,7 +1471,7 @@
 									"cost_type": "points"
 								},
 								{
-									"id": "m2uR-jUoY7u3VbaUA",
+									"id": "mTqNk2CQs0KGDGIcX",
 									"name": "Written",
 									"reference": "B24",
 									"notes": "None",
@@ -1207,7 +1479,7 @@
 									"disabled": true
 								},
 								{
-									"id": "mgzXkah5GN5NZQL8q",
+									"id": "mXjScDGVyL4WwnMKZ",
 									"name": "Written",
 									"reference": "B24",
 									"notes": "Broken",
@@ -1216,15 +1488,16 @@
 									"disabled": true
 								},
 								{
-									"id": "mw_j5KkCgpZi2mLLf",
+									"id": "mC_Jg4qEzWGgRL6al",
 									"name": "Written",
 									"reference": "B24",
 									"notes": "Accented",
 									"cost": 2,
-									"cost_type": "points"
+									"cost_type": "points",
+									"disabled": true
 								},
 								{
-									"id": "mfB3KuAmK8NAcB334",
+									"id": "mO8n9RUvRiyHIq309",
 									"name": "Written",
 									"reference": "B24",
 									"notes": "Native",
@@ -1233,7 +1506,7 @@
 								}
 							],
 							"calc": {
-								"points": 10
+								"points": 6
 							}
 						},
 						{
@@ -1241,24 +1514,37 @@
 							"name": "30 Points chosen from",
 							"children": [
 								{
-									"id": "TwEWCansINdX5tKHe",
+									"id": "TN4kcwS5MciO1NNgU",
 									"name": "Everyman Advantages",
 									"children": [
 										{
-											"id": "t8vN-ldXjIsa6E3RG",
-											"name": "Suit Familiarity (Vacc Suit)",
+											"id": "t8ej5Jtvsr25KUdHu",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Power Ups/Power Ups Traits.adq",
+												"id": "t3RCXCI5W-zjvxaf-"
+											},
+											"name": "Suit Familiarity (@Environment Suit skill@)",
 											"reference": "PU2:9",
 											"tags": [
 												"Perk",
 												"Physical"
 											],
+											"replacements": {
+												"Environment Suit skill": "Vacc Suit"
+											},
 											"base_points": 1,
 											"calc": {
 												"points": 1
 											}
 										},
 										{
-											"id": "tMw7Bx1tvM2avXRu-",
+											"id": "tj_RNyk_zeygzgnvp",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tkiJQ7nfyi9aAdGHK"
+											},
 											"name": "Serendipity",
 											"reference": "B83,P73",
 											"tags": [
@@ -1267,17 +1553,24 @@
 											],
 											"modifiers": [
 												{
-													"id": "mE6hSkGRKWnibd4Ih",
+													"id": "mVU6sSJEyN8Gvb_fj",
 													"name": "Wishing",
 													"reference": "P73",
 													"cost": 100,
 													"disabled": true
 												},
 												{
-													"id": "mBCRiRQ7Fy8u4dSrU",
+													"id": "m2AQaAsV40MRFK_Qm",
 													"name": "Wishing",
 													"reference": "P73",
 													"notes": "For others only",
+													"disabled": true
+												},
+												{
+													"id": "m7g5ZRbNfrct2fjtL",
+													"name": "Game Time",
+													"reference": "P108",
+													"notes": "Uses per game week equal to its maximum possible uses per session",
 													"disabled": true
 												}
 											],
@@ -1289,8 +1582,13 @@
 											}
 										},
 										{
-											"id": "t9N4enB1Aq9GGNJq3",
-											"name": "Resistant to Acceleration",
+											"id": "tZdd-AXaPeBsF-q1w",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tJTfFdHM7YI5IZR7I"
+											},
+											"name": "Resistant",
 											"reference": "B81,P71,MA47",
 											"tags": [
 												"Advantage",
@@ -1298,7 +1596,7 @@
 											],
 											"modifiers": [
 												{
-													"id": "mu__5Pb_QgQ2XES3C",
+													"id": "mCd7Z304tA0Z3nwVj",
 													"name": "@Very Common: Metabolic Hazards, etc.@",
 													"reference": "B80",
 													"cost": 30,
@@ -1306,7 +1604,7 @@
 													"disabled": true
 												},
 												{
-													"id": "myO8NzJtMWJb4u8JI",
+													"id": "mzQX-im9beyMAA8O5",
 													"name": "@Common: Poison, Sickness, etc.@",
 													"reference": "B81",
 													"cost": 15,
@@ -1314,7 +1612,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m7SzZbnQTTjDTy6-Z",
+													"id": "mlpH5QgLLL94Po7ql",
 													"name": "@Occasional: Disease, Ingested Poison, etc.@",
 													"reference": "B81",
 													"cost": 10,
@@ -1322,14 +1620,17 @@
 													"disabled": true
 												},
 												{
-													"id": "mnF_n4gcsoNSa4u-n",
+													"id": "mFdZBGB4iADPhNIAD",
 													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
 													"reference": "B81",
+													"replacements": {
+														"Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.": "Space Sickness"
+													},
 													"cost": 5,
 													"cost_type": "points"
 												},
 												{
-													"id": "mlNWc5WsZaMJ-90n0",
+													"id": "mcsFlvxVdT3o7czXx",
 													"name": "Immunity",
 													"reference": "B81",
 													"cost": 1,
@@ -1337,152 +1638,14 @@
 													"disabled": true
 												},
 												{
-													"id": "m-9OCwOveJNO8mfW9",
-													"name": "+8 to all HT rolls to resist",
-													"reference": "B81",
-													"cost": 0.5,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mAlFWd1NDi25xehLs",
-													"name": "+3 to all HT rolls to resist",
-													"reference": "B81",
-													"cost": 0.33,
-													"cost_type": "multiplier"
-												}
-											],
-											"round_down": true,
-											"calc": {
-												"points": 1
-											}
-										},
-										{
-											"id": "ta1WzkYuZQc0zfDZ-",
-											"name": "Resistant to Space Sickness",
-											"reference": "B81,P71,MA47",
-											"tags": [
-												"Advantage",
-												"Physical"
-											],
-											"modifiers": [
-												{
-													"id": "mVTUn5sYtQMmIxi-R",
-													"name": "@Very Common: Metabolic Hazards, etc.@",
-													"reference": "B80",
-													"cost": 30,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m9CU8p6T--YiZwc4V",
-													"name": "@Common: Poison, Sickness, etc.@",
-													"reference": "B81",
-													"cost": 15,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mvi92rCLnaAWyJuhT",
-													"name": "@Occasional: Disease, Ingested Poison, etc.@",
-													"reference": "B81",
-													"cost": 10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mzVDB-UlkppbAWOBW",
-													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
-													"reference": "B81",
-													"cost": 5,
-													"cost_type": "points"
-												},
-												{
-													"id": "mJJjuAK-WPeTQ3oMo",
-													"name": "Immunity",
-													"reference": "B81",
-													"cost": 1,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "meUzmo4hzKO6m2jIQ",
-													"name": "+8 to all HT rolls to resist",
-													"reference": "B81",
-													"cost": 0.5,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mSKe1xN_4HbmtssLr",
-													"name": "+3 to all HT rolls to resist",
-													"reference": "B81",
-													"cost": 0.33,
-													"cost_type": "multiplier"
-												}
-											],
-											"round_down": true,
-											"calc": {
-												"points": 1
-											}
-										},
-										{
-											"id": "tJsIU5_h-JChloh7E",
-											"name": "Resistant to Space Sickness",
-											"reference": "B81,P71,MA47",
-											"tags": [
-												"Advantage",
-												"Physical"
-											],
-											"modifiers": [
-												{
-													"id": "mRFwz37Ez2geZAI0r",
-													"name": "@Very Common: Metabolic Hazards, etc.@",
-													"reference": "B80",
-													"cost": 30,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mTibtgfnKuK7prFrk",
-													"name": "@Common: Poison, Sickness, etc.@",
-													"reference": "B81",
-													"cost": 15,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mU7xYaC4AWjA562z7",
-													"name": "@Occasional: Disease, Ingested Poison, etc.@",
-													"reference": "B81",
-													"cost": 10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m9GocmfuF95Qa9Dyz",
-													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
-													"reference": "B81",
-													"cost": 5,
-													"cost_type": "points"
-												},
-												{
-													"id": "mM1rOfbmigTbc6mnP",
-													"name": "Immunity",
-													"reference": "B81",
-													"cost": 1,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mL1-sVr1_Qz8XptzE",
+													"id": "m5cPwCRppSIDJZ1hi",
 													"name": "+8 to all HT rolls to resist",
 													"reference": "B81",
 													"cost": 0.5,
 													"cost_type": "multiplier"
 												},
 												{
-													"id": "mmtXQGs_P0aSQgVU7",
+													"id": "moSGOgtt0JEtG3SOY",
 													"name": "+3 to all HT rolls to resist",
 													"reference": "B81",
 													"cost": 0.33,
@@ -1496,8 +1659,167 @@
 											}
 										},
 										{
-											"id": "toTM6GGLMuml7vLEA",
-											"name": "Reputation",
+											"id": "tmAa6rcorQpeP7zig",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tJTfFdHM7YI5IZR7I"
+											},
+											"name": "Resistant",
+											"reference": "B81,P71,MA47",
+											"tags": [
+												"Advantage",
+												"Physical"
+											],
+											"modifiers": [
+												{
+													"id": "mnrUnEyf42uKfTs6j",
+													"name": "@Very Common: Metabolic Hazards, etc.@",
+													"reference": "B80",
+													"cost": 30,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mcBcIx1S6kVk-DRNh",
+													"name": "@Common: Poison, Sickness, etc.@",
+													"reference": "B81",
+													"cost": 15,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mzvucJo4tx9Z4nXsZ",
+													"name": "@Occasional: Disease, Ingested Poison, etc.@",
+													"reference": "B81",
+													"cost": 10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m6nziE5P9yXl0sUFC",
+													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+													"reference": "B81",
+													"replacements": {
+														"Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.": "Space Sickness"
+													},
+													"cost": 5,
+													"cost_type": "points"
+												},
+												{
+													"id": "mszXrv2BQHzblIKKX",
+													"name": "Immunity",
+													"reference": "B81",
+													"cost": 1,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mLjLmwRg04MXSspF2",
+													"name": "+8 to all HT rolls to resist",
+													"reference": "B81",
+													"cost": 0.5,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mkN-IgTSFp8pTSx40",
+													"name": "+3 to all HT rolls to resist",
+													"reference": "B81",
+													"cost": 0.33,
+													"cost_type": "multiplier"
+												}
+											],
+											"round_down": true,
+											"calc": {
+												"points": 1
+											}
+										},
+										{
+											"id": "ts8ryt1N0Br9tVdYM",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tJTfFdHM7YI5IZR7I"
+											},
+											"name": "Resistant",
+											"reference": "B81,P71,MA47",
+											"tags": [
+												"Advantage",
+												"Physical"
+											],
+											"modifiers": [
+												{
+													"id": "mOB3JMMQrOo5v0wiI",
+													"name": "@Very Common: Metabolic Hazards, etc.@",
+													"reference": "B80",
+													"cost": 30,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "maDJDsOStha9zEhi2",
+													"name": "@Common: Poison, Sickness, etc.@",
+													"reference": "B81",
+													"cost": 15,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mhMQ2jotN_mYd7e59",
+													"name": "@Occasional: Disease, Ingested Poison, etc.@",
+													"reference": "B81",
+													"cost": 10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mon2m-iSYfnyoYF7R",
+													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+													"reference": "B81",
+													"replacements": {
+														"Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.": "Acceleration"
+													},
+													"cost": 5,
+													"cost_type": "points"
+												},
+												{
+													"id": "myunWuLqbL-RAXjXp",
+													"name": "Immunity",
+													"reference": "B81",
+													"cost": 1,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "m4NWLXu2_ghw-PwGY",
+													"name": "+8 to all HT rolls to resist",
+													"reference": "B81",
+													"cost": 0.5,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "m1RYyF0z2ruZQaqap",
+													"name": "+3 to all HT rolls to resist",
+													"reference": "B81",
+													"cost": 0.33,
+													"cost_type": "multiplier"
+												}
+											],
+											"round_down": true,
+											"calc": {
+												"points": 1
+											}
+										},
+										{
+											"id": "t50l-leNjeY2GJDhG",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "ta04iFiZ_Kw0s0juj"
+											},
+											"name": "Good Reputation",
 											"reference": "B26,MA54",
 											"tags": [
 												"Advantage",
@@ -1505,7 +1827,7 @@
 											],
 											"modifiers": [
 												{
-													"id": "mNuE3G13zNAu8_dwi",
+													"id": "mWdh-ECHvLu1NEjij",
 													"name": "People Affected",
 													"reference": "B27",
 													"notes": "Almost everyone",
@@ -1514,7 +1836,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mPHUq75nf2xLNjner",
+													"id": "maoLgf3t8pWjHy7b1",
 													"name": "People Affected",
 													"reference": "B27",
 													"notes": "Almost everyone except @large class of people@",
@@ -1523,7 +1845,7 @@
 													"disabled": true
 												},
 												{
-													"id": "meWZ7noHkQPTaliVW",
+													"id": "m0q4dH8VjRIqHXafT",
 													"name": "People Affected",
 													"reference": "B27",
 													"notes": "@Large class of people@",
@@ -1532,7 +1854,7 @@
 													"disabled": true
 												},
 												{
-													"id": "msBNrq4mCD4OjTY2m",
+													"id": "mTdnLf7ODg7RlwGDm",
 													"name": "People Affected",
 													"reference": "B27",
 													"notes": "@Small class of people@",
@@ -1541,7 +1863,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m3DgRawshqQTIyMoX",
+													"id": "mJRiVSK_sCQEiemi_",
 													"name": "Recognized all the time",
 													"reference": "B28",
 													"cost": 1,
@@ -1549,7 +1871,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mjz_np9bnjwT2htQy",
+													"id": "mFu3GsGFOYRMZm9Hn",
 													"name": "Recognized sometimes",
 													"reference": "B28",
 													"notes": "10-",
@@ -1558,7 +1880,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m4-Xg8kYejQgT1ffP",
+													"id": "mgrgCRDNQOKV-o0BI",
 													"name": "Recognized occasionally",
 													"reference": "B28",
 													"notes": "7-",
@@ -1568,6 +1890,14 @@
 												}
 											],
 											"points_per_level": 5,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others aware of your reputation",
+													"amount": 1,
+													"per_level": true
+												}
+											],
 											"round_down": true,
 											"can_level": true,
 											"levels": 1,
@@ -1576,16 +1906,24 @@
 											}
 										},
 										{
-											"id": "tbdqADXs3EBxuudzs",
-											"name": "Military Rank",
+											"id": "tHgNIr9ApWRfZA1T-",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tmp8yecgaZq9TOk59"
+											},
+											"name": "@Type@ Rank",
 											"reference": "B29",
 											"tags": [
 												"Advantage",
-												"Physical"
+												"Social"
 											],
+											"replacements": {
+												"Type": "Military"
+											},
 											"modifiers": [
 												{
-													"id": "mhxFNDvDX4odd8sya",
+													"id": "mzUqLaAR0-R3LWzcd",
 													"name": "Replaces Status",
 													"reference": "B29",
 													"cost": 5,
@@ -1594,7 +1932,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mrjCF_uAU0DqE2Nb5",
+													"id": "mwWdxSwJ3PwzhSvIu",
 													"name": "Courtesy",
 													"reference": "B29",
 													"cost": -4,
@@ -1611,16 +1949,24 @@
 											}
 										},
 										{
-											"id": "to8OafcTiRnP0zBio",
-											"name": "Merchant Rank",
+											"id": "timO2h0uUt34ynNrg",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tmp8yecgaZq9TOk59"
+											},
+											"name": "@Type@ Rank",
 											"reference": "B29",
 											"tags": [
 												"Advantage",
-												"Physical"
+												"Social"
 											],
+											"replacements": {
+												"Type": "Merchant"
+											},
 											"modifiers": [
 												{
-													"id": "mbOJ-F28XDIbzixeE",
+													"id": "mHZcfO0AU8Ul5-UXC",
 													"name": "Replaces Status",
 													"reference": "B29",
 													"cost": 5,
@@ -1629,7 +1975,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m5_fwISueApnL1_RB",
+													"id": "mR4If_3ZHac4dMQkA",
 													"name": "Courtesy",
 													"reference": "B29",
 													"cost": -4,
@@ -1646,17 +1992,21 @@
 											}
 										},
 										{
-											"id": "tdGAARexfpcs-asul",
+											"id": "tEQ9cCKBlMVzsAj4K",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t6Nq6oInwkU1qbAP1"
+											},
 											"name": "Patron",
 											"reference": "B72,P65",
-											"notes": "Ship's owner or provider",
 											"tags": [
 												"Advantage",
 												"Social"
 											],
 											"modifiers": [
 												{
-													"id": "mNA8GdUVor0e8_uaO",
+													"id": "mYFNlznpl7ZX5W26P",
 													"name": "@Who: Individual with 150% of PC's starting points@",
 													"reference": "B72",
 													"cost": 10,
@@ -1664,7 +2014,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mM6Uvx_VGmjb7wV4b",
+													"id": "mQ2ckrdY7JOcmHXQP",
 													"name": "@Who: Organization with assets of at least 1000 times starting wealth@",
 													"reference": "B72",
 													"cost": 10,
@@ -1672,7 +2022,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mCWqeZexYFnb6vcOl",
+													"id": "mmtLUM8LEhCWDC1ES",
 													"name": "@Who: Individual with twice the PC's starting points@",
 													"reference": "B72",
 													"cost": 15,
@@ -1680,7 +2030,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mBFVVsINWweWOLbxz",
+													"id": "mTK64nmpXwtw7WGSX",
 													"name": "@Who: Organization with assets of at least 10000 times starting wealth@",
 													"reference": "B72",
 													"cost": 15,
@@ -1688,7 +2038,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mhxxwO0yfyUJL-hwZ",
+													"id": "mNjcD6iM_KtX76CrD",
 													"name": "@Who: An ultra-powerful individual@",
 													"reference": "B72",
 													"cost": 20,
@@ -1696,7 +2046,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mtflv8v3aA_N_aRSG",
+													"id": "m7YeUG5wtUzYByJNH",
 													"name": "@Who: Organization with assets of at least 100000 times starting wealth@",
 													"reference": "B72",
 													"cost": 20,
@@ -1704,7 +2054,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mFzqeOaHHNIu4-1Gr",
+													"id": "mnvJIefKSNO7R96p4",
 													"name": "@Who: Organization with assets of at least 1000000 times starting wealth@",
 													"reference": "B72",
 													"cost": 25,
@@ -1712,7 +2062,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mhC-FxRQJ9gF2a6wO",
+													"id": "mMZ7B9rm9t-nbt7zq",
 													"name": "@Who: A national government or giant multi-national organization@",
 													"reference": "B72",
 													"cost": 30,
@@ -1720,7 +2070,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mSLNnY4Z4vagfQEIN",
+													"id": "maVucrqLbyXXXO2y8",
 													"name": "@Who: A deity@",
 													"reference": "B72",
 													"cost": 30,
@@ -1728,7 +2078,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m83yAYSMN-izv3AUk",
+													"id": "mWrfLLBc_cBdvpZlZ",
 													"name": "Appears almost all the time",
 													"reference": "B36",
 													"notes": "15-",
@@ -1737,7 +2087,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m0ruxClvb-pphq1jp",
+													"id": "m4zgfB-ftu7FvqcJt",
 													"name": "Appears quite often",
 													"reference": "B36",
 													"notes": "12-",
@@ -1746,7 +2096,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mRtMEi_zwULeNqv57",
+													"id": "mvq6C-0dZ9ZfsfudD",
 													"name": "Appears fairly often",
 													"reference": "B36",
 													"notes": "9-",
@@ -1755,7 +2105,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mGIAn50GBh4d1dq6I",
+													"id": "mRp6OZTbMn78XHJsL",
 													"name": "Appears quite rarely",
 													"reference": "B36",
 													"notes": "6-",
@@ -1764,7 +2114,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mJotB3FnwG5rTCJSl",
+													"id": "muc9FjZFK59TVFivX",
 													"name": "Equipment",
 													"reference": "B73",
 													"notes": "@Equipment worth no more than average starting wealth@",
@@ -1772,7 +2122,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mWEjUZYzAA0qnaYr5",
+													"id": "mvQ0HZ8n56gEo8Evl",
 													"name": "Equipment",
 													"reference": "B73",
 													"notes": "@Equipment worth more than average starting wealth@",
@@ -1780,14 +2130,14 @@
 													"disabled": true
 												},
 												{
-													"id": "maV794Qvgt-y-GWDm",
+													"id": "mGhh273U3I1pWiKp8",
 													"name": "Highly Accessible",
 													"reference": "B73",
 													"cost": 50,
 													"disabled": true
 												},
 												{
-													"id": "mIRNX2JdvLQqM-2Mo",
+													"id": "mMs9AuT_RxAbE-5BR",
 													"name": "Special Abilities",
 													"reference": "B73",
 													"notes": "@Extensive social or political power@",
@@ -1795,7 +2145,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mGR5fechvrRyjobyk",
+													"id": "mtG-oNS9p79s1UuqX",
 													"name": "Special Abilities",
 													"reference": "B73",
 													"notes": "@Magical powers in a non-magical world, higher TL equipment, grants special powers or is supernatural@",
@@ -1803,28 +2153,28 @@
 													"disabled": true
 												},
 												{
-													"id": "mvbeEZYlejP2n1fbc",
+													"id": "mi29jycWMEkGa7dxN",
 													"name": "Minimal Interventions",
 													"reference": "B73",
 													"cost": -50,
 													"disabled": true
 												},
 												{
-													"id": "mVcKZBm9mF1Y8-Xek",
+													"id": "mxFrynGaVppQz954E",
 													"name": "Secret",
 													"reference": "B73",
 													"cost": -50,
 													"disabled": true
 												},
 												{
-													"id": "mZfJ5oc2g-LEStUae",
+													"id": "mKRW1ipg0vFNWI_3t",
 													"name": "Unwilling",
 													"reference": "B74",
 													"cost": -50,
 													"disabled": true
 												},
 												{
-													"id": "mZMLMs3Bpr8nkI2vS",
+													"id": "mX1ldNbVnR0L9qj-J",
 													"name": "Favor",
 													"reference": "B55",
 													"cost": 0.2,
@@ -1837,7 +2187,12 @@
 											}
 										},
 										{
-											"id": "tVDyZnAKVt8-pwZkZ",
+											"id": "t4oUGUqUZe1CGrv2S",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tz-USDL9B_KrrVqDi"
+											},
 											"name": "Luck",
 											"reference": "B66,P59",
 											"notes": "Usable once per hour of play",
@@ -1847,14 +2202,14 @@
 											],
 											"modifiers": [
 												{
-													"id": "munxKwdsjhBi-z_qb",
+													"id": "mtqxOQvc0X8EaGX-A",
 													"name": "Active",
 													"reference": "B66",
 													"cost": -40,
 													"disabled": true
 												},
 												{
-													"id": "mq5rh7CeNxJJvxQeS",
+													"id": "mQ--DnUsBZaKDAl3x",
 													"name": "Aspected",
 													"reference": "B66",
 													"notes": "@Aspect@",
@@ -1862,17 +2217,24 @@
 													"disabled": true
 												},
 												{
-													"id": "mdDKoPCCvefvV3vom",
+													"id": "mtomuqznhcDYTNGBJ",
 													"name": "Defensive",
 													"reference": "B66",
 													"cost": -20,
 													"disabled": true
 												},
 												{
-													"id": "mZPW7RRW6HRcPaFbB",
+													"id": "mK7xWzAdJfzZGzD_J",
 													"name": "Wishing",
 													"reference": "P59",
 													"cost": 100,
+													"disabled": true
+												},
+												{
+													"id": "mshk2M1B3UL-OKYFs",
+													"name": "Game Time",
+													"reference": "P108",
+													"notes": "Uses per game day equal to its maximum possible uses per real hour",
 													"disabled": true
 												}
 											],
@@ -1882,7 +2244,12 @@
 											}
 										},
 										{
-											"id": "tRIlob0lOeSP8B5l3",
+											"id": "tDGvdq6RXKZxkiKtt",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tMxgHfzVEy_QQtlfB"
+											},
 											"name": "Less Sleep",
 											"reference": "B65",
 											"notes": "Require 1 hour/level less sleep for a full night's rest (max 4)",
@@ -1898,7 +2265,12 @@
 											}
 										},
 										{
-											"id": "tMoe_w2HcUygXaDa-",
+											"id": "tPq6woUaNkfGUJ0Bo",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tw1Ad0oSMw2ATM4X1"
+											},
 											"name": "Language: @Language@",
 											"reference": "B24",
 											"tags": [
@@ -1906,9 +2278,26 @@
 												"Language",
 												"Mental"
 											],
+											"prereqs": {
+												"type": "prereq_list",
+												"all": true,
+												"prereqs": [
+													{
+														"type": "trait_prereq",
+														"has": false,
+														"name": {
+															"compare": "is",
+															"qualifier": "Language Talent"
+														},
+														"level": {
+															"compare": "at_least"
+														}
+													}
+												]
+											},
 											"modifiers": [
 												{
-													"id": "mAz4AxseKmucz8u6i",
+													"id": "mEg5kQDmqaMadTcii",
 													"name": "Native",
 													"reference": "B23",
 													"cost": -6,
@@ -1916,7 +2305,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m8PT2yZvVbQ8z-J7t",
+													"id": "mIxTt4prMghyqSKoE",
 													"name": "Spoken",
 													"reference": "B24",
 													"notes": "None",
@@ -1924,7 +2313,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mBMyQMo7RIcl4wcnh",
+													"id": "mK6kq6DBwIzqSji7z",
 													"name": "Spoken",
 													"reference": "B24",
 													"notes": "Broken",
@@ -1933,7 +2322,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m90xwgsbPCYZZP5iI",
+													"id": "mYSqVUCs1lDe7DcSj",
 													"name": "Spoken",
 													"reference": "B24",
 													"notes": "Accented",
@@ -1941,7 +2330,7 @@
 													"cost_type": "points"
 												},
 												{
-													"id": "mNz0MzMcGCM_fngUe",
+													"id": "m4uhDd8u59DCQTwFa",
 													"name": "Spoken",
 													"reference": "B24",
 													"notes": "Native",
@@ -1950,7 +2339,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m_Lv4DCijFRj6YJT8",
+													"id": "m54ZNResQDslT5WF_",
 													"name": "Written",
 													"reference": "B24",
 													"notes": "None",
@@ -1958,7 +2347,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mjfC4eobKm-s41iwd",
+													"id": "mStcmD-QLchMaDVey",
 													"name": "Written",
 													"reference": "B24",
 													"notes": "Broken",
@@ -1967,7 +2356,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mJ5HCv9O--gYN6oob",
+													"id": "mLJXJ_z0b7mHb_zma",
 													"name": "Written",
 													"reference": "B24",
 													"notes": "Accented",
@@ -1975,7 +2364,7 @@
 													"cost_type": "points"
 												},
 												{
-													"id": "mk0BXAjqkjXL31feE",
+													"id": "mE4j-DXhpf1x080Ua",
 													"name": "Written",
 													"reference": "B24",
 													"notes": "Native",
@@ -1989,7 +2378,12 @@
 											}
 										},
 										{
-											"id": "tR_MMIPJGMCI2mHiA",
+											"id": "ts416gtQ-0YKvGctB",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "txREhxV6L1SKixwe_"
+											},
 											"name": "Improved G-tolerance",
 											"reference": "B60",
 											"tags": [
@@ -1998,7 +2392,7 @@
 											],
 											"modifiers": [
 												{
-													"id": "mNNxdxFLZYcGjDPl0",
+													"id": "mF6pKfHyCkFj9RO_a",
 													"name": "0.3G",
 													"reference": "B60",
 													"cost": 5,
@@ -2006,7 +2400,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m67Nhv5aOqSxzgOxU",
+													"id": "mM8CdZnfQFNT1jq92",
 													"name": "0.5G",
 													"reference": "B60",
 													"cost": 10,
@@ -2014,7 +2408,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mWq36ON0ZWYBVOjIt",
+													"id": "mlKf6mecix0OoQowQ",
 													"name": "1G",
 													"reference": "B60",
 													"cost": 15,
@@ -2022,7 +2416,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mLzMzf2xvm92lHnm_",
+													"id": "mrIC-PL5K0O0MaUOe",
 													"name": "5G",
 													"reference": "B60",
 													"cost": 20,
@@ -2030,7 +2424,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mp3CZ3Vqj9UJYxP9t",
+													"id": "miMcxVD8WiYks0BLF",
 													"name": "10G",
 													"reference": "B60",
 													"cost": 25,
@@ -2043,7 +2437,12 @@
 											}
 										},
 										{
-											"id": "tAMDfnL9WEWvq-o1P",
+											"id": "tsy9B6HTcuVtyaQdo",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t7blIRUzFpiHS_mnO"
+											},
 											"name": "Gizmo",
 											"reference": "B57,MA45",
 											"tags": [
@@ -2058,7 +2457,12 @@
 											}
 										},
 										{
-											"id": "tESOt67hIkOwXq8g0",
+											"id": "t-lYkVVVmRiFYbSQB",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tHNrjEQFQBNOgwmzK"
+											},
 											"name": "G-Experience (All)",
 											"reference": "B57",
 											"tags": [
@@ -2071,7 +2475,12 @@
 											}
 										},
 										{
-											"id": "tNdEIkkoSBqPxIUyZ",
+											"id": "tvvssFMxdHs0chZ8y",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tu3GuYC47Sx6bnm4k"
+											},
 											"name": "G-Experience",
 											"reference": "B57",
 											"tags": [
@@ -2086,7 +2495,12 @@
 											}
 										},
 										{
-											"id": "t9eVzseLK3FlN44ov",
+											"id": "tfKxjyoEbxV9cTD7f",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "toTe273Ky82B6YdW5"
+											},
 											"name": "Fit",
 											"reference": "B55",
 											"notes": "Recover FP at twice the normal rate (but not FP spent for spells or psi powers)",
@@ -2107,7 +2521,12 @@
 											}
 										},
 										{
-											"id": "tJI_3nsdNxTpSXLww",
+											"id": "t1XdcuVbq2M1ASYuE",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tQa3EUrs4Hjt9gxK6"
+											},
 											"name": "Fearlessness",
 											"reference": "B55,MA44",
 											"tags": [
@@ -2144,7 +2563,12 @@
 											}
 										},
 										{
-											"id": "t54Iu4aghaG7x2DmT",
+											"id": "tpLFTb2m2upSkajlz",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t5j2Ox4jaIV9j0rpz"
+											},
 											"name": "Deep Sleeper",
 											"reference": "B101",
 											"tags": [
@@ -2157,7 +2581,12 @@
 											}
 										},
 										{
-											"id": "tVYgxYMCPIxDK5k4g",
+											"id": "tikHSCQosfgECQGlk",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tNBE3sLoyrUvAgoZ3"
+											},
 											"name": "Cybernetics",
 											"reference": "B46",
 											"tags": [
@@ -2169,7 +2598,12 @@
 											}
 										},
 										{
-											"id": "tupUjNln3ZUx1Ynnj",
+											"id": "tWhkVLMq37_9wD-ms",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "toXBQ8q4Nek5lsLPF"
+											},
 											"name": "Cultural Familiarity (@Culture@)",
 											"reference": "B23",
 											"notes": "Do not suffer the normal -3 penalty for unfamiliarity",
@@ -2179,14 +2613,14 @@
 											],
 											"modifiers": [
 												{
-													"id": "mvFqtkDFuDrm52OPh",
+													"id": "m5FLYQp8ZMaSDeAqf",
 													"name": "Alien",
 													"cost": 1,
 													"cost_type": "points",
 													"disabled": true
 												},
 												{
-													"id": "mBOBrizsFlXVzCayI",
+													"id": "mmsmiIBg-YLsGT6_y",
 													"name": "Native",
 													"cost": -1,
 													"cost_type": "points",
@@ -2199,9 +2633,14 @@
 											}
 										},
 										{
-											"id": "tLkBtsXF8o3PqyfpU",
-											"name": "Alien Friend",
-											"reference": "S220",
+											"id": "tdZeI26CK5X5QusVH",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Power Ups/Power Ups Traits.adq",
+												"id": "t3msobZZ06J7dZ8xu"
+											},
+											"name": "Talent (Born Spacer)",
+											"reference": "PU3:7",
 											"tags": [
 												"Advantage",
 												"Mental",
@@ -2209,106 +2648,60 @@
 											],
 											"modifiers": [
 												{
-													"id": "mB2igUNmDhJSqYJhy",
-													"name": "Alternate Benefit",
-													"notes": "@Alternate Benefit@",
-													"disabled": true
-												},
-												{
-													"id": "mf0upfnDUfq3cwexj",
+													"id": "mi8NfghXMTcWhhDWt",
 													"name": "Alternative Cost",
+													"cost": 1,
 													"cost_type": "points",
 													"affects": "levels_only",
 													"disabled": true
-												}
-											],
-											"points_per_level": 5,
-											"features": [
-												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "Anthropology"
-													},
-													"amount": 1,
-													"per_level": true
 												},
 												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "Diplomacy"
-													},
-													"amount": 1,
-													"per_level": true
-												},
-												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "Expert Skill"
-													},
-													"amount": 1,
-													"per_level": true
-												},
-												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "History"
-													},
-													"amount": 1,
-													"per_level": true
-												},
-												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "Psychology"
-													},
-													"amount": 1,
-													"per_level": true
-												},
-												{
-													"type": "reaction_bonus",
-													"situation": "Aliens",
-													"amount": 1,
-													"per_level": true
-												}
-											],
-											"can_level": true,
-											"levels": 1,
-											"calc": {
-												"points": 5
-											}
-										},
-										{
-											"id": "t4rJJPPd-m2Pzm1VU",
-											"name": "Born Spacer",
-											"reference": "THSCT40",
-											"tags": [
-												"Advantage",
-												"Mental",
-												"Talent"
-											],
-											"modifiers": [
-												{
-													"id": "mdwIW5fOGqZ_sjv_W",
-													"name": "Alternate Benefit",
-													"notes": "@Alternate Benefit@",
-													"disabled": true
-												},
-												{
-													"id": "mZ4-q4St8PVOW6Yxc",
-													"name": "Alternative Cost",
-													"cost_type": "points",
-													"affects": "levels_only",
-													"disabled": true
+													"id": "MV8OPGSzo6R_jzWE7",
+													"name": "Benefits",
+													"children": [
+														{
+															"id": "mUTSEt8xbPAZUTP2U",
+															"name": "Reaction Bonus",
+															"use_level_from_trait": true,
+															"features": [
+																{
+																	"type": "reaction_bonus",
+																	"situation": "From professional Spacers.",
+																	"amount": 1,
+																	"per_level": true
+																}
+															]
+														},
+														{
+															"id": "mFuLRPtkvSIMUvWVW",
+															"name": "Bonus to pushing off",
+															"reference": "BX350",
+															"reference_highlight": "ST/2",
+															"use_level_from_trait": true,
+															"features": [
+																{
+																	"type": "conditional_modifier",
+																	"situation": "Bonus to ST for zero G push off",
+																	"amount": 1,
+																	"per_level": true
+																}
+															],
+															"disabled": true
+														},
+														{
+															"id": "m96FjJpHjnZDlg1Lk",
+															"name": "Spacecraft Familiarity",
+															"use_level_from_trait": true,
+															"features": [
+																{
+																	"type": "conditional_modifier",
+																	"situation": "Counteracts Familiarity for spacecraft.",
+																	"amount": 1
+																}
+															],
+															"disabled": true
+														}
+													]
 												}
 											],
 											"points_per_level": 5,
@@ -2340,6 +2733,10 @@
 														"compare": "is",
 														"qualifier": "Navigation"
 													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "Space"
+													},
 													"amount": 1,
 													"per_level": true
 												},
@@ -2351,8 +2748,36 @@
 														"qualifier": "Piloting"
 													},
 													"specialization": {
-														"compare": "contains",
-														"qualifier": "Spacecraft"
+														"compare": "is",
+														"qualifier": "High-Performance Spacecraft"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Piloting"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "Low-Performance Spacecraft"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Piloting"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "Aerospace"
 													},
 													"amount": 1,
 													"per_level": true
@@ -2376,10 +2801,99 @@
 													},
 													"amount": 1,
 													"per_level": true
+												}
+											],
+											"can_level": true,
+											"levels": 1,
+											"calc": {
+												"points": 5
+											}
+										},
+										{
+											"id": "tx-OaxjAaXCEPiplo",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Power Ups/Power Ups Traits.adq",
+												"id": "tcCw979nTBoztowCU"
+											},
+											"name": "Talent (Alien Friend)",
+											"reference": "PU3:6",
+											"tags": [
+												"Advantage",
+												"Mental",
+												"Talent"
+											],
+											"points_per_level": 5,
+											"features": [
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Diplomacy"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Expert Skill"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "Xenology"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Anthropology"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "@Alien@"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "History"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "@Alien@"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Psychology"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "@Alien@"
+													},
+													"amount": 1,
+													"per_level": true
 												},
 												{
 													"type": "reaction_bonus",
-													"situation": "Professional Spacers",
+													"situation": "From aliens.",
 													"amount": 1,
 													"per_level": true
 												}
@@ -2391,7 +2905,12 @@
 											}
 										},
 										{
-											"id": "tXCUV04O8ru888fPU",
+											"id": "tiuojaWebVt_-PIt5",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tM6z7Mx6e2V4VvUR4"
+											},
 											"name": "Absolute Direction",
 											"reference": "B34",
 											"tags": [
@@ -2401,14 +2920,14 @@
 											],
 											"modifiers": [
 												{
-													"id": "mSERMHSbzqfZXUIy8",
+													"id": "m3J4nvpJskMDlqnij",
 													"name": "Requires signal",
 													"reference": "B34",
 													"cost": -20,
 													"disabled": true
 												},
 												{
-													"id": "mPwKIciwEQo9P65Al",
+													"id": "mYiaNz8i3YpLzOlYa",
 													"name": "3D Spatial Sense",
 													"reference": "B34",
 													"cost": 5,
@@ -2531,7 +3050,12 @@
 									}
 								},
 								{
-									"id": "t0RZcv2c5aapk55yy",
+									"id": "tkSd8H0xaE4lSJL_A",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t6XtSYhM7yan5_B73"
+									},
 									"name": "Acute Hearing",
 									"reference": "B35",
 									"tags": [
@@ -2554,7 +3078,12 @@
 									}
 								},
 								{
-									"id": "th6eZKECXj3l7UVBV",
+									"id": "tib462kKuEb245P8t",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tpefZX7zoFMtZULZj"
+									},
 									"name": "Talent (Born to Be Wired)",
 									"reference": "PU3:8",
 									"tags": [
@@ -2564,12 +3093,59 @@
 									],
 									"modifiers": [
 										{
-											"id": "m0tHBJk2pM7rBsSO1",
+											"id": "muaDIcnIumi_AIMgY",
 											"name": "Alternative Cost",
 											"cost": 1,
 											"cost_type": "points",
 											"affects": "levels_only",
 											"disabled": true
+										},
+										{
+											"id": "MsN6kDmn9zSLUzmh4",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "mWH2i0Vv_7aun9sYy",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From hackers; people buying stock in your dot-com.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "mf-sSaBPfqPWxPcho",
+													"name": "Familiarity",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Less-severe penalties from Familiarity (p. B169) for unfamiliar computer equipment,",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mBTKkHreoFiviKcvM",
+													"name": "Improvised Software",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Success at Computer Hacking or Computer Programming lets you improvise code that removes -1/level from the penalty for not having proper software for a task that requires it (p. B345).",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
 										}
 									],
 									"points_per_level": 5,
@@ -2633,18 +3209,6 @@
 											},
 											"amount": 1,
 											"per_level": true
-										},
-										{
-											"type": "reaction_bonus",
-											"situation": "From hackers; people buying stock in your dot-com.",
-											"amount": 1,
-											"per_level": true
-										},
-										{
-											"type": "conditional_modifier",
-											"situation": "Less-severe penalties from Familiarity (p. B169) for unfamiliar computer equipment, and/or success at Computer Hacking or Computer Programming lets you improvise code that removes -1/level from the penalty for not having proper software for a task that requires it (p. B345).",
-											"amount": 1,
-											"per_level": true
 										}
 									],
 									"can_level": true,
@@ -2654,13 +3218,53 @@
 									}
 								},
 								{
-									"id": "t_f68oOdtdI-n9iDt",
+									"id": "tXzmjQdcI0lqOOUrY",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tqoCYR-O1ke1yxxex"
+									},
 									"name": "Talent (Circuit Sense)",
 									"reference": "PU3:8",
 									"tags": [
 										"Advantage",
 										"Mental",
 										"Talent"
+									],
+									"modifiers": [
+										{
+											"id": "MjTEZm5AQ-iFuEtHs",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "mf_0sYrg8_qOHuzcs",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From anyone for whom you use your skills.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "mHPKF8sZm_j3dsH30",
+													"name": "Alternative Benefit",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Less-severe penalties from Familiarity (p. B169) – which can run to -10 in certain cases (see p. B189) – when using any skill to operate unfamiliar gear that runs on electricity.",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
+										}
 									],
 									"points_per_level": 5,
 									"features": [
@@ -2703,18 +3307,6 @@
 											},
 											"amount": 1,
 											"per_level": true
-										},
-										{
-											"type": "reaction_bonus",
-											"situation": "From anyone for whom you use your skills.",
-											"amount": 1,
-											"per_level": true
-										},
-										{
-											"type": "conditional_modifier",
-											"situation": "Less-severe penalties from Familiarity (p. B169) – which can run to -10 in certain cases (see p. B189) – when using any skill to operate unfamiliar gear that runs on electricity.",
-											"amount": 1,
-											"per_level": true
 										}
 									],
 									"can_level": true,
@@ -2724,7 +3316,12 @@
 									}
 								},
 								{
-									"id": "tH5_LqQfsfYHT67mf",
+									"id": "trAX-01vDQ4mub0L8",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tqetdf5KErUAWx7CS"
+									},
 									"name": "Talent (Computer Wizard)",
 									"reference": "PU3:9",
 									"tags": [
@@ -2734,12 +3331,45 @@
 									],
 									"modifiers": [
 										{
-											"id": "mW_AzC7nNd1D3DK1m",
+											"id": "mnPedA6UiAdESQ15g",
 											"name": "Alternative Cost",
 											"cost": 1,
 											"cost_type": "points",
 											"affects": "levels_only",
 											"disabled": true
+										},
+										{
+											"id": "MnKLk29azsmplifKb",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "ma3_7OYpWBqnQCkV0",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From computer professionals and AIs.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "mnFp-m08AEMrHlpFl",
+													"name": "Alternative Benefit",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Reduce Familiarity penalties for computers. Roll Hacking/Programming to improvise software to reduce equipment penalty.",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
 										}
 									],
 									"points_per_level": 5,
@@ -2832,18 +3462,6 @@
 												"qualifier": "AI"
 											},
 											"amount": 1
-										},
-										{
-											"type": "reaction_bonus",
-											"situation": "From computer professionals and AIs.",
-											"amount": 1,
-											"per_level": true
-										},
-										{
-											"type": "conditional_modifier",
-											"situation": "Reduce Familiarity penalties for computers. Roll Hacking/Programming to improvise software to reduce equipment penalty.",
-											"amount": 1,
-											"per_level": true
 										}
 									],
 									"can_level": true,
@@ -2853,7 +3471,12 @@
 									}
 								},
 								{
-									"id": "tcQSgYCUb1qT1Kg1h",
+									"id": "thJ9qlFaAddZf7thB",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tW-eAzIKBWa5Yc9cI"
+									},
 									"name": "Eidetic Memory",
 									"reference": "B51",
 									"tags": [
@@ -2862,7 +3485,7 @@
 									],
 									"modifiers": [
 										{
-											"id": "mWLDKFPBwuULuaR0-",
+											"id": "m4hOKondYPCq_V4SQ",
 											"name": "Photographic",
 											"reference": "B51",
 											"cost": 5,
@@ -2876,7 +3499,39 @@
 									}
 								},
 								{
-									"id": "tF4OwuWvngXkd5cFN",
+									"id": "tJlfJTH6FAmb8rfIz",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tW-eAzIKBWa5Yc9cI"
+									},
+									"name": "Eidetic Memory",
+									"reference": "B51",
+									"tags": [
+										"Advantage",
+										"Mental"
+									],
+									"modifiers": [
+										{
+											"id": "mK8Dn3l6jAGl7HZPt",
+											"name": "Photographic",
+											"reference": "B51",
+											"cost": 5,
+											"cost_type": "points"
+										}
+									],
+									"base_points": 5,
+									"calc": {
+										"points": 10
+									}
+								},
+								{
+									"id": "tl1atqAs62tKjAL4-",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tqseLS-LNinGOwJ2z"
+									},
 									"name": "Language Talent",
 									"reference": "B65",
 									"tags": [
@@ -2889,7 +3544,12 @@
 									}
 								},
 								{
-									"id": "tfktiEp90nOvjp3nm",
+									"id": "tmDjtou6qEex0cH7i",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t2vba3l0J2mCZM50M"
+									},
 									"name": "Voice",
 									"reference": "B97",
 									"tags": [
@@ -2982,17 +3642,17 @@
 								}
 							],
 							"calc": {
-								"points": 143
+								"points": 153
 							}
 						}
 					],
 					"calc": {
-						"points": 193
+						"points": 199
 					}
 				}
 			],
 			"calc": {
-				"points": 68
+				"points": 29
 			}
 		},
 		{
@@ -3005,7 +3665,12 @@
 					"name": "Multi-Role",
 					"children": [
 						{
-							"id": "t-ilDITM4hANylhrE",
+							"id": "tTYPMZATVQ7ANhTfw",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t1w1RFcFceKR2T9_e"
+							},
 							"name": "Increased Intelligence",
 							"reference": "B15",
 							"tags": [
@@ -3029,13 +3694,53 @@
 							}
 						},
 						{
-							"id": "t0oppqsOif5Vd3KZo",
+							"id": "t2s1Gz0Tn3FPj61Zk",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "tqoCYR-O1ke1yxxex"
+							},
 							"name": "Talent (Circuit Sense)",
 							"reference": "PU3:8",
 							"tags": [
 								"Advantage",
 								"Mental",
 								"Talent"
+							],
+							"modifiers": [
+								{
+									"id": "MGRLEANkxXiBp2oPZ",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "mb_kiI6k9VzotoWv9",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From anyone for whom you use your skills.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "m8qt4dDVeleywaF_D",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Less-severe penalties from Familiarity (p. B169) – which can run to -10 in certain cases (see p. B189) – when using any skill to operate unfamiliar gear that runs on electricity.",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
+								}
 							],
 							"points_per_level": 5,
 							"features": [
@@ -3076,18 +3781,6 @@
 										"compare": "is",
 										"qualifier": "Engineer (Electrical and Electronics)"
 									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "reaction_bonus",
-									"situation": "From anyone for whom you use your skills.",
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "conditional_modifier",
-									"situation": "Less-severe penalties from Familiarity (p. B169) – which can run to -10 in certain cases (see p. B189) – when using any skill to operate unfamiliar gear that runs on electricity.",
 									"amount": 1,
 									"per_level": true
 								}
@@ -3108,7 +3801,12 @@
 					"name": "Legendary",
 					"children": [
 						{
-							"id": "tkZ4x8J4SNXxU8DR_",
+							"id": "tIys_bPucBg3YWyxV",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t1w1RFcFceKR2T9_e"
+							},
 							"name": "Increased Intelligence",
 							"reference": "B15",
 							"tags": [
@@ -3132,13 +3830,53 @@
 							}
 						},
 						{
-							"id": "tjO3JR--07AfWT-wz",
+							"id": "trBTA3s7tKY3DRBUk",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "tqoCYR-O1ke1yxxex"
+							},
 							"name": "Talent (Circuit Sense)",
 							"reference": "PU3:8",
 							"tags": [
 								"Advantage",
 								"Mental",
 								"Talent"
+							],
+							"modifiers": [
+								{
+									"id": "MvtTd30PHUUqS6raa",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "meA6bNYMFnMJ4RDCm",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From anyone for whom you use your skills.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "mWRDjbpHgGBO2Vo5t",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Less-severe penalties from Familiarity (p. B169) – which can run to -10 in certain cases (see p. B189) – when using any skill to operate unfamiliar gear that runs on electricity.",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
+								}
 							],
 							"points_per_level": 5,
 							"features": [
@@ -3181,18 +3919,6 @@
 									},
 									"amount": 1,
 									"per_level": true
-								},
-								{
-									"type": "reaction_bonus",
-									"situation": "From anyone for whom you use your skills.",
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "conditional_modifier",
-									"situation": "Less-severe penalties from Familiarity (p. B169) – which can run to -10 in certain cases (see p. B189) – when using any skill to operate unfamiliar gear that runs on electricity.",
-									"amount": 1,
-									"per_level": true
 								}
 							],
 							"can_level": true,
@@ -3202,85 +3928,20 @@
 							}
 						},
 						{
-							"id": "teO6Y0UbLZ0ny-lJx",
-							"name": "Compartmentalized Mind",
-							"reference": "B43,PSI13",
+							"id": "tbaQnw9Wlkyfsaskm",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Template Toolkit/Template Toolkit 3 - Starship Crew/Starship Crew Traits.adq",
+								"id": "thmdPLVO-wMIpvPf6"
+							},
+							"name": "Compartmentalized Mind (Multi-Tasking)",
+							"reference": "TT3:5, B43",
+							"notes": "Reduces the number of mundane tasks you're doing at the same time by this level when assessing multi-tasking penalties.",
 							"tags": [
 								"Advantage",
-								"Exotic",
 								"Mental"
 							],
-							"modifiers": [
-								{
-									"id": "msVvWxE-5ewiyHddH",
-									"name": "Massively Parallel",
-									"reference": "SU26",
-									"cost": 20,
-									"disabled": true
-								},
-								{
-									"id": "mpXsYb0S-4GrP9BOu",
-									"name": "Controls",
-									"reference": "B43",
-									"cost": -25,
-									"cost_type": "points",
-									"affects": "base_only",
-									"disabled": true
-								},
-								{
-									"id": "mgBaYax38SScY_ENj",
-									"name": "Dedicated Controls",
-									"reference": "B43",
-									"cost": -40,
-									"cost_type": "points",
-									"affects": "base_only",
-									"disabled": true
-								},
-								{
-									"id": "mRFOunrFsHkPa7R6K",
-									"name": "Limited, One Ability",
-									"reference": "PSI13",
-									"notes": "@Ability@",
-									"cost": -30,
-									"disabled": true
-								},
-								{
-									"id": "mA0oD-VHLZ5gi_TZ1",
-									"name": "Limited, One Power",
-									"reference": "PSI13",
-									"notes": "@Power@",
-									"cost": -20,
-									"disabled": true
-								},
-								{
-									"id": "mlvxZv3ocHZtybeIJ",
-									"name": "Mental Separation Only",
-									"reference": "PSI13",
-									"cost": -80,
-									"disabled": true
-								},
-								{
-									"id": "mk6pqHCdbfeLKbm42",
-									"name": "Mentalism",
-									"reference": "PSI14",
-									"cost": -10,
-									"disabled": true
-								},
-								{
-									"id": "mFaPmumVD4RdjI0oc",
-									"name": "No Mental Separation",
-									"reference": "PSI14",
-									"cost": -20,
-									"disabled": true
-								},
-								{
-									"id": "m-pdHxPzoKhg6-VeQ",
-									"name": "Multi-Tasking",
-									"reference": "TT3:5",
-									"cost": -50
-								}
-							],
-							"points_per_level": 50,
+							"points_per_level": 25,
 							"can_level": true,
 							"levels": 1,
 							"calc": {
@@ -3309,7 +3970,12 @@
 					"name": "Primary Skills",
 					"children": [
 						{
-							"id": "sJAdbMHm-1SCoPftP",
+							"id": "sZkumkJEoKhoJJk63",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "ssHhRG7LH-Ma3YDnH"
+							},
 							"name": "Computer Operation",
 							"reference": "B184",
 							"tags": [
@@ -3328,7 +3994,12 @@
 							"points": 4
 						},
 						{
-							"id": "shD-UEM88FpLDCd-f",
+							"id": "s4sEB_nJeDlRcRsra",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "swXuff1DBhSQbTqy1"
+							},
 							"name": "Electronics Operation",
 							"reference": "B189",
 							"tags": [
@@ -3363,7 +4034,12 @@
 							"points": 1
 						},
 						{
-							"id": "sWKh_evoNnICA3ER3",
+							"id": "sW0rOVjkbyUUziYGL",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sluTeYhSTpIbVNfA5"
+							},
 							"name": "Electronics Operation",
 							"reference": "B189",
 							"tags": [
@@ -3398,7 +4074,12 @@
 							"points": 1
 						},
 						{
-							"id": "s599-4vBoJZV0LWIU",
+							"id": "sHHCTi2mAIoeYHfCo",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "smQb4vkfHH6Aaczt2"
+							},
 							"name": "Electronics Repair",
 							"reference": "B190",
 							"tags": [
@@ -3434,7 +4115,12 @@
 							"points": 1
 						},
 						{
-							"id": "sB_hA5qnWwfEzgBrz",
+							"id": "sxTsBOzIrZgvgzJKr",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sqH7X8s6knQ9FmK-F"
+							},
 							"name": "Electronics Repair",
 							"reference": "B190",
 							"tags": [
@@ -3469,7 +4155,12 @@
 							"points": 1
 						},
 						{
-							"id": "si1ZVUriJBM9NIgTq",
+							"id": "sMdw9KrMiHKe72eYn",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sfGjvfoOWTcgmqI06"
+							},
 							"name": "Electronics Repair",
 							"reference": "B190",
 							"tags": [
@@ -3511,7 +4202,12 @@
 					"name": "Secondary Skills",
 					"children": [
 						{
-							"id": "s81DLY2IPXvA27HLu",
+							"id": "sWfey09zKyHP7Dnxh",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "stFawUEv8gxldDoiC"
+							},
 							"name": "Research",
 							"reference": "B217",
 							"tags": [
@@ -3601,10 +4297,15 @@
 								]
 							},
 							"tech_level": "",
-							"points": 1
+							"points": 2
 						},
 						{
-							"id": "s-6NpZAuOacSY57Hb",
+							"id": "sQcnA-5BN1wdaCEHN",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sBY-R7Xmf64T7WzZ4"
+							},
 							"name": "Computer Programming",
 							"reference": "B184",
 							"tags": [
@@ -3613,10 +4314,43 @@
 							],
 							"difficulty": "iq/h",
 							"tech_level": "",
-							"points": 1
+							"points": 4
 						},
 						{
-							"id": "s7apx2Lu601icT3X7",
+							"id": "ssVvdykeXd1nmauZd",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "s8j6tcaNxXkF89Xbt"
+							},
+							"name": "Diplomacy",
+							"reference": "B187",
+							"tags": [
+								"Business",
+								"Police",
+								"Social"
+							],
+							"difficulty": "iq/h",
+							"defaults": [
+								{
+									"type": "iq",
+									"modifier": -6
+								},
+								{
+									"type": "skill",
+									"name": "Politics",
+									"modifier": -6
+								}
+							],
+							"points": 4
+						},
+						{
+							"id": "s3t4CueeKUzhO6DMa",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "srkpvMJuu4TRxCcO7"
+							},
 							"name": "Expert Skill",
 							"reference": "B193,MA56",
 							"tags": [
@@ -3626,7 +4360,32 @@
 							],
 							"specialization": "Computer Security",
 							"difficulty": "iq/h",
-							"points": 1
+							"points": 4
+						},
+						{
+							"id": "sn-OC-fQ9DcW4hP-j",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sKEmDeUJja8G_ZlSV"
+							},
+							"name": "Cryptography",
+							"reference": "B186",
+							"tags": [
+								"Military",
+								"Spy"
+							],
+							"difficulty": "iq/h",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Mathematics",
+									"specialization": "Cryptology",
+									"modifier": -5
+								}
+							],
+							"tech_level": "",
+							"points": 2
 						}
 					]
 				},
@@ -3635,15 +4394,104 @@
 					"name": "Background Skills",
 					"children": [
 						{
+							"id": "sp6-YlBpxDicUSw8K",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "s7kVwKFERTuMYO3O8"
+							},
+							"name": "Free Fall",
+							"reference": "B197",
+							"tags": [
+								"Athletic"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "ht",
+									"modifier": -5
+								},
+								{
+									"type": "dx",
+									"modifier": -5
+								}
+							],
+							"points": 4
+						},
+						{
+							"id": "sz04ljrKWLeaTRhX1",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "s9IHT34mK8yfSB7d_"
+							},
+							"name": "Spacer",
+							"reference": "B185",
+							"tags": [
+								"Vehicle"
+							],
+							"difficulty": "iq/e",
+							"defaults": [
+								{
+									"type": "iq",
+									"modifier": -4
+								}
+							],
+							"tech_level": "",
+							"points": 1
+						},
+						{
+							"id": "sCTp56zeDufJ7riHT",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sAmDzPjf0rKZ6I5G1"
+							},
+							"name": "Vacc Suit",
+							"reference": "B192",
+							"tags": [
+								"Technical"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Diving Suit",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "NBC Suit",
+									"modifier": -2
+								},
+								{
+									"type": "skill",
+									"name": "Battlesuit",
+									"modifier": -2
+								}
+							],
+							"tech_level": "",
+							"points": 4
+						},
+						{
 							"id": "Slm-1r_--S6gqFn7-",
 							"name": "10 Points chosen from",
 							"children": [
 								{
-									"id": "STO5zIr0dnfMHpm5Y",
+									"id": "Se_ozY-GaR3eUgSEN",
 									"name": "Everyman Skills",
 									"children": [
 										{
-											"id": "sB4ygT6o_lxt7v6QZ",
+											"id": "so52d40OX5r-TGDXx",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sTXDrqXH0sT2NSD_b"
+											},
 											"name": "Area Knowledge",
 											"reference": "B176",
 											"notes": "Location of the capitals of interplanetary states and the homeworlds of major races; general awareness of all major races; knowledge of individuals of Status 8; general understanding of relations between interplanetary states",
@@ -3664,7 +4512,12 @@
 											"points": 1
 										},
 										{
-											"id": "s3qkfX0HQG-Skkw4s",
+											"id": "sr6bMu0-jMfL5taYu",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "s-Ckyxw5PmHIvbZab"
+											},
 											"name": "Area Knowledge",
 											"reference": "B176",
 											"notes": "Location of major planets; familiarity with all known races (but not necessarily expertise); knowledge of people of Status 7+; general understanding of the economic and political situation",
@@ -3672,13 +4525,9 @@
 												"Everyman",
 												"Knowledge"
 											],
-											"specialization": "@Interplanetary State@; Lived there",
+											"specialization": "@Interplanetary State@",
 											"difficulty": "iq/e",
 											"defaults": [
-												{
-													"type": "iq",
-													"modifier": -4
-												},
 												{
 													"type": "skill",
 													"name": "Geography",
@@ -3689,7 +4538,12 @@
 											"points": 1
 										},
 										{
-											"id": "ssUIC7A7yYb_bIvcx",
+											"id": "sLx8x-o2nvgDx8rbK",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "strhX4LEdd46xgmIS"
+											},
 											"name": "Area Knowledge",
 											"reference": "B176",
 											"notes": "Location of its major cities and important sites; awareness of its major customs, ethnic groups, and languages (but not necessarily expertise); names of folk of Status 7+; and a general understanding of the economic and political situation",
@@ -3697,13 +4551,9 @@
 												"Everyman",
 												"Knowledge"
 											],
-											"specialization": "@Planet@; Lived there",
+											"specialization": "@Planet@",
 											"difficulty": "iq/e",
 											"defaults": [
-												{
-													"type": "iq",
-													"modifier": -4
-												},
 												{
 													"type": "skill",
 													"name": "Geography",
@@ -3714,7 +4564,12 @@
 											"points": 1
 										},
 										{
-											"id": "sfTcqHr_MffhMJJ31",
+											"id": "sKZfxX97n6PoPJgKE",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sBJgeWUs81Ifhob4Z"
+											},
 											"name": "Beam Weapons",
 											"reference": "B179",
 											"tags": [
@@ -3745,7 +4600,12 @@
 											"points": 1
 										},
 										{
-											"id": "svB0WOhSY-nKDkqTZ",
+											"id": "sE1gRwT_J4ufX2KlX",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sOp4wssAMtUc1ukJI"
+											},
 											"name": "Body Language",
 											"reference": "B181",
 											"tags": [
@@ -3769,10 +4629,14 @@
 											"points": 1
 										},
 										{
-											"id": "s4lnxDj-c-qAg6j6C",
+											"id": "sRNUHNLDSEFa6wdcG",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sziMa9_9xTvR2iiqx"
+											},
 											"name": "Body Sense",
 											"reference": "B181",
-											"notes": "For settings with matter transmission",
 											"tags": [
 												"Athletic"
 											],
@@ -3791,7 +4655,12 @@
 											"points": 1
 										},
 										{
-											"id": "szaTyuSSAfeG8ShfQ",
+											"id": "s4qsUxtFruIbry5g8",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "shtDdl5thrvKSnJHf"
+											},
 											"name": "Brawling",
 											"reference": "B182,MA55",
 											"tags": [
@@ -3819,7 +4688,12 @@
 											"points": 1
 										},
 										{
-											"id": "s0NFCIqUY2lvvoOUX",
+											"id": "sl-83vv_eNEqaMo1b",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "si-upI7A5RgdO0cjC"
+											},
 											"name": "Carousing",
 											"reference": "B183",
 											"tags": [
@@ -3837,7 +4711,12 @@
 											"points": 1
 										},
 										{
-											"id": "suJ6EJNE_aQSHrE36",
+											"id": "sZg4KRQW--PIOPiix",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sWFtA7Gvclq4aL-Yb"
+											},
 											"name": "Current Affairs",
 											"reference": "B186",
 											"tags": [
@@ -3868,7 +4747,12 @@
 											"points": 1
 										},
 										{
-											"id": "seLh5U8xBp5yvc-i3",
+											"id": "sCZpBJ2F4CNmtNaoK",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "s9mV--3lpIfXO7N6Z"
+											},
 											"name": "First Aid",
 											"reference": "B195",
 											"tags": [
@@ -3899,7 +4783,12 @@
 											"points": 1
 										},
 										{
-											"id": "ssGUw5yDzNTVfWlF_",
+											"id": "srgbXGBMLjQVseG7j",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sWB9ypJAq43MF3O0n"
+											},
 											"name": "Gambling",
 											"reference": "B197",
 											"tags": [
@@ -3923,7 +4812,12 @@
 											"points": 1
 										},
 										{
-											"id": "slJD_g6HMWbEHACde",
+											"id": "sXwEkYHKip1kIoVk1",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "syfSQ9N8yETqQbhFK"
+											},
 											"name": "Games",
 											"reference": "B197,MA57",
 											"tags": [
@@ -3940,7 +4834,12 @@
 											"points": 1
 										},
 										{
-											"id": "s3_hzIYqPQ434Mdf1",
+											"id": "sFSN2c5k3f_hfEQ4d",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sGz21GskAlJXL1hYP"
+											},
 											"name": "Gesture",
 											"reference": "B198",
 											"tags": [
@@ -3956,7 +4855,12 @@
 											"points": 1
 										},
 										{
-											"id": "sCwQhaDRk9ohIiPLv",
+											"id": "stbJEajnimOohsDfO",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sT5htbz4-Mr0PFCk7"
+											},
 											"name": "Guns",
 											"reference": "B198",
 											"tags": [
@@ -3981,7 +4885,12 @@
 											"points": 1
 										},
 										{
-											"id": "snE5h9dvkEo_ePpZl",
+											"id": "sKhie9LWLyHU2QyFw",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sOtPessbzkRjGaQPR"
+											},
 											"name": "Hobby Skill",
 											"reference": "B200,MA57",
 											"tags": [
@@ -3998,7 +4907,12 @@
 											"points": 1
 										},
 										{
-											"id": "saVm2NqZaE9VA_UoT",
+											"id": "sVtrPue9eO1zsPIw6",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sDLf4crz0sGRjVDFi"
+											},
 											"name": "Hobby Skill",
 											"reference": "B200,MA57",
 											"tags": [
@@ -4015,7 +4929,12 @@
 											"points": 1
 										},
 										{
-											"id": "sU8zvP7AUjJX-f-Wm",
+											"id": "sM6rjr7Ovx97bDbj6",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sfZrwMVUibhbtdssl"
+											},
 											"name": "Housekeeping",
 											"reference": "B200",
 											"tags": [
@@ -4031,7 +4950,12 @@
 											"points": 1
 										},
 										{
-											"id": "s6hyq0aJeck5F7Mu_",
+											"id": "s67Xq9rq2Iescay8D",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sdl9m7gHE7hlMX0AX"
+											},
 											"name": "Lip Reading",
 											"reference": "B205",
 											"tags": [
@@ -4047,7 +4971,12 @@
 											"points": 1
 										},
 										{
-											"id": "szABZi8BR1Eo9J9yp",
+											"id": "s1Z7xweZGddqRfojf",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sx1CDkGBR830IZrmz"
+											},
 											"name": "Professional Skill",
 											"reference": "B215",
 											"tags": [
@@ -4064,7 +4993,12 @@
 											"points": 1
 										},
 										{
-											"id": "s0GUu2AIu9wZxAbq0",
+											"id": "s-Y-U-HFytVrzLD0T",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sBec-o4Z7gPpbg2f9"
+											},
 											"name": "Professional Skill",
 											"reference": "B215",
 											"tags": [
@@ -4081,7 +5015,12 @@
 											"points": 1
 										},
 										{
-											"id": "s97P7ePJk09x1pXyz",
+											"id": "sNUy59IfalaX5qtmy",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "smxkcngH5Kz54yeN3"
+											},
 											"name": "Sports",
 											"reference": "B222,MA59",
 											"tags": [
@@ -4098,7 +5037,12 @@
 											"points": 1
 										},
 										{
-											"id": "sX7LsDTN19_JGFYoX",
+											"id": "sTqnLHJTcOvFvIQEm",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "smTUpMWJGqPeT1KER"
+											},
 											"name": "Streetwise",
 											"reference": "B223",
 											"tags": [
@@ -4119,7 +5063,12 @@
 									]
 								},
 								{
-									"id": "sbB2OHJRRIYbkBi9H",
+									"id": "sPDqPnamMOEFm6maM",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "scAysIf1hcMnIL0Ca"
+									},
 									"name": "Electrician",
 									"reference": "B189",
 									"tags": [
@@ -4143,13 +5092,21 @@
 									"points": 1
 								},
 								{
-									"id": "syLA-GjWRYSAGxsnF",
+									"id": "sqOkmUWdEk4hnbeet",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sUOQKAH8IaMhpxk1o"
+									},
 									"name": "Electronics Operation",
 									"reference": "B189",
 									"tags": [
 										"Technical"
 									],
-									"specialization": "@Any other@",
+									"replacements": {
+										"Electronics type": "@Any other@"
+									},
+									"specialization": "@Electronics type@",
 									"difficulty": "iq/a",
 									"defaults": [
 										{
@@ -4178,14 +5135,22 @@
 									"points": 1
 								},
 								{
-									"id": "sZvS75LWUMv7iomMF",
+									"id": "szLKlbNy2LaiFBAtC",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sYwZvSMZ9tfHES4z7"
+									},
 									"name": "Electronics Repair",
 									"reference": "B190",
 									"tags": [
 										"Maintenance",
 										"Repair"
 									],
-									"specialization": "@Any other@",
+									"replacements": {
+										"Electronics type": "@Any other@"
+									},
+									"specialization": "@Electronics type@",
 									"difficulty": "iq/a",
 									"defaults": [
 										{
@@ -4214,7 +5179,108 @@
 									"points": 1
 								},
 								{
-									"id": "spwSkQQE_0n00M9i8",
+									"id": "s5EY4UU7JxGSlcMG3",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sMIEoVTEXT8J2IGwj"
+									},
+									"name": "Engineer",
+									"reference": "B190",
+									"tags": [
+										"Design",
+										"Engineer",
+										"Invention"
+									],
+									"specialization": "Electronics",
+									"difficulty": "iq/h",
+									"defaults": [
+										{
+											"type": "skill",
+											"name": "Electronics Repair",
+											"modifier": -6
+										}
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"when_tl": {
+											"compare": "at_least",
+											"qualifier": 5
+										},
+										"prereqs": [
+											{
+												"type": "skill_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "mathematics"
+												},
+												"specialization": {
+													"compare": "is",
+													"qualifier": "applied"
+												}
+											}
+										]
+									},
+									"tech_level": "",
+									"points": 1
+								},
+								{
+									"id": "sV6AbRhVAluSOhxdr",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "s1tGkNec9Plmq9fGX"
+									},
+									"name": "Engineer",
+									"reference": "B190",
+									"tags": [
+										"Design",
+										"Engineer",
+										"Invention"
+									],
+									"specialization": "Electrical",
+									"difficulty": "iq/h",
+									"defaults": [
+										{
+											"type": "skill",
+											"name": "Electrician",
+											"modifier": -6
+										}
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"when_tl": {
+											"compare": "at_least",
+											"qualifier": 5
+										},
+										"prereqs": [
+											{
+												"type": "skill_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "mathematics"
+												},
+												"specialization": {
+													"compare": "is",
+													"qualifier": "applied"
+												}
+											}
+										]
+									},
+									"tech_level": "",
+									"points": 1
+								},
+								{
+									"id": "sTFFY_vxbSX2C_pTD",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sgF2Eqa7ywSdRHR47"
+									},
 									"name": "Linguistics",
 									"reference": "B205",
 									"tags": [
@@ -4225,13 +5291,46 @@
 									"points": 1
 								},
 								{
-									"id": "s7XmJzIWLQkf4As7Z",
+									"id": "sk-zcYPUbTgUXCuhR",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sGj0s0Ofs7NkYOFsy"
+									},
 									"name": "Mathematics",
 									"reference": "B207",
 									"tags": [
 										"Natural Science"
 									],
-									"specialization": "@Applied, Computer Science, or Cryptology@",
+									"specialization": "Cryptology",
+									"difficulty": "iq/h",
+									"defaults": [
+										{
+											"type": "iq",
+											"modifier": -6
+										},
+										{
+											"type": "skill",
+											"name": "Cryptography",
+											"modifier": -5
+										}
+									],
+									"tech_level": "",
+									"points": 1
+								},
+								{
+									"id": "swjYCLzEkNnW13dwK",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sC4i1u83C2BZjqIDe"
+									},
+									"name": "Mathematics",
+									"reference": "B207",
+									"tags": [
+										"Natural Science"
+									],
+									"specialization": "Computer Science",
 									"difficulty": "iq/h",
 									"defaults": [
 										{
@@ -4241,6 +5340,39 @@
 										{
 											"type": "skill",
 											"name": "Computer Programming",
+											"modifier": -5
+										}
+									],
+									"tech_level": "",
+									"points": 1
+								},
+								{
+									"id": "sGlAdPzqgMWNrRr-k",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sGgBbCTe-AwY1nu3W"
+									},
+									"name": "Mathematics",
+									"reference": "B207",
+									"tags": [
+										"Natural Science"
+									],
+									"specialization": "Applied",
+									"difficulty": "iq/h",
+									"defaults": [
+										{
+											"type": "iq",
+											"modifier": -6
+										},
+										{
+											"type": "skill",
+											"name": "Physics",
+											"modifier": -5
+										},
+										{
+											"type": "skill",
+											"name": "Engineer",
 											"modifier": -5
 										}
 									],
@@ -4263,7 +5395,12 @@
 					"name": "Multi-Role",
 					"children": [
 						{
-							"id": "suTL5mhD0O7qZF8N5",
+							"id": "s0L8bL6rWqE0Yl5q2",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "swXuff1DBhSQbTqy1"
+							},
 							"name": "Electronics Operation",
 							"reference": "B189",
 							"tags": [
@@ -4298,7 +5435,12 @@
 							"points": 1
 						},
 						{
-							"id": "shplYEhS9qPLdSh4g",
+							"id": "sza2PSE4bwcgBXbjS",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sluTeYhSTpIbVNfA5"
+							},
 							"name": "Electronics Operation",
 							"reference": "B189",
 							"tags": [
@@ -4333,7 +5475,12 @@
 							"points": 1
 						},
 						{
-							"id": "s2f82LS4xLhoJTCwZ",
+							"id": "sDhXBlb8hRktJJPaC",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "smQb4vkfHH6Aaczt2"
+							},
 							"name": "Electronics Repair",
 							"reference": "B190",
 							"tags": [
@@ -4369,7 +5516,12 @@
 							"points": 1
 						},
 						{
-							"id": "sCzCUcRjjTidosvlf",
+							"id": "saJEfOM0qE8R3fNmr",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sqH7X8s6knQ9FmK-F"
+							},
 							"name": "Electronics Repair",
 							"reference": "B190",
 							"tags": [
@@ -4404,7 +5556,12 @@
 							"points": 1
 						},
 						{
-							"id": "sh6QKeBnEMRXoK5Ts",
+							"id": "sv4s0E-2YHtTZzK3F",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sfGjvfoOWTcgmqI06"
+							},
 							"name": "Electronics Repair",
 							"reference": "B190",
 							"tags": [
@@ -4440,7 +5597,12 @@
 							"points": 1
 						},
 						{
-							"id": "s4QfPxfdJNjLEwbMB",
+							"id": "sRWqo-MrNIaPzhspd",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sBY-R7Xmf64T7WzZ4"
+							},
 							"name": "Computer Programming",
 							"reference": "B184",
 							"tags": [
@@ -4452,7 +5614,12 @@
 							"points": 4
 						},
 						{
-							"id": "sUp5co3t0IhF3EXuC",
+							"id": "sWFTUfCC1gaxJA5-N",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "srkpvMJuu4TRxCcO7"
+							},
 							"name": "Expert Skill",
 							"reference": "B193,MA56",
 							"tags": [
@@ -4465,7 +5632,12 @@
 							"points": 4
 						},
 						{
-							"id": "sgdA2WRmiWtaOWRPB",
+							"id": "sz-sWRRFWEiWpU3Ro",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sKEmDeUJja8G_ZlSV"
+							},
 							"name": "Cryptography",
 							"reference": "B186",
 							"tags": [

--- a/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Science Officer.gct
+++ b/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Science Officer.gct
@@ -12,7 +12,12 @@
 					"name": "Attributes",
 					"children": [
 						{
-							"id": "tMsnZRJhCAHXn9tDZ",
+							"id": "tgGK-EdbDRU9BSTbG",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t1w1RFcFceKR2T9_e"
+							},
 							"name": "Increased Intelligence",
 							"reference": "B15",
 							"tags": [
@@ -36,7 +41,12 @@
 							}
 						},
 						{
-							"id": "t52QZazcjnhLTC5Tz",
+							"id": "tdOshLwExigh9lOPL",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tVt3SvdGWNchJ8z4o"
+							},
 							"name": "Increased Health",
 							"reference": "B14",
 							"tags": [
@@ -69,7 +79,12 @@
 					"name": "Class Advantages",
 					"children": [
 						{
-							"id": "to_MrpAxMcQ8JKhGE",
+							"id": "tGp8LtQI1TKlI7WO6",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "ttrmORiWbD1uv2rpD"
+							},
 							"name": "Talent (Natural Scientist)",
 							"reference": "PU3:13",
 							"tags": [
@@ -79,12 +94,45 @@
 							],
 							"modifiers": [
 								{
-									"id": "mtE-hJ2I64ivHSxmD",
+									"id": "m9SPoWYCvAx-2CBwl",
 									"name": "Alternative Cost",
 									"cost": 1,
 									"cost_type": "points",
 									"affects": "levels_only",
 									"disabled": true
+								},
+								{
+									"id": "M1r-qLj528_o8Md7V",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "mgykcVWvjRKutumVM",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From scientists and those impressed by \"smart people\".",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "m-H8IM_4L1q5F5KBr",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Reduce TL and familiarity penalties for gear examined for an hour with a covered skill",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
 								}
 							],
 							"points_per_level": 10,
@@ -218,18 +266,6 @@
 									},
 									"amount": 1,
 									"per_level": true
-								},
-								{
-									"type": "reaction_bonus",
-									"situation": "From scientists and those impressed by \"smart people\".",
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "conditional_modifier",
-									"situation": "Reduce TL and familiarity penalties for gear examined for an hour with a covered skill",
-									"amount": 1,
-									"per_level": true
 								}
 							],
 							"can_level": true,
@@ -243,24 +279,194 @@
 							"name": "30 Points chosen from",
 							"children": [
 								{
-									"id": "TFTqkqjDnImuEL67y",
+									"id": "T-t0AxZtnpsuDArex",
+									"name": "Better attributes",
+									"children": [
+										{
+											"id": "tuaKXurcc8PCPRXZU",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tGWOSEE6SmBHACE6Y"
+											},
+											"name": "Increased Dexterity",
+											"reference": "B15",
+											"tags": [
+												"Advantage",
+												"Attribute",
+												"Physical"
+											],
+											"modifiers": [
+												{
+													"id": "mbPVvopUo9Wf9a3y3",
+													"name": "No Fine Manipulators",
+													"cost": -40,
+													"disabled": true
+												}
+											],
+											"points_per_level": 20,
+											"features": [
+												{
+													"type": "attribute_bonus",
+													"attribute": "dx",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"can_level": true,
+											"levels": 1,
+											"calc": {
+												"points": 20
+											}
+										},
+										{
+											"id": "tFHeZDt17NxW2M2SQ",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tVt3SvdGWNchJ8z4o"
+											},
+											"name": "Increased Health",
+											"reference": "B14",
+											"tags": [
+												"Advantage",
+												"Attribute",
+												"Physical"
+											],
+											"points_per_level": 10,
+											"features": [
+												{
+													"type": "attribute_bonus",
+													"attribute": "ht",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"can_level": true,
+											"levels": 3,
+											"calc": {
+												"points": 30
+											}
+										},
+										{
+											"id": "ts22fjZCEh10__V7l",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t1w1RFcFceKR2T9_e"
+											},
+											"name": "Increased Intelligence",
+											"reference": "B15",
+											"tags": [
+												"Advantage",
+												"Attribute",
+												"Mental"
+											],
+											"points_per_level": 20,
+											"features": [
+												{
+													"type": "attribute_bonus",
+													"attribute": "iq",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"can_level": true,
+											"levels": 1,
+											"calc": {
+												"points": 20
+											}
+										},
+										{
+											"id": "tPBOFNuEwcJ0DV34G",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tqha9GlDBU9P-Wg-6"
+											},
+											"name": "Increased Strength",
+											"reference": "B14",
+											"tags": [
+												"Advantage",
+												"Attribute",
+												"Physical"
+											],
+											"modifiers": [
+												{
+													"id": "mS6e9gayfGDuAiDa6",
+													"name": "No Fine Manipulators",
+													"reference": "B15",
+													"cost": -40,
+													"disabled": true
+												},
+												{
+													"id": "mjnd0c_dNFTAReQiO",
+													"name": "Size",
+													"reference": "B15",
+													"cost": -10,
+													"levels": 1,
+													"disabled": true
+												},
+												{
+													"id": "m7xqPwOW-P-HEpD34",
+													"name": "Super-Effort",
+													"reference": "SU24",
+													"cost": 300,
+													"disabled": true
+												}
+											],
+											"points_per_level": 10,
+											"features": [
+												{
+													"type": "attribute_bonus",
+													"attribute": "st",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"can_level": true,
+											"levels": 3,
+											"calc": {
+												"points": 30
+											}
+										}
+									],
+									"calc": {
+										"points": 100
+									}
+								},
+								{
+									"id": "T-x3gvf7Z52rXBJLx",
 									"name": "Everyman Advantages",
 									"children": [
 										{
-											"id": "tvPNX8Tldml2niqDF",
-											"name": "Suit Familiarity (Vacc Suit)",
+											"id": "tcGcOv73BVWYxZgQS",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Power Ups/Power Ups Traits.adq",
+												"id": "t3RCXCI5W-zjvxaf-"
+											},
+											"name": "Suit Familiarity (@Environment Suit skill@)",
 											"reference": "PU2:9",
 											"tags": [
 												"Perk",
 												"Physical"
 											],
+											"replacements": {
+												"Environment Suit skill": "Vacc Suit"
+											},
 											"base_points": 1,
 											"calc": {
 												"points": 1
 											}
 										},
 										{
-											"id": "t5sD9pIJtK1MIOWS8",
+											"id": "tYbD50HJ8mgl7LFUb",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tkiJQ7nfyi9aAdGHK"
+											},
 											"name": "Serendipity",
 											"reference": "B83,P73",
 											"tags": [
@@ -269,17 +475,24 @@
 											],
 											"modifiers": [
 												{
-													"id": "m6cGrCQnSsVf26kqs",
+													"id": "m0Od50BMjW_98YRnr",
 													"name": "Wishing",
 													"reference": "P73",
 													"cost": 100,
 													"disabled": true
 												},
 												{
-													"id": "m8byCL7aGFy5hIRUN",
+													"id": "majTtT8Oloe-r2S4R",
 													"name": "Wishing",
 													"reference": "P73",
 													"notes": "For others only",
+													"disabled": true
+												},
+												{
+													"id": "ml-kIvRFOuLnBkG55",
+													"name": "Game Time",
+													"reference": "P108",
+													"notes": "Uses per game week equal to its maximum possible uses per session",
 													"disabled": true
 												}
 											],
@@ -291,8 +504,13 @@
 											}
 										},
 										{
-											"id": "t4thR4U9ikJTs1OHJ",
-											"name": "Resistant to Acceleration",
+											"id": "tTxx0Mn0JlcHmFv2s",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tJTfFdHM7YI5IZR7I"
+											},
+											"name": "Resistant",
 											"reference": "B81,P71,MA47",
 											"tags": [
 												"Advantage",
@@ -300,7 +518,7 @@
 											],
 											"modifiers": [
 												{
-													"id": "mvJPBijPr6Fv01525",
+													"id": "mKBML5KI-475VprkB",
 													"name": "@Very Common: Metabolic Hazards, etc.@",
 													"reference": "B80",
 													"cost": 30,
@@ -308,7 +526,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mL32wAsiehpS8tLld",
+													"id": "mKdB3LpM0LczZ0jk5",
 													"name": "@Common: Poison, Sickness, etc.@",
 													"reference": "B81",
 													"cost": 15,
@@ -316,7 +534,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mN-OKf8Av1GYWUGMk",
+													"id": "miMvP1PvSU_fNsJCf",
 													"name": "@Occasional: Disease, Ingested Poison, etc.@",
 													"reference": "B81",
 													"cost": 10,
@@ -324,14 +542,17 @@
 													"disabled": true
 												},
 												{
-													"id": "m5a-M9qiNYo-JWfU-",
+													"id": "mxRNL-cd9EB7KdWHL",
 													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
 													"reference": "B81",
+													"replacements": {
+														"Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.": "Space Sickness"
+													},
 													"cost": 5,
 													"cost_type": "points"
 												},
 												{
-													"id": "mIWTgdW-CRl3PMLaI",
+													"id": "mwZkveH5PslNcgybZ",
 													"name": "Immunity",
 													"reference": "B81",
 													"cost": 1,
@@ -339,152 +560,14 @@
 													"disabled": true
 												},
 												{
-													"id": "mGBfZzcP3DWOoDj_R",
-													"name": "+8 to all HT rolls to resist",
-													"reference": "B81",
-													"cost": 0.5,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mJuzY8rkzvIKeSG9j",
-													"name": "+3 to all HT rolls to resist",
-													"reference": "B81",
-													"cost": 0.33,
-													"cost_type": "multiplier"
-												}
-											],
-											"round_down": true,
-											"calc": {
-												"points": 1
-											}
-										},
-										{
-											"id": "tsqrQJSk-DH9DB2zL",
-											"name": "Resistant to Space Sickness",
-											"reference": "B81,P71,MA47",
-											"tags": [
-												"Advantage",
-												"Physical"
-											],
-											"modifiers": [
-												{
-													"id": "mrS-RU_RkGVW8gIbn",
-													"name": "@Very Common: Metabolic Hazards, etc.@",
-													"reference": "B80",
-													"cost": 30,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m5fw0eW_gy8-7y58H",
-													"name": "@Common: Poison, Sickness, etc.@",
-													"reference": "B81",
-													"cost": 15,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mDip29lgyQ5c5ieXZ",
-													"name": "@Occasional: Disease, Ingested Poison, etc.@",
-													"reference": "B81",
-													"cost": 10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mO3ch192W-X1T3_pm",
-													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
-													"reference": "B81",
-													"cost": 5,
-													"cost_type": "points"
-												},
-												{
-													"id": "mcXx6ef6McuLSJKrT",
-													"name": "Immunity",
-													"reference": "B81",
-													"cost": 1,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "m0d5da02Ut_LLilNS",
-													"name": "+8 to all HT rolls to resist",
-													"reference": "B81",
-													"cost": 0.5,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mDM1sLkCagODoL7RD",
-													"name": "+3 to all HT rolls to resist",
-													"reference": "B81",
-													"cost": 0.33,
-													"cost_type": "multiplier"
-												}
-											],
-											"round_down": true,
-											"calc": {
-												"points": 1
-											}
-										},
-										{
-											"id": "tQE-YdpeaqLPwcnlw",
-											"name": "Resistant to Space Sickness",
-											"reference": "B81,P71,MA47",
-											"tags": [
-												"Advantage",
-												"Physical"
-											],
-											"modifiers": [
-												{
-													"id": "mRt9umrVrxUMarXsw",
-													"name": "@Very Common: Metabolic Hazards, etc.@",
-													"reference": "B80",
-													"cost": 30,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mGaPEhqzfJ3YlPP2G",
-													"name": "@Common: Poison, Sickness, etc.@",
-													"reference": "B81",
-													"cost": 15,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mwa3IPsW6gbArMBQ-",
-													"name": "@Occasional: Disease, Ingested Poison, etc.@",
-													"reference": "B81",
-													"cost": 10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m6gO-r1E43VugtuXh",
-													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
-													"reference": "B81",
-													"cost": 5,
-													"cost_type": "points"
-												},
-												{
-													"id": "mq_W2_WiVesMwz9ZP",
-													"name": "Immunity",
-													"reference": "B81",
-													"cost": 1,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mDtga5Cbjb_3_T0iW",
+													"id": "m4a7v3DZ6vhKy4Xb3",
 													"name": "+8 to all HT rolls to resist",
 													"reference": "B81",
 													"cost": 0.5,
 													"cost_type": "multiplier"
 												},
 												{
-													"id": "mX6V68Isuc1RZudCk",
+													"id": "mCYrdcUlxBhgmw2Nt",
 													"name": "+3 to all HT rolls to resist",
 													"reference": "B81",
 													"cost": 0.33,
@@ -498,8 +581,167 @@
 											}
 										},
 										{
-											"id": "tpc8uEMYI6a8OLxhW",
-											"name": "Reputation",
+											"id": "tpK05cxoZ1Ber8Bkc",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tJTfFdHM7YI5IZR7I"
+											},
+											"name": "Resistant",
+											"reference": "B81,P71,MA47",
+											"tags": [
+												"Advantage",
+												"Physical"
+											],
+											"modifiers": [
+												{
+													"id": "mxpUNu7nsPcpVPDOu",
+													"name": "@Very Common: Metabolic Hazards, etc.@",
+													"reference": "B80",
+													"cost": 30,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m2dLMNPmgmqNyaSah",
+													"name": "@Common: Poison, Sickness, etc.@",
+													"reference": "B81",
+													"cost": 15,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m1mdHJOQt_F6Hdpgv",
+													"name": "@Occasional: Disease, Ingested Poison, etc.@",
+													"reference": "B81",
+													"cost": 10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mjInqDnExqSe2aTcV",
+													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+													"reference": "B81",
+													"replacements": {
+														"Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.": "Space Sickness"
+													},
+													"cost": 5,
+													"cost_type": "points"
+												},
+												{
+													"id": "mTdj1_6tMKqG6i7O7",
+													"name": "Immunity",
+													"reference": "B81",
+													"cost": 1,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mkNrHHmyr4xI1OvxN",
+													"name": "+8 to all HT rolls to resist",
+													"reference": "B81",
+													"cost": 0.5,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mn_D5q_FPJCBkprLu",
+													"name": "+3 to all HT rolls to resist",
+													"reference": "B81",
+													"cost": 0.33,
+													"cost_type": "multiplier"
+												}
+											],
+											"round_down": true,
+											"calc": {
+												"points": 1
+											}
+										},
+										{
+											"id": "tReXxwwwD1iXXbHJ0",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tJTfFdHM7YI5IZR7I"
+											},
+											"name": "Resistant",
+											"reference": "B81,P71,MA47",
+											"tags": [
+												"Advantage",
+												"Physical"
+											],
+											"modifiers": [
+												{
+													"id": "mazLBx8XqcSrUz19N",
+													"name": "@Very Common: Metabolic Hazards, etc.@",
+													"reference": "B80",
+													"cost": 30,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mlqH-bBfI29H3aoMH",
+													"name": "@Common: Poison, Sickness, etc.@",
+													"reference": "B81",
+													"cost": 15,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mRx2Wfzb131YN4AhY",
+													"name": "@Occasional: Disease, Ingested Poison, etc.@",
+													"reference": "B81",
+													"cost": 10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mZBzj0zopUYC16Ccc",
+													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+													"reference": "B81",
+													"replacements": {
+														"Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.": "Acceleration"
+													},
+													"cost": 5,
+													"cost_type": "points"
+												},
+												{
+													"id": "mlEeIcps38l-8dDLx",
+													"name": "Immunity",
+													"reference": "B81",
+													"cost": 1,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mktJZEWXgpL1gbHA_",
+													"name": "+8 to all HT rolls to resist",
+													"reference": "B81",
+													"cost": 0.5,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "msWYuHU4HaNWaaT1q",
+													"name": "+3 to all HT rolls to resist",
+													"reference": "B81",
+													"cost": 0.33,
+													"cost_type": "multiplier"
+												}
+											],
+											"round_down": true,
+											"calc": {
+												"points": 1
+											}
+										},
+										{
+											"id": "tsV3zP3FgptIM182O",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "ta04iFiZ_Kw0s0juj"
+											},
+											"name": "Good Reputation",
 											"reference": "B26,MA54",
 											"tags": [
 												"Advantage",
@@ -507,7 +749,7 @@
 											],
 											"modifiers": [
 												{
-													"id": "mIV_IRvCjv5Yfa35y",
+													"id": "mNvNq5EOagQphhF2A",
 													"name": "People Affected",
 													"reference": "B27",
 													"notes": "Almost everyone",
@@ -516,7 +758,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mrYTTU42chIjB6rJH",
+													"id": "m2xU1hwEGts7UfsWm",
 													"name": "People Affected",
 													"reference": "B27",
 													"notes": "Almost everyone except @large class of people@",
@@ -525,7 +767,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m4j51KEn21vxJJtb-",
+													"id": "muONnny2TNTXD979u",
 													"name": "People Affected",
 													"reference": "B27",
 													"notes": "@Large class of people@",
@@ -534,7 +776,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mOpk572Au1Pc6Of9A",
+													"id": "mzEX5TEyMqrRzci75",
 													"name": "People Affected",
 													"reference": "B27",
 													"notes": "@Small class of people@",
@@ -543,7 +785,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mDCZ53tQTW-UrykSn",
+													"id": "mUyy_T1hGnBhhMDU4",
 													"name": "Recognized all the time",
 													"reference": "B28",
 													"cost": 1,
@@ -551,7 +793,7 @@
 													"disabled": true
 												},
 												{
-													"id": "myt4vMjOxJwlrCM-Q",
+													"id": "mFpcWnlXYArf7Kyje",
 													"name": "Recognized sometimes",
 													"reference": "B28",
 													"notes": "10-",
@@ -560,7 +802,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mE9IFpAEC0mvRCAfX",
+													"id": "m1vYFgXHR3T4P6b2o",
 													"name": "Recognized occasionally",
 													"reference": "B28",
 													"notes": "7-",
@@ -570,6 +812,14 @@
 												}
 											],
 											"points_per_level": 5,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others aware of your reputation",
+													"amount": 1,
+													"per_level": true
+												}
+											],
 											"round_down": true,
 											"can_level": true,
 											"levels": 1,
@@ -578,16 +828,24 @@
 											}
 										},
 										{
-											"id": "t6r4UYKXyCcrQnbvP",
-											"name": "Military Rank",
+											"id": "tKFMpx2Dl5pBCtm3E",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tmp8yecgaZq9TOk59"
+											},
+											"name": "@Type@ Rank",
 											"reference": "B29",
 											"tags": [
 												"Advantage",
-												"Physical"
+												"Social"
 											],
+											"replacements": {
+												"Type": "Military"
+											},
 											"modifiers": [
 												{
-													"id": "mCpyE8EVYmvXgfj2t",
+													"id": "mfx7hSqW46uJmKQUh",
 													"name": "Replaces Status",
 													"reference": "B29",
 													"cost": 5,
@@ -596,7 +854,7 @@
 													"disabled": true
 												},
 												{
-													"id": "meLoV6EJQwDi5LVVv",
+													"id": "mbzZ84iLyAYdF_vyf",
 													"name": "Courtesy",
 													"reference": "B29",
 													"cost": -4,
@@ -613,16 +871,24 @@
 											}
 										},
 										{
-											"id": "tX3AXQkfWpIIec2NJ",
-											"name": "Merchant Rank",
+											"id": "tBhScDdLEqyW_BMRl",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tmp8yecgaZq9TOk59"
+											},
+											"name": "@Type@ Rank",
 											"reference": "B29",
 											"tags": [
 												"Advantage",
-												"Physical"
+												"Social"
 											],
+											"replacements": {
+												"Type": "Merchant"
+											},
 											"modifiers": [
 												{
-													"id": "mUKqDN2kDcoNOGdMZ",
+													"id": "mXIh-h5jzXpsHULLs",
 													"name": "Replaces Status",
 													"reference": "B29",
 													"cost": 5,
@@ -631,7 +897,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m2BEB_fWllUL3uSAB",
+													"id": "mgDKJrWMRBvV_vwVC",
 													"name": "Courtesy",
 													"reference": "B29",
 													"cost": -4,
@@ -648,17 +914,21 @@
 											}
 										},
 										{
-											"id": "tzFv-32z6eBM8P689",
+											"id": "tgsS-3cFs5S0sYDO3",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t6Nq6oInwkU1qbAP1"
+											},
 											"name": "Patron",
 											"reference": "B72,P65",
-											"notes": "Ship's owner or provider",
 											"tags": [
 												"Advantage",
 												"Social"
 											],
 											"modifiers": [
 												{
-													"id": "mXh54YABAncQf5PqE",
+													"id": "mEQEHA7GkTjymiXjO",
 													"name": "@Who: Individual with 150% of PC's starting points@",
 													"reference": "B72",
 													"cost": 10,
@@ -666,7 +936,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m2mOL_LlNrUTnwtVz",
+													"id": "mX48VXlKti6wJkoSL",
 													"name": "@Who: Organization with assets of at least 1000 times starting wealth@",
 													"reference": "B72",
 													"cost": 10,
@@ -674,7 +944,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mzKkG-6XjWUZq4_g2",
+													"id": "mRNL0T-dl_PMWAV1z",
 													"name": "@Who: Individual with twice the PC's starting points@",
 													"reference": "B72",
 													"cost": 15,
@@ -682,7 +952,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mIFI02xNZl7aOIUGb",
+													"id": "mpRY5ui1_IVCTVKWv",
 													"name": "@Who: Organization with assets of at least 10000 times starting wealth@",
 													"reference": "B72",
 													"cost": 15,
@@ -690,7 +960,7 @@
 													"disabled": true
 												},
 												{
-													"id": "miI05_6FoSD0-oPJ1",
+													"id": "miZ3duzLy4khiLRJU",
 													"name": "@Who: An ultra-powerful individual@",
 													"reference": "B72",
 													"cost": 20,
@@ -698,7 +968,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mgBFk-8xrW9k1yaaZ",
+													"id": "m46Afga4Jc47nbfQO",
 													"name": "@Who: Organization with assets of at least 100000 times starting wealth@",
 													"reference": "B72",
 													"cost": 20,
@@ -706,7 +976,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mwV3-sV17PLuiaNLl",
+													"id": "mSHMjpcQSCukXU3Io",
 													"name": "@Who: Organization with assets of at least 1000000 times starting wealth@",
 													"reference": "B72",
 													"cost": 25,
@@ -714,7 +984,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mzZLImcZrCVarx3Ip",
+													"id": "mNjvl6Fqyq1rdUneN",
 													"name": "@Who: A national government or giant multi-national organization@",
 													"reference": "B72",
 													"cost": 30,
@@ -722,7 +992,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mTW6E5IPdHuhfDqxM",
+													"id": "mZyDySWUADPyB38T8",
 													"name": "@Who: A deity@",
 													"reference": "B72",
 													"cost": 30,
@@ -730,7 +1000,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mHPf_sgrZKljeGBsp",
+													"id": "mQsM4Jf5U84EtFSlA",
 													"name": "Appears almost all the time",
 													"reference": "B36",
 													"notes": "15-",
@@ -739,7 +1009,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m0U5IVecdDzaABmAL",
+													"id": "mLSRYvGMinmXAsXeg",
 													"name": "Appears quite often",
 													"reference": "B36",
 													"notes": "12-",
@@ -748,7 +1018,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mu0IeqQdfw6bthl9C",
+													"id": "m2D9YSOy7LlkbI-WA",
 													"name": "Appears fairly often",
 													"reference": "B36",
 													"notes": "9-",
@@ -757,7 +1027,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mi2u3KNZM_hhehCaG",
+													"id": "m2HGUcrO2JZUM7MOB",
 													"name": "Appears quite rarely",
 													"reference": "B36",
 													"notes": "6-",
@@ -766,7 +1036,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m7N1RjOuB9dC2lzFW",
+													"id": "mCknWRs1D-XDLs2bF",
 													"name": "Equipment",
 													"reference": "B73",
 													"notes": "@Equipment worth no more than average starting wealth@",
@@ -774,7 +1044,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m5O4YTnX-ldbPs9X6",
+													"id": "mMyeeH8O1-0M829bf",
 													"name": "Equipment",
 													"reference": "B73",
 													"notes": "@Equipment worth more than average starting wealth@",
@@ -782,14 +1052,14 @@
 													"disabled": true
 												},
 												{
-													"id": "mQx9qdOaLU2pzWyyP",
+													"id": "megJkq16U3D8ZVn8n",
 													"name": "Highly Accessible",
 													"reference": "B73",
 													"cost": 50,
 													"disabled": true
 												},
 												{
-													"id": "mAUkZSB9rV2t7952w",
+													"id": "msLXrFEf7nXzaDrRy",
 													"name": "Special Abilities",
 													"reference": "B73",
 													"notes": "@Extensive social or political power@",
@@ -797,7 +1067,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mg5QajM_CiLtBW7JC",
+													"id": "m8DLEIvqs7lzWIajR",
 													"name": "Special Abilities",
 													"reference": "B73",
 													"notes": "@Magical powers in a non-magical world, higher TL equipment, grants special powers or is supernatural@",
@@ -805,28 +1075,28 @@
 													"disabled": true
 												},
 												{
-													"id": "mq0qgpp3B1OSef0Rf",
+													"id": "mm3QH3jtB5inkbyiP",
 													"name": "Minimal Interventions",
 													"reference": "B73",
 													"cost": -50,
 													"disabled": true
 												},
 												{
-													"id": "mcnM6Ye-gNXui8409",
+													"id": "mmna_83QRniz15epC",
 													"name": "Secret",
 													"reference": "B73",
 													"cost": -50,
 													"disabled": true
 												},
 												{
-													"id": "muYBfKMmNXjpVLpEq",
+													"id": "mIeE092EJIl4VSw7Q",
 													"name": "Unwilling",
 													"reference": "B74",
 													"cost": -50,
 													"disabled": true
 												},
 												{
-													"id": "mzFbaqyclEHJuQZUN",
+													"id": "muFP9thDUPxIpedAA",
 													"name": "Favor",
 													"reference": "B55",
 													"cost": 0.2,
@@ -839,7 +1109,12 @@
 											}
 										},
 										{
-											"id": "t5mlji478H9OyKWcP",
+											"id": "tUy0o9UrjSy1CJnJO",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tz-USDL9B_KrrVqDi"
+											},
 											"name": "Luck",
 											"reference": "B66,P59",
 											"notes": "Usable once per hour of play",
@@ -849,14 +1124,14 @@
 											],
 											"modifiers": [
 												{
-													"id": "mWlo_D9Ll11QOMhE1",
+													"id": "mQnATg7ikq7pm65sm",
 													"name": "Active",
 													"reference": "B66",
 													"cost": -40,
 													"disabled": true
 												},
 												{
-													"id": "mJzTxmPxnrWoWZvWl",
+													"id": "mcY29jR0ewTIUNcow",
 													"name": "Aspected",
 													"reference": "B66",
 													"notes": "@Aspect@",
@@ -864,17 +1139,24 @@
 													"disabled": true
 												},
 												{
-													"id": "mufqVZgqaKXXbHwdQ",
+													"id": "mYsqrCwYdO6BhdbtB",
 													"name": "Defensive",
 													"reference": "B66",
 													"cost": -20,
 													"disabled": true
 												},
 												{
-													"id": "mKwHECiTZNGJqvevk",
+													"id": "mG_WxtUUUvye8zuJj",
 													"name": "Wishing",
 													"reference": "P59",
 													"cost": 100,
+													"disabled": true
+												},
+												{
+													"id": "mHcF0b4xx1_CWYWBr",
+													"name": "Game Time",
+													"reference": "P108",
+													"notes": "Uses per game day equal to its maximum possible uses per real hour",
 													"disabled": true
 												}
 											],
@@ -884,7 +1166,12 @@
 											}
 										},
 										{
-											"id": "tC1xr4gx5Qly5v6Kh",
+											"id": "tjl9mDzCo7umeZAFh",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tMxgHfzVEy_QQtlfB"
+											},
 											"name": "Less Sleep",
 											"reference": "B65",
 											"notes": "Require 1 hour/level less sleep for a full night's rest (max 4)",
@@ -900,7 +1187,12 @@
 											}
 										},
 										{
-											"id": "t132i4krfoa6C__K7",
+											"id": "trjJ4i9e1jVpO8zZd",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tw1Ad0oSMw2ATM4X1"
+											},
 											"name": "Language: @Language@",
 											"reference": "B24",
 											"tags": [
@@ -908,9 +1200,26 @@
 												"Language",
 												"Mental"
 											],
+											"prereqs": {
+												"type": "prereq_list",
+												"all": true,
+												"prereqs": [
+													{
+														"type": "trait_prereq",
+														"has": false,
+														"name": {
+															"compare": "is",
+															"qualifier": "Language Talent"
+														},
+														"level": {
+															"compare": "at_least"
+														}
+													}
+												]
+											},
 											"modifiers": [
 												{
-													"id": "mTKsx7y1uDVEhHrqp",
+													"id": "mzfBrSlazwIuaa_ki",
 													"name": "Native",
 													"reference": "B23",
 													"cost": -6,
@@ -918,7 +1227,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mwwGkIHOR6WfE8Ovf",
+													"id": "mzNCWMr40JYAQd1DC",
 													"name": "Spoken",
 													"reference": "B24",
 													"notes": "None",
@@ -926,7 +1235,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mc5mZbEko0T6ZJ_Wx",
+													"id": "mm61MfoVOAiwTmxw9",
 													"name": "Spoken",
 													"reference": "B24",
 													"notes": "Broken",
@@ -935,7 +1244,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mUXTob7IhrvAICNtJ",
+													"id": "m6ZdgJJ-0lqkfdj4x",
 													"name": "Spoken",
 													"reference": "B24",
 													"notes": "Accented",
@@ -943,7 +1252,7 @@
 													"cost_type": "points"
 												},
 												{
-													"id": "mSMNNySpGOIKr_-sX",
+													"id": "mb7jLJnjsu_Wwaf5-",
 													"name": "Spoken",
 													"reference": "B24",
 													"notes": "Native",
@@ -952,7 +1261,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mUjFPIhkZyCuMo2lX",
+													"id": "mndyEnqIF6-7svcsf",
 													"name": "Written",
 													"reference": "B24",
 													"notes": "None",
@@ -960,7 +1269,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mBb6WIEERKI41tHSD",
+													"id": "my5XoxF2goEhVEg-g",
 													"name": "Written",
 													"reference": "B24",
 													"notes": "Broken",
@@ -969,7 +1278,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mF-IjFSEJ-TwAmxTX",
+													"id": "m1xWLrzpP9jytURGe",
 													"name": "Written",
 													"reference": "B24",
 													"notes": "Accented",
@@ -977,7 +1286,7 @@
 													"cost_type": "points"
 												},
 												{
-													"id": "mznLiAqz40KgNC8wH",
+													"id": "mQ0wlRqrm1af91h6g",
 													"name": "Written",
 													"reference": "B24",
 													"notes": "Native",
@@ -991,7 +1300,12 @@
 											}
 										},
 										{
-											"id": "tk-5d0K5iS5INa7Bo",
+											"id": "t9iL84BeN54gFclvG",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "txREhxV6L1SKixwe_"
+											},
 											"name": "Improved G-tolerance",
 											"reference": "B60",
 											"tags": [
@@ -1000,7 +1314,7 @@
 											],
 											"modifiers": [
 												{
-													"id": "mLJh0beWh6MAC43UU",
+													"id": "mnpOydPYlQe8I0r2j",
 													"name": "0.3G",
 													"reference": "B60",
 													"cost": 5,
@@ -1008,7 +1322,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m-ca4D6fCsEk1nTwj",
+													"id": "mkH4678_SC0wpWjlf",
 													"name": "0.5G",
 													"reference": "B60",
 													"cost": 10,
@@ -1016,7 +1330,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mpAbnEW2LmXharO29",
+													"id": "mszvAOyxRSoS8sLDy",
 													"name": "1G",
 													"reference": "B60",
 													"cost": 15,
@@ -1024,7 +1338,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mF7fXKBFHK3aaAfMz",
+													"id": "moqGJygBYkIT9KjQc",
 													"name": "5G",
 													"reference": "B60",
 													"cost": 20,
@@ -1032,7 +1346,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mqSmHbkQCBhwvVAb1",
+													"id": "mu0zED0ZBMvG-BIpF",
 													"name": "10G",
 													"reference": "B60",
 													"cost": 25,
@@ -1045,7 +1359,12 @@
 											}
 										},
 										{
-											"id": "tOYtR3vyH5HU28b9l",
+											"id": "tNFIBmj8jKzi3XAK6",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t7blIRUzFpiHS_mnO"
+											},
 											"name": "Gizmo",
 											"reference": "B57,MA45",
 											"tags": [
@@ -1060,7 +1379,12 @@
 											}
 										},
 										{
-											"id": "tdedpXSl694vBsjcv",
+											"id": "t9pBp8tByAGHihhcq",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tHNrjEQFQBNOgwmzK"
+											},
 											"name": "G-Experience (All)",
 											"reference": "B57",
 											"tags": [
@@ -1073,7 +1397,12 @@
 											}
 										},
 										{
-											"id": "tu5kAebX3wmdYyr8F",
+											"id": "tbOqBd60m7kD-4zcv",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tu3GuYC47Sx6bnm4k"
+											},
 											"name": "G-Experience",
 											"reference": "B57",
 											"tags": [
@@ -1088,7 +1417,12 @@
 											}
 										},
 										{
-											"id": "tk9JUjwXmnSQMXk93",
+											"id": "twmxdy1-P9pa91V-I",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "toTe273Ky82B6YdW5"
+											},
 											"name": "Fit",
 											"reference": "B55",
 											"notes": "Recover FP at twice the normal rate (but not FP spent for spells or psi powers)",
@@ -1109,7 +1443,12 @@
 											}
 										},
 										{
-											"id": "twn6-hdnDpUrGQ8Gi",
+											"id": "tGza5tMU3Reb_RQeZ",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tQa3EUrs4Hjt9gxK6"
+											},
 											"name": "Fearlessness",
 											"reference": "B55,MA44",
 											"tags": [
@@ -1146,7 +1485,12 @@
 											}
 										},
 										{
-											"id": "txmeKHMzFWN9pc6_o",
+											"id": "tLdpy30vjot6YCHwL",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t5j2Ox4jaIV9j0rpz"
+											},
 											"name": "Deep Sleeper",
 											"reference": "B101",
 											"tags": [
@@ -1159,7 +1503,12 @@
 											}
 										},
 										{
-											"id": "ty-t-A7_V2dywgJwK",
+											"id": "teA4I_8s3pR5FqNih",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tNBE3sLoyrUvAgoZ3"
+											},
 											"name": "Cybernetics",
 											"reference": "B46",
 											"tags": [
@@ -1171,7 +1520,12 @@
 											}
 										},
 										{
-											"id": "taujsiCt21r0Cqmd5",
+											"id": "tKmEqrkpESp80vSl0",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "toXBQ8q4Nek5lsLPF"
+											},
 											"name": "Cultural Familiarity (@Culture@)",
 											"reference": "B23",
 											"notes": "Do not suffer the normal -3 penalty for unfamiliarity",
@@ -1181,14 +1535,14 @@
 											],
 											"modifiers": [
 												{
-													"id": "mSqU1V9P-IS1xTv9p",
+													"id": "m4xXD_85F0c-EqR5t",
 													"name": "Alien",
 													"cost": 1,
 													"cost_type": "points",
 													"disabled": true
 												},
 												{
-													"id": "m_3kxtFi-o1PaIZkt",
+													"id": "mwa3skn-kTYQhkmHI",
 													"name": "Native",
 													"cost": -1,
 													"cost_type": "points",
@@ -1201,9 +1555,14 @@
 											}
 										},
 										{
-											"id": "t8PxSkgK2K9_dskc2",
-											"name": "Alien Friend",
-											"reference": "S220",
+											"id": "tDY2GCH7xlkK3mEwN",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Power Ups/Power Ups Traits.adq",
+												"id": "t3msobZZ06J7dZ8xu"
+											},
+											"name": "Talent (Born Spacer)",
+											"reference": "PU3:7",
 											"tags": [
 												"Advantage",
 												"Mental",
@@ -1211,106 +1570,60 @@
 											],
 											"modifiers": [
 												{
-													"id": "mSS2dBnMC5r1NRhk0",
-													"name": "Alternate Benefit",
-													"notes": "@Alternate Benefit@",
-													"disabled": true
-												},
-												{
-													"id": "mY_cwq9QmiVCTytky",
+													"id": "m8F7FU4nQV85quKsM",
 													"name": "Alternative Cost",
+													"cost": 1,
 													"cost_type": "points",
 													"affects": "levels_only",
 													"disabled": true
-												}
-											],
-											"points_per_level": 5,
-											"features": [
-												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "Anthropology"
-													},
-													"amount": 1,
-													"per_level": true
 												},
 												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "Diplomacy"
-													},
-													"amount": 1,
-													"per_level": true
-												},
-												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "Expert Skill"
-													},
-													"amount": 1,
-													"per_level": true
-												},
-												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "History"
-													},
-													"amount": 1,
-													"per_level": true
-												},
-												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "Psychology"
-													},
-													"amount": 1,
-													"per_level": true
-												},
-												{
-													"type": "reaction_bonus",
-													"situation": "Aliens",
-													"amount": 1,
-													"per_level": true
-												}
-											],
-											"can_level": true,
-											"levels": 1,
-											"calc": {
-												"points": 5
-											}
-										},
-										{
-											"id": "tbnlsZmz86DQSk4Vu",
-											"name": "Born Spacer",
-											"reference": "THSCT40",
-											"tags": [
-												"Advantage",
-												"Mental",
-												"Talent"
-											],
-											"modifiers": [
-												{
-													"id": "melYJXu4rietsZjcp",
-													"name": "Alternate Benefit",
-													"notes": "@Alternate Benefit@",
-													"disabled": true
-												},
-												{
-													"id": "mSJouMQ2NpocNdyWg",
-													"name": "Alternative Cost",
-													"cost_type": "points",
-													"affects": "levels_only",
-													"disabled": true
+													"id": "MM43q_dFpMTIC4NxZ",
+													"name": "Benefits",
+													"children": [
+														{
+															"id": "mWUWMJraZfKvBL4ZJ",
+															"name": "Reaction Bonus",
+															"use_level_from_trait": true,
+															"features": [
+																{
+																	"type": "reaction_bonus",
+																	"situation": "From professional Spacers.",
+																	"amount": 1,
+																	"per_level": true
+																}
+															]
+														},
+														{
+															"id": "mwD2aWoBs-lDsIxRV",
+															"name": "Bonus to pushing off",
+															"reference": "BX350",
+															"reference_highlight": "ST/2",
+															"use_level_from_trait": true,
+															"features": [
+																{
+																	"type": "conditional_modifier",
+																	"situation": "Bonus to ST for zero G push off",
+																	"amount": 1,
+																	"per_level": true
+																}
+															],
+															"disabled": true
+														},
+														{
+															"id": "mHUYkoagh_0sTQy1V",
+															"name": "Spacecraft Familiarity",
+															"use_level_from_trait": true,
+															"features": [
+																{
+																	"type": "conditional_modifier",
+																	"situation": "Counteracts Familiarity for spacecraft.",
+																	"amount": 1
+																}
+															],
+															"disabled": true
+														}
+													]
 												}
 											],
 											"points_per_level": 5,
@@ -1342,6 +1655,10 @@
 														"compare": "is",
 														"qualifier": "Navigation"
 													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "Space"
+													},
 													"amount": 1,
 													"per_level": true
 												},
@@ -1353,8 +1670,36 @@
 														"qualifier": "Piloting"
 													},
 													"specialization": {
-														"compare": "contains",
-														"qualifier": "Spacecraft"
+														"compare": "is",
+														"qualifier": "High-Performance Spacecraft"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Piloting"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "Low-Performance Spacecraft"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Piloting"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "Aerospace"
 													},
 													"amount": 1,
 													"per_level": true
@@ -1378,10 +1723,99 @@
 													},
 													"amount": 1,
 													"per_level": true
+												}
+											],
+											"can_level": true,
+											"levels": 1,
+											"calc": {
+												"points": 5
+											}
+										},
+										{
+											"id": "tKHl3HkNIIpDaPz8e",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Power Ups/Power Ups Traits.adq",
+												"id": "tcCw979nTBoztowCU"
+											},
+											"name": "Talent (Alien Friend)",
+											"reference": "PU3:6",
+											"tags": [
+												"Advantage",
+												"Mental",
+												"Talent"
+											],
+											"points_per_level": 5,
+											"features": [
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Diplomacy"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Expert Skill"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "Xenology"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Anthropology"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "@Alien@"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "History"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "@Alien@"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Psychology"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "@Alien@"
+													},
+													"amount": 1,
+													"per_level": true
 												},
 												{
 													"type": "reaction_bonus",
-													"situation": "Professional Spacers",
+													"situation": "From aliens.",
 													"amount": 1,
 													"per_level": true
 												}
@@ -1393,7 +1827,12 @@
 											}
 										},
 										{
-											"id": "tLW4UYe-kTvCAV1pp",
+											"id": "tGGhF8w4kpVEeijnt",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tM6z7Mx6e2V4VvUR4"
+											},
 											"name": "Absolute Direction",
 											"reference": "B34",
 											"tags": [
@@ -1403,14 +1842,14 @@
 											],
 											"modifiers": [
 												{
-													"id": "mUR1msE1nl9yL34gx",
+													"id": "mOUC0nWfrG2WyJKrb",
 													"name": "Requires signal",
 													"reference": "B34",
 													"cost": -20,
 													"disabled": true
 												},
 												{
-													"id": "mKuFawNf5kZvhR2cB",
+													"id": "mVuMPpZcXxITa6lnN",
 													"name": "3D Spatial Sense",
 													"reference": "B34",
 													"cost": 5,
@@ -1533,7 +1972,12 @@
 									}
 								},
 								{
-									"id": "texK8q50ttBJ1ti8u",
+									"id": "tPFU10UsBAgXjYgLu",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tqSO2a00yPEs8sCn3"
+									},
 									"name": "Common Sense",
 									"reference": "B43,P45",
 									"tags": [
@@ -1542,7 +1986,7 @@
 									],
 									"modifiers": [
 										{
-											"id": "mRdOhvAEDjUN2r5w9",
+											"id": "mXwFYmT6bl5BbfuCV",
 											"name": "Concious",
 											"reference": "P45",
 											"cost": 50,
@@ -1555,13 +1999,21 @@
 									}
 								},
 								{
-									"id": "tmDCfvVOKLVk51Yyw",
-									"name": "Courtesy Title (Professor)",
+									"id": "t-mRJaAEvShYEGHrG",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "t-fZMUi0t0mEONQuz"
+									},
+									"name": "Courtesy Title (@Title@)",
 									"reference": "PU2:18",
 									"tags": [
 										"Perk",
 										"Social"
 									],
+									"replacements": {
+										"Title": "Professor"
+									},
 									"points_per_level": 1,
 									"can_level": true,
 									"levels": 1,
@@ -1570,7 +2022,12 @@
 									}
 								},
 								{
-									"id": "tuy1NebTeEWy82hL_",
+									"id": "tk0pFN3yB-QfC2jfX",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tW-eAzIKBWa5Yc9cI"
+									},
 									"name": "Eidetic Memory",
 									"reference": "B51",
 									"tags": [
@@ -1579,7 +2036,35 @@
 									],
 									"modifiers": [
 										{
-											"id": "m2saekxYmKIeSE4iq",
+											"id": "mANIi0SWuAu9y0aB-",
+											"name": "Photographic",
+											"reference": "B51",
+											"cost": 5,
+											"cost_type": "points",
+											"disabled": true
+										}
+									],
+									"base_points": 5,
+									"calc": {
+										"points": 5
+									}
+								},
+								{
+									"id": "tbL9yjmZ-XbkAA-Rf",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tW-eAzIKBWa5Yc9cI"
+									},
+									"name": "Eidetic Memory",
+									"reference": "B51",
+									"tags": [
+										"Advantage",
+										"Mental"
+									],
+									"modifiers": [
+										{
+											"id": "mTdd7Iq0rTubYS4cm",
 											"name": "Photographic",
 											"reference": "B51",
 											"cost": 5,
@@ -1592,7 +2077,12 @@
 									}
 								},
 								{
-									"id": "tXZ8Cxfc-e_q8o-fk",
+									"id": "tmI3QQjGL2EpDXiWX",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t5mke7RFjA2ZT0KRA"
+									},
 									"name": "Gadgeteer",
 									"reference": "B57",
 									"tags": [
@@ -1601,7 +2091,7 @@
 									],
 									"modifiers": [
 										{
-											"id": "mbIj3vqQR9fieQrJP",
+											"id": "m0SdUE6BhLorqXXlQ",
 											"name": "Quick",
 											"reference": "B57",
 											"cost": 25,
@@ -1615,7 +2105,12 @@
 									}
 								},
 								{
-									"id": "tb-piC4EHiCrTtDSb",
+									"id": "txPCTLkh9kDfX2Pa4",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t7blIRUzFpiHS_mnO"
+									},
 									"name": "Gizmo",
 									"reference": "B57,MA45",
 									"tags": [
@@ -1630,29 +2125,12 @@
 									}
 								},
 								{
-									"id": "tQRaaBmJf0CW6u6Ry",
-									"name": "Intuition",
-									"reference": "B63,P56",
-									"tags": [
-										"Advantage",
-										"Mental"
-									],
-									"modifiers": [
-										{
-											"id": "mE73_Bt0mYj_dUGLG",
-											"name": "Inspired",
-											"reference": "P56",
-											"cost": 100,
-											"disabled": true
-										}
-									],
-									"base_points": 15,
-									"calc": {
-										"points": 15
-									}
-								},
-								{
-									"id": "tvMJSVo4xTHGMCoxm",
+									"id": "titkhqvCVvgwZJ-ed",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tq6b1t_pc4X18GAWi"
+									},
 									"name": "Lightning Calculator",
 									"reference": "B66",
 									"tags": [
@@ -1661,7 +2139,35 @@
 									],
 									"modifiers": [
 										{
-											"id": "mm9lertxRZmcqSnhj",
+											"id": "mTqEianGM7h33e2h1",
+											"name": "Intuitive Mathematician",
+											"reference": "B66",
+											"cost": 3,
+											"cost_type": "points",
+											"disabled": true
+										}
+									],
+									"base_points": 2,
+									"calc": {
+										"points": 2
+									}
+								},
+								{
+									"id": "tgHXRBTRZJ6qXuDYv",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tq6b1t_pc4X18GAWi"
+									},
+									"name": "Lightning Calculator",
+									"reference": "B66",
+									"tags": [
+										"Advantage",
+										"Mental"
+									],
+									"modifiers": [
+										{
+											"id": "mqOCWJN5zzXJ8geOX",
 											"name": "Intuitive Mathematician",
 											"reference": "B66",
 											"cost": 3,
@@ -1674,7 +2180,12 @@
 									}
 								},
 								{
-									"id": "t7qwTZRqiz2ZG6Pzy",
+									"id": "tUCmtgesuCL68H2EK",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tnwcy0qKBgz2clkYl"
+									},
 									"name": "Talent (Mathematical Ability)",
 									"reference": "PU3:12",
 									"tags": [
@@ -1684,12 +2195,45 @@
 									],
 									"modifiers": [
 										{
-											"id": "m7pA-KVrBbpWTPFMl",
+											"id": "mspz-G_oFqjO4MwHD",
 											"name": "Alternative Cost",
 											"cost": -2,
 											"cost_type": "points",
 											"affects": "levels_only",
 											"disabled": true
+										},
+										{
+											"id": "McF7IBUR2oNipgxPe",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "mbpmSxs5ktFfeWG1P",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From engineers and scientists.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "mQNX2QoicXmJeKVl5",
+													"name": "Alternative Benefit",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Bonus to resist deception involving numbers",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
 										}
 									],
 									"points_per_level": 10,
@@ -1773,18 +2317,6 @@
 											},
 											"amount": 1,
 											"per_level": true
-										},
-										{
-											"type": "reaction_bonus",
-											"situation": "From engineers and scientists.",
-											"amount": 1,
-											"per_level": true
-										},
-										{
-											"type": "conditional_modifier",
-											"situation": "Bonus to resist deception involving numbers",
-											"amount": 1,
-											"per_level": true
 										}
 									],
 									"can_level": true,
@@ -1794,7 +2326,12 @@
 									}
 								},
 								{
-									"id": "tRb5Qnn_CsZT14AGH",
+									"id": "tYzVp4y82v2rziuJP",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "ttrmORiWbD1uv2rpD"
+									},
 									"name": "Talent (Natural Scientist)",
 									"reference": "PU3:13",
 									"tags": [
@@ -1804,12 +2341,45 @@
 									],
 									"modifiers": [
 										{
-											"id": "mueDQ7lh8tFLYy_Vs",
+											"id": "mhzEAQvjDx98UkU89",
 											"name": "Alternative Cost",
 											"cost": 1,
 											"cost_type": "points",
 											"affects": "levels_only",
 											"disabled": true
+										},
+										{
+											"id": "MdtpRTGPu1GNRmNfr",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "mWnKuuMnPx0xTMQeO",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From scientists and those impressed by \"smart people\".",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "mKktr4aaEbJVJQAwn",
+													"name": "Alternative Benefit",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Reduce TL and familiarity penalties for gear examined for an hour with a covered skill",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
 										}
 									],
 									"points_per_level": 10,
@@ -1943,18 +2513,6 @@
 											},
 											"amount": 1,
 											"per_level": true
-										},
-										{
-											"type": "reaction_bonus",
-											"situation": "From scientists and those impressed by \"smart people\".",
-											"amount": 1,
-											"per_level": true
-										},
-										{
-											"type": "conditional_modifier",
-											"situation": "Reduce TL and familiarity penalties for gear examined for an hour with a covered skill",
-											"amount": 1,
-											"per_level": true
 										}
 									],
 									"can_level": true,
@@ -1964,7 +2522,12 @@
 									}
 								},
 								{
-									"id": "tj2o7070JqEEd498k",
+									"id": "ttsrRR8sjAR8SNYjw",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tUzmcuTXRq35xQ-rB"
+									},
 									"name": "Single-Minded",
 									"reference": "B85",
 									"tags": [
@@ -1989,7 +2552,12 @@
 									}
 								},
 								{
-									"id": "t8PwevAlR0XFtAZoJ",
+									"id": "tPNZ056mOqVAlACo0",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tDPqnU1ciDF13F4kZ"
+									},
 									"name": "Versatile",
 									"reference": "B96",
 									"tags": [
@@ -2010,12 +2578,12 @@
 								}
 							],
 							"calc": {
-								"points": 212
+								"points": 304
 							}
 						}
 					],
 					"calc": {
-						"points": 242
+						"points": 334
 					}
 				},
 				{
@@ -2027,14 +2595,56 @@
 							"name": "-40 Points chosen from",
 							"children": [
 								{
-									"id": "TaDXkf5SMuBusXGNB",
+									"id": "Ta5ZsA8vma6knGxz9",
 									"name": "Everyman Disadvantages",
 									"tags": [
 										"Disadvantage"
 									],
 									"children": [
 										{
-											"id": "tVB8luxlKQ4p_Jfx4",
+											"id": "tqR0QeyL1qyxQXVaH",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tX9XXLPFBvyQSpA4k"
+											},
+											"name": "Xenophilia",
+											"reference": "B162",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"cr": 12,
+											"base_points": -10,
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "tQj8flS5VzheiNv7n",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t8I0xw1Lj1_222aEN"
+											},
+											"name": "Workaholic",
+											"reference": "B162",
+											"tags": [
+												"Disadvantage",
+												"Physical"
+											],
+											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										},
+										{
+											"id": "tolNh6G2ge0NZRY_i",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t7U0VbIzs6SqefwLr"
+											},
 											"name": "Social Stigma (Criminal Record)",
 											"reference": "B155",
 											"tags": [
@@ -2054,23 +2664,162 @@
 											}
 										},
 										{
-											"id": "tGfWAoLq8pD_v3NZ0",
-											"name": "Chummy",
-											"reference": "B126",
+											"id": "t2g68beAo6HcxlRrf",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "thSMVzJ590v7gAD8d"
+											},
+											"name": "Pacifism: Self-Defense Only",
+											"reference": "B148",
+											"notes": "You only fight to defend yourself or those in your care, using only as much force as necessary (no pre-emptive strikes allowed!). You must do your best to discourage others from starting fights.",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
+											"modifiers": [
+												{
+													"id": "m2aZHmtfqZVae2Dzp",
+													"name": "Species-Specific",
+													"reference": "UT32",
+													"cost": -80,
+													"disabled": true
+												}
+											],
+											"base_points": -15,
+											"calc": {
+												"points": -15
+											}
+										},
+										{
+											"id": "tUMBGHJnji57GC4la",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tV_f_75HmwzWOPhuu"
+											},
+											"name": "Pacifism: Reluctant Killer",
+											"reference": "B148",
+											"notes": "You are psychologically unprepared to kill people. Whenever you make a deadly attack (e.g., with a knife or a gun) against an obvious person whose face is visible to you, you are at -4 to hit and may not Aim. If you cannot see the foe’s face (due to a mask, darkness, or distance, or because you attacked from behind), the penalty is only -2, save in close combat. You have no penalty to attack a vehicle (even an occupied one), an opponent you do not believe is a person (including things with Horrific or Monstrous appearance), or a target you can’t actually see (e.g., a set of map coordinates or a blip on a radar screen). If you kill a recognizable person, the effect on you is the same as for Pacifism: Cannot Kill. You have no problem with your allies killing; you may even supply ammo, loaded weapons, and encouragement! You just can’t do the killing yourself.",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"modifiers": [
+												{
+													"id": "mqWw7e3PNndzxWsUr",
+													"name": "Species-Specific",
+													"reference": "UT32",
+													"cost": -80,
+													"disabled": true
+												}
+											],
 											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										},
+										{
+											"id": "tR0kq_52KKqHL3spc",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "th9TK1Jmqg8uKe6SC"
+											},
+											"name": "Pacifism: Cannot Harm Innocents",
+											"reference": "B148",
+											"notes": "You may fight – you may even start fights – but you may only use deadly force on a foe that is attempting to do you serious harm. Capture is not “serious harm” unless you are already under penalty of death or have a Code of Honor that would require suicide if captured. You never intentionally do anything that causes, or even threatens to cause, injury to the uninvolved – particularly if they are “ordinary folks.”",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"modifiers": [
+												{
+													"id": "mSvfBvAguklAibN76",
+													"name": "Species-Specific",
+													"reference": "UT32",
+													"cost": -80,
+													"disabled": true
+												}
+											],
+											"base_points": -10,
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "tKflq7KBdsKqH0lgr",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tSiOKuvTJkqJhuRrI"
+											},
+											"name": "Lecherousness",
+											"reference": "B142",
+											"notes": "Make a self-control roll whenever you have more than the briefest contact with an appealing member of the sex you find attractive, at -5 if this person is Handsome/Beautiful, or at -10 if Very Handsome/Very Beautiful. If you fail, you must make a “pass” using whatever wiles and skills you can bring to bear.",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"cr": 12,
+											"base_points": -15,
+											"calc": {
+												"points": -15
+											}
+										},
+										{
+											"id": "tjzwgB-I4IGFiyevZ",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "ttHkLI9zwzfeOIEZc"
+											},
+											"name": "Intolerance (@Class, Ethnicity, Nationality, Religion, Sex, or Species@)",
+											"reference": "B140",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"replacements": {
+												"Class, Ethnicity, Nationality, Religion, Sex, or Species": "Rival civilization or species"
+											},
+											"modifiers": [
+												{
+													"id": "mhvnlR9mYKkURk5fY",
+													"name": "Scope: Common",
+													"reference": "B140",
+													"cost": -5,
+													"cost_type": "points"
+												},
+												{
+													"id": "mBAEGiy5MBG6wtrYC",
+													"name": "Scope: Occasional",
+													"reference": "B140",
+													"cost": -2,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mWd9eQGFdS-5AlwwT",
+													"name": "Scope: Rare",
+													"reference": "B140",
+													"cost": -1,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m0n4kiv3oNXrK2qoD",
+													"name": "Scope: Anyone unlike you",
+													"reference": "B140",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												}
+											],
 											"features": [
 												{
 													"type": "reaction_bonus",
-													"situation": "to others",
-													"amount": 2
-												},
-												{
-													"type": "conditional_modifier",
-													"situation": "to IQ-based skills when alone",
+													"situation": "from victims of your intolerance (may be as much as -5, at GM's discretion)",
 													"amount": -1
 												}
 											],
@@ -2079,49 +2828,383 @@
 											}
 										},
 										{
-											"id": "tgu4cKP-RdtfkDWm2",
-											"name": "Code of Honor (Mercanary's)",
-											"reference": "S221",
-											"notes": "A merc should look out for his buddies, take care of his gear, and fight for the honor of the unit. Obey the rule's of engagement. Don't poach on another unit's contract. Do the job you're hired for.",
+											"id": "t6hgoWR1DYS1LV-pO",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t7pCgXTVkswkTjOZO"
+											},
+											"name": "Honesty",
+											"reference": "B138",
+											"notes": "Make a self-control roll when faced with the “need” to break unreasonable laws; if you fail, you must obey the law, whatever the consequences. If you manage to resist your urges and break the law, make a second self-control roll afterward. If you fail, you must turn yourself in to the authorities!",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
+											"cr": 12,
 											"base_points": -10,
 											"calc": {
 												"points": -10
 											}
 										},
 										{
-											"id": "tfAJQUHOy0LzPfc5E",
-											"name": "Code of Honor (Pirate's)",
-											"reference": "B127",
-											"notes": "Always avenge an insult, regardless of the danger; your buddy’s foe is your own; never attack a fellow crewman or buddy except in a fair, open duel.",
+											"id": "tHCGTluAUfX6smxUs",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t5bwP6TnS4cX-zM8L"
+											},
+											"name": "Enemy (@Who@)",
+											"reference": "B135",
+											"tags": [
+												"Disadvantage",
+												"Social"
+											],
+											"modifiers": [
+												{
+													"id": "mZqQABS6JuuiMugOl",
+													"name": "Weak Individual",
+													"reference": "B135",
+													"notes": "50% of your starting points",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m48w1NhsmVeV43_fc",
+													"name": "Equal Individual",
+													"reference": "B135",
+													"notes": "100% of your starting points",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mbJ_zGgH0NqmqSKbV",
+													"name": "Powerful Individual",
+													"reference": "B135",
+													"notes": "\u003e150% of your starting points",
+													"cost": -20,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mjEIxVkCqC29ruZrn",
+													"name": "Weak Group",
+													"reference": "B135",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mSqPobON0I0r58A2M",
+													"name": "Medium Group",
+													"reference": "B135",
+													"cost": -20,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "moG3QgE945GDumhlo",
+													"name": "Appears almost all the time",
+													"reference": "B36",
+													"notes": "15-",
+													"cost": 3,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mOpbvH2dPoZijcBeh",
+													"name": "Appears quite often",
+													"reference": "B36",
+													"notes": "12-",
+													"cost": 2,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "m7npjoa3uPLRHUSjE",
+													"name": "Appears fairly often",
+													"reference": "B36",
+													"notes": "9-",
+													"cost": 1,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "m3QZozA7lBebwsD6T",
+													"name": "Appears quite rarely",
+													"reference": "B36",
+													"notes": "6-",
+													"cost": 0.5,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mjXf95Jz_SsrPIhhz",
+													"name": "Large/Powerful Group",
+													"reference": "B135",
+													"cost": -30,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mrxhvugx9lTQVXzTb",
+													"name": "Utterly Formidable Group",
+													"reference": "B135",
+													"cost": -40,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mAdMMjWZSB_GKOZGe",
+													"name": "Unknown",
+													"reference": "B135",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m3dx1s_6Rp8v4ItcB",
+													"name": "Evil Twin",
+													"reference": "B135",
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mc_g2Zgv1ykg9ebYR",
+													"name": "Evil Twin",
+													"reference": "B135",
+													"notes": "More skilled or extra abilities",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mJixpUoJtcKTLro42",
+													"name": "Evil Twin",
+													"reference": "B135",
+													"notes": "More skilled and extra abilities",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mBlAHuSITMw0ZvLqZ",
+													"name": "Watcher",
+													"reference": "B135",
+													"cost": 0.25,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mvR8lV_qNbpmTXaoq",
+													"name": "Rival",
+													"reference": "B135",
+													"cost": 0.5,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "m_ZN997w3lpIyCp7W",
+													"name": "Hunter",
+													"reference": "B135",
+													"cost": 1,
+													"cost_type": "multiplier",
+													"disabled": true
+												}
+											],
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "tZRzZMkzWU6mVxK5A",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t1HUGl4o498iCyvrw"
+											},
+											"name": "Duty (@Duty@)",
+											"reference": "B133",
+											"tags": [
+												"Disadvantage",
+												"Social"
+											],
+											"replacements": {
+												"Duty": "To ship's owner or provider"
+											},
+											"modifiers": [
+												{
+													"id": "mUCceXAsZ39YQtRIn",
+													"name": "FR: 6",
+													"cost": -2,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mjbKku0Yp4h4kv2gk",
+													"name": "FR: 9",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "msyR44lwzey2ajexp",
+													"name": "FR: 12",
+													"cost": -10,
+													"cost_type": "points"
+												},
+												{
+													"id": "ma6Q6lNmgxrbwlhly",
+													"name": "FR: 15",
+													"cost": -15,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "myaok6OHffxHercaz",
+													"name": "Extremely Hazardous",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m7oeCpojw0nL9BwMQ",
+													"name": "Involuntary",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mZEjBZGO8ZAXfD0J8",
+													"name": "Nonhazardous",
+													"cost": 5,
+													"cost_type": "points",
+													"disabled": true
+												}
+											],
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "tccFUZzIHBCydAZHI",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t1HUGl4o498iCyvrw"
+											},
+											"name": "Duty (@Duty@)",
+											"reference": "B133",
+											"tags": [
+												"Disadvantage",
+												"Social"
+											],
+											"replacements": {
+												"Duty": "To ship's owner or provider"
+											},
+											"modifiers": [
+												{
+													"id": "miOud3CQ7FYJExDRv",
+													"name": "FR: 6",
+													"cost": -2,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mIrbUGpRhiY0IbMt4",
+													"name": "FR: 9",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mfEuzEtFBLGpIbf5i",
+													"name": "FR: 12",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m72IpNcFeX-7679kN",
+													"name": "FR: 15",
+													"cost": -15,
+													"cost_type": "points"
+												},
+												{
+													"id": "mw_KWRKxcSDr7Waqb",
+													"name": "Extremely Hazardous",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "myee28NbdNj5H8apk",
+													"name": "Involuntary",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mWSMu_dBA8tdHcV3R",
+													"name": "Nonhazardous",
+													"cost": 5,
+													"cost_type": "points",
+													"disabled": true
+												}
+											],
+											"calc": {
+												"points": -15
+											}
+										},
+										{
+											"id": "tsXsdkmOPI1-f8Z4d",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tXFf9MSQ3FMT2psO8"
+											},
+											"name": "Demophobia (Crowds)",
+											"reference": "B149",
+											"notes": "Any group of over a dozen people sets off this fear unless they are all well known to you. The self-control roll is at -1 for over 25 people, -2 for a crowd of 100 or more, -3 for 1,000, -4 for 10,000, and so on.",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
+											"cr_adj": "action_penalty",
+											"cr": 12,
+											"base_points": -15,
+											"calc": {
+												"points": -15
+											}
+										},
+										{
+											"id": "tF1HPFNXWDzeeXTCB",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tK4QdVZYxGAd4cqr_"
+											},
+											"name": "Compulsive Gambling",
+											"reference": "B128",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"cr": 12,
 											"base_points": -5,
 											"calc": {
 												"points": -5
 											}
 										},
 										{
-											"id": "t1iJeOA-bLBkSdklV",
-											"name": "Code of Honor (Soldier's)",
-											"reference": "B127",
-											"notes": "An officer should be tough but fair, lead from the front, and look out for his men; an enlisted man should look out for his buddies and take care of his kit. Every soldier should be willing to fight and die for the honor of his unit, service, and country; follow orders; obey the “rules of war”; treat an honorable enemy with respect (a dishonorable enemy deserves a bullet); and wear the uniform with pride.",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"base_points": -10,
-											"calc": {
-												"points": -10
-											}
-										},
-										{
-											"id": "tnN4nb6OtUyQuFIHk",
+											"id": "tqdbRLIKjfDM6VAQp",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tapWLsuN75Unedmwn"
+											},
 											"name": "Compulsive Carousing",
 											"reference": "B128",
 											"tags": [
@@ -2147,308 +3230,115 @@
 											}
 										},
 										{
-											"id": "t0Bn-tU6mD9PscrRA",
-											"name": "Compulsive Gambling",
-											"reference": "B128",
+											"id": "t7CXdC4MuE1pQ_ElV",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "txSrmgLB0M36uR802"
+											},
+											"name": "Code of Honor (Soldier's)",
+											"reference": "B127",
+											"notes": "An officer should be tough but fair, lead from the front, and look out for his men; an enlisted man should look out for his buddies and take care of his kit. Every soldier should be willing to fight and die for the honor of his unit, service, and country; follow orders; obey the “rules of war”; treat an honorable enemy with respect (a dishonorable enemy deserves a bullet); and wear the uniform with pride.",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
-											"cr": 12,
-											"base_points": -5,
-											"calc": {
-												"points": -5
-											}
-										},
-										{
-											"id": "t6xjJryvW_D1qV0PC",
-											"name": "Duty (To ship's owner or provider)",
-											"reference": "B133",
-											"tags": [
-												"Disadvantage",
-												"Social"
-											],
-											"modifiers": [
-												{
-													"id": "mF1jYNEz7H2mAGIAH",
-													"name": "FR: 6",
-													"cost": -2,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mcXT0Xvcd30WoAR3t",
-													"name": "FR: 9",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "muTLTzNewc1Zaxw0F",
-													"name": "FR: 12",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mZix06bZ1szzZYdEH",
-													"name": "FR: 15",
-													"cost": -15,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mBeuJ8JaUDRD4e7P2",
-													"name": "Extremely Hazardous",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "muyRmFeCAfRrkcjQd",
-													"name": "Involuntary",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mZr9BznfQkxCtqlQX",
-													"name": "Nonhazardous",
-													"cost": 5,
-													"cost_type": "points",
-													"disabled": true
-												}
-											],
-											"calc": {
-												"points": 0
-											}
-										},
-										{
-											"id": "tC8DWCpT7QEG8dls3",
-											"name": "Enemy (@Who@)",
-											"reference": "B135",
-											"tags": [
-												"Disadvantage",
-												"Social"
-											],
-											"modifiers": [
-												{
-													"id": "mNO3hX9A2T1G5jLzR",
-													"name": "Weak Individual",
-													"reference": "B135",
-													"notes": "50% of your starting points",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mpQXgtmxm-v9CxrYj",
-													"name": "Equal Individual",
-													"reference": "B135",
-													"notes": "100% of your starting points",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m4D10Eu8Tf1ZbH2ic",
-													"name": "Powerful Individual",
-													"reference": "B135",
-													"notes": "\u003e150% of your starting points",
-													"cost": -20,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "miyJ6Xtjdhspr_p_s",
-													"name": "Weak Group",
-													"reference": "B135",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m9EZ0lmqVXhsttA0t",
-													"name": "Medium Group",
-													"reference": "B135",
-													"cost": -20,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mzsUF8LeBrdl5wurP",
-													"name": "Appears almost all the time",
-													"reference": "B36",
-													"notes": "15-",
-													"cost": 3,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mJSM58sVm_qh-ETe-",
-													"name": "Appears quite often",
-													"reference": "B36",
-													"notes": "12-",
-													"cost": 2,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mBMhBHjIv5fAyU77F",
-													"name": "Appears fairly often",
-													"reference": "B36",
-													"notes": "9-",
-													"cost": 1,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mmKRAZAcU3xnHNFsb",
-													"name": "Appears quite rarely",
-													"reference": "B36",
-													"notes": "6-",
-													"cost": 0.5,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "m88XBwn3Vm4LFCW-7",
-													"name": "Large/Powerful Group",
-													"reference": "B135",
-													"cost": -30,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mBknVSzta1Lggpd-9",
-													"name": "Utterly Formidable Group",
-													"reference": "B135",
-													"cost": -40,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mDKtQvTcsZlkJyHvp",
-													"name": "Unknown",
-													"reference": "B135",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mncrlIerg2Oi5BGDU",
-													"name": "Evil Twin",
-													"reference": "B135",
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mPlO6Cq8UEaTTC6Jd",
-													"name": "Evil Twin",
-													"reference": "B135",
-													"notes": "More skilled or extra abilities",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m9fH6q2Stfn1XnWu6",
-													"name": "Evil Twin",
-													"reference": "B135",
-													"notes": "More skilled and extra abilities",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mLcmfxDTfaCvT9VH4",
-													"name": "Watcher",
-													"reference": "B135",
-													"cost": 0.25,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mRrgYFXjsoNJGRCej",
-													"name": "Rival",
-													"reference": "B135",
-													"cost": 0.5,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mmKZmJv9rUzZWotWr",
-													"name": "Hunter",
-													"reference": "B135",
-													"cost": 1,
-													"cost_type": "multiplier",
-													"disabled": true
-												}
-											],
-											"calc": {
-												"points": 0
-											}
-										},
-										{
-											"id": "tUEkK06sA-sj3SJVX",
-											"name": "Honesty",
-											"reference": "B138",
-											"notes": "Make a self-control roll when faced with the “need” to break unreasonable laws; if you fail, you must obey the law, whatever the consequences. If you manage to resist your urges and break the law, make a second self-control roll afterward. If you fail, you must turn yourself in to the authorities!",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"cr": 12,
 											"base_points": -10,
 											"calc": {
 												"points": -10
 											}
 										},
 										{
-											"id": "tkiaOVVYogX0EhBFE",
-											"name": "Intolerance (@Rival civilization or species@)",
-											"reference": "B140",
+											"id": "tdrte4SuhAJkwisa7",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Space/Space Traits.adq",
+												"id": "teNSsqOsjstajwmxn"
+											},
+											"name": "Code of Honor (Mercenary's Code)",
+											"reference": "B127, S221",
+											"notes": "A merc should look out for his buddies, take care of his gear, and fight for the honor of the unit. Obey the rules of engagement. Don’t poach on another unit’s contract. Do the job you’re hired for.",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
-											"modifiers": [
-												{
-													"id": "mCXCMuqeodVuLcLv7",
-													"name": "Scope: Common",
-													"reference": "B140",
-													"cost": -5,
-													"cost_type": "points"
-												},
-												{
-													"id": "mbpNdrS15WUJYRTD3",
-													"name": "Scope: Occasional",
-													"reference": "B140",
-													"cost": -2,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mmFl9YNyzAOA47e5V",
-													"name": "Scope: Rare",
-													"reference": "B140",
-													"cost": -1,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m6EwVi04PJgyz3nLV",
-													"name": "Scope: Anyone unlike you",
-													"reference": "B140",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												}
+											"base_points": -10,
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "tAu2ccymHEz5qj_J_",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tqq24I9NJrLajsURv"
+											},
+											"name": "Code of Honor (Pirate's)",
+											"reference": "B127",
+											"notes": "Always avenge an insult, regardless of the danger; your buddy’s foe is your own; never attack a fellow crewman or buddy except in a fair, open duel.",
+											"tags": [
+												"Disadvantage",
+												"Mental"
 											],
+											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										},
+										{
+											"id": "tUuGvq2EWfb-Ib4rB",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t4KGpV0KBExr-fEb2"
+											},
+											"name": "Gregarious",
+											"reference": "B126",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"base_points": -10,
 											"features": [
 												{
 													"type": "reaction_bonus",
-													"situation": "from victims of your intolerance (may be as much as -5, at GM's discretion)",
+													"situation": "to others",
+													"amount": 4
+												},
+												{
+													"type": "conditional_modifier",
+													"situation": "to IQ-based skills when alone, or only -1 if in a group of 4 or less",
+													"amount": -2
+												}
+											],
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "tqjoVC37L1dE-LVNC",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tzBDG0xUlT_dh7FuY"
+											},
+											"name": "Chummy",
+											"reference": "B126",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"base_points": -5,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "to others",
+													"amount": 2
+												},
+												{
+													"type": "conditional_modifier",
+													"situation": "to IQ-based skills when alone",
 													"amount": -1
 												}
 											],
@@ -2457,91 +3347,12 @@
 											}
 										},
 										{
-											"id": "tdlGl09IFsSgMAzbm",
-											"name": "Lecherousness",
-											"reference": "B142",
-											"notes": "Make a self-control roll whenever you have more than the briefest contact with an appealing member of the sex you find attractive, at -5 if this person is Handsome/Beautiful, or at -10 if Very Handsome/Very Beautiful. If you fail, you must make a “pass” using whatever wiles and skills you can bring to bear.",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"cr": 12,
-											"base_points": -15,
-											"calc": {
-												"points": -15
-											}
-										},
-										{
-											"id": "tajxvRlDWYr5bJslU",
-											"name": "Pacifism: Reluctant Killer",
-											"reference": "B148",
-											"notes": "You are psychologically unprepared to kill people. Whenever you make a deadly attack (e.g., with a knife or a gun) against an obvious person whose face is visible to you, you are at -4 to hit and may not Aim. If you cannot see the foe’s face (due to a mask, darkness, or distance, or because you attacked from behind), the penalty is only -2, save in close combat. You have no penalty to attack a vehicle (even an occupied one), an opponent you do not believe is a person (including things with Horrific or Monstrous appearance), or a target you can’t actually see (e.g., a set of map coordinates or a blip on a radar screen). If you kill a recognizable person, the effect on you is the same as for Pacifism: Cannot Kill. You have no problem with your allies killing; you may even supply ammo, loaded weapons, and encouragement! You just can’t do the killing yourself.",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"modifiers": [
-												{
-													"id": "mYlT68XIjCG88d8kK",
-													"name": "Species-Specific",
-													"reference": "UT32",
-													"cost": -80,
-													"disabled": true
-												}
-											],
-											"base_points": -5,
-											"calc": {
-												"points": -5
-											}
-										},
-										{
-											"id": "tJkaIOMezzVDxpgC6",
-											"name": "Pacifism: Self-Defense Only",
-											"reference": "B148",
-											"notes": "You only fight to defend yourself or those in your care, using only as much force as necessary (no pre-emptive strikes allowed!). You must do your best to discourage others from starting fights.",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"modifiers": [
-												{
-													"id": "mqcrOm4CyI1e4x2r-",
-													"name": "Species-Specific",
-													"reference": "UT32",
-													"cost": -80,
-													"disabled": true
-												}
-											],
-											"base_points": -15,
-											"calc": {
-												"points": -15
-											}
-										},
-										{
-											"id": "tT-EOHy7432FVsneC",
-											"name": "Pacifism: Cannot Harm Innocents",
-											"reference": "B148",
-											"notes": "You may fight – you may even start fights – but you may only use deadly force on a foe that is attempting to do you serious harm. Capture is not “serious harm” unless you are already under penalty of death or have a Code of Honor that would require suicide if captured. You never intentionally do anything that causes, or even threatens to cause, injury to the uninvolved – particularly if they are “ordinary folks.”",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"modifiers": [
-												{
-													"id": "mgti4x-faQ_WeG6DA",
-													"name": "Species-Specific",
-													"reference": "UT32",
-													"cost": -80,
-													"disabled": true
-												}
-											],
-											"base_points": -10,
-											"calc": {
-												"points": -10
-											}
-										},
-										{
-											"id": "tIqvkWcfup3W932_4",
+											"id": "thRWyLKJfH9bRtttp",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "taFPI7E0PJwXbS5nL"
+											},
 											"name": "Agoraphobia (Open Spaces)",
 											"reference": "B150",
 											"notes": "You are uncomfortable whenever you are outside, and actually become frightened when there are no walls within 50 feet.",
@@ -2555,120 +3366,19 @@
 											"calc": {
 												"points": -10
 											}
-										},
-										{
-											"id": "tXcw4TDIhb5ak7DfW",
-											"name": "Demophobia (Crowds)",
-											"reference": "B149",
-											"notes": "Any group of over a dozen people sets off this fear unless they are all well known to you. The self-control roll is at -1 for over 25 people, -2 for a crowd of 100 or more, -3 for 1,000, -4 for 10,000, and so on.",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"cr_adj": "action_penalty",
-											"cr": 12,
-											"base_points": -15,
-											"calc": {
-												"points": -15
-											}
-										},
-										{
-											"id": "tEbaByKV_Yq6tQHj7",
-											"name": "Duty (To ship's owner or provider)",
-											"reference": "B133",
-											"tags": [
-												"Disadvantage",
-												"Social"
-											],
-											"modifiers": [
-												{
-													"id": "mBhpJ76ocUNh_T_9f",
-													"name": "FR: 6",
-													"cost": -2,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mg4f3qo8cTt3XuiCo",
-													"name": "FR: 9",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mHX9kXb2Jh0nZsLeB",
-													"name": "FR: 12",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mW0wIfRD7pAg9Qdsu",
-													"name": "FR: 15",
-													"cost": -15,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mS1K-P8tNkm1_cooq",
-													"name": "Extremely Hazardous",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mRJb4XpSdOaKUSomb",
-													"name": "Involuntary",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mS4aCp1NfMUJOQ6Rm",
-													"name": "Nonhazardous",
-													"cost": 5,
-													"cost_type": "points",
-													"disabled": true
-												}
-											],
-											"calc": {
-												"points": 0
-											}
-										},
-										{
-											"id": "tkXGA4LvHRWzRMD6N",
-											"name": "Workaholic",
-											"reference": "B162",
-											"tags": [
-												"Disadvantage",
-												"Physical"
-											],
-											"base_points": -5,
-											"calc": {
-												"points": -5
-											}
-										},
-										{
-											"id": "tSXsIGtqEuMyKyc1z",
-											"name": "Xenophilia",
-											"reference": "B162",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"cr": 12,
-											"base_points": -10,
-											"calc": {
-												"points": -10
-											}
 										}
 									],
 									"calc": {
-										"points": -145
+										"points": -180
 									}
 								},
 								{
-									"id": "tbMQkX4958bvXQcvr",
+									"id": "teaFrHnoApLJ4nBaW",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tbB8FlaUVuRanGu-T"
+									},
 									"name": "Absent-Mindedness",
 									"reference": "B122",
 									"notes": "Once adrift in your own thoughts, you must roll against Perception-5 in order to notice any event short of personal physical injury",
@@ -2689,7 +3399,12 @@
 									}
 								},
 								{
-									"id": "taPBZZ1KkeW7eeFux",
+									"id": "taYzW70UtXPXHxmI7",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t5Qs23yaRu3D4T_hM"
+									},
 									"name": "Attentive",
 									"reference": "B163",
 									"tags": [
@@ -2709,7 +3424,12 @@
 									}
 								},
 								{
-									"id": "tsR_HDmqVqCmdQQLH",
+									"id": "tgICnPQ-hleo1CUqr",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t-ZuUbg_LrqZ1hi6c"
+									},
 									"name": "Careful",
 									"reference": "B163",
 									"tags": [
@@ -2722,7 +3442,12 @@
 									}
 								},
 								{
-									"id": "tS1o3HADroX4ma7rb",
+									"id": "tXsEsuMUVwEjlvjT2",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "ttlpxHmhTlHZvLehl"
+									},
 									"name": "Clueless",
 									"reference": "B126",
 									"tags": [
@@ -2742,7 +3467,7 @@
 										},
 										{
 											"type": "reaction_bonus",
-											"situation": "from others",
+											"situation": "from others aware of your clueless nature",
 											"amount": -2
 										},
 										{
@@ -2756,7 +3481,12 @@
 									}
 								},
 								{
-									"id": "t_uIcztd3R6PB_QWf",
+									"id": "twjFUAvHuk7RVXQ5J",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t2O8gMxbRPpAWLej9"
+									},
 									"name": "Curious",
 									"reference": "B129",
 									"notes": "Make a self-control roll when presented with an interesting item or situation",
@@ -2771,7 +3501,12 @@
 									}
 								},
 								{
-									"id": "tFOMU04nSn3md3-ee",
+									"id": "tKT-ay6FDbq1mXUTi",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "ta2gcuebm2uhQ5XyB"
+									},
 									"name": "Dreamer",
 									"reference": "B164",
 									"tags": [
@@ -2791,7 +3526,12 @@
 									}
 								},
 								{
-									"id": "t5tcmt8EdXldC2NQB",
+									"id": "tDQsEPk2iP_8Xeztx",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tYNyLy2IqVVc5zHut"
+									},
 									"name": "Oblivious",
 									"reference": "B146",
 									"tags": [
@@ -2865,7 +3605,12 @@
 									}
 								},
 								{
-									"id": "t756g21_CyJMx5bGb",
+									"id": "tjxsWwsp0s_SMb9xm",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tPbL1_rekOzkM86wz"
+									},
 									"name": "Overconfidence",
 									"reference": "B148",
 									"notes": "You must make a self-control roll any time the GM feels you show an unreasonable degree of caution. If you fail, you must go ahead as though you were able to handle the situation!",
@@ -2892,7 +3637,12 @@
 									}
 								},
 								{
-									"id": "tPis6YEqXmJqrVO18",
+									"id": "tG6qjy8sn-gjln7_L",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tcLpFfSmbHHdHy5Yd"
+									},
 									"name": "Post-Combat Shakes",
 									"reference": "B150",
 									"notes": "Make a self-control roll at the end of any battle. If you fail, roll 3d, add the amount by which you failed your self-control roll, and look up the result on the Fright Check Table.",
@@ -2907,7 +3657,12 @@
 									}
 								},
 								{
-									"id": "tM-wsZOwlPmtHdV8V",
+									"id": "tp-O5nvi0NXoxma8C",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tfujsOp4WL4ZholTv"
+									},
 									"name": "Mild Shyness",
 									"reference": "B154",
 									"notes": "You are uneasy with strangers, especially assertive or attractive ones.",
@@ -3058,7 +3813,12 @@
 									}
 								},
 								{
-									"id": "tm7coq2StXbPF1tap",
+									"id": "tC7Y4HLTCyO6MGdD0",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tqyAIJKZUTPhxkhbU"
+									},
 									"name": "Truthfulness",
 									"reference": "B159",
 									"notes": "Make a self-control roll whenever you must keep silent about an uncomfortable truth (lying by omission). Roll at -5 if you actually have to tell a falsehood! If you fail, you blurt out the truth, or stumble so much that your lie is obvious.",
@@ -3074,7 +3834,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "fast talk"
+												"qualifier": "fast-talk"
 											},
 											"amount": -5
 										}
@@ -3085,17 +3845,17 @@
 								}
 							],
 							"calc": {
-								"points": -203
+								"points": -238
 							}
 						}
 					],
 					"calc": {
-						"points": -203
+						"points": -238
 					}
 				}
 			],
 			"calc": {
-				"points": 129
+				"points": 186
 			}
 		},
 		{
@@ -3108,7 +3868,12 @@
 					"name": "Multi-Role",
 					"children": [
 						{
-							"id": "thnUxS9ODs45koGBV",
+							"id": "t2SQqG9c9DkwF6TvU",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t1w1RFcFceKR2T9_e"
+							},
 							"name": "Increased Intelligence",
 							"reference": "B15",
 							"tags": [
@@ -3132,7 +3897,12 @@
 							}
 						},
 						{
-							"id": "tFIEtJ1Fnunh7K0Sc",
+							"id": "tzbhYaJKRjLoQq4v3",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "ttrmORiWbD1uv2rpD"
+							},
 							"name": "Talent (Natural Scientist)",
 							"reference": "PU3:13",
 							"tags": [
@@ -3142,12 +3912,45 @@
 							],
 							"modifiers": [
 								{
-									"id": "mqZfTlNHutMg-0v6D",
+									"id": "mBY00lw0YCllSymPY",
 									"name": "Alternative Cost",
 									"cost": 1,
 									"cost_type": "points",
 									"affects": "levels_only",
 									"disabled": true
+								},
+								{
+									"id": "MogyhQfAJGpSPKciu",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "mcI-CJoqsB6wF89_i",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From scientists and those impressed by \"smart people\".",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "mg3aA-fVc2KASX9tR",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Reduce TL and familiarity penalties for gear examined for an hour with a covered skill",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
 								}
 							],
 							"points_per_level": 10,
@@ -3281,18 +4084,6 @@
 									},
 									"amount": 1,
 									"per_level": true
-								},
-								{
-									"type": "reaction_bonus",
-									"situation": "From scientists and those impressed by \"smart people\".",
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "conditional_modifier",
-									"situation": "Reduce TL and familiarity penalties for gear examined for an hour with a covered skill",
-									"amount": 1,
-									"per_level": true
 								}
 							],
 							"can_level": true,
@@ -3311,7 +4102,12 @@
 					"name": "Legendary",
 					"children": [
 						{
-							"id": "t7i1d9DKgZ76uZdaJ",
+							"id": "tHvbDdN2KjjTVCI6A",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t1w1RFcFceKR2T9_e"
+							},
 							"name": "Increased Intelligence",
 							"reference": "B15",
 							"tags": [
@@ -3335,7 +4131,12 @@
 							}
 						},
 						{
-							"id": "tj0SO52Ge1o83jz14",
+							"id": "tdkxsQb-ZP6JwKA4M",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "ttrmORiWbD1uv2rpD"
+							},
 							"name": "Talent (Natural Scientist)",
 							"reference": "PU3:13",
 							"tags": [
@@ -3345,12 +4146,45 @@
 							],
 							"modifiers": [
 								{
-									"id": "mEcq-N1QHxvIdciZG",
+									"id": "meirxYl0qHcCAiwD3",
 									"name": "Alternative Cost",
 									"cost": 1,
 									"cost_type": "points",
 									"affects": "levels_only",
 									"disabled": true
+								},
+								{
+									"id": "MNmWv8X8jpVEHx2Cs",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "mbxwSjLC-6Gq3-tYQ",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From scientists and those impressed by \"smart people\".",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "myzZmNglk2vfWd4r0",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Reduce TL and familiarity penalties for gear examined for an hour with a covered skill",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
 								}
 							],
 							"points_per_level": 10,
@@ -3482,18 +4316,6 @@
 										"compare": "is",
 										"qualifier": "Pysiology"
 									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "reaction_bonus",
-									"situation": "From scientists and those impressed by \"smart people\".",
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "conditional_modifier",
-									"situation": "Reduce TL and familiarity penalties for gear examined for an hour with a covered skill",
 									"amount": 1,
 									"per_level": true
 								}
@@ -3526,7 +4348,12 @@
 					"name": "Primary Skills",
 					"children": [
 						{
-							"id": "s-MxgcEGZM7Hehypw",
+							"id": "sNdQdpLDTDzHK0JVL",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sirFPuXXZfzdkM7Zm"
+							},
 							"name": "Electronics Operation",
 							"reference": "B189",
 							"tags": [
@@ -3561,7 +4388,12 @@
 							"points": 4
 						},
 						{
-							"id": "svH7XFy75HJ9-n8bu",
+							"id": "srmEwwMD8EMTB4fd4",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "stFawUEv8gxldDoiC"
+							},
 							"name": "Research",
 							"reference": "B217",
 							"tags": [
@@ -3654,7 +4486,12 @@
 							"points": 4
 						},
 						{
-							"id": "sGJ1-IhLdCNi94nzs",
+							"id": "sX5a5iM6fjGi_5GrN",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sbcabbj7Zf2iurxxA"
+							},
 							"name": "Astronomy",
 							"reference": "B179",
 							"tags": [
@@ -3689,7 +4526,12 @@
 							"points": 1
 						},
 						{
-							"id": "sHLy1gk8_am7IWZZx",
+							"id": "s9d9uiOaiuUEri7iX",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sNo8fl03x7a76gaOU"
+							},
 							"name": "Chemistry",
 							"reference": "B183",
 							"tags": [
@@ -3711,7 +4553,12 @@
 							"points": 1
 						},
 						{
-							"id": "sqY4DivwiE3YohzOC",
+							"id": "s-hG9GgytVkf9AU8-",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "s2YhViBIYuLf4xevN"
+							},
 							"name": "Geology",
 							"reference": "B198",
 							"tags": [
@@ -3740,7 +4587,12 @@
 							"points": 1
 						},
 						{
-							"id": "sUTeP4PmiCGar5GVJ",
+							"id": "sbZvedoQu0PApbLYQ",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sGgBbCTe-AwY1nu3W"
+							},
 							"name": "Mathematics",
 							"reference": "B207",
 							"tags": [
@@ -3768,7 +4620,12 @@
 							"points": 1
 						},
 						{
-							"id": "s3xDWYNBIMljG3YCm",
+							"id": "scvpWCpEQldWWtdgw",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sb6LoqgrQgzKvzHH2"
+							},
 							"name": "Biology",
 							"reference": "B180",
 							"tags": [
@@ -3792,7 +4649,12 @@
 							"points": 2
 						},
 						{
-							"id": "sXuuZ10fJYblyPIEl",
+							"id": "sBggbPakvgzg6hKWB",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "snf1C1wltuy8_tanr"
+							},
 							"name": "Physics",
 							"reference": "B213",
 							"tags": [
@@ -3835,7 +4697,12 @@
 							"name": "Three of",
 							"children": [
 								{
-									"id": "sg96Na9NpXHp1FD6f",
+									"id": "sWpz0B9C_0sdJ9cAj",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "skeyxidllluafSmPY"
+									},
 									"name": "Meteorology",
 									"reference": "B209",
 									"tags": [
@@ -3853,7 +4720,12 @@
 									"points": 1
 								},
 								{
-									"id": "sj9J9LC-0dhXS-vjT",
+									"id": "sirtlHTR5ybzbpwYW",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "swPEguEhGicG5M08E"
+									},
 									"name": "Expert Skill",
 									"reference": "B193,MA56",
 									"tags": [
@@ -3866,13 +4738,21 @@
 									"points": 1
 								},
 								{
-									"id": "sgOJr65Oeuj8tZ57J",
+									"id": "snL-KIUUZlFv2D3YY",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "s2YhViBIYuLf4xevN"
+									},
 									"name": "Geology",
 									"reference": "B198",
 									"tags": [
 										"Natural Science"
 									],
-									"specialization": "@Any other@",
+									"replacements": {
+										"Planet class": "@Any other@"
+									},
+									"specialization": "@Planet class@",
 									"difficulty": "iq/h",
 									"defaults": [
 										{
@@ -3895,13 +4775,21 @@
 									"points": 1
 								},
 								{
-									"id": "sk2RRFqZYGriIBx-D",
+									"id": "s1ZuPGgGCdk7TsbvS",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sDKy9mOhQeiZ6fjvq"
+									},
 									"name": "Mathematics",
 									"reference": "B207",
 									"tags": [
 										"Natural Science"
 									],
-									"specialization": "@Any other@",
+									"replacements": {
+										"Specialization": "@Any other@"
+									},
+									"specialization": "@Specialization@",
 									"difficulty": "iq/h",
 									"defaults": [
 										{
@@ -3910,7 +4798,12 @@
 										},
 										{
 											"type": "skill",
-											"name": "Computer Programming",
+											"name": "Physics",
+											"modifier": -5
+										},
+										{
+											"type": "skill",
+											"name": "Engineer",
 											"modifier": -5
 										}
 									],
@@ -3918,7 +4811,12 @@
 									"points": 1
 								},
 								{
-									"id": "sOOY-vSC6aKkSVXND",
+									"id": "soMPZqbtQZQpPYNBU",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "spTsoXZjc2oRCK8Cz"
+									},
 									"name": "Metallurgy",
 									"reference": "B209",
 									"tags": [
@@ -3946,7 +4844,12 @@
 									"points": 1
 								},
 								{
-									"id": "sF3zTH3iQVKo5kZ2_",
+									"id": "sTNEnU2fbEOMJ3rq3",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "s65U7Q64hLe7e_7UR"
+									},
 									"name": "Paleontology",
 									"reference": "B212",
 									"tags": [
@@ -3972,7 +4875,12 @@
 									"points": 1
 								},
 								{
-									"id": "s6gHPhb4hSH9P90PL",
+									"id": "sBFpAJFEgtV89jkaZ",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sSnvf-r4ViMOrA_5y"
+									},
 									"name": "Bioengineering",
 									"reference": "B180",
 									"tags": [
@@ -3997,7 +4905,12 @@
 									"points": 1
 								},
 								{
-									"id": "s8sDgXrmeY2uR4VZR",
+									"id": "s9qJ7HFuZI6j-q9YU",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sBY-R7Xmf64T7WzZ4"
+									},
 									"name": "Computer Programming",
 									"reference": "B184",
 									"tags": [
@@ -4009,7 +4922,12 @@
 									"points": 1
 								},
 								{
-									"id": "sbwRAkntnwH7Cb6J4",
+									"id": "sTdIdTUr4w0PGfFFK",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "s_QPsaG-MtZBFWSgN"
+									},
 									"name": "Engineer",
 									"reference": "B190",
 									"tags": [
@@ -4017,7 +4935,7 @@
 										"Engineer",
 										"Invention"
 									],
-									"specialization": "@Any@",
+									"specialization": "@Field of expertise@",
 									"difficulty": "iq/h",
 									"defaults": [
 										{
@@ -4053,7 +4971,12 @@
 									"points": 1
 								},
 								{
-									"id": "smw4kDa3Qgw_xfkyn",
+									"id": "sQps7dZrXl-IzS418",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sqKieRudf_Tp4-T6T"
+									},
 									"name": "Expert Skill",
 									"reference": "B193,MA56",
 									"tags": [
@@ -4067,14 +4990,22 @@
 									"points": 1
 								},
 								{
-									"id": "s_voapd3nigOlbg5l",
+									"id": "sU8lf0xu_dieYp8lg",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sb6LoqgrQgzKvzHH2"
+									},
 									"name": "Biology",
 									"reference": "B180",
 									"tags": [
 										"Natural Science",
 										"Plant"
 									],
-									"specialization": "@any other@",
+									"replacements": {
+										"Specialty": "@Any other@"
+									},
+									"specialization": "@Specialty@",
 									"difficulty": "iq/vh",
 									"defaults": [
 										{
@@ -4099,7 +5030,12 @@
 					"name": "Secondary Skills",
 					"children": [
 						{
-							"id": "sgFjpjoccoSb5cBc_",
+							"id": "slLP5Xfzu9d17Gru6",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "ssHhRG7LH-Ma3YDnH"
+							},
 							"name": "Computer Operation",
 							"reference": "B184",
 							"tags": [
@@ -4118,7 +5054,12 @@
 							"points": 1
 						},
 						{
-							"id": "snpKUEjGtP0xZW7DI",
+							"id": "skN0X_9gPMiF5KmAj",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sluTeYhSTpIbVNfA5"
+							},
 							"name": "Electronics Operation",
 							"reference": "B189",
 							"tags": [
@@ -4150,10 +5091,15 @@
 								}
 							],
 							"tech_level": "",
-							"points": 4
+							"points": 1
 						},
 						{
-							"id": "s7im4XfcoBQmLP_JO",
+							"id": "s15JYdS0_uboPSYUE",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "s9IHT34mK8yfSB7d_"
+							},
 							"name": "Spacer",
 							"reference": "B185",
 							"tags": [
@@ -4176,7 +5122,12 @@
 					"name": "Background Skills",
 					"children": [
 						{
-							"id": "s_UXQW4-231EA0I1V",
+							"id": "snhuMiTdgy_e8Vosi",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "s7kVwKFERTuMYO3O8"
+							},
 							"name": "Free Fall",
 							"reference": "B197",
 							"tags": [
@@ -4193,10 +5144,15 @@
 									"modifier": -5
 								}
 							],
-							"points": 1
+							"points": 2
 						},
 						{
-							"id": "sCPBZgdtnOPSpY898",
+							"id": "sI90JiUUDR0XfoHZA",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "swjwM4R_hmkH-UXlB"
+							},
 							"name": "NBC Suit",
 							"reference": "B192",
 							"tags": [
@@ -4226,10 +5182,15 @@
 								}
 							],
 							"tech_level": "",
-							"points": 1
+							"points": 2
 						},
 						{
-							"id": "s5qrkbdCB4Woz7R3O",
+							"id": "so1ZrnLRhG1nE2Zwv",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sAmDzPjf0rKZ6I5G1"
+							},
 							"name": "Vacc Suit",
 							"reference": "B192",
 							"tags": [
@@ -4258,20 +5219,28 @@
 								}
 							],
 							"tech_level": "",
-							"points": 1
+							"points": 2
 						},
 						{
 							"id": "S2ksx3xJtwmE4Deyv",
 							"name": "Two of",
 							"children": [
 								{
-									"id": "sIWCjswlPZvcvHEya",
+									"id": "stgSXBPGz6FqTTtD-",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sUOQKAH8IaMhpxk1o"
+									},
 									"name": "Electronics Operation",
 									"reference": "B189",
 									"tags": [
 										"Technical"
 									],
-									"specialization": "@any other@",
+									"replacements": {
+										"Electronics type": "@Any other@"
+									},
+									"specialization": "@Electronics type@",
 									"difficulty": "iq/a",
 									"defaults": [
 										{
@@ -4300,7 +5269,12 @@
 									"points": 1
 								},
 								{
-									"id": "sYJMgxKyndlRDTwtI",
+									"id": "sS5gwYnVPkx8Q9YLK",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sn9Y6a4YbUfsQ8GxY"
+									},
 									"name": "Hazardous Materials",
 									"reference": "B199",
 									"tags": [
@@ -4318,7 +5292,12 @@
 									"points": 1
 								},
 								{
-									"id": "syPj-Sa6TYtpua66J",
+									"id": "sWRJO_qmqsuh7vVG3",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sHJ4snJkuJRXIT85e"
+									},
 									"name": "Teaching",
 									"reference": "B224",
 									"tags": [
@@ -4335,7 +5314,12 @@
 									"points": 1
 								},
 								{
-									"id": "sjoYuGREctOVFDoeZ",
+									"id": "s7qe_SofnlCX3-Eyt",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sHuT7RWMID47mVbzP"
+									},
 									"name": "Writing",
 									"reference": "B228",
 									"tags": [
@@ -4359,11 +5343,16 @@
 							"name": "10 Points chosen from",
 							"children": [
 								{
-									"id": "ShBTY8Rhoq1V2WZMv",
+									"id": "S3K48pwG8mcMemj3I",
 									"name": "Everyman Skills",
 									"children": [
 										{
-											"id": "suapWTeub8bWBx6T7",
+											"id": "sWMHliQ3RlLYPwXBu",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sTXDrqXH0sT2NSD_b"
+											},
 											"name": "Area Knowledge",
 											"reference": "B176",
 											"notes": "Location of the capitals of interplanetary states and the homeworlds of major races; general awareness of all major races; knowledge of individuals of Status 8; general understanding of relations between interplanetary states",
@@ -4384,7 +5373,12 @@
 											"points": 1
 										},
 										{
-											"id": "sNiyk5H98jr-mpkU4",
+											"id": "smGNtJlagQz0nfQyJ",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "s-Ckyxw5PmHIvbZab"
+											},
 											"name": "Area Knowledge",
 											"reference": "B176",
 											"notes": "Location of major planets; familiarity with all known races (but not necessarily expertise); knowledge of people of Status 7+; general understanding of the economic and political situation",
@@ -4392,13 +5386,9 @@
 												"Everyman",
 												"Knowledge"
 											],
-											"specialization": "@Interplanetary State@; Lived there",
+											"specialization": "@Interplanetary State@",
 											"difficulty": "iq/e",
 											"defaults": [
-												{
-													"type": "iq",
-													"modifier": -4
-												},
 												{
 													"type": "skill",
 													"name": "Geography",
@@ -4409,7 +5399,12 @@
 											"points": 1
 										},
 										{
-											"id": "stlEceNmyoeqeBea_",
+											"id": "sjbY9r3eByYIDJUZU",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "strhX4LEdd46xgmIS"
+											},
 											"name": "Area Knowledge",
 											"reference": "B176",
 											"notes": "Location of its major cities and important sites; awareness of its major customs, ethnic groups, and languages (but not necessarily expertise); names of folk of Status 7+; and a general understanding of the economic and political situation",
@@ -4417,13 +5412,9 @@
 												"Everyman",
 												"Knowledge"
 											],
-											"specialization": "@Planet@; Lived there",
+											"specialization": "@Planet@",
 											"difficulty": "iq/e",
 											"defaults": [
-												{
-													"type": "iq",
-													"modifier": -4
-												},
 												{
 													"type": "skill",
 													"name": "Geography",
@@ -4434,7 +5425,12 @@
 											"points": 1
 										},
 										{
-											"id": "s_PTFypPmd_GIlI4V",
+											"id": "s7D3t-ITq-KL6CY2D",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sBJgeWUs81Ifhob4Z"
+											},
 											"name": "Beam Weapons",
 											"reference": "B179",
 											"tags": [
@@ -4465,7 +5461,12 @@
 											"points": 1
 										},
 										{
-											"id": "sCQQbfEuDGCGMhb5j",
+											"id": "sGRK7in9qKPVf_qyV",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sOp4wssAMtUc1ukJI"
+											},
 											"name": "Body Language",
 											"reference": "B181",
 											"tags": [
@@ -4489,10 +5490,14 @@
 											"points": 1
 										},
 										{
-											"id": "sHFcQH4SMRvE_t3vz",
+											"id": "sck086SaZx-lLLwFd",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sziMa9_9xTvR2iiqx"
+											},
 											"name": "Body Sense",
 											"reference": "B181",
-											"notes": "For settings with matter transmission",
 											"tags": [
 												"Athletic"
 											],
@@ -4511,7 +5516,12 @@
 											"points": 1
 										},
 										{
-											"id": "sDmaeejN3avBSJPTN",
+											"id": "sai5De75JfANXBXU-",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "shtDdl5thrvKSnJHf"
+											},
 											"name": "Brawling",
 											"reference": "B182,MA55",
 											"tags": [
@@ -4539,7 +5549,12 @@
 											"points": 1
 										},
 										{
-											"id": "sqpyX3Eo8YDEHjJuW",
+											"id": "sDmTWwiHkV5vN5W8v",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "si-upI7A5RgdO0cjC"
+											},
 											"name": "Carousing",
 											"reference": "B183",
 											"tags": [
@@ -4557,7 +5572,12 @@
 											"points": 1
 										},
 										{
-											"id": "sRjpCtAh1heihYu_r",
+											"id": "s_fIhClioZC2v2TB2",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sWFtA7Gvclq4aL-Yb"
+											},
 											"name": "Current Affairs",
 											"reference": "B186",
 											"tags": [
@@ -4588,7 +5608,12 @@
 											"points": 1
 										},
 										{
-											"id": "s-1k-cC9-tD96HPp3",
+											"id": "s9Vd3fmxV_ZW32KVa",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "s9mV--3lpIfXO7N6Z"
+											},
 											"name": "First Aid",
 											"reference": "B195",
 											"tags": [
@@ -4619,7 +5644,12 @@
 											"points": 1
 										},
 										{
-											"id": "snkne6SAsbB38TgLY",
+											"id": "sMY_EueoLxIb5vGP4",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sWB9ypJAq43MF3O0n"
+											},
 											"name": "Gambling",
 											"reference": "B197",
 											"tags": [
@@ -4643,7 +5673,12 @@
 											"points": 1
 										},
 										{
-											"id": "sPmCWyVKZ6TMwXVur",
+											"id": "syF1P2LYMTWr9FDun",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "syfSQ9N8yETqQbhFK"
+											},
 											"name": "Games",
 											"reference": "B197,MA57",
 											"tags": [
@@ -4660,7 +5695,12 @@
 											"points": 1
 										},
 										{
-											"id": "svFarayWnWQlQe4nN",
+											"id": "sN4uUecH_-ChJxSwe",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sGz21GskAlJXL1hYP"
+											},
 											"name": "Gesture",
 											"reference": "B198",
 											"tags": [
@@ -4676,7 +5716,12 @@
 											"points": 1
 										},
 										{
-											"id": "sBZjyOVJdwRZ0gI-3",
+											"id": "s5k6HM67dvMCH8t1p",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sT5htbz4-Mr0PFCk7"
+											},
 											"name": "Guns",
 											"reference": "B198",
 											"tags": [
@@ -4701,7 +5746,12 @@
 											"points": 1
 										},
 										{
-											"id": "sGB9ktUSE-_ZOYhyf",
+											"id": "sbKRQ7zwsvbvRsSC7",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sOtPessbzkRjGaQPR"
+											},
 											"name": "Hobby Skill",
 											"reference": "B200,MA57",
 											"tags": [
@@ -4718,7 +5768,12 @@
 											"points": 1
 										},
 										{
-											"id": "sdYDgRL9z1ngt2gau",
+											"id": "sqIhIDjwvc6-xbyNF",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sDLf4crz0sGRjVDFi"
+											},
 											"name": "Hobby Skill",
 											"reference": "B200,MA57",
 											"tags": [
@@ -4735,7 +5790,12 @@
 											"points": 1
 										},
 										{
-											"id": "s_G3QBtyodTYCP1BB",
+											"id": "swAZcDxT5qWS-XXLp",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sfZrwMVUibhbtdssl"
+											},
 											"name": "Housekeeping",
 											"reference": "B200",
 											"tags": [
@@ -4751,7 +5811,12 @@
 											"points": 1
 										},
 										{
-											"id": "slGVaMBJtsHjne2NB",
+											"id": "sZOgZ5R4C61wDcori",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sdl9m7gHE7hlMX0AX"
+											},
 											"name": "Lip Reading",
 											"reference": "B205",
 											"tags": [
@@ -4767,7 +5832,12 @@
 											"points": 1
 										},
 										{
-											"id": "sJeqsINY5cZWaisnd",
+											"id": "svZX6wD4ks7FTv78X",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sx1CDkGBR830IZrmz"
+											},
 											"name": "Professional Skill",
 											"reference": "B215",
 											"tags": [
@@ -4784,7 +5854,12 @@
 											"points": 1
 										},
 										{
-											"id": "sBqzW50vAg2ptiLWg",
+											"id": "sP-yJCiFXTXN1p9JN",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sBec-o4Z7gPpbg2f9"
+											},
 											"name": "Professional Skill",
 											"reference": "B215",
 											"tags": [
@@ -4801,7 +5876,12 @@
 											"points": 1
 										},
 										{
-											"id": "s430W07mISIRzJhPS",
+											"id": "sLasKAWIOB-3YDpB-",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "smxkcngH5Kz54yeN3"
+											},
 											"name": "Sports",
 											"reference": "B222,MA59",
 											"tags": [
@@ -4818,7 +5898,12 @@
 											"points": 1
 										},
 										{
-											"id": "stu2jfzeGCiIWatHU",
+											"id": "sbUzX8gGmuz7th8b5",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "smTUpMWJGqPeT1KER"
+											},
 											"name": "Streetwise",
 											"reference": "B223",
 											"tags": [
@@ -4854,7 +5939,12 @@
 					"name": "Multi-Role",
 					"children": [
 						{
-							"id": "s8mX7ytwGAsnXJeve",
+							"id": "sX4fuHaJahe0rmFdo",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sirFPuXXZfzdkM7Zm"
+							},
 							"name": "Electronics Operation",
 							"reference": "B189",
 							"tags": [
@@ -4889,7 +5979,12 @@
 							"points": 2
 						},
 						{
-							"id": "sOPgAmZLTehV5lEJj",
+							"id": "sBeAAoKs1gTEDpu78",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "stFawUEv8gxldDoiC"
+							},
 							"name": "Research",
 							"reference": "B217",
 							"tags": [
@@ -4982,7 +6077,12 @@
 							"points": 2
 						},
 						{
-							"id": "sj8YJzhCM4KcIFAOM",
+							"id": "sqnVNro7XMyU4X91i",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sbcabbj7Zf2iurxxA"
+							},
 							"name": "Astronomy",
 							"reference": "B179",
 							"tags": [
@@ -5017,7 +6117,12 @@
 							"points": 1
 						},
 						{
-							"id": "skNxEYF0NkuPYkjhI",
+							"id": "sQUAj_wX8aYamIIfO",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sNo8fl03x7a76gaOU"
+							},
 							"name": "Chemistry",
 							"reference": "B183",
 							"tags": [
@@ -5039,7 +6144,12 @@
 							"points": 1
 						},
 						{
-							"id": "s2fkbTIkNa_qhAQsZ",
+							"id": "sV2_11_AmpHame7ag",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "s2YhViBIYuLf4xevN"
+							},
 							"name": "Geology",
 							"reference": "B198",
 							"tags": [
@@ -5068,7 +6178,12 @@
 							"points": 1
 						},
 						{
-							"id": "so2ZTow1rJSzktRgv",
+							"id": "sQY-K8-0W6Auka9jy",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sGgBbCTe-AwY1nu3W"
+							},
 							"name": "Mathematics",
 							"reference": "B207",
 							"tags": [
@@ -5096,7 +6211,12 @@
 							"points": 1
 						},
 						{
-							"id": "svzMQ1A-9lFjkQ0H_",
+							"id": "sl23NcQX0EVNcjyOr",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sb6LoqgrQgzKvzHH2"
+							},
 							"name": "Biology",
 							"reference": "B180",
 							"tags": [
@@ -5120,7 +6240,12 @@
 							"points": 1
 						},
 						{
-							"id": "s9yzHpBk6gfrgfgYW",
+							"id": "sRjhxWlTXRZSCfa9K",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "snf1C1wltuy8_tanr"
+							},
 							"name": "Physics",
 							"reference": "B213",
 							"tags": [

--- a/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Security Officer.gct
+++ b/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Security Officer.gct
@@ -12,7 +12,12 @@
 					"name": "Attributes",
 					"children": [
 						{
-							"id": "tTPbl5fXhEPu-uVCs",
+							"id": "t2twFC1GMgtDFdjHM",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tqha9GlDBU9P-Wg-6"
+							},
 							"name": "Increased Strength",
 							"reference": "B14",
 							"tags": [
@@ -22,14 +27,14 @@
 							],
 							"modifiers": [
 								{
-									"id": "mIM3wdmHkZEk1OuJf",
+									"id": "mbQIx0idqducu7Me5",
 									"name": "No Fine Manipulators",
 									"reference": "B15",
 									"cost": -40,
 									"disabled": true
 								},
 								{
-									"id": "m68wzVfDdHjfKahrg",
+									"id": "mapZXmbzpLYJngTcS",
 									"name": "Size",
 									"reference": "B15",
 									"cost": -10,
@@ -37,7 +42,7 @@
 									"disabled": true
 								},
 								{
-									"id": "mhUC1cGHosCTA0con",
+									"id": "m9WaWUvVZfitLLL9o",
 									"name": "Super-Effort",
 									"reference": "SU24",
 									"cost": 300,
@@ -60,7 +65,49 @@
 							}
 						},
 						{
-							"id": "tMh0A8WadQantYf0h",
+							"id": "ttUBz4o7H9X9VFBJt",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tGWOSEE6SmBHACE6Y"
+							},
+							"name": "Increased Dexterity",
+							"reference": "B15",
+							"tags": [
+								"Advantage",
+								"Attribute",
+								"Physical"
+							],
+							"modifiers": [
+								{
+									"id": "mTuefookUHeSvGGYn",
+									"name": "No Fine Manipulators",
+									"cost": -40,
+									"disabled": true
+								}
+							],
+							"points_per_level": 20,
+							"features": [
+								{
+									"type": "attribute_bonus",
+									"attribute": "dx",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"levels": 2,
+							"calc": {
+								"points": 40
+							}
+						},
+						{
+							"id": "tVXwyzfplH5Mqx_Ve",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t1w1RFcFceKR2T9_e"
+							},
 							"name": "Increased Intelligence",
 							"reference": "B15",
 							"tags": [
@@ -84,39 +131,12 @@
 							}
 						},
 						{
-							"id": "tviFglWnjJXa7lggp",
-							"name": "Increased Dexterity",
-							"reference": "B15",
-							"tags": [
-								"Advantage",
-								"Attribute",
-								"Physical"
-							],
-							"modifiers": [
-								{
-									"id": "mi0EeHG9Y0C671uOY",
-									"name": "No Fine Manipulators",
-									"cost": -40,
-									"disabled": true
-								}
-							],
-							"points_per_level": 20,
-							"features": [
-								{
-									"type": "attribute_bonus",
-									"attribute": "dx",
-									"amount": 1,
-									"per_level": true
-								}
-							],
-							"can_level": true,
-							"levels": 2,
-							"calc": {
-								"points": 40
-							}
-						},
-						{
-							"id": "toMPk1iXouuxfnZG6",
+							"id": "tlSrgFPxFZSr2HdJ4",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tVt3SvdGWNchJ8z4o"
+							},
 							"name": "Increased Health",
 							"reference": "B14",
 							"tags": [
@@ -149,7 +169,12 @@
 					"name": "Secondary Characteristics",
 					"children": [
 						{
-							"id": "tNrlYbaMA-RofrwQT",
+							"id": "t_GdqEzqW8X_uz46t",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tWF1J_Z0Ziz-qJ6pn"
+							},
 							"name": "Increased Basic Speed",
 							"reference": "B17",
 							"tags": [
@@ -190,7 +215,12 @@
 									"name": "Better Attributes",
 									"children": [
 										{
-											"id": "tY-wc2Uc8wz3YnWrX",
+											"id": "ttmk0n_JAsGv2C0vA",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tGWOSEE6SmBHACE6Y"
+											},
 											"name": "Increased Dexterity",
 											"reference": "B15",
 											"tags": [
@@ -200,7 +230,7 @@
 											],
 											"modifiers": [
 												{
-													"id": "mk6Z0AQLTC7kNE3YE",
+													"id": "manLsYP2cZzRpw2uI",
 													"name": "No Fine Manipulators",
 													"cost": -40,
 													"disabled": true
@@ -222,7 +252,12 @@
 											}
 										},
 										{
-											"id": "trn9nW65_zC6RcfF5",
+											"id": "twhJCfRn3BtOLnlWX",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tVt3SvdGWNchJ8z4o"
+											},
 											"name": "Increased Health",
 											"reference": "B14",
 											"tags": [
@@ -246,7 +281,65 @@
 											}
 										},
 										{
-											"id": "t_Wfo-9A3LiUMWHen",
+											"id": "tEqtXkjkMtgwtv4iX",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tqha9GlDBU9P-Wg-6"
+											},
+											"name": "Increased Strength",
+											"reference": "B14",
+											"tags": [
+												"Advantage",
+												"Attribute",
+												"Physical"
+											],
+											"modifiers": [
+												{
+													"id": "mnpSCxHPLeaJFwMgf",
+													"name": "No Fine Manipulators",
+													"reference": "B15",
+													"cost": -40,
+													"disabled": true
+												},
+												{
+													"id": "m9fruf1kIC0l3crfI",
+													"name": "Size",
+													"reference": "B15",
+													"cost": -10,
+													"levels": 1,
+													"disabled": true
+												},
+												{
+													"id": "m0JsEhsJgiBauzYjz",
+													"name": "Super-Effort",
+													"reference": "SU24",
+													"cost": 300,
+													"disabled": true
+												}
+											],
+											"points_per_level": 10,
+											"features": [
+												{
+													"type": "attribute_bonus",
+													"attribute": "st",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"can_level": true,
+											"levels": 3,
+											"calc": {
+												"points": 30
+											}
+										},
+										{
+											"id": "tdsERN0DJfgcEdIWL",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t1w1RFcFceKR2T9_e"
+											},
 											"name": "Increased Intelligence",
 											"reference": "B15",
 											"tags": [
@@ -268,54 +361,6 @@
 											"calc": {
 												"points": 20
 											}
-										},
-										{
-											"id": "tx1jQMVmfPA65ilNE",
-											"name": "Increased Strength",
-											"reference": "B14",
-											"tags": [
-												"Advantage",
-												"Attribute",
-												"Physical"
-											],
-											"modifiers": [
-												{
-													"id": "m4l9ZzlnvGjptpO3S",
-													"name": "No Fine Manipulators",
-													"reference": "B15",
-													"cost": -40,
-													"disabled": true
-												},
-												{
-													"id": "mL7cQmqagvCyYRuKM",
-													"name": "Size",
-													"reference": "B15",
-													"cost": -10,
-													"levels": 1,
-													"disabled": true
-												},
-												{
-													"id": "mA-cH7Xbnja5I1bim",
-													"name": "Super-Effort",
-													"reference": "SU24",
-													"cost": 300,
-													"disabled": true
-												}
-											],
-											"points_per_level": 10,
-											"features": [
-												{
-													"type": "attribute_bonus",
-													"attribute": "st",
-													"amount": 1,
-													"per_level": true
-												}
-											],
-											"can_level": true,
-											"levels": 3,
-											"calc": {
-												"points": 30
-											}
 										}
 									],
 									"calc": {
@@ -323,24 +368,37 @@
 									}
 								},
 								{
-									"id": "TEbhzxvqwA9Z_5XWR",
+									"id": "TDvfNC8jVJRB8tOhg",
 									"name": "Everyman Advantages",
 									"children": [
 										{
-											"id": "t8_n-vMl66aCm3JYf",
-											"name": "Suit Familiarity (Vacc Suit)",
+											"id": "tOMmxUl9ssSimoYZP",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Power Ups/Power Ups Traits.adq",
+												"id": "t3RCXCI5W-zjvxaf-"
+											},
+											"name": "Suit Familiarity (@Environment Suit skill@)",
 											"reference": "PU2:9",
 											"tags": [
 												"Perk",
 												"Physical"
 											],
+											"replacements": {
+												"Environment Suit skill": "Vacc Suit"
+											},
 											"base_points": 1,
 											"calc": {
 												"points": 1
 											}
 										},
 										{
-											"id": "twTbWNdJO7ETUQCIz",
+											"id": "tqVFY1oD1bdHkEgoC",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tkiJQ7nfyi9aAdGHK"
+											},
 											"name": "Serendipity",
 											"reference": "B83,P73",
 											"tags": [
@@ -349,17 +407,24 @@
 											],
 											"modifiers": [
 												{
-													"id": "mHvwgJ9k009Tb9SLH",
+													"id": "mV0MERB2hpJQoGfS9",
 													"name": "Wishing",
 													"reference": "P73",
 													"cost": 100,
 													"disabled": true
 												},
 												{
-													"id": "mgVSpOU8wIn0Kati8",
+													"id": "m6gAVC0Z4T15lecf5",
 													"name": "Wishing",
 													"reference": "P73",
 													"notes": "For others only",
+													"disabled": true
+												},
+												{
+													"id": "m12gUUIyFGYI-P9Vj",
+													"name": "Game Time",
+													"reference": "P108",
+													"notes": "Uses per game week equal to its maximum possible uses per session",
 													"disabled": true
 												}
 											],
@@ -371,8 +436,13 @@
 											}
 										},
 										{
-											"id": "tQIauT3jIHybl9DaE",
-											"name": "Resistant to Acceleration",
+											"id": "tMR5XjcDgd1Jyf4qu",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tJTfFdHM7YI5IZR7I"
+											},
+											"name": "Resistant",
 											"reference": "B81,P71,MA47",
 											"tags": [
 												"Advantage",
@@ -380,7 +450,7 @@
 											],
 											"modifiers": [
 												{
-													"id": "mbk23TNEyQMMvR1RZ",
+													"id": "mirT1fS5OW09snAb4",
 													"name": "@Very Common: Metabolic Hazards, etc.@",
 													"reference": "B80",
 													"cost": 30,
@@ -388,7 +458,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mnt1FYnEbFbgUnLBl",
+													"id": "mmW7-hUVnyZkjl5dx",
 													"name": "@Common: Poison, Sickness, etc.@",
 													"reference": "B81",
 													"cost": 15,
@@ -396,7 +466,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m70HcYJ0OzJL3t3VI",
+													"id": "mPosbjjyv6Xm1E7Ak",
 													"name": "@Occasional: Disease, Ingested Poison, etc.@",
 													"reference": "B81",
 													"cost": 10,
@@ -404,14 +474,17 @@
 													"disabled": true
 												},
 												{
-													"id": "mokuqEhTCHpj8_Mdp",
+													"id": "m1V0S8Be0VXeq8B0Y",
 													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
 													"reference": "B81",
+													"replacements": {
+														"Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.": "Space Sickness"
+													},
 													"cost": 5,
 													"cost_type": "points"
 												},
 												{
-													"id": "mdIl1mPbdmYAtkpFc",
+													"id": "mzyZvzozSin_Y4FWg",
 													"name": "Immunity",
 													"reference": "B81",
 													"cost": 1,
@@ -419,152 +492,14 @@
 													"disabled": true
 												},
 												{
-													"id": "mQycZTPl3o58TfnIB",
-													"name": "+8 to all HT rolls to resist",
-													"reference": "B81",
-													"cost": 0.5,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "m3AbSVJcOPlWeENpt",
-													"name": "+3 to all HT rolls to resist",
-													"reference": "B81",
-													"cost": 0.33,
-													"cost_type": "multiplier"
-												}
-											],
-											"round_down": true,
-											"calc": {
-												"points": 1
-											}
-										},
-										{
-											"id": "tcdkLLWIJqHaZFo6D",
-											"name": "Resistant to Space Sickness",
-											"reference": "B81,P71,MA47",
-											"tags": [
-												"Advantage",
-												"Physical"
-											],
-											"modifiers": [
-												{
-													"id": "mEBk1upJujU4C7Ukh",
-													"name": "@Very Common: Metabolic Hazards, etc.@",
-													"reference": "B80",
-													"cost": 30,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m8V3O6ToTO_fXAFed",
-													"name": "@Common: Poison, Sickness, etc.@",
-													"reference": "B81",
-													"cost": 15,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mjUQDJUp3oEuaqAjZ",
-													"name": "@Occasional: Disease, Ingested Poison, etc.@",
-													"reference": "B81",
-													"cost": 10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mcvegu-qWY0BKgvlO",
-													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
-													"reference": "B81",
-													"cost": 5,
-													"cost_type": "points"
-												},
-												{
-													"id": "mddNywX_AIbHyytnp",
-													"name": "Immunity",
-													"reference": "B81",
-													"cost": 1,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mZIoY9ruCYvctI0j2",
-													"name": "+8 to all HT rolls to resist",
-													"reference": "B81",
-													"cost": 0.5,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "m1xl2ZuMZdGvfaZIG",
-													"name": "+3 to all HT rolls to resist",
-													"reference": "B81",
-													"cost": 0.33,
-													"cost_type": "multiplier"
-												}
-											],
-											"round_down": true,
-											"calc": {
-												"points": 1
-											}
-										},
-										{
-											"id": "t_AJGgP5Yb1jpuESR",
-											"name": "Resistant to Space Sickness",
-											"reference": "B81,P71,MA47",
-											"tags": [
-												"Advantage",
-												"Physical"
-											],
-											"modifiers": [
-												{
-													"id": "mRFjtE0WP0iHVlvPT",
-													"name": "@Very Common: Metabolic Hazards, etc.@",
-													"reference": "B80",
-													"cost": 30,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "muCrkbrqgNh7YwgaL",
-													"name": "@Common: Poison, Sickness, etc.@",
-													"reference": "B81",
-													"cost": 15,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mWROpJF5V8DMzDi5d",
-													"name": "@Occasional: Disease, Ingested Poison, etc.@",
-													"reference": "B81",
-													"cost": 10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m6M7A6uipaUvTuwai",
-													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
-													"reference": "B81",
-													"cost": 5,
-													"cost_type": "points"
-												},
-												{
-													"id": "mFjvD-cCq9BzoDMLA",
-													"name": "Immunity",
-													"reference": "B81",
-													"cost": 1,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mmdafyCCk92oD48Bn",
+													"id": "msZrulKi_Tag67iw6",
 													"name": "+8 to all HT rolls to resist",
 													"reference": "B81",
 													"cost": 0.5,
 													"cost_type": "multiplier"
 												},
 												{
-													"id": "mXdLWo4IolR7t3EiB",
+													"id": "mnLmvcmMID4Ng6W2t",
 													"name": "+3 to all HT rolls to resist",
 													"reference": "B81",
 													"cost": 0.33,
@@ -578,8 +513,167 @@
 											}
 										},
 										{
-											"id": "t7SD6jmCp-gw6uCmZ",
-											"name": "Reputation",
+											"id": "ttoACCBqr73Ot1OBT",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tJTfFdHM7YI5IZR7I"
+											},
+											"name": "Resistant",
+											"reference": "B81,P71,MA47",
+											"tags": [
+												"Advantage",
+												"Physical"
+											],
+											"modifiers": [
+												{
+													"id": "mMV1cXBNpW4LdqvVB",
+													"name": "@Very Common: Metabolic Hazards, etc.@",
+													"reference": "B80",
+													"cost": 30,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mAoaaihQ2QIEUCNJd",
+													"name": "@Common: Poison, Sickness, etc.@",
+													"reference": "B81",
+													"cost": 15,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mraoSr6DTpm57_hCn",
+													"name": "@Occasional: Disease, Ingested Poison, etc.@",
+													"reference": "B81",
+													"cost": 10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mxLkk7EvQ47L1LAyd",
+													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+													"reference": "B81",
+													"replacements": {
+														"Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.": "Space Sickness"
+													},
+													"cost": 5,
+													"cost_type": "points"
+												},
+												{
+													"id": "mr9gru84QH3zG-6WK",
+													"name": "Immunity",
+													"reference": "B81",
+													"cost": 1,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mID9xWoUuF5CBgWmE",
+													"name": "+8 to all HT rolls to resist",
+													"reference": "B81",
+													"cost": 0.5,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "m1JwNdp4qpVmqckmK",
+													"name": "+3 to all HT rolls to resist",
+													"reference": "B81",
+													"cost": 0.33,
+													"cost_type": "multiplier"
+												}
+											],
+											"round_down": true,
+											"calc": {
+												"points": 1
+											}
+										},
+										{
+											"id": "tVNNBmhnxVgdAirkb",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tJTfFdHM7YI5IZR7I"
+											},
+											"name": "Resistant",
+											"reference": "B81,P71,MA47",
+											"tags": [
+												"Advantage",
+												"Physical"
+											],
+											"modifiers": [
+												{
+													"id": "mWgFEHwJO_xAOvtcx",
+													"name": "@Very Common: Metabolic Hazards, etc.@",
+													"reference": "B80",
+													"cost": 30,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "moSkp4sEI0I8q8GX3",
+													"name": "@Common: Poison, Sickness, etc.@",
+													"reference": "B81",
+													"cost": 15,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mx-l0xI4mJlf3D17s",
+													"name": "@Occasional: Disease, Ingested Poison, etc.@",
+													"reference": "B81",
+													"cost": 10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mBQXWxnFXghkOqYUL",
+													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+													"reference": "B81",
+													"replacements": {
+														"Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.": "Acceleration"
+													},
+													"cost": 5,
+													"cost_type": "points"
+												},
+												{
+													"id": "mYwg7Hhr6RsMczjo9",
+													"name": "Immunity",
+													"reference": "B81",
+													"cost": 1,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mLzC7gBM9pqzp-HgG",
+													"name": "+8 to all HT rolls to resist",
+													"reference": "B81",
+													"cost": 0.5,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mfXr0n7XEznSy5SDt",
+													"name": "+3 to all HT rolls to resist",
+													"reference": "B81",
+													"cost": 0.33,
+													"cost_type": "multiplier"
+												}
+											],
+											"round_down": true,
+											"calc": {
+												"points": 1
+											}
+										},
+										{
+											"id": "tqix54PrEVxMASHoR",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "ta04iFiZ_Kw0s0juj"
+											},
+											"name": "Good Reputation",
 											"reference": "B26,MA54",
 											"tags": [
 												"Advantage",
@@ -587,7 +681,7 @@
 											],
 											"modifiers": [
 												{
-													"id": "mVCC8pd7ef2sUtj3w",
+													"id": "mMQFSrPA1CgJJOkxW",
 													"name": "People Affected",
 													"reference": "B27",
 													"notes": "Almost everyone",
@@ -596,7 +690,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m17hSV_N3nNC7O9OW",
+													"id": "mFzQLEj9OuwJj66KR",
 													"name": "People Affected",
 													"reference": "B27",
 													"notes": "Almost everyone except @large class of people@",
@@ -605,7 +699,7 @@
 													"disabled": true
 												},
 												{
-													"id": "miKbEP69lcUUjWOqP",
+													"id": "m7p8BXrZwQQLIGVsE",
 													"name": "People Affected",
 													"reference": "B27",
 													"notes": "@Large class of people@",
@@ -614,7 +708,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m5kNX65PE5nrd2Sak",
+													"id": "mKsEqVOFNW9wz58K4",
 													"name": "People Affected",
 													"reference": "B27",
 													"notes": "@Small class of people@",
@@ -623,7 +717,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mc8t4gD1I7jhTv42N",
+													"id": "mv5lHkz_LUNEt9k26",
 													"name": "Recognized all the time",
 													"reference": "B28",
 													"cost": 1,
@@ -631,7 +725,7 @@
 													"disabled": true
 												},
 												{
-													"id": "msmz5Vl3-Tn1wAc-e",
+													"id": "mZoXQNRplk3z-Cnsp",
 													"name": "Recognized sometimes",
 													"reference": "B28",
 													"notes": "10-",
@@ -640,7 +734,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mMYOtnqyxTgpqIcmb",
+													"id": "m89SbPa2iD-lgSD9N",
 													"name": "Recognized occasionally",
 													"reference": "B28",
 													"notes": "7-",
@@ -650,6 +744,14 @@
 												}
 											],
 											"points_per_level": 5,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others aware of your reputation",
+													"amount": 1,
+													"per_level": true
+												}
+											],
 											"round_down": true,
 											"can_level": true,
 											"levels": 1,
@@ -658,16 +760,24 @@
 											}
 										},
 										{
-											"id": "tH3ThE3DQvA2qLO24",
-											"name": "Military Rank",
+											"id": "tQlAhQFNoGEIVV_1R",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tmp8yecgaZq9TOk59"
+											},
+											"name": "@Type@ Rank",
 											"reference": "B29",
 											"tags": [
 												"Advantage",
-												"Physical"
+												"Social"
 											],
+											"replacements": {
+												"Type": "Military"
+											},
 											"modifiers": [
 												{
-													"id": "mxrkCyYnO3SiSWCNp",
+													"id": "mdJmj-DWzIcbjJzdQ",
 													"name": "Replaces Status",
 													"reference": "B29",
 													"cost": 5,
@@ -676,7 +786,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mj3F8wBgvHMLK1foA",
+													"id": "mrdMn95HbDtgUflL4",
 													"name": "Courtesy",
 													"reference": "B29",
 													"cost": -4,
@@ -693,16 +803,24 @@
 											}
 										},
 										{
-											"id": "t58zri5QPmT5aTi4b",
-											"name": "Merchant Rank",
+											"id": "tJMUaUbuhWy2ZZ0N2",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tmp8yecgaZq9TOk59"
+											},
+											"name": "@Type@ Rank",
 											"reference": "B29",
 											"tags": [
 												"Advantage",
-												"Physical"
+												"Social"
 											],
+											"replacements": {
+												"Type": "Merchant"
+											},
 											"modifiers": [
 												{
-													"id": "moZmuB8pyDky-LZz9",
+													"id": "m2HZ6w9lPfurYXN7C",
 													"name": "Replaces Status",
 													"reference": "B29",
 													"cost": 5,
@@ -711,7 +829,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mJY8XgXWNQmqZIMGv",
+													"id": "mI-uLzJXo9-wXTpXL",
 													"name": "Courtesy",
 													"reference": "B29",
 													"cost": -4,
@@ -728,17 +846,21 @@
 											}
 										},
 										{
-											"id": "tXR9YdBmLdmikXGop",
+											"id": "tgVWZ2O1y5QOOQ2WK",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t6Nq6oInwkU1qbAP1"
+											},
 											"name": "Patron",
 											"reference": "B72,P65",
-											"notes": "Ship's owner or provider",
 											"tags": [
 												"Advantage",
 												"Social"
 											],
 											"modifiers": [
 												{
-													"id": "mC3oRTonKCOD4ssLg",
+													"id": "mlMgN-I3IebaBz8dm",
 													"name": "@Who: Individual with 150% of PC's starting points@",
 													"reference": "B72",
 													"cost": 10,
@@ -746,7 +868,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mDCLqUqNNZavsWPV-",
+													"id": "mcmNmzRuVOztn7T38",
 													"name": "@Who: Organization with assets of at least 1000 times starting wealth@",
 													"reference": "B72",
 													"cost": 10,
@@ -754,7 +876,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m8RRsaE71OPU4SVk4",
+													"id": "mE_AZfMCsq2wIfo1q",
 													"name": "@Who: Individual with twice the PC's starting points@",
 													"reference": "B72",
 													"cost": 15,
@@ -762,7 +884,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mpzXGFJccfoND7mpF",
+													"id": "monSdKksGD3_gstFB",
 													"name": "@Who: Organization with assets of at least 10000 times starting wealth@",
 													"reference": "B72",
 													"cost": 15,
@@ -770,7 +892,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mkH0gdhj-Nx7qXJBa",
+													"id": "mGwZIn9teRrLGy3Bn",
 													"name": "@Who: An ultra-powerful individual@",
 													"reference": "B72",
 													"cost": 20,
@@ -778,7 +900,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m1CwHayWnqDI0FOBf",
+													"id": "mc9i338OyXBb96QQ6",
 													"name": "@Who: Organization with assets of at least 100000 times starting wealth@",
 													"reference": "B72",
 													"cost": 20,
@@ -786,7 +908,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mJfj3SNwbz_7jDsDH",
+													"id": "msNc25QmrvzPztBzC",
 													"name": "@Who: Organization with assets of at least 1000000 times starting wealth@",
 													"reference": "B72",
 													"cost": 25,
@@ -794,7 +916,7 @@
 													"disabled": true
 												},
 												{
-													"id": "msmARCUhAu-nnL8sX",
+													"id": "mMm7pRC_SyRkIQKiL",
 													"name": "@Who: A national government or giant multi-national organization@",
 													"reference": "B72",
 													"cost": 30,
@@ -802,7 +924,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mD_7nW8nWb0C6P6nM",
+													"id": "mVmTkU2OXHk8NfqPu",
 													"name": "@Who: A deity@",
 													"reference": "B72",
 													"cost": 30,
@@ -810,7 +932,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mL8V2xY5Ilp6pd2OF",
+													"id": "m296ask94i6gCBanM",
 													"name": "Appears almost all the time",
 													"reference": "B36",
 													"notes": "15-",
@@ -819,7 +941,7 @@
 													"disabled": true
 												},
 												{
-													"id": "msTU7TLoz62zMc3aF",
+													"id": "m8byJRSgh8zKCuS9G",
 													"name": "Appears quite often",
 													"reference": "B36",
 													"notes": "12-",
@@ -828,7 +950,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mWIC2A4JwVWUcbcIh",
+													"id": "mKjal7ILzt3gtDFCy",
 													"name": "Appears fairly often",
 													"reference": "B36",
 													"notes": "9-",
@@ -837,7 +959,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mNXigrZe2rRBt2WKe",
+													"id": "mp04hl2G7oFgEr9x9",
 													"name": "Appears quite rarely",
 													"reference": "B36",
 													"notes": "6-",
@@ -846,7 +968,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mz2lgU9k9jlTofmXf",
+													"id": "mRanDWJz9iICGgc9b",
 													"name": "Equipment",
 													"reference": "B73",
 													"notes": "@Equipment worth no more than average starting wealth@",
@@ -854,7 +976,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mOiciwOzOWZ3-XnWg",
+													"id": "mVX1gwYIpg74OCdbl",
 													"name": "Equipment",
 													"reference": "B73",
 													"notes": "@Equipment worth more than average starting wealth@",
@@ -862,14 +984,14 @@
 													"disabled": true
 												},
 												{
-													"id": "mhqYY5HjySPTZfRgY",
+													"id": "m0HGs4pf_NSlnAyFu",
 													"name": "Highly Accessible",
 													"reference": "B73",
 													"cost": 50,
 													"disabled": true
 												},
 												{
-													"id": "mjDcbCO0cEaaCvgK5",
+													"id": "mlJMrwc5L1qFaxL3y",
 													"name": "Special Abilities",
 													"reference": "B73",
 													"notes": "@Extensive social or political power@",
@@ -877,7 +999,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m3Du0YiKOerc22Oru",
+													"id": "mO7XxeZAIj4_KCYE-",
 													"name": "Special Abilities",
 													"reference": "B73",
 													"notes": "@Magical powers in a non-magical world, higher TL equipment, grants special powers or is supernatural@",
@@ -885,28 +1007,28 @@
 													"disabled": true
 												},
 												{
-													"id": "mLeeOkgSmpVftTnqi",
+													"id": "mZYRzPq5n6DUqEzHQ",
 													"name": "Minimal Interventions",
 													"reference": "B73",
 													"cost": -50,
 													"disabled": true
 												},
 												{
-													"id": "mQ6kQ_vm6aR7QYgwd",
+													"id": "m24q5OykhRHJGR772",
 													"name": "Secret",
 													"reference": "B73",
 													"cost": -50,
 													"disabled": true
 												},
 												{
-													"id": "mlFluma0LSGbpqXZA",
+													"id": "mBHyAAgM-IRIKP_-D",
 													"name": "Unwilling",
 													"reference": "B74",
 													"cost": -50,
 													"disabled": true
 												},
 												{
-													"id": "mGBRAsmgqxDM5diZU",
+													"id": "mpx59HMSK9M66KMYe",
 													"name": "Favor",
 													"reference": "B55",
 													"cost": 0.2,
@@ -919,7 +1041,12 @@
 											}
 										},
 										{
-											"id": "tr7kl0h5TxumppkBr",
+											"id": "tfyCVxutZW1Jv7IxZ",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tz-USDL9B_KrrVqDi"
+											},
 											"name": "Luck",
 											"reference": "B66,P59",
 											"notes": "Usable once per hour of play",
@@ -929,14 +1056,14 @@
 											],
 											"modifiers": [
 												{
-													"id": "m0-XfWwRuxr5pT9Xm",
+													"id": "mkoL4ysz1Gmz_7NP_",
 													"name": "Active",
 													"reference": "B66",
 													"cost": -40,
 													"disabled": true
 												},
 												{
-													"id": "mJL0LFrZ-Gg21t-L_",
+													"id": "mU5u_S7yHOd5CK7p7",
 													"name": "Aspected",
 													"reference": "B66",
 													"notes": "@Aspect@",
@@ -944,17 +1071,24 @@
 													"disabled": true
 												},
 												{
-													"id": "mCFQbwx1_MwhKGtgr",
+													"id": "modtcG1PJ-SRUZzm7",
 													"name": "Defensive",
 													"reference": "B66",
 													"cost": -20,
 													"disabled": true
 												},
 												{
-													"id": "mVCs-UoXWiGWZGtJC",
+													"id": "mNqRChkKqA5a1Xu9B",
 													"name": "Wishing",
 													"reference": "P59",
 													"cost": 100,
+													"disabled": true
+												},
+												{
+													"id": "m8650L8mUyfPTr6Gp",
+													"name": "Game Time",
+													"reference": "P108",
+													"notes": "Uses per game day equal to its maximum possible uses per real hour",
 													"disabled": true
 												}
 											],
@@ -964,7 +1098,12 @@
 											}
 										},
 										{
-											"id": "to9rxjIyyQIA59Zj2",
+											"id": "tu24Jhje7Eg4BQBO0",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tMxgHfzVEy_QQtlfB"
+											},
 											"name": "Less Sleep",
 											"reference": "B65",
 											"notes": "Require 1 hour/level less sleep for a full night's rest (max 4)",
@@ -980,7 +1119,12 @@
 											}
 										},
 										{
-											"id": "tDDVfX96I767BQQvz",
+											"id": "tqJXl2yejl4m-W9zn",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tw1Ad0oSMw2ATM4X1"
+											},
 											"name": "Language: @Language@",
 											"reference": "B24",
 											"tags": [
@@ -988,9 +1132,26 @@
 												"Language",
 												"Mental"
 											],
+											"prereqs": {
+												"type": "prereq_list",
+												"all": true,
+												"prereqs": [
+													{
+														"type": "trait_prereq",
+														"has": false,
+														"name": {
+															"compare": "is",
+															"qualifier": "Language Talent"
+														},
+														"level": {
+															"compare": "at_least"
+														}
+													}
+												]
+											},
 											"modifiers": [
 												{
-													"id": "mwdbAaayewacOT7WK",
+													"id": "maC7RGSKi8LrRD_ao",
 													"name": "Native",
 													"reference": "B23",
 													"cost": -6,
@@ -998,7 +1159,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mD6gpWLIm8aA8GqjI",
+													"id": "mAiJfIuq17Pdy64x9",
 													"name": "Spoken",
 													"reference": "B24",
 													"notes": "None",
@@ -1006,7 +1167,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mIwM3qxlEBhwjp9Cx",
+													"id": "mOVkVVydjumy2RIUs",
 													"name": "Spoken",
 													"reference": "B24",
 													"notes": "Broken",
@@ -1015,7 +1176,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mqDY8GqFeDN0hrwGP",
+													"id": "mQ0T_DMWv_zSj7v-z",
 													"name": "Spoken",
 													"reference": "B24",
 													"notes": "Accented",
@@ -1023,7 +1184,7 @@
 													"cost_type": "points"
 												},
 												{
-													"id": "m0FXdeM-gnORcSbIm",
+													"id": "m2zAHVLXJCzVC02R6",
 													"name": "Spoken",
 													"reference": "B24",
 													"notes": "Native",
@@ -1032,7 +1193,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mUguzh4FiacAc_b0e",
+													"id": "mnoKadslfgVDmFz-Z",
 													"name": "Written",
 													"reference": "B24",
 													"notes": "None",
@@ -1040,7 +1201,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mw-NxkIckcLB_7m68",
+													"id": "mQwDTcUmjsUiUEqA4",
 													"name": "Written",
 													"reference": "B24",
 													"notes": "Broken",
@@ -1049,7 +1210,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m-JQjS7Fw-nwMMlBS",
+													"id": "mG7BXWgVmE1_bHfc3",
 													"name": "Written",
 													"reference": "B24",
 													"notes": "Accented",
@@ -1057,7 +1218,7 @@
 													"cost_type": "points"
 												},
 												{
-													"id": "mSUFohfX737VnuaR6",
+													"id": "mgE-WYEHTMCuge1Vi",
 													"name": "Written",
 													"reference": "B24",
 													"notes": "Native",
@@ -1071,7 +1232,12 @@
 											}
 										},
 										{
-											"id": "trp_HmpkasrFWhF3S",
+											"id": "tiw1ZVvNrBvz4KnuO",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "txREhxV6L1SKixwe_"
+											},
 											"name": "Improved G-tolerance",
 											"reference": "B60",
 											"tags": [
@@ -1080,7 +1246,7 @@
 											],
 											"modifiers": [
 												{
-													"id": "m5PqV_4eikP9h3cLH",
+													"id": "mFitB63DWnaW3FUqA",
 													"name": "0.3G",
 													"reference": "B60",
 													"cost": 5,
@@ -1088,7 +1254,7 @@
 													"disabled": true
 												},
 												{
-													"id": "muI6l6iykjU54PKzO",
+													"id": "mk_Z-1SpWfvD_hTBQ",
 													"name": "0.5G",
 													"reference": "B60",
 													"cost": 10,
@@ -1096,7 +1262,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mjzb38UmsSu_5smsa",
+													"id": "meYoSgo26rvV-FSc8",
 													"name": "1G",
 													"reference": "B60",
 													"cost": 15,
@@ -1104,7 +1270,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mQJqqntpVE3iUepr-",
+													"id": "mUCxPquFn3mDh8oJi",
 													"name": "5G",
 													"reference": "B60",
 													"cost": 20,
@@ -1112,7 +1278,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mD4eJsWKOof42JY8m",
+													"id": "ml-aQenvsdUwjQuVD",
 													"name": "10G",
 													"reference": "B60",
 													"cost": 25,
@@ -1125,7 +1291,12 @@
 											}
 										},
 										{
-											"id": "tbZ9dbtWFwID_zSAg",
+											"id": "t84-qJagErLjKDxyU",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t7blIRUzFpiHS_mnO"
+											},
 											"name": "Gizmo",
 											"reference": "B57,MA45",
 											"tags": [
@@ -1140,7 +1311,12 @@
 											}
 										},
 										{
-											"id": "tXmuYeM4h5iUZNiXU",
+											"id": "tqsNLJZvwIPwSxxOm",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tHNrjEQFQBNOgwmzK"
+											},
 											"name": "G-Experience (All)",
 											"reference": "B57",
 											"tags": [
@@ -1153,7 +1329,12 @@
 											}
 										},
 										{
-											"id": "tVA0k4zDqHb8j-lyz",
+											"id": "tD2sT67QMcdOA4un7",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tu3GuYC47Sx6bnm4k"
+											},
 											"name": "G-Experience",
 											"reference": "B57",
 											"tags": [
@@ -1168,7 +1349,12 @@
 											}
 										},
 										{
-											"id": "t1y02Gc223gX9rgpX",
+											"id": "txujPAnklW1sKnmW1",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "toTe273Ky82B6YdW5"
+											},
 											"name": "Fit",
 											"reference": "B55",
 											"notes": "Recover FP at twice the normal rate (but not FP spent for spells or psi powers)",
@@ -1189,7 +1375,12 @@
 											}
 										},
 										{
-											"id": "tlBkTfngN4wkr0HSf",
+											"id": "t0khj8wZLoeRZHQGh",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tQa3EUrs4Hjt9gxK6"
+											},
 											"name": "Fearlessness",
 											"reference": "B55,MA44",
 											"tags": [
@@ -1226,7 +1417,12 @@
 											}
 										},
 										{
-											"id": "tlZuNQr-WlM2CGYi0",
+											"id": "txlBPQqxq9DR84LNe",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t5j2Ox4jaIV9j0rpz"
+											},
 											"name": "Deep Sleeper",
 											"reference": "B101",
 											"tags": [
@@ -1239,7 +1435,12 @@
 											}
 										},
 										{
-											"id": "t6fBFIzH1cziJE-_t",
+											"id": "tcvBDVd4FyBQsBD7j",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tNBE3sLoyrUvAgoZ3"
+											},
 											"name": "Cybernetics",
 											"reference": "B46",
 											"tags": [
@@ -1251,7 +1452,12 @@
 											}
 										},
 										{
-											"id": "tzaLQQTrzI0y3dVQc",
+											"id": "taTVM8y2MRN_Q8yaM",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "toXBQ8q4Nek5lsLPF"
+											},
 											"name": "Cultural Familiarity (@Culture@)",
 											"reference": "B23",
 											"notes": "Do not suffer the normal -3 penalty for unfamiliarity",
@@ -1261,14 +1467,14 @@
 											],
 											"modifiers": [
 												{
-													"id": "msKHH4IUMAeL70WVR",
+													"id": "mZT8F6JkwEaYHVh91",
 													"name": "Alien",
 													"cost": 1,
 													"cost_type": "points",
 													"disabled": true
 												},
 												{
-													"id": "mt5W2XvaFLqOVIB6o",
+													"id": "mb1nq6xVjoEvMQPAB",
 													"name": "Native",
 													"cost": -1,
 													"cost_type": "points",
@@ -1281,9 +1487,14 @@
 											}
 										},
 										{
-											"id": "txn8T7zCm6PmNlVeF",
-											"name": "Alien Friend",
-											"reference": "S220",
+											"id": "t5tfmJyNm-yvhUrZq",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Power Ups/Power Ups Traits.adq",
+												"id": "t3msobZZ06J7dZ8xu"
+											},
+											"name": "Talent (Born Spacer)",
+											"reference": "PU3:7",
 											"tags": [
 												"Advantage",
 												"Mental",
@@ -1291,106 +1502,60 @@
 											],
 											"modifiers": [
 												{
-													"id": "mCyFj3fBOdFz9iYY8",
-													"name": "Alternate Benefit",
-													"notes": "@Alternate Benefit@",
-													"disabled": true
-												},
-												{
-													"id": "mkAaXQTiompaPmmny",
+													"id": "mjAcQIByNbHW0-MCo",
 													"name": "Alternative Cost",
+													"cost": 1,
 													"cost_type": "points",
 													"affects": "levels_only",
 													"disabled": true
-												}
-											],
-											"points_per_level": 5,
-											"features": [
-												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "Anthropology"
-													},
-													"amount": 1,
-													"per_level": true
 												},
 												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "Diplomacy"
-													},
-													"amount": 1,
-													"per_level": true
-												},
-												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "Expert Skill"
-													},
-													"amount": 1,
-													"per_level": true
-												},
-												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "History"
-													},
-													"amount": 1,
-													"per_level": true
-												},
-												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "Psychology"
-													},
-													"amount": 1,
-													"per_level": true
-												},
-												{
-													"type": "reaction_bonus",
-													"situation": "Aliens",
-													"amount": 1,
-													"per_level": true
-												}
-											],
-											"can_level": true,
-											"levels": 1,
-											"calc": {
-												"points": 5
-											}
-										},
-										{
-											"id": "tJ2y9pNBm9YqVH3hT",
-											"name": "Born Spacer",
-											"reference": "THSCT40",
-											"tags": [
-												"Advantage",
-												"Mental",
-												"Talent"
-											],
-											"modifiers": [
-												{
-													"id": "mGX0GszTRmnSxuWKc",
-													"name": "Alternate Benefit",
-													"notes": "@Alternate Benefit@",
-													"disabled": true
-												},
-												{
-													"id": "mTctiNpr4Ec6HfOVO",
-													"name": "Alternative Cost",
-													"cost_type": "points",
-													"affects": "levels_only",
-													"disabled": true
+													"id": "MNn-RcSwxoPB5O6D1",
+													"name": "Benefits",
+													"children": [
+														{
+															"id": "mSTo7NhJa-3vgSPfd",
+															"name": "Reaction Bonus",
+															"use_level_from_trait": true,
+															"features": [
+																{
+																	"type": "reaction_bonus",
+																	"situation": "From professional Spacers.",
+																	"amount": 1,
+																	"per_level": true
+																}
+															]
+														},
+														{
+															"id": "mKdDuxUmrrhjJuPMV",
+															"name": "Bonus to pushing off",
+															"reference": "BX350",
+															"reference_highlight": "ST/2",
+															"use_level_from_trait": true,
+															"features": [
+																{
+																	"type": "conditional_modifier",
+																	"situation": "Bonus to ST for zero G push off",
+																	"amount": 1,
+																	"per_level": true
+																}
+															],
+															"disabled": true
+														},
+														{
+															"id": "mW2iONqukJCIhcpgY",
+															"name": "Spacecraft Familiarity",
+															"use_level_from_trait": true,
+															"features": [
+																{
+																	"type": "conditional_modifier",
+																	"situation": "Counteracts Familiarity for spacecraft.",
+																	"amount": 1
+																}
+															],
+															"disabled": true
+														}
+													]
 												}
 											],
 											"points_per_level": 5,
@@ -1422,6 +1587,10 @@
 														"compare": "is",
 														"qualifier": "Navigation"
 													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "Space"
+													},
 													"amount": 1,
 													"per_level": true
 												},
@@ -1433,8 +1602,36 @@
 														"qualifier": "Piloting"
 													},
 													"specialization": {
-														"compare": "contains",
-														"qualifier": "Spacecraft"
+														"compare": "is",
+														"qualifier": "High-Performance Spacecraft"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Piloting"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "Low-Performance Spacecraft"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Piloting"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "Aerospace"
 													},
 													"amount": 1,
 													"per_level": true
@@ -1458,10 +1655,99 @@
 													},
 													"amount": 1,
 													"per_level": true
+												}
+											],
+											"can_level": true,
+											"levels": 1,
+											"calc": {
+												"points": 5
+											}
+										},
+										{
+											"id": "tbDSPFpiDRoMOI39Q",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Power Ups/Power Ups Traits.adq",
+												"id": "tcCw979nTBoztowCU"
+											},
+											"name": "Talent (Alien Friend)",
+											"reference": "PU3:6",
+											"tags": [
+												"Advantage",
+												"Mental",
+												"Talent"
+											],
+											"points_per_level": 5,
+											"features": [
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Diplomacy"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Expert Skill"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "Xenology"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Anthropology"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "@Alien@"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "History"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "@Alien@"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Psychology"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "@Alien@"
+													},
+													"amount": 1,
+													"per_level": true
 												},
 												{
 													"type": "reaction_bonus",
-													"situation": "Professional Spacers",
+													"situation": "From aliens.",
 													"amount": 1,
 													"per_level": true
 												}
@@ -1473,7 +1759,12 @@
 											}
 										},
 										{
-											"id": "tcw4vkGGIr0025Fbb",
+											"id": "td95nLEgIwSEUUUm_",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tM6z7Mx6e2V4VvUR4"
+											},
 											"name": "Absolute Direction",
 											"reference": "B34",
 											"tags": [
@@ -1483,14 +1774,14 @@
 											],
 											"modifiers": [
 												{
-													"id": "mF-GBy4Hk7EpEOS2S",
+													"id": "ml_l_VObSB0ZIOrV9",
 													"name": "Requires signal",
 													"reference": "B34",
 													"cost": -20,
 													"disabled": true
 												},
 												{
-													"id": "mYZZKjqO_fnfCbKZF",
+													"id": "mLevHc_GoyU2ISwgI",
 													"name": "3D Spatial Sense",
 													"reference": "B34",
 													"cost": 5,
@@ -1613,7 +1904,12 @@
 									}
 								},
 								{
-									"id": "t10XI4MS8SLOir6Qg",
+									"id": "tdNDFD7WXl1MT1oYE",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tE_Ykx9nKvsgBGb6L"
+									},
 									"name": "Ambidexterity",
 									"reference": "B39",
 									"tags": [
@@ -1626,7 +1922,12 @@
 									}
 								},
 								{
-									"id": "tM0Z9-z0IABYE-p7h",
+									"id": "tYHJ4ypk5o5MMaWkm",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tGjjVtxav9KsrG7Wx"
+									},
 									"name": "Combat Reflexes",
 									"reference": "B43",
 									"notes": "Never freeze",
@@ -1695,7 +1996,12 @@
 									}
 								},
 								{
-									"id": "tSE0HxK34DGiZxxBd",
+									"id": "tdOm5ux-ddKzK_Uxx",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tgjE-yMzESTjq695x"
+									},
 									"name": "Danger Sense",
 									"reference": "B47,P46",
 									"tags": [
@@ -1708,7 +2014,12 @@
 									}
 								},
 								{
-									"id": "tK0YFVyr7_HfqHICA",
+									"id": "tVIT7wQ-GMam56OEy",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "twGsZPV8OE0NLFaXl"
+									},
 									"name": "Enhanced Dodge",
 									"reference": "B51,MA43",
 									"tags": [
@@ -1731,7 +2042,12 @@
 									}
 								},
 								{
-									"id": "t1nKm5mnmtAQUqvDV",
+									"id": "t-XQyrfl4hD0ixpPk",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tnoTxbCUvvok5k1Ep"
+									},
 									"name": "Extra Attack",
 									"reference": "B53,P49,MA44",
 									"tags": [
@@ -1740,14 +2056,14 @@
 									],
 									"modifiers": [
 										{
-											"id": "mToCTxrbVvAfwSGSf",
+											"id": "mcWVE5QoEY-rZ8aFr",
 											"name": "Multi-Strike",
 											"reference": "P49",
 											"cost": 20,
 											"disabled": true
 										},
 										{
-											"id": "mbKHBvKbaXmSFzfJA",
+											"id": "mkmB2jlJ9C71ksxfS",
 											"name": "Single Skill",
 											"reference": "P49",
 											"notes": "@Skill@",
@@ -1763,7 +2079,12 @@
 									}
 								},
 								{
-									"id": "tmIlINfFUZIyAmdgm",
+									"id": "toaUvhVo0anBDTryU",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t-TwxuBLxBKZX3AeN"
+									},
 									"name": "Gunslinger",
 									"reference": "B58,MA45,GF15",
 									"tags": [
@@ -1772,28 +2093,28 @@
 									],
 									"modifiers": [
 										{
-											"id": "mOViZsCmnI_estQCU",
+											"id": "mHKKRhntEhi4Ud0n0",
 											"name": "Arsenal: @Type@ Only",
 											"reference": "GF16",
 											"cost": -20,
 											"disabled": true
 										},
 										{
-											"id": "mQp9haK3Zcm9fqDtu",
+											"id": "mhY-osMKbcJdtgeyW",
 											"name": "Gun Rack: @Type@ Only",
 											"reference": "GF16",
 											"cost": -40,
 											"disabled": true
 										},
 										{
-											"id": "mq2zfjin6LqekZ3ON",
+											"id": "mUZUMZyopNpJz0onc",
 											"name": "Type: @Type@ Only",
 											"reference": "GF16",
 											"cost": -60,
 											"disabled": true
 										},
 										{
-											"id": "mUmfaOqd3vpICY6oz",
+											"id": "meMx-fJrg4RE5tQ32",
 											"name": "Model: @Model@ Only",
 											"reference": "GF16",
 											"cost": -80,
@@ -1853,7 +2174,12 @@
 									}
 								},
 								{
-									"id": "t4eqctOLA9EpmQuTM",
+									"id": "t4ZJZ9Es1fc37MRuD",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "txSLRSX9nxLwQkE2n"
+									},
 									"name": "Hard to Kill",
 									"reference": "B58",
 									"tags": [
@@ -1876,7 +2202,12 @@
 									}
 								},
 								{
-									"id": "tq1APct5lH1JjBTrd",
+									"id": "t9xJ9rpdVcSmi-JJi",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t5K9V7-_MYD_0BOQ8"
+									},
 									"name": "Hard to Subdue",
 									"reference": "B59",
 									"tags": [
@@ -1899,7 +2230,12 @@
 									}
 								},
 								{
-									"id": "tQ_bqXcArSYX_jMbq",
+									"id": "tPLsqJ0W_A-qg2FuF",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "teRggYn926_I1YeWO"
+									},
 									"name": "High Pain Threshold",
 									"reference": "B59",
 									"notes": "Never suffer shock penalties when injured",
@@ -1925,13 +2261,53 @@
 									}
 								},
 								{
-									"id": "tdurG3F99qiOgIOf8",
+									"id": "t9RE_Y5m9McLRmPJj",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tOjsbk80G_rSNlfY3"
+									},
 									"name": "Talent (Natural Copper)",
 									"reference": "PU3:13",
 									"tags": [
 										"Advantage",
 										"Mental",
 										"Talent"
+									],
+									"modifiers": [
+										{
+											"id": "MC2f_pIaBBx6b9FyR",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "mN2m_VrLZutI2EdCv",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From police and PIs.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "mMimao8kahoSzorva",
+													"name": "Alternative Benefit",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Bonus to unskilled Per rolls to notice clues, and to all rolls to use Intuition",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
+										}
 									],
 									"points_per_level": 10,
 									"features": [
@@ -2034,18 +2410,6 @@
 											},
 											"amount": 1,
 											"per_level": true
-										},
-										{
-											"type": "reaction_bonus",
-											"situation": "From police and PIs.",
-											"amount": 1,
-											"per_level": true
-										},
-										{
-											"type": "conditional_modifier",
-											"situation": "Bonus to unskilled Per rolls to notice clues, and to all rolls to use Intuition",
-											"amount": 1,
-											"per_level": true
 										}
 									],
 									"can_level": true,
@@ -2055,7 +2419,12 @@
 									}
 								},
 								{
-									"id": "tNBeZQrYEBZohK-oH",
+									"id": "tVk0bgzfm5WdfckMg",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tc74I5tb8McOGp5nr"
+									},
 									"name": "Peripheral Vision",
 									"reference": "B74,P87",
 									"tags": [
@@ -2064,7 +2433,7 @@
 									],
 									"modifiers": [
 										{
-											"id": "mLPAm5qSl_rnlao_L",
+											"id": "mgFlxchcsc5Y43iMC",
 											"name": "Easy to Hit",
 											"reference": "B75",
 											"notes": "Others can target your eyes at only -6 to hit",
@@ -2078,7 +2447,12 @@
 									}
 								},
 								{
-									"id": "tplDsxR3eK6JUAVCz",
+									"id": "tdw0Dp-rHrBs9bMEd",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "trMfToThYl9fEmPdt"
+									},
 									"name": "Rapid Healing",
 									"reference": "B79",
 									"tags": [
@@ -2113,7 +2487,12 @@
 									}
 								},
 								{
-									"id": "tsc-osE1JAzzLGjBV",
+									"id": "tryEh59U9adi5TL36",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "trClz3uZE-XIfFJKI"
+									},
 									"name": "Unfazeable",
 									"reference": "B95",
 									"notes": "Exempt from fright checks. Reaction modifiers do not affect you.",
@@ -2123,7 +2502,7 @@
 									],
 									"modifiers": [
 										{
-											"id": "mHHJEZLPx1xox-JcR",
+											"id": "ms_PExs5EP_OodL_J",
 											"name": "Familiar Horrors",
 											"reference": "H20",
 											"cost": -50,
@@ -2136,7 +2515,12 @@
 									}
 								},
 								{
-									"id": "tddLOW87cr2Z6OQLb",
+									"id": "tR-YGkO9DRtr9xaqx",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tOQfp3YosDgO4S3yI"
+									},
 									"name": "Very Fit",
 									"reference": "B55",
 									"notes": "Recover FP at twice the normal rate; lose FP at half the normal rate (in both cases, not FP spent for spells or psi powers)",
@@ -2157,7 +2541,12 @@
 									}
 								},
 								{
-									"id": "tvs7FOt8bRNyhGitD",
+									"id": "tNU4Lu8rPAV4k4leH",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tEZdqelJmsl7LDkOF"
+									},
 									"name": "Weapon Bond (@Specific Weapon@)",
 									"reference": "PU2:9",
 									"tags": [
@@ -2188,14 +2577,56 @@
 							"name": "-40 Points chosen from",
 							"children": [
 								{
-									"id": "TRg86vBMfAPHIuS7X",
+									"id": "TWfqic3jn9ElWrrRq",
 									"name": "Everyman Disadvantages",
 									"tags": [
 										"Disadvantage"
 									],
 									"children": [
 										{
-											"id": "tNTE5NlMGZ2VqEF3c",
+											"id": "tAUUWQvAX9aPZ76IE",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tX9XXLPFBvyQSpA4k"
+											},
+											"name": "Xenophilia",
+											"reference": "B162",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"cr": 12,
+											"base_points": -10,
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "tl5WWhNoBWB_daZAS",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t8I0xw1Lj1_222aEN"
+											},
+											"name": "Workaholic",
+											"reference": "B162",
+											"tags": [
+												"Disadvantage",
+												"Physical"
+											],
+											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										},
+										{
+											"id": "tjQFS8nHgmAgRrpbU",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t7U0VbIzs6SqefwLr"
+											},
 											"name": "Social Stigma (Criminal Record)",
 											"reference": "B155",
 											"tags": [
@@ -2215,23 +2646,162 @@
 											}
 										},
 										{
-											"id": "tbEYOxvP439UNJMvt",
-											"name": "Chummy",
-											"reference": "B126",
+											"id": "tDh7TDdkFPpKTm9Ia",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "thSMVzJ590v7gAD8d"
+											},
+											"name": "Pacifism: Self-Defense Only",
+											"reference": "B148",
+											"notes": "You only fight to defend yourself or those in your care, using only as much force as necessary (no pre-emptive strikes allowed!). You must do your best to discourage others from starting fights.",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
+											"modifiers": [
+												{
+													"id": "mZ9m0FsEZRjMDpgHn",
+													"name": "Species-Specific",
+													"reference": "UT32",
+													"cost": -80,
+													"disabled": true
+												}
+											],
+											"base_points": -15,
+											"calc": {
+												"points": -15
+											}
+										},
+										{
+											"id": "tHBj3cnkWj3cti0Ft",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tV_f_75HmwzWOPhuu"
+											},
+											"name": "Pacifism: Reluctant Killer",
+											"reference": "B148",
+											"notes": "You are psychologically unprepared to kill people. Whenever you make a deadly attack (e.g., with a knife or a gun) against an obvious person whose face is visible to you, you are at -4 to hit and may not Aim. If you cannot see the foe’s face (due to a mask, darkness, or distance, or because you attacked from behind), the penalty is only -2, save in close combat. You have no penalty to attack a vehicle (even an occupied one), an opponent you do not believe is a person (including things with Horrific or Monstrous appearance), or a target you can’t actually see (e.g., a set of map coordinates or a blip on a radar screen). If you kill a recognizable person, the effect on you is the same as for Pacifism: Cannot Kill. You have no problem with your allies killing; you may even supply ammo, loaded weapons, and encouragement! You just can’t do the killing yourself.",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"modifiers": [
+												{
+													"id": "mO_47iNCBHPbYZ83K",
+													"name": "Species-Specific",
+													"reference": "UT32",
+													"cost": -80,
+													"disabled": true
+												}
+											],
 											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										},
+										{
+											"id": "tVodWSoZis-mC0knN",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "th9TK1Jmqg8uKe6SC"
+											},
+											"name": "Pacifism: Cannot Harm Innocents",
+											"reference": "B148",
+											"notes": "You may fight – you may even start fights – but you may only use deadly force on a foe that is attempting to do you serious harm. Capture is not “serious harm” unless you are already under penalty of death or have a Code of Honor that would require suicide if captured. You never intentionally do anything that causes, or even threatens to cause, injury to the uninvolved – particularly if they are “ordinary folks.”",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"modifiers": [
+												{
+													"id": "mgl2hygrbUy_-kzqj",
+													"name": "Species-Specific",
+													"reference": "UT32",
+													"cost": -80,
+													"disabled": true
+												}
+											],
+											"base_points": -10,
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "tcp5y3Do__YUqdOp4",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tSiOKuvTJkqJhuRrI"
+											},
+											"name": "Lecherousness",
+											"reference": "B142",
+											"notes": "Make a self-control roll whenever you have more than the briefest contact with an appealing member of the sex you find attractive, at -5 if this person is Handsome/Beautiful, or at -10 if Very Handsome/Very Beautiful. If you fail, you must make a “pass” using whatever wiles and skills you can bring to bear.",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"cr": 12,
+											"base_points": -15,
+											"calc": {
+												"points": -15
+											}
+										},
+										{
+											"id": "tkZYn4uR5F4A6jVSS",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "ttHkLI9zwzfeOIEZc"
+											},
+											"name": "Intolerance (@Class, Ethnicity, Nationality, Religion, Sex, or Species@)",
+											"reference": "B140",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"replacements": {
+												"Class, Ethnicity, Nationality, Religion, Sex, or Species": "Rival civilization or species"
+											},
+											"modifiers": [
+												{
+													"id": "m0McSCilT5QLM0p5M",
+													"name": "Scope: Common",
+													"reference": "B140",
+													"cost": -5,
+													"cost_type": "points"
+												},
+												{
+													"id": "mGsIPYiATdMebm2KT",
+													"name": "Scope: Occasional",
+													"reference": "B140",
+													"cost": -2,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "migqNHpRGvG58McE6",
+													"name": "Scope: Rare",
+													"reference": "B140",
+													"cost": -1,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mMM-SDWVtuo2ka_WK",
+													"name": "Scope: Anyone unlike you",
+													"reference": "B140",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												}
+											],
 											"features": [
 												{
 													"type": "reaction_bonus",
-													"situation": "to others",
-													"amount": 2
-												},
-												{
-													"type": "conditional_modifier",
-													"situation": "to IQ-based skills when alone",
+													"situation": "from victims of your intolerance (may be as much as -5, at GM's discretion)",
 													"amount": -1
 												}
 											],
@@ -2240,49 +2810,383 @@
 											}
 										},
 										{
-											"id": "tDdimpTUc6T6kOzfd",
-											"name": "Code of Honor (Mercanary's)",
-											"reference": "S221",
-											"notes": "A merc should look out for his buddies, take care of his gear, and fight for the honor of the unit. Obey the rule's of engagement. Don't poach on another unit's contract. Do the job you're hired for.",
+											"id": "tBwBwrkLMY3wACNfB",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t7pCgXTVkswkTjOZO"
+											},
+											"name": "Honesty",
+											"reference": "B138",
+											"notes": "Make a self-control roll when faced with the “need” to break unreasonable laws; if you fail, you must obey the law, whatever the consequences. If you manage to resist your urges and break the law, make a second self-control roll afterward. If you fail, you must turn yourself in to the authorities!",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
+											"cr": 12,
 											"base_points": -10,
 											"calc": {
 												"points": -10
 											}
 										},
 										{
-											"id": "tioYnDG0OrL97d0JI",
-											"name": "Code of Honor (Pirate's)",
-											"reference": "B127",
-											"notes": "Always avenge an insult, regardless of the danger; your buddy’s foe is your own; never attack a fellow crewman or buddy except in a fair, open duel.",
+											"id": "tc2S-L-CUq6CyzRjc",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t5bwP6TnS4cX-zM8L"
+											},
+											"name": "Enemy (@Who@)",
+											"reference": "B135",
+											"tags": [
+												"Disadvantage",
+												"Social"
+											],
+											"modifiers": [
+												{
+													"id": "mJap2Vu0_WrqMAjRm",
+													"name": "Weak Individual",
+													"reference": "B135",
+													"notes": "50% of your starting points",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m0ngIU99xvaFeBk54",
+													"name": "Equal Individual",
+													"reference": "B135",
+													"notes": "100% of your starting points",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "me04sEBez3HhbooP5",
+													"name": "Powerful Individual",
+													"reference": "B135",
+													"notes": "\u003e150% of your starting points",
+													"cost": -20,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mDkyrSBjZxlVhKaGQ",
+													"name": "Weak Group",
+													"reference": "B135",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mzIz9Yv5uXyAWThYr",
+													"name": "Medium Group",
+													"reference": "B135",
+													"cost": -20,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mmVvIa7SGR4gx6fQF",
+													"name": "Appears almost all the time",
+													"reference": "B36",
+													"notes": "15-",
+													"cost": 3,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mIJo1miIowTz1t0jN",
+													"name": "Appears quite often",
+													"reference": "B36",
+													"notes": "12-",
+													"cost": 2,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mikmk3sGt6IWJRWhV",
+													"name": "Appears fairly often",
+													"reference": "B36",
+													"notes": "9-",
+													"cost": 1,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "m-3cuagtl83qb1V3F",
+													"name": "Appears quite rarely",
+													"reference": "B36",
+													"notes": "6-",
+													"cost": 0.5,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "m-NXI636IxBeWH3NW",
+													"name": "Large/Powerful Group",
+													"reference": "B135",
+													"cost": -30,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mRVw3Ekj7JiCKjbE2",
+													"name": "Utterly Formidable Group",
+													"reference": "B135",
+													"cost": -40,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mHee2CaDvIRGkhJ8i",
+													"name": "Unknown",
+													"reference": "B135",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m_-NbZI--feNURGmW",
+													"name": "Evil Twin",
+													"reference": "B135",
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m_NjMp0EsDaqbX2fU",
+													"name": "Evil Twin",
+													"reference": "B135",
+													"notes": "More skilled or extra abilities",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mC4eX2x9AoGb5LMxA",
+													"name": "Evil Twin",
+													"reference": "B135",
+													"notes": "More skilled and extra abilities",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m5f2nF37eVINHWqb1",
+													"name": "Watcher",
+													"reference": "B135",
+													"cost": 0.25,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mEys20VtSjdzpHAh2",
+													"name": "Rival",
+													"reference": "B135",
+													"cost": 0.5,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mXLQ5UWwGHBKEOSzP",
+													"name": "Hunter",
+													"reference": "B135",
+													"cost": 1,
+													"cost_type": "multiplier",
+													"disabled": true
+												}
+											],
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "txazrvk9cjcRTvmxM",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t1HUGl4o498iCyvrw"
+											},
+											"name": "Duty (@Duty@)",
+											"reference": "B133",
+											"tags": [
+												"Disadvantage",
+												"Social"
+											],
+											"replacements": {
+												"Duty": "To ship's owner or provider"
+											},
+											"modifiers": [
+												{
+													"id": "m7aiFxAOwQ115W0qj",
+													"name": "FR: 6",
+													"cost": -2,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mjbyzT15rFZNblR3V",
+													"name": "FR: 9",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "muO8Mp9Nspj-K_ZZs",
+													"name": "FR: 12",
+													"cost": -10,
+													"cost_type": "points"
+												},
+												{
+													"id": "maqo2ESdi0OW-uCcN",
+													"name": "FR: 15",
+													"cost": -15,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mPHylE_UVteDCEr4L",
+													"name": "Extremely Hazardous",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m-E1gUk-fFCBeU6Ju",
+													"name": "Involuntary",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mn2VUIXFbBBHX0S_n",
+													"name": "Nonhazardous",
+													"cost": 5,
+													"cost_type": "points",
+													"disabled": true
+												}
+											],
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "tF_FjIAf9uHnbv0JN",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t1HUGl4o498iCyvrw"
+											},
+											"name": "Duty (@Duty@)",
+											"reference": "B133",
+											"tags": [
+												"Disadvantage",
+												"Social"
+											],
+											"replacements": {
+												"Duty": "To ship's owner or provider"
+											},
+											"modifiers": [
+												{
+													"id": "m_4qE0sqrKLCeMXtg",
+													"name": "FR: 6",
+													"cost": -2,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mdK2d5vtLqRY1RzJa",
+													"name": "FR: 9",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m8asZcRoTM397ih0I",
+													"name": "FR: 12",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mkyKYIo0c8J9QQ6gp",
+													"name": "FR: 15",
+													"cost": -15,
+													"cost_type": "points"
+												},
+												{
+													"id": "mEPedIqDL2iT-YYvC",
+													"name": "Extremely Hazardous",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m-W4an4wWHUziEocM",
+													"name": "Involuntary",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m2nNDnel_z4F2jNNi",
+													"name": "Nonhazardous",
+													"cost": 5,
+													"cost_type": "points",
+													"disabled": true
+												}
+											],
+											"calc": {
+												"points": -15
+											}
+										},
+										{
+											"id": "thMRl1DmzqOlalHfe",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tXFf9MSQ3FMT2psO8"
+											},
+											"name": "Demophobia (Crowds)",
+											"reference": "B149",
+											"notes": "Any group of over a dozen people sets off this fear unless they are all well known to you. The self-control roll is at -1 for over 25 people, -2 for a crowd of 100 or more, -3 for 1,000, -4 for 10,000, and so on.",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
+											"cr_adj": "action_penalty",
+											"cr": 12,
+											"base_points": -15,
+											"calc": {
+												"points": -15
+											}
+										},
+										{
+											"id": "tXCl2nTKmOdg0fOVt",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tK4QdVZYxGAd4cqr_"
+											},
+											"name": "Compulsive Gambling",
+											"reference": "B128",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"cr": 12,
 											"base_points": -5,
 											"calc": {
 												"points": -5
 											}
 										},
 										{
-											"id": "t5bV320ICfePLS9Td",
-											"name": "Code of Honor (Soldier's)",
-											"reference": "B127",
-											"notes": "An officer should be tough but fair, lead from the front, and look out for his men; an enlisted man should look out for his buddies and take care of his kit. Every soldier should be willing to fight and die for the honor of his unit, service, and country; follow orders; obey the “rules of war”; treat an honorable enemy with respect (a dishonorable enemy deserves a bullet); and wear the uniform with pride.",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"base_points": -10,
-											"calc": {
-												"points": -10
-											}
-										},
-										{
-											"id": "tm50ojnr0Xpx5NafE",
+											"id": "tyftdxiW0YDx4GY5p",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tapWLsuN75Unedmwn"
+											},
 											"name": "Compulsive Carousing",
 											"reference": "B128",
 											"tags": [
@@ -2308,308 +3212,115 @@
 											}
 										},
 										{
-											"id": "tW9QTnBkYe_jfVrAl",
-											"name": "Compulsive Gambling",
-											"reference": "B128",
+											"id": "tGToHoVPbjeC00GAH",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "txSrmgLB0M36uR802"
+											},
+											"name": "Code of Honor (Soldier's)",
+											"reference": "B127",
+											"notes": "An officer should be tough but fair, lead from the front, and look out for his men; an enlisted man should look out for his buddies and take care of his kit. Every soldier should be willing to fight and die for the honor of his unit, service, and country; follow orders; obey the “rules of war”; treat an honorable enemy with respect (a dishonorable enemy deserves a bullet); and wear the uniform with pride.",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
-											"cr": 12,
-											"base_points": -5,
-											"calc": {
-												"points": -5
-											}
-										},
-										{
-											"id": "tUEY-zr07UYWVAONe",
-											"name": "Duty (To ship's owner or provider)",
-											"reference": "B133",
-											"tags": [
-												"Disadvantage",
-												"Social"
-											],
-											"modifiers": [
-												{
-													"id": "moGgXG6EezwyzUhF3",
-													"name": "FR: 6",
-													"cost": -2,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "muAtx6FoA5qkJEo4W",
-													"name": "FR: 9",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mOXDzgDh3e2fdC_jS",
-													"name": "FR: 12",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "meZQ-FT1rgey8-h6t",
-													"name": "FR: 15",
-													"cost": -15,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mHxt0nDuenPX8bDcz",
-													"name": "Extremely Hazardous",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m1zyJoNzm_YAg0Fxl",
-													"name": "Involuntary",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mbDje6dxsn_C9mkT7",
-													"name": "Nonhazardous",
-													"cost": 5,
-													"cost_type": "points",
-													"disabled": true
-												}
-											],
-											"calc": {
-												"points": 0
-											}
-										},
-										{
-											"id": "t0xJwmDq0KYzmf4bn",
-											"name": "Enemy (@Who@)",
-											"reference": "B135",
-											"tags": [
-												"Disadvantage",
-												"Social"
-											],
-											"modifiers": [
-												{
-													"id": "mlqgkF2cqV8Dr3YLZ",
-													"name": "Weak Individual",
-													"reference": "B135",
-													"notes": "50% of your starting points",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m0Jdf4y7NbsFydp2q",
-													"name": "Equal Individual",
-													"reference": "B135",
-													"notes": "100% of your starting points",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mZlLALr4F87ONWvBW",
-													"name": "Powerful Individual",
-													"reference": "B135",
-													"notes": "\u003e150% of your starting points",
-													"cost": -20,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mz5uKilcCZyEvMq5v",
-													"name": "Weak Group",
-													"reference": "B135",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mRHuOdO6tgwbM3hRv",
-													"name": "Medium Group",
-													"reference": "B135",
-													"cost": -20,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mBFyILJd3gK3V6guh",
-													"name": "Appears almost all the time",
-													"reference": "B36",
-													"notes": "15-",
-													"cost": 3,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "msmoLqYwaG8f2cIxR",
-													"name": "Appears quite often",
-													"reference": "B36",
-													"notes": "12-",
-													"cost": 2,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "m63H0z15bJ1MMfvkX",
-													"name": "Appears fairly often",
-													"reference": "B36",
-													"notes": "9-",
-													"cost": 1,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "m1zejr-M51xUyMACC",
-													"name": "Appears quite rarely",
-													"reference": "B36",
-													"notes": "6-",
-													"cost": 0.5,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mxJ9_uNECRWOzEnJg",
-													"name": "Large/Powerful Group",
-													"reference": "B135",
-													"cost": -30,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m06ZthTLhEGDL6w4N",
-													"name": "Utterly Formidable Group",
-													"reference": "B135",
-													"cost": -40,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mzZ99PLzycXZw779W",
-													"name": "Unknown",
-													"reference": "B135",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mFf7AcQuzF9skw1kh",
-													"name": "Evil Twin",
-													"reference": "B135",
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m58t0D_f2JvzIirFO",
-													"name": "Evil Twin",
-													"reference": "B135",
-													"notes": "More skilled or extra abilities",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mfe6saXGZtlw5YRGw",
-													"name": "Evil Twin",
-													"reference": "B135",
-													"notes": "More skilled and extra abilities",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mNwtrIaYdJGQXEtq4",
-													"name": "Watcher",
-													"reference": "B135",
-													"cost": 0.25,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "m0rZDaR0xMBV7y31H",
-													"name": "Rival",
-													"reference": "B135",
-													"cost": 0.5,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mu-KSJLFaoW6RuXKi",
-													"name": "Hunter",
-													"reference": "B135",
-													"cost": 1,
-													"cost_type": "multiplier",
-													"disabled": true
-												}
-											],
-											"calc": {
-												"points": 0
-											}
-										},
-										{
-											"id": "tz9NwRyKjLNgjfp27",
-											"name": "Honesty",
-											"reference": "B138",
-											"notes": "Make a self-control roll when faced with the “need” to break unreasonable laws; if you fail, you must obey the law, whatever the consequences. If you manage to resist your urges and break the law, make a second self-control roll afterward. If you fail, you must turn yourself in to the authorities!",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"cr": 12,
 											"base_points": -10,
 											"calc": {
 												"points": -10
 											}
 										},
 										{
-											"id": "tpFzB3r2gF4WeSzKn",
-											"name": "Intolerance (@Rival civilization or species@)",
-											"reference": "B140",
+											"id": "tiaXgqNHJ0Q7KDzMP",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Space/Space Traits.adq",
+												"id": "teNSsqOsjstajwmxn"
+											},
+											"name": "Code of Honor (Mercenary's Code)",
+											"reference": "B127, S221",
+											"notes": "A merc should look out for his buddies, take care of his gear, and fight for the honor of the unit. Obey the rules of engagement. Don’t poach on another unit’s contract. Do the job you’re hired for.",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
-											"modifiers": [
-												{
-													"id": "mI6Ncq-5WzZNtixNK",
-													"name": "Scope: Common",
-													"reference": "B140",
-													"cost": -5,
-													"cost_type": "points"
-												},
-												{
-													"id": "myDGQ5bdMHdWmCjlg",
-													"name": "Scope: Occasional",
-													"reference": "B140",
-													"cost": -2,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mt0KKdpGlxtiZl1QI",
-													"name": "Scope: Rare",
-													"reference": "B140",
-													"cost": -1,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mXYpxgBUC0Hl7shDn",
-													"name": "Scope: Anyone unlike you",
-													"reference": "B140",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												}
+											"base_points": -10,
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "t-42IDpxYsNddPV9F",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tqq24I9NJrLajsURv"
+											},
+											"name": "Code of Honor (Pirate's)",
+											"reference": "B127",
+											"notes": "Always avenge an insult, regardless of the danger; your buddy’s foe is your own; never attack a fellow crewman or buddy except in a fair, open duel.",
+											"tags": [
+												"Disadvantage",
+												"Mental"
 											],
+											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										},
+										{
+											"id": "tKRpM5BMQK-7KMCPl",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t4KGpV0KBExr-fEb2"
+											},
+											"name": "Gregarious",
+											"reference": "B126",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"base_points": -10,
 											"features": [
 												{
 													"type": "reaction_bonus",
-													"situation": "from victims of your intolerance (may be as much as -5, at GM's discretion)",
+													"situation": "to others",
+													"amount": 4
+												},
+												{
+													"type": "conditional_modifier",
+													"situation": "to IQ-based skills when alone, or only -1 if in a group of 4 or less",
+													"amount": -2
+												}
+											],
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "t0r2VOudpd8soeHna",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tzBDG0xUlT_dh7FuY"
+											},
+											"name": "Chummy",
+											"reference": "B126",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"base_points": -5,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "to others",
+													"amount": 2
+												},
+												{
+													"type": "conditional_modifier",
+													"situation": "to IQ-based skills when alone",
 													"amount": -1
 												}
 											],
@@ -2618,91 +3329,12 @@
 											}
 										},
 										{
-											"id": "tKoOFVNENms_gHqWU",
-											"name": "Lecherousness",
-											"reference": "B142",
-											"notes": "Make a self-control roll whenever you have more than the briefest contact with an appealing member of the sex you find attractive, at -5 if this person is Handsome/Beautiful, or at -10 if Very Handsome/Very Beautiful. If you fail, you must make a “pass” using whatever wiles and skills you can bring to bear.",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"cr": 12,
-											"base_points": -15,
-											"calc": {
-												"points": -15
-											}
-										},
-										{
-											"id": "tyrdg3-9JOyReXCqI",
-											"name": "Pacifism: Reluctant Killer",
-											"reference": "B148",
-											"notes": "You are psychologically unprepared to kill people. Whenever you make a deadly attack (e.g., with a knife or a gun) against an obvious person whose face is visible to you, you are at -4 to hit and may not Aim. If you cannot see the foe’s face (due to a mask, darkness, or distance, or because you attacked from behind), the penalty is only -2, save in close combat. You have no penalty to attack a vehicle (even an occupied one), an opponent you do not believe is a person (including things with Horrific or Monstrous appearance), or a target you can’t actually see (e.g., a set of map coordinates or a blip on a radar screen). If you kill a recognizable person, the effect on you is the same as for Pacifism: Cannot Kill. You have no problem with your allies killing; you may even supply ammo, loaded weapons, and encouragement! You just can’t do the killing yourself.",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"modifiers": [
-												{
-													"id": "m6Cdq2EFAsQcI8av9",
-													"name": "Species-Specific",
-													"reference": "UT32",
-													"cost": -80,
-													"disabled": true
-												}
-											],
-											"base_points": -5,
-											"calc": {
-												"points": -5
-											}
-										},
-										{
-											"id": "tC5k42jLnyo6Z6vUP",
-											"name": "Pacifism: Self-Defense Only",
-											"reference": "B148",
-											"notes": "You only fight to defend yourself or those in your care, using only as much force as necessary (no pre-emptive strikes allowed!). You must do your best to discourage others from starting fights.",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"modifiers": [
-												{
-													"id": "m6CKn_F5SVvXRMd68",
-													"name": "Species-Specific",
-													"reference": "UT32",
-													"cost": -80,
-													"disabled": true
-												}
-											],
-											"base_points": -15,
-											"calc": {
-												"points": -15
-											}
-										},
-										{
-											"id": "tzwVFE1CKN9essG9E",
-											"name": "Pacifism: Cannot Harm Innocents",
-											"reference": "B148",
-											"notes": "You may fight – you may even start fights – but you may only use deadly force on a foe that is attempting to do you serious harm. Capture is not “serious harm” unless you are already under penalty of death or have a Code of Honor that would require suicide if captured. You never intentionally do anything that causes, or even threatens to cause, injury to the uninvolved – particularly if they are “ordinary folks.”",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"modifiers": [
-												{
-													"id": "mYxRMihTlp9nlmuxh",
-													"name": "Species-Specific",
-													"reference": "UT32",
-													"cost": -80,
-													"disabled": true
-												}
-											],
-											"base_points": -10,
-											"calc": {
-												"points": -10
-											}
-										},
-										{
-											"id": "tn6QRI73_fS6mOFd7",
+											"id": "tAkzk5JkggifuiPOp",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "taFPI7E0PJwXbS5nL"
+											},
 											"name": "Agoraphobia (Open Spaces)",
 											"reference": "B150",
 											"notes": "You are uncomfortable whenever you are outside, and actually become frightened when there are no walls within 50 feet.",
@@ -2716,120 +3348,19 @@
 											"calc": {
 												"points": -10
 											}
-										},
-										{
-											"id": "t3wOmGD7dVS2QQko8",
-											"name": "Demophobia (Crowds)",
-											"reference": "B149",
-											"notes": "Any group of over a dozen people sets off this fear unless they are all well known to you. The self-control roll is at -1 for over 25 people, -2 for a crowd of 100 or more, -3 for 1,000, -4 for 10,000, and so on.",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"cr_adj": "action_penalty",
-											"cr": 12,
-											"base_points": -15,
-											"calc": {
-												"points": -15
-											}
-										},
-										{
-											"id": "t0UZ_l3P6zNkUP9wx",
-											"name": "Duty (To ship's owner or provider)",
-											"reference": "B133",
-											"tags": [
-												"Disadvantage",
-												"Social"
-											],
-											"modifiers": [
-												{
-													"id": "mDX41fTWKARHPfWKl",
-													"name": "FR: 6",
-													"cost": -2,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mQmDVN80_efubZ4fQ",
-													"name": "FR: 9",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mkVzlBuINWvCfv2fh",
-													"name": "FR: 12",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mAPMq_KOAMKe9ZcJT",
-													"name": "FR: 15",
-													"cost": -15,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m6vn9_eBUznLWGCIM",
-													"name": "Extremely Hazardous",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mZHaNjRWN7v3BbRMo",
-													"name": "Involuntary",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m9nhRj5E-UW_frLhL",
-													"name": "Nonhazardous",
-													"cost": 5,
-													"cost_type": "points",
-													"disabled": true
-												}
-											],
-											"calc": {
-												"points": 0
-											}
-										},
-										{
-											"id": "tyWMeQeQ4--zyodxo",
-											"name": "Workaholic",
-											"reference": "B162",
-											"tags": [
-												"Disadvantage",
-												"Physical"
-											],
-											"base_points": -5,
-											"calc": {
-												"points": -5
-											}
-										},
-										{
-											"id": "tOtLdMJTHBdI165G6",
-											"name": "Xenophilia",
-											"reference": "B162",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"cr": 12,
-											"base_points": -10,
-											"calc": {
-												"points": -10
-											}
 										}
 									],
 									"calc": {
-										"points": -145
+										"points": -180
 									}
 								},
 								{
-									"id": "tm-kc00KbNUzug1-4",
+									"id": "t5RysOhptrCQ6uyoZ",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tnrtPQ0mWF4k75plo"
+									},
 									"name": "Bad Temper",
 									"reference": "B124",
 									"tags": [
@@ -2843,7 +3374,12 @@
 									}
 								},
 								{
-									"id": "tESnJjtXpkEUOGhTi",
+									"id": "td5mv3XIug2dalhmw",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tMrRhiOyGg6WNz09k"
+									},
 									"name": "Bully",
 									"reference": "B125",
 									"tags": [
@@ -2864,7 +3400,12 @@
 									}
 								},
 								{
-									"id": "tvbVBYUmd1DDj1FX6",
+									"id": "tpWcIL6QEv4JO2NL6",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tNe543pbMl1IkZxSo"
+									},
 									"name": "Callous",
 									"reference": "B125",
 									"tags": [
@@ -2907,7 +3448,12 @@
 									}
 								},
 								{
-									"id": "teD5HwOQzATBwYUYh",
+									"id": "tn7eF_3qYsusiAGVM",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t-ZuUbg_LrqZ1hi6c"
+									},
 									"name": "Careful",
 									"reference": "B163",
 									"tags": [
@@ -2920,7 +3466,12 @@
 									}
 								},
 								{
-									"id": "tsKSxyB_rogPSP8R1",
+									"id": "t-MCVFhv1oorbPr4f",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t7x0UhMbIv9VWYd8n"
+									},
 									"name": "Hidebound",
 									"reference": "B138",
 									"tags": [
@@ -2940,7 +3491,12 @@
 									}
 								},
 								{
-									"id": "tnaDqSjOTc__GUsT6",
+									"id": "tDBlGTQaA-Lo0XLTN",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tM8LVZ-8-HpvEFsPi"
+									},
 									"name": "Incurious",
 									"reference": "B140",
 									"notes": "Make a self-control roll when confronted with something strange. If you fail, you ignore it!",
@@ -2962,7 +3518,12 @@
 									}
 								},
 								{
-									"id": "t5F4gpBiqIt-UaJDH",
+									"id": "tNPaiyRPS5Y_gIafD",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tOW5XqmChX0NBm1AP"
+									},
 									"name": "Light Sleeper",
 									"reference": "B142",
 									"notes": "Whenever you must sleep in an uncomfortable place, or whenever there is more than the slightest noise, you must make a HT roll in order to fall asleep. On a failure, you can try again after one hour, but you will suffer all the usual effects of one hour of missed sleep.",
@@ -2976,12 +3537,17 @@
 									}
 								},
 								{
-									"id": "tsUKpdiTogEhW8p0l",
+									"id": "tAjbyDDHPUIlT0nI_",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tAFhfFoZosiPCFUhy"
+									},
 									"name": "No Sense of Humor",
 									"reference": "B146",
 									"tags": [
 										"Disadvantage",
-										"Physical"
+										"Mental"
 									],
 									"base_points": -10,
 									"features": [
@@ -2996,7 +3562,12 @@
 									}
 								},
 								{
-									"id": "tQo6v1eo7JSWNVHrc",
+									"id": "twHYjsLItM8_4GVS_",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tYWjKdrALVt_raSxk"
+									},
 									"name": "Paranoia",
 									"reference": "B148",
 									"tags": [
@@ -3021,7 +3592,12 @@
 									}
 								},
 								{
-									"id": "t0GNMKs_OH9pLe51e",
+									"id": "tbd5r77-LOgKHaGBL",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t4gqkFmqABx7dLjkS"
+									},
 									"name": "Stubbornness",
 									"reference": "B157",
 									"tags": [
@@ -3041,7 +3617,12 @@
 									}
 								},
 								{
-									"id": "tKzuyF2TNbaOB_72u",
+									"id": "tOa_IxJhyg4aDMnyL",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tAKQUtRTjZeOEbA5y"
+									},
 									"name": "Wounded",
 									"reference": "B162",
 									"tags": [
@@ -3055,17 +3636,17 @@
 								}
 							],
 							"calc": {
-								"points": -216
+								"points": -251
 							}
 						}
 					],
 					"calc": {
-						"points": -216
+						"points": -251
 					}
 				}
 			],
 			"calc": {
-				"points": 280
+				"points": 245
 			}
 		},
 		{
@@ -3078,7 +3659,12 @@
 					"name": "Multi-Role",
 					"children": [
 						{
-							"id": "troLB9eDLEGBp5733",
+							"id": "trfrZHPrWgiZAhYNj",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tGWOSEE6SmBHACE6Y"
+							},
 							"name": "Increased Dexterity",
 							"reference": "B15",
 							"tags": [
@@ -3088,7 +3674,7 @@
 							],
 							"modifiers": [
 								{
-									"id": "mhFB3WH6HFbdX6jwd",
+									"id": "mrDGJoxV4tSuH6F9m",
 									"name": "No Fine Manipulators",
 									"cost": -40,
 									"disabled": true
@@ -3119,7 +3705,12 @@
 					"name": "Legendary",
 					"children": [
 						{
-							"id": "tbskM4Ig5VUS_p73i",
+							"id": "tNbIax4vVUVyR_8RK",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tGWOSEE6SmBHACE6Y"
+							},
 							"name": "Increased Dexterity",
 							"reference": "B15",
 							"tags": [
@@ -3129,7 +3720,7 @@
 							],
 							"modifiers": [
 								{
-									"id": "mPjxaraY1koTo39QY",
+									"id": "mMiFsQxCb9YdvH9rU",
 									"name": "No Fine Manipulators",
 									"cost": -40,
 									"disabled": true
@@ -3151,7 +3742,12 @@
 							}
 						},
 						{
-							"id": "tvrNZ1bx1NGEh9Sju",
+							"id": "t8FFN-PLlESpClotH",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tmpxhXmSORakqvrbn"
+							},
 							"name": "Increased Perception",
 							"reference": "B16",
 							"tags": [
@@ -3180,7 +3776,12 @@
 							"name": "20 Points chosen from",
 							"children": [
 								{
-									"id": "t_KFfUn9Ojb8CMzjk",
+									"id": "thTZsTcpQua1VxMq3",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tqha9GlDBU9P-Wg-6"
+									},
 									"name": "Increased Strength",
 									"reference": "B14",
 									"tags": [
@@ -3190,14 +3791,14 @@
 									],
 									"modifiers": [
 										{
-											"id": "mTqzGd7rCzGzEzGl_",
+											"id": "mAXKctDO16Z_QY8mc",
 											"name": "No Fine Manipulators",
 											"reference": "B15",
 											"cost": -40,
 											"disabled": true
 										},
 										{
-											"id": "m-ET7IlK3lgdB1bm3",
+											"id": "mFWFTITSwxfyMtKo_",
 											"name": "Size",
 											"reference": "B15",
 											"cost": -10,
@@ -3205,7 +3806,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mX-ljbGt2Q1UG5ObP",
+											"id": "m1SZ3WuHueuLx8IWo",
 											"name": "Super-Effort",
 											"reference": "SU24",
 											"cost": 300,
@@ -3228,7 +3829,12 @@
 									}
 								},
 								{
-									"id": "ttYYtBsRBv25l9izq",
+									"id": "tEOkMb-JX3cev8DgO",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tGWOSEE6SmBHACE6Y"
+									},
 									"name": "Increased Dexterity",
 									"reference": "B15",
 									"tags": [
@@ -3238,7 +3844,7 @@
 									],
 									"modifiers": [
 										{
-											"id": "m43FoMcTS6Qrph1JV",
+											"id": "mrvBcjJhwl_HwiDMx",
 											"name": "No Fine Manipulators",
 											"cost": -40,
 											"disabled": true
@@ -3260,7 +3866,12 @@
 									}
 								},
 								{
-									"id": "t6Zw1merpS3L3XXqm",
+									"id": "tL-OsU5kTbGydUmRC",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tVt3SvdGWNchJ8z4o"
+									},
 									"name": "Increased Health",
 									"reference": "B14",
 									"tags": [
@@ -3284,7 +3895,12 @@
 									}
 								},
 								{
-									"id": "ttaWh9tjeHGiY1hsp",
+									"id": "tkOYQaN8bfDfkaU1r",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tmpxhXmSORakqvrbn"
+									},
 									"name": "Increased Perception",
 									"reference": "B16",
 									"tags": [
@@ -3309,7 +3925,12 @@
 									}
 								},
 								{
-									"id": "toPh0WtypvFEBPJTz",
+									"id": "t5DjsWc7ZphP2n80H",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tGjjVtxav9KsrG7Wx"
+									},
 									"name": "Combat Reflexes",
 									"reference": "B43",
 									"notes": "Never freeze",
@@ -3378,7 +3999,12 @@
 									}
 								},
 								{
-									"id": "t2Tp1vThFjwWpdaE9",
+									"id": "tTMTs92Tm68ZnJYO5",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tgjE-yMzESTjq695x"
+									},
 									"name": "Danger Sense",
 									"reference": "B47,P46",
 									"tags": [
@@ -3391,36 +4017,53 @@
 									}
 								},
 								{
-									"id": "tJvboHJbxUEsLBh6I",
-									"name": "Peripheral Vision",
-									"reference": "B74,P87",
-									"tags": [
-										"Advantage",
-										"Physical"
-									],
-									"modifiers": [
-										{
-											"id": "mjErUjo6Fxiu8_P0l",
-											"name": "Easy to Hit",
-											"reference": "B75",
-											"notes": "Others can target your eyes at only -6 to hit",
-											"cost": -20,
-											"disabled": true
-										}
-									],
-									"base_points": 15,
-									"calc": {
-										"points": 15
-									}
-								},
-								{
-									"id": "t3pjzjSOF-ZAgjz7e",
+									"id": "tVWbauojEG-DoE8-d",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tOjsbk80G_rSNlfY3"
+									},
 									"name": "Talent (Natural Copper)",
 									"reference": "PU3:13",
 									"tags": [
 										"Advantage",
 										"Mental",
 										"Talent"
+									],
+									"modifiers": [
+										{
+											"id": "Mklt4STjcZNBLgRqR",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "mSani3grXNiKJErKO",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From police and PIs.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "mjXAQ2fL27yMkK8Zc",
+													"name": "Alternative Benefit",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Bonus to unskilled Per rolls to notice clues, and to all rolls to use Intuition",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
+										}
 									],
 									"points_per_level": 10,
 									"features": [
@@ -3523,24 +4166,40 @@
 											},
 											"amount": 1,
 											"per_level": true
-										},
-										{
-											"type": "reaction_bonus",
-											"situation": "From police and PIs.",
-											"amount": 1,
-											"per_level": true
-										},
-										{
-											"type": "conditional_modifier",
-											"situation": "Bonus to unskilled Per rolls to notice clues, and to all rolls to use Intuition",
-											"amount": 1,
-											"per_level": true
 										}
 									],
 									"can_level": true,
 									"levels": 2,
 									"calc": {
 										"points": 20
+									}
+								},
+								{
+									"id": "tNgdfGS2m5VfjpnkZ",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tc74I5tb8McOGp5nr"
+									},
+									"name": "Peripheral Vision",
+									"reference": "B74,P87",
+									"tags": [
+										"Advantage",
+										"Physical"
+									],
+									"modifiers": [
+										{
+											"id": "m33ZwCx3pWMdxv-gm",
+											"name": "Easy to Hit",
+											"reference": "B75",
+											"notes": "Others can target your eyes at only -6 to hit",
+											"cost": -20,
+											"disabled": true
+										}
+									],
+									"base_points": 15,
+									"calc": {
+										"points": 15
 									}
 								}
 							],
@@ -3570,7 +4229,12 @@
 					"name": "Primary Skills",
 					"children": [
 						{
-							"id": "sCq0Uha9rYfQtnBIv",
+							"id": "saJaZcqYF9DMbux78",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sLoMDn7X8itpfsDPv"
+							},
 							"name": "Criminology",
 							"reference": "B186",
 							"tags": [
@@ -3594,7 +4258,12 @@
 							"points": 2
 						},
 						{
-							"id": "sEIAb3fKkOsW8_Z4k",
+							"id": "srfGeQLVbXQPtdWtd",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sfB-d4kTee0C-BZv0"
+							},
 							"name": "Interrogation",
 							"reference": "B202",
 							"tags": [
@@ -3622,7 +4291,12 @@
 							"points": 2
 						},
 						{
-							"id": "sq4fU3WiMJyL_gHio",
+							"id": "sHdZnWXoBdCkye7RQ",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "slXlqD4FNReNHmsov"
+							},
 							"name": "Electronics Operation",
 							"reference": "B189",
 							"tags": [
@@ -3660,7 +4334,12 @@
 							"points": 2
 						},
 						{
-							"id": "sTVClKFT45MBcdYkZ",
+							"id": "smAid16rrFVQ0CjdO",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sgWf_qVqI7HrPQUo7"
+							},
 							"name": "Tactics",
 							"reference": "B224,MA60",
 							"tags": [
@@ -3682,7 +4361,12 @@
 							"points": 4
 						},
 						{
-							"id": "sEBTkTSDvgL2dlrza",
+							"id": "srKB9EyB2bgQxZyVh",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sPyZ0zxFI-Kygrzie"
+							},
 							"name": "Intelligence Analysis",
 							"reference": "B201",
 							"tags": [
@@ -3706,7 +4390,12 @@
 							"points": 4
 						},
 						{
-							"id": "sBVnSI9tXwzdZQYtH",
+							"id": "st6OB2fKD92vXKDtx",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "s6Yn2IClGb4i4LgOQ"
+							},
 							"name": "Observation",
 							"reference": "B211",
 							"tags": [
@@ -3731,7 +4420,12 @@
 							"points": 2
 						},
 						{
-							"id": "sJqFDRY2xmBi7QhLu",
+							"id": "snjDNVjffHcQkzb8c",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sW_dr_6QZxz1zrODT"
+							},
 							"name": "Search",
 							"reference": "B219",
 							"tags": [
@@ -3757,7 +4451,12 @@
 							"name": "One of",
 							"children": [
 								{
-									"id": "sFt4IjXjJ283zF1vG",
+									"id": "s7dTdFZrFKBce4Xns",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sBJgeWUs81Ifhob4Z"
+									},
 									"name": "Beam Weapons",
 									"reference": "B179",
 									"tags": [
@@ -3788,7 +4487,12 @@
 									"points": 4
 								},
 								{
-									"id": "s07i3BJEB_Nk2z5Qt",
+									"id": "stcyGj9iJ-Fm1wVqp",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sT5htbz4-Mr0PFCk7"
+									},
 									"name": "Guns",
 									"reference": "B198",
 									"tags": [
@@ -3819,7 +4523,12 @@
 							"name": "One of",
 							"children": [
 								{
-									"id": "sI8QLeUSe9K4-y9_F",
+									"id": "sSUkZGZ9l8h8BzI_B",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "shtDdl5thrvKSnJHf"
+									},
 									"name": "Brawling",
 									"reference": "B182,MA55",
 									"tags": [
@@ -3847,7 +4556,12 @@
 									"points": 4
 								},
 								{
-									"id": "sKQAZ-eQ0AXxll8aX",
+									"id": "sPV855DSMiRvt-L-O",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sEw2VcGPL_pN66Fah"
+									},
 									"name": "Boxing",
 									"reference": "B182,MA55",
 									"tags": [
@@ -3889,7 +4603,12 @@
 									"points": 4
 								},
 								{
-									"id": "sSRRNZ5n66X7uQSBr",
+									"id": "sf1-FzzCHruOfdYMc",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sU4bjpp9TsvnRavPN"
+									},
 									"name": "Karate",
 									"reference": "B203,MA57",
 									"tags": [
@@ -3937,7 +4656,12 @@
 							"name": "One of",
 							"children": [
 								{
-									"id": "sahQK6wgFNlPgupIP",
+									"id": "s5ewpDs04qxqydNAD",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "s8parl7zgbXys0OF2"
+									},
 									"name": "Wrestling",
 									"reference": "B228,MA61",
 									"tags": [
@@ -3949,7 +4673,12 @@
 									"points": 4
 								},
 								{
-									"id": "s-DnSwZln6wBAypjf",
+									"id": "sV9_cx3O5WD-vKxpX",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sWVqswxT3hi7db0kD"
+									},
 									"name": "Judo",
 									"reference": "B203,MA57",
 									"notes": "Allows parrying two different attacks per turn, one with each hand.",
@@ -3971,21 +4700,55 @@
 					"name": "Secondary Skills",
 					"children": [
 						{
-							"id": "ssjaiR37lN__qqP7y",
-							"name": "Fast-Draw",
-							"reference": "B194,MA56",
-							"tags": [
-								"Combat",
-								"Ranged Combat",
-								"Weapon"
-							],
-							"specialization": "@Ammo or Pistol@",
-							"difficulty": "dx/e",
-							"tech_level": "",
-							"points": 1
+							"id": "STYzyI9gNMoe2p2jB",
+							"name": "One of",
+							"children": [
+								{
+									"id": "svrJk4GUPiZLaa8VE",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "slFkOhWAAPF7DTJRe"
+									},
+									"name": "Fast-Draw",
+									"reference": "B194,MA56",
+									"tags": [
+										"Combat",
+										"Ranged Combat",
+										"Weapon"
+									],
+									"specialization": "Pistol",
+									"difficulty": "dx/e",
+									"points": 1
+								},
+								{
+									"id": "sTC658ON4A_jrf9IX",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "scP0IdjWrVEveSeDl"
+									},
+									"name": "Fast-Draw",
+									"reference": "B194,MA56",
+									"tags": [
+										"Combat",
+										"Ranged Combat",
+										"Weapon"
+									],
+									"specialization": "Ammo",
+									"difficulty": "dx/e",
+									"tech_level": "",
+									"points": 1
+								}
+							]
 						},
 						{
-							"id": "sPbS3-Gvkf7sBfaKm",
+							"id": "sm8KcD1G6o_88DsYR",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sxSlxLiSgB95HINP_"
+							},
 							"name": "Forced Entry",
 							"reference": "B196",
 							"tags": [
@@ -4002,7 +4765,12 @@
 							"name": "Three of",
 							"children": [
 								{
-									"id": "s7V09TFRXerem9UYR",
+									"id": "sYa1xVXQi-h-27bOC",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "siupVKFgi0pYYp4oa"
+									},
 									"name": "Battlesuit",
 									"reference": "B192",
 									"tags": [
@@ -4035,7 +4803,12 @@
 									"points": 2
 								},
 								{
-									"id": "sF5u7Vo8tHbFR9PQY",
+									"id": "seD0XNjtqKet12DDt",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sku11uyd1oUdTaIPX"
+									},
 									"name": "Armoury",
 									"reference": "B178",
 									"tags": [
@@ -4043,7 +4816,7 @@
 										"Military",
 										"Repair"
 									],
-									"specialization": "@Battlesuits, Body Armor, or Small Arms@",
+									"specialization": "Battlesuits",
 									"difficulty": "iq/a",
 									"defaults": [
 										{
@@ -4061,14 +4834,83 @@
 									"points": 2
 								},
 								{
-									"id": "s9FkG8IcIzQWY7rWL",
+									"id": "sPM7_PKUXykTujVFh",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "su8_7IR5w48OtVqU-"
+									},
+									"name": "Armoury",
+									"reference": "B178",
+									"tags": [
+										"Maintenance",
+										"Military",
+										"Repair"
+									],
+									"specialization": "Body Armor",
+									"difficulty": "iq/a",
+									"defaults": [
+										{
+											"type": "iq",
+											"modifier": -5
+										},
+										{
+											"type": "skill",
+											"name": "Engineer",
+											"specialization": "Body Armor",
+											"modifier": -4
+										}
+									],
+									"tech_level": "",
+									"points": 2
+								},
+								{
+									"id": "soupCnUAZmppA5bSY",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sECLIE914su-sEPNx"
+									},
+									"name": "Armoury",
+									"reference": "B178",
+									"tags": [
+										"Maintenance",
+										"Military",
+										"Repair"
+									],
+									"specialization": "Small Arms",
+									"difficulty": "iq/a",
+									"defaults": [
+										{
+											"type": "iq",
+											"modifier": -5
+										},
+										{
+											"type": "skill",
+											"name": "Engineer",
+											"specialization": "Small Arms",
+											"modifier": -4
+										}
+									],
+									"tech_level": "",
+									"points": 2
+								},
+								{
+									"id": "sGj2hL_222Hs3e9Gl",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sANKIfg-p4ifPKXvT"
+									},
 									"name": "Explosives",
 									"reference": "B194",
 									"tags": [
+										"Criminal",
 										"Military",
+										"Street",
 										"Technical"
 									],
-									"specialization": "@Demolition, EOD, or NOD@",
+									"specialization": "Demolition",
 									"difficulty": "iq/a",
 									"defaults": [
 										{
@@ -4103,7 +4945,98 @@
 									"points": 2
 								},
 								{
-									"id": "sZvPXWgRgyaYZd8I5",
+									"id": "s-BCtFOIwxbt7ul_m",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sBHpgicbxJl1DmtOS"
+									},
+									"name": "Explosives",
+									"reference": "B194",
+									"tags": [
+										"Military",
+										"Police",
+										"Technical"
+									],
+									"specialization": "Explosive Ordnance Disposal",
+									"difficulty": "iq/a",
+									"defaults": [
+										{
+											"type": "iq",
+											"modifier": -5
+										},
+										{
+											"type": "skill",
+											"name": "Explosives",
+											"specialization": "Nuclear Ordnance Disposal",
+											"modifier": -2
+										},
+										{
+											"type": "skill",
+											"name": "Explosives",
+											"modifier": -4
+										}
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "attribute_prereq",
+												"has": true,
+												"qualifier": {
+													"compare": "at_least",
+													"qualifier": 12
+												},
+												"which": "dx"
+											}
+										]
+									},
+									"tech_level": "",
+									"points": 2
+								},
+								{
+									"id": "sFCogGXv9hAgNEzhy",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "s3PxRYNUoB072onld"
+									},
+									"name": "Explosives",
+									"reference": "B194",
+									"tags": [
+										"Military",
+										"Technical"
+									],
+									"specialization": "Nuclear Ordnance Disposal",
+									"difficulty": "iq/a",
+									"defaults": [
+										{
+											"type": "iq",
+											"modifier": -5
+										},
+										{
+											"type": "skill",
+											"name": "Explosives",
+											"specialization": "Explosive Ordnance Disposal",
+											"modifier": -2
+										},
+										{
+											"type": "skill",
+											"name": "Explosives",
+											"modifier": -4
+										}
+									],
+									"tech_level": "",
+									"points": 2
+								},
+								{
+									"id": "sGBgn4qWAUIsiH4Ad",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sSxGnNPMXyZpZKoFZ"
+									},
 									"name": "Leadership",
 									"reference": "B204",
 									"tags": [
@@ -4120,7 +5053,12 @@
 									"points": 2
 								},
 								{
-									"id": "sA0HLrsVmPW0VD2bS",
+									"id": "siIls3muotOXjoqW2",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sqFw3NucoHE6Ki4XP"
+									},
 									"name": "Shadowing",
 									"reference": "B219",
 									"tags": [
@@ -4149,7 +5087,12 @@
 									"points": 2
 								},
 								{
-									"id": "soOdVq1WjkGiYlj39",
+									"id": "se8B7gnuOnPO1Ihx2",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "smTUpMWJGqPeT1KER"
+									},
 									"name": "Streetwise",
 									"reference": "B223",
 									"tags": [
@@ -4168,7 +5111,12 @@
 									"points": 2
 								},
 								{
-									"id": "sfavTrZuD_tH1oR9c",
+									"id": "sp6YbRFnPNgTs9q0M",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "s8j6tcaNxXkF89Xbt"
+									},
 									"name": "Diplomacy",
 									"reference": "B187",
 									"tags": [
@@ -4191,7 +5139,12 @@
 									"points": 2
 								},
 								{
-									"id": "spr8ejzuHzrD0jvrF",
+									"id": "sFH-ZnHPB1vceYYDS",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sKWsnqVrAhUQFZUr5"
+									},
 									"name": "Forensics",
 									"reference": "B196",
 									"tags": [
@@ -4213,7 +5166,12 @@
 									"points": 2
 								},
 								{
-									"id": "stOf0ZH1OaRHUqU0u",
+									"id": "sfZ-MIc1cBLKIlXpD",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "shun-iitiwyWbrGcF"
+									},
 									"name": "Intimidation",
 									"reference": "B202",
 									"tags": [
@@ -4237,7 +5195,12 @@
 									"points": 2
 								},
 								{
-									"id": "s_BQL9PusEDTQ3MP_",
+									"id": "sQEoEt83Pi5OiKtg4",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sOp4wssAMtUc1ukJI"
+									},
 									"name": "Body Language",
 									"reference": "B181",
 									"tags": [
@@ -4261,7 +5224,12 @@
 									"points": 2
 								},
 								{
-									"id": "s2JScdu5_7tikX8BN",
+									"id": "s4np-Zd_v4X3jrysj",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sIegIM7jx4oMnRMm2"
+									},
 									"name": "Detect Lies",
 									"reference": "B187",
 									"tags": [
@@ -4297,7 +5265,12 @@
 					"name": "Background Skills",
 					"children": [
 						{
-							"id": "sa6xSDgujlQ9KQmmd",
+							"id": "sYVEzjYNi3xsnw3jM",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "ssHhRG7LH-Ma3YDnH"
+							},
 							"name": "Computer Operation",
 							"reference": "B184",
 							"tags": [
@@ -4316,7 +5289,12 @@
 							"points": 1
 						},
 						{
-							"id": "sAz8w15d-lGovS1Y-",
+							"id": "sxaT5RmqemY5eoYTL",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "s7kVwKFERTuMYO3O8"
+							},
 							"name": "Free Fall",
 							"reference": "B197",
 							"tags": [
@@ -4336,7 +5314,12 @@
 							"points": 1
 						},
 						{
-							"id": "se-7zPCL_6lG-B-UH",
+							"id": "slcZS7ZNCd8SR3v62",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "s9IHT34mK8yfSB7d_"
+							},
 							"name": "Spacer",
 							"reference": "B185",
 							"tags": [
@@ -4353,15 +5336,57 @@
 							"points": 1
 						},
 						{
+							"id": "sn5aeWXrHTb34z1nH",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sAmDzPjf0rKZ6I5G1"
+							},
+							"name": "Vacc Suit",
+							"reference": "B192",
+							"tags": [
+								"Technical"
+							],
+							"difficulty": "dx/a",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Diving Suit",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "NBC Suit",
+									"modifier": -2
+								},
+								{
+									"type": "skill",
+									"name": "Battlesuit",
+									"modifier": -2
+								}
+							],
+							"tech_level": "",
+							"points": 1
+						},
+						{
 							"id": "SO3DHqkQz31rvyde-",
 							"name": "10 Points chosen from",
 							"children": [
 								{
-									"id": "SSZ7kIU53wHiGVqDB",
+									"id": "SoUrnRTUz52MTXCah",
 									"name": "Everyman Skills",
 									"children": [
 										{
-											"id": "s5gzqDP36GijGbBIP",
+											"id": "sgQL0vQF6pUGXF7ny",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sTXDrqXH0sT2NSD_b"
+											},
 											"name": "Area Knowledge",
 											"reference": "B176",
 											"notes": "Location of the capitals of interplanetary states and the homeworlds of major races; general awareness of all major races; knowledge of individuals of Status 8; general understanding of relations between interplanetary states",
@@ -4382,7 +5407,12 @@
 											"points": 1
 										},
 										{
-											"id": "sNlg8og4_Bums6OKg",
+											"id": "sO6T7Rp-s_NhRy8Jk",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "s-Ckyxw5PmHIvbZab"
+											},
 											"name": "Area Knowledge",
 											"reference": "B176",
 											"notes": "Location of major planets; familiarity with all known races (but not necessarily expertise); knowledge of people of Status 7+; general understanding of the economic and political situation",
@@ -4390,13 +5420,9 @@
 												"Everyman",
 												"Knowledge"
 											],
-											"specialization": "@Interplanetary State@; Lived there",
+											"specialization": "@Interplanetary State@",
 											"difficulty": "iq/e",
 											"defaults": [
-												{
-													"type": "iq",
-													"modifier": -4
-												},
 												{
 													"type": "skill",
 													"name": "Geography",
@@ -4407,7 +5433,12 @@
 											"points": 1
 										},
 										{
-											"id": "sZqlbEA01v9rYBCoj",
+											"id": "swao2_CHl34mvXORw",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "strhX4LEdd46xgmIS"
+											},
 											"name": "Area Knowledge",
 											"reference": "B176",
 											"notes": "Location of its major cities and important sites; awareness of its major customs, ethnic groups, and languages (but not necessarily expertise); names of folk of Status 7+; and a general understanding of the economic and political situation",
@@ -4415,13 +5446,9 @@
 												"Everyman",
 												"Knowledge"
 											],
-											"specialization": "@Planet@; Lived there",
+											"specialization": "@Planet@",
 											"difficulty": "iq/e",
 											"defaults": [
-												{
-													"type": "iq",
-													"modifier": -4
-												},
 												{
 													"type": "skill",
 													"name": "Geography",
@@ -4432,7 +5459,12 @@
 											"points": 1
 										},
 										{
-											"id": "s8Toa5uXuD-mqDQaa",
+											"id": "ssfmO1EPU0vwL6tjR",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sBJgeWUs81Ifhob4Z"
+											},
 											"name": "Beam Weapons",
 											"reference": "B179",
 											"tags": [
@@ -4463,7 +5495,12 @@
 											"points": 1
 										},
 										{
-											"id": "s6K6G9WZzIQotoPKd",
+											"id": "sEiF91ZFioKqUwawP",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sOp4wssAMtUc1ukJI"
+											},
 											"name": "Body Language",
 											"reference": "B181",
 											"tags": [
@@ -4487,10 +5524,14 @@
 											"points": 1
 										},
 										{
-											"id": "sCflZ2ADK59IkyG4C",
+											"id": "scUQUvNpXzNb_gLHB",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sziMa9_9xTvR2iiqx"
+											},
 											"name": "Body Sense",
 											"reference": "B181",
-											"notes": "For settings with matter transmission",
 											"tags": [
 												"Athletic"
 											],
@@ -4509,7 +5550,12 @@
 											"points": 1
 										},
 										{
-											"id": "s53JseoWh01NueyGK",
+											"id": "syltHA54bWk0jTyIm",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "shtDdl5thrvKSnJHf"
+											},
 											"name": "Brawling",
 											"reference": "B182,MA55",
 											"tags": [
@@ -4537,7 +5583,12 @@
 											"points": 1
 										},
 										{
-											"id": "sDz19__GZNHaads8J",
+											"id": "s0CTU-KVIq0VSDdxK",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "si-upI7A5RgdO0cjC"
+											},
 											"name": "Carousing",
 											"reference": "B183",
 											"tags": [
@@ -4555,7 +5606,12 @@
 											"points": 1
 										},
 										{
-											"id": "s1DRUONLWg2VkPYSn",
+											"id": "s6hhD4YiOryh_vSvI",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sWFtA7Gvclq4aL-Yb"
+											},
 											"name": "Current Affairs",
 											"reference": "B186",
 											"tags": [
@@ -4586,7 +5642,12 @@
 											"points": 1
 										},
 										{
-											"id": "sDDnt_LAqi73zpGqd",
+											"id": "sb6nLWbi3gktsccDd",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "s9mV--3lpIfXO7N6Z"
+											},
 											"name": "First Aid",
 											"reference": "B195",
 											"tags": [
@@ -4617,7 +5678,12 @@
 											"points": 1
 										},
 										{
-											"id": "sOp0jAcb1OHtWdSNV",
+											"id": "slyh4dARr3mkGSYYR",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sWB9ypJAq43MF3O0n"
+											},
 											"name": "Gambling",
 											"reference": "B197",
 											"tags": [
@@ -4641,7 +5707,12 @@
 											"points": 1
 										},
 										{
-											"id": "sx1OCXD5CoL-kKeX-",
+											"id": "sdmwtg9jLfU-H5MBo",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "syfSQ9N8yETqQbhFK"
+											},
 											"name": "Games",
 											"reference": "B197,MA57",
 											"tags": [
@@ -4658,7 +5729,12 @@
 											"points": 1
 										},
 										{
-											"id": "sYypu87BxeDB0oC5N",
+											"id": "sdQKBMGTIxJ6UmJqH",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sGz21GskAlJXL1hYP"
+											},
 											"name": "Gesture",
 											"reference": "B198",
 											"tags": [
@@ -4674,7 +5750,12 @@
 											"points": 1
 										},
 										{
-											"id": "s_oM138c5suvbH6wP",
+											"id": "s9lCgLalWh2P8_nqS",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sT5htbz4-Mr0PFCk7"
+											},
 											"name": "Guns",
 											"reference": "B198",
 											"tags": [
@@ -4699,7 +5780,12 @@
 											"points": 1
 										},
 										{
-											"id": "sSWtKq5fXo_HzzgZe",
+											"id": "sWZKYJkERAR-Tta7n",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sOtPessbzkRjGaQPR"
+											},
 											"name": "Hobby Skill",
 											"reference": "B200,MA57",
 											"tags": [
@@ -4716,7 +5802,12 @@
 											"points": 1
 										},
 										{
-											"id": "sQlT21fyEJ9iA25LL",
+											"id": "s5XSXbqLJOsYFRhOC",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sDLf4crz0sGRjVDFi"
+											},
 											"name": "Hobby Skill",
 											"reference": "B200,MA57",
 											"tags": [
@@ -4733,7 +5824,12 @@
 											"points": 1
 										},
 										{
-											"id": "sHdGm8Ds6N_mJNY69",
+											"id": "sxcJ8qPPBn6y6qssE",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sfZrwMVUibhbtdssl"
+											},
 											"name": "Housekeeping",
 											"reference": "B200",
 											"tags": [
@@ -4749,7 +5845,12 @@
 											"points": 1
 										},
 										{
-											"id": "sXih117zzqXGhfkVv",
+											"id": "soTrW-L0Um8fEqER1",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sdl9m7gHE7hlMX0AX"
+											},
 											"name": "Lip Reading",
 											"reference": "B205",
 											"tags": [
@@ -4765,7 +5866,12 @@
 											"points": 1
 										},
 										{
-											"id": "swn6Tu-TZOvP9IIgP",
+											"id": "sHiMjGvwbVAyqXOdg",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sx1CDkGBR830IZrmz"
+											},
 											"name": "Professional Skill",
 											"reference": "B215",
 											"tags": [
@@ -4782,7 +5888,12 @@
 											"points": 1
 										},
 										{
-											"id": "sczQZfffT8A3yU3DN",
+											"id": "svCyVLk4WA11HyUql",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sBec-o4Z7gPpbg2f9"
+											},
 											"name": "Professional Skill",
 											"reference": "B215",
 											"tags": [
@@ -4799,7 +5910,12 @@
 											"points": 1
 										},
 										{
-											"id": "s9hB4tq1Lkhz4mCBF",
+											"id": "sjQDsxYhQ3OwTio1V",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "smxkcngH5Kz54yeN3"
+											},
 											"name": "Sports",
 											"reference": "B222,MA59",
 											"tags": [
@@ -4816,7 +5932,12 @@
 											"points": 1
 										},
 										{
-											"id": "sD3vlvcaeJOBjupY3",
+											"id": "sasMiJPZ5yinUCwAD",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "smTUpMWJGqPeT1KER"
+											},
 											"name": "Streetwise",
 											"reference": "B223",
 											"tags": [
@@ -4847,7 +5968,12 @@
 							"name": "Three of",
 							"children": [
 								{
-									"id": "s7fEzvtWTLCxzLVl_",
+									"id": "sT8jbWbFMXsfSP6CU",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sBJgeWUs81Ifhob4Z"
+									},
 									"name": "Beam Weapons",
 									"reference": "B179",
 									"tags": [
@@ -4855,7 +5981,10 @@
 										"Ranged Combat",
 										"Weapon"
 									],
-									"specialization": "@any other@",
+									"replacements": {
+										"Weapon class": "@any other@"
+									},
+									"specialization": "@Weapon class@",
 									"difficulty": "dx/e",
 									"defaults": [
 										{
@@ -4878,7 +6007,12 @@
 									"points": 1
 								},
 								{
-									"id": "sEDucX6gbDXSReumH",
+									"id": "sa28Lpu4Y1JRjfYYN",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "s5xh6bANmCGbYersa"
+									},
 									"name": "Fast-Draw",
 									"reference": "B194,MA56",
 									"tags": [
@@ -4886,13 +6020,39 @@
 										"Ranged Combat",
 										"Weapon"
 									],
-									"specialization": "@any other@",
+									"replacements": {
+										"Specialization": "@any other@"
+									},
+									"specialization": "@Specialization@",
+									"difficulty": "dx/e",
+									"points": 1
+								},
+								{
+									"id": "sMjy3QBseaXH7dEkd",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "scP0IdjWrVEveSeDl"
+									},
+									"name": "Fast-Draw",
+									"reference": "B194,MA56",
+									"tags": [
+										"Combat",
+										"Ranged Combat",
+										"Weapon"
+									],
+									"specialization": "Ammo",
 									"difficulty": "dx/e",
 									"tech_level": "",
 									"points": 1
 								},
 								{
-									"id": "sgi1vl3QrDyk5g6Po",
+									"id": "seIW83RKhXT5nI_Ob",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "snZtm1wwlLIeerPuO"
+									},
 									"name": "Gunner",
 									"reference": "B198",
 									"tags": [
@@ -4917,7 +6077,12 @@
 									"points": 1
 								},
 								{
-									"id": "sBus3-_rnmg_tIly5",
+									"id": "sPXrcJ9DTuj8Z1fT9",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sT5htbz4-Mr0PFCk7"
+									},
 									"name": "Guns",
 									"reference": "B198",
 									"tags": [
@@ -4925,7 +6090,10 @@
 										"Ranged Combat",
 										"Weapon"
 									],
-									"specialization": "@any other@",
+									"replacements": {
+										"Gun class": "@any other@"
+									},
+									"specialization": "@Gun class@",
 									"difficulty": "dx/e",
 									"defaults": [
 										{
@@ -4942,30 +6110,60 @@
 									"points": 1
 								},
 								{
-									"id": "s15eo4Geqc4SOKvxr",
+									"id": "sieU8oI7I3qJ1SxMb",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sPTlfb6j7JYiJ2sdx"
+									},
 									"name": "Savoir-Faire",
 									"reference": "B218,MA59",
 									"tags": [
 										"Knowledge",
+										"Military",
 										"Social"
 									],
-									"specialization": "@Military or Police@",
+									"specialization": "Military",
 									"difficulty": "iq/e",
 									"defaults": [
 										{
 											"type": "iq",
 											"modifier": -4
-										},
-										{
-											"type": "skill",
-											"name": "Games",
-											"modifier": -3
 										}
 									],
 									"points": 1
 								},
 								{
-									"id": "sKJi2JOZcDrBzdZZI",
+									"id": "sIAt8545JwplHOh4b",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sW_7zfEtZS5wjZRD-"
+									},
+									"name": "Savoir-Faire",
+									"reference": "B218,MA59",
+									"tags": [
+										"Knowledge",
+										"Police",
+										"Social"
+									],
+									"specialization": "Police",
+									"difficulty": "iq/e",
+									"defaults": [
+										{
+											"type": "iq",
+											"modifier": -4
+										}
+									],
+									"points": 1
+								},
+								{
+									"id": "snsFnRYHo7j8k6oSK",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "siUwhUBcqrDAPgud8"
+									},
 									"name": "Artillery",
 									"reference": "B178",
 									"tags": [
@@ -4985,7 +6183,12 @@
 									"points": 1
 								},
 								{
-									"id": "sG0_sXy-ep41vBs_y",
+									"id": "s_LN9BZYjkKclSME9",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "s88gTPKTH8WGPQqDI"
+									},
 									"name": "Expert Skill",
 									"reference": "B193,MA56",
 									"tags": [
@@ -5013,7 +6216,12 @@
 					"name": "Multi-Role",
 					"children": [
 						{
-							"id": "sQ_6_EIKAc02NP226",
+							"id": "s8rQJB09gmXelbH9R",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sLoMDn7X8itpfsDPv"
+							},
 							"name": "Criminology",
 							"reference": "B186",
 							"tags": [
@@ -5037,7 +6245,12 @@
 							"points": 2
 						},
 						{
-							"id": "sPl2LYz-ocnE1LLgM",
+							"id": "sBpdWzkIDIU_UGbhp",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sfB-d4kTee0C-BZv0"
+							},
 							"name": "Interrogation",
 							"reference": "B202",
 							"tags": [
@@ -5065,7 +6278,12 @@
 							"points": 2
 						},
 						{
-							"id": "sLrGXXf70cQBhIrqm",
+							"id": "sGIsU8HLQhbno9_hQ",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "slXlqD4FNReNHmsov"
+							},
 							"name": "Electronics Operation",
 							"reference": "B189",
 							"tags": [
@@ -5103,7 +6321,12 @@
 							"points": 2
 						},
 						{
-							"id": "s-v7Vnu_yOgGCCzsC",
+							"id": "stGnw6-fl4wdAY21j",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sgWf_qVqI7HrPQUo7"
+							},
 							"name": "Tactics",
 							"reference": "B224,MA60",
 							"tags": [
@@ -5125,7 +6348,12 @@
 							"points": 4
 						},
 						{
-							"id": "sD_cjJacqgiSSHh9l",
+							"id": "s1yvNV3jTR5pzl8bE",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sPyZ0zxFI-Kygrzie"
+							},
 							"name": "Intelligence Analysis",
 							"reference": "B201",
 							"tags": [
@@ -5149,7 +6377,12 @@
 							"points": 4
 						},
 						{
-							"id": "s5wU37LaXasKzJji7",
+							"id": "sh6oIResEWZzwJrgg",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "s6Yn2IClGb4i4LgOQ"
+							},
 							"name": "Observation",
 							"reference": "B211",
 							"tags": [
@@ -5174,7 +6407,12 @@
 							"points": 2
 						},
 						{
-							"id": "sIWeVOGVX97YuWfuS",
+							"id": "sKae8PQ3DwT0xbpQ5",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sW_dr_6QZxz1zrODT"
+							},
 							"name": "Search",
 							"reference": "B219",
 							"tags": [
@@ -5196,11 +6434,16 @@
 							"points": 2
 						},
 						{
-							"id": "S27zmL7bxxbz7ipZQ",
-							"name": "Either",
+							"id": "SOqp-sWW2ZY2f5LKf",
+							"name": "One of",
 							"children": [
 								{
-									"id": "sFgmXXcbW9P6zslJn",
+									"id": "s1ELuwzSFyTodsjbq",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sBJgeWUs81Ifhob4Z"
+									},
 									"name": "Beam Weapons",
 									"reference": "B179",
 									"tags": [
@@ -5231,7 +6474,12 @@
 									"points": 4
 								},
 								{
-									"id": "sY3L58b1b4rR31wMD",
+									"id": "sfo2G-9MRiEoOYwqV",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sT5htbz4-Mr0PFCk7"
+									},
 									"name": "Guns",
 									"reference": "B198",
 									"tags": [
@@ -5258,53 +6506,16 @@
 							]
 						},
 						{
-							"id": "S3vqk7ihIHfUBjfBO",
+							"id": "S1CctStO_hB-FZ3A1",
 							"name": "One of",
 							"children": [
 								{
-									"id": "suVJs9jIWjzsZ61cP",
-									"name": "Karate",
-									"reference": "B203,MA57",
-									"tags": [
-										"Combat",
-										"Melee Combat",
-										"Weapon"
-									],
-									"difficulty": "dx/h",
-									"encumbrance_penalty_multiplier": 1,
-									"features": [
-										{
-											"type": "weapon_bonus",
-											"selection_type": "weapons_with_required_skill",
-											"name": {
-												"compare": "is",
-												"qualifier": "Karate"
-											},
-											"level": {
-												"compare": "at_least"
-											},
-											"amount": 1,
-											"per_die": true
-										},
-										{
-											"type": "weapon_bonus",
-											"selection_type": "weapons_with_required_skill",
-											"name": {
-												"compare": "is",
-												"qualifier": "Karate"
-											},
-											"level": {
-												"compare": "at_least",
-												"qualifier": 1
-											},
-											"amount": 1,
-											"per_die": true
-										}
-									],
-									"points": 1
-								},
-								{
-									"id": "s2SM_f24RpQaSQCEv",
+									"id": "sRt0dPsku1vc_Ikst",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "shtDdl5thrvKSnJHf"
+									},
 									"name": "Brawling",
 									"reference": "B182,MA55",
 									"tags": [
@@ -5329,10 +6540,15 @@
 											"per_die": true
 										}
 									],
-									"points": 1
+									"points": 4
 								},
 								{
-									"id": "sW-R8Kq_H3LDiA6ex",
+									"id": "swxlU_YakgCSY8gxJ",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sEw2VcGPL_pN66Fah"
+									},
 									"name": "Boxing",
 									"reference": "B182,MA55",
 									"tags": [
@@ -5371,16 +6587,68 @@
 											"per_die": true
 										}
 									],
-									"points": 1
+									"points": 4
+								},
+								{
+									"id": "s_U6e9HrbDKUcyznO",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sU4bjpp9TsvnRavPN"
+									},
+									"name": "Karate",
+									"reference": "B203,MA57",
+									"tags": [
+										"Combat",
+										"Melee Combat",
+										"Weapon"
+									],
+									"difficulty": "dx/h",
+									"encumbrance_penalty_multiplier": 1,
+									"features": [
+										{
+											"type": "weapon_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Karate"
+											},
+											"level": {
+												"compare": "at_least"
+											},
+											"amount": 1,
+											"per_die": true
+										},
+										{
+											"type": "weapon_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Karate"
+											},
+											"level": {
+												"compare": "at_least",
+												"qualifier": 1
+											},
+											"amount": 1,
+											"per_die": true
+										}
+									],
+									"points": 4
 								}
 							]
 						},
 						{
-							"id": "SJdLD0sIJUTS42czP",
-							"name": "Either",
+							"id": "SGWqlkFGxoVZ83oAU",
+							"name": "One of",
 							"children": [
 								{
-									"id": "sGYTd73hTxTTyCKR8",
+									"id": "sVXybNHnhctsImEc4",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "s8parl7zgbXys0OF2"
+									},
 									"name": "Wrestling",
 									"reference": "B228,MA61",
 									"tags": [
@@ -5389,10 +6657,15 @@
 										"Weapon"
 									],
 									"difficulty": "dx/a",
-									"points": 1
+									"points": 4
 								},
 								{
-									"id": "slHocXZp4sc8Cdjea",
+									"id": "sNYCdeQJ3Apq3_CTg",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sWVqswxT3hi7db0kD"
+									},
 									"name": "Judo",
 									"reference": "B203,MA57",
 									"notes": "Allows parrying two different attacks per turn, one with each hand.",
@@ -5403,7 +6676,7 @@
 									],
 									"difficulty": "dx/h",
 									"encumbrance_penalty_multiplier": 1,
-									"points": 1
+									"points": 4
 								}
 							]
 						}

--- a/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Starship Crew Traits.adq
+++ b/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Starship Crew Traits.adq
@@ -1,0 +1,92 @@
+{
+	"version": 5,
+	"rows": [
+		{
+			"id": "ty6xQhthuc1s_qAW6",
+			"name": "Enhanced Dodge (@Piloting Skill@)",
+			"reference": "TT3:5, B51",
+			"tags": [
+				"Advantage",
+				"Mental"
+			],
+			"points_per_level": 5,
+			"features": [
+				{
+					"type": "conditional_modifier",
+					"situation": "to vehicular dodges with @Piloting Skill@",
+					"amount": 1,
+					"per_level": true
+				}
+			],
+			"can_level": true,
+			"levels": 1,
+			"calc": {
+				"points": 5
+			}
+		},
+		{
+			"id": "t6EG4LOMfRtVLO4OD",
+			"name": "Higher Purpose (Medic!)",
+			"reference": "TT3:7,B59",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Mental"
+			],
+			"points_per_level": 5,
+			"features": [
+				{
+					"type": "conditional_modifier",
+					"situation": "to success rolls made to aid injured crew or passengers whenever this puts you at risk",
+					"amount": 1,
+					"per_level": true
+				}
+			],
+			"can_level": true,
+			"levels": 1,
+			"calc": {
+				"points": 5
+			}
+		},
+		{
+			"id": "txwHeC5OlbtuDV6Mw",
+			"name": "Higher Purpose (Save my ship!)",
+			"reference": "TT3:7,B59",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Mental"
+			],
+			"points_per_level": 5,
+			"features": [
+				{
+					"type": "conditional_modifier",
+					"situation": "to success rolls made to save the starship whenever this puts you at risk",
+					"amount": 1,
+					"per_level": true
+				}
+			],
+			"can_level": true,
+			"levels": 1,
+			"calc": {
+				"points": 5
+			}
+		},
+		{
+			"id": "thmdPLVO-wMIpvPf6",
+			"name": "Compartmentalized Mind (Multi-Tasking)",
+			"reference": "TT3:5, B43",
+			"notes": "Reduces the number of mundane tasks you're doing at the same time by this level when assessing multi-tasking penalties.",
+			"tags": [
+				"Advantage",
+				"Mental"
+			],
+			"points_per_level": 25,
+			"can_level": true,
+			"levels": 1,
+			"calc": {
+				"points": 25
+			}
+		}
+	]
+}

--- a/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Steward.gct
+++ b/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Steward.gct
@@ -12,7 +12,12 @@
 					"name": "Attributes",
 					"children": [
 						{
-							"id": "tl35k3JLOb1v3eYxt",
+							"id": "t3qyOWUdvICK24031",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t1w1RFcFceKR2T9_e"
+							},
 							"name": "Increased Intelligence",
 							"reference": "B15",
 							"tags": [
@@ -36,7 +41,12 @@
 							}
 						},
 						{
-							"id": "tafC49ZH_wW-bHuxD",
+							"id": "tHtszjzdkBo-ailQx",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tVt3SvdGWNchJ8z4o"
+							},
 							"name": "Increased Health",
 							"reference": "B14",
 							"tags": [
@@ -69,7 +79,12 @@
 					"name": "Class Advantages",
 					"children": [
 						{
-							"id": "tG_S6JS7V2_dZWYQH",
+							"id": "tdth2EhQG6wSfRRpC",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "t47ychA98bECqxqRM"
+							},
 							"name": "Talent (Smooth Operator)",
 							"reference": "PU3:15",
 							"tags": [
@@ -79,12 +94,45 @@
 							],
 							"modifiers": [
 								{
-									"id": "mOXxi3EX5kOuAAORE",
+									"id": "m5w8w1hQBLCtxoEU6",
 									"name": "Alternative Cost",
 									"cost": -2,
 									"cost_type": "points",
 									"affects": "levels_only",
 									"disabled": true
+								},
+								{
+									"id": "M5u6afVEnFLJ9RTw4",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "mU64DIkPBBdrGWceF",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From con artists, politicians, salesmen, etc. – but only if you aren’t trying to manipulate them.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "m6k4alMWIs90kTtkM",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Bonus to resist covered skills",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
 								}
 							],
 							"points_per_level": 15,
@@ -254,18 +302,6 @@
 									},
 									"amount": 1,
 									"per_level": true
-								},
-								{
-									"type": "reaction_bonus",
-									"situation": "From con artists, politicians, salesmen, etc. – but only if you aren’t trying to manipulate them.",
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "conditional_modifier",
-									"situation": "Bonus to resist covered skills",
-									"amount": 1,
-									"per_level": true
 								}
 							],
 							"can_level": true,
@@ -283,7 +319,12 @@
 									"name": "Better Attributes",
 									"children": [
 										{
-											"id": "tk-Nr-wNzUN0kS3Yf",
+											"id": "tRzGiikL9y-nHURqV",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tGWOSEE6SmBHACE6Y"
+											},
 											"name": "Increased Dexterity",
 											"reference": "B15",
 											"tags": [
@@ -293,7 +334,7 @@
 											],
 											"modifiers": [
 												{
-													"id": "miDoKpYptMhiDbE6v",
+													"id": "mr9U5vKNfnvKjA066",
 													"name": "No Fine Manipulators",
 													"cost": -40,
 													"disabled": true
@@ -315,7 +356,12 @@
 											}
 										},
 										{
-											"id": "t2A1fOqEbA9xgXw0y",
+											"id": "tkT1cel1RHniZLsQy",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tVt3SvdGWNchJ8z4o"
+											},
 											"name": "Increased Health",
 											"reference": "B14",
 											"tags": [
@@ -339,7 +385,12 @@
 											}
 										},
 										{
-											"id": "t-L9BZTvNxwr-P4VG",
+											"id": "tjxkHvz8YS-QzdP8Y",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t1w1RFcFceKR2T9_e"
+											},
 											"name": "Increased Intelligence",
 											"reference": "B15",
 											"tags": [
@@ -363,7 +414,12 @@
 											}
 										},
 										{
-											"id": "tQNImyuAdM9wvb2MG",
+											"id": "tr3EMnPd0kuwd8-tg",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tqha9GlDBU9P-Wg-6"
+											},
 											"name": "Increased Strength",
 											"reference": "B14",
 											"tags": [
@@ -373,14 +429,14 @@
 											],
 											"modifiers": [
 												{
-													"id": "my8ythiMxc1awTKZ4",
+													"id": "mHFW7FldomAKmKjPc",
 													"name": "No Fine Manipulators",
 													"reference": "B15",
 													"cost": -40,
 													"disabled": true
 												},
 												{
-													"id": "m2BifaeZYljfGywne",
+													"id": "mI_U9wgtK76XlLbec",
 													"name": "Size",
 													"reference": "B15",
 													"cost": -10,
@@ -388,7 +444,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mrVsXemnodJypGEUe",
+													"id": "mMwUSBNODjp6hcQUp",
 													"name": "Super-Effort",
 													"reference": "SU24",
 													"cost": 300,
@@ -416,11 +472,1403 @@
 									}
 								},
 								{
-									"id": "TLCFtBw_47_aOJDp7",
+									"id": "TRuCTEXHKOnPD46AX",
 									"name": "Everyman Advantages",
 									"children": [
 										{
-											"id": "txnCajien3PgLFQzi",
+											"id": "t3OmZNZz_dLqI6cXB",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Power Ups/Power Ups Traits.adq",
+												"id": "t3RCXCI5W-zjvxaf-"
+											},
+											"name": "Suit Familiarity (@Environment Suit skill@)",
+											"reference": "PU2:9",
+											"tags": [
+												"Perk",
+												"Physical"
+											],
+											"replacements": {
+												"Environment Suit skill": "Vacc Suit"
+											},
+											"base_points": 1,
+											"calc": {
+												"points": 1
+											}
+										},
+										{
+											"id": "tyZIm35pEOtXokiBC",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tkiJQ7nfyi9aAdGHK"
+											},
+											"name": "Serendipity",
+											"reference": "B83,P73",
+											"tags": [
+												"Advantage",
+												"Mental"
+											],
+											"modifiers": [
+												{
+													"id": "mLr53dKsXXEln1yuE",
+													"name": "Wishing",
+													"reference": "P73",
+													"cost": 100,
+													"disabled": true
+												},
+												{
+													"id": "mL3-9j8vNp4SGVkRM",
+													"name": "Wishing",
+													"reference": "P73",
+													"notes": "For others only",
+													"disabled": true
+												},
+												{
+													"id": "mTTi4DGF4NjCpL5--",
+													"name": "Game Time",
+													"reference": "P108",
+													"notes": "Uses per game week equal to its maximum possible uses per session",
+													"disabled": true
+												}
+											],
+											"points_per_level": 15,
+											"can_level": true,
+											"levels": 1,
+											"calc": {
+												"points": 15
+											}
+										},
+										{
+											"id": "tWA3a61SMlrn-rPgW",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tJTfFdHM7YI5IZR7I"
+											},
+											"name": "Resistant",
+											"reference": "B81,P71,MA47",
+											"tags": [
+												"Advantage",
+												"Physical"
+											],
+											"modifiers": [
+												{
+													"id": "mQ76QEpSgHnigf-Bw",
+													"name": "@Very Common: Metabolic Hazards, etc.@",
+													"reference": "B80",
+													"cost": 30,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mQIFrlyPr3UpG1FTh",
+													"name": "@Common: Poison, Sickness, etc.@",
+													"reference": "B81",
+													"cost": 15,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mWXwVqPq2fMGPv4JL",
+													"name": "@Occasional: Disease, Ingested Poison, etc.@",
+													"reference": "B81",
+													"cost": 10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mz1AsrcPnLX83HNdY",
+													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+													"reference": "B81",
+													"replacements": {
+														"Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.": "Space Sickness"
+													},
+													"cost": 5,
+													"cost_type": "points"
+												},
+												{
+													"id": "mzTj2pYyKGaYeFYkf",
+													"name": "Immunity",
+													"reference": "B81",
+													"cost": 1,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mNc_cGFpMNcBujl0p",
+													"name": "+8 to all HT rolls to resist",
+													"reference": "B81",
+													"cost": 0.5,
+													"cost_type": "multiplier"
+												},
+												{
+													"id": "mLGGqVuEfEtBiVvo4",
+													"name": "+3 to all HT rolls to resist",
+													"reference": "B81",
+													"cost": 0.33,
+													"cost_type": "multiplier",
+													"disabled": true
+												}
+											],
+											"round_down": true,
+											"calc": {
+												"points": 2
+											}
+										},
+										{
+											"id": "tnooM5HNKSFRDJ6-0",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tJTfFdHM7YI5IZR7I"
+											},
+											"name": "Resistant",
+											"reference": "B81,P71,MA47",
+											"tags": [
+												"Advantage",
+												"Physical"
+											],
+											"modifiers": [
+												{
+													"id": "mlX-3esonJIrSMMpf",
+													"name": "@Very Common: Metabolic Hazards, etc.@",
+													"reference": "B80",
+													"cost": 30,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mj_ng-P5bbaCEzC5x",
+													"name": "@Common: Poison, Sickness, etc.@",
+													"reference": "B81",
+													"cost": 15,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mAd9Qo-dOoPz55ENI",
+													"name": "@Occasional: Disease, Ingested Poison, etc.@",
+													"reference": "B81",
+													"cost": 10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "my-jMXvtWMffa1FnO",
+													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+													"reference": "B81",
+													"replacements": {
+														"Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.": "Space Sickness"
+													},
+													"cost": 5,
+													"cost_type": "points"
+												},
+												{
+													"id": "mc-nfR2j4VVvQPYOD",
+													"name": "Immunity",
+													"reference": "B81",
+													"cost": 1,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "m8fSV3C6-DRDlmONA",
+													"name": "+8 to all HT rolls to resist",
+													"reference": "B81",
+													"cost": 0.5,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "m-kVbPyaSI9Sn9vaw",
+													"name": "+3 to all HT rolls to resist",
+													"reference": "B81",
+													"cost": 0.33,
+													"cost_type": "multiplier"
+												}
+											],
+											"round_down": true,
+											"calc": {
+												"points": 1
+											}
+										},
+										{
+											"id": "tb0ApNt2U5b69Xxsn",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tJTfFdHM7YI5IZR7I"
+											},
+											"name": "Resistant",
+											"reference": "B81,P71,MA47",
+											"tags": [
+												"Advantage",
+												"Physical"
+											],
+											"modifiers": [
+												{
+													"id": "m0p-buC1RlXJzLXOs",
+													"name": "@Very Common: Metabolic Hazards, etc.@",
+													"reference": "B80",
+													"cost": 30,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mdsPQeJ7HzJb5jF7b",
+													"name": "@Common: Poison, Sickness, etc.@",
+													"reference": "B81",
+													"cost": 15,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mDh5vT4awsi0570vQ",
+													"name": "@Occasional: Disease, Ingested Poison, etc.@",
+													"reference": "B81",
+													"cost": 10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mxLSL2BI_oV8Su-E8",
+													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+													"reference": "B81",
+													"replacements": {
+														"Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.": "Acceleration"
+													},
+													"cost": 5,
+													"cost_type": "points"
+												},
+												{
+													"id": "m9tdoyBNnud-HJd60",
+													"name": "Immunity",
+													"reference": "B81",
+													"cost": 1,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mdQ37XJ0maLHvGhJL",
+													"name": "+8 to all HT rolls to resist",
+													"reference": "B81",
+													"cost": 0.5,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mXq-qoJFv5TYbGbiV",
+													"name": "+3 to all HT rolls to resist",
+													"reference": "B81",
+													"cost": 0.33,
+													"cost_type": "multiplier"
+												}
+											],
+											"round_down": true,
+											"calc": {
+												"points": 1
+											}
+										},
+										{
+											"id": "tmsAtDZzPCKVPC3R7",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "ta04iFiZ_Kw0s0juj"
+											},
+											"name": "Good Reputation",
+											"reference": "B26,MA54",
+											"tags": [
+												"Advantage",
+												"Social"
+											],
+											"modifiers": [
+												{
+													"id": "mGTYxf2twcrhELjv3",
+													"name": "People Affected",
+													"reference": "B27",
+													"notes": "Almost everyone",
+													"cost": 1,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mwAAd1YMUK8_PflKi",
+													"name": "People Affected",
+													"reference": "B27",
+													"notes": "Almost everyone except @large class of people@",
+													"cost": 0.67,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "m_ClBxGuMiDiYnjsa",
+													"name": "People Affected",
+													"reference": "B27",
+													"notes": "@Large class of people@",
+													"cost": 0.5,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "ma9Kc3YnWIuOfVgfs",
+													"name": "People Affected",
+													"reference": "B27",
+													"notes": "@Small class of people@",
+													"cost": 0.33,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mv_nr54j51ZItP7w2",
+													"name": "Recognized all the time",
+													"reference": "B28",
+													"cost": 1,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mQSchul_JV6903RX9",
+													"name": "Recognized sometimes",
+													"reference": "B28",
+													"notes": "10-",
+													"cost": 0.5,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "msF0pQ4uORp8QiZE5",
+													"name": "Recognized occasionally",
+													"reference": "B28",
+													"notes": "7-",
+													"cost": 0.33,
+													"cost_type": "multiplier",
+													"disabled": true
+												}
+											],
+											"points_per_level": 5,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others aware of your reputation",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"round_down": true,
+											"can_level": true,
+											"levels": 1,
+											"calc": {
+												"points": 5
+											}
+										},
+										{
+											"id": "ttd5ki6ACHHlqd29N",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tmp8yecgaZq9TOk59"
+											},
+											"name": "@Type@ Rank",
+											"reference": "B29",
+											"tags": [
+												"Advantage",
+												"Social"
+											],
+											"replacements": {
+												"Type": "Military"
+											},
+											"modifiers": [
+												{
+													"id": "mOeSX9-t6XI-Lbct9",
+													"name": "Replaces Status",
+													"reference": "B29",
+													"cost": 5,
+													"cost_type": "points",
+													"affects": "levels_only",
+													"disabled": true
+												},
+												{
+													"id": "mi3eZPTLWM2SuGc_h",
+													"name": "Courtesy",
+													"reference": "B29",
+													"cost": -4,
+													"cost_type": "points",
+													"affects": "levels_only",
+													"disabled": true
+												}
+											],
+											"points_per_level": 5,
+											"can_level": true,
+											"levels": 1,
+											"calc": {
+												"points": 5
+											}
+										},
+										{
+											"id": "tKfOUx4XYCblsW9Ty",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tmp8yecgaZq9TOk59"
+											},
+											"name": "@Type@ Rank",
+											"reference": "B29",
+											"tags": [
+												"Advantage",
+												"Social"
+											],
+											"replacements": {
+												"Type": "Merchant"
+											},
+											"modifiers": [
+												{
+													"id": "mUQHPHiYp9lIxpKl8",
+													"name": "Replaces Status",
+													"reference": "B29",
+													"cost": 5,
+													"cost_type": "points",
+													"affects": "levels_only",
+													"disabled": true
+												},
+												{
+													"id": "mRMgBvdZwWL1WIVS5",
+													"name": "Courtesy",
+													"reference": "B29",
+													"cost": -4,
+													"cost_type": "points",
+													"affects": "levels_only",
+													"disabled": true
+												}
+											],
+											"points_per_level": 5,
+											"can_level": true,
+											"levels": 1,
+											"calc": {
+												"points": 5
+											}
+										},
+										{
+											"id": "t3OrD1pDjvkoqO0H4",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t6Nq6oInwkU1qbAP1"
+											},
+											"name": "Patron",
+											"reference": "B72,P65",
+											"tags": [
+												"Advantage",
+												"Social"
+											],
+											"modifiers": [
+												{
+													"id": "m0i67q_j_aHOue53L",
+													"name": "@Who: Individual with 150% of PC's starting points@",
+													"reference": "B72",
+													"cost": 10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mklkIJ5kl5GE36Q5D",
+													"name": "@Who: Organization with assets of at least 1000 times starting wealth@",
+													"reference": "B72",
+													"cost": 10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mMyv5J5nP02ragUFd",
+													"name": "@Who: Individual with twice the PC's starting points@",
+													"reference": "B72",
+													"cost": 15,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mX6sb_ChUabCSpoMx",
+													"name": "@Who: Organization with assets of at least 10000 times starting wealth@",
+													"reference": "B72",
+													"cost": 15,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m03q5D_HBJulf4wT0",
+													"name": "@Who: An ultra-powerful individual@",
+													"reference": "B72",
+													"cost": 20,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mXAZLwm6-2e44S30w",
+													"name": "@Who: Organization with assets of at least 100000 times starting wealth@",
+													"reference": "B72",
+													"cost": 20,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mcC17Q9OgHdM1FxZU",
+													"name": "@Who: Organization with assets of at least 1000000 times starting wealth@",
+													"reference": "B72",
+													"cost": 25,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mAfJMUpDxZyj74nss",
+													"name": "@Who: A national government or giant multi-national organization@",
+													"reference": "B72",
+													"cost": 30,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mIy2rnnk9StFj9z-x",
+													"name": "@Who: A deity@",
+													"reference": "B72",
+													"cost": 30,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m3KGiCKG8wGs6t31C",
+													"name": "Appears almost all the time",
+													"reference": "B36",
+													"notes": "15-",
+													"cost": 3,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mm2IiNts4yS9Xeg4p",
+													"name": "Appears quite often",
+													"reference": "B36",
+													"notes": "12-",
+													"cost": 2,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "m2xf67rpLVVqOPqtG",
+													"name": "Appears fairly often",
+													"reference": "B36",
+													"notes": "9-",
+													"cost": 1,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mpQ6hVk7_SNiu4g6y",
+													"name": "Appears quite rarely",
+													"reference": "B36",
+													"notes": "6-",
+													"cost": 0.5,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "m7_aZSKcD_tovSh8z",
+													"name": "Equipment",
+													"reference": "B73",
+													"notes": "@Equipment worth no more than average starting wealth@",
+													"cost": 50,
+													"disabled": true
+												},
+												{
+													"id": "mWEiWor-gPA4U2Ro3",
+													"name": "Equipment",
+													"reference": "B73",
+													"notes": "@Equipment worth more than average starting wealth@",
+													"cost": 100,
+													"disabled": true
+												},
+												{
+													"id": "mkP6TsnI8sVWtwZyM",
+													"name": "Highly Accessible",
+													"reference": "B73",
+													"cost": 50,
+													"disabled": true
+												},
+												{
+													"id": "muRM1w7V2IVKNv2y-",
+													"name": "Special Abilities",
+													"reference": "B73",
+													"notes": "@Extensive social or political power@",
+													"cost": 50,
+													"disabled": true
+												},
+												{
+													"id": "mGUKxRsRhFrf7yHbH",
+													"name": "Special Abilities",
+													"reference": "B73",
+													"notes": "@Magical powers in a non-magical world, higher TL equipment, grants special powers or is supernatural@",
+													"cost": 100,
+													"disabled": true
+												},
+												{
+													"id": "mIcOPvcG3I81lpQ6f",
+													"name": "Minimal Interventions",
+													"reference": "B73",
+													"cost": -50,
+													"disabled": true
+												},
+												{
+													"id": "m1rNiT-P23bN9ps81",
+													"name": "Secret",
+													"reference": "B73",
+													"cost": -50,
+													"disabled": true
+												},
+												{
+													"id": "mwb2SRmrudG7XXWWS",
+													"name": "Unwilling",
+													"reference": "B74",
+													"cost": -50,
+													"disabled": true
+												},
+												{
+													"id": "muLUjSRiqLKGjEffc",
+													"name": "Favor",
+													"reference": "B55",
+													"cost": 0.2,
+													"cost_type": "multiplier",
+													"disabled": true
+												}
+											],
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "tE-Vklxe502PPFtOx",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tz-USDL9B_KrrVqDi"
+											},
+											"name": "Luck",
+											"reference": "B66,P59",
+											"notes": "Usable once per hour of play",
+											"tags": [
+												"Advantage",
+												"Mental"
+											],
+											"modifiers": [
+												{
+													"id": "mPS7qv-71urmq1X1r",
+													"name": "Active",
+													"reference": "B66",
+													"cost": -40,
+													"disabled": true
+												},
+												{
+													"id": "mJOGcKVJfZcYdvo8B",
+													"name": "Aspected",
+													"reference": "B66",
+													"notes": "@Aspect@",
+													"cost": -20,
+													"disabled": true
+												},
+												{
+													"id": "mNYarx9CDdRFmHPnp",
+													"name": "Defensive",
+													"reference": "B66",
+													"cost": -20,
+													"disabled": true
+												},
+												{
+													"id": "mn1MxQhktmn8Eg79I",
+													"name": "Wishing",
+													"reference": "P59",
+													"cost": 100,
+													"disabled": true
+												},
+												{
+													"id": "mAVGmsNzerKOMElXB",
+													"name": "Game Time",
+													"reference": "P108",
+													"notes": "Uses per game day equal to its maximum possible uses per real hour",
+													"disabled": true
+												}
+											],
+											"base_points": 15,
+											"calc": {
+												"points": 15
+											}
+										},
+										{
+											"id": "tlUzngR-uCQfWD7Ln",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tMxgHfzVEy_QQtlfB"
+											},
+											"name": "Less Sleep",
+											"reference": "B65",
+											"notes": "Require 1 hour/level less sleep for a full night's rest (max 4)",
+											"tags": [
+												"Advantage",
+												"Physical"
+											],
+											"points_per_level": 2,
+											"can_level": true,
+											"levels": 1,
+											"calc": {
+												"points": 2
+											}
+										},
+										{
+											"id": "tRE9U1Jhd6THtc4sK",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tw1Ad0oSMw2ATM4X1"
+											},
+											"name": "Language: @Language@",
+											"reference": "B24",
+											"tags": [
+												"Advantage",
+												"Language",
+												"Mental"
+											],
+											"prereqs": {
+												"type": "prereq_list",
+												"all": true,
+												"prereqs": [
+													{
+														"type": "trait_prereq",
+														"has": false,
+														"name": {
+															"compare": "is",
+															"qualifier": "Language Talent"
+														},
+														"level": {
+															"compare": "at_least"
+														}
+													}
+												]
+											},
+											"modifiers": [
+												{
+													"id": "mbuVf5z1bhsew-Gaj",
+													"name": "Native",
+													"reference": "B23",
+													"cost": -6,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mDV0yumTzlUM-GNGW",
+													"name": "Spoken",
+													"reference": "B24",
+													"notes": "None",
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mkDliZh14G5nz7FlA",
+													"name": "Spoken",
+													"reference": "B24",
+													"notes": "Broken",
+													"cost": 1,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m3OWeEfuxZ0gO9i58",
+													"name": "Spoken",
+													"reference": "B24",
+													"notes": "Accented",
+													"cost": 2,
+													"cost_type": "points"
+												},
+												{
+													"id": "mhg66hViy6CiaraGR",
+													"name": "Spoken",
+													"reference": "B24",
+													"notes": "Native",
+													"cost": 3,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mlfgdJCgM2QVoWsZG",
+													"name": "Written",
+													"reference": "B24",
+													"notes": "None",
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m4XZ6yx-53drOph2j",
+													"name": "Written",
+													"reference": "B24",
+													"notes": "Broken",
+													"cost": 1,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mawzNtxrfufbQfB_E",
+													"name": "Written",
+													"reference": "B24",
+													"notes": "Accented",
+													"cost": 2,
+													"cost_type": "points"
+												},
+												{
+													"id": "mK5ZqBcQrOZlMRTB2",
+													"name": "Written",
+													"reference": "B24",
+													"notes": "Native",
+													"cost": 3,
+													"cost_type": "points",
+													"disabled": true
+												}
+											],
+											"calc": {
+												"points": 4
+											}
+										},
+										{
+											"id": "tl1IfSzMBj9GJyRMF",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "txREhxV6L1SKixwe_"
+											},
+											"name": "Improved G-tolerance",
+											"reference": "B60",
+											"tags": [
+												"Advantage",
+												"Physical"
+											],
+											"modifiers": [
+												{
+													"id": "mspT_Tp4h2avwumqa",
+													"name": "0.3G",
+													"reference": "B60",
+													"cost": 5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mmdpXAUDAF9wzxkGF",
+													"name": "0.5G",
+													"reference": "B60",
+													"cost": 10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "muV7jqw3cUZHGwyC8",
+													"name": "1G",
+													"reference": "B60",
+													"cost": 15,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mrS_xl0Y-2m9RMdIS",
+													"name": "5G",
+													"reference": "B60",
+													"cost": 20,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mT3sUfcE7oiJJtKN7",
+													"name": "10G",
+													"reference": "B60",
+													"cost": 25,
+													"cost_type": "points",
+													"disabled": true
+												}
+											],
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "tiUUuJUs_DeVmsCZD",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t7blIRUzFpiHS_mnO"
+											},
+											"name": "Gizmo",
+											"reference": "B57,MA45",
+											"tags": [
+												"Advantage",
+												"Mental"
+											],
+											"points_per_level": 5,
+											"can_level": true,
+											"levels": 1,
+											"calc": {
+												"points": 5
+											}
+										},
+										{
+											"id": "tdTx16D-kKZA7U9Qh",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tHNrjEQFQBNOgwmzK"
+											},
+											"name": "G-Experience (All)",
+											"reference": "B57",
+											"tags": [
+												"Advantage",
+												"Mental"
+											],
+											"base_points": 10,
+											"calc": {
+												"points": 10
+											}
+										},
+										{
+											"id": "t4g8oYE1Yj8HiVWkT",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tu3GuYC47Sx6bnm4k"
+											},
+											"name": "G-Experience",
+											"reference": "B57",
+											"tags": [
+												"Advantage",
+												"Mental"
+											],
+											"points_per_level": 1,
+											"can_level": true,
+											"levels": 1,
+											"calc": {
+												"points": 1
+											}
+										},
+										{
+											"id": "t4w9_BxxaYXrBd7lt",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "toTe273Ky82B6YdW5"
+											},
+											"name": "Fit",
+											"reference": "B55",
+											"notes": "Recover FP at twice the normal rate (but not FP spent for spells or psi powers)",
+											"tags": [
+												"Advantage",
+												"Physical"
+											],
+											"base_points": 5,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "to all HT rolls to stay conscious, avoid death, resist disease, or resist poison",
+													"amount": 1
+												}
+											],
+											"calc": {
+												"points": 5
+											}
+										},
+										{
+											"id": "tebobaalvtYVJevQd",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tQa3EUrs4Hjt9gxK6"
+											},
+											"name": "Fearlessness",
+											"reference": "B55,MA44",
+											"tags": [
+												"Advantage",
+												"Mental"
+											],
+											"prereqs": {
+												"type": "prereq_list",
+												"all": true,
+												"prereqs": [
+													{
+														"type": "trait_prereq",
+														"has": false,
+														"name": {
+															"compare": "is",
+															"qualifier": "Fearfulness"
+														}
+													}
+												]
+											},
+											"points_per_level": 2,
+											"features": [
+												{
+													"type": "attribute_bonus",
+													"attribute": "fright_check",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"can_level": true,
+											"levels": 1,
+											"calc": {
+												"points": 2
+											}
+										},
+										{
+											"id": "tU3MpQjY8YhcFwJmJ",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t5j2Ox4jaIV9j0rpz"
+											},
+											"name": "Deep Sleeper",
+											"reference": "B101",
+											"tags": [
+												"Perk",
+												"Physical"
+											],
+											"base_points": 1,
+											"calc": {
+												"points": 1
+											}
+										},
+										{
+											"id": "t3nV1Vy0vHsJwLSMy",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tNBE3sLoyrUvAgoZ3"
+											},
+											"name": "Cybernetics",
+											"reference": "B46",
+											"tags": [
+												"Advantage",
+												"Physical"
+											],
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "t2PX7USmcykFXfbV6",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "toXBQ8q4Nek5lsLPF"
+											},
+											"name": "Cultural Familiarity (@Culture@)",
+											"reference": "B23",
+											"notes": "Do not suffer the normal -3 penalty for unfamiliarity",
+											"tags": [
+												"Advantage",
+												"Mental"
+											],
+											"modifiers": [
+												{
+													"id": "mFRaRumTflH4PuuCK",
+													"name": "Alien",
+													"cost": 1,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "myktSkoT6rPSi3Wj0",
+													"name": "Native",
+													"cost": -1,
+													"cost_type": "points",
+													"disabled": true
+												}
+											],
+											"base_points": 1,
+											"calc": {
+												"points": 1
+											}
+										},
+										{
+											"id": "tOnFVaga_g8OVpJ2D",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Power Ups/Power Ups Traits.adq",
+												"id": "t3msobZZ06J7dZ8xu"
+											},
+											"name": "Talent (Born Spacer)",
+											"reference": "PU3:7",
+											"tags": [
+												"Advantage",
+												"Mental",
+												"Talent"
+											],
+											"modifiers": [
+												{
+													"id": "mjAXXxmx_ABng_-jJ",
+													"name": "Alternative Cost",
+													"cost": 1,
+													"cost_type": "points",
+													"affects": "levels_only",
+													"disabled": true
+												},
+												{
+													"id": "Ml2407NLGuLFNoxMS",
+													"name": "Benefits",
+													"children": [
+														{
+															"id": "mWlERZL4eaIkB81mb",
+															"name": "Reaction Bonus",
+															"use_level_from_trait": true,
+															"features": [
+																{
+																	"type": "reaction_bonus",
+																	"situation": "From professional Spacers.",
+																	"amount": 1,
+																	"per_level": true
+																}
+															]
+														},
+														{
+															"id": "m8ew6sFmU3XGsrQMS",
+															"name": "Bonus to pushing off",
+															"reference": "BX350",
+															"reference_highlight": "ST/2",
+															"use_level_from_trait": true,
+															"features": [
+																{
+																	"type": "conditional_modifier",
+																	"situation": "Bonus to ST for zero G push off",
+																	"amount": 1,
+																	"per_level": true
+																}
+															],
+															"disabled": true
+														},
+														{
+															"id": "mUjkU_j8gOu1y6KmM",
+															"name": "Spacecraft Familiarity",
+															"use_level_from_trait": true,
+															"features": [
+																{
+																	"type": "conditional_modifier",
+																	"situation": "Counteracts Familiarity for spacecraft.",
+																	"amount": 1
+																}
+															],
+															"disabled": true
+														}
+													]
+												}
+											],
+											"points_per_level": 5,
+											"features": [
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Aerobatics"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Free Fall"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Navigation"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "Space"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Piloting"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "High-Performance Spacecraft"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Piloting"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "Low-Performance Spacecraft"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Piloting"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "Aerospace"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Spacer"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Vacc Suit"
+													},
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"can_level": true,
+											"levels": 1,
+											"calc": {
+												"points": 5
+											}
+										},
+										{
+											"id": "tf97INAQQyuLM5OH4",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Power Ups/Power Ups Traits.adq",
+												"id": "tcCw979nTBoztowCU"
+											},
+											"name": "Talent (Alien Friend)",
+											"reference": "PU3:6",
+											"tags": [
+												"Advantage",
+												"Mental",
+												"Talent"
+											],
+											"points_per_level": 5,
+											"features": [
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Diplomacy"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Expert Skill"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "Xenology"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Anthropology"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "@Alien@"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "History"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "@Alien@"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Psychology"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "@Alien@"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "reaction_bonus",
+													"situation": "From aliens.",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"can_level": true,
+											"levels": 1,
+											"calc": {
+												"points": 5
+											}
+										},
+										{
+											"id": "tcD7TQaiP6IEDFXyg",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tM6z7Mx6e2V4VvUR4"
+											},
 											"name": "Absolute Direction",
 											"reference": "B34",
 											"tags": [
@@ -430,14 +1878,14 @@
 											],
 											"modifiers": [
 												{
-													"id": "mBs6YAl6bQYiBdBOc",
+													"id": "m7kgBRSsNDwXHJWXI",
 													"name": "Requires signal",
 													"reference": "B34",
 													"cost": -20,
 													"disabled": true
 												},
 												{
-													"id": "mkXwZv719_EqqNeJL",
+													"id": "mq5zthbaKWNA7CnId",
 													"name": "3D Spatial Sense",
 													"reference": "B34",
 													"cost": 5,
@@ -553,1152 +2001,6 @@
 											"calc": {
 												"points": 10
 											}
-										},
-										{
-											"id": "tts7--QjqaybFukpn",
-											"name": "Alien Friend",
-											"reference": "S220",
-											"tags": [
-												"Advantage",
-												"Mental",
-												"Talent"
-											],
-											"modifiers": [
-												{
-													"id": "mBZcdB2h7qcXkXRmc",
-													"name": "Alternate Benefit",
-													"notes": "@Alternate Benefit@",
-													"disabled": true
-												},
-												{
-													"id": "mS33tmWBLn61mdP03",
-													"name": "Alternative Cost",
-													"cost_type": "points",
-													"affects": "levels_only",
-													"disabled": true
-												}
-											],
-											"points_per_level": 5,
-											"features": [
-												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "Anthropology"
-													},
-													"amount": 1,
-													"per_level": true
-												},
-												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "Diplomacy"
-													},
-													"amount": 1,
-													"per_level": true
-												},
-												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "Expert Skill"
-													},
-													"amount": 1,
-													"per_level": true
-												},
-												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "History"
-													},
-													"amount": 1,
-													"per_level": true
-												},
-												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "Psychology"
-													},
-													"amount": 1,
-													"per_level": true
-												},
-												{
-													"type": "reaction_bonus",
-													"situation": "Aliens",
-													"amount": 1,
-													"per_level": true
-												}
-											],
-											"can_level": true,
-											"levels": 1,
-											"calc": {
-												"points": 5
-											}
-										},
-										{
-											"id": "tW-Xl5j52ZFmrFKW1",
-											"name": "Born Spacer",
-											"reference": "THSCT40",
-											"tags": [
-												"Advantage",
-												"Mental",
-												"Talent"
-											],
-											"modifiers": [
-												{
-													"id": "mk943s09zjoSGcTlA",
-													"name": "Alternate Benefit",
-													"notes": "@Alternate Benefit@",
-													"disabled": true
-												},
-												{
-													"id": "mPmxYKN11_z8RdjO7",
-													"name": "Alternative Cost",
-													"cost_type": "points",
-													"affects": "levels_only",
-													"disabled": true
-												}
-											],
-											"points_per_level": 5,
-											"features": [
-												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "Aerobatics"
-													},
-													"amount": 1,
-													"per_level": true
-												},
-												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "Free Fall"
-													},
-													"amount": 1,
-													"per_level": true
-												},
-												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "Navigation"
-													},
-													"amount": 1,
-													"per_level": true
-												},
-												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "Piloting"
-													},
-													"specialization": {
-														"compare": "contains",
-														"qualifier": "Spacecraft"
-													},
-													"amount": 1,
-													"per_level": true
-												},
-												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "Spacer"
-													},
-													"amount": 1,
-													"per_level": true
-												},
-												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "Vacc Suit"
-													},
-													"amount": 1,
-													"per_level": true
-												},
-												{
-													"type": "reaction_bonus",
-													"situation": "Professional Spacers",
-													"amount": 1,
-													"per_level": true
-												}
-											],
-											"can_level": true,
-											"levels": 1,
-											"calc": {
-												"points": 5
-											}
-										},
-										{
-											"id": "tq8v8lqZZQ8_uSOtI",
-											"name": "Cultural Familiarity (@Culture@)",
-											"reference": "B23",
-											"notes": "Do not suffer the normal -3 penalty for unfamiliarity",
-											"tags": [
-												"Advantage",
-												"Mental"
-											],
-											"modifiers": [
-												{
-													"id": "mO1823AeJOof4vRO7",
-													"name": "Alien",
-													"cost": 1,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mjj9iPjWe6x1IfTL-",
-													"name": "Native",
-													"cost": -1,
-													"cost_type": "points",
-													"disabled": true
-												}
-											],
-											"base_points": 1,
-											"calc": {
-												"points": 1
-											}
-										},
-										{
-											"id": "teLYUcq-CdXHbQ3uI",
-											"name": "Cybernetics",
-											"reference": "B46",
-											"tags": [
-												"Advantage",
-												"Physical"
-											],
-											"calc": {
-												"points": 0
-											}
-										},
-										{
-											"id": "t7c4u3bEFNhl4Cbq_",
-											"name": "Deep Sleeper",
-											"reference": "B101",
-											"tags": [
-												"Perk",
-												"Physical"
-											],
-											"base_points": 1,
-											"calc": {
-												"points": 1
-											}
-										},
-										{
-											"id": "tFtJYltDpos4KoRxd",
-											"name": "Fearlessness",
-											"reference": "B55,MA44",
-											"tags": [
-												"Advantage",
-												"Mental"
-											],
-											"prereqs": {
-												"type": "prereq_list",
-												"all": true,
-												"prereqs": [
-													{
-														"type": "trait_prereq",
-														"has": false,
-														"name": {
-															"compare": "is",
-															"qualifier": "Fearfulness"
-														}
-													}
-												]
-											},
-											"points_per_level": 2,
-											"features": [
-												{
-													"type": "attribute_bonus",
-													"attribute": "fright_check",
-													"amount": 1,
-													"per_level": true
-												}
-											],
-											"can_level": true,
-											"levels": 1,
-											"calc": {
-												"points": 2
-											}
-										},
-										{
-											"id": "tSjcpo6pyhREtEqKf",
-											"name": "Fit",
-											"reference": "B55",
-											"notes": "Recover FP at twice the normal rate (but not FP spent for spells or psi powers)",
-											"tags": [
-												"Advantage",
-												"Physical"
-											],
-											"base_points": 5,
-											"features": [
-												{
-													"type": "conditional_modifier",
-													"situation": "to all HT rolls to stay conscious, avoid death, resist disease, or resist poison",
-													"amount": 1
-												}
-											],
-											"calc": {
-												"points": 5
-											}
-										},
-										{
-											"id": "t1iwIpCKnjCkZ-NYK",
-											"name": "G-Experience",
-											"reference": "B57",
-											"tags": [
-												"Advantage",
-												"Mental"
-											],
-											"points_per_level": 1,
-											"can_level": true,
-											"levels": 1,
-											"calc": {
-												"points": 1
-											}
-										},
-										{
-											"id": "tGEcbLt_KlgwlYGbx",
-											"name": "G-Experience (All)",
-											"reference": "B57",
-											"tags": [
-												"Advantage",
-												"Mental"
-											],
-											"base_points": 10,
-											"calc": {
-												"points": 10
-											}
-										},
-										{
-											"id": "ty6HxSfMqnd7yR4bT",
-											"name": "Gizmo",
-											"reference": "B57,MA45",
-											"tags": [
-												"Advantage",
-												"Mental"
-											],
-											"points_per_level": 5,
-											"can_level": true,
-											"levels": 1,
-											"calc": {
-												"points": 5
-											}
-										},
-										{
-											"id": "tgKPrBeZpzX3xfuNT",
-											"name": "Improved G-tolerance",
-											"reference": "B60",
-											"tags": [
-												"Advantage",
-												"Physical"
-											],
-											"modifiers": [
-												{
-													"id": "mDH9HYzKRnvt_6jBB",
-													"name": "0.3G",
-													"reference": "B60",
-													"cost": 5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mnq_A8-ClPw1VoNia",
-													"name": "0.5G",
-													"reference": "B60",
-													"cost": 10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mn1TLt9aHcYWjUDxI",
-													"name": "1G",
-													"reference": "B60",
-													"cost": 15,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m23kNLhx2bXq2WqAD",
-													"name": "5G",
-													"reference": "B60",
-													"cost": 20,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mnCFsg0qa05viU6Iz",
-													"name": "10G",
-													"reference": "B60",
-													"cost": 25,
-													"cost_type": "points",
-													"disabled": true
-												}
-											],
-											"calc": {
-												"points": 0
-											}
-										},
-										{
-											"id": "th0hOuQPvbI1-aPtt",
-											"name": "Language: @Language@",
-											"reference": "B24",
-											"tags": [
-												"Advantage",
-												"Language",
-												"Mental"
-											],
-											"modifiers": [
-												{
-													"id": "mcAuh6LlyjOUFQTh4",
-													"name": "Native",
-													"reference": "B23",
-													"cost": -6,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mt-lyuH_3uIctX35A",
-													"name": "Spoken",
-													"reference": "B24",
-													"notes": "None",
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mRyfCCxdW6z53c_Yo",
-													"name": "Spoken",
-													"reference": "B24",
-													"notes": "Broken",
-													"cost": 1,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mdiOB-OwzVi1VbpY_",
-													"name": "Spoken",
-													"reference": "B24",
-													"notes": "Accented",
-													"cost": 2,
-													"cost_type": "points"
-												},
-												{
-													"id": "mkT_GldflV-e4f-Uo",
-													"name": "Spoken",
-													"reference": "B24",
-													"notes": "Native",
-													"cost": 3,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "miyZWeIBYJaKe_x3B",
-													"name": "Written",
-													"reference": "B24",
-													"notes": "None",
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mhwka5t8veU-t2hSV",
-													"name": "Written",
-													"reference": "B24",
-													"notes": "Broken",
-													"cost": 1,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "miUMN3ipwyOKGofhm",
-													"name": "Written",
-													"reference": "B24",
-													"notes": "Accented",
-													"cost": 2,
-													"cost_type": "points"
-												},
-												{
-													"id": "mc-L2PwRDaNUOybS1",
-													"name": "Written",
-													"reference": "B24",
-													"notes": "Native",
-													"cost": 3,
-													"cost_type": "points",
-													"disabled": true
-												}
-											],
-											"calc": {
-												"points": 4
-											}
-										},
-										{
-											"id": "t1vrqtM5STBjP-ZuG",
-											"name": "Less Sleep",
-											"reference": "B65",
-											"notes": "Require 1 hour/level less sleep for a full night's rest (max 4)",
-											"tags": [
-												"Advantage",
-												"Physical"
-											],
-											"points_per_level": 2,
-											"can_level": true,
-											"levels": 1,
-											"calc": {
-												"points": 2
-											}
-										},
-										{
-											"id": "tBP4xtN1kbdbv4zla",
-											"name": "Luck",
-											"reference": "B66,P59",
-											"notes": "Usable once per hour of play",
-											"tags": [
-												"Advantage",
-												"Mental"
-											],
-											"modifiers": [
-												{
-													"id": "mGWF58iSx0ZHEI8ut",
-													"name": "Active",
-													"reference": "B66",
-													"cost": -40,
-													"disabled": true
-												},
-												{
-													"id": "mXSzR2BDOxbHFiNOq",
-													"name": "Aspected",
-													"reference": "B66",
-													"notes": "@Aspect@",
-													"cost": -20,
-													"disabled": true
-												},
-												{
-													"id": "m3KhW1aHyGX5MGp6B",
-													"name": "Defensive",
-													"reference": "B66",
-													"cost": -20,
-													"disabled": true
-												},
-												{
-													"id": "m9hEZ_7E2T2MWGubs",
-													"name": "Wishing",
-													"reference": "P59",
-													"cost": 100,
-													"disabled": true
-												}
-											],
-											"base_points": 15,
-											"calc": {
-												"points": 15
-											}
-										},
-										{
-											"id": "tc5GWWlnxzOdSC6YY",
-											"name": "Merchant Rank",
-											"reference": "B29",
-											"tags": [
-												"Advantage",
-												"Physical"
-											],
-											"modifiers": [
-												{
-													"id": "mIhoxXxzUfAFko55W",
-													"name": "Replaces Status",
-													"reference": "B29",
-													"cost": 5,
-													"cost_type": "points",
-													"affects": "levels_only",
-													"disabled": true
-												},
-												{
-													"id": "m2st3D3hbGI4Ftslj",
-													"name": "Courtesy",
-													"reference": "B29",
-													"cost": -4,
-													"cost_type": "points",
-													"affects": "levels_only",
-													"disabled": true
-												}
-											],
-											"points_per_level": 5,
-											"can_level": true,
-											"levels": 1,
-											"calc": {
-												"points": 5
-											}
-										},
-										{
-											"id": "tdtQzm5sLp0B1BbD6",
-											"name": "Military Rank",
-											"reference": "B29",
-											"tags": [
-												"Advantage",
-												"Physical"
-											],
-											"modifiers": [
-												{
-													"id": "mX3b66FQdpafFEs3r",
-													"name": "Replaces Status",
-													"reference": "B29",
-													"cost": 5,
-													"cost_type": "points",
-													"affects": "levels_only",
-													"disabled": true
-												},
-												{
-													"id": "mi5kvOuOfpub81eQ2",
-													"name": "Courtesy",
-													"reference": "B29",
-													"cost": -4,
-													"cost_type": "points",
-													"affects": "levels_only",
-													"disabled": true
-												}
-											],
-											"points_per_level": 5,
-											"can_level": true,
-											"levels": 1,
-											"calc": {
-												"points": 5
-											}
-										},
-										{
-											"id": "tR17ZyGdwx3FrMUAd",
-											"name": "Patron",
-											"reference": "B72,P65",
-											"notes": "Ship's owner or provider",
-											"tags": [
-												"Advantage",
-												"Social"
-											],
-											"modifiers": [
-												{
-													"id": "mqgACOYAccDQMtD-6",
-													"name": "@Who: Individual with 150% of PC's starting points@",
-													"reference": "B72",
-													"cost": 10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mOoTcEUmG80Ke2OJp",
-													"name": "@Who: Organization with assets of at least 1000 times starting wealth@",
-													"reference": "B72",
-													"cost": 10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mOX9yExNKOkghNqhK",
-													"name": "@Who: Individual with twice the PC's starting points@",
-													"reference": "B72",
-													"cost": 15,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mKPjqhgkNtAz63Fpa",
-													"name": "@Who: Organization with assets of at least 10000 times starting wealth@",
-													"reference": "B72",
-													"cost": 15,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mm7IDPa1O92q2S03f",
-													"name": "@Who: An ultra-powerful individual@",
-													"reference": "B72",
-													"cost": 20,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mAA32bFxzwXKfOGHc",
-													"name": "@Who: Organization with assets of at least 100000 times starting wealth@",
-													"reference": "B72",
-													"cost": 20,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mgpLmN4ufhPaE0wv1",
-													"name": "@Who: Organization with assets of at least 1000000 times starting wealth@",
-													"reference": "B72",
-													"cost": 25,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mj7nv56zt33gb7rK_",
-													"name": "@Who: A national government or giant multi-national organization@",
-													"reference": "B72",
-													"cost": 30,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m4kkqH0VMQmQ66pOq",
-													"name": "@Who: A deity@",
-													"reference": "B72",
-													"cost": 30,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mI4-l1Jo9Y0TSYvvm",
-													"name": "Appears almost all the time",
-													"reference": "B36",
-													"notes": "15-",
-													"cost": 3,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mhFpoF63-11AqNwB3",
-													"name": "Appears quite often",
-													"reference": "B36",
-													"notes": "12-",
-													"cost": 2,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mOrchTcAN_WIhtuZd",
-													"name": "Appears fairly often",
-													"reference": "B36",
-													"notes": "9-",
-													"cost": 1,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mENKlZSCyUwJYMtBO",
-													"name": "Appears quite rarely",
-													"reference": "B36",
-													"notes": "6-",
-													"cost": 0.5,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "magv8tC-YDeurwgvZ",
-													"name": "Equipment",
-													"reference": "B73",
-													"notes": "@Equipment worth no more than average starting wealth@",
-													"cost": 50,
-													"disabled": true
-												},
-												{
-													"id": "mjP2S-0zZH1jOD_f2",
-													"name": "Equipment",
-													"reference": "B73",
-													"notes": "@Equipment worth more than average starting wealth@",
-													"cost": 100,
-													"disabled": true
-												},
-												{
-													"id": "mT87usXK0KJ7akINt",
-													"name": "Highly Accessible",
-													"reference": "B73",
-													"cost": 50,
-													"disabled": true
-												},
-												{
-													"id": "mkigsx4-Nbw15m2Mt",
-													"name": "Special Abilities",
-													"reference": "B73",
-													"notes": "@Extensive social or political power@",
-													"cost": 50,
-													"disabled": true
-												},
-												{
-													"id": "mJ6uDL_8xDKlYu7HA",
-													"name": "Special Abilities",
-													"reference": "B73",
-													"notes": "@Magical powers in a non-magical world, higher TL equipment, grants special powers or is supernatural@",
-													"cost": 100,
-													"disabled": true
-												},
-												{
-													"id": "mjyRi_sKdDRTlWsrg",
-													"name": "Minimal Interventions",
-													"reference": "B73",
-													"cost": -50,
-													"disabled": true
-												},
-												{
-													"id": "mnt2ozll5MOS9Ck1o",
-													"name": "Secret",
-													"reference": "B73",
-													"cost": -50,
-													"disabled": true
-												},
-												{
-													"id": "mTnaa6Uuojl080kCe",
-													"name": "Unwilling",
-													"reference": "B74",
-													"cost": -50,
-													"disabled": true
-												},
-												{
-													"id": "mlj81ExVsDPgquipb",
-													"name": "Favor",
-													"reference": "B55",
-													"cost": 0.2,
-													"cost_type": "multiplier",
-													"disabled": true
-												}
-											],
-											"calc": {
-												"points": 0
-											}
-										},
-										{
-											"id": "tZnEYreKHnHgPNpQ8",
-											"name": "Reputation",
-											"reference": "B26,MA54",
-											"tags": [
-												"Advantage",
-												"Social"
-											],
-											"modifiers": [
-												{
-													"id": "mdoFP2ru6uN2S8bYq",
-													"name": "People Affected",
-													"reference": "B27",
-													"notes": "Almost everyone",
-													"cost": 1,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mU69IHruVNyTtbWYZ",
-													"name": "People Affected",
-													"reference": "B27",
-													"notes": "Almost everyone except @large class of people@",
-													"cost": 0.67,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "m7w-i_yEU26Cvy8RU",
-													"name": "People Affected",
-													"reference": "B27",
-													"notes": "@Large class of people@",
-													"cost": 0.5,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mgCcg0KXMmleHzGnV",
-													"name": "People Affected",
-													"reference": "B27",
-													"notes": "@Small class of people@",
-													"cost": 0.33,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mvcVXmILhNYDHfrzE",
-													"name": "Recognized all the time",
-													"reference": "B28",
-													"cost": 1,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mh84N8yiu903_jyM7",
-													"name": "Recognized sometimes",
-													"reference": "B28",
-													"notes": "10-",
-													"cost": 0.5,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mQjRk6EFsbMtTzB3b",
-													"name": "Recognized occasionally",
-													"reference": "B28",
-													"notes": "7-",
-													"cost": 0.33,
-													"cost_type": "multiplier",
-													"disabled": true
-												}
-											],
-											"points_per_level": 5,
-											"round_down": true,
-											"can_level": true,
-											"levels": 1,
-											"calc": {
-												"points": 5
-											}
-										},
-										{
-											"id": "tcQsRt-Ua475BC-8n",
-											"name": "Resistant to Acceleration",
-											"reference": "B81,P71,MA47",
-											"tags": [
-												"Advantage",
-												"Physical"
-											],
-											"modifiers": [
-												{
-													"id": "mDt5x9e0EB4BE-BsN",
-													"name": "@Very Common: Metabolic Hazards, etc.@",
-													"reference": "B80",
-													"cost": 30,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m-F0RgosYCNGuxBqb",
-													"name": "@Common: Poison, Sickness, etc.@",
-													"reference": "B81",
-													"cost": 15,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mV9VzDhqjADPgrTiS",
-													"name": "@Occasional: Disease, Ingested Poison, etc.@",
-													"reference": "B81",
-													"cost": 10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m7pq8mpEDQUhnaYcQ",
-													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
-													"reference": "B81",
-													"cost": 5,
-													"cost_type": "points"
-												},
-												{
-													"id": "msCZtSg9ioFfwa0_c",
-													"name": "Immunity",
-													"reference": "B81",
-													"cost": 1,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mU3vAd0iJXfVGkYYC",
-													"name": "+8 to all HT rolls to resist",
-													"reference": "B81",
-													"cost": 0.5,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mypwENlIWwL1E7-Fe",
-													"name": "+3 to all HT rolls to resist",
-													"reference": "B81",
-													"cost": 0.33,
-													"cost_type": "multiplier"
-												}
-											],
-											"round_down": true,
-											"calc": {
-												"points": 1
-											}
-										},
-										{
-											"id": "tQ2HJY1Xxz0GA6O3U",
-											"name": "Resistant to Space Sickness",
-											"reference": "B81,P71,MA47",
-											"tags": [
-												"Advantage",
-												"Physical"
-											],
-											"modifiers": [
-												{
-													"id": "mGalymNWh_GnUuMdW",
-													"name": "@Very Common: Metabolic Hazards, etc.@",
-													"reference": "B80",
-													"cost": 30,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mjKWkJOVd4-ElRP9w",
-													"name": "@Common: Poison, Sickness, etc.@",
-													"reference": "B81",
-													"cost": 15,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mjueKKLxhMxnGweNJ",
-													"name": "@Occasional: Disease, Ingested Poison, etc.@",
-													"reference": "B81",
-													"cost": 10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mKLQaJH-2RHUvLZHe",
-													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
-													"reference": "B81",
-													"cost": 5,
-													"cost_type": "points"
-												},
-												{
-													"id": "my61SBe2i0di9hS-m",
-													"name": "Immunity",
-													"reference": "B81",
-													"cost": 1,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mBggrz0dCenOyj2cB",
-													"name": "+8 to all HT rolls to resist",
-													"reference": "B81",
-													"cost": 0.5,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "myxPEPscHI2jPAdxy",
-													"name": "+3 to all HT rolls to resist",
-													"reference": "B81",
-													"cost": 0.33,
-													"cost_type": "multiplier"
-												}
-											],
-											"round_down": true,
-											"calc": {
-												"points": 1
-											}
-										},
-										{
-											"id": "tF94DTPXWY0hse1ap",
-											"name": "Resistant to Space Sickness",
-											"reference": "B81,P71,MA47",
-											"tags": [
-												"Advantage",
-												"Physical"
-											],
-											"modifiers": [
-												{
-													"id": "mVsfK3seEyeOG35_p",
-													"name": "@Very Common: Metabolic Hazards, etc.@",
-													"reference": "B80",
-													"cost": 30,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mY6dijmU_X_dXSKbz",
-													"name": "@Common: Poison, Sickness, etc.@",
-													"reference": "B81",
-													"cost": 15,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mMo-rfMZsTOR6TK_W",
-													"name": "@Occasional: Disease, Ingested Poison, etc.@",
-													"reference": "B81",
-													"cost": 10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mDkmBu4QGTo_vqI7A",
-													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
-													"reference": "B81",
-													"cost": 5,
-													"cost_type": "points"
-												},
-												{
-													"id": "mnV4fgT-7TDUp3E6a",
-													"name": "Immunity",
-													"reference": "B81",
-													"cost": 1,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "m-SsiDjMrC93sCDZh",
-													"name": "+8 to all HT rolls to resist",
-													"reference": "B81",
-													"cost": 0.5,
-													"cost_type": "multiplier"
-												},
-												{
-													"id": "mxR9ty1EzpdZiHCOm",
-													"name": "+3 to all HT rolls to resist",
-													"reference": "B81",
-													"cost": 0.33,
-													"cost_type": "multiplier",
-													"disabled": true
-												}
-											],
-											"round_down": true,
-											"calc": {
-												"points": 2
-											}
-										},
-										{
-											"id": "tYujwqlTBFYE61iey",
-											"name": "Serendipity",
-											"reference": "B83,P73",
-											"tags": [
-												"Advantage",
-												"Mental"
-											],
-											"modifiers": [
-												{
-													"id": "mhsrzVbo8efR6g7nQ",
-													"name": "Wishing",
-													"reference": "P73",
-													"cost": 100,
-													"disabled": true
-												},
-												{
-													"id": "mcKEdEdX7wqw-JRif",
-													"name": "Wishing",
-													"reference": "P73",
-													"notes": "For others only",
-													"disabled": true
-												}
-											],
-											"points_per_level": 15,
-											"can_level": true,
-											"levels": 1,
-											"calc": {
-												"points": 15
-											}
-										},
-										{
-											"id": "tw1FCQ8_sY1-2czAg",
-											"name": "Suit Familiarity (Vacc Suit)",
-											"reference": "PU2:9",
-											"tags": [
-												"Perk",
-												"Physical"
-											],
-											"base_points": 1,
-											"calc": {
-												"points": 1
-											}
 										}
 									],
 									"calc": {
@@ -1706,7 +2008,12 @@
 									}
 								},
 								{
-									"id": "tZIOt7Td-U6mLVqaF",
+									"id": "tdCDrw91KjVwFOn9e",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t59wSfU9kpC1rus5P"
+									},
 									"name": "Alcohol Tolerance",
 									"reference": "B100",
 									"tags": [
@@ -1726,7 +2033,12 @@
 									}
 								},
 								{
-									"id": "tWofMlrVvdEAyDGqg",
+									"id": "t-BcQWZCH620qMANI",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tdlCZw4YB4T7QkOnj"
+									},
 									"name": "Appearance",
 									"reference": "B21",
 									"tags": [
@@ -1735,7 +2047,7 @@
 									],
 									"modifiers": [
 										{
-											"id": "m4Y7iobfbtW6Zmueu",
+											"id": "mnR8BsDgM_Hww6uWt",
 											"name": "Attractive",
 											"reference": "B21",
 											"cost": 4,
@@ -1750,14 +2062,14 @@
 											"disabled": true
 										},
 										{
-											"id": "mtlqDaxRgirSKnxim",
+											"id": "m4LFtKyuc-KuRvUxN",
 											"name": "Average",
 											"reference": "B21",
 											"cost_type": "points",
 											"disabled": true
 										},
 										{
-											"id": "mT45GfUaY9MJ9R9kh",
+											"id": "mpfi5aMYvkhWPU3X3",
 											"name": "Beautiful",
 											"reference": "B21",
 											"cost": 12,
@@ -1772,7 +2084,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mLT5fibrnGKISXe8u",
+											"id": "me4oofvr4Uwe0h_rp",
 											"name": "Beautiful (Androgynous)",
 											"reference": "B21",
 											"cost": 12,
@@ -1787,7 +2099,7 @@
 											"disabled": true
 										},
 										{
-											"id": "m3q_EgvDjQ7rdYweT",
+											"id": "m6Y0whELv6Ehm1QpY",
 											"name": "Beautiful (Impressive)",
 											"reference": "B21",
 											"cost": 12,
@@ -1802,7 +2114,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mk7pBLVHqAgO04BT8",
+											"id": "m8tJQT9S_YFbJBq4Q",
 											"name": "Handsome",
 											"reference": "B21",
 											"cost": 12,
@@ -1817,7 +2129,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mCHysViQiHFxn4IKi",
+											"id": "msFpmP4CiLU_ussCZ",
 											"name": "Handsome (Androgynous)",
 											"reference": "B21",
 											"cost": 12,
@@ -1832,7 +2144,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mlEVwwgpEzFkqHDUn",
+											"id": "moH9Tb4tAmO431m5j",
 											"name": "Handsome (Impressive)",
 											"reference": "B21",
 											"cost": 12,
@@ -1847,12 +2159,21 @@
 											"disabled": true
 										},
 										{
-											"id": "mwoGza-yrRfHg5CEU",
+											"id": "mmIT8tLrBX8JNxFpg",
 											"name": "Hideous",
-											"reference": "B21",
+											"reference": "B21,B202",
 											"cost": -16,
 											"cost_type": "points",
 											"features": [
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Intimidation"
+													},
+													"amount": 2
+												},
 												{
 													"type": "reaction_bonus",
 													"situation": "from others",
@@ -1862,12 +2183,21 @@
 											"disabled": true
 										},
 										{
-											"id": "mwowsrlg2lqlMK2Fc",
+											"id": "m1RoIxzdSZRinHriH",
 											"name": "Horrific",
-											"reference": "B21",
+											"reference": "B21,B202",
 											"cost": -24,
 											"cost_type": "points",
 											"features": [
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Intimidation"
+													},
+													"amount": 4
+												},
 												{
 													"type": "reaction_bonus",
 													"situation": "from others",
@@ -1877,19 +2207,28 @@
 											"disabled": true
 										},
 										{
-											"id": "mxeyTPsy1vszjOwVp",
+											"id": "mW45X2inkHNET_F4D",
 											"name": "Impressive",
 											"reference": "B21",
 											"cost_type": "points",
 											"disabled": true
 										},
 										{
-											"id": "mYZf2iL30Z4fP8vvS",
+											"id": "moHXVa18CS5-VPN2h",
 											"name": "Monstrous",
-											"reference": "B21",
+											"reference": "B21,B202",
 											"cost": -20,
 											"cost_type": "points",
 											"features": [
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Intimidation"
+													},
+													"amount": 3
+												},
 												{
 													"type": "reaction_bonus",
 													"situation": "from others",
@@ -1899,7 +2238,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mpkb3_8XXo6aQ860J",
+											"id": "mG35jDowQhh5t4JoS",
 											"name": "Off-the-Shelf Looks",
 											"reference": "B21",
 											"notes": "Halves the usual reaction bonus - adjust manually",
@@ -1907,7 +2246,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mdW40VBUaD65ipQ6X",
+											"id": "mjzn84kLQEG79WBiN",
 											"name": "Transcendent",
 											"reference": "B21",
 											"cost": 20,
@@ -1922,7 +2261,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mw6ZhN1aRu7NTOPlm",
+											"id": "mXUi8h4rbTeGyOCP4",
 											"name": "Transcendent (Androgynous)",
 											"reference": "B21",
 											"cost": 20,
@@ -1937,7 +2276,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mao1En8hrSztzjca5",
+											"id": "mD8vbxhRaBbgyJgsd",
 											"name": "Transcendent (Impressive)",
 											"reference": "B21",
 											"cost": 20,
@@ -1952,7 +2291,7 @@
 											"disabled": true
 										},
 										{
-											"id": "ml0qBXco8g3VCoJBx",
+											"id": "mqF3X5TWQkRINbesg",
 											"name": "Ugly",
 											"reference": "B21",
 											"cost": -8,
@@ -1967,7 +2306,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mL6eErnQxNBnMHXC6",
+											"id": "m6roZbBnSQqtHnsQX",
 											"name": "Unattractive",
 											"reference": "B21",
 											"cost": -4,
@@ -1982,14 +2321,14 @@
 											"disabled": true
 										},
 										{
-											"id": "mnRxstpnIJy0yND1w",
+											"id": "mkt3gf1aq8jsuEMrA",
 											"name": "Universal",
 											"reference": "B21",
 											"cost": 25,
 											"disabled": true
 										},
 										{
-											"id": "mxz4OfV8OmeO3jqpX",
+											"id": "mnsAGy-zJCF4oMxYg",
 											"name": "Very Beautiful",
 											"reference": "B21",
 											"cost": 16,
@@ -2004,7 +2343,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mrcEQkZF3vAJWmXDu",
+											"id": "mkq8V0D814xpOQ8IE",
 											"name": "Very Beautiful (Androgynous)",
 											"reference": "B21",
 											"cost": 16,
@@ -2019,7 +2358,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mD5x6zw5RTxAEYkvQ",
+											"id": "mASRpxmtX4zbYKtd6",
 											"name": "Very Beautiful (Impressive)",
 											"reference": "B21",
 											"cost": 16,
@@ -2034,7 +2373,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mFefQTbDTPdwMgF8p",
+											"id": "meDkHBjj36S2rJcAx",
 											"name": "Very Handsome",
 											"reference": "B21",
 											"cost": 16,
@@ -2049,7 +2388,7 @@
 											"disabled": true
 										},
 										{
-											"id": "m1w-c77ip0MQ557Vo",
+											"id": "mOXky6shJJ_iVtg0m",
 											"name": "Very Handsome (Androgynous)",
 											"reference": "B21",
 											"cost": 16,
@@ -2064,7 +2403,7 @@
 											"disabled": true
 										},
 										{
-											"id": "m3HNxq9YHVMcWegJ0",
+											"id": "mOUEtjVLEr9q2zN5l",
 											"name": "Very Handsome (Impressive)",
 											"reference": "B21",
 											"cost": 16,
@@ -2084,7 +2423,12 @@
 									}
 								},
 								{
-									"id": "tRusjYmaMEZNw0AN8",
+									"id": "tT2iEu18r3ZFSz8RR",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tePEpgFmqM2QDb9q6"
+									},
 									"name": "Talent (Business Acumen)",
 									"reference": "PU3:7",
 									"tags": [
@@ -2094,12 +2438,59 @@
 									],
 									"modifiers": [
 										{
-											"id": "mmv3_s_SiPQRFGO4a",
+											"id": "mWlBQhxATHAaCeftu",
 											"name": "Alternative Cost",
 											"cost": -2,
 											"cost_type": "points",
 											"affects": "levels_only",
 											"disabled": true
+										},
+										{
+											"id": "Me3a-_w5Xj-roCqPP",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "mpk0hUJPBttdgtc-o",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From anyone with whom you do business.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "myQrmxeypZkY_cWRT",
+													"name": "Jobs and hirelings",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "To all rolls to find hirelings or jobs (pp. B517-518)",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mZJ9mCyK7M-SL-v77",
+													"name": "Resist scams",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "To will rolls to resist others' attempts to use Influence skills to scam money.",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
 										}
 									],
 									"points_per_level": 10,
@@ -2183,18 +2574,6 @@
 											},
 											"amount": 1,
 											"per_level": true
-										},
-										{
-											"type": "reaction_bonus",
-											"situation": "From anyone with whom you do business.",
-											"amount": 1,
-											"per_level": true
-										},
-										{
-											"type": "conditional_modifier",
-											"situation": "Bonus to all rolls to find hirelings or jobs (pp. B517-518), and/or to Will rolls to resist others' attempts to use Influence skills to scam money.",
-											"amount": 1,
-											"per_level": true
 										}
 									],
 									"can_level": true,
@@ -2204,7 +2583,12 @@
 									}
 								},
 								{
-									"id": "tWmknBWygLAm4zVGS",
+									"id": "tyFJ8U4xUQSZwx9Ml",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tMMQWflrKUPOkyIF9"
+									},
 									"name": "Charisma",
 									"reference": "B41",
 									"tags": [
@@ -2273,7 +2657,12 @@
 									}
 								},
 								{
-									"id": "trCK7d_ZWCnFpX1ZU",
+									"id": "tez92Y3C3k5Ffb9YZ",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tqSO2a00yPEs8sCn3"
+									},
 									"name": "Common Sense",
 									"reference": "B43,P45",
 									"tags": [
@@ -2282,7 +2671,7 @@
 									],
 									"modifiers": [
 										{
-											"id": "mGy_xfUYMPUiTn9Pd",
+											"id": "m3lwiF-7x1D7hZ4z6",
 											"name": "Concious",
 											"reference": "P45",
 											"cost": 50,
@@ -2295,7 +2684,12 @@
 									}
 								},
 								{
-									"id": "thbAOva9dG2d9Im1I",
+									"id": "tKv-MoMtUdMG1aNlM",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t7U76B4j7M7hCGD_H"
+									},
 									"name": "Contact (@Who@)",
 									"reference": "B44",
 									"tags": [
@@ -2304,7 +2698,7 @@
 									],
 									"modifiers": [
 										{
-											"id": "m3tg5Krk8nOv2EGDP",
+											"id": "mkBPJ4ODzrB-vKBAY",
 											"name": "Effective skill",
 											"notes": "12",
 											"cost": 1,
@@ -2312,7 +2706,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mXFHHeQZB3HOT1zJq",
+											"id": "mtsFAZZc4AyXxbZUv",
 											"name": "Effective skill",
 											"notes": "15",
 											"cost": 2,
@@ -2320,7 +2714,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mem-RAA7sUtUh5h2n",
+											"id": "mIZOET2IPQjAkjZCq",
 											"name": "Effective skill",
 											"notes": "18",
 											"cost": 3,
@@ -2328,7 +2722,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mIkrjQeIxSpys6JxP",
+											"id": "m6h6EZ4Z9buwjrdsy",
 											"name": "Effective skill",
 											"notes": "21",
 											"cost": 4,
@@ -2336,21 +2730,20 @@
 											"disabled": true
 										},
 										{
-											"id": "mq7lPuPVT1_7Ziv8a",
+											"id": "m68OMqizjOH0lZuTq",
 											"name": "Can obtain information using supernatural talents",
 											"cost": 1,
 											"cost_type": "points",
 											"disabled": true
 										},
 										{
-											"id": "m5TcsKr3vDwNBi6zh",
+											"id": "m9_EyVTKCzmC1LQ4j",
 											"name": "Group",
 											"cost": 5,
-											"cost_type": "multiplier",
-											"disabled": true
+											"cost_type": "multiplier"
 										},
 										{
-											"id": "my_Y8orMqNtvGhYAX",
+											"id": "mGfYIr8Q4jYKjv930",
 											"name": "Appears almost all the time",
 											"notes": "15-",
 											"cost": 3,
@@ -2358,7 +2751,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mlcUDv78cBGurmoKz",
+											"id": "mX1adSwczHELpzqUB",
 											"name": "Appears quite often",
 											"notes": "12-",
 											"cost": 2,
@@ -2366,7 +2759,7 @@
 											"disabled": true
 										},
 										{
-											"id": "m_X48W5qfoHZGfuMj",
+											"id": "mAsruL58p_U11lLbX",
 											"name": "Appears fairly often",
 											"notes": "9-",
 											"cost": 1,
@@ -2374,7 +2767,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mQH7WpWqeVyf-2B4H",
+											"id": "mmn_Xx-3n5d1eG562",
 											"name": "Appears quite rarely",
 											"notes": "6-",
 											"cost": 0.5,
@@ -2382,35 +2775,35 @@
 											"disabled": true
 										},
 										{
-											"id": "mm4HF5EZuaqarMXKD",
+											"id": "m9GQ5vAImwQRvCA9m",
 											"name": "Completely reliable",
 											"cost": 3,
 											"cost_type": "multiplier",
 											"disabled": true
 										},
 										{
-											"id": "mNN7fPRtpgxcMvPWc",
+											"id": "mAJaC_w7dE22WwEel",
 											"name": "Usually reliable",
 											"cost": 2,
 											"cost_type": "multiplier",
 											"disabled": true
 										},
 										{
-											"id": "mKTRoBrRf5N8Bmgja",
+											"id": "mZ5wSyKgsjPAT9wpc",
 											"name": "Somewhat reliable",
 											"cost": 1,
 											"cost_type": "multiplier",
 											"disabled": true
 										},
 										{
-											"id": "m_MxPYUCYBe6ZGMwI",
+											"id": "mXXnSR617MqgbFRkN",
 											"name": "Unreliable",
 											"cost": 0.5,
 											"cost_type": "multiplier",
 											"disabled": true
 										},
 										{
-											"id": "myknLfZvh8KzKt-Yk",
+											"id": "mkw1Fri38ekNPU5Lk",
 											"name": "Favor",
 											"reference": "B55",
 											"cost": 0.2,
@@ -2423,7 +2816,145 @@
 									}
 								},
 								{
-									"id": "tAoi97vY8PO9Qp_SO",
+									"id": "tdf6xo2enWwnotoVG",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t7U76B4j7M7hCGD_H"
+									},
+									"name": "Contact (@Who@)",
+									"reference": "B44",
+									"tags": [
+										"Advantage",
+										"Social"
+									],
+									"modifiers": [
+										{
+											"id": "m-QuPSice4pW_RQ0k",
+											"name": "Effective skill",
+											"notes": "12",
+											"cost": 1,
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "mKdI5tFFYvyxOG6ko",
+											"name": "Effective skill",
+											"notes": "15",
+											"cost": 2,
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "mjOrypPxjDRWe7asK",
+											"name": "Effective skill",
+											"notes": "18",
+											"cost": 3,
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "m4xYLa_bFLpFbI3t_",
+											"name": "Effective skill",
+											"notes": "21",
+											"cost": 4,
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "mhcjktkufNcOvgY9g",
+											"name": "Can obtain information using supernatural talents",
+											"cost": 1,
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "mNqI_T-Os0UmWPu5n",
+											"name": "Group",
+											"cost": 5,
+											"cost_type": "multiplier",
+											"disabled": true
+										},
+										{
+											"id": "mwuOF5yGauIgVs9fi",
+											"name": "Appears almost all the time",
+											"notes": "15-",
+											"cost": 3,
+											"cost_type": "multiplier",
+											"disabled": true
+										},
+										{
+											"id": "moz1-9pvabUt9h4RP",
+											"name": "Appears quite often",
+											"notes": "12-",
+											"cost": 2,
+											"cost_type": "multiplier",
+											"disabled": true
+										},
+										{
+											"id": "mZFr5uYKQUQ3Sx2Vp",
+											"name": "Appears fairly often",
+											"notes": "9-",
+											"cost": 1,
+											"cost_type": "multiplier",
+											"disabled": true
+										},
+										{
+											"id": "mf4uFPH2iob-FIQfz",
+											"name": "Appears quite rarely",
+											"notes": "6-",
+											"cost": 0.5,
+											"cost_type": "multiplier",
+											"disabled": true
+										},
+										{
+											"id": "mWDVgVqQ6quXxNyfr",
+											"name": "Completely reliable",
+											"cost": 3,
+											"cost_type": "multiplier",
+											"disabled": true
+										},
+										{
+											"id": "mLrnDIskG_Gelv7fZ",
+											"name": "Usually reliable",
+											"cost": 2,
+											"cost_type": "multiplier",
+											"disabled": true
+										},
+										{
+											"id": "mrJ8uvBYDNc_Utp5P",
+											"name": "Somewhat reliable",
+											"cost": 1,
+											"cost_type": "multiplier",
+											"disabled": true
+										},
+										{
+											"id": "mHlFJ8TnT9bE531jD",
+											"name": "Unreliable",
+											"cost": 0.5,
+											"cost_type": "multiplier",
+											"disabled": true
+										},
+										{
+											"id": "miVb3K6JlAD3mBBUi",
+											"name": "Favor",
+											"reference": "B55",
+											"cost": 0.2,
+											"cost_type": "multiplier",
+											"disabled": true
+										}
+									],
+									"calc": {
+										"points": 0
+									}
+								},
+								{
+									"id": "tXQPoZqEPa-aiGG1l",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t5D4nXKgejnaua22T"
+									},
 									"name": "Cultural Adaptability",
 									"reference": "B46",
 									"tags": [
@@ -2432,7 +2963,34 @@
 									],
 									"modifiers": [
 										{
-											"id": "m2u1acW4xWdXX6Kv1",
+											"id": "mZYXjjBMdW9mqgaBI",
+											"name": "Xeno",
+											"cost": 10,
+											"cost_type": "points",
+											"disabled": true
+										}
+									],
+									"base_points": 10,
+									"calc": {
+										"points": 10
+									}
+								},
+								{
+									"id": "trjjP1s99slDhWEKB",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t5D4nXKgejnaua22T"
+									},
+									"name": "Cultural Adaptability",
+									"reference": "B46",
+									"tags": [
+										"Advantage",
+										"Mental"
+									],
+									"modifiers": [
+										{
+											"id": "mqsQph8_kuwSTvNwD",
 											"name": "Xeno",
 											"cost": 10,
 											"cost_type": "points"
@@ -2444,7 +3002,12 @@
 									}
 								},
 								{
-									"id": "tAeDNbpk6VLsx7s4a",
+									"id": "tyi1U5cWPWO8SBAzE",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t7Qbxl8TTnvlyYeUJ"
+									},
 									"name": "Fashion Sense",
 									"reference": "B21",
 									"tags": [
@@ -2469,7 +3032,12 @@
 									}
 								},
 								{
-									"id": "tSvRxGThBFkRroaTu",
+									"id": "t9PJdlW3xeX2IOGPF",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tuMfT5QpkN-4bDjWi"
+									},
 									"name": "Headhunter",
 									"reference": "PU2:13",
 									"tags": [
@@ -2482,7 +3050,12 @@
 									}
 								},
 								{
-									"id": "tuHrguJPhB7xlHSrg",
+									"id": "tOLwJOvYLRcDnsif2",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tiyTlKuFuS-SfRj2l"
+									},
 									"name": "Honest Face",
 									"reference": "PU2:4",
 									"tags": [
@@ -2495,7 +3068,12 @@
 									}
 								},
 								{
-									"id": "tp3nuH87ujEvHgaOf",
+									"id": "tZIRxoUrooWwIhVUZ",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t4ANWaWCephx_yJpO"
+									},
 									"name": "Indomitable",
 									"reference": "B60",
 									"notes": "Impossible to influence through ordinary words or actions",
@@ -2509,7 +3087,12 @@
 									}
 								},
 								{
-									"id": "t_O-i2SylPrjNSQY-",
+									"id": "tzsbuNaBJuQF6tZpU",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tqseLS-LNinGOwJ2z"
+									},
 									"name": "Language Talent",
 									"reference": "B65",
 									"tags": [
@@ -2522,7 +3105,12 @@
 									}
 								},
 								{
-									"id": "tX3yBnIgnzTRzDwls",
+									"id": "tDVdw1octZg4Ig3K1",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tq6b1t_pc4X18GAWi"
+									},
 									"name": "Lightning Calculator",
 									"reference": "B66",
 									"tags": [
@@ -2531,7 +3119,7 @@
 									],
 									"modifiers": [
 										{
-											"id": "mx0GQnhEUGlDGm7jy",
+											"id": "mX7WbNaLe9WMoWS6S",
 											"name": "Intuitive Mathematician",
 											"reference": "B66",
 											"cost": 3,
@@ -2545,7 +3133,12 @@
 									}
 								},
 								{
-									"id": "tVaaTEJTOkpDKG6OL",
+									"id": "tBcbsC68n9OzhHlqa",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tHd6RZWGO9p5R91Vo"
+									},
 									"name": "Rapier Wit",
 									"reference": "B79,P70",
 									"tags": [
@@ -2554,7 +3147,7 @@
 									],
 									"modifiers": [
 										{
-											"id": "m_Z3VkYfQ6W-zxbF0",
+											"id": "mIxMsV4eviU7UcJa7",
 											"name": "Words of Power",
 											"reference": "P70",
 											"cost": 100,
@@ -2567,7 +3160,12 @@
 									}
 								},
 								{
-									"id": "tJBNUoYHmxUbiM8Pv",
+									"id": "ttKRrlu7QPJz_AKDz",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t24PEm7VuLQlQZbMN"
+									},
 									"name": "Empathy (Sensitive)",
 									"reference": "B51",
 									"tags": [
@@ -2576,7 +3174,7 @@
 									],
 									"modifiers": [
 										{
-											"id": "md8sgucM2jDOhhl_J",
+											"id": "mjVFENnbY6a5vQKIG",
 											"name": "Remote",
 											"reference": "P48",
 											"cost": 50,
@@ -2618,7 +3216,12 @@
 									}
 								},
 								{
-									"id": "t4KFdhgpnxcOIu_DA",
+									"id": "t-tF49BbKnUGBrooi",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "txfWfYkxkkcwmLAS4"
+									},
 									"name": "Empathy",
 									"reference": "B51,P48",
 									"tags": [
@@ -2627,7 +3230,7 @@
 									],
 									"modifiers": [
 										{
-											"id": "mGtNPK9H4A_T62F7Q",
+											"id": "mM4-HlLCg9s_TKNmj",
 											"name": "Remote",
 											"reference": "P48",
 											"cost": 50,
@@ -2669,7 +3272,12 @@
 									}
 								},
 								{
-									"id": "t5o88GNzx1-kqoQmm",
+									"id": "tz6oarJCpTxtDsFWI",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "t47ychA98bECqxqRM"
+									},
 									"name": "Talent (Smooth Operator)",
 									"reference": "PU3:15",
 									"tags": [
@@ -2679,12 +3287,45 @@
 									],
 									"modifiers": [
 										{
-											"id": "m5C7eGyP0rjSAfz7P",
+											"id": "mG_NQ7yT2KZAtXqk-",
 											"name": "Alternative Cost",
 											"cost": -2,
 											"cost_type": "points",
 											"affects": "levels_only",
 											"disabled": true
+										},
+										{
+											"id": "MJKHuWErI1Z9t1OKr",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "myvTALsdjy3Xnc0NO",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From con artists, politicians, salesmen, etc. – but only if you aren’t trying to manipulate them.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "mG606IeNs_at3A4UR",
+													"name": "Alternative Benefit",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Bonus to resist covered skills",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
 										}
 									],
 									"points_per_level": 15,
@@ -2854,18 +3495,6 @@
 											},
 											"amount": 1,
 											"per_level": true
-										},
-										{
-											"type": "reaction_bonus",
-											"situation": "From con artists, politicians, salesmen, etc. – but only if you aren’t trying to manipulate them.",
-											"amount": 1,
-											"per_level": true
-										},
-										{
-											"type": "conditional_modifier",
-											"situation": "Bonus to resist covered skills",
-											"amount": 1,
-											"per_level": true
 										}
 									],
 									"can_level": true,
@@ -2875,7 +3504,12 @@
 									}
 								},
 								{
-									"id": "tjMQ3CdMlTqwCilSM",
+									"id": "twuckvPPB_ddKJ6b5",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tI6dwoBoTEQ-gfy0a"
+									},
 									"name": "Social Chameleon",
 									"reference": "B86",
 									"notes": "Exempt from reaction penalties due to differences in Rank or Status",
@@ -2896,7 +3530,12 @@
 									}
 								},
 								{
-									"id": "tOv6CBmh4ccN1Tj_R",
+									"id": "t9ZDZnr7PrXilCqBi",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t2vba3l0J2mCZM50M"
+									},
 									"name": "Voice",
 									"reference": "B97",
 									"tags": [
@@ -2989,7 +3628,7 @@
 								}
 							],
 							"calc": {
-								"points": 351
+								"points": 361
 							}
 						},
 						{
@@ -2997,7 +3636,12 @@
 							"name": "10 Points chosen from any amount of",
 							"children": [
 								{
-									"id": "t133DyEb9kF3grLCQ",
+									"id": "tMHCMGV5H2LdQxVCG",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tw1Ad0oSMw2ATM4X1"
+									},
 									"name": "Language: @Language@",
 									"reference": "B24",
 									"tags": [
@@ -3005,9 +3649,26 @@
 										"Language",
 										"Mental"
 									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Language Talent"
+												},
+												"level": {
+													"compare": "at_least"
+												}
+											}
+										]
+									},
 									"modifiers": [
 										{
-											"id": "mAyc7lQdTxrdfEIjJ",
+											"id": "mb9OVBFyf3HN-S2rA",
 											"name": "Native",
 											"reference": "B23",
 											"cost": -6,
@@ -3015,7 +3676,7 @@
 											"disabled": true
 										},
 										{
-											"id": "m884bC1NDIrBnLTTN",
+											"id": "mlc_7n5H8bkCliWQl",
 											"name": "Spoken",
 											"reference": "B24",
 											"notes": "None",
@@ -3023,7 +3684,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mDl6H_Ct8DCMrQ59r",
+											"id": "mqNEm78Urfh0PHgZF",
 											"name": "Spoken",
 											"reference": "B24",
 											"notes": "Broken",
@@ -3032,7 +3693,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mhp1SU7RF52-p5faJ",
+											"id": "mnEH2MxFAh31EVxiL",
 											"name": "Spoken",
 											"reference": "B24",
 											"notes": "Accented",
@@ -3041,7 +3702,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mmV78HYHomMPNQPTj",
+											"id": "m0ynhfwvdcjgoZFCk",
 											"name": "Spoken",
 											"reference": "B24",
 											"notes": "Native",
@@ -3049,7 +3710,7 @@
 											"cost_type": "points"
 										},
 										{
-											"id": "maLkBLWEpteUD-MBa",
+											"id": "m1ufw3EMiK8nodk4R",
 											"name": "Written",
 											"reference": "B24",
 											"notes": "None",
@@ -3057,7 +3718,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mcNMPdrJvI4np_dVr",
+											"id": "m4TpNVHyRC7sP8KR3",
 											"name": "Written",
 											"reference": "B24",
 											"notes": "Broken",
@@ -3066,7 +3727,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mcDvBhsfWKOpnmR7z",
+											"id": "mg2ZqDEz-oWQO1xas",
 											"name": "Written",
 											"reference": "B24",
 											"notes": "Accented",
@@ -3075,7 +3736,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mklBRsZFp63K6ND8S",
+											"id": "mJCkI66RHNFO4O0EP",
 											"name": "Written",
 											"reference": "B24",
 											"notes": "Native",
@@ -3088,7 +3749,12 @@
 									}
 								},
 								{
-									"id": "t5x_MIjRouAiW20C0",
+									"id": "tefsELI8iX8Ggc1o0",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "toXBQ8q4Nek5lsLPF"
+									},
 									"name": "Cultural Familiarity (@Culture@)",
 									"reference": "B23",
 									"notes": "Do not suffer the normal -3 penalty for unfamiliarity",
@@ -3098,14 +3764,14 @@
 									],
 									"modifiers": [
 										{
-											"id": "mC0Y3i3-n57cbvp9r",
+											"id": "m4FHTwsg7mlp23Vkf",
 											"name": "Alien",
 											"cost": 1,
 											"cost_type": "points",
 											"disabled": true
 										},
 										{
-											"id": "mSC6m-7_5eFCNhSdX",
+											"id": "mLFcXqH_0DUBRmxI_",
 											"name": "Native",
 											"cost": -1,
 											"cost_type": "points",
@@ -3124,7 +3790,7 @@
 						}
 					],
 					"calc": {
-						"points": 388
+						"points": 398
 					}
 				},
 				{
@@ -3136,22 +3802,25 @@
 							"name": "-40 Points chosen from",
 							"children": [
 								{
-									"id": "TiNlkPG2P0J6vAWwF",
+									"id": "TGixTY8ubFQ0OPC7e",
 									"name": "Everyman Disadvantages",
 									"tags": [
 										"Disadvantage"
 									],
 									"children": [
 										{
-											"id": "tEVhPu94AoT4C5BIr",
-											"name": "Agoraphobia (Open Spaces)",
-											"reference": "B150",
-											"notes": "You are uncomfortable whenever you are outside, and actually become frightened when there are no walls within 50 feet.",
+											"id": "tYH2_rajLDBsYDvsS",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tX9XXLPFBvyQSpA4k"
+											},
+											"name": "Xenophilia",
+											"reference": "B162",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
-											"cr_adj": "action_penalty",
 											"cr": 12,
 											"base_points": -10,
 											"calc": {
@@ -3159,23 +3828,41 @@
 											}
 										},
 										{
-											"id": "tNHmWBQuVmUkRqCRG",
-											"name": "Chummy",
-											"reference": "B126",
+											"id": "tKYzrl5VabGBALcnt",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t8I0xw1Lj1_222aEN"
+											},
+											"name": "Workaholic",
+											"reference": "B162",
 											"tags": [
 												"Disadvantage",
-												"Mental"
+												"Physical"
+											],
+											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										},
+										{
+											"id": "tgCzfm4S0YQK5vYGz",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t7U0VbIzs6SqefwLr"
+											},
+											"name": "Social Stigma (Criminal Record)",
+											"reference": "B155",
+											"tags": [
+												"Disadvantage",
+												"Social"
 											],
 											"base_points": -5,
 											"features": [
 												{
 													"type": "reaction_bonus",
-													"situation": "to others",
-													"amount": 2
-												},
-												{
-													"type": "conditional_modifier",
-													"situation": "to IQ-based skills when alone",
+													"situation": "from non-criminals who learn of your Criminal Record. Police, judges, vigilantes, and other law-and-order types react at -2",
 													"amount": -1
 												}
 											],
@@ -3184,27 +3871,55 @@
 											}
 										},
 										{
-											"id": "tP6Cr7kBdl4APz8GZ",
-											"name": "Code of Honor (Mercanary's)",
-											"reference": "S221",
-											"notes": "A merc should look out for his buddies, take care of his gear, and fight for the honor of the unit. Obey the rule's of engagement. Don't poach on another unit's contract. Do the job you're hired for.",
+											"id": "t8vEItkvaD3XWlswW",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "thSMVzJ590v7gAD8d"
+											},
+											"name": "Pacifism: Self-Defense Only",
+											"reference": "B148",
+											"notes": "You only fight to defend yourself or those in your care, using only as much force as necessary (no pre-emptive strikes allowed!). You must do your best to discourage others from starting fights.",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
-											"base_points": -10,
+											"modifiers": [
+												{
+													"id": "mdMAfVB4aVfk8ygcW",
+													"name": "Species-Specific",
+													"reference": "UT32",
+													"cost": -80,
+													"disabled": true
+												}
+											],
+											"base_points": -15,
 											"calc": {
-												"points": -10
+												"points": -15
 											}
 										},
 										{
-											"id": "tTMMyccQ502iWz7ZE",
-											"name": "Code of Honor (Pirate's)",
-											"reference": "B127",
-											"notes": "Always avenge an insult, regardless of the danger; your buddy’s foe is your own; never attack a fellow crewman or buddy except in a fair, open duel.",
+											"id": "txSeij0AvKcvCOvo6",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tV_f_75HmwzWOPhuu"
+											},
+											"name": "Pacifism: Reluctant Killer",
+											"reference": "B148",
+											"notes": "You are psychologically unprepared to kill people. Whenever you make a deadly attack (e.g., with a knife or a gun) against an obvious person whose face is visible to you, you are at -4 to hit and may not Aim. If you cannot see the foe’s face (due to a mask, darkness, or distance, or because you attacked from behind), the penalty is only -2, save in close combat. You have no penalty to attack a vehicle (even an occupied one), an opponent you do not believe is a person (including things with Horrific or Monstrous appearance), or a target you can’t actually see (e.g., a set of map coordinates or a blip on a radar screen). If you kill a recognizable person, the effect on you is the same as for Pacifism: Cannot Kill. You have no problem with your allies killing; you may even supply ammo, loaded weapons, and encouragement! You just can’t do the killing yourself.",
 											"tags": [
 												"Disadvantage",
 												"Mental"
+											],
+											"modifiers": [
+												{
+													"id": "mQJllmuycYav_3anK",
+													"name": "Species-Specific",
+													"reference": "UT32",
+													"cost": -80,
+													"disabled": true
+												}
 											],
 											"base_points": -5,
 											"calc": {
@@ -3212,13 +3927,27 @@
 											}
 										},
 										{
-											"id": "tSr4zSY5vtzZyO7MW",
-											"name": "Code of Honor (Soldier's)",
-											"reference": "B127",
-											"notes": "An officer should be tough but fair, lead from the front, and look out for his men; an enlisted man should look out for his buddies and take care of his kit. Every soldier should be willing to fight and die for the honor of his unit, service, and country; follow orders; obey the “rules of war”; treat an honorable enemy with respect (a dishonorable enemy deserves a bullet); and wear the uniform with pride.",
+											"id": "ticvDTXkeFtKsqTku",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "th9TK1Jmqg8uKe6SC"
+											},
+											"name": "Pacifism: Cannot Harm Innocents",
+											"reference": "B148",
+											"notes": "You may fight – you may even start fights – but you may only use deadly force on a foe that is attempting to do you serious harm. Capture is not “serious harm” unless you are already under penalty of death or have a Code of Honor that would require suicide if captured. You never intentionally do anything that causes, or even threatens to cause, injury to the uninvolved – particularly if they are “ordinary folks.”",
 											"tags": [
 												"Disadvantage",
 												"Mental"
+											],
+											"modifiers": [
+												{
+													"id": "mwOp1PWeGIuS22y68",
+													"name": "Species-Specific",
+													"reference": "UT32",
+													"cost": -80,
+													"disabled": true
+												}
 											],
 											"base_points": -10,
 											"calc": {
@@ -3226,7 +3955,463 @@
 											}
 										},
 										{
-											"id": "tpluDmCXo1vbWLnEK",
+											"id": "txff_MSfvGEHSSImH",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tSiOKuvTJkqJhuRrI"
+											},
+											"name": "Lecherousness",
+											"reference": "B142",
+											"notes": "Make a self-control roll whenever you have more than the briefest contact with an appealing member of the sex you find attractive, at -5 if this person is Handsome/Beautiful, or at -10 if Very Handsome/Very Beautiful. If you fail, you must make a “pass” using whatever wiles and skills you can bring to bear.",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"cr": 12,
+											"base_points": -15,
+											"calc": {
+												"points": -15
+											}
+										},
+										{
+											"id": "tONDCkx_HJ-GZezN_",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "ttHkLI9zwzfeOIEZc"
+											},
+											"name": "Intolerance (@Class, Ethnicity, Nationality, Religion, Sex, or Species@)",
+											"reference": "B140",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"replacements": {
+												"Class, Ethnicity, Nationality, Religion, Sex, or Species": "Rival civilization or species"
+											},
+											"modifiers": [
+												{
+													"id": "ml6hk766Wk2SILqZ1",
+													"name": "Scope: Common",
+													"reference": "B140",
+													"cost": -5,
+													"cost_type": "points"
+												},
+												{
+													"id": "m7aTfPeV6vrpADsXs",
+													"name": "Scope: Occasional",
+													"reference": "B140",
+													"cost": -2,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mNABn_mgWZWKs4ZQH",
+													"name": "Scope: Rare",
+													"reference": "B140",
+													"cost": -1,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mPkt2IlhBrHarjbsm",
+													"name": "Scope: Anyone unlike you",
+													"reference": "B140",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												}
+											],
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from victims of your intolerance (may be as much as -5, at GM's discretion)",
+													"amount": -1
+												}
+											],
+											"calc": {
+												"points": -5
+											}
+										},
+										{
+											"id": "tx4EHM5RXXszbrT4A",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t7pCgXTVkswkTjOZO"
+											},
+											"name": "Honesty",
+											"reference": "B138",
+											"notes": "Make a self-control roll when faced with the “need” to break unreasonable laws; if you fail, you must obey the law, whatever the consequences. If you manage to resist your urges and break the law, make a second self-control roll afterward. If you fail, you must turn yourself in to the authorities!",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"cr": 12,
+											"base_points": -10,
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "tmoDWYu_Pwk4CoGeA",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t5bwP6TnS4cX-zM8L"
+											},
+											"name": "Enemy (@Who@)",
+											"reference": "B135",
+											"tags": [
+												"Disadvantage",
+												"Social"
+											],
+											"modifiers": [
+												{
+													"id": "mikrpc-AFafnkNv4-",
+													"name": "Weak Individual",
+													"reference": "B135",
+													"notes": "50% of your starting points",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mL2EWdzoQbWlE8qLM",
+													"name": "Equal Individual",
+													"reference": "B135",
+													"notes": "100% of your starting points",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mH2jPI6wlcL3LrYrQ",
+													"name": "Powerful Individual",
+													"reference": "B135",
+													"notes": "\u003e150% of your starting points",
+													"cost": -20,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mWIibWBZ9-hPeCIQ9",
+													"name": "Weak Group",
+													"reference": "B135",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "muCvnbpzrOVzJaGEn",
+													"name": "Medium Group",
+													"reference": "B135",
+													"cost": -20,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mXuFxrvQTqobojYL-",
+													"name": "Appears almost all the time",
+													"reference": "B36",
+													"notes": "15-",
+													"cost": 3,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mKR7bdYEh8WiPS0N-",
+													"name": "Appears quite often",
+													"reference": "B36",
+													"notes": "12-",
+													"cost": 2,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mpOTYOBZep1QUVuUE",
+													"name": "Appears fairly often",
+													"reference": "B36",
+													"notes": "9-",
+													"cost": 1,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mhLB0PS6Q1h4JXF90",
+													"name": "Appears quite rarely",
+													"reference": "B36",
+													"notes": "6-",
+													"cost": 0.5,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "m_kG02bpjoOYSoToC",
+													"name": "Large/Powerful Group",
+													"reference": "B135",
+													"cost": -30,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mw57usD0y4P3Km60D",
+													"name": "Utterly Formidable Group",
+													"reference": "B135",
+													"cost": -40,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mBBZTLhILX-zpphTg",
+													"name": "Unknown",
+													"reference": "B135",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mle84PmyOZW7gPGs_",
+													"name": "Evil Twin",
+													"reference": "B135",
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mo7MHAhy53B2MjvNP",
+													"name": "Evil Twin",
+													"reference": "B135",
+													"notes": "More skilled or extra abilities",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m9ScxPTjsp3FAUbEQ",
+													"name": "Evil Twin",
+													"reference": "B135",
+													"notes": "More skilled and extra abilities",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mImT8pYo0S3L3pR9X",
+													"name": "Watcher",
+													"reference": "B135",
+													"cost": 0.25,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mbi49nLVu-1IxgMw7",
+													"name": "Rival",
+													"reference": "B135",
+													"cost": 0.5,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mpe7n4UyI9jZLrbHZ",
+													"name": "Hunter",
+													"reference": "B135",
+													"cost": 1,
+													"cost_type": "multiplier",
+													"disabled": true
+												}
+											],
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "tcNKvYgxFvlECXRve",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t1HUGl4o498iCyvrw"
+											},
+											"name": "Duty (@Duty@)",
+											"reference": "B133",
+											"tags": [
+												"Disadvantage",
+												"Social"
+											],
+											"replacements": {
+												"Duty": "To ship's owner or provider"
+											},
+											"modifiers": [
+												{
+													"id": "mc9mGZZVtdh0g7njd",
+													"name": "FR: 6",
+													"cost": -2,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mr9S5yJf1Fu-sKFYb",
+													"name": "FR: 9",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m5GvCLy7syqbfa8Nn",
+													"name": "FR: 12",
+													"cost": -10,
+													"cost_type": "points"
+												},
+												{
+													"id": "m60nXQerxHS24X6NG",
+													"name": "FR: 15",
+													"cost": -15,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m2wij18PGDuI3xXMe",
+													"name": "Extremely Hazardous",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mLqbHOsiO__7C6ssa",
+													"name": "Involuntary",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mIXO1YTXrVoINgmjK",
+													"name": "Nonhazardous",
+													"cost": 5,
+													"cost_type": "points",
+													"disabled": true
+												}
+											],
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "t8QcPMwkZS9m6Ul7U",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t1HUGl4o498iCyvrw"
+											},
+											"name": "Duty (@Duty@)",
+											"reference": "B133",
+											"tags": [
+												"Disadvantage",
+												"Social"
+											],
+											"replacements": {
+												"Duty": "To ship's owner or provider"
+											},
+											"modifiers": [
+												{
+													"id": "mYrzme30Tt4-3CVFA",
+													"name": "FR: 6",
+													"cost": -2,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mJ7mHQLS3_dmc95DX",
+													"name": "FR: 9",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mN82km31YHsiz1tYb",
+													"name": "FR: 12",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mxIgbTMShSXiqFJ_e",
+													"name": "FR: 15",
+													"cost": -15,
+													"cost_type": "points"
+												},
+												{
+													"id": "mE2DDSTzM1Gf1euPQ",
+													"name": "Extremely Hazardous",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mjZEPO1RfldEZVU8o",
+													"name": "Involuntary",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mbKZQuffEe8Hmypuh",
+													"name": "Nonhazardous",
+													"cost": 5,
+													"cost_type": "points",
+													"disabled": true
+												}
+											],
+											"calc": {
+												"points": -15
+											}
+										},
+										{
+											"id": "tqa8yZboKb0a_ArtC",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tXFf9MSQ3FMT2psO8"
+											},
+											"name": "Demophobia (Crowds)",
+											"reference": "B149",
+											"notes": "Any group of over a dozen people sets off this fear unless they are all well known to you. The self-control roll is at -1 for over 25 people, -2 for a crowd of 100 or more, -3 for 1,000, -4 for 10,000, and so on.",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"cr_adj": "action_penalty",
+											"cr": 12,
+											"base_points": -15,
+											"calc": {
+												"points": -15
+											}
+										},
+										{
+											"id": "t3oUUTo7GeFTvsrEn",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tK4QdVZYxGAd4cqr_"
+											},
+											"name": "Compulsive Gambling",
+											"reference": "B128",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"cr": 12,
+											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										},
+										{
+											"id": "t5vnFyb9Pdvzp3muP",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tapWLsuN75Unedmwn"
+											},
 											"name": "Compulsive Carousing",
 											"reference": "B128",
 											"tags": [
@@ -3252,519 +4437,137 @@
 											}
 										},
 										{
-											"id": "tLkePEJP3BlCQqhdj",
-											"name": "Compulsive Gambling",
-											"reference": "B128",
+											"id": "tAFXB_wEmlJ_aOVty",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "txSrmgLB0M36uR802"
+											},
+											"name": "Code of Honor (Soldier's)",
+											"reference": "B127",
+											"notes": "An officer should be tough but fair, lead from the front, and look out for his men; an enlisted man should look out for his buddies and take care of his kit. Every soldier should be willing to fight and die for the honor of his unit, service, and country; follow orders; obey the “rules of war”; treat an honorable enemy with respect (a dishonorable enemy deserves a bullet); and wear the uniform with pride.",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
-											"cr": 12,
+											"base_points": -10,
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "t6rN_DjeTmUrM7opn",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Space/Space Traits.adq",
+												"id": "teNSsqOsjstajwmxn"
+											},
+											"name": "Code of Honor (Mercenary's Code)",
+											"reference": "B127, S221",
+											"notes": "A merc should look out for his buddies, take care of his gear, and fight for the honor of the unit. Obey the rules of engagement. Don’t poach on another unit’s contract. Do the job you’re hired for.",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"base_points": -10,
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "tejHQshL-3tt_xihD",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tqq24I9NJrLajsURv"
+											},
+											"name": "Code of Honor (Pirate's)",
+											"reference": "B127",
+											"notes": "Always avenge an insult, regardless of the danger; your buddy’s foe is your own; never attack a fellow crewman or buddy except in a fair, open duel.",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
 											"base_points": -5,
 											"calc": {
 												"points": -5
 											}
 										},
 										{
-											"id": "tnKSxF1qYE7AW63iA",
-											"name": "Demophobia (Crowds)",
-											"reference": "B149",
-											"notes": "Any group of over a dozen people sets off this fear unless they are all well known to you. The self-control roll is at -1 for over 25 people, -2 for a crowd of 100 or more, -3 for 1,000, -4 for 10,000, and so on.",
+											"id": "tmN5UhcAtw3Nvtq0A",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t4KGpV0KBExr-fEb2"
+											},
+											"name": "Gregarious",
+											"reference": "B126",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"base_points": -10,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "to others",
+													"amount": 4
+												},
+												{
+													"type": "conditional_modifier",
+													"situation": "to IQ-based skills when alone, or only -1 if in a group of 4 or less",
+													"amount": -2
+												}
+											],
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "t07FT2sFTihENV5gK",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tzBDG0xUlT_dh7FuY"
+											},
+											"name": "Chummy",
+											"reference": "B126",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"base_points": -5,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "to others",
+													"amount": 2
+												},
+												{
+													"type": "conditional_modifier",
+													"situation": "to IQ-based skills when alone",
+													"amount": -1
+												}
+											],
+											"calc": {
+												"points": -5
+											}
+										},
+										{
+											"id": "tlBEJmvVaWoHZUTFH",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "taFPI7E0PJwXbS5nL"
+											},
+											"name": "Agoraphobia (Open Spaces)",
+											"reference": "B150",
+											"notes": "You are uncomfortable whenever you are outside, and actually become frightened when there are no walls within 50 feet.",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
 											"cr_adj": "action_penalty",
-											"cr": 12,
-											"base_points": -15,
-											"calc": {
-												"points": -15
-											}
-										},
-										{
-											"id": "tBhuSIlyA1LVHt9yE",
-											"name": "Duty (To ship's owner or provider)",
-											"reference": "B133",
-											"tags": [
-												"Disadvantage",
-												"Social"
-											],
-											"modifiers": [
-												{
-													"id": "mn_9IzKwvGfmvEjN4",
-													"name": "FR: 6",
-													"cost": -2,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mWHBAN0nsHrWBGL-L",
-													"name": "FR: 9",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "muvfNl9vPu3qUGLWk",
-													"name": "FR: 12",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "miUqc94XnVvztcOur",
-													"name": "FR: 15",
-													"cost": -15,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mYliKOTQpEAm9fT35",
-													"name": "Extremely Hazardous",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mUJEQV7Ufc1Q4cQzO",
-													"name": "Involuntary",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "my5w85yj8_P44aATO",
-													"name": "Nonhazardous",
-													"cost": 5,
-													"cost_type": "points",
-													"disabled": true
-												}
-											],
-											"calc": {
-												"points": 0
-											}
-										},
-										{
-											"id": "t-VaaOhv4-Osg4SbF",
-											"name": "Duty (To ship's owner or provider)",
-											"reference": "B133",
-											"tags": [
-												"Disadvantage",
-												"Social"
-											],
-											"modifiers": [
-												{
-													"id": "mlTfdW77Ic1e3ajee",
-													"name": "FR: 6",
-													"cost": -2,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mRw_JwSDF8wmAqK-t",
-													"name": "FR: 9",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mmtDP5FkDRFhUIP9G",
-													"name": "FR: 12",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mfrLMW1ZE4iz-bT2y",
-													"name": "FR: 15",
-													"cost": -15,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mb0O-zCRFTV9vWLQ1",
-													"name": "Extremely Hazardous",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mgIMj3E2kHML24ieX",
-													"name": "Involuntary",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m-LFv89cSOG3Auz0-",
-													"name": "Nonhazardous",
-													"cost": 5,
-													"cost_type": "points",
-													"disabled": true
-												}
-											],
-											"calc": {
-												"points": 0
-											}
-										},
-										{
-											"id": "t0zjk9opljd_rApQ8",
-											"name": "Enemy (@Who@)",
-											"reference": "B135",
-											"tags": [
-												"Disadvantage",
-												"Social"
-											],
-											"modifiers": [
-												{
-													"id": "m17o_YDkXsbJ2gjbu",
-													"name": "Weak Individual",
-													"reference": "B135",
-													"notes": "50% of your starting points",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mjip0pcQe7cLUOZla",
-													"name": "Equal Individual",
-													"reference": "B135",
-													"notes": "100% of your starting points",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mWfPnyJ5q_3n3MTRq",
-													"name": "Powerful Individual",
-													"reference": "B135",
-													"notes": "\u003e150% of your starting points",
-													"cost": -20,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "maMNn1-IY66TOcHfD",
-													"name": "Weak Group",
-													"reference": "B135",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mtX5mwU6l4zi1KC41",
-													"name": "Medium Group",
-													"reference": "B135",
-													"cost": -20,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mFIMZpo1MbITTKFbq",
-													"name": "Appears almost all the time",
-													"reference": "B36",
-													"notes": "15-",
-													"cost": 3,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mpOIKVRu0ZtI4ckt8",
-													"name": "Appears quite often",
-													"reference": "B36",
-													"notes": "12-",
-													"cost": 2,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mlXYczN0OzNaw6oRP",
-													"name": "Appears fairly often",
-													"reference": "B36",
-													"notes": "9-",
-													"cost": 1,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mfcv4kSjPk_Q2VVzb",
-													"name": "Appears quite rarely",
-													"reference": "B36",
-													"notes": "6-",
-													"cost": 0.5,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "m1cmFLcd2QNcyu6Wj",
-													"name": "Large/Powerful Group",
-													"reference": "B135",
-													"cost": -30,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "miRt627JMm2vGrr3n",
-													"name": "Utterly Formidable Group",
-													"reference": "B135",
-													"cost": -40,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mU6iYXgv8d5hol0kB",
-													"name": "Unknown",
-													"reference": "B135",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m3YnWOVPMLz9ooton",
-													"name": "Evil Twin",
-													"reference": "B135",
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mOkig6-WawxkGE3GZ",
-													"name": "Evil Twin",
-													"reference": "B135",
-													"notes": "More skilled or extra abilities",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mv3LgTD_ayJdfv5Sw",
-													"name": "Evil Twin",
-													"reference": "B135",
-													"notes": "More skilled and extra abilities",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mae6rv9pvTREz_A5g",
-													"name": "Watcher",
-													"reference": "B135",
-													"cost": 0.25,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "moVqyUqKVDB2ri7eP",
-													"name": "Rival",
-													"reference": "B135",
-													"cost": 0.5,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mn68peptkD_CLWXTg",
-													"name": "Hunter",
-													"reference": "B135",
-													"cost": 1,
-													"cost_type": "multiplier",
-													"disabled": true
-												}
-											],
-											"calc": {
-												"points": 0
-											}
-										},
-										{
-											"id": "tSd71zW59gGcJi6M3",
-											"name": "Honesty",
-											"reference": "B138",
-											"notes": "Make a self-control roll when faced with the “need” to break unreasonable laws; if you fail, you must obey the law, whatever the consequences. If you manage to resist your urges and break the law, make a second self-control roll afterward. If you fail, you must turn yourself in to the authorities!",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"cr": 12,
-											"base_points": -10,
-											"calc": {
-												"points": -10
-											}
-										},
-										{
-											"id": "tBz2J9hhS0FdpVc54",
-											"name": "Intolerance (@Rival civilization or species@)",
-											"reference": "B140",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"modifiers": [
-												{
-													"id": "m69xnBhukJUdN7glF",
-													"name": "Scope: Common",
-													"reference": "B140",
-													"cost": -5,
-													"cost_type": "points"
-												},
-												{
-													"id": "mImnzBiMuOPhX52Ft",
-													"name": "Scope: Occasional",
-													"reference": "B140",
-													"cost": -2,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m_-MsOfK9DCQE9dad",
-													"name": "Scope: Rare",
-													"reference": "B140",
-													"cost": -1,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mYX4XEIdhpFovuBxb",
-													"name": "Scope: Anyone unlike you",
-													"reference": "B140",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												}
-											],
-											"features": [
-												{
-													"type": "reaction_bonus",
-													"situation": "from victims of your intolerance (may be as much as -5, at GM's discretion)",
-													"amount": -1
-												}
-											],
-											"calc": {
-												"points": -5
-											}
-										},
-										{
-											"id": "tcsZL8Rev_09HBUAz",
-											"name": "Lecherousness",
-											"reference": "B142",
-											"notes": "Make a self-control roll whenever you have more than the briefest contact with an appealing member of the sex you find attractive, at -5 if this person is Handsome/Beautiful, or at -10 if Very Handsome/Very Beautiful. If you fail, you must make a “pass” using whatever wiles and skills you can bring to bear.",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"cr": 12,
-											"base_points": -15,
-											"calc": {
-												"points": -15
-											}
-										},
-										{
-											"id": "toND4ViVd-ezpdDxY",
-											"name": "Pacifism: Cannot Harm Innocents",
-											"reference": "B148",
-											"notes": "You may fight – you may even start fights – but you may only use deadly force on a foe that is attempting to do you serious harm. Capture is not “serious harm” unless you are already under penalty of death or have a Code of Honor that would require suicide if captured. You never intentionally do anything that causes, or even threatens to cause, injury to the uninvolved – particularly if they are “ordinary folks.”",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"modifiers": [
-												{
-													"id": "mA4VYDhRg654_so4D",
-													"name": "Species-Specific",
-													"reference": "UT32",
-													"cost": -80,
-													"disabled": true
-												}
-											],
-											"base_points": -10,
-											"calc": {
-												"points": -10
-											}
-										},
-										{
-											"id": "tpQIaHAuWSNLr4d2Z",
-											"name": "Pacifism: Reluctant Killer",
-											"reference": "B148",
-											"notes": "You are psychologically unprepared to kill people. Whenever you make a deadly attack (e.g., with a knife or a gun) against an obvious person whose face is visible to you, you are at -4 to hit and may not Aim. If you cannot see the foe’s face (due to a mask, darkness, or distance, or because you attacked from behind), the penalty is only -2, save in close combat. You have no penalty to attack a vehicle (even an occupied one), an opponent you do not believe is a person (including things with Horrific or Monstrous appearance), or a target you can’t actually see (e.g., a set of map coordinates or a blip on a radar screen). If you kill a recognizable person, the effect on you is the same as for Pacifism: Cannot Kill. You have no problem with your allies killing; you may even supply ammo, loaded weapons, and encouragement! You just can’t do the killing yourself.",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"modifiers": [
-												{
-													"id": "mZNxEZjd9WS9TsWQu",
-													"name": "Species-Specific",
-													"reference": "UT32",
-													"cost": -80,
-													"disabled": true
-												}
-											],
-											"base_points": -5,
-											"calc": {
-												"points": -5
-											}
-										},
-										{
-											"id": "tVzta4I2lLqmd33qT",
-											"name": "Pacifism: Self-Defense Only",
-											"reference": "B148",
-											"notes": "You only fight to defend yourself or those in your care, using only as much force as necessary (no pre-emptive strikes allowed!). You must do your best to discourage others from starting fights.",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"modifiers": [
-												{
-													"id": "mEUl7_7JERVV-R0zy",
-													"name": "Species-Specific",
-													"reference": "UT32",
-													"cost": -80,
-													"disabled": true
-												}
-											],
-											"base_points": -15,
-											"calc": {
-												"points": -15
-											}
-										},
-										{
-											"id": "tonLsXY2RKRd4SI_S",
-											"name": "Social Stigma (Criminal Record)",
-											"reference": "B155",
-											"tags": [
-												"Disadvantage",
-												"Social"
-											],
-											"base_points": -5,
-											"features": [
-												{
-													"type": "reaction_bonus",
-													"situation": "from non-criminals who learn of your Criminal Record. Police, judges, vigilantes, and other law-and-order types react at -2",
-													"amount": -1
-												}
-											],
-											"calc": {
-												"points": -5
-											}
-										},
-										{
-											"id": "tSOMREjR7dXCz39rz",
-											"name": "Workaholic",
-											"reference": "B162",
-											"tags": [
-												"Disadvantage",
-												"Physical"
-											],
-											"base_points": -5,
-											"calc": {
-												"points": -5
-											}
-										},
-										{
-											"id": "tVSM7AjBhFL4-vMEE",
-											"name": "Xenophilia",
-											"reference": "B162",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
 											"cr": 12,
 											"base_points": -10,
 											"calc": {
@@ -3773,11 +4576,16 @@
 										}
 									],
 									"calc": {
-										"points": -145
+										"points": -180
 									}
 								},
 								{
-									"id": "t0V7RGtqIqwdOpFq7",
+									"id": "t_vPe8x0c5ROnVtrs",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tYHaB3nA17KP6h1DZ"
+									},
 									"name": "Gluttony",
 									"reference": "B137",
 									"notes": "Make a self-control roll when presented with a tempting morsel or good wine that, for some reason, you should resist. If you fail, you partake – regardless of the consequences.",
@@ -3792,7 +4600,12 @@
 									}
 								},
 								{
-									"id": "tLwi60URAlvNDxhiM",
+									"id": "ttJR8f2kseHejonZD",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tvF5dIQf3Jrwb_KXv"
+									},
 									"name": "Greed",
 									"reference": "B137",
 									"notes": "Make a self-control roll any time riches are offered – as payment for fair work, gains from adventure, spoils of crime, or just bait. If you fail, you do whatever it takes to get the payoff.",
@@ -3807,7 +4620,12 @@
 									}
 								},
 								{
-									"id": "tU6PsUb8ebq-Jj0wP",
+									"id": "t7GDptCSe2MeY8MiS",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tG1q2hcai2DaeRlhm"
+									},
 									"name": "Kleptomania",
 									"reference": "B141",
 									"notes": "Make a self-control roll whenever you are presented with a chance to steal, at up to -3 if the item is especially interesting to you (not necessarily valuable, unless you are poor or have Greed). If you fail, you must try to steal it. You may keep or sell stolen items, but you may not return or discard them.",
@@ -3822,7 +4640,12 @@
 									}
 								},
 								{
-									"id": "t0DtCGnptpImpMcu2",
+									"id": "tRyUitPdTKcMshZEn",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tj2zJQBTiP1QtLdMy"
+									},
 									"name": "Miserliness",
 									"reference": "B144",
 									"notes": "Make a self-control roll any time you are called on to spend money. If the expenditure is large, this roll may be at -5 or worse (GM’s decision). If you fail, you refuse to spend the money.",
@@ -3837,7 +4660,12 @@
 									}
 								},
 								{
-									"id": "tYsJyEIsnL3cfmBx9",
+									"id": "tJWzrP2xeYKA81824",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tYggvuZw_KmnKdpZ0"
+									},
 									"name": "Mysophobia (Dirt)",
 									"reference": "B149",
 									"notes": "You are deathly afraid of infection, or just of dirt and filth. Make a self-control roll when you must do something that might get you dirty. Roll at -5 to eat any unaccustomed food. You should act as “finicky” as possible.",
@@ -3853,7 +4681,12 @@
 									}
 								},
 								{
-									"id": "tQOqiHuvSbZVDsDP4",
+									"id": "tLK9lIuZrSt0wU76o",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tcLpFfSmbHHdHy5Yd"
+									},
 									"name": "Post-Combat Shakes",
 									"reference": "B150",
 									"notes": "Make a self-control roll at the end of any battle. If you fail, roll 3d, add the amount by which you failed your self-control roll, and look up the result on the Fright Check Table.",
@@ -3868,7 +4701,12 @@
 									}
 								},
 								{
-									"id": "tKDBWFsazY_Ki5-27",
+									"id": "tijqlBrO89XxoXZUN",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tw81RysAzky-yjNYN"
+									},
 									"name": "Selfless",
 									"reference": "B153",
 									"notes": "You must make a self-control roll to put your needs – even survival – before those of someone else.",
@@ -3883,7 +4721,12 @@
 									}
 								},
 								{
-									"id": "tbANk06EAqgxLS2pr",
+									"id": "t3jiae4b7laciSPKa",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t13yTTSBQSX7LOZsh"
+									},
 									"name": "Overweight",
 									"reference": "B19",
 									"tags": [
@@ -3930,7 +4773,12 @@
 									}
 								},
 								{
-									"id": "tt3Vc9Sx8g-uNAhAG",
+									"id": "tt7CUhAIMDNNfYzIv",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t9AQLL8Dg1-8M1swK"
+									},
 									"name": "Fat",
 									"reference": "B19",
 									"tags": [
@@ -3992,7 +4840,12 @@
 									}
 								},
 								{
-									"id": "tzyGBe5zSFJd_OUeS",
+									"id": "tjLUd0Mj8w_AxoekL",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "taOx80jhwjy_A0peM"
+									},
 									"name": "Very Fat",
 									"reference": "B19",
 									"tags": [
@@ -4055,17 +4908,17 @@
 								}
 							],
 							"calc": {
-								"points": -219
+								"points": -254
 							}
 						}
 					],
 					"calc": {
-						"points": -219
+						"points": -254
 					}
 				}
 			],
 			"calc": {
-				"points": 239
+				"points": 214
 			}
 		},
 		{
@@ -4077,7 +4930,12 @@
 					"name": "Multi-Role",
 					"children": [
 						{
-							"id": "tT-rsJlcLI8lrk2uw",
+							"id": "t01rdXJNuQjxhhUw4",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t1w1RFcFceKR2T9_e"
+							},
 							"name": "Increased Intelligence",
 							"reference": "B15",
 							"tags": [
@@ -4101,7 +4959,12 @@
 							}
 						},
 						{
-							"id": "tZczgeG-ljV8UP0ZV",
+							"id": "tCjqwq23hoGDlweHN",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "t47ychA98bECqxqRM"
+							},
 							"name": "Talent (Smooth Operator)",
 							"reference": "PU3:15",
 							"tags": [
@@ -4111,12 +4974,45 @@
 							],
 							"modifiers": [
 								{
-									"id": "mv0RFfV0WtDQsbbel",
+									"id": "mwM3EwDG3mHgYHctO",
 									"name": "Alternative Cost",
 									"cost": -2,
 									"cost_type": "points",
 									"affects": "levels_only",
 									"disabled": true
+								},
+								{
+									"id": "M5I_NZfQq3vMVbuUF",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "mhS5ni9QEB6zbQTCs",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From con artists, politicians, salesmen, etc. – but only if you aren’t trying to manipulate them.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "m0ultbnM_2CPpIiHS",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Bonus to resist covered skills",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
 								}
 							],
 							"points_per_level": 15,
@@ -4284,18 +5180,6 @@
 									"name": {
 										"compare": "is"
 									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "reaction_bonus",
-									"situation": "From con artists, politicians, salesmen, etc. – but only if you aren’t trying to manipulate them.",
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "conditional_modifier",
-									"situation": "Bonus to resist covered skills",
 									"amount": 1,
 									"per_level": true
 								}
@@ -4316,7 +5200,12 @@
 					"name": "Legendary",
 					"children": [
 						{
-							"id": "tsvYtkIICKmCGiJoG",
+							"id": "tUlbhfTmryp17UjC6",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t1w1RFcFceKR2T9_e"
+							},
 							"name": "Increased Intelligence",
 							"reference": "B15",
 							"tags": [
@@ -4340,7 +5229,12 @@
 							}
 						},
 						{
-							"id": "tGpUxls7OlDyEBrRZ",
+							"id": "tyMCa1Zto0tjPj1K_",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "t47ychA98bECqxqRM"
+							},
 							"name": "Talent (Smooth Operator)",
 							"reference": "PU3:15",
 							"tags": [
@@ -4350,12 +5244,45 @@
 							],
 							"modifiers": [
 								{
-									"id": "mA2S7WTJGMpt3dTJv",
+									"id": "m2dcv0W1jmXwe1EdP",
 									"name": "Alternative Cost",
 									"cost": -2,
 									"cost_type": "points",
 									"affects": "levels_only",
 									"disabled": true
+								},
+								{
+									"id": "MoR-1g1CCDh4fE398",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "mMhSHpVBumW3HPQ1B",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From con artists, politicians, salesmen, etc. – but only if you aren’t trying to manipulate them.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "mtuM7QBUC4_OuO3v4",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Bonus to resist covered skills",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
 								}
 							],
 							"points_per_level": 15,
@@ -4523,18 +5450,6 @@
 									"name": {
 										"compare": "is"
 									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "reaction_bonus",
-									"situation": "From con artists, politicians, salesmen, etc. – but only if you aren’t trying to manipulate them.",
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "conditional_modifier",
-									"situation": "Bonus to resist covered skills",
 									"amount": 1,
 									"per_level": true
 								}
@@ -4567,7 +5482,12 @@
 					"name": "Primary Skills",
 					"children": [
 						{
-							"id": "s1VjB64mzxlVJHfxX",
+							"id": "sBoHiVLnA1ZSM07hV",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "s8j6tcaNxXkF89Xbt"
+							},
 							"name": "Diplomacy",
 							"reference": "B187",
 							"tags": [
@@ -4590,7 +5510,12 @@
 							"points": 4
 						},
 						{
-							"id": "sLaa6-vLdV4TRrcIE",
+							"id": "sTOZxq3_Q1FbBHn52",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "shHyf3H441PtZMBlJ"
+							},
 							"name": "Merchant",
 							"reference": "B209",
 							"tags": [
@@ -4617,7 +5542,12 @@
 							"points": 8
 						},
 						{
-							"id": "snXUtK62AITcaYWiQ",
+							"id": "s-5876ja3jTwwOhTt",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "s8sGblB3JWt6f_2hf"
+							},
 							"name": "Savoir-Faire",
 							"reference": "B218,MA59",
 							"tags": [
@@ -4646,7 +5576,12 @@
 							"name": "Three of",
 							"children": [
 								{
-									"id": "sA_fIk6NZdD2KprSG",
+									"id": "sdu1cS3-4V-DjnMsr",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sQ7hn7pW3tIPfsU8Z"
+									},
 									"name": "Acting",
 									"reference": "B174",
 									"tags": [
@@ -4673,7 +5608,12 @@
 									"points": 2
 								},
 								{
-									"id": "s2Kt6wdS97kR5O7u2",
+									"id": "sUHl-2c5p4ioXfks0",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "s7zUqAO5PEC5JKk_W"
+									},
 									"name": "Fast-Talk",
 									"reference": "B195",
 									"tags": [
@@ -4697,7 +5637,12 @@
 									"points": 2
 								},
 								{
-									"id": "sTTQoIhQjB8-M7RLN",
+									"id": "s4ffpQBJeL7PrAazU",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sSxGnNPMXyZpZKoFZ"
+									},
 									"name": "Leadership",
 									"reference": "B204",
 									"tags": [
@@ -4714,7 +5659,12 @@
 									"points": 2
 								},
 								{
-									"id": "seJIP6w3znNaBMtL_",
+									"id": "sQSpUOH8TV52KKf30",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "spGG-fpOy0g88rFDO"
+									},
 									"name": "Public Speaking",
 									"reference": "B216",
 									"tags": [
@@ -4747,7 +5697,12 @@
 									"points": 2
 								},
 								{
-									"id": "sd-_151BejPsReCwp",
+									"id": "siks1yZjLxw8yUvCb",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "smTUpMWJGqPeT1KER"
+									},
 									"name": "Streetwise",
 									"reference": "B223",
 									"tags": [
@@ -4766,7 +5721,12 @@
 									"points": 2
 								},
 								{
-									"id": "skRnDWdRx7zE7j-gF",
+									"id": "sh5QMCf8VcKvSuzFp",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "si-upI7A5RgdO0cjC"
+									},
 									"name": "Carousing",
 									"reference": "B183",
 									"tags": [
@@ -4784,7 +5744,12 @@
 									"points": 2
 								},
 								{
-									"id": "sjqWG2ORbG6ZNS0mL",
+									"id": "s9Vwm_2J3u3U4kX4q",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sLAU6vDBL4XaQNS0z"
+									},
 									"name": "Sex Appeal",
 									"reference": "B219",
 									"tags": [
@@ -4808,7 +5773,12 @@
 					"name": "Secondary Skills",
 					"children": [
 						{
-							"id": "s62jT0wJM-p2Krbth",
+							"id": "s5MYrIZl6iN4WcnX5",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "s9mV--3lpIfXO7N6Z"
+							},
 							"name": "First Aid",
 							"reference": "B195",
 							"tags": [
@@ -4839,7 +5809,12 @@
 							"points": 1
 						},
 						{
-							"id": "snK4hygIz45nqITrE",
+							"id": "s8RiKRm3M3FVCCT-T",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sfZrwMVUibhbtdssl"
+							},
 							"name": "Housekeeping",
 							"reference": "B200",
 							"tags": [
@@ -4855,7 +5830,12 @@
 							"points": 1
 						},
 						{
-							"id": "sRezaflN49Jd4Bgtw",
+							"id": "s78KJY6ohPTgqbo4D",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sn-AqOk3ggCs7fqIQ"
+							},
 							"name": "Administration",
 							"reference": "B174",
 							"tags": [
@@ -4877,7 +5857,12 @@
 							"points": 1
 						},
 						{
-							"id": "scCvt-gylWZk0n02k",
+							"id": "szZkyDDuRr_zq-ROR",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sVspKJvpEaYNHFmRo"
+							},
 							"name": "Freight Handling",
 							"reference": "B197",
 							"tags": [
@@ -4895,7 +5880,12 @@
 							"points": 1
 						},
 						{
-							"id": "sbDPpMRZ8ZF9j-frM",
+							"id": "s_3a_18wq7RsUStoO",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "s67Roch7cMOY4VSj-"
+							},
 							"name": "Accounting",
 							"reference": "B174",
 							"tags": [
@@ -4927,7 +5917,12 @@
 							"points": 2
 						},
 						{
-							"id": "s4X3264YCW4-miexc",
+							"id": "sHggF0Fq3NldJ6x1_",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sQ2Nj_TqMYKV7skUF"
+							},
 							"name": "Scrounging",
 							"reference": "B218",
 							"tags": [
@@ -4948,7 +5943,12 @@
 							"name": "Four of",
 							"children": [
 								{
-									"id": "sUg_zQeLSkpwNsizN",
+									"id": "smmC7RAoKJn8C-Q6I",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "s2SdStcV1J3cLdM7e"
+									},
 									"name": "Connoisseur",
 									"reference": "B185,MA56",
 									"tags": [
@@ -4968,7 +5968,12 @@
 									"points": 1
 								},
 								{
-									"id": "sBcqh6hoq5kfJloZo",
+									"id": "sHj-jdq9H2Rc0ochj",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sxglmNWmcsR5YcSDw"
+									},
 									"name": "Cooking",
 									"reference": "B185",
 									"tags": [
@@ -4989,13 +5994,18 @@
 									"points": 1
 								},
 								{
-									"id": "s810NBJWNyboyjJJP",
+									"id": "sqfxQMt0Wrz6ltpul",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "swXuff1DBhSQbTqy1"
+									},
 									"name": "Electronics Operation",
 									"reference": "B189",
 									"tags": [
 										"Technical"
 									],
-									"specialization": "@Comm or Media@",
+									"specialization": "Communications",
 									"difficulty": "iq/a",
 									"defaults": [
 										{
@@ -5024,14 +6034,64 @@
 									"points": 1
 								},
 								{
-									"id": "sBRCk4cTte4ewdyOy",
+									"id": "sVcewsjW2xVvh1IPS",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sLDuQRGJ4yzEXiQ0G"
+									},
+									"name": "Electronics Operation",
+									"reference": "B189",
+									"tags": [
+										"Arts",
+										"Entertainment",
+										"Technical"
+									],
+									"specialization": "Media",
+									"difficulty": "iq/a",
+									"defaults": [
+										{
+											"type": "iq",
+											"modifier": -5
+										},
+										{
+											"type": "skill",
+											"name": "Electronics Repair",
+											"specialization": "Media",
+											"modifier": -5
+										},
+										{
+											"type": "skill",
+											"name": "Engineer",
+											"specialization": "Electronics",
+											"modifier": -5
+										},
+										{
+											"type": "skill",
+											"name": "Electronics Operation",
+											"modifier": -4
+										}
+									],
+									"tech_level": "",
+									"points": 1
+								},
+								{
+									"id": "s_xjSMyeLsIgIhu7y",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sjiPOdZOS0Ve3xMhr"
+									},
 									"name": "Mechanic",
 									"reference": "B207",
 									"tags": [
 										"Maintenance",
 										"Repair"
 									],
-									"specialization": "Life Support",
+									"replacements": {
+										"Machine class": "Life Support"
+									},
+									"specialization": "@Machine class@",
 									"difficulty": "iq/a",
 									"defaults": [
 										{
@@ -5041,7 +6101,7 @@
 										{
 											"type": "skill",
 											"name": "Engineer",
-											"specialization": "Aerospace",
+											"specialization": "@Machine class@",
 											"modifier": -4
 										},
 										{
@@ -5059,13 +6119,21 @@
 									"points": 1
 								},
 								{
-									"id": "s6gzvTchSGVLHsNuY",
+									"id": "sqtwMaSKICyjJQj5x",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sx1CDkGBR830IZrmz"
+									},
 									"name": "Professional Skill",
 									"reference": "B215",
 									"tags": [
 										"Knowledge"
 									],
-									"specialization": "@Bartender, Hairdresser, Massuer, etc.@",
+									"replacements": {
+										"Mental Skill": "@Bartender, Hairdresser, Massuer, etc.@"
+									},
+									"specialization": "@Mental Skill@",
 									"difficulty": "iq/a",
 									"defaults": [
 										{
@@ -5076,7 +6144,12 @@
 									"points": 1
 								},
 								{
-									"id": "sqAqwGTCvWspmv7P3",
+									"id": "sO2q78NU8TahLxlZf",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "swYZeCAKyU5w-2tzd"
+									},
 									"name": "Smuggling",
 									"reference": "B221",
 									"tags": [
@@ -5094,7 +6167,12 @@
 									"points": 1
 								},
 								{
-									"id": "sHXsDY0fYY_937E1j",
+									"id": "s5vlKvUer42RivP3Q",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sqKieRudf_Tp4-T6T"
+									},
 									"name": "Expert Skill",
 									"reference": "B193,MA56",
 									"tags": [
@@ -5108,7 +6186,12 @@
 									"points": 1
 								},
 								{
-									"id": "so9VXWKpLT8AzHy4k",
+									"id": "ssvw-QpTg45PddruB",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sjU9kn3jTX-_5Q5p5"
+									},
 									"name": "Psychology",
 									"reference": "B216",
 									"tags": [
@@ -5130,7 +6213,12 @@
 									"points": 1
 								},
 								{
-									"id": "scFEjR9QhFm6Nz7Bi",
+									"id": "sJx8oSFxORXFONPn7",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sW_dr_6QZxz1zrODT"
+									},
 									"name": "Search",
 									"reference": "B219",
 									"tags": [
@@ -5160,7 +6248,12 @@
 					"name": "Background Skills",
 					"children": [
 						{
-							"id": "s8H-X_R2tYj6cC8V5",
+							"id": "sn_HUDJiXYT1XHhrM",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "ssHhRG7LH-Ma3YDnH"
+							},
 							"name": "Computer Operation",
 							"reference": "B184",
 							"tags": [
@@ -5179,7 +6272,12 @@
 							"points": 1
 						},
 						{
-							"id": "sG3Xeo-IQt5BU7MEH",
+							"id": "sk81kdGTNO2uZGTjv",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "s7kVwKFERTuMYO3O8"
+							},
 							"name": "Free Fall",
 							"reference": "B197",
 							"tags": [
@@ -5199,7 +6297,12 @@
 							"points": 4
 						},
 						{
-							"id": "saR2Md1xvAPc_LLce",
+							"id": "sAMEmT3DLoa7ED_Gg",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "s9IHT34mK8yfSB7d_"
+							},
 							"name": "Spacer",
 							"reference": "B185",
 							"tags": [
@@ -5216,7 +6319,12 @@
 							"points": 1
 						},
 						{
-							"id": "sHiFoY-JxjnPAayEo",
+							"id": "sd1yWMTsALZNmcdtu",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sAmDzPjf0rKZ6I5G1"
+							},
 							"name": "Vacc Suit",
 							"reference": "B192",
 							"tags": [
@@ -5252,11 +6360,16 @@
 							"name": "10 Points chosen from",
 							"children": [
 								{
-									"id": "SCq-_K4IN8putIeGt",
+									"id": "SW-uRdKCgBXCBArtJ",
 									"name": "Everyman Skills",
 									"children": [
 										{
-											"id": "s-uLlIue05im1JBak",
+											"id": "srYlNMuTehHp7pSK-",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sTXDrqXH0sT2NSD_b"
+											},
 											"name": "Area Knowledge",
 											"reference": "B176",
 											"notes": "Location of the capitals of interplanetary states and the homeworlds of major races; general awareness of all major races; knowledge of individuals of Status 8; general understanding of relations between interplanetary states",
@@ -5277,7 +6390,12 @@
 											"points": 1
 										},
 										{
-											"id": "sflqS0sMxFLksTEXC",
+											"id": "s7GiPWBbE4QsF8KqV",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "s-Ckyxw5PmHIvbZab"
+											},
 											"name": "Area Knowledge",
 											"reference": "B176",
 											"notes": "Location of major planets; familiarity with all known races (but not necessarily expertise); knowledge of people of Status 7+; general understanding of the economic and political situation",
@@ -5285,13 +6403,9 @@
 												"Everyman",
 												"Knowledge"
 											],
-											"specialization": "@Interplanetary State@; Lived there",
+											"specialization": "@Interplanetary State@",
 											"difficulty": "iq/e",
 											"defaults": [
-												{
-													"type": "iq",
-													"modifier": -4
-												},
 												{
 													"type": "skill",
 													"name": "Geography",
@@ -5302,7 +6416,12 @@
 											"points": 1
 										},
 										{
-											"id": "sgipm7Bf_1p8W1UU1",
+											"id": "saEk_eJkRZbvPddXl",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "strhX4LEdd46xgmIS"
+											},
 											"name": "Area Knowledge",
 											"reference": "B176",
 											"notes": "Location of its major cities and important sites; awareness of its major customs, ethnic groups, and languages (but not necessarily expertise); names of folk of Status 7+; and a general understanding of the economic and political situation",
@@ -5310,13 +6429,9 @@
 												"Everyman",
 												"Knowledge"
 											],
-											"specialization": "@Planet@; Lived there",
+											"specialization": "@Planet@",
 											"difficulty": "iq/e",
 											"defaults": [
-												{
-													"type": "iq",
-													"modifier": -4
-												},
 												{
 													"type": "skill",
 													"name": "Geography",
@@ -5327,7 +6442,12 @@
 											"points": 1
 										},
 										{
-											"id": "so552xS-I5INmqcgT",
+											"id": "so9EhojL2oVS2OWQD",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sBJgeWUs81Ifhob4Z"
+											},
 											"name": "Beam Weapons",
 											"reference": "B179",
 											"tags": [
@@ -5358,7 +6478,12 @@
 											"points": 1
 										},
 										{
-											"id": "shvVN3Hjj6yCNJ3Q3",
+											"id": "sKEJsZjPf-ojtOKUb",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sOp4wssAMtUc1ukJI"
+											},
 											"name": "Body Language",
 											"reference": "B181",
 											"tags": [
@@ -5382,10 +6507,14 @@
 											"points": 1
 										},
 										{
-											"id": "sGHM-HJFibEgenMJA",
+											"id": "stt6JwiZ7rNOg6wWJ",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sziMa9_9xTvR2iiqx"
+											},
 											"name": "Body Sense",
 											"reference": "B181",
-											"notes": "For settings with matter transmission",
 											"tags": [
 												"Athletic"
 											],
@@ -5404,7 +6533,12 @@
 											"points": 1
 										},
 										{
-											"id": "s-zf-TIT87FFfTVQL",
+											"id": "soD2duesPnhHnK4vr",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "shtDdl5thrvKSnJHf"
+											},
 											"name": "Brawling",
 											"reference": "B182,MA55",
 											"tags": [
@@ -5432,7 +6566,12 @@
 											"points": 1
 										},
 										{
-											"id": "srqNqKFAw42fXXChW",
+											"id": "s_RCEcKKRkYmds4L8",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "si-upI7A5RgdO0cjC"
+											},
 											"name": "Carousing",
 											"reference": "B183",
 											"tags": [
@@ -5450,7 +6589,12 @@
 											"points": 1
 										},
 										{
-											"id": "scCxL4fEEvK3x_VZq",
+											"id": "stRZILTXS-BHjpiOX",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sWFtA7Gvclq4aL-Yb"
+											},
 											"name": "Current Affairs",
 											"reference": "B186",
 											"tags": [
@@ -5481,7 +6625,12 @@
 											"points": 1
 										},
 										{
-											"id": "sXrp1te7fDUtScF37",
+											"id": "sL7r_AW5m0NiGjf_K",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "s9mV--3lpIfXO7N6Z"
+											},
 											"name": "First Aid",
 											"reference": "B195",
 											"tags": [
@@ -5512,7 +6661,12 @@
 											"points": 1
 										},
 										{
-											"id": "sIwfHrPHnaTR576X3",
+											"id": "saWRkiLvIchMO9b73",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sWB9ypJAq43MF3O0n"
+											},
 											"name": "Gambling",
 											"reference": "B197",
 											"tags": [
@@ -5536,7 +6690,12 @@
 											"points": 1
 										},
 										{
-											"id": "sPrbYZ7-wZcPCydYl",
+											"id": "spxa1qMBNQeY2sNA0",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "syfSQ9N8yETqQbhFK"
+											},
 											"name": "Games",
 											"reference": "B197,MA57",
 											"tags": [
@@ -5553,7 +6712,12 @@
 											"points": 1
 										},
 										{
-											"id": "sjSSI2MdZ7vuC21Mz",
+											"id": "sfG6WM0VfFTFp-eyl",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sGz21GskAlJXL1hYP"
+											},
 											"name": "Gesture",
 											"reference": "B198",
 											"tags": [
@@ -5569,7 +6733,12 @@
 											"points": 1
 										},
 										{
-											"id": "sgDd2-YE0avHabgo0",
+											"id": "sRJxYoR9TxSKYxC68",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sT5htbz4-Mr0PFCk7"
+											},
 											"name": "Guns",
 											"reference": "B198",
 											"tags": [
@@ -5594,7 +6763,12 @@
 											"points": 1
 										},
 										{
-											"id": "svanhfT7cEBcq2pPn",
+											"id": "sbN5LVJlHvtf64Ozd",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sOtPessbzkRjGaQPR"
+											},
 											"name": "Hobby Skill",
 											"reference": "B200,MA57",
 											"tags": [
@@ -5611,7 +6785,12 @@
 											"points": 1
 										},
 										{
-											"id": "saI6996dF8-aFqDMF",
+											"id": "sNJ_c-7XxVieeaBCx",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sDLf4crz0sGRjVDFi"
+											},
 											"name": "Hobby Skill",
 											"reference": "B200,MA57",
 											"tags": [
@@ -5628,7 +6807,12 @@
 											"points": 1
 										},
 										{
-											"id": "svCdqYgzcEQuJU9Ob",
+											"id": "s9dew8q6JuFFeDPtH",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sfZrwMVUibhbtdssl"
+											},
 											"name": "Housekeeping",
 											"reference": "B200",
 											"tags": [
@@ -5644,7 +6828,12 @@
 											"points": 1
 										},
 										{
-											"id": "sdco7ybXXTgBEXuMG",
+											"id": "s-xk0eQDtzJlhMsAU",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sdl9m7gHE7hlMX0AX"
+											},
 											"name": "Lip Reading",
 											"reference": "B205",
 											"tags": [
@@ -5660,7 +6849,12 @@
 											"points": 1
 										},
 										{
-											"id": "sc4fat8hzc_NlHW5J",
+											"id": "sDpwykqcq8MY1W8YM",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sx1CDkGBR830IZrmz"
+											},
 											"name": "Professional Skill",
 											"reference": "B215",
 											"tags": [
@@ -5677,7 +6871,12 @@
 											"points": 1
 										},
 										{
-											"id": "ssky9_NANNjEqwH4e",
+											"id": "sCEFJ_t_PagdCFPNj",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sBec-o4Z7gPpbg2f9"
+											},
 											"name": "Professional Skill",
 											"reference": "B215",
 											"tags": [
@@ -5694,7 +6893,12 @@
 											"points": 1
 										},
 										{
-											"id": "sulxkT2e3sDldp5zF",
+											"id": "sHAeToirhiN1MwjZo",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "smxkcngH5Kz54yeN3"
+											},
 											"name": "Sports",
 											"reference": "B222,MA59",
 											"tags": [
@@ -5711,7 +6915,12 @@
 											"points": 1
 										},
 										{
-											"id": "s82x8O5s-8oR7GWw6",
+											"id": "saK7Q4fU7gyhPlsBG",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "smTUpMWJGqPeT1KER"
+											},
 											"name": "Streetwise",
 											"reference": "B223",
 											"tags": [
@@ -5751,7 +6960,12 @@
 					"name": "Multi-Role",
 					"children": [
 						{
-							"id": "sTOflJ9xJj_tYIZ8d",
+							"id": "slcjyfEjBNAWQt0Du",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "s8j6tcaNxXkF89Xbt"
+							},
 							"name": "Diplomacy",
 							"reference": "B187",
 							"tags": [
@@ -5774,7 +6988,12 @@
 							"points": 4
 						},
 						{
-							"id": "smgvmHDznkTJX1g2V",
+							"id": "s4JoiAsq774av4D51",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "shHyf3H441PtZMBlJ"
+							},
 							"name": "Merchant",
 							"reference": "B209",
 							"tags": [
@@ -5801,7 +7020,12 @@
 							"points": 4
 						},
 						{
-							"id": "sqkAAsraSaOs5JGAI",
+							"id": "sfhu7A3BaDh_if4Tf",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "s8sGblB3JWt6f_2hf"
+							},
 							"name": "Savoir-Faire",
 							"reference": "B218,MA59",
 							"tags": [
@@ -5830,7 +7054,12 @@
 							"name": "6 Points chosen from",
 							"children": [
 								{
-									"id": "svflWBBnL7PxU-cDr",
+									"id": "sIEMl6oi7hr6SgPSL",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "s9mV--3lpIfXO7N6Z"
+									},
 									"name": "First Aid",
 									"reference": "B195",
 									"tags": [
@@ -5861,7 +7090,12 @@
 									"points": 1
 								},
 								{
-									"id": "sSxPBx-95qaEEHKtU",
+									"id": "sWs-v652C8cKsg3Ir",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sfZrwMVUibhbtdssl"
+									},
 									"name": "Housekeeping",
 									"reference": "B200",
 									"tags": [
@@ -5877,7 +7111,12 @@
 									"points": 1
 								},
 								{
-									"id": "s-jBPB2xBpxgyZxWs",
+									"id": "sFKdIeuBfqfqhuyGv",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sQ7hn7pW3tIPfsU8Z"
+									},
 									"name": "Acting",
 									"reference": "B174",
 									"tags": [
@@ -5904,7 +7143,12 @@
 									"points": 1
 								},
 								{
-									"id": "so9mor4qoSPnD5z_k",
+									"id": "sUj_jTnySkaPFEC57",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "s7zUqAO5PEC5JKk_W"
+									},
 									"name": "Fast-Talk",
 									"reference": "B195",
 									"tags": [
@@ -5928,7 +7172,12 @@
 									"points": 1
 								},
 								{
-									"id": "sIObw4Vzsvxi0J4VT",
+									"id": "snGDqoalg4a-r0bF6",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sSxGnNPMXyZpZKoFZ"
+									},
 									"name": "Leadership",
 									"reference": "B204",
 									"tags": [
@@ -5945,7 +7194,12 @@
 									"points": 1
 								},
 								{
-									"id": "sBmDA75lFEbsGq5jW",
+									"id": "s9ZrZqzNBhEkPUFj9",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "spGG-fpOy0g88rFDO"
+									},
 									"name": "Public Speaking",
 									"reference": "B216",
 									"tags": [
@@ -5978,7 +7232,12 @@
 									"points": 1
 								},
 								{
-									"id": "sQYTr9lb-kCIgVByh",
+									"id": "s7fgQrXmu9rEl_CoB",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "smTUpMWJGqPeT1KER"
+									},
 									"name": "Streetwise",
 									"reference": "B223",
 									"tags": [
@@ -5997,7 +7256,12 @@
 									"points": 1
 								},
 								{
-									"id": "siDwfV9XwwvWf07aa",
+									"id": "sUq3PFPHimcbl6WwM",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sn-AqOk3ggCs7fqIQ"
+									},
 									"name": "Administration",
 									"reference": "B174",
 									"tags": [
@@ -6019,7 +7283,12 @@
 									"points": 1
 								},
 								{
-									"id": "sR7dtTZiOiY30zCt_",
+									"id": "snRLAq9wNVzDhQChM",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "s2SdStcV1J3cLdM7e"
+									},
 									"name": "Connoisseur",
 									"reference": "B185,MA56",
 									"tags": [
@@ -6039,7 +7308,12 @@
 									"points": 1
 								},
 								{
-									"id": "sfQ-St-DKcidpX7tL",
+									"id": "s6wliGLpkCTHVowSU",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sxglmNWmcsR5YcSDw"
+									},
 									"name": "Cooking",
 									"reference": "B185",
 									"tags": [
@@ -6060,13 +7334,18 @@
 									"points": 1
 								},
 								{
-									"id": "srj4Xgx4H33baRa8S",
+									"id": "s1TCiK0Gg4J8FrNJI",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "swXuff1DBhSQbTqy1"
+									},
 									"name": "Electronics Operation",
 									"reference": "B189",
 									"tags": [
 										"Technical"
 									],
-									"specialization": "@Comm or Media@",
+									"specialization": "Communications",
 									"difficulty": "iq/a",
 									"defaults": [
 										{
@@ -6095,7 +7374,54 @@
 									"points": 1
 								},
 								{
-									"id": "se8NyC60QjlWo_cut",
+									"id": "s0PNWnkgEWFTeTtRM",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sLDuQRGJ4yzEXiQ0G"
+									},
+									"name": "Electronics Operation",
+									"reference": "B189",
+									"tags": [
+										"Arts",
+										"Entertainment",
+										"Technical"
+									],
+									"specialization": "Media",
+									"difficulty": "iq/a",
+									"defaults": [
+										{
+											"type": "iq",
+											"modifier": -5
+										},
+										{
+											"type": "skill",
+											"name": "Electronics Repair",
+											"specialization": "Media",
+											"modifier": -5
+										},
+										{
+											"type": "skill",
+											"name": "Engineer",
+											"specialization": "Electronics",
+											"modifier": -5
+										},
+										{
+											"type": "skill",
+											"name": "Electronics Operation",
+											"modifier": -4
+										}
+									],
+									"tech_level": "",
+									"points": 1
+								},
+								{
+									"id": "sxv0XgcPty5eAOLGw",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sVspKJvpEaYNHFmRo"
+									},
 									"name": "Freight Handling",
 									"reference": "B197",
 									"tags": [
@@ -6113,14 +7439,22 @@
 									"points": 1
 								},
 								{
-									"id": "sZ7VZvQnKZrCXlb3A",
+									"id": "siX6exg0NhyWNKlH-",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sjiPOdZOS0Ve3xMhr"
+									},
 									"name": "Mechanic",
 									"reference": "B207",
 									"tags": [
 										"Maintenance",
 										"Repair"
 									],
-									"specialization": "Life Support",
+									"replacements": {
+										"Machine class": "Life Support"
+									},
+									"specialization": "@Machine class@",
 									"difficulty": "iq/a",
 									"defaults": [
 										{
@@ -6130,7 +7464,7 @@
 										{
 											"type": "skill",
 											"name": "Engineer",
-											"specialization": "Aerospace",
+											"specialization": "@Machine class@",
 											"modifier": -4
 										},
 										{
@@ -6148,12 +7482,20 @@
 									"points": 1
 								},
 								{
-									"id": "shGfdndhvIaneDXZ2",
+									"id": "sXL365PyX-QcJ4rrz",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sx1CDkGBR830IZrmz"
+									},
 									"name": "Professional Skill",
 									"reference": "B215",
 									"tags": [
 										"Knowledge"
 									],
+									"replacements": {
+										"Mental Skill": "@Bartender, Hairdresser, Massuer, etc.@"
+									},
 									"specialization": "@Mental Skill@",
 									"difficulty": "iq/a",
 									"defaults": [
@@ -6165,7 +7507,12 @@
 									"points": 1
 								},
 								{
-									"id": "sOJ1poqxk6-qgef2w",
+									"id": "ssRd6uD34OqMqbtDU",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "swYZeCAKyU5w-2tzd"
+									},
 									"name": "Smuggling",
 									"reference": "B221",
 									"tags": [
@@ -6183,7 +7530,12 @@
 									"points": 1
 								},
 								{
-									"id": "sqrJASIx6r_5QBeum",
+									"id": "sGRs3D6wNBfk5XUlh",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "s67Roch7cMOY4VSj-"
+									},
 									"name": "Accounting",
 									"reference": "B174",
 									"tags": [
@@ -6212,10 +7564,15 @@
 											"modifier": -5
 										}
 									],
-									"points": 1
+									"points": 2
 								},
 								{
-									"id": "sDQOlnSButjn6p779",
+									"id": "syMXLogjSp4JISklk",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sjU9kn3jTX-_5Q5p5"
+									},
 									"name": "Psychology",
 									"reference": "B216",
 									"tags": [
@@ -6237,7 +7594,12 @@
 									"points": 1
 								},
 								{
-									"id": "s8DBLGt01SENgQZfF",
+									"id": "s6g4bvLOBejguago4",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "si-upI7A5RgdO0cjC"
+									},
 									"name": "Carousing",
 									"reference": "B183",
 									"tags": [
@@ -6252,10 +7614,15 @@
 											"modifier": -4
 										}
 									],
-									"points": 1
+									"points": 2
 								},
 								{
-									"id": "sJDrVZs8O2mK3JtMc",
+									"id": "s1JVIXJJMVVdcwb2Q",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sLAU6vDBL4XaQNS0z"
+									},
 									"name": "Sex Appeal",
 									"reference": "B219",
 									"tags": [
@@ -6268,10 +7635,15 @@
 											"modifier": -3
 										}
 									],
-									"points": 1
+									"points": 2
 								},
 								{
-									"id": "sfm4927aJBsO0YD5K",
+									"id": "sPKa-8G2YppKl0Lxs",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sQ2Nj_TqMYKV7skUF"
+									},
 									"name": "Scrounging",
 									"reference": "B218",
 									"tags": [
@@ -6288,7 +7660,12 @@
 									"points": 1
 								},
 								{
-									"id": "s3Qn-lktFL9lc6uXY",
+									"id": "spqx2ONd4VnMuLAcV",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sW_dr_6QZxz1zrODT"
+									},
 									"name": "Search",
 									"reference": "B219",
 									"tags": [

--- a/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Tactical Officer.gct
+++ b/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Tactical Officer.gct
@@ -12,7 +12,12 @@
 					"name": "Attributes",
 					"children": [
 						{
-							"id": "tl-pa7cf4KXiWOrNB",
+							"id": "tGilufaPP6ueja25Z",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tGWOSEE6SmBHACE6Y"
+							},
 							"name": "Increased Dexterity",
 							"reference": "B15",
 							"tags": [
@@ -22,7 +27,7 @@
 							],
 							"modifiers": [
 								{
-									"id": "motaxqN_CkkFTdd-e",
+									"id": "m9Q6kLBwQfcO6ldQ3",
 									"name": "No Fine Manipulators",
 									"cost": -40,
 									"disabled": true
@@ -44,7 +49,12 @@
 							}
 						},
 						{
-							"id": "tt4Xdxhx-qhKoR_yt",
+							"id": "tTz7Vc8BN6rxc6RqH",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t1w1RFcFceKR2T9_e"
+							},
 							"name": "Increased Intelligence",
 							"reference": "B15",
 							"tags": [
@@ -68,7 +78,12 @@
 							}
 						},
 						{
-							"id": "t1E0VB8YFSVbtCe4X",
+							"id": "tkqgPvnc23tAVOuG2",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tVt3SvdGWNchJ8z4o"
+							},
 							"name": "Increased Health",
 							"reference": "B14",
 							"tags": [
@@ -101,7 +116,12 @@
 					"name": "Secondary Characteristics",
 					"children": [
 						{
-							"id": "tnJ2RmHrEYGS0tRwI",
+							"id": "tFQsaZWtuULnnJ7Xn",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tWF1J_Z0Ziz-qJ6pn"
+							},
 							"name": "Increased Basic Speed",
 							"reference": "B17",
 							"tags": [
@@ -119,14 +139,14 @@
 								}
 							],
 							"can_level": true,
-							"levels": 1,
+							"levels": 2,
 							"calc": {
-								"points": 5
+								"points": 10
 							}
 						}
 					],
 					"calc": {
-						"points": 5
+						"points": 10
 					}
 				},
 				{
@@ -134,13 +154,53 @@
 					"name": "Class Advantages",
 					"children": [
 						{
-							"id": "tdxjnG8tMEO0RMYZv",
+							"id": "t0ZzxPgLA7NmzedSp",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "tgnQFo-hK7YwexD2S"
+							},
 							"name": "Talent (Born War Leader)",
 							"reference": "DF1:14,PU3:12",
 							"tags": [
 								"Advantage",
 								"Physical",
 								"Talent"
+							],
+							"modifiers": [
+								{
+									"id": "MFhTbYl2yaYjBg7N1",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "m3Y7tH_9tfaoMoQuQ",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "m4b6V9Q0aial_cmNR",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Bonus to initiative rolls if leader",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
+								}
 							],
 							"points_per_level": 5,
 							"features": [
@@ -197,18 +257,6 @@
 									},
 									"amount": 1,
 									"per_level": true
-								},
-								{
-									"type": "reaction_bonus",
-									"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "conditional_modifier",
-									"situation": "Bonus to initiative rolls if leader",
-									"amount": 1,
-									"per_level": true
 								}
 							],
 							"can_level": true,
@@ -218,7 +266,12 @@
 							}
 						},
 						{
-							"id": "tgghFsgV0vjDfAvmb",
+							"id": "tzpJQ0xCTlijr3_po",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tGjjVtxav9KsrG7Wx"
+							},
 							"name": "Combat Reflexes",
 							"reference": "B43",
 							"notes": "Never freeze",
@@ -295,7 +348,12 @@
 									"name": "Better Attributes",
 									"children": [
 										{
-											"id": "t__87esvCBRO95R3n",
+											"id": "tjQuGwA3y8X9xocVO",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tGWOSEE6SmBHACE6Y"
+											},
 											"name": "Increased Dexterity",
 											"reference": "B15",
 											"tags": [
@@ -305,7 +363,7 @@
 											],
 											"modifiers": [
 												{
-													"id": "m0H5jWNlp-2IUQRz5",
+													"id": "meJxbzFe2F50V1XXN",
 													"name": "No Fine Manipulators",
 													"cost": -40,
 													"disabled": true
@@ -327,7 +385,12 @@
 											}
 										},
 										{
-											"id": "tCTvAcvBYI_AYvmEi",
+											"id": "t46YaGy5LpKB8eumB",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tVt3SvdGWNchJ8z4o"
+											},
 											"name": "Increased Health",
 											"reference": "B14",
 											"tags": [
@@ -351,7 +414,12 @@
 											}
 										},
 										{
-											"id": "tYybMqkWy0wqm6UiW",
+											"id": "t7_uZRiBH7Gby0uap",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t1w1RFcFceKR2T9_e"
+											},
 											"name": "Increased Intelligence",
 											"reference": "B15",
 											"tags": [
@@ -375,7 +443,12 @@
 											}
 										},
 										{
-											"id": "t04rSKDtrJ9b0Bl3d",
+											"id": "tFqhV4uW7d-FQyrHx",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tqha9GlDBU9P-Wg-6"
+											},
 											"name": "Increased Strength",
 											"reference": "B14",
 											"tags": [
@@ -385,14 +458,14 @@
 											],
 											"modifiers": [
 												{
-													"id": "mmA2jCSV3CzAiHXSn",
+													"id": "mT8FQDPW8WKpz_zof",
 													"name": "No Fine Manipulators",
 													"reference": "B15",
 													"cost": -40,
 													"disabled": true
 												},
 												{
-													"id": "mJwW4pBh2XrGOFizt",
+													"id": "mro2BYHP0aogiTq4S",
 													"name": "Size",
 													"reference": "B15",
 													"cost": -10,
@@ -400,7 +473,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mMIKqBvJSrwBDjiSR",
+													"id": "mpw-MBUWmGE-YZDlV",
 													"name": "Super-Effort",
 													"reference": "SU24",
 													"cost": 300,
@@ -428,24 +501,37 @@
 									}
 								},
 								{
-									"id": "TKJE6Asw-ehV4YBBx",
+									"id": "TOpVENDRfcHZZe4Pj",
 									"name": "Everyman Advantages",
 									"children": [
 										{
-											"id": "tTInQoU7nJHM5d2DA",
-											"name": "Suit Familiarity (Vacc Suit)",
+											"id": "tr67hluIjdzH7Ih2j",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Power Ups/Power Ups Traits.adq",
+												"id": "t3RCXCI5W-zjvxaf-"
+											},
+											"name": "Suit Familiarity (@Environment Suit skill@)",
 											"reference": "PU2:9",
 											"tags": [
 												"Perk",
 												"Physical"
 											],
+											"replacements": {
+												"Environment Suit skill": "Vacc Suit"
+											},
 											"base_points": 1,
 											"calc": {
 												"points": 1
 											}
 										},
 										{
-											"id": "tr8iRoT--OD02K-LF",
+											"id": "tyAUEgdj2WonAdF39",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tkiJQ7nfyi9aAdGHK"
+											},
 											"name": "Serendipity",
 											"reference": "B83,P73",
 											"tags": [
@@ -454,17 +540,24 @@
 											],
 											"modifiers": [
 												{
-													"id": "mwlwFhloaWS0j8ech",
+													"id": "mZDsHw-O5MCvavY_W",
 													"name": "Wishing",
 													"reference": "P73",
 													"cost": 100,
 													"disabled": true
 												},
 												{
-													"id": "ml3yW0SRyEEzscC34",
+													"id": "mKy6w1_DJ-SOnCouF",
 													"name": "Wishing",
 													"reference": "P73",
 													"notes": "For others only",
+													"disabled": true
+												},
+												{
+													"id": "mLEavxPcAnbWNa87N",
+													"name": "Game Time",
+													"reference": "P108",
+													"notes": "Uses per game week equal to its maximum possible uses per session",
 													"disabled": true
 												}
 											],
@@ -476,8 +569,13 @@
 											}
 										},
 										{
-											"id": "thwOD1ozolYtsRPFR",
-											"name": "Resistant to Acceleration",
+											"id": "tc6w9ACyMh8SR_JKj",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tJTfFdHM7YI5IZR7I"
+											},
+											"name": "Resistant",
 											"reference": "B81,P71,MA47",
 											"tags": [
 												"Advantage",
@@ -485,7 +583,7 @@
 											],
 											"modifiers": [
 												{
-													"id": "mMuy1WgjtlrTqhjw-",
+													"id": "mNEiiccf9FjXo0I2y",
 													"name": "@Very Common: Metabolic Hazards, etc.@",
 													"reference": "B80",
 													"cost": 30,
@@ -493,7 +591,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mDGknF5LXzp3pkPfI",
+													"id": "mNAWJDx223HmPqSeV",
 													"name": "@Common: Poison, Sickness, etc.@",
 													"reference": "B81",
 													"cost": 15,
@@ -501,7 +599,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m1Sc5aqFwx7J3_UXR",
+													"id": "mty57xBDdUJj2Crjz",
 													"name": "@Occasional: Disease, Ingested Poison, etc.@",
 													"reference": "B81",
 													"cost": 10,
@@ -509,14 +607,17 @@
 													"disabled": true
 												},
 												{
-													"id": "mCzJ8_zUEQhIq2gaK",
+													"id": "mmR0jjoU7HJqiQQUW",
 													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
 													"reference": "B81",
+													"replacements": {
+														"Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.": "Space Sickness"
+													},
 													"cost": 5,
 													"cost_type": "points"
 												},
 												{
-													"id": "m-V37oWwltQ2GopWe",
+													"id": "mQpCZGEkPpQxRoqZG",
 													"name": "Immunity",
 													"reference": "B81",
 													"cost": 1,
@@ -524,152 +625,14 @@
 													"disabled": true
 												},
 												{
-													"id": "mcA1Kerw4GHf6p9Cr",
-													"name": "+8 to all HT rolls to resist",
-													"reference": "B81",
-													"cost": 0.5,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mzvfKV_4C9KI0C-hM",
-													"name": "+3 to all HT rolls to resist",
-													"reference": "B81",
-													"cost": 0.33,
-													"cost_type": "multiplier"
-												}
-											],
-											"round_down": true,
-											"calc": {
-												"points": 1
-											}
-										},
-										{
-											"id": "tj1-dIneaLBl9xLnd",
-											"name": "Resistant to Space Sickness",
-											"reference": "B81,P71,MA47",
-											"tags": [
-												"Advantage",
-												"Physical"
-											],
-											"modifiers": [
-												{
-													"id": "msBIPN3VX4l6w1xoD",
-													"name": "@Very Common: Metabolic Hazards, etc.@",
-													"reference": "B80",
-													"cost": 30,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m3NtaXuXD9pfjtjSp",
-													"name": "@Common: Poison, Sickness, etc.@",
-													"reference": "B81",
-													"cost": 15,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mGkZDbLMO_rn5Jhfu",
-													"name": "@Occasional: Disease, Ingested Poison, etc.@",
-													"reference": "B81",
-													"cost": 10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mXOosA-23MQ2UPeG_",
-													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
-													"reference": "B81",
-													"cost": 5,
-													"cost_type": "points"
-												},
-												{
-													"id": "mD7EMOY7Uk7SPcc03",
-													"name": "Immunity",
-													"reference": "B81",
-													"cost": 1,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "m2J7Wc9A6xlYBlhIa",
-													"name": "+8 to all HT rolls to resist",
-													"reference": "B81",
-													"cost": 0.5,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mOREbrmHRgQ9mMBxW",
-													"name": "+3 to all HT rolls to resist",
-													"reference": "B81",
-													"cost": 0.33,
-													"cost_type": "multiplier"
-												}
-											],
-											"round_down": true,
-											"calc": {
-												"points": 1
-											}
-										},
-										{
-											"id": "tWl3zqUv1LzRQ7Jrp",
-											"name": "Resistant to Space Sickness",
-											"reference": "B81,P71,MA47",
-											"tags": [
-												"Advantage",
-												"Physical"
-											],
-											"modifiers": [
-												{
-													"id": "mTmZ0sp1VihDezjrl",
-													"name": "@Very Common: Metabolic Hazards, etc.@",
-													"reference": "B80",
-													"cost": 30,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mZXHRpj4nQuecgt-D",
-													"name": "@Common: Poison, Sickness, etc.@",
-													"reference": "B81",
-													"cost": 15,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mqO0DXPK8dnpOJ2Zu",
-													"name": "@Occasional: Disease, Ingested Poison, etc.@",
-													"reference": "B81",
-													"cost": 10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mBFMWUR9jTo1xNo3x",
-													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
-													"reference": "B81",
-													"cost": 5,
-													"cost_type": "points"
-												},
-												{
-													"id": "mvBZ_wtN_CBpChXPq",
-													"name": "Immunity",
-													"reference": "B81",
-													"cost": 1,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mp0--_NlWuU1QWfHA",
+													"id": "mGOkXp9lHdaWeCPbS",
 													"name": "+8 to all HT rolls to resist",
 													"reference": "B81",
 													"cost": 0.5,
 													"cost_type": "multiplier"
 												},
 												{
-													"id": "mRasDj83Y-iTWFv1S",
+													"id": "mWKsxE5GPnarSp7rs",
 													"name": "+3 to all HT rolls to resist",
 													"reference": "B81",
 													"cost": 0.33,
@@ -683,8 +646,167 @@
 											}
 										},
 										{
-											"id": "txlRhwYzyHIT5CFUh",
-											"name": "Reputation",
+											"id": "t9b2ZjSaeQ8_gruSh",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tJTfFdHM7YI5IZR7I"
+											},
+											"name": "Resistant",
+											"reference": "B81,P71,MA47",
+											"tags": [
+												"Advantage",
+												"Physical"
+											],
+											"modifiers": [
+												{
+													"id": "m-931QjOZqRYf2W5O",
+													"name": "@Very Common: Metabolic Hazards, etc.@",
+													"reference": "B80",
+													"cost": 30,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m4CSSIacIEVLi4ioP",
+													"name": "@Common: Poison, Sickness, etc.@",
+													"reference": "B81",
+													"cost": 15,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m7-JfZiXeE-Gwe01H",
+													"name": "@Occasional: Disease, Ingested Poison, etc.@",
+													"reference": "B81",
+													"cost": 10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "msL8b4dE87AiGNbA9",
+													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+													"reference": "B81",
+													"replacements": {
+														"Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.": "Space Sickness"
+													},
+													"cost": 5,
+													"cost_type": "points"
+												},
+												{
+													"id": "m-dJ-2nSMo_CD_8MS",
+													"name": "Immunity",
+													"reference": "B81",
+													"cost": 1,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "maDLdFkYkfbnnBtHN",
+													"name": "+8 to all HT rolls to resist",
+													"reference": "B81",
+													"cost": 0.5,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "m8MSF1wmgJ2JXiLuq",
+													"name": "+3 to all HT rolls to resist",
+													"reference": "B81",
+													"cost": 0.33,
+													"cost_type": "multiplier"
+												}
+											],
+											"round_down": true,
+											"calc": {
+												"points": 1
+											}
+										},
+										{
+											"id": "tNe7NVeyvSkWZGjOd",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tJTfFdHM7YI5IZR7I"
+											},
+											"name": "Resistant",
+											"reference": "B81,P71,MA47",
+											"tags": [
+												"Advantage",
+												"Physical"
+											],
+											"modifiers": [
+												{
+													"id": "mdN96OKBXjkgX4R8g",
+													"name": "@Very Common: Metabolic Hazards, etc.@",
+													"reference": "B80",
+													"cost": 30,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m6363Zv-gPKkBNhQM",
+													"name": "@Common: Poison, Sickness, etc.@",
+													"reference": "B81",
+													"cost": 15,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mNlmU9gszCSJNeZ_i",
+													"name": "@Occasional: Disease, Ingested Poison, etc.@",
+													"reference": "B81",
+													"cost": 10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mInmPbhIbPW0v2j04",
+													"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+													"reference": "B81",
+													"replacements": {
+														"Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.": "Acceleration"
+													},
+													"cost": 5,
+													"cost_type": "points"
+												},
+												{
+													"id": "mz0JdDItKBarvNr7z",
+													"name": "Immunity",
+													"reference": "B81",
+													"cost": 1,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mfCH-Zxp7uWaBaXmG",
+													"name": "+8 to all HT rolls to resist",
+													"reference": "B81",
+													"cost": 0.5,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mVpv8NJPdjEs3L3cf",
+													"name": "+3 to all HT rolls to resist",
+													"reference": "B81",
+													"cost": 0.33,
+													"cost_type": "multiplier"
+												}
+											],
+											"round_down": true,
+											"calc": {
+												"points": 1
+											}
+										},
+										{
+											"id": "ty5FRNgEu56gS8nVc",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "ta04iFiZ_Kw0s0juj"
+											},
+											"name": "Good Reputation",
 											"reference": "B26,MA54",
 											"tags": [
 												"Advantage",
@@ -692,7 +814,7 @@
 											],
 											"modifiers": [
 												{
-													"id": "mMMkBpZqX-QlTzUcm",
+													"id": "m9JVi6kmU77lIT2FN",
 													"name": "People Affected",
 													"reference": "B27",
 													"notes": "Almost everyone",
@@ -701,7 +823,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mrJp0zsvqnoYYbIyz",
+													"id": "m2g40VNIHqyKjArko",
 													"name": "People Affected",
 													"reference": "B27",
 													"notes": "Almost everyone except @large class of people@",
@@ -710,7 +832,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m02eYUXC5GjtVFzRZ",
+													"id": "mU_3ZdXhzXkSTjpE6",
 													"name": "People Affected",
 													"reference": "B27",
 													"notes": "@Large class of people@",
@@ -719,7 +841,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mJp9d916S5Fj56jYM",
+													"id": "mbIJLkEjvmltCWZnO",
 													"name": "People Affected",
 													"reference": "B27",
 													"notes": "@Small class of people@",
@@ -728,7 +850,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mGCLMwkj9NweBZbn9",
+													"id": "mNw74Dfg5Uj9AwJ6W",
 													"name": "Recognized all the time",
 													"reference": "B28",
 													"cost": 1,
@@ -736,7 +858,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m7pNXoiVQ8MwARUd_",
+													"id": "mIjqDINdrr7cYjgJu",
 													"name": "Recognized sometimes",
 													"reference": "B28",
 													"notes": "10-",
@@ -745,7 +867,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mma7Jf4CMdv9fBPT8",
+													"id": "mGOZ5IeKEkgf1Uw_L",
 													"name": "Recognized occasionally",
 													"reference": "B28",
 													"notes": "7-",
@@ -755,6 +877,14 @@
 												}
 											],
 											"points_per_level": 5,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others aware of your reputation",
+													"amount": 1,
+													"per_level": true
+												}
+											],
 											"round_down": true,
 											"can_level": true,
 											"levels": 1,
@@ -763,16 +893,24 @@
 											}
 										},
 										{
-											"id": "t5tuL2suy-FxZE3EO",
-											"name": "Military Rank",
+											"id": "tQJGJ_OPIBPaA_bOe",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tmp8yecgaZq9TOk59"
+											},
+											"name": "@Type@ Rank",
 											"reference": "B29",
 											"tags": [
 												"Advantage",
-												"Physical"
+												"Social"
 											],
+											"replacements": {
+												"Type": "Military"
+											},
 											"modifiers": [
 												{
-													"id": "m3DxbwhsZvj1HjYQQ",
+													"id": "mz8KzF8_XWUC-JD8O",
 													"name": "Replaces Status",
 													"reference": "B29",
 													"cost": 5,
@@ -781,7 +919,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mPzLt_7vTfHbPhmMy",
+													"id": "mRZcTu_xOUOfYfgQh",
 													"name": "Courtesy",
 													"reference": "B29",
 													"cost": -4,
@@ -798,16 +936,24 @@
 											}
 										},
 										{
-											"id": "twfeGqKSFEt4bcJOG",
-											"name": "Merchant Rank",
+											"id": "tb8pYablTmhICWZOF",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tmp8yecgaZq9TOk59"
+											},
+											"name": "@Type@ Rank",
 											"reference": "B29",
 											"tags": [
 												"Advantage",
-												"Physical"
+												"Social"
 											],
+											"replacements": {
+												"Type": "Merchant"
+											},
 											"modifiers": [
 												{
-													"id": "mAfO0y1Wf8g1QmG0u",
+													"id": "myeISUDtrWm8wKlkI",
 													"name": "Replaces Status",
 													"reference": "B29",
 													"cost": 5,
@@ -816,7 +962,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mHeFaR29lDwNoniXW",
+													"id": "moZoZI4Q5MIH8_84F",
 													"name": "Courtesy",
 													"reference": "B29",
 													"cost": -4,
@@ -833,17 +979,21 @@
 											}
 										},
 										{
-											"id": "t--R28_V3j8kaIW-9",
+											"id": "tWSp4Y625vwdsUItF",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t6Nq6oInwkU1qbAP1"
+											},
 											"name": "Patron",
 											"reference": "B72,P65",
-											"notes": "Ship's owner or provider",
 											"tags": [
 												"Advantage",
 												"Social"
 											],
 											"modifiers": [
 												{
-													"id": "m_5zP3mpKojwc7mVo",
+													"id": "mU9pNUHE5Xa3eFAKC",
 													"name": "@Who: Individual with 150% of PC's starting points@",
 													"reference": "B72",
 													"cost": 10,
@@ -851,7 +1001,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mZsvmhXUZh1vk-apw",
+													"id": "mXtrXUq79VoMPh-i2",
 													"name": "@Who: Organization with assets of at least 1000 times starting wealth@",
 													"reference": "B72",
 													"cost": 10,
@@ -859,7 +1009,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mgltnfDLADAkne5iK",
+													"id": "mPFbeONAgS13LE3uO",
 													"name": "@Who: Individual with twice the PC's starting points@",
 													"reference": "B72",
 													"cost": 15,
@@ -867,7 +1017,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mgHVYX5ST3h0NhDDr",
+													"id": "mPKi4SdMLZpFDL1_p",
 													"name": "@Who: Organization with assets of at least 10000 times starting wealth@",
 													"reference": "B72",
 													"cost": 15,
@@ -875,7 +1025,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mYGJiizyu8IpUbZ02",
+													"id": "m2CVl3XRVYaUpDofM",
 													"name": "@Who: An ultra-powerful individual@",
 													"reference": "B72",
 													"cost": 20,
@@ -883,7 +1033,7 @@
 													"disabled": true
 												},
 												{
-													"id": "maBLBl2TdOtqiRUYW",
+													"id": "mtcfjpRa9ayEF1_WS",
 													"name": "@Who: Organization with assets of at least 100000 times starting wealth@",
 													"reference": "B72",
 													"cost": 20,
@@ -891,7 +1041,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mNqFYedN7CXUYAYma",
+													"id": "mnr2V9m46R6cT8O1x",
 													"name": "@Who: Organization with assets of at least 1000000 times starting wealth@",
 													"reference": "B72",
 													"cost": 25,
@@ -899,7 +1049,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mkjzu6K_9j31tQ3oX",
+													"id": "mSvkJ_l8CAqmVQZkJ",
 													"name": "@Who: A national government or giant multi-national organization@",
 													"reference": "B72",
 													"cost": 30,
@@ -907,7 +1057,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mPihva6fU1WPi_b7-",
+													"id": "m9inLgBBb_yRTEUKZ",
 													"name": "@Who: A deity@",
 													"reference": "B72",
 													"cost": 30,
@@ -915,7 +1065,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mQRUovXTwJawu4rja",
+													"id": "moOyEERAeXvBmQl2h",
 													"name": "Appears almost all the time",
 													"reference": "B36",
 													"notes": "15-",
@@ -924,7 +1074,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mtZiL6tEBxYLU8X-U",
+													"id": "mryDluKnQgdwpg6gi",
 													"name": "Appears quite often",
 													"reference": "B36",
 													"notes": "12-",
@@ -933,7 +1083,7 @@
 													"disabled": true
 												},
 												{
-													"id": "m3Oh23mq91BrRDlLz",
+													"id": "mzzAZf4CbJfWnz4J1",
 													"name": "Appears fairly often",
 													"reference": "B36",
 													"notes": "9-",
@@ -942,7 +1092,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mMZxo4KZgMa5rpX-f",
+													"id": "m7qmdLDB9Jyq6eDep",
 													"name": "Appears quite rarely",
 													"reference": "B36",
 													"notes": "6-",
@@ -951,7 +1101,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mCdPcoYxD03duIEHD",
+													"id": "m_l3lmCsc2f6Nyv0H",
 													"name": "Equipment",
 													"reference": "B73",
 													"notes": "@Equipment worth no more than average starting wealth@",
@@ -959,7 +1109,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mhRJO16XKRVpDQ7CJ",
+													"id": "mUuHM8JJbNTwSPAm9",
 													"name": "Equipment",
 													"reference": "B73",
 													"notes": "@Equipment worth more than average starting wealth@",
@@ -967,14 +1117,14 @@
 													"disabled": true
 												},
 												{
-													"id": "mCY78T33LzCqBtkEG",
+													"id": "mpzYVtytIAxPyPYYt",
 													"name": "Highly Accessible",
 													"reference": "B73",
 													"cost": 50,
 													"disabled": true
 												},
 												{
-													"id": "mEEVumB5RPugrWHWh",
+													"id": "mGGNMBc5bjhJnVp__",
 													"name": "Special Abilities",
 													"reference": "B73",
 													"notes": "@Extensive social or political power@",
@@ -982,7 +1132,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mz0i9omwGbCsnbTOD",
+													"id": "myHVgcGvb8VzfXapJ",
 													"name": "Special Abilities",
 													"reference": "B73",
 													"notes": "@Magical powers in a non-magical world, higher TL equipment, grants special powers or is supernatural@",
@@ -990,28 +1140,28 @@
 													"disabled": true
 												},
 												{
-													"id": "mD32PMv690yL6CCS2",
+													"id": "m8umazP7t-bHUIkrt",
 													"name": "Minimal Interventions",
 													"reference": "B73",
 													"cost": -50,
 													"disabled": true
 												},
 												{
-													"id": "mWF1FEoUFfapY_ALh",
+													"id": "mI7xnY04qEJjbwNap",
 													"name": "Secret",
 													"reference": "B73",
 													"cost": -50,
 													"disabled": true
 												},
 												{
-													"id": "mFw0l4WxV0Ivw0k21",
+													"id": "mKyx0QddcVO6ABeZF",
 													"name": "Unwilling",
 													"reference": "B74",
 													"cost": -50,
 													"disabled": true
 												},
 												{
-													"id": "mlC7ZW-c9rN3ShMif",
+													"id": "mp8O4EXXkm34NcxfW",
 													"name": "Favor",
 													"reference": "B55",
 													"cost": 0.2,
@@ -1024,7 +1174,12 @@
 											}
 										},
 										{
-											"id": "twG8IWptcfk2H9Sce",
+											"id": "tF66jN6Bz5SMC2yEy",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tz-USDL9B_KrrVqDi"
+											},
 											"name": "Luck",
 											"reference": "B66,P59",
 											"notes": "Usable once per hour of play",
@@ -1034,14 +1189,14 @@
 											],
 											"modifiers": [
 												{
-													"id": "mUIpvcfdISumPrqSN",
+													"id": "mL7jpmFarbgiNhPrz",
 													"name": "Active",
 													"reference": "B66",
 													"cost": -40,
 													"disabled": true
 												},
 												{
-													"id": "mWxvjIAYvhEMM97fu",
+													"id": "mWONbBZmvGIgWftLk",
 													"name": "Aspected",
 													"reference": "B66",
 													"notes": "@Aspect@",
@@ -1049,17 +1204,24 @@
 													"disabled": true
 												},
 												{
-													"id": "mma87zjatKkH5jCj8",
+													"id": "mo0_RkYeodCHnSsVS",
 													"name": "Defensive",
 													"reference": "B66",
 													"cost": -20,
 													"disabled": true
 												},
 												{
-													"id": "mf4EaHqGQqNza0sob",
+													"id": "m17XjCRsN80xa04CD",
 													"name": "Wishing",
 													"reference": "P59",
 													"cost": 100,
+													"disabled": true
+												},
+												{
+													"id": "mFqZKyQzcgc1UFIkM",
+													"name": "Game Time",
+													"reference": "P108",
+													"notes": "Uses per game day equal to its maximum possible uses per real hour",
 													"disabled": true
 												}
 											],
@@ -1069,7 +1231,12 @@
 											}
 										},
 										{
-											"id": "tO2BtoZ72Lt4h5SyN",
+											"id": "teQM0VZgEhO1D0i51",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tMxgHfzVEy_QQtlfB"
+											},
 											"name": "Less Sleep",
 											"reference": "B65",
 											"notes": "Require 1 hour/level less sleep for a full night's rest (max 4)",
@@ -1085,7 +1252,12 @@
 											}
 										},
 										{
-											"id": "tvSXgHxTuj0bIbiGr",
+											"id": "t94UgmT8CfekA2RhS",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tw1Ad0oSMw2ATM4X1"
+											},
 											"name": "Language: @Language@",
 											"reference": "B24",
 											"tags": [
@@ -1093,9 +1265,26 @@
 												"Language",
 												"Mental"
 											],
+											"prereqs": {
+												"type": "prereq_list",
+												"all": true,
+												"prereqs": [
+													{
+														"type": "trait_prereq",
+														"has": false,
+														"name": {
+															"compare": "is",
+															"qualifier": "Language Talent"
+														},
+														"level": {
+															"compare": "at_least"
+														}
+													}
+												]
+											},
 											"modifiers": [
 												{
-													"id": "mBbhTDp7OQ6Vo4scE",
+													"id": "mESh4k3KpBY8wkIXi",
 													"name": "Native",
 													"reference": "B23",
 													"cost": -6,
@@ -1103,7 +1292,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mMibVgo2C0CPGimRM",
+													"id": "msQ7ra0bHbhTSwVET",
 													"name": "Spoken",
 													"reference": "B24",
 													"notes": "None",
@@ -1111,7 +1300,7 @@
 													"disabled": true
 												},
 												{
-													"id": "miIJznPO9OHtb0JjC",
+													"id": "m_cj0yLBTiFTqDPAc",
 													"name": "Spoken",
 													"reference": "B24",
 													"notes": "Broken",
@@ -1120,7 +1309,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mlyVrFhkzzNeckyIT",
+													"id": "mCSzHHwBv0dgZWKB9",
 													"name": "Spoken",
 													"reference": "B24",
 													"notes": "Accented",
@@ -1128,7 +1317,7 @@
 													"cost_type": "points"
 												},
 												{
-													"id": "mMdr3EYhCQ6xyKloj",
+													"id": "mgVM5hIb_Aj_zri6N",
 													"name": "Spoken",
 													"reference": "B24",
 													"notes": "Native",
@@ -1137,7 +1326,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mrdqG2M_UYoGqH6lS",
+													"id": "mrAR_OLVUV2_e6oxH",
 													"name": "Written",
 													"reference": "B24",
 													"notes": "None",
@@ -1145,7 +1334,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mHam65pOkGPCPxuWN",
+													"id": "m2uZcpadCS_cme8bZ",
 													"name": "Written",
 													"reference": "B24",
 													"notes": "Broken",
@@ -1154,7 +1343,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mw_IG-IYc4hne0glu",
+													"id": "mMeceHKjkPPqmXtf2",
 													"name": "Written",
 													"reference": "B24",
 													"notes": "Accented",
@@ -1162,7 +1351,7 @@
 													"cost_type": "points"
 												},
 												{
-													"id": "mgi9Z8uV66ZHYWOS_",
+													"id": "moIa5lfNQHoDC8QzO",
 													"name": "Written",
 													"reference": "B24",
 													"notes": "Native",
@@ -1176,7 +1365,12 @@
 											}
 										},
 										{
-											"id": "tQ_ogrJ0yyZamQsg3",
+											"id": "ty_tHfNM6HFQ-KqFN",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "txREhxV6L1SKixwe_"
+											},
 											"name": "Improved G-tolerance",
 											"reference": "B60",
 											"tags": [
@@ -1185,7 +1379,7 @@
 											],
 											"modifiers": [
 												{
-													"id": "m-_IX681pE17fyppS",
+													"id": "mEWQpVokz4HVwyhT0",
 													"name": "0.3G",
 													"reference": "B60",
 													"cost": 5,
@@ -1193,7 +1387,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mS3lyi9ErOPRGg8b0",
+													"id": "mmuDwUgo6d4c2o0xH",
 													"name": "0.5G",
 													"reference": "B60",
 													"cost": 10,
@@ -1201,7 +1395,7 @@
 													"disabled": true
 												},
 												{
-													"id": "medVjtMCqt92LQH16",
+													"id": "mrSEGfrWi_anCXapj",
 													"name": "1G",
 													"reference": "B60",
 													"cost": 15,
@@ -1209,7 +1403,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mS3HKjZFG4ckR2i7O",
+													"id": "mQSpX_FMEnvYo1ZJt",
 													"name": "5G",
 													"reference": "B60",
 													"cost": 20,
@@ -1217,7 +1411,7 @@
 													"disabled": true
 												},
 												{
-													"id": "mz13qQQEiaIjhFHLd",
+													"id": "mjWt617YnTefcrXCF",
 													"name": "10G",
 													"reference": "B60",
 													"cost": 25,
@@ -1230,7 +1424,12 @@
 											}
 										},
 										{
-											"id": "tz2B1yLuVGIw0uhaP",
+											"id": "tSGzrQYAg7ZT5Wxu7",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t7blIRUzFpiHS_mnO"
+											},
 											"name": "Gizmo",
 											"reference": "B57,MA45",
 											"tags": [
@@ -1245,7 +1444,12 @@
 											}
 										},
 										{
-											"id": "tDr44rKngmhNgARns",
+											"id": "tId5tTbp4AP1_kEkD",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tHNrjEQFQBNOgwmzK"
+											},
 											"name": "G-Experience (All)",
 											"reference": "B57",
 											"tags": [
@@ -1258,7 +1462,12 @@
 											}
 										},
 										{
-											"id": "tNYmBpqx883LrO-hN",
+											"id": "trJxuw45tGYKBf6UL",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tu3GuYC47Sx6bnm4k"
+											},
 											"name": "G-Experience",
 											"reference": "B57",
 											"tags": [
@@ -1273,7 +1482,12 @@
 											}
 										},
 										{
-											"id": "t-3YonrYYy9kWZWU-",
+											"id": "tpwZ9VmLpaPzXmdTy",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "toTe273Ky82B6YdW5"
+											},
 											"name": "Fit",
 											"reference": "B55",
 											"notes": "Recover FP at twice the normal rate (but not FP spent for spells or psi powers)",
@@ -1294,7 +1508,12 @@
 											}
 										},
 										{
-											"id": "tHe_WTyMSnAD2wCV4",
+											"id": "tNNePhVv79emwPLQ4",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tQa3EUrs4Hjt9gxK6"
+											},
 											"name": "Fearlessness",
 											"reference": "B55,MA44",
 											"tags": [
@@ -1331,7 +1550,12 @@
 											}
 										},
 										{
-											"id": "tqIQOguS6UE61D7Ru",
+											"id": "t2xU-xZ6hFRBoIXUE",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t5j2Ox4jaIV9j0rpz"
+											},
 											"name": "Deep Sleeper",
 											"reference": "B101",
 											"tags": [
@@ -1344,7 +1568,12 @@
 											}
 										},
 										{
-											"id": "tQDziC6-P3BjgE-uO",
+											"id": "t8i_3QO6JoLY0cCzy",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tNBE3sLoyrUvAgoZ3"
+											},
 											"name": "Cybernetics",
 											"reference": "B46",
 											"tags": [
@@ -1356,7 +1585,12 @@
 											}
 										},
 										{
-											"id": "tvie8ApcXSzblJje2",
+											"id": "t-c1BqOuyVb-PYNH1",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "toXBQ8q4Nek5lsLPF"
+											},
 											"name": "Cultural Familiarity (@Culture@)",
 											"reference": "B23",
 											"notes": "Do not suffer the normal -3 penalty for unfamiliarity",
@@ -1366,14 +1600,14 @@
 											],
 											"modifiers": [
 												{
-													"id": "mPIAl6ZpfYFT6LOpO",
+													"id": "mIODCZYbN85aAZsZy",
 													"name": "Alien",
 													"cost": 1,
 													"cost_type": "points",
 													"disabled": true
 												},
 												{
-													"id": "mJay-QY3sT4U7nl0P",
+													"id": "mXQCmRyMI6Bv0hS65",
 													"name": "Native",
 													"cost": -1,
 													"cost_type": "points",
@@ -1386,9 +1620,14 @@
 											}
 										},
 										{
-											"id": "t0mAHLRnp8qOFS0gl",
-											"name": "Alien Friend",
-											"reference": "S220",
+											"id": "tBAqVEaiFWseAOA2t",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Power Ups/Power Ups Traits.adq",
+												"id": "t3msobZZ06J7dZ8xu"
+											},
+											"name": "Talent (Born Spacer)",
+											"reference": "PU3:7",
 											"tags": [
 												"Advantage",
 												"Mental",
@@ -1396,106 +1635,60 @@
 											],
 											"modifiers": [
 												{
-													"id": "mG4Ku_YpkRp5Dn6kJ",
-													"name": "Alternate Benefit",
-													"notes": "@Alternate Benefit@",
-													"disabled": true
-												},
-												{
-													"id": "mlxKjVEenC5jD-O9T",
+													"id": "mco3zTT02A1j2oJPO",
 													"name": "Alternative Cost",
+													"cost": 1,
 													"cost_type": "points",
 													"affects": "levels_only",
 													"disabled": true
-												}
-											],
-											"points_per_level": 5,
-											"features": [
-												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "Anthropology"
-													},
-													"amount": 1,
-													"per_level": true
 												},
 												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "Diplomacy"
-													},
-													"amount": 1,
-													"per_level": true
-												},
-												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "Expert Skill"
-													},
-													"amount": 1,
-													"per_level": true
-												},
-												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "History"
-													},
-													"amount": 1,
-													"per_level": true
-												},
-												{
-													"type": "skill_bonus",
-													"selection_type": "skills_with_name",
-													"name": {
-														"compare": "is",
-														"qualifier": "Psychology"
-													},
-													"amount": 1,
-													"per_level": true
-												},
-												{
-													"type": "reaction_bonus",
-													"situation": "Aliens",
-													"amount": 1,
-													"per_level": true
-												}
-											],
-											"can_level": true,
-											"levels": 1,
-											"calc": {
-												"points": 5
-											}
-										},
-										{
-											"id": "tuDTcDphyqi282ZAQ",
-											"name": "Born Spacer",
-											"reference": "THSCT40",
-											"tags": [
-												"Advantage",
-												"Mental",
-												"Talent"
-											],
-											"modifiers": [
-												{
-													"id": "mdy8AY8XpqNo-TiPI",
-													"name": "Alternate Benefit",
-													"notes": "@Alternate Benefit@",
-													"disabled": true
-												},
-												{
-													"id": "mo7XriAknOu1PClFH",
-													"name": "Alternative Cost",
-													"cost_type": "points",
-													"affects": "levels_only",
-													"disabled": true
+													"id": "My24WuZR9tHC_PO89",
+													"name": "Benefits",
+													"children": [
+														{
+															"id": "mZ7tiRQseY3463b4K",
+															"name": "Reaction Bonus",
+															"use_level_from_trait": true,
+															"features": [
+																{
+																	"type": "reaction_bonus",
+																	"situation": "From professional Spacers.",
+																	"amount": 1,
+																	"per_level": true
+																}
+															]
+														},
+														{
+															"id": "mevKfYJI88YCiUXkv",
+															"name": "Bonus to pushing off",
+															"reference": "BX350",
+															"reference_highlight": "ST/2",
+															"use_level_from_trait": true,
+															"features": [
+																{
+																	"type": "conditional_modifier",
+																	"situation": "Bonus to ST for zero G push off",
+																	"amount": 1,
+																	"per_level": true
+																}
+															],
+															"disabled": true
+														},
+														{
+															"id": "mji2guHmDpYLm21Cw",
+															"name": "Spacecraft Familiarity",
+															"use_level_from_trait": true,
+															"features": [
+																{
+																	"type": "conditional_modifier",
+																	"situation": "Counteracts Familiarity for spacecraft.",
+																	"amount": 1
+																}
+															],
+															"disabled": true
+														}
+													]
 												}
 											],
 											"points_per_level": 5,
@@ -1527,6 +1720,10 @@
 														"compare": "is",
 														"qualifier": "Navigation"
 													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "Space"
+													},
 													"amount": 1,
 													"per_level": true
 												},
@@ -1538,8 +1735,36 @@
 														"qualifier": "Piloting"
 													},
 													"specialization": {
-														"compare": "contains",
-														"qualifier": "Spacecraft"
+														"compare": "is",
+														"qualifier": "High-Performance Spacecraft"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Piloting"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "Low-Performance Spacecraft"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Piloting"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "Aerospace"
 													},
 													"amount": 1,
 													"per_level": true
@@ -1563,10 +1788,99 @@
 													},
 													"amount": 1,
 													"per_level": true
+												}
+											],
+											"can_level": true,
+											"levels": 1,
+											"calc": {
+												"points": 5
+											}
+										},
+										{
+											"id": "tOyiV_WE2TzTKNtoE",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Power Ups/Power Ups Traits.adq",
+												"id": "tcCw979nTBoztowCU"
+											},
+											"name": "Talent (Alien Friend)",
+											"reference": "PU3:6",
+											"tags": [
+												"Advantage",
+												"Mental",
+												"Talent"
+											],
+											"points_per_level": 5,
+											"features": [
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Diplomacy"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Expert Skill"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "Xenology"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Anthropology"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "@Alien@"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "History"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "@Alien@"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Psychology"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "@Alien@"
+													},
+													"amount": 1,
+													"per_level": true
 												},
 												{
 													"type": "reaction_bonus",
-													"situation": "Professional Spacers",
+													"situation": "From aliens.",
 													"amount": 1,
 													"per_level": true
 												}
@@ -1578,7 +1892,12 @@
 											}
 										},
 										{
-											"id": "ttup4j_Q40MK6mfc0",
+											"id": "tzRi6S6_FUohpfk5E",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tM6z7Mx6e2V4VvUR4"
+											},
 											"name": "Absolute Direction",
 											"reference": "B34",
 											"tags": [
@@ -1588,14 +1907,14 @@
 											],
 											"modifiers": [
 												{
-													"id": "mZQRSTDvc6JvBtXom",
+													"id": "mBQo3VFHFta0UGDCO",
 													"name": "Requires signal",
 													"reference": "B34",
 													"cost": -20,
 													"disabled": true
 												},
 												{
-													"id": "mo6g44WCyOXPwvK8N",
+													"id": "mzX-II2NAOgILgPdn",
 													"name": "3D Spatial Sense",
 													"reference": "B34",
 													"cost": 5,
@@ -1718,7 +2037,12 @@
 									}
 								},
 								{
-									"id": "ttVg76FvGCvhIkZd9",
+									"id": "tPB6KCbyoIEpGujKG",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tkdGzhkqoMAQbknEc"
+									},
 									"name": "Acute Vision",
 									"reference": "B35",
 									"tags": [
@@ -1741,13 +2065,53 @@
 									}
 								},
 								{
-									"id": "tQpomSyJmif6WxF5m",
+									"id": "teR650aT1HtGiQifv",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tgnQFo-hK7YwexD2S"
+									},
 									"name": "Talent (Born War Leader)",
 									"reference": "DF1:14,PU3:12",
 									"tags": [
 										"Advantage",
 										"Physical",
 										"Talent"
+									],
+									"modifiers": [
+										{
+											"id": "MAx_IU4gX16r8t814",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "mmWwnNjf4LDCZrSx8",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "mzkx9MAH8DFjcFUWH",
+													"name": "Alternative Benefit",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Bonus to initiative rolls if leader",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
+										}
 									],
 									"points_per_level": 5,
 									"features": [
@@ -1804,18 +2168,6 @@
 											},
 											"amount": 1,
 											"per_level": true
-										},
-										{
-											"type": "reaction_bonus",
-											"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
-											"amount": 1,
-											"per_level": true
-										},
-										{
-											"type": "conditional_modifier",
-											"situation": "Bonus to initiative rolls if leader",
-											"amount": 1,
-											"per_level": true
 										}
 									],
 									"can_level": true,
@@ -1825,7 +2177,12 @@
 									}
 								},
 								{
-									"id": "tZUJK76x5t5zse-ty",
+									"id": "tv4IjuOknsZGIFV_o",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tgjE-yMzESTjq695x"
+									},
 									"name": "Danger Sense",
 									"reference": "B47,P46",
 									"tags": [
@@ -1838,7 +2195,12 @@
 									}
 								},
 								{
-									"id": "tMJ8BGx9PirUm0MlC",
+									"id": "tYLvCVINk3uV0iOBK",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tIctG8MNDcvQf_UwX"
+									},
 									"name": "Eye for Distance",
 									"reference": "PU2:13",
 									"tags": [
@@ -1851,20 +2213,37 @@
 									}
 								},
 								{
-									"id": "tNQvJRw-cBxxmQ8EY",
+									"id": "tWowfQ1BTwud_0GeF",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tHRgrj_fBsqwVk5Gh"
+									},
 									"name": "Penetrating Voice",
-									"reference": "PU2:14",
+									"reference": "B101",
 									"tags": [
 										"Perk",
 										"Physical"
 									],
 									"base_points": 1,
+									"features": [
+										{
+											"type": "conditional_modifier",
+											"situation": "to others' Hearing roll in siturations where you want to be heard over noise",
+											"amount": 3
+										}
+									],
 									"calc": {
 										"points": 1
 									}
 								},
 								{
-									"id": "tQlxWz36e3p4O_xPL",
+									"id": "tSTbP5pHehTISL5C4",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tJTfFdHM7YI5IZR7I"
+									},
 									"name": "Resistant",
 									"reference": "B81,P71,MA47",
 									"tags": [
@@ -1873,7 +2252,7 @@
 									],
 									"modifiers": [
 										{
-											"id": "mLRAV3mXUuH_MTS7w",
+											"id": "mnxtVofmoXSfWO4Bp",
 											"name": "@Very Common: Metabolic Hazards, etc.@",
 											"reference": "B80",
 											"cost": 30,
@@ -1881,7 +2260,7 @@
 											"disabled": true
 										},
 										{
-											"id": "ma-VSTHG7trEVb4zB",
+											"id": "mT-gZAikFKk6rzt-w",
 											"name": "@Common: Poison, Sickness, etc.@",
 											"reference": "B81",
 											"cost": 15,
@@ -1889,7 +2268,7 @@
 											"disabled": true
 										},
 										{
-											"id": "msu-xVByhBJPmpnHX",
+											"id": "m0-xaZZKLaYHkKhMe",
 											"name": "@Occasional: Disease, Ingested Poison, etc.@",
 											"reference": "B81",
 											"cost": 10,
@@ -1897,14 +2276,17 @@
 											"disabled": true
 										},
 										{
-											"id": "mZpLgiGEtyPC_Tjmt",
-											"name": "Acceleration",
+											"id": "mfN7MaoK21ZrrgFTb",
+											"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
 											"reference": "B81",
+											"replacements": {
+												"Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.": "Acceleration"
+											},
 											"cost": 5,
 											"cost_type": "points"
 										},
 										{
-											"id": "mrDvGUfkbmtGhCTZ1",
+											"id": "mIkfgJRjd5jzKgRW_",
 											"name": "Immunity",
 											"reference": "B81",
 											"cost": 1,
@@ -1912,14 +2294,14 @@
 											"disabled": true
 										},
 										{
-											"id": "m2FikCaqReMixxUO9",
+											"id": "m416uFcbXgc-0oE4V",
 											"name": "+8 to all HT rolls to resist",
 											"reference": "B81",
 											"cost": 0.5,
 											"cost_type": "multiplier"
 										},
 										{
-											"id": "m-3W2ddtS2otlFWVW",
+											"id": "mglEe93_E09ioLt6B",
 											"name": "+3 to all HT rolls to resist",
 											"reference": "B81",
 											"cost": 0.33,
@@ -1933,7 +2315,12 @@
 									}
 								},
 								{
-									"id": "t9CR_u8QL-QN918sq",
+									"id": "t0BZC1a-E1nQCTUaR",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "trClz3uZE-XIfFJKI"
+									},
 									"name": "Unfazeable",
 									"reference": "B95",
 									"notes": "Exempt from fright checks. Reaction modifiers do not affect you.",
@@ -1943,7 +2330,7 @@
 									],
 									"modifiers": [
 										{
-											"id": "myovrT3TruCUyvtTh",
+											"id": "mNiA1ckNmOXk_twP6",
 											"name": "Familiar Horrors",
 											"reference": "H20",
 											"cost": -50,
@@ -1974,14 +2361,56 @@
 							"name": "-40 Points chosen from",
 							"children": [
 								{
-									"id": "T-7hVtm_Kb-5L7ELs",
+									"id": "TIJtYoBCCEx3CDy7L",
 									"name": "Everyman Disadvantages",
 									"tags": [
 										"Disadvantage"
 									],
 									"children": [
 										{
-											"id": "thvR1AtXB6hSFacuU",
+											"id": "tSttHOF0WMnsItkh-",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tX9XXLPFBvyQSpA4k"
+											},
+											"name": "Xenophilia",
+											"reference": "B162",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"cr": 12,
+											"base_points": -10,
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "tTjadaThDD-IUa8nW",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t8I0xw1Lj1_222aEN"
+											},
+											"name": "Workaholic",
+											"reference": "B162",
+											"tags": [
+												"Disadvantage",
+												"Physical"
+											],
+											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										},
+										{
+											"id": "t6tmbsylI4DE5lNGP",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t7U0VbIzs6SqefwLr"
+											},
 											"name": "Social Stigma (Criminal Record)",
 											"reference": "B155",
 											"tags": [
@@ -2001,23 +2430,162 @@
 											}
 										},
 										{
-											"id": "tg6XtFkJXrgrvfUM9",
-											"name": "Chummy",
-											"reference": "B126",
+											"id": "tP_1cs3NKIlY3YcOD",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "thSMVzJ590v7gAD8d"
+											},
+											"name": "Pacifism: Self-Defense Only",
+											"reference": "B148",
+											"notes": "You only fight to defend yourself or those in your care, using only as much force as necessary (no pre-emptive strikes allowed!). You must do your best to discourage others from starting fights.",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
+											"modifiers": [
+												{
+													"id": "m9-nGE1ZCWyRFfJRV",
+													"name": "Species-Specific",
+													"reference": "UT32",
+													"cost": -80,
+													"disabled": true
+												}
+											],
+											"base_points": -15,
+											"calc": {
+												"points": -15
+											}
+										},
+										{
+											"id": "tr56VlMQB3S1ssSlN",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tV_f_75HmwzWOPhuu"
+											},
+											"name": "Pacifism: Reluctant Killer",
+											"reference": "B148",
+											"notes": "You are psychologically unprepared to kill people. Whenever you make a deadly attack (e.g., with a knife or a gun) against an obvious person whose face is visible to you, you are at -4 to hit and may not Aim. If you cannot see the foe’s face (due to a mask, darkness, or distance, or because you attacked from behind), the penalty is only -2, save in close combat. You have no penalty to attack a vehicle (even an occupied one), an opponent you do not believe is a person (including things with Horrific or Monstrous appearance), or a target you can’t actually see (e.g., a set of map coordinates or a blip on a radar screen). If you kill a recognizable person, the effect on you is the same as for Pacifism: Cannot Kill. You have no problem with your allies killing; you may even supply ammo, loaded weapons, and encouragement! You just can’t do the killing yourself.",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"modifiers": [
+												{
+													"id": "mLGSnfyQkwp2suLfU",
+													"name": "Species-Specific",
+													"reference": "UT32",
+													"cost": -80,
+													"disabled": true
+												}
+											],
 											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										},
+										{
+											"id": "tuEa4hEBDVWDk8mWA",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "th9TK1Jmqg8uKe6SC"
+											},
+											"name": "Pacifism: Cannot Harm Innocents",
+											"reference": "B148",
+											"notes": "You may fight – you may even start fights – but you may only use deadly force on a foe that is attempting to do you serious harm. Capture is not “serious harm” unless you are already under penalty of death or have a Code of Honor that would require suicide if captured. You never intentionally do anything that causes, or even threatens to cause, injury to the uninvolved – particularly if they are “ordinary folks.”",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"modifiers": [
+												{
+													"id": "mVpKGXwv5bYZ1anjA",
+													"name": "Species-Specific",
+													"reference": "UT32",
+													"cost": -80,
+													"disabled": true
+												}
+											],
+											"base_points": -10,
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "tOKlKARsgrpCKI1Ep",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tSiOKuvTJkqJhuRrI"
+											},
+											"name": "Lecherousness",
+											"reference": "B142",
+											"notes": "Make a self-control roll whenever you have more than the briefest contact with an appealing member of the sex you find attractive, at -5 if this person is Handsome/Beautiful, or at -10 if Very Handsome/Very Beautiful. If you fail, you must make a “pass” using whatever wiles and skills you can bring to bear.",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"cr": 12,
+											"base_points": -15,
+											"calc": {
+												"points": -15
+											}
+										},
+										{
+											"id": "tucVYpBJDGykgc2zK",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "ttHkLI9zwzfeOIEZc"
+											},
+											"name": "Intolerance (@Class, Ethnicity, Nationality, Religion, Sex, or Species@)",
+											"reference": "B140",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"replacements": {
+												"Class, Ethnicity, Nationality, Religion, Sex, or Species": "Rival civilization or species"
+											},
+											"modifiers": [
+												{
+													"id": "m_kOGdfGdbGMzMGb3",
+													"name": "Scope: Common",
+													"reference": "B140",
+													"cost": -5,
+													"cost_type": "points"
+												},
+												{
+													"id": "mGYnLogeMxiStHKSI",
+													"name": "Scope: Occasional",
+													"reference": "B140",
+													"cost": -2,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mnG16wi11OcwO1DKp",
+													"name": "Scope: Rare",
+													"reference": "B140",
+													"cost": -1,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mM2mstKbGVz7R9G1O",
+													"name": "Scope: Anyone unlike you",
+													"reference": "B140",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												}
+											],
 											"features": [
 												{
 													"type": "reaction_bonus",
-													"situation": "to others",
-													"amount": 2
-												},
-												{
-													"type": "conditional_modifier",
-													"situation": "to IQ-based skills when alone",
+													"situation": "from victims of your intolerance (may be as much as -5, at GM's discretion)",
 													"amount": -1
 												}
 											],
@@ -2026,49 +2594,383 @@
 											}
 										},
 										{
-											"id": "tx0B3pG7f3ou_Tj_i",
-											"name": "Code of Honor (Mercanary's)",
-											"reference": "S221",
-											"notes": "A merc should look out for his buddies, take care of his gear, and fight for the honor of the unit. Obey the rule's of engagement. Don't poach on another unit's contract. Do the job you're hired for.",
+											"id": "tbJe8eNQ1kA831VmH",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t7pCgXTVkswkTjOZO"
+											},
+											"name": "Honesty",
+											"reference": "B138",
+											"notes": "Make a self-control roll when faced with the “need” to break unreasonable laws; if you fail, you must obey the law, whatever the consequences. If you manage to resist your urges and break the law, make a second self-control roll afterward. If you fail, you must turn yourself in to the authorities!",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
+											"cr": 12,
 											"base_points": -10,
 											"calc": {
 												"points": -10
 											}
 										},
 										{
-											"id": "tV0wMoK3gF1C85IPt",
-											"name": "Code of Honor (Pirate's)",
-											"reference": "B127",
-											"notes": "Always avenge an insult, regardless of the danger; your buddy’s foe is your own; never attack a fellow crewman or buddy except in a fair, open duel.",
+											"id": "tmpBJoxWbHsQdhxk-",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t5bwP6TnS4cX-zM8L"
+											},
+											"name": "Enemy (@Who@)",
+											"reference": "B135",
+											"tags": [
+												"Disadvantage",
+												"Social"
+											],
+											"modifiers": [
+												{
+													"id": "mqyEM89SeNyIUea2c",
+													"name": "Weak Individual",
+													"reference": "B135",
+													"notes": "50% of your starting points",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mXX3metElDulwPrG9",
+													"name": "Equal Individual",
+													"reference": "B135",
+													"notes": "100% of your starting points",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "msNKLD7y1c1fmdCkY",
+													"name": "Powerful Individual",
+													"reference": "B135",
+													"notes": "\u003e150% of your starting points",
+													"cost": -20,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m189q886671ieku8V",
+													"name": "Weak Group",
+													"reference": "B135",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mVVXaxn_c8zMH_EXj",
+													"name": "Medium Group",
+													"reference": "B135",
+													"cost": -20,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mVisSxvJHQnIpO_Wg",
+													"name": "Appears almost all the time",
+													"reference": "B36",
+													"notes": "15-",
+													"cost": 3,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mpMn5afggBiRgdcrL",
+													"name": "Appears quite often",
+													"reference": "B36",
+													"notes": "12-",
+													"cost": 2,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mDjP0fAOIgIDYjdYB",
+													"name": "Appears fairly often",
+													"reference": "B36",
+													"notes": "9-",
+													"cost": 1,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "m7a2r2SavspuLvbcs",
+													"name": "Appears quite rarely",
+													"reference": "B36",
+													"notes": "6-",
+													"cost": 0.5,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mlr7SFgFaW9wxoiWX",
+													"name": "Large/Powerful Group",
+													"reference": "B135",
+													"cost": -30,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m46ZPNaG-MCK4nV_7",
+													"name": "Utterly Formidable Group",
+													"reference": "B135",
+													"cost": -40,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mbNZVAXO4r7OBV_1n",
+													"name": "Unknown",
+													"reference": "B135",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mZgnN7cb7D6tixAFw",
+													"name": "Evil Twin",
+													"reference": "B135",
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mSs05ntLbH7Pz6xIE",
+													"name": "Evil Twin",
+													"reference": "B135",
+													"notes": "More skilled or extra abilities",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mt3YJsmY0DeYt1rv_",
+													"name": "Evil Twin",
+													"reference": "B135",
+													"notes": "More skilled and extra abilities",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mXa3fIe0XKxCPWMMC",
+													"name": "Watcher",
+													"reference": "B135",
+													"cost": 0.25,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "m9MyxPof07Njka0Vr",
+													"name": "Rival",
+													"reference": "B135",
+													"cost": 0.5,
+													"cost_type": "multiplier",
+													"disabled": true
+												},
+												{
+													"id": "mSJNionBE4B7zDxrN",
+													"name": "Hunter",
+													"reference": "B135",
+													"cost": 1,
+													"cost_type": "multiplier",
+													"disabled": true
+												}
+											],
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "tr95kjMYVj7DtWeN8",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t1HUGl4o498iCyvrw"
+											},
+											"name": "Duty (@Duty@)",
+											"reference": "B133",
+											"tags": [
+												"Disadvantage",
+												"Social"
+											],
+											"replacements": {
+												"Duty": "To ship's owner or provider"
+											},
+											"modifiers": [
+												{
+													"id": "mEyH857m3ifd1AOT8",
+													"name": "FR: 6",
+													"cost": -2,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mHtGUJ5BT85QPfTZj",
+													"name": "FR: 9",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mp75shd67LwaLno8f",
+													"name": "FR: 12",
+													"cost": -10,
+													"cost_type": "points"
+												},
+												{
+													"id": "m_b68bk5uSIL8xD5u",
+													"name": "FR: 15",
+													"cost": -15,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mt8LHCNoL6hB8nK4l",
+													"name": "Extremely Hazardous",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mDEUeqURnpQlxPKSQ",
+													"name": "Involuntary",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mTi08IjYfudVD86tM",
+													"name": "Nonhazardous",
+													"cost": 5,
+													"cost_type": "points",
+													"disabled": true
+												}
+											],
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "tQxQWZao_z2leBI0g",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t1HUGl4o498iCyvrw"
+											},
+											"name": "Duty (@Duty@)",
+											"reference": "B133",
+											"tags": [
+												"Disadvantage",
+												"Social"
+											],
+											"replacements": {
+												"Duty": "To ship's owner or provider"
+											},
+											"modifiers": [
+												{
+													"id": "mdXvNHRWu6j_JlgK3",
+													"name": "FR: 6",
+													"cost": -2,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "manpZ_abDreJnCu0u",
+													"name": "FR: 9",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mSm4302i8ot11D7Od",
+													"name": "FR: 12",
+													"cost": -10,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mcisT_sy1bhryI54T",
+													"name": "FR: 15",
+													"cost": -15,
+													"cost_type": "points"
+												},
+												{
+													"id": "mJ_93qMtkedhGCzW3",
+													"name": "Extremely Hazardous",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mt9UOUqBhlgw2GXUA",
+													"name": "Involuntary",
+													"cost": -5,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mFSKJ4qfB8ZF2QIp-",
+													"name": "Nonhazardous",
+													"cost": 5,
+													"cost_type": "points",
+													"disabled": true
+												}
+											],
+											"calc": {
+												"points": -15
+											}
+										},
+										{
+											"id": "tSL6emcuaF9hz87sV",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tXFf9MSQ3FMT2psO8"
+											},
+											"name": "Demophobia (Crowds)",
+											"reference": "B149",
+											"notes": "Any group of over a dozen people sets off this fear unless they are all well known to you. The self-control roll is at -1 for over 25 people, -2 for a crowd of 100 or more, -3 for 1,000, -4 for 10,000, and so on.",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
+											"cr_adj": "action_penalty",
+											"cr": 12,
+											"base_points": -15,
+											"calc": {
+												"points": -15
+											}
+										},
+										{
+											"id": "tzGqP0f9IsAvq5muM",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tK4QdVZYxGAd4cqr_"
+											},
+											"name": "Compulsive Gambling",
+											"reference": "B128",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"cr": 12,
 											"base_points": -5,
 											"calc": {
 												"points": -5
 											}
 										},
 										{
-											"id": "teP1gBI13rTzVv4Fj",
-											"name": "Code of Honor (Soldier's)",
-											"reference": "B127",
-											"notes": "An officer should be tough but fair, lead from the front, and look out for his men; an enlisted man should look out for his buddies and take care of his kit. Every soldier should be willing to fight and die for the honor of his unit, service, and country; follow orders; obey the “rules of war”; treat an honorable enemy with respect (a dishonorable enemy deserves a bullet); and wear the uniform with pride.",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"base_points": -10,
-											"calc": {
-												"points": -10
-											}
-										},
-										{
-											"id": "tnPFdPLnvsi975vTq",
+											"id": "taOL6eW1plIfN3jBq",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tapWLsuN75Unedmwn"
+											},
 											"name": "Compulsive Carousing",
 											"reference": "B128",
 											"tags": [
@@ -2094,308 +2996,115 @@
 											}
 										},
 										{
-											"id": "tj9lyVH_REYH1-xF2",
-											"name": "Compulsive Gambling",
-											"reference": "B128",
+											"id": "to7XDPxYxPxL8MDLY",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "txSrmgLB0M36uR802"
+											},
+											"name": "Code of Honor (Soldier's)",
+											"reference": "B127",
+											"notes": "An officer should be tough but fair, lead from the front, and look out for his men; an enlisted man should look out for his buddies and take care of his kit. Every soldier should be willing to fight and die for the honor of his unit, service, and country; follow orders; obey the “rules of war”; treat an honorable enemy with respect (a dishonorable enemy deserves a bullet); and wear the uniform with pride.",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
-											"cr": 12,
-											"base_points": -5,
-											"calc": {
-												"points": -5
-											}
-										},
-										{
-											"id": "tS8D-AQkEkWuOrsW1",
-											"name": "Duty (To ship's owner or provider)",
-											"reference": "B133",
-											"tags": [
-												"Disadvantage",
-												"Social"
-											],
-											"modifiers": [
-												{
-													"id": "mzjBSC3I76Lw-Plr1",
-													"name": "FR: 6",
-													"cost": -2,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mkegV-f-Z2cVQBxZd",
-													"name": "FR: 9",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "ms2-0L3LQqI9MrcYH",
-													"name": "FR: 12",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mDLN2cepKXmpwNLvx",
-													"name": "FR: 15",
-													"cost": -15,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m-Eljm9C7lyjmJZQK",
-													"name": "Extremely Hazardous",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m5bo-nR5ge8T5pQd5",
-													"name": "Involuntary",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mu9FGZQHI9pmL4sfU",
-													"name": "Nonhazardous",
-													"cost": 5,
-													"cost_type": "points",
-													"disabled": true
-												}
-											],
-											"calc": {
-												"points": 0
-											}
-										},
-										{
-											"id": "t8JoxWAQKqxODEXb6",
-											"name": "Enemy (@Who@)",
-											"reference": "B135",
-											"tags": [
-												"Disadvantage",
-												"Social"
-											],
-											"modifiers": [
-												{
-													"id": "mzsyOj4C-GgsHcU_I",
-													"name": "Weak Individual",
-													"reference": "B135",
-													"notes": "50% of your starting points",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mbU0B5A-osgsUzld1",
-													"name": "Equal Individual",
-													"reference": "B135",
-													"notes": "100% of your starting points",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mG4XUiCy0dLgg6fNG",
-													"name": "Powerful Individual",
-													"reference": "B135",
-													"notes": "\u003e150% of your starting points",
-													"cost": -20,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mGE5I-FMp2mn71Yzv",
-													"name": "Weak Group",
-													"reference": "B135",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m6n9yHrdM7c5e64db",
-													"name": "Medium Group",
-													"reference": "B135",
-													"cost": -20,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m2QZOzo2Jws5UDrpy",
-													"name": "Appears almost all the time",
-													"reference": "B36",
-													"notes": "15-",
-													"cost": 3,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mgNLjBPV30U6aNZQv",
-													"name": "Appears quite often",
-													"reference": "B36",
-													"notes": "12-",
-													"cost": 2,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mDvUVBEN8iuD96SyA",
-													"name": "Appears fairly often",
-													"reference": "B36",
-													"notes": "9-",
-													"cost": 1,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mgBfk0GGljCNpp9Io",
-													"name": "Appears quite rarely",
-													"reference": "B36",
-													"notes": "6-",
-													"cost": 0.5,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "m0l8If7Y30ZpDMe6s",
-													"name": "Large/Powerful Group",
-													"reference": "B135",
-													"cost": -30,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m_GVzuddyVpE4GYdH",
-													"name": "Utterly Formidable Group",
-													"reference": "B135",
-													"cost": -40,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "myTsooZDUZXzzhb1B",
-													"name": "Unknown",
-													"reference": "B135",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mhJTb5tz1ZVtACTwp",
-													"name": "Evil Twin",
-													"reference": "B135",
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mcWYMS_r-b84nH5d1",
-													"name": "Evil Twin",
-													"reference": "B135",
-													"notes": "More skilled or extra abilities",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mQALrPF_bHsOlPRBT",
-													"name": "Evil Twin",
-													"reference": "B135",
-													"notes": "More skilled and extra abilities",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "md77Rk9uwKZbVt36H",
-													"name": "Watcher",
-													"reference": "B135",
-													"cost": 0.25,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "mZ0MlGtTcPTkEkdly",
-													"name": "Rival",
-													"reference": "B135",
-													"cost": 0.5,
-													"cost_type": "multiplier",
-													"disabled": true
-												},
-												{
-													"id": "miBHhwCuGwPaFyocG",
-													"name": "Hunter",
-													"reference": "B135",
-													"cost": 1,
-													"cost_type": "multiplier",
-													"disabled": true
-												}
-											],
-											"calc": {
-												"points": 0
-											}
-										},
-										{
-											"id": "tAIl2M_hzHOb_fd5l",
-											"name": "Honesty",
-											"reference": "B138",
-											"notes": "Make a self-control roll when faced with the “need” to break unreasonable laws; if you fail, you must obey the law, whatever the consequences. If you manage to resist your urges and break the law, make a second self-control roll afterward. If you fail, you must turn yourself in to the authorities!",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"cr": 12,
 											"base_points": -10,
 											"calc": {
 												"points": -10
 											}
 										},
 										{
-											"id": "tDCVVvkutn7QneerG",
-											"name": "Intolerance (@Rival civilization or species@)",
-											"reference": "B140",
+											"id": "t0VIrMQuoFocI3bH0",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Space/Space Traits.adq",
+												"id": "teNSsqOsjstajwmxn"
+											},
+											"name": "Code of Honor (Mercenary's Code)",
+											"reference": "B127, S221",
+											"notes": "A merc should look out for his buddies, take care of his gear, and fight for the honor of the unit. Obey the rules of engagement. Don’t poach on another unit’s contract. Do the job you’re hired for.",
 											"tags": [
 												"Disadvantage",
 												"Mental"
 											],
-											"modifiers": [
-												{
-													"id": "miQ0CLfGGAO1d-InD",
-													"name": "Scope: Common",
-													"reference": "B140",
-													"cost": -5,
-													"cost_type": "points"
-												},
-												{
-													"id": "mR8iAn1lDydo61Fuj",
-													"name": "Scope: Occasional",
-													"reference": "B140",
-													"cost": -2,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mJiDEarDCdP4965JL",
-													"name": "Scope: Rare",
-													"reference": "B140",
-													"cost": -1,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m7j1Wx7T-kh9EB0c-",
-													"name": "Scope: Anyone unlike you",
-													"reference": "B140",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												}
+											"base_points": -10,
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "tEMpjT1xReH0maN7a",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tqq24I9NJrLajsURv"
+											},
+											"name": "Code of Honor (Pirate's)",
+											"reference": "B127",
+											"notes": "Always avenge an insult, regardless of the danger; your buddy’s foe is your own; never attack a fellow crewman or buddy except in a fair, open duel.",
+											"tags": [
+												"Disadvantage",
+												"Mental"
 											],
+											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										},
+										{
+											"id": "tg8YIzb66ojDXJqNK",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t4KGpV0KBExr-fEb2"
+											},
+											"name": "Gregarious",
+											"reference": "B126",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"base_points": -10,
 											"features": [
 												{
 													"type": "reaction_bonus",
-													"situation": "from victims of your intolerance (may be as much as -5, at GM's discretion)",
+													"situation": "to others",
+													"amount": 4
+												},
+												{
+													"type": "conditional_modifier",
+													"situation": "to IQ-based skills when alone, or only -1 if in a group of 4 or less",
+													"amount": -2
+												}
+											],
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "t7t43TG3ZTdNt2FZ2",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tzBDG0xUlT_dh7FuY"
+											},
+											"name": "Chummy",
+											"reference": "B126",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"base_points": -5,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "to others",
+													"amount": 2
+												},
+												{
+													"type": "conditional_modifier",
+													"situation": "to IQ-based skills when alone",
 													"amount": -1
 												}
 											],
@@ -2404,91 +3113,12 @@
 											}
 										},
 										{
-											"id": "tIDwOtq1RCPsrP5Ej",
-											"name": "Lecherousness",
-											"reference": "B142",
-											"notes": "Make a self-control roll whenever you have more than the briefest contact with an appealing member of the sex you find attractive, at -5 if this person is Handsome/Beautiful, or at -10 if Very Handsome/Very Beautiful. If you fail, you must make a “pass” using whatever wiles and skills you can bring to bear.",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"cr": 12,
-											"base_points": -15,
-											"calc": {
-												"points": -15
-											}
-										},
-										{
-											"id": "ttzXbslKin3g2godb",
-											"name": "Pacifism: Reluctant Killer",
-											"reference": "B148",
-											"notes": "You are psychologically unprepared to kill people. Whenever you make a deadly attack (e.g., with a knife or a gun) against an obvious person whose face is visible to you, you are at -4 to hit and may not Aim. If you cannot see the foe’s face (due to a mask, darkness, or distance, or because you attacked from behind), the penalty is only -2, save in close combat. You have no penalty to attack a vehicle (even an occupied one), an opponent you do not believe is a person (including things with Horrific or Monstrous appearance), or a target you can’t actually see (e.g., a set of map coordinates or a blip on a radar screen). If you kill a recognizable person, the effect on you is the same as for Pacifism: Cannot Kill. You have no problem with your allies killing; you may even supply ammo, loaded weapons, and encouragement! You just can’t do the killing yourself.",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"modifiers": [
-												{
-													"id": "mJR5B0hPYkYsKCfc-",
-													"name": "Species-Specific",
-													"reference": "UT32",
-													"cost": -80,
-													"disabled": true
-												}
-											],
-											"base_points": -5,
-											"calc": {
-												"points": -5
-											}
-										},
-										{
-											"id": "tBpiNgmz1pdPuTJfH",
-											"name": "Pacifism: Self-Defense Only",
-											"reference": "B148",
-											"notes": "You only fight to defend yourself or those in your care, using only as much force as necessary (no pre-emptive strikes allowed!). You must do your best to discourage others from starting fights.",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"modifiers": [
-												{
-													"id": "m8Y90ggNHAEs1x6vB",
-													"name": "Species-Specific",
-													"reference": "UT32",
-													"cost": -80,
-													"disabled": true
-												}
-											],
-											"base_points": -15,
-											"calc": {
-												"points": -15
-											}
-										},
-										{
-											"id": "tJyGU166uzyfi0KuY",
-											"name": "Pacifism: Cannot Harm Innocents",
-											"reference": "B148",
-											"notes": "You may fight – you may even start fights – but you may only use deadly force on a foe that is attempting to do you serious harm. Capture is not “serious harm” unless you are already under penalty of death or have a Code of Honor that would require suicide if captured. You never intentionally do anything that causes, or even threatens to cause, injury to the uninvolved – particularly if they are “ordinary folks.”",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"modifiers": [
-												{
-													"id": "muFIhmQv3HVUsd_-2",
-													"name": "Species-Specific",
-													"reference": "UT32",
-													"cost": -80,
-													"disabled": true
-												}
-											],
-											"base_points": -10,
-											"calc": {
-												"points": -10
-											}
-										},
-										{
-											"id": "tyyggtGqK0CjJsWgM",
+											"id": "tpftp8pDJ586MV7Ih",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "taFPI7E0PJwXbS5nL"
+											},
 											"name": "Agoraphobia (Open Spaces)",
 											"reference": "B150",
 											"notes": "You are uncomfortable whenever you are outside, and actually become frightened when there are no walls within 50 feet.",
@@ -2502,125 +3132,24 @@
 											"calc": {
 												"points": -10
 											}
-										},
-										{
-											"id": "tI7p8wfpTzR4v7Oxj",
-											"name": "Demophobia (Crowds)",
-											"reference": "B149",
-											"notes": "Any group of over a dozen people sets off this fear unless they are all well known to you. The self-control roll is at -1 for over 25 people, -2 for a crowd of 100 or more, -3 for 1,000, -4 for 10,000, and so on.",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"cr_adj": "action_penalty",
-											"cr": 12,
-											"base_points": -15,
-											"calc": {
-												"points": -15
-											}
-										},
-										{
-											"id": "tZ2iEneHjUbelHOup",
-											"name": "Duty (To ship's owner or provider)",
-											"reference": "B133",
-											"tags": [
-												"Disadvantage",
-												"Social"
-											],
-											"modifiers": [
-												{
-													"id": "msIChJn1jIGkG8twD",
-													"name": "FR: 6",
-													"cost": -2,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mMsg1EkRY9id30JK6",
-													"name": "FR: 9",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m4fJap3Dfd8xHVdJE",
-													"name": "FR: 12",
-													"cost": -10,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m6bpcD70GzQBC2Fic",
-													"name": "FR: 15",
-													"cost": -15,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mIR-aa90d4jwkc5c1",
-													"name": "Extremely Hazardous",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "mQWpGH7siXm9ssajQ",
-													"name": "Involuntary",
-													"cost": -5,
-													"cost_type": "points",
-													"disabled": true
-												},
-												{
-													"id": "m-Kce1nJ57yBh9dRG",
-													"name": "Nonhazardous",
-													"cost": 5,
-													"cost_type": "points",
-													"disabled": true
-												}
-											],
-											"calc": {
-												"points": 0
-											}
-										},
-										{
-											"id": "thjMo9PSYMfcCmeju",
-											"name": "Workaholic",
-											"reference": "B162",
-											"tags": [
-												"Disadvantage",
-												"Physical"
-											],
-											"base_points": -5,
-											"calc": {
-												"points": -5
-											}
-										},
-										{
-											"id": "ttk2ts2A71FR5hGzO",
-											"name": "Xenophilia",
-											"reference": "B162",
-											"tags": [
-												"Disadvantage",
-												"Mental"
-											],
-											"cr": 12,
-											"base_points": -10,
-											"calc": {
-												"points": -10
-											}
 										}
 									],
 									"calc": {
-										"points": -145
+										"points": -180
 									}
 								}
 							],
 							"calc": {
-								"points": -145
+								"points": -180
 							}
 						},
 						{
-							"id": "tf7TPUTO2lChnsGYY",
+							"id": "txIfskX63-V6DLIRt",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tmRX0o0iO20zWIVyo"
+							},
 							"name": "Bloodlust",
 							"reference": "B125",
 							"notes": "You must make a self-control roll whenever you need to accept a surrender, evade a sentry, take a prisoner, etc.",
@@ -2635,7 +3164,12 @@
 							}
 						},
 						{
-							"id": "t93hUjA5jHdnv92nC",
+							"id": "taV4Cp2cRlLmBAZto",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tNe543pbMl1IkZxSo"
+							},
 							"name": "Callous",
 							"reference": "B125",
 							"tags": [
@@ -2678,7 +3212,12 @@
 							}
 						},
 						{
-							"id": "tQzIQN4DzUCulV743",
+							"id": "tUQ4bkqrGj991A-_M",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tPbL1_rekOzkM86wz"
+							},
 							"name": "Overconfidence",
 							"reference": "B148",
 							"notes": "You must make a self-control roll any time the GM feels you show an unreasonable degree of caution. If you fail, you must go ahead as though you were able to handle the situation!",
@@ -2705,7 +3244,12 @@
 							}
 						},
 						{
-							"id": "tTxFcsBL9o_CaZxNa",
+							"id": "tOE7JK7_59g5XJOMb",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t4gqkFmqABx7dLjkS"
+							},
 							"name": "Stubbornness",
 							"reference": "B157",
 							"tags": [
@@ -2725,7 +3269,12 @@
 							}
 						},
 						{
-							"id": "tf6rGfpu23ZFO0mJ5",
+							"id": "tZwH_MMpQ98xv_CIo",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tAKQUtRTjZeOEbA5y"
+							},
 							"name": "Wounded",
 							"reference": "B162",
 							"tags": [
@@ -2739,12 +3288,12 @@
 						}
 					],
 					"calc": {
-						"points": -175
+						"points": -210
 					}
 				}
 			],
 			"calc": {
-				"points": 172
+				"points": 142
 			}
 		},
 		{
@@ -2761,7 +3310,12 @@
 							"name": "One of",
 							"children": [
 								{
-									"id": "t9xigDQlbwqQnEZnT",
+									"id": "tcB7ikH1tLdqESSlk",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t1w1RFcFceKR2T9_e"
+									},
 									"name": "Increased Intelligence",
 									"reference": "B15",
 									"tags": [
@@ -2785,7 +3339,12 @@
 									}
 								},
 								{
-									"id": "tIAaIDL0FrR5pHV_e",
+									"id": "tfnpAfkwvXyTV1db3",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tGWOSEE6SmBHACE6Y"
+									},
 									"name": "Increased Dexterity",
 									"reference": "B15",
 									"tags": [
@@ -2795,7 +3354,7 @@
 									],
 									"modifiers": [
 										{
-											"id": "m3dmBzq-Q7WoWjIzt",
+											"id": "mD67yUGinOKHZrHN0",
 											"name": "No Fine Manipulators",
 											"cost": -40,
 											"disabled": true
@@ -2817,7 +3376,12 @@
 									}
 								},
 								{
-									"id": "t0IJR5O4dUaz16zYr",
+									"id": "td1K0BiMfij_MiVmA",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tWF1J_Z0Ziz-qJ6pn"
+									},
 									"name": "Increased Basic Speed",
 									"reference": "B17",
 									"tags": [
@@ -2846,13 +3410,53 @@
 							}
 						},
 						{
-							"id": "tbK_dUPDDH18CtdLR",
+							"id": "tiYloLxrdx46O7PIg",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "tgnQFo-hK7YwexD2S"
+							},
 							"name": "Talent (Born War Leader)",
 							"reference": "DF1:14,PU3:12",
 							"tags": [
 								"Advantage",
 								"Physical",
 								"Talent"
+							],
+							"modifiers": [
+								{
+									"id": "MyRxD_JlZcur9MlaR",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "m0hV559skbP-zTm6M",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "mB-Lj0p73uOG84ASf",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Bonus to initiative rolls if leader",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
+								}
 							],
 							"points_per_level": 5,
 							"features": [
@@ -2909,18 +3513,6 @@
 									},
 									"amount": 1,
 									"per_level": true
-								},
-								{
-									"type": "reaction_bonus",
-									"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "conditional_modifier",
-									"situation": "Bonus to initiative rolls if leader",
-									"amount": 1,
-									"per_level": true
 								}
 							],
 							"can_level": true,
@@ -2939,7 +3531,12 @@
 					"name": "Legendary",
 					"children": [
 						{
-							"id": "to1hDQK47wUiv-nEN",
+							"id": "tJ8tpvXfHwyP-iNL2",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tGWOSEE6SmBHACE6Y"
+							},
 							"name": "Increased Dexterity",
 							"reference": "B15",
 							"tags": [
@@ -2949,7 +3546,7 @@
 							],
 							"modifiers": [
 								{
-									"id": "mDZTQHaldppPusd8Y",
+									"id": "mOJS--Qt2P8Mxej8P",
 									"name": "No Fine Manipulators",
 									"cost": -40,
 									"disabled": true
@@ -2971,7 +3568,12 @@
 							}
 						},
 						{
-							"id": "tPm3nrrDMDw9-Pz2_",
+							"id": "tQ8Ed6P5OBCXj99DL",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t1w1RFcFceKR2T9_e"
+							},
 							"name": "Increased Intelligence",
 							"reference": "B15",
 							"tags": [
@@ -2995,13 +3597,53 @@
 							}
 						},
 						{
-							"id": "tDudUWwtaWPi_Idsk",
+							"id": "thscYZ4J93zYNR4bY",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "tgnQFo-hK7YwexD2S"
+							},
 							"name": "Talent (Born War Leader)",
 							"reference": "DF1:14,PU3:12",
 							"tags": [
 								"Advantage",
 								"Physical",
 								"Talent"
+							],
+							"modifiers": [
+								{
+									"id": "M8JH_cKVwcgZ0tCih",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "mqVhJyHhJa4jIdrJU",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "mbz74lDkmPLwH-Oqf",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Bonus to initiative rolls if leader",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
+								}
 							],
 							"points_per_level": 5,
 							"features": [
@@ -3058,34 +3700,22 @@
 									},
 									"amount": 1,
 									"per_level": true
-								},
-								{
-									"type": "reaction_bonus",
-									"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "conditional_modifier",
-									"situation": "Bonus to initiative rolls if leader",
-									"amount": 1,
-									"per_level": true
 								}
 							],
 							"can_level": true,
-							"levels": 2,
+							"levels": 1,
 							"calc": {
-								"points": 10
+								"points": 5
 							}
 						}
 					],
 					"calc": {
-						"points": 50
+						"points": 45
 					}
 				}
 			],
 			"calc": {
-				"points": 120
+				"points": 115
 			}
 		}
 	],
@@ -3100,7 +3730,12 @@
 					"name": "Primary Skills",
 					"children": [
 						{
-							"id": "sveDCYEzVmx1okulR",
+							"id": "s8rWLxQedJjIPaG26",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sSxGnNPMXyZpZKoFZ"
+							},
 							"name": "Leadership",
 							"reference": "B204",
 							"tags": [
@@ -3117,7 +3752,12 @@
 							"points": 1
 						},
 						{
-							"id": "sDrgjvAV2jdUu5eXx",
+							"id": "s9bF59rbm-4A36SX4",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sPyZ0zxFI-Kygrzie"
+							},
 							"name": "Intelligence Analysis",
 							"reference": "B201",
 							"tags": [
@@ -3141,7 +3781,12 @@
 							"points": 2
 						},
 						{
-							"id": "s5mwTD4RP59hOBTSN",
+							"id": "sdJkRjCNlue6VV8mP",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "svZCidrvq9QTwwV3-"
+							},
 							"name": "Strategy",
 							"reference": "B222",
 							"tags": [
@@ -3173,7 +3818,12 @@
 							"points": 2
 						},
 						{
-							"id": "sKjYkEVmyp67OVZso",
+							"id": "skm9kKxmvmKIFNiUP",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sgWf_qVqI7HrPQUo7"
+							},
 							"name": "Tactics",
 							"reference": "B224,MA60",
 							"tags": [
@@ -3199,7 +3849,12 @@
 							"name": "Two of",
 							"children": [
 								{
-									"id": "s0UE3Flupe130ApCu",
+									"id": "sq67jG-qRzYQsYBAW",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "snZtm1wwlLIeerPuO"
+									},
 									"name": "Gunner",
 									"reference": "B198",
 									"tags": [
@@ -3224,7 +3879,12 @@
 									"points": 8
 								},
 								{
-									"id": "sZ_PWeCkD8Eah8VXZ",
+									"id": "s6MuUL7TGOOGs0EuV",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "s3VHZqqfZBcYRa58N"
+									},
 									"name": "Artillery",
 									"reference": "B178",
 									"tags": [
@@ -3244,7 +3904,12 @@
 									"points": 8
 								},
 								{
-									"id": "sDZniCq6Tn3w-XEAV",
+									"id": "sOfInAxWmmxqqAN_I",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "scStJPSR5vxAFYM7j"
+									},
 									"name": "Electronics Operation",
 									"reference": "B189",
 									"tags": [
@@ -3287,7 +3952,12 @@
 					"name": "Secondary Skills",
 					"children": [
 						{
-							"id": "sPN-ljJcFCpIVpPbL",
+							"id": "szBTr1n7oRsMxK_Wr",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sluTeYhSTpIbVNfA5"
+							},
 							"name": "Electronics Operation",
 							"reference": "B189",
 							"tags": [
@@ -3322,7 +3992,12 @@
 							"points": 2
 						},
 						{
-							"id": "sc0xDNpgF6e58O3M2",
+							"id": "scT89_d5uklr_Ld2Z",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "s88gTPKTH8WGPQqDI"
+							},
 							"name": "Expert Skill",
 							"reference": "B193,MA56",
 							"tags": [
@@ -3335,7 +4010,12 @@
 							"points": 4
 						},
 						{
-							"id": "sOqEaEAuVwUsTE1nI",
+							"id": "sZ4r251OPQgnvj6ni",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "s9IHT34mK8yfSB7d_"
+							},
 							"name": "Spacer",
 							"reference": "B185",
 							"tags": [
@@ -3356,7 +4036,12 @@
 							"name": "One of",
 							"children": [
 								{
-									"id": "sG2pH8HwUpdM7hzio",
+									"id": "sQ87gYqnP8HtIA3Bx",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "snZtm1wwlLIeerPuO"
+									},
 									"name": "Gunner",
 									"reference": "B198",
 									"tags": [
@@ -3364,7 +4049,10 @@
 										"Ranged Combat",
 										"Weapon"
 									],
-									"specialization": "@Any other@",
+									"replacements": {
+										"Gun class": "@Any other@"
+									},
+									"specialization": "@Gun class@",
 									"difficulty": "dx/e",
 									"defaults": [
 										{
@@ -3381,7 +4069,12 @@
 									"points": 4
 								},
 								{
-									"id": "s7RN9BlvBozPb4qRB",
+									"id": "s5iJl81dEqX3_K6YS",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "s3VHZqqfZBcYRa58N"
+									},
 									"name": "Artillery",
 									"reference": "B178",
 									"tags": [
@@ -3389,7 +4082,10 @@
 										"Ranged Combat",
 										"Weapon"
 									],
-									"specialization": "@Any other@",
+									"replacements": {
+										"Weapon type": "@Any other@"
+									},
+									"specialization": "@Weapon type@",
 									"difficulty": "iq/a",
 									"defaults": [
 										{
@@ -3409,7 +4105,12 @@
 					"name": "Background Skills",
 					"children": [
 						{
-							"id": "sudcnxl7RjsCuYh1V",
+							"id": "sm_sd1A79weuwOKM3",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "ssHhRG7LH-Ma3YDnH"
+							},
 							"name": "Computer Operation",
 							"reference": "B184",
 							"tags": [
@@ -3428,7 +4129,12 @@
 							"points": 1
 						},
 						{
-							"id": "sQYgbfnZ9ISbpeVqn",
+							"id": "sN4rQAd2Lizh7bUTh",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "s7kVwKFERTuMYO3O8"
+							},
 							"name": "Free Fall",
 							"reference": "B197",
 							"tags": [
@@ -3448,7 +4154,12 @@
 							"points": 2
 						},
 						{
-							"id": "sNQm2LUl_1tjaj2BR",
+							"id": "sIG1F8oZyRjoXQPej",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sAmDzPjf0rKZ6I5G1"
+							},
 							"name": "Vacc Suit",
 							"reference": "B192",
 							"tags": [
@@ -3484,11 +4195,16 @@
 							"name": "10 Points chosen from",
 							"children": [
 								{
-									"id": "S-Gb0wZlFf2JL1RYS",
+									"id": "SmCKLPH6DcrvQlW0S",
 									"name": "Everyman Skills",
 									"children": [
 										{
-											"id": "s5MZVRMPdXXxjXY6q",
+											"id": "sPhKyDbtytxf4rnbs",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sTXDrqXH0sT2NSD_b"
+											},
 											"name": "Area Knowledge",
 											"reference": "B176",
 											"notes": "Location of the capitals of interplanetary states and the homeworlds of major races; general awareness of all major races; knowledge of individuals of Status 8; general understanding of relations between interplanetary states",
@@ -3509,7 +4225,12 @@
 											"points": 1
 										},
 										{
-											"id": "sYG6oplQ5_sjDXOfR",
+											"id": "sm-I5-gf-iz_EjWrO",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "s-Ckyxw5PmHIvbZab"
+											},
 											"name": "Area Knowledge",
 											"reference": "B176",
 											"notes": "Location of major planets; familiarity with all known races (but not necessarily expertise); knowledge of people of Status 7+; general understanding of the economic and political situation",
@@ -3517,13 +4238,9 @@
 												"Everyman",
 												"Knowledge"
 											],
-											"specialization": "@Interplanetary State@; Lived there",
+											"specialization": "@Interplanetary State@",
 											"difficulty": "iq/e",
 											"defaults": [
-												{
-													"type": "iq",
-													"modifier": -4
-												},
 												{
 													"type": "skill",
 													"name": "Geography",
@@ -3534,7 +4251,12 @@
 											"points": 1
 										},
 										{
-											"id": "sCb1YB6NuBIwBvPEq",
+											"id": "sJOMAaYoGJBm8_Feb",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "strhX4LEdd46xgmIS"
+											},
 											"name": "Area Knowledge",
 											"reference": "B176",
 											"notes": "Location of its major cities and important sites; awareness of its major customs, ethnic groups, and languages (but not necessarily expertise); names of folk of Status 7+; and a general understanding of the economic and political situation",
@@ -3542,13 +4264,9 @@
 												"Everyman",
 												"Knowledge"
 											],
-											"specialization": "@Planet@; Lived there",
+											"specialization": "@Planet@",
 											"difficulty": "iq/e",
 											"defaults": [
-												{
-													"type": "iq",
-													"modifier": -4
-												},
 												{
 													"type": "skill",
 													"name": "Geography",
@@ -3559,7 +4277,12 @@
 											"points": 1
 										},
 										{
-											"id": "sdFg9pIcospzvuXTb",
+											"id": "sDdiZYlcvQejBcVTQ",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sBJgeWUs81Ifhob4Z"
+											},
 											"name": "Beam Weapons",
 											"reference": "B179",
 											"tags": [
@@ -3590,7 +4313,12 @@
 											"points": 1
 										},
 										{
-											"id": "sDc6cGvGFUDRARQkM",
+											"id": "s1g0aj09kHc-i6iyB",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sOp4wssAMtUc1ukJI"
+											},
 											"name": "Body Language",
 											"reference": "B181",
 											"tags": [
@@ -3614,10 +4342,14 @@
 											"points": 1
 										},
 										{
-											"id": "sdX9fiZ2ualHcVJFB",
+											"id": "s1iednaXt-s7f_LC0",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sziMa9_9xTvR2iiqx"
+											},
 											"name": "Body Sense",
 											"reference": "B181",
-											"notes": "For settings with matter transmission",
 											"tags": [
 												"Athletic"
 											],
@@ -3636,7 +4368,12 @@
 											"points": 1
 										},
 										{
-											"id": "se5AsM78nPKcR2Cbt",
+											"id": "sNt7M6KgeQD-YXLl9",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "shtDdl5thrvKSnJHf"
+											},
 											"name": "Brawling",
 											"reference": "B182,MA55",
 											"tags": [
@@ -3664,7 +4401,12 @@
 											"points": 1
 										},
 										{
-											"id": "sTfpV-PMYqAcM6jQh",
+											"id": "sOul8FmZONuUo0i6v",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "si-upI7A5RgdO0cjC"
+											},
 											"name": "Carousing",
 											"reference": "B183",
 											"tags": [
@@ -3682,7 +4424,12 @@
 											"points": 1
 										},
 										{
-											"id": "s41tVVrWh8nQaNQRB",
+											"id": "sRRJmD-ySJ8ngMHm_",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sWFtA7Gvclq4aL-Yb"
+											},
 											"name": "Current Affairs",
 											"reference": "B186",
 											"tags": [
@@ -3713,7 +4460,12 @@
 											"points": 1
 										},
 										{
-											"id": "sbz1TwNQM_s-Oty9X",
+											"id": "s-75ykFS-o4bbjL9G",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "s9mV--3lpIfXO7N6Z"
+											},
 											"name": "First Aid",
 											"reference": "B195",
 											"tags": [
@@ -3744,7 +4496,12 @@
 											"points": 1
 										},
 										{
-											"id": "sUTRTlZWwTUuhAn2S",
+											"id": "sdgU3LF7lRUHu1fVY",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sWB9ypJAq43MF3O0n"
+											},
 											"name": "Gambling",
 											"reference": "B197",
 											"tags": [
@@ -3768,7 +4525,12 @@
 											"points": 1
 										},
 										{
-											"id": "sr3r8mi-KNfxTNf-e",
+											"id": "sK4kNev8yLeJP7u9v",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "syfSQ9N8yETqQbhFK"
+											},
 											"name": "Games",
 											"reference": "B197,MA57",
 											"tags": [
@@ -3785,7 +4547,12 @@
 											"points": 1
 										},
 										{
-											"id": "s6ISP_fQ4xSSduM_9",
+											"id": "snoePQ4fpzIbLC7j6",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sGz21GskAlJXL1hYP"
+											},
 											"name": "Gesture",
 											"reference": "B198",
 											"tags": [
@@ -3801,7 +4568,12 @@
 											"points": 1
 										},
 										{
-											"id": "sQPY6FGCH-NpYkBtX",
+											"id": "s8oTn7xxmHeaFfSIu",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sT5htbz4-Mr0PFCk7"
+											},
 											"name": "Guns",
 											"reference": "B198",
 											"tags": [
@@ -3826,7 +4598,12 @@
 											"points": 1
 										},
 										{
-											"id": "sB-fx-0-9LOudeHAn",
+											"id": "sTRwqM_m4OxLcAnp8",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sOtPessbzkRjGaQPR"
+											},
 											"name": "Hobby Skill",
 											"reference": "B200,MA57",
 											"tags": [
@@ -3843,7 +4620,12 @@
 											"points": 1
 										},
 										{
-											"id": "s8oRI2diLUaNiXLJQ",
+											"id": "sgU_EcfDyTUfuN46T",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sDLf4crz0sGRjVDFi"
+											},
 											"name": "Hobby Skill",
 											"reference": "B200,MA57",
 											"tags": [
@@ -3860,7 +4642,12 @@
 											"points": 1
 										},
 										{
-											"id": "sjSfg2IOmxmvVw98X",
+											"id": "swCIVIZ88uma-YLWM",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sfZrwMVUibhbtdssl"
+											},
 											"name": "Housekeeping",
 											"reference": "B200",
 											"tags": [
@@ -3876,7 +4663,12 @@
 											"points": 1
 										},
 										{
-											"id": "sN9n0KcGq9DSFUA-1",
+											"id": "spOHBPQrpmDoiBQLq",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sdl9m7gHE7hlMX0AX"
+											},
 											"name": "Lip Reading",
 											"reference": "B205",
 											"tags": [
@@ -3892,7 +4684,12 @@
 											"points": 1
 										},
 										{
-											"id": "shlTxxjpooe8Xtsuz",
+											"id": "sR8m09DHppAHt8dGf",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sx1CDkGBR830IZrmz"
+											},
 											"name": "Professional Skill",
 											"reference": "B215",
 											"tags": [
@@ -3909,7 +4706,12 @@
 											"points": 1
 										},
 										{
-											"id": "spYBBRqu2dv9z3rxE",
+											"id": "sBwFewoD6GLHid5F3",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "sBec-o4Z7gPpbg2f9"
+											},
 											"name": "Professional Skill",
 											"reference": "B215",
 											"tags": [
@@ -3926,7 +4728,12 @@
 											"points": 1
 										},
 										{
-											"id": "sAWlnX5s0qHN1holL",
+											"id": "sVaDAJvT8GOzTISt_",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "smxkcngH5Kz54yeN3"
+											},
 											"name": "Sports",
 											"reference": "B222,MA59",
 											"tags": [
@@ -3943,7 +4750,12 @@
 											"points": 1
 										},
 										{
-											"id": "sbyMtCcpAA9WHAR2D",
+											"id": "s6wu9JoKTp_yiSfWV",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "smTUpMWJGqPeT1KER"
+											},
 											"name": "Streetwise",
 											"reference": "B223",
 											"tags": [
@@ -3964,7 +4776,12 @@
 									]
 								},
 								{
-									"id": "snrHdOzT1FvzjQwEV",
+									"id": "sl3Z2Qyf5jEUmtxcP",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "snZtm1wwlLIeerPuO"
+									},
 									"name": "Gunner",
 									"reference": "B198",
 									"tags": [
@@ -3972,7 +4789,10 @@
 										"Ranged Combat",
 										"Weapon"
 									],
-									"specialization": "@Any other@",
+									"replacements": {
+										"Gun class": "@Any other@"
+									},
+									"specialization": "@Gun class@",
 									"difficulty": "dx/e",
 									"defaults": [
 										{
@@ -3989,7 +4809,12 @@
 									"points": 1
 								},
 								{
-									"id": "sDANH-JlqesEOFgHw",
+									"id": "sHgOtrLTCgaHAfP3x",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sPTlfb6j7JYiJ2sdx"
+									},
 									"name": "Savoir-Faire",
 									"reference": "B218,MA59",
 									"tags": [
@@ -4008,7 +4833,12 @@
 									"points": 1
 								},
 								{
-									"id": "sOomKGmf9r4Pm82OI",
+									"id": "sdvUihSEyurVVgHFn",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "s_sZinIoG3OeLxjPX"
+									},
 									"name": "Armoury",
 									"reference": "B178",
 									"tags": [
@@ -4016,7 +4846,7 @@
 										"Military",
 										"Repair"
 									],
-									"specialization": "@Force Sheilds, Heavy Weapons, or Vehicular Armor@",
+									"specialization": "Force Shields",
 									"difficulty": "iq/a",
 									"defaults": [
 										{
@@ -4026,7 +4856,7 @@
 										{
 											"type": "skill",
 											"name": "Engineer",
-											"specialization": "Battlesuits",
+											"specialization": "Force Shields",
 											"modifier": -4
 										}
 									],
@@ -4034,7 +4864,74 @@
 									"points": 1
 								},
 								{
-									"id": "sy-OIe4dNQ5lN_-_j",
+									"id": "scXyf0yEu52hNQuUp",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "siSKgRr1MizPF9IrU"
+									},
+									"name": "Armoury",
+									"reference": "B178",
+									"tags": [
+										"Maintenance",
+										"Military",
+										"Repair"
+									],
+									"specialization": "Heavy Weapons",
+									"difficulty": "iq/a",
+									"defaults": [
+										{
+											"type": "iq",
+											"modifier": -5
+										},
+										{
+											"type": "skill",
+											"name": "Engineer",
+											"specialization": "Heavy Weapons",
+											"modifier": -4
+										}
+									],
+									"tech_level": "",
+									"points": 1
+								},
+								{
+									"id": "siFEevhTzwmTH3OtO",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sF2gsndOW8j3EX1CG"
+									},
+									"name": "Armoury",
+									"reference": "B178",
+									"tags": [
+										"Maintenance",
+										"Military",
+										"Repair"
+									],
+									"specialization": "Vehicular Armor",
+									"difficulty": "iq/a",
+									"defaults": [
+										{
+											"type": "iq",
+											"modifier": -5
+										},
+										{
+											"type": "skill",
+											"name": "Engineer",
+											"specialization": "Vehicular Armor",
+											"modifier": -4
+										}
+									],
+									"tech_level": "",
+									"points": 1
+								},
+								{
+									"id": "sbY5aQ0nvnEVwSLsY",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "s3VHZqqfZBcYRa58N"
+									},
 									"name": "Artillery",
 									"reference": "B178",
 									"tags": [
@@ -4042,7 +4939,10 @@
 										"Ranged Combat",
 										"Weapon"
 									],
-									"specialization": "@Any other@",
+									"replacements": {
+										"Weapon type": "@Any other@"
+									},
+									"specialization": "@Weapon type@",
 									"difficulty": "iq/a",
 									"defaults": [
 										{
@@ -4054,7 +4954,12 @@
 									"points": 1
 								},
 								{
-									"id": "sukMAN68a56plKFRK",
+									"id": "sTP93C-tzrWAV3iRR",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sANKIfg-p4ifPKXvT"
+									},
 									"name": "Explosives",
 									"reference": "B194",
 									"tags": [
@@ -4098,7 +5003,12 @@
 									"points": 1
 								},
 								{
-									"id": "seol0PzZRNeK9FHyM",
+									"id": "sgcXM3IR6wmhGQOZ4",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "shun-iitiwyWbrGcF"
+									},
 									"name": "Intimidation",
 									"reference": "B202",
 									"tags": [
@@ -4137,7 +5047,12 @@
 					"name": "Multi-Role",
 					"children": [
 						{
-							"id": "spPetWPtzHS2EQSt_",
+							"id": "sWnpN6CDw9_HI6xjC",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sSxGnNPMXyZpZKoFZ"
+							},
 							"name": "Leadership",
 							"reference": "B204",
 							"tags": [
@@ -4154,7 +5069,12 @@
 							"points": 1
 						},
 						{
-							"id": "sJW_njkTNQvRWqjyg",
+							"id": "sAVmu2pV4qnuj_FXU",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sPyZ0zxFI-Kygrzie"
+							},
 							"name": "Intelligence Analysis",
 							"reference": "B201",
 							"tags": [
@@ -4178,7 +5098,12 @@
 							"points": 2
 						},
 						{
-							"id": "sqcc-SEQmxeQgWqVH",
+							"id": "sgkeHJWEcIxUezO4G",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "svZCidrvq9QTwwV3-"
+							},
 							"name": "Strategy",
 							"reference": "B222",
 							"tags": [
@@ -4210,7 +5135,12 @@
 							"points": 2
 						},
 						{
-							"id": "sp1zHL3AF_VA2Rfne",
+							"id": "sRqB0rcTyY2IN7Mou",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sgWf_qVqI7HrPQUo7"
+							},
 							"name": "Tactics",
 							"reference": "B224,MA60",
 							"tags": [
@@ -4232,7 +5162,12 @@
 							"points": 2
 						},
 						{
-							"id": "sKZWvCNksEpp30V9w",
+							"id": "s0wB9Iv2ZwVylAdQT",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "s88gTPKTH8WGPQqDI"
+							},
 							"name": "Expert Skill",
 							"reference": "B193,MA56",
 							"tags": [
@@ -4249,7 +5184,12 @@
 							"name": "Three of",
 							"children": [
 								{
-									"id": "sK9_vubqEAPq9Wdbl",
+									"id": "s_I-6pXk19EzzygtJ",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "snZtm1wwlLIeerPuO"
+									},
 									"name": "Gunner",
 									"reference": "B198",
 									"tags": [
@@ -4274,7 +5214,12 @@
 									"points": 4
 								},
 								{
-									"id": "sxjPpmsJ1cZ5TrBhS",
+									"id": "se1O_AMr0soU5FiY7",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "s3VHZqqfZBcYRa58N"
+									},
 									"name": "Artillery",
 									"reference": "B178",
 									"tags": [
@@ -4294,7 +5239,12 @@
 									"points": 4
 								},
 								{
-									"id": "sc1xrPYk2Q4t4SAxj",
+									"id": "sOsoolBs3_7AUnbFd",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "scStJPSR5vxAFYM7j"
+									},
 									"name": "Electronics Operation",
 									"reference": "B189",
 									"tags": [


### PR DESCRIPTION
Source library info was added to the gcs data model after the Spaceship Crew templates were created, and adding source library sync info adds some amount of confidence that you can change items in libraries without having to check everything (though when I last ran `gcs --sync .` on the gcs master library there were a lot of unrelated changes that I didn't feel confident to check).

In the course of supporting source library sync, I have made some changes and additions to supporting libraries that I noticed.

The full list of changes, to the best of my knowledge, are:
* Template Toolkit: Starship Crew:
  - Added the Omnicompetent lens for Starship Crew.
  - Every trait and skill in the Template Toolkit: Starship Crew templates has been replaced with one copied from a trait or skill library so that it includes source library information.
  - Where I noticed, I added skills and traits that had accidentally been missed off the template.
  - Where I noticed, I corrected the number of points in particular skills.
  - I split some trait and skill options into specific variants (e.g. Intuitive Mathematician is a modifier for Lightning Calculator that is enabled, I created one option with it enabled, and one without) where I think it might be ambiguous what's allowed.
  - Most of the specific disambiguation, and fixes to missing/mispriced traits/skills are listed in the commit messages but I was sloppy at the start.
* Supers: Fix an incorrect page reference for Speed Talent
* Space: Add new traits that weren't represented exactly by traits in other libraries (mostly codes of honour and social stigma)
* Power-ups traits: Add equipment bond (this one might require some discussion. it lets users decide whether to apply a conditional modifier or a skill bonus)
* Basic Set traits:
  - Make Higher Purpose levelled and  substitutable (so that it can fill in for any Higher Purpose, and because some campaign frameworks allow Higher Purpose with multiple levels, like Dungeon Fantasy)
  - Add a generic Compulsive Behaviour disadvantage
  - Add a generic Social Stigma disadvantage (uses Reaction Bonus modifiers, with some generic options for *how* people know you've been stigmatised)
* Basic Set skills:
  - fix Mechanic (@Machine Type@) defaulting from Engineer(Aerospace)
  - add substitutable versions of Fast-Draw, Hazardous Materials, Mathematics and Paleontology (these all have specialisations listed, but templates often ask you to choose one and listing every option is often overly-verbose and possibly incorrect)
* Add Starship Crew traits
  - Enhanced Dodge (Piloting Skill) adds a conditional bonus to be used with vehicular dodges.
  - Higher Purpose (Medic!) is very similar to the Action one, but Starship Crew defines it, too.
  - Higher Purpose (Save my ship!) is completely new. I created a new one despite creating a generic Higher Purpose because it also has a definition with a page reference.
  - Compartmentalized Mind (Multi-Tasking) is completely new. I created a separate trait because none of the built-in modifiers for the basic Compartmentalized Mind seemed applicable so it would be confusing to let you combine them.
