### PR TITLE
Add TL11 Starship Crew Loadouts

### DIFF
--- a/Library/Loadouts/Starship Crew/TL11/Armed.gct
+++ b/Library/Loadouts/Starship Crew/TL11/Armed.gct
@@ -1,0 +1,267 @@
+{
+	"version": 5,
+	"id": "Bf4uJBe7g0UlJVUjN",
+	"equipment": [
+		{
+			"id": "EyA672FEYBxmrBher",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "High Tech/High Tech Equipment.eqp",
+				"id": "E73yMX2SGu09jndtY"
+			},
+			"description": "Retention Holster",
+			"reference": "HT154",
+			"local_notes": "+2 Retain Weapon.",
+			"tech_level": "7",
+			"tags": [
+				"Firearm Accessories"
+			],
+			"base_value": "100",
+			"base_weight": "0.5 lb",
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "Eju2_6b08jxTHoCQQ",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eLdup3xMnqKVMq5Hu"
+					},
+					"description": "Blaster Pistol",
+					"reference": "UT123",
+					"local_notes": "C/40 shots.",
+					"tech_level": "11",
+					"legality_class": "3",
+					"tags": [
+						"Missile Weapon",
+						"Weaponry"
+					],
+					"base_value": "2200",
+					"base_weight": "1.6 lb",
+					"weapons": [
+						{
+							"id": "WSXid9JO92WZGj-hO",
+							"damage": {
+								"type": "burn, sur",
+								"base": "3d",
+								"armor_divisor": 5
+							},
+							"strength": "4",
+							"accuracy": "5",
+							"range": "300/900",
+							"rate_of_fire": "3",
+							"shots": "40(3)",
+							"bulk": "-2",
+							"recoil": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Beam Weapons",
+									"specialization": "Pistol"
+								},
+								{
+									"type": "skill",
+									"name": "Beam Weapons",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Guns",
+									"specialization": "Pistol",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -4
+								}
+							],
+							"calc": {
+								"damage": "3d(5) burn, sur"
+							}
+						},
+						{
+							"id": "WGi5VQ_g9MOGBqbW8",
+							"damage": {
+								"type": "HT-3 aff",
+								"armor_divisor": 3
+							},
+							"strength": "4",
+							"usage": "Omni-Blaster Stun",
+							"accuracy": "5",
+							"range": "300/900",
+							"rate_of_fire": "3",
+							"shots": "40(3)",
+							"bulk": "-2",
+							"recoil": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Beam Weapons",
+									"specialization": "Pistol"
+								},
+								{
+									"type": "skill",
+									"name": "Beam Weapons",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Guns",
+									"specialization": "Pistol",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -4
+								}
+							],
+							"calc": {
+								"damage": "(3) HT-3 aff"
+							}
+						}
+					],
+					"modifiers": [
+						{
+							"id": "fricHeBw78IR6newt",
+							"name": "Omni-Blaster",
+							"local_notes": "note: manually unhide Omni-Blaster Stun",
+							"cost": "+100%"
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"children": [
+						{
+							"id": "e2vEHQbls-ZPaw4Ik",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "e5ek-okmhFuGtRQ7N"
+							},
+							"description": "Smartgrip",
+							"reference": "UT152",
+							"local_notes": "Reduces minimum ST by 1.",
+							"tech_level": "10",
+							"tags": [
+								"Firearm Accessories",
+								"Weaponry"
+							],
+							"base_value": "500",
+							"quantity": 1,
+							"equipped": true,
+							"calc": {
+								"value": 500,
+								"extended_value": 500,
+								"weight": "0 lb",
+								"extended_weight": "0 lb"
+							}
+						},
+						{
+							"id": "E5tPUHHH47mvLzfX4",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "e5DIbfpp4o2Sdu7tY"
+							},
+							"description": "Accessory Rail",
+							"reference": "UT150",
+							"tech_level": "9",
+							"tags": [
+								"Firearm Accessories",
+								"Weaponry"
+							],
+							"base_value": "100",
+							"base_weight": "2 lb",
+							"quantity": 1,
+							"equipped": true,
+							"children": [
+								{
+									"id": "eqBs2u781eg4m0e9U",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+										"id": "eL55XD_2gh5v1kg6u"
+									},
+									"description": "Compact Targeting Scope",
+									"reference": "UT149",
+									"local_notes": "+3 to aimed shots. A/100hr.",
+									"tech_level": "11",
+									"tags": [
+										"Firearm Accessories",
+										"Weaponry"
+									],
+									"base_value": "1000",
+									"base_weight": "0.5 lb",
+									"quantity": 1,
+									"equipped": true,
+									"calc": {
+										"value": 1000,
+										"extended_value": 1000,
+										"weight": "0.5 lb",
+										"extended_weight": "0.5 lb"
+									}
+								}
+							],
+							"calc": {
+								"value": 100,
+								"extended_value": 1100,
+								"weight": "2 lb",
+								"extended_weight": "2.5 lb"
+							}
+						}
+					],
+					"calc": {
+						"value": 4400,
+						"extended_value": 6000,
+						"weight": "1.6 lb",
+						"extended_weight": "4.1 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 100,
+				"extended_value": 6100,
+				"weight": "0.5 lb",
+				"extended_weight": "4.6 lb"
+			}
+		},
+		{
+			"id": "E3X03yrr4itASHRXs",
+			"description": "Add to Waist Pack",
+			"legality_class": "4",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"value": 0,
+				"extended_value": 0,
+				"weight": "0 lb",
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "e_GZzugJG0hbmXGIW",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+				"id": "ev80WwcnBpiGFrkol"
+			},
+			"description": "C cell",
+			"reference": "UT19",
+			"tech_level": "9",
+			"tags": [
+				"Power"
+			],
+			"base_value": "10",
+			"base_weight": "0.5 lb",
+			"quantity": 2,
+			"equipped": true,
+			"calc": {
+				"value": 10,
+				"extended_value": 20,
+				"weight": "0.5 lb",
+				"extended_weight": "1 lb"
+			}
+		}
+	]
+}

--- a/Library/Loadouts/Starship Crew/TL11/Battlesuit Trooper.gct
+++ b/Library/Loadouts/Starship Crew/TL11/Battlesuit Trooper.gct
@@ -1,0 +1,2614 @@
+{
+	"version": 5,
+	"id": "BHjnAA3OYfCnQK_N9",
+	"equipment": [
+		{
+			"id": "EQnof_wKvdGVeAO-7",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+				"id": "eFtJmVE767dnsV8Kq"
+			},
+			"description": "Military Cybersuit",
+			"reference": "UT186",
+			"local_notes": "Super Jump 2. Flexible. 10 yr. power supply.",
+			"tech_level": "11",
+			"legality_class": "2",
+			"tags": [
+				"Armor",
+				"Defenses"
+			],
+			"base_value": "50000",
+			"base_weight": "50 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"all"
+					],
+					"amount": 80
+				},
+				{
+					"type": "attribute_bonus",
+					"limitation": "lifting_only",
+					"attribute": "st",
+					"amount": 10
+				},
+				{
+					"type": "attribute_bonus",
+					"limitation": "striking_only",
+					"attribute": "st",
+					"amount": 10
+				},
+				{
+					"type": "attribute_bonus",
+					"attribute": "basic_move",
+					"amount": 1
+				}
+			],
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "eFT_Uuneu3hHoV-tQ",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eIf4IUjEVfxZcJwS1"
+					},
+					"description": "Biomedical Sensors",
+					"reference": "UT187",
+					"local_notes": "A/24hr.",
+					"tech_level": "9",
+					"tags": [
+						"Defenses"
+					],
+					"base_value": "200",
+					"base_weight": "0.2 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 200,
+						"extended_value": 200,
+						"weight": "0.2 lb",
+						"extended_weight": "0.2 lb"
+					}
+				},
+				{
+					"id": "EgMXXXfl4-WuTQpFn",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "euCVhRYMuK7QZVmpw"
+					},
+					"description": "Microbot Arteries",
+					"reference": "UT189",
+					"local_notes": "For battlesuits. Maximum of two per suit.",
+					"tech_level": "10",
+					"tags": [
+						"Defenses"
+					],
+					"base_value": "500",
+					"quantity": 1,
+					"equipped": true,
+					"children": [
+						{
+							"id": "eukybhdzTrGm0s0cP",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "eRd4HdGkY3padXW2c"
+							},
+							"description": "@Microbot/Nanobot Type@ Swarm",
+							"reference": "UT35",
+							"tech_level": "10",
+							"tags": [
+								"Swarmbots"
+							],
+							"base_weight": "2 lb",
+							"replacements": {
+								"Microbot/Nanobot Type": "Paramedical"
+							},
+							"modifiers": [
+								{
+									"id": "FX9mnV2z_Tm9zyiC4",
+									"name": "Swarm Type",
+									"reference": "UT37",
+									"local_notes": "at TL11 microbots can have two types, at TL12 nanobots can have two types",
+									"children": [
+										{
+											"id": "fEBYPNy6RhidoGUgl",
+											"name": "Bughunter",
+											"reference": "UT106",
+											"local_notes": "LC3",
+											"tags": [
+												"Counter-Surveillance and ECM",
+												"Security and Surveillance",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+4000",
+											"disabled": true
+										},
+										{
+											"id": "fuaVLOcbFPnD3aWLr",
+											"name": "Cannibal",
+											"reference": "UT169",
+											"local_notes": "LC1",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "12",
+											"cost": "+15000",
+											"disabled": true
+										},
+										{
+											"id": "fK6hBPsvyMuVQ2n9M",
+											"name": "Cleaning",
+											"reference": "UT69",
+											"local_notes": "LC4",
+											"tags": [
+												"Domestic Equipment and Appliances",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fecqTSO2JhECJn-wg",
+											"name": "Construction",
+											"reference": "UT86",
+											"local_notes": "LC4",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fW8ZXrxIsRxY9kcwp",
+											"name": "Decontamination (@Hazard Type@)",
+											"reference": "UT87",
+											"local_notes": "LC3; Hazardous Materials (@Hazard Type@)-12",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fnLEe_hBhHNzR3V5N",
+											"name": "Decontamination (@Hazard Type@)",
+											"reference": "UT87",
+											"local_notes": "LC3; Hazardous Materials (@Hazard Type@)-13",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "11",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fweop-2x3yS29WrxZ",
+											"name": "Decontamination (@Hazard Type@)",
+											"reference": "UT87",
+											"local_notes": "LC3; Hazardous Materials (@Hazard Type@)-14",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "12",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fRJExdkKYdZKXnXGs",
+											"name": "Defoliator",
+											"reference": "UT87",
+											"local_notes": "LC3",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fqjKlnwAaq3Xcg16v",
+											"name": "Devourer",
+											"reference": "UT169",
+											"local_notes": "LC1",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "10",
+											"cost": "+8000",
+											"disabled": true
+										},
+										{
+											"id": "f7th32POvVqX2DwQt",
+											"name": "Disassembler",
+											"reference": "UT169",
+											"local_notes": "LC1",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "11",
+											"cost": "+10000",
+											"disabled": true
+										},
+										{
+											"id": "fiGOS1GEkcAS6lS0k",
+											"name": "Explorer",
+											"reference": "UT80",
+											"local_notes": "LC4",
+											"tags": [
+												"Expedition Gear",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+500",
+											"disabled": true
+										},
+										{
+											"id": "fbnwfbhtGK2pRiwke",
+											"name": "Firefly",
+											"reference": "UT74",
+											"local_notes": "LC4",
+											"tags": [
+												"Domestic Equipment and Appliances",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+100",
+											"disabled": true
+										},
+										{
+											"id": "fDgS3iKhudGTbKkqa",
+											"name": "Forensic",
+											"reference": "UT107",
+											"local_notes": "LC3",
+											"tags": [
+												"Enforcement and Coercion",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+4000",
+											"disabled": true
+										},
+										{
+											"id": "fBxDvBPdmHGQEnbTf",
+											"name": "Gremlin",
+											"reference": "UT169",
+											"local_notes": "LC2",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "10",
+											"cost": "+2000",
+											"disabled": true
+										},
+										{
+											"id": "fcSLRMduGN5SAYwIW",
+											"name": "Harvester",
+											"reference": "UT87",
+											"local_notes": "LC4",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+2000",
+											"disabled": true
+										},
+										{
+											"id": "fdWHBoFWrUHb2elHR",
+											"name": "Massage",
+											"reference": "UT41",
+											"local_notes": "LC4",
+											"tags": [
+												"Robots",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+200",
+											"disabled": true
+										},
+										{
+											"id": "fDYARqgKT72zXKxKf",
+											"name": "Painter",
+											"reference": "UT87",
+											"local_notes": "LC4",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+500",
+											"disabled": true
+										},
+										{
+											"id": "fd3uFk_sQ1_x48RNN",
+											"name": "Paramedical",
+											"reference": "UT201",
+											"local_notes": "LC3; Diagnosis-10, First Aid-10",
+											"tags": [
+												"Medical",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+6000",
+											"disabled": true
+										},
+										{
+											"id": "f_0fpjyCfh6G7Rn7Q",
+											"name": "Paramedical",
+											"reference": "UT201",
+											"local_notes": "LC3; Diagnosis-11, First Aid-11",
+											"tags": [
+												"Medical",
+												"Swarmbots"
+											],
+											"tech_level": "11",
+											"cost": "+6000"
+										},
+										{
+											"id": "fCXaqvRVH7_mFUM7o",
+											"name": "Paramedical",
+											"reference": "UT201",
+											"local_notes": "LC3; Diagnosis-12, First Aid-12",
+											"tags": [
+												"Medical",
+												"Swarmbots"
+											],
+											"tech_level": "12",
+											"cost": "+6000",
+											"disabled": true
+										},
+										{
+											"id": "fbXLKvAn4bqNMIzoz",
+											"name": "Pesticide",
+											"reference": "UT87",
+											"local_notes": "LC3",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fyl9gZEYqzG9BHi1z",
+											"name": "Play",
+											"reference": "UT41",
+											"local_notes": "LC4",
+											"tags": [
+												"Robots",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+200",
+											"disabled": true
+										},
+										{
+											"id": "f7UDf-rPLeW3m0_Mk",
+											"name": "Pollinator",
+											"reference": "UT87",
+											"local_notes": "LC4",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fJNOLTp8ncbVWHERc",
+											"name": "Repair (@Equipment@)",
+											"reference": "UT87",
+											"local_notes": "LC4; Repair Skill-12",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+500",
+											"disabled": true
+										},
+										{
+											"id": "fCM6-zzzSdShyjj62",
+											"name": "Repair (@Equipment@)",
+											"reference": "UT87",
+											"local_notes": "LC4; Repair Skill-13",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "11",
+											"cost": "+500",
+											"disabled": true
+										},
+										{
+											"id": "fKrSXOjJFrEDQ4FZg",
+											"name": "Repair (@Other Equipment 1@)",
+											"reference": "UT87",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+250",
+											"disabled": true
+										},
+										{
+											"id": "f_GUeKXigXARQr54p",
+											"name": "Repair (@Other Equipment 2@)",
+											"reference": "UT87",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+250",
+											"disabled": true
+										},
+										{
+											"id": "f_q9SmIHAQzVi8tdM",
+											"name": "Repair (@Other Equipment 3@)",
+											"reference": "UT87",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+250",
+											"disabled": true
+										},
+										{
+											"id": "fpm7ywuaN4dvAO54F",
+											"name": "Security",
+											"reference": "UT104",
+											"local_notes": "LC3",
+											"tags": [
+												"Security and Surveillance",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "f-jB0TX6PWqJ6FpRa",
+											"name": "Sentry",
+											"reference": "UT169",
+											"local_notes": "LC3",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "10",
+											"cost": "+5000",
+											"disabled": true
+										},
+										{
+											"id": "fLcTgpRIi2fcgrXFD",
+											"name": "Stinger",
+											"reference": "UT169",
+											"local_notes": "LC2",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "10",
+											"cost": "+1500",
+											"disabled": true
+										},
+										{
+											"id": "fsZCwNbD6iTX6rMok",
+											"name": "Surveillance",
+											"reference": "UT106",
+											"local_notes": "LC3",
+											"tags": [
+												"Security and Surveillance",
+												"Surveillance and Tracking Devices",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+500",
+											"disabled": true
+										},
+										{
+											"id": "fLzpoSY1Hp4Qe3KHT",
+											"name": "Terminator",
+											"reference": "UT169",
+											"local_notes": "LC1",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "10",
+											"cost": "+1500",
+											"disabled": true
+										}
+									]
+								},
+								{
+									"id": "fIyHY9cI5BRuh-Bcy",
+									"name": "Self-Replicating",
+									"reference": "UT37",
+									"local_notes": "only for defoliator, devourer or pesticide",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_base_cost",
+									"cost": "x10",
+									"disabled": true
+								},
+								{
+									"id": "FOTZTaL0KEj2FGAZW",
+									"name": "Chassis",
+									"local_notes": "choose one microbot or nanobot chassis",
+									"children": [
+										{
+											"id": "FZTNXo4EZYwtBdbVY",
+											"name": "Microbot Chassis",
+											"children": [
+												{
+													"id": "f2N9SpSSaY1CpGfyt",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "f7eMKwMF7BTYFbxhq"
+													},
+													"name": "Microbot Aerostat",
+													"reference": "UT36",
+													"local_notes": "Air Move 2",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "10"
+												},
+												{
+													"id": "fXEVjCjCK6fau7j_l",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fcVKEB14BedQI1jGA"
+													},
+													"name": "Microbot Crawler",
+													"reference": "UT36",
+													"local_notes": "Move 3; Water Move 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "10",
+													"disabled": true
+												},
+												{
+													"id": "f1HRLhcSaIMUzHiSv",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fScgdTYLwKE9CEYfl"
+													},
+													"name": "Microbot Crawler, Armored",
+													"reference": "UT36",
+													"local_notes": "Move 2, 2x HP",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "10",
+													"cost": "+100%",
+													"disabled": true
+												},
+												{
+													"id": "fW-Z-aHlJIQSVT-J0",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fpAVv9yE3m3t0Egt_"
+													},
+													"name": "Microbot Flier",
+													"reference": "UT36",
+													"local_notes": "Move 1; Air Move 6",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "10",
+													"cost": "+100%",
+													"disabled": true
+												},
+												{
+													"id": "fjPPtXgEI5K45kDDu",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "ffHj2SBngzuewdrbB"
+													},
+													"name": "Microbot Hopper",
+													"reference": "UT36",
+													"local_notes": "Move 4; Super Jump 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "10",
+													"cost": "+50%",
+													"disabled": true
+												},
+												{
+													"id": "fyGEZU9464YAqN--2",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fr6wQjKaUic-BpBCO"
+													},
+													"name": "Microbot Space",
+													"reference": "UT36",
+													"local_notes": "Move 1; 0.0001G solar sail",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "10",
+													"cost": "+0",
+													"disabled": true
+												},
+												{
+													"id": "fI5AQrSpSIrWDT714",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fsL5rGqz66ht8cVvg"
+													},
+													"name": "Microbot Swimmer",
+													"reference": "UT36",
+													"local_notes": "Water Move 4",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "10",
+													"cost": "+0",
+													"disabled": true
+												},
+												{
+													"id": "fY0WThfDnhAFjwgBE",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fvVo7_8gzuQpK50fc"
+													},
+													"name": "Microbot Contragrav (CG) Flier",
+													"reference": "UT36",
+													"local_notes": "Move 1; Air Move 20",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11^",
+													"cost": "+200%",
+													"disabled": true
+												}
+											]
+										},
+										{
+											"id": "FgJ9E9P0VtHtJuRAK",
+											"name": "Nanobot Chassis",
+											"children": [
+												{
+													"id": "fMm7Q_EI5rijnaE-V",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "f6RvvKoBN0DqIjBjQ"
+													},
+													"name": "Nanobot Aerostat",
+													"reference": "UT36",
+													"local_notes": "Air Move 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "11",
+													"disabled": true
+												},
+												{
+													"id": "f695JrOcdvwvy6P_X",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "f1OLvlafFuNITe6na"
+													},
+													"name": "Nanobot Crawler",
+													"reference": "UT36",
+													"local_notes": "Move 3; Water Move 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "11",
+													"disabled": true
+												},
+												{
+													"id": "f-p8MUMk5Y3b9GEB5",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fASzj6iYz6hUA-TBB"
+													},
+													"name": "Nanobot Crawler, Armored",
+													"reference": "UT36",
+													"local_notes": "Move 2, 2x HP",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11",
+													"cost": "+100%",
+													"disabled": true
+												},
+												{
+													"id": "fLiWEXqimJ7Nf1jUp",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fLuL-pD4o6s0lREJs"
+													},
+													"name": "Nanobot Dust",
+													"reference": "UT36",
+													"local_notes": "Immobile",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11",
+													"cost": "-80%",
+													"disabled": true
+												},
+												{
+													"id": "fxmrXsne-IVLOK3rh",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fKeArqcSSvcPk5QTp"
+													},
+													"name": "Nanobot Flier",
+													"reference": "UT36",
+													"local_notes": "Move 1; Air Move 3",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11",
+													"cost": "+100%",
+													"disabled": true
+												},
+												{
+													"id": "fTWX3QYh_VOkZjcSu",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fyATVIBpOaRfq3tKe"
+													},
+													"name": "Nanobot Hopper",
+													"reference": "UT36",
+													"local_notes": "Move 4; Super Jump 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11",
+													"cost": "+50%",
+													"disabled": true
+												},
+												{
+													"id": "fsV87PKgDgNwQtmlL",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "f80KO0VZYaEJb9hbs"
+													},
+													"name": "Nanobot Space",
+													"reference": "UT36",
+													"local_notes": "Move 1; 0.0001G solar sail",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "11",
+													"cost": "+0",
+													"disabled": true
+												},
+												{
+													"id": "fRHHQEfclRtkcvahy",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fa36bUxm5RcsG_mOk"
+													},
+													"name": "Nanobot Swimmer",
+													"reference": "UT36",
+													"local_notes": "Water Move 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "11",
+													"cost": "+0",
+													"disabled": true
+												},
+												{
+													"id": "f8ys_QRU5jkxSJ7MQ",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fPgd1Z13foKJXxTND"
+													},
+													"name": "Nanobot Contragrav (CG) Flier",
+													"reference": "UT36",
+													"local_notes": "Move 1; Air Move 10",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11^",
+													"cost": "+200%",
+													"disabled": true
+												}
+											]
+										}
+									]
+								},
+								{
+									"id": "FQtjlIh19si6jt-kb",
+									"name": "Stealth",
+									"children": [
+										{
+											"id": "fkxmP8bmkywNgayOW",
+											"name": "Disguise",
+											"reference": "UT36",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_cost",
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fmp0or1a_Z2rrwnW5",
+											"name": "Thermo-Optic Chameleon Surface",
+											"reference": "UT37, UT98",
+											"local_notes": "LC3",
+											"tags": [
+												"Deception and Intrusion",
+												"Swarmbots"
+											],
+											"cost_type": "to_final_cost",
+											"tech_level": "9",
+											"cost": "+4000",
+											"weight": "+4 lb",
+											"disabled": true
+										},
+										{
+											"id": "f7_YtjD9cm1IM_TEk",
+											"name": "Multispectral Chameleon Surface",
+											"reference": "UT37, UT99",
+											"local_notes": "LC3",
+											"tags": [
+												"Deception and Intrusion",
+												"Swarmbots"
+											],
+											"cost_type": "to_final_cost",
+											"tech_level": "10",
+											"cost": "+6000",
+											"weight": "+4 lb",
+											"disabled": true
+										},
+										{
+											"id": "fRgmIBtn9p4ZTm3K5",
+											"name": "Dynamic Multispectral Chameleon Surface",
+											"reference": "UT37, UT99",
+											"local_notes": "LC3",
+											"tags": [
+												"Deception and Intrusion",
+												"Swarmbots"
+											],
+											"cost_type": "to_final_cost",
+											"tech_level": "11",
+											"cost": "+8000",
+											"weight": "+4 lb",
+											"disabled": true
+										},
+										{
+											"id": "f8EsgDTwh5dTkeozy",
+											"name": "Ultimate Chameleon Surface",
+											"reference": "UT37, UT99",
+											"local_notes": "LC3",
+											"tags": [
+												"Deception and Intrusion",
+												"Swarmbots"
+											],
+											"cost_type": "to_final_cost",
+											"tech_level": "12",
+											"cost": "+10000",
+											"weight": "+4 lb",
+											"disabled": true
+										}
+									]
+								},
+								{
+									"id": "FL4370Cwn9CoiiDrY",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "F5Q7h4gAuvWsoUiFV"
+									},
+									"name": "Power Supply",
+									"children": [
+										{
+											"id": "fo3MJuU0_j_HpE-ka",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "faj6YgnYeEKAy39jw"
+											},
+											"name": "Power Cells",
+											"reference": "UT36",
+											"local_notes": "Recharges in a Hive; C/12hr.",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"disabled": true
+										},
+										{
+											"id": "fmSgOs99Mh23eirbJ",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fCJ9sdOXfXoLN594u"
+											},
+											"name": "Power Cells",
+											"reference": "UT36",
+											"local_notes": "Recharges in a Hive; C/72hr.",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "11"
+										},
+										{
+											"id": "f4JDjmcI4ctmK-cQh",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f7WMm14XwVJyvz2NQ"
+											},
+											"name": "Power Cells",
+											"reference": "UT36",
+											"local_notes": "Recharges in a Hive; C/5 days.",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "12",
+											"disabled": true
+										},
+										{
+											"id": "fuvQp3LLJf4BPdBly",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fGv5njL67i7rODIpL"
+											},
+											"name": "Beamed Power",
+											"reference": "UT36",
+											"local_notes": "C cell receiver",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "f_aJ740yG3St5IPUw",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fS-7nLrwLytJp5mLZ"
+											},
+											"name": "Gastrobot",
+											"reference": "UT36",
+											"local_notes": "Consumes 0.1lbs./hr. of biomass",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+100%",
+											"disabled": true
+										},
+										{
+											"id": "fV64nmUz7slag7H2Y",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fhT3sMtcrOGbTzLku"
+											},
+											"name": "Radio-Thermal Generator (RTG)",
+											"reference": "UT36",
+											"local_notes": "Lasts 1 year; LC1",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+100%",
+											"disabled": true
+										},
+										{
+											"id": "fN96yQAriEF09aSIr",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "faJkuSBjewuh2TdLg"
+											},
+											"name": "Solar Cell",
+											"reference": "UT36",
+											"local_notes": "Recharges 3 hours' activity in 1 hour",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "fSQtPH6_6YtuXSio5",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f2u0xwoaeDxGjxCRq"
+											},
+											"name": "Solar Cell",
+											"reference": "UT36",
+											"local_notes": "Recharges 4 hours' activity in 1 hour",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "fPLT5uEF9_UlUJe0r",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "ff9wLL0l7uzB0IRXf"
+											},
+											"name": "Solar Cell",
+											"reference": "UT36",
+											"local_notes": "Recharges 5 hours' activity in 1 hour",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "12",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "f_iwbGA3BA3gVImRS",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f4SVyLNBYhfPgNZC0"
+											},
+											"name": "Organovore",
+											"reference": "UT36",
+											"local_notes": "Consumes 0.1-0.5 lbs./hr. of carbon-based matter; LC3",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11",
+											"cost": "+200%",
+											"disabled": true
+										},
+										{
+											"id": "fTrVzsI_0IT7xPhVW",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fi-Vh6iRVAbMGaOiO"
+											},
+											"name": "Broadcast Power",
+											"reference": "UT37",
+											"local_notes": "C cell receiver",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11^",
+											"cost": "+100%",
+											"disabled": true
+										}
+									]
+								}
+							],
+							"quantity": 1,
+							"equipped": true,
+							"calc": {
+								"value": 6000,
+								"extended_value": 6000,
+								"weight": "2 lb",
+								"extended_weight": "2 lb"
+							}
+						}
+					],
+					"calc": {
+						"value": 500,
+						"extended_value": 6500,
+						"weight": "0 lb",
+						"extended_weight": "2 lb"
+					}
+				},
+				{
+					"id": "EZw56EW5riDRfUD6c",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "euCVhRYMuK7QZVmpw"
+					},
+					"description": "Microbot Arteries",
+					"reference": "UT189",
+					"local_notes": "For battlesuits. Maximum of two per suit.",
+					"tech_level": "10",
+					"tags": [
+						"Defenses"
+					],
+					"base_value": "500",
+					"quantity": 1,
+					"equipped": true,
+					"children": [
+						{
+							"id": "en2bCaWq_8aJX1yhU",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "eRd4HdGkY3padXW2c"
+							},
+							"description": "@Microbot/Nanobot Type@ Swarm",
+							"reference": "UT35",
+							"tech_level": "10",
+							"tags": [
+								"Swarmbots"
+							],
+							"base_weight": "2 lb",
+							"replacements": {
+								"Equipment": "Military Cybersuit",
+								"Microbot/Nanobot Type": "Repair"
+							},
+							"modifiers": [
+								{
+									"id": "Fyi4RNmIB3fvDBQ3E",
+									"name": "Swarm Type",
+									"reference": "UT37",
+									"local_notes": "at TL11 microbots can have two types, at TL12 nanobots can have two types",
+									"children": [
+										{
+											"id": "fFrviRNDsX9-imBUI",
+											"name": "Bughunter",
+											"reference": "UT106",
+											"local_notes": "LC3",
+											"tags": [
+												"Counter-Surveillance and ECM",
+												"Security and Surveillance",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+4000",
+											"disabled": true
+										},
+										{
+											"id": "fbRH0-pXFgzjAXLhO",
+											"name": "Cannibal",
+											"reference": "UT169",
+											"local_notes": "LC1",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "12",
+											"cost": "+15000",
+											"disabled": true
+										},
+										{
+											"id": "f5Qyn9fBMTnK-VNji",
+											"name": "Cleaning",
+											"reference": "UT69",
+											"local_notes": "LC4",
+											"tags": [
+												"Domestic Equipment and Appliances",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fCOOWAXzUIUf0heWT",
+											"name": "Construction",
+											"reference": "UT86",
+											"local_notes": "LC4",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "ffeWXCLNIaj2Mf1_8",
+											"name": "Decontamination (@Hazard Type@)",
+											"reference": "UT87",
+											"local_notes": "LC3; Hazardous Materials (@Hazard Type@)-12",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fxY8MrpIm33W2g498",
+											"name": "Decontamination (@Hazard Type@)",
+											"reference": "UT87",
+											"local_notes": "LC3; Hazardous Materials (@Hazard Type@)-13",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "11",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fIQI4HKrPf14gIWVe",
+											"name": "Decontamination (@Hazard Type@)",
+											"reference": "UT87",
+											"local_notes": "LC3; Hazardous Materials (@Hazard Type@)-14",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "12",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fToDYaEqUVUqavslO",
+											"name": "Defoliator",
+											"reference": "UT87",
+											"local_notes": "LC3",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fL9T_mI2bybfWXq3i",
+											"name": "Devourer",
+											"reference": "UT169",
+											"local_notes": "LC1",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "10",
+											"cost": "+8000",
+											"disabled": true
+										},
+										{
+											"id": "f4s69TwYv_-G-YScP",
+											"name": "Disassembler",
+											"reference": "UT169",
+											"local_notes": "LC1",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "11",
+											"cost": "+10000",
+											"disabled": true
+										},
+										{
+											"id": "fhNkgWl1Q7Oirqa2d",
+											"name": "Explorer",
+											"reference": "UT80",
+											"local_notes": "LC4",
+											"tags": [
+												"Expedition Gear",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+500",
+											"disabled": true
+										},
+										{
+											"id": "f7XRcKatVNvF317wW",
+											"name": "Firefly",
+											"reference": "UT74",
+											"local_notes": "LC4",
+											"tags": [
+												"Domestic Equipment and Appliances",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+100",
+											"disabled": true
+										},
+										{
+											"id": "fWhk4bz6-CLEfURoj",
+											"name": "Forensic",
+											"reference": "UT107",
+											"local_notes": "LC3",
+											"tags": [
+												"Enforcement and Coercion",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+4000",
+											"disabled": true
+										},
+										{
+											"id": "fJOr0YJt6Px10oDJb",
+											"name": "Gremlin",
+											"reference": "UT169",
+											"local_notes": "LC2",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "10",
+											"cost": "+2000",
+											"disabled": true
+										},
+										{
+											"id": "f4U1_-3SayIoF21TE",
+											"name": "Harvester",
+											"reference": "UT87",
+											"local_notes": "LC4",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+2000",
+											"disabled": true
+										},
+										{
+											"id": "fu27gOm_q8a7bbay1",
+											"name": "Massage",
+											"reference": "UT41",
+											"local_notes": "LC4",
+											"tags": [
+												"Robots",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+200",
+											"disabled": true
+										},
+										{
+											"id": "f0BsWuxFtc6TDTy1u",
+											"name": "Painter",
+											"reference": "UT87",
+											"local_notes": "LC4",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+500",
+											"disabled": true
+										},
+										{
+											"id": "fGgXe09xbn2anNXG-",
+											"name": "Paramedical",
+											"reference": "UT201",
+											"local_notes": "LC3; Diagnosis-10, First Aid-10",
+											"tags": [
+												"Medical",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+6000",
+											"disabled": true
+										},
+										{
+											"id": "fEE4BmTdvBt6fmx3T",
+											"name": "Paramedical",
+											"reference": "UT201",
+											"local_notes": "LC3; Diagnosis-11, First Aid-11",
+											"tags": [
+												"Medical",
+												"Swarmbots"
+											],
+											"tech_level": "11",
+											"cost": "+6000",
+											"disabled": true
+										},
+										{
+											"id": "fYit5bWs5dPx1M0En",
+											"name": "Paramedical",
+											"reference": "UT201",
+											"local_notes": "LC3; Diagnosis-12, First Aid-12",
+											"tags": [
+												"Medical",
+												"Swarmbots"
+											],
+											"tech_level": "12",
+											"cost": "+6000",
+											"disabled": true
+										},
+										{
+											"id": "f2a4fkGEhWpdRtiO9",
+											"name": "Pesticide",
+											"reference": "UT87",
+											"local_notes": "LC3",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fWbL-Hta1aJ0rqUCP",
+											"name": "Play",
+											"reference": "UT41",
+											"local_notes": "LC4",
+											"tags": [
+												"Robots",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+200",
+											"disabled": true
+										},
+										{
+											"id": "fIzb5jM8umfSKWSt_",
+											"name": "Pollinator",
+											"reference": "UT87",
+											"local_notes": "LC4",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fxe1w_ZCFYTUef_iE",
+											"name": "Repair (@Equipment@)",
+											"reference": "UT87",
+											"local_notes": "LC4; Repair Skill-12",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+500",
+											"disabled": true
+										},
+										{
+											"id": "f223e8y3pUOub6UaD",
+											"name": "Repair (@Equipment@)",
+											"reference": "UT87",
+											"local_notes": "LC4; Repair Skill-13",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "11",
+											"cost": "+500"
+										},
+										{
+											"id": "fThaTSJATI_xyRyBt",
+											"name": "Repair (@Other Equipment 1@)",
+											"reference": "UT87",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+250",
+											"disabled": true
+										},
+										{
+											"id": "fOKs3t6y9MXlGxZXK",
+											"name": "Repair (@Other Equipment 2@)",
+											"reference": "UT87",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+250",
+											"disabled": true
+										},
+										{
+											"id": "fgGf3QbvBbk76W0kq",
+											"name": "Repair (@Other Equipment 3@)",
+											"reference": "UT87",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+250",
+											"disabled": true
+										},
+										{
+											"id": "fqK65KLOgD1UV3CiE",
+											"name": "Security",
+											"reference": "UT104",
+											"local_notes": "LC3",
+											"tags": [
+												"Security and Surveillance",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fzKp5445wUr38T7k0",
+											"name": "Sentry",
+											"reference": "UT169",
+											"local_notes": "LC3",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "10",
+											"cost": "+5000",
+											"disabled": true
+										},
+										{
+											"id": "fXQcp589TQZ0hKcUs",
+											"name": "Stinger",
+											"reference": "UT169",
+											"local_notes": "LC2",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "10",
+											"cost": "+1500",
+											"disabled": true
+										},
+										{
+											"id": "fAmk03BnFxZUASZ-U",
+											"name": "Surveillance",
+											"reference": "UT106",
+											"local_notes": "LC3",
+											"tags": [
+												"Security and Surveillance",
+												"Surveillance and Tracking Devices",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+500",
+											"disabled": true
+										},
+										{
+											"id": "f6KtA-b6b4nB598n5",
+											"name": "Terminator",
+											"reference": "UT169",
+											"local_notes": "LC1",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "10",
+											"cost": "+1500",
+											"disabled": true
+										}
+									]
+								},
+								{
+									"id": "f4_1UH62ZfSxaP838",
+									"name": "Self-Replicating",
+									"reference": "UT37",
+									"local_notes": "only for defoliator, devourer or pesticide",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_base_cost",
+									"cost": "x10",
+									"disabled": true
+								},
+								{
+									"id": "FpCogwUpGF7_weZTz",
+									"name": "Chassis",
+									"local_notes": "choose one microbot or nanobot chassis",
+									"children": [
+										{
+											"id": "FV_rpiURsDIas9rLh",
+											"name": "Microbot Chassis",
+											"children": [
+												{
+													"id": "fptgi1f_5FDXrNXB8",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "f7eMKwMF7BTYFbxhq"
+													},
+													"name": "Microbot Aerostat",
+													"reference": "UT36",
+													"local_notes": "Air Move 2",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "10",
+													"disabled": true
+												},
+												{
+													"id": "fMs4BRWnaNO2r_ma2",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fcVKEB14BedQI1jGA"
+													},
+													"name": "Microbot Crawler",
+													"reference": "UT36",
+													"local_notes": "Move 3; Water Move 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "10"
+												},
+												{
+													"id": "fvY2j31otQKPN7N63",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fScgdTYLwKE9CEYfl"
+													},
+													"name": "Microbot Crawler, Armored",
+													"reference": "UT36",
+													"local_notes": "Move 2, 2x HP",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "10",
+													"cost": "+100%",
+													"disabled": true
+												},
+												{
+													"id": "ff2-Dv-D54hRwQKMw",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fpAVv9yE3m3t0Egt_"
+													},
+													"name": "Microbot Flier",
+													"reference": "UT36",
+													"local_notes": "Move 1; Air Move 6",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "10",
+													"cost": "+100%",
+													"disabled": true
+												},
+												{
+													"id": "fCWtGyxtTqStB2ERh",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "ffHj2SBngzuewdrbB"
+													},
+													"name": "Microbot Hopper",
+													"reference": "UT36",
+													"local_notes": "Move 4; Super Jump 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "10",
+													"cost": "+50%",
+													"disabled": true
+												},
+												{
+													"id": "fdYTrC2OYnDfaN_nP",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fr6wQjKaUic-BpBCO"
+													},
+													"name": "Microbot Space",
+													"reference": "UT36",
+													"local_notes": "Move 1; 0.0001G solar sail",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "10",
+													"cost": "+0",
+													"disabled": true
+												},
+												{
+													"id": "fwOJvYwQj8oa6fJKq",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fsL5rGqz66ht8cVvg"
+													},
+													"name": "Microbot Swimmer",
+													"reference": "UT36",
+													"local_notes": "Water Move 4",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "10",
+													"cost": "+0",
+													"disabled": true
+												},
+												{
+													"id": "fU5GkQybqwuJm5hzp",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fvVo7_8gzuQpK50fc"
+													},
+													"name": "Microbot Contragrav (CG) Flier",
+													"reference": "UT36",
+													"local_notes": "Move 1; Air Move 20",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11^",
+													"cost": "+200%",
+													"disabled": true
+												}
+											]
+										},
+										{
+											"id": "F918gXsyUsk426ONJ",
+											"name": "Nanobot Chassis",
+											"children": [
+												{
+													"id": "fJwyZzekx7htu2LRu",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "f6RvvKoBN0DqIjBjQ"
+													},
+													"name": "Nanobot Aerostat",
+													"reference": "UT36",
+													"local_notes": "Air Move 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "11",
+													"disabled": true
+												},
+												{
+													"id": "fY6eG2N1R9De87f-h",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "f1OLvlafFuNITe6na"
+													},
+													"name": "Nanobot Crawler",
+													"reference": "UT36",
+													"local_notes": "Move 3; Water Move 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "11",
+													"disabled": true
+												},
+												{
+													"id": "fZwj-mt-jp_QpPfmX",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fASzj6iYz6hUA-TBB"
+													},
+													"name": "Nanobot Crawler, Armored",
+													"reference": "UT36",
+													"local_notes": "Move 2, 2x HP",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11",
+													"cost": "+100%",
+													"disabled": true
+												},
+												{
+													"id": "fRnrwrtIKlQkut0ej",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fLuL-pD4o6s0lREJs"
+													},
+													"name": "Nanobot Dust",
+													"reference": "UT36",
+													"local_notes": "Immobile",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11",
+													"cost": "-80%",
+													"disabled": true
+												},
+												{
+													"id": "fX_jWVLotX6coyRF3",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fKeArqcSSvcPk5QTp"
+													},
+													"name": "Nanobot Flier",
+													"reference": "UT36",
+													"local_notes": "Move 1; Air Move 3",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11",
+													"cost": "+100%",
+													"disabled": true
+												},
+												{
+													"id": "f5o5kFn_vMIiFBEyf",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fyATVIBpOaRfq3tKe"
+													},
+													"name": "Nanobot Hopper",
+													"reference": "UT36",
+													"local_notes": "Move 4; Super Jump 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11",
+													"cost": "+50%",
+													"disabled": true
+												},
+												{
+													"id": "fmdZriEEry7pbc9Iw",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "f80KO0VZYaEJb9hbs"
+													},
+													"name": "Nanobot Space",
+													"reference": "UT36",
+													"local_notes": "Move 1; 0.0001G solar sail",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "11",
+													"cost": "+0",
+													"disabled": true
+												},
+												{
+													"id": "f5alrqUzs-9lI8oE6",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fa36bUxm5RcsG_mOk"
+													},
+													"name": "Nanobot Swimmer",
+													"reference": "UT36",
+													"local_notes": "Water Move 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "11",
+													"cost": "+0",
+													"disabled": true
+												},
+												{
+													"id": "fRj86AepWP-T6Hvzg",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fPgd1Z13foKJXxTND"
+													},
+													"name": "Nanobot Contragrav (CG) Flier",
+													"reference": "UT36",
+													"local_notes": "Move 1; Air Move 10",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11^",
+													"cost": "+200%",
+													"disabled": true
+												}
+											]
+										}
+									]
+								},
+								{
+									"id": "FIjltP3R8GKZi-ezT",
+									"name": "Stealth",
+									"children": [
+										{
+											"id": "f1E0Wwe4fBaXWTcvv",
+											"name": "Disguise",
+											"reference": "UT36",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_cost",
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fKXlqxU4MGMoJKMbD",
+											"name": "Thermo-Optic Chameleon Surface",
+											"reference": "UT37, UT98",
+											"local_notes": "LC3",
+											"tags": [
+												"Deception and Intrusion",
+												"Swarmbots"
+											],
+											"cost_type": "to_final_cost",
+											"tech_level": "9",
+											"cost": "+4000",
+											"weight": "+4 lb",
+											"disabled": true
+										},
+										{
+											"id": "f0zeymq20K4c-yWV_",
+											"name": "Multispectral Chameleon Surface",
+											"reference": "UT37, UT99",
+											"local_notes": "LC3",
+											"tags": [
+												"Deception and Intrusion",
+												"Swarmbots"
+											],
+											"cost_type": "to_final_cost",
+											"tech_level": "10",
+											"cost": "+6000",
+											"weight": "+4 lb",
+											"disabled": true
+										},
+										{
+											"id": "fiPLzccveBOJigrAJ",
+											"name": "Dynamic Multispectral Chameleon Surface",
+											"reference": "UT37, UT99",
+											"local_notes": "LC3",
+											"tags": [
+												"Deception and Intrusion",
+												"Swarmbots"
+											],
+											"cost_type": "to_final_cost",
+											"tech_level": "11",
+											"cost": "+8000",
+											"weight": "+4 lb",
+											"disabled": true
+										},
+										{
+											"id": "fWIyjBMeEXpRjspXb",
+											"name": "Ultimate Chameleon Surface",
+											"reference": "UT37, UT99",
+											"local_notes": "LC3",
+											"tags": [
+												"Deception and Intrusion",
+												"Swarmbots"
+											],
+											"cost_type": "to_final_cost",
+											"tech_level": "12",
+											"cost": "+10000",
+											"weight": "+4 lb",
+											"disabled": true
+										}
+									]
+								},
+								{
+									"id": "FIVKJ6f5yzo90npfQ",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "F5Q7h4gAuvWsoUiFV"
+									},
+									"name": "Power Supply",
+									"children": [
+										{
+											"id": "fRCNGD0r-8Rkb9GED",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "faj6YgnYeEKAy39jw"
+											},
+											"name": "Power Cells",
+											"reference": "UT36",
+											"local_notes": "Recharges in a Hive; C/12hr.",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"disabled": true
+										},
+										{
+											"id": "f7Gw_ehCaLXWcwm7U",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fCJ9sdOXfXoLN594u"
+											},
+											"name": "Power Cells",
+											"reference": "UT36",
+											"local_notes": "Recharges in a Hive; C/72hr.",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "11"
+										},
+										{
+											"id": "fwXGt4fUkxnUj3rlv",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f7WMm14XwVJyvz2NQ"
+											},
+											"name": "Power Cells",
+											"reference": "UT36",
+											"local_notes": "Recharges in a Hive; C/5 days.",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "12",
+											"disabled": true
+										},
+										{
+											"id": "fy7X6dAKTrTsyME83",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fGv5njL67i7rODIpL"
+											},
+											"name": "Beamed Power",
+											"reference": "UT36",
+											"local_notes": "C cell receiver",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "frEi_n-PSJXVhENu3",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fS-7nLrwLytJp5mLZ"
+											},
+											"name": "Gastrobot",
+											"reference": "UT36",
+											"local_notes": "Consumes 0.1lbs./hr. of biomass",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+100%",
+											"disabled": true
+										},
+										{
+											"id": "feYvdpb1LXMEd7x19",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fhT3sMtcrOGbTzLku"
+											},
+											"name": "Radio-Thermal Generator (RTG)",
+											"reference": "UT36",
+											"local_notes": "Lasts 1 year; LC1",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+100%",
+											"disabled": true
+										},
+										{
+											"id": "foAQiCqMFwJHF8pJH",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "faJkuSBjewuh2TdLg"
+											},
+											"name": "Solar Cell",
+											"reference": "UT36",
+											"local_notes": "Recharges 3 hours' activity in 1 hour",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "fiW9O_RGGayjYyq_Y",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f2u0xwoaeDxGjxCRq"
+											},
+											"name": "Solar Cell",
+											"reference": "UT36",
+											"local_notes": "Recharges 4 hours' activity in 1 hour",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "fsySLJ6LlkaoHnCoV",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "ff9wLL0l7uzB0IRXf"
+											},
+											"name": "Solar Cell",
+											"reference": "UT36",
+											"local_notes": "Recharges 5 hours' activity in 1 hour",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "12",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "fMz0K9CPxLjVP5_Mm",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f4SVyLNBYhfPgNZC0"
+											},
+											"name": "Organovore",
+											"reference": "UT36",
+											"local_notes": "Consumes 0.1-0.5 lbs./hr. of carbon-based matter; LC3",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11",
+											"cost": "+200%",
+											"disabled": true
+										},
+										{
+											"id": "f2nxzzz-bv6fgIpIJ",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fi-Vh6iRVAbMGaOiO"
+											},
+											"name": "Broadcast Power",
+											"reference": "UT37",
+											"local_notes": "C cell receiver",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11^",
+											"cost": "+100%",
+											"disabled": true
+										}
+									]
+								}
+							],
+							"quantity": 1,
+							"equipped": true,
+							"calc": {
+								"value": 500,
+								"extended_value": 500,
+								"weight": "2 lb",
+								"extended_weight": "2 lb"
+							}
+						}
+					],
+					"calc": {
+						"value": 500,
+						"extended_value": 1000,
+						"weight": "0 lb",
+						"extended_weight": "2 lb"
+					}
+				},
+				{
+					"id": "e5bm9f5Oh8_0k5C_b",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "e3ndgVXcnUultfit9"
+					},
+					"description": "Magnetized Plates",
+					"reference": "UT187",
+					"tech_level": "9",
+					"tags": [
+						"Defenses"
+					],
+					"base_value": "100",
+					"base_weight": "0.5 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 100,
+						"extended_value": 100,
+						"weight": "0.5 lb",
+						"extended_weight": "0.5 lb"
+					}
+				},
+				{
+					"id": "E7JafOTKW-DKBf5jn",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "e2XREMcl4i-VloB4a"
+					},
+					"description": "Trauma Maintenance System",
+					"reference": "UT189",
+					"local_notes": "For battlesuits. A/1yr.",
+					"tech_level": "9",
+					"tags": [
+						"Defenses"
+					],
+					"base_value": "2000",
+					"quantity": 1,
+					"equipped": true,
+					"children": [
+						{
+							"id": "euzb2NnLglVnjrECa",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Bio-Tech/Bio-Tech Equipment.eqp",
+								"id": "etXcdY09RGaOSNceE"
+							},
+							"description": "Analgine",
+							"reference": "BT149",
+							"tech_level": "9",
+							"legality_class": "3",
+							"tags": [
+								"Drug"
+							],
+							"base_value": "2",
+							"quantity": 2,
+							"equipped": true,
+							"calc": {
+								"value": 2,
+								"extended_value": 4,
+								"weight": "0 lb",
+								"extended_weight": "0 lb"
+							}
+						},
+						{
+							"id": "eWmjEYvi4QEP-nt2X",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Bio-Tech/Bio-Tech Equipment.eqp",
+								"id": "eiVH5MDuE6qyc6g8P"
+							},
+							"description": "Antirad",
+							"reference": "BT152",
+							"local_notes": "gives Radiation Tolerance 5",
+							"tech_level": "10",
+							"legality_class": "3",
+							"tags": [
+								"Drug"
+							],
+							"base_value": "50",
+							"quantity": 2,
+							"equipped": true,
+							"calc": {
+								"value": 50,
+								"extended_value": 100,
+								"weight": "0 lb",
+								"extended_weight": "0 lb"
+							}
+						},
+						{
+							"id": "eS84Oe4PwY2YLhPjt",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Bio-Tech/Bio-Tech Equipment.eqp",
+								"id": "eU-e8frDyDIpFiw2U"
+							},
+							"description": "Superstim",
+							"reference": "BT152",
+							"tech_level": "9",
+							"legality_class": "4",
+							"tags": [
+								"Drug"
+							],
+							"base_value": "10",
+							"quantity": 2,
+							"equipped": true,
+							"calc": {
+								"value": 10,
+								"extended_value": 20,
+								"weight": "0 lb",
+								"extended_weight": "0 lb"
+							}
+						},
+						{
+							"id": "eHFqFGHtJLqyae1Ao",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Bio-Tech/Bio-Tech Equipment.eqp",
+								"id": "efuwwCGnTHfK9cqsQ"
+							},
+							"description": "Tempo",
+							"reference": "BT156",
+							"local_notes": "Lasts (25-HT) minutes",
+							"tech_level": "10",
+							"legality_class": "2",
+							"tags": [
+								"Drug"
+							],
+							"base_value": "45",
+							"quantity": 2,
+							"equipped": true,
+							"calc": {
+								"value": 45,
+								"extended_value": 90,
+								"weight": "0 lb",
+								"extended_weight": "0 lb"
+							}
+						},
+						{
+							"id": "e8bE79p6TI4GIdwnv",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Bio-Tech/Bio-Tech Equipment.eqp",
+								"id": "eXwZ2RaEg1NstR3cG"
+							},
+							"description": "Wideawake",
+							"reference": "BT152",
+							"local_notes": "one dose lasts a week",
+							"tech_level": "10",
+							"legality_class": "4",
+							"tags": [
+								"Drug"
+							],
+							"base_value": "20",
+							"quantity": 2,
+							"equipped": true,
+							"calc": {
+								"value": 20,
+								"extended_value": 40,
+								"weight": "0 lb",
+								"extended_weight": "0 lb"
+							}
+						}
+					],
+					"calc": {
+						"value": 2000,
+						"extended_value": 2254,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 50000,
+				"extended_value": 60054,
+				"weight": "50 lb",
+				"extended_weight": "54.7 lb"
+			}
+		},
+		{
+			"id": "Ew8AwyKlRgooc5eZ9",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Basic Set/Basic Set Equipment.eqp",
+				"id": "ESjtIfyzScVP49ity"
+			},
+			"description": "Backpack, Small",
+			"reference": "B288",
+			"tech_level": "1",
+			"tags": [
+				"Camping and Survival Gear"
+			],
+			"base_value": "60",
+			"base_weight": "3 lb",
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "contained_weight_prereq",
+						"has": true,
+						"qualifier": {
+							"compare": "at_most",
+							"qualifier": "40 lb"
+						}
+					}
+				]
+			},
+			"modifiers": [
+				{
+					"id": "fSXKOD1brxGF6O_vk",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+						"id": "f3AMg_F7eHdJ-u_bX"
+					},
+					"name": "Expensive",
+					"reference": "UT15",
+					"cost_type": "to_base_cost",
+					"weight_type": "to_base_weight",
+					"cost": "+1 CF",
+					"weight": "x2/3"
+				}
+			],
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "eq_vNXBaVJ8rWjMci",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eolfoSjDZrWRDXA6e"
+					},
+					"description": "Armoury (@Specialization@) Toolkit",
+					"reference": "UT82",
+					"local_notes": "10B/10hr.",
+					"tech_level": "9",
+					"tags": [
+						"Expedition Gear"
+					],
+					"base_value": "600",
+					"base_weight": "20 lb",
+					"replacements": {
+						"Specialization": "Battlesuits"
+					},
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 600,
+						"extended_value": 600,
+						"weight": "20 lb",
+						"extended_weight": "20 lb"
+					}
+				},
+				{
+					"id": "eqRPrvsitovnzBmt2",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "enQNM0RB6euc5mo7i"
+					},
+					"description": "B cell",
+					"reference": "UT19",
+					"tech_level": "9",
+					"tags": [
+						"Power"
+					],
+					"base_value": "3",
+					"base_weight": "0.05 lb",
+					"quantity": 10,
+					"equipped": true,
+					"calc": {
+						"value": 3,
+						"extended_value": 30,
+						"weight": "0.05 lb",
+						"extended_weight": "0.5 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 120,
+				"extended_value": 750,
+				"weight": "2 lb",
+				"extended_weight": "22.5 lb"
+			}
+		},
+		{
+			"id": "EFCgea-5oTLgOCt5e",
+			"description": "Stored in vehicle",
+			"legality_class": "4",
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "ezDwicGYjfLnlVL2L",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "efeekclqs54nOsbVN"
+					},
+					"description": "Swarmbot Hive",
+					"reference": "UT37",
+					"tech_level": "10",
+					"base_value": "200",
+					"base_weight": "10 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 200,
+						"extended_value": 200,
+						"weight": "10 lb",
+						"extended_weight": "10 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 0,
+				"extended_value": 200,
+				"weight": "0 lb",
+				"extended_weight": "10 lb"
+			}
+		}
+	],
+	"notes": [
+		{
+			"id": "n3DA6MU5VHW1-u8eg",
+			"markdown": "Requires Signature Gear 2 and the Battlesuit skill"
+		},
+		{
+			"id": "nnCiGE2a39EmPL96Q",
+			"markdown": "Remove Cybersuit and Repair Swarm from the TL11 Basic Spacer Kit"
+		}
+	]
+}

--- a/Library/Loadouts/Starship Crew/TL11/Better Living Through Chemistry.gct
+++ b/Library/Loadouts/Starship Crew/TL11/Better Living Through Chemistry.gct
@@ -1,0 +1,331 @@
+{
+	"version": 5,
+	"id": "BR71luaHxxjxhqAFC",
+	"equipment": [
+		{
+			"id": "ETUdNLMWWT2wzEbmV",
+			"description": "Add to the Waist Pack",
+			"legality_class": "4",
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "ejugA9ETb6DdSdP7_",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "em9ZRPPzEh54KNqXX"
+					},
+					"description": "Pneumohypo",
+					"reference": "UT199",
+					"tech_level": "9",
+					"tags": [
+						"Medical"
+					],
+					"base_value": "20",
+					"base_weight": "0.1 lb",
+					"weapons": [
+						{
+							"id": "wUf4a3ikt0Taef76S",
+							"damage": {
+								"type": "Spec"
+							},
+							"usage": "Stab",
+							"reach": "C",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Knife"
+								},
+								{
+									"type": "dx",
+									"modifier": -4
+								}
+							],
+							"calc": {
+								"damage": "Spec"
+							}
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 20,
+						"extended_value": 20,
+						"weight": "0.1 lb",
+						"extended_weight": "0.1 lb"
+					}
+				},
+				{
+					"id": "ea7t8ZkoQNSRATuwV",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Equipment.eqp",
+						"id": "epE_e-1WbBXnObwLC"
+					},
+					"description": "Adder (DX)",
+					"reference": "BT155",
+					"local_notes": "lasts (25-HT)/4 hours",
+					"tech_level": "9",
+					"legality_class": "3",
+					"tags": [
+						"Drug"
+					],
+					"base_value": "25",
+					"quantity": 4,
+					"equipped": true,
+					"calc": {
+						"value": 25,
+						"extended_value": 100,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				},
+				{
+					"id": "etrRUan46llMy-j4Z",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Equipment.eqp",
+						"id": "er0csnhilBRz4bK2x"
+					},
+					"description": "Adder (IQ)",
+					"reference": "BT155",
+					"local_notes": "lasts (25-HT)/4 hours",
+					"tech_level": "9",
+					"legality_class": "3",
+					"tags": [
+						"Drug"
+					],
+					"base_value": "25",
+					"quantity": 4,
+					"equipped": true,
+					"calc": {
+						"value": 25,
+						"extended_value": 100,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				},
+				{
+					"id": "eGkOoBCh-xhH1BX2r",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Equipment.eqp",
+						"id": "eOyt3JvGkE7D6mtz_"
+					},
+					"description": "Focus",
+					"reference": "BT162",
+					"local_notes": "Lasts (25-HT)/4 hours",
+					"tech_level": "10",
+					"legality_class": "4",
+					"tags": [
+						"Drug"
+					],
+					"base_value": "160",
+					"quantity": 2,
+					"equipped": true,
+					"calc": {
+						"value": 160,
+						"extended_value": 320,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				},
+				{
+					"id": "ehis2CToTO8AYu-Fp",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Equipment.eqp",
+						"id": "eInMDU7AH6b_7I0QB"
+					},
+					"description": "Mnemosin",
+					"reference": "BT155",
+					"local_notes": "Lasts (25-HT) minutes",
+					"tech_level": "9",
+					"legality_class": "4",
+					"tags": [
+						"Drug"
+					],
+					"base_value": "20",
+					"quantity": 5,
+					"equipped": true,
+					"calc": {
+						"value": 20,
+						"extended_value": 100,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				},
+				{
+					"id": "esQyyoWdrqsfsVCiI",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Equipment.eqp",
+						"id": "etgBN_qj2R0KMb-7A"
+					},
+					"description": "Sobriety Pill",
+					"reference": "BT158",
+					"tech_level": "9",
+					"legality_class": "4",
+					"tags": [
+						"Drug"
+					],
+					"base_value": "2",
+					"quantity": 10,
+					"equipped": true,
+					"calc": {
+						"value": 2,
+						"extended_value": 20,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				},
+				{
+					"id": "eRKgu7eRXr1_DoTG8",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Equipment.eqp",
+						"id": "eV0phB_Gd2_Aisi3o"
+					},
+					"description": "Ursaline",
+					"reference": "BT151",
+					"tech_level": "9",
+					"legality_class": "4",
+					"tags": [
+						"Drug"
+					],
+					"base_value": "25",
+					"quantity": 4,
+					"equipped": true,
+					"calc": {
+						"value": 25,
+						"extended_value": 100,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				},
+				{
+					"id": "eNylanmLxvmXGngb6",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Equipment.eqp",
+						"id": "ez3FTS57Y4pXAqK-o"
+					},
+					"description": "Panimmunity (Level 2)",
+					"reference": "BT165",
+					"local_notes": "Lasts one day to two weeks; Takes effect in one hour",
+					"tech_level": "10",
+					"legality_class": "4",
+					"tags": [
+						"Drug"
+					],
+					"base_value": "250",
+					"quantity": 2,
+					"equipped": true,
+					"calc": {
+						"value": 250,
+						"extended_value": 500,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				},
+				{
+					"id": "elt2iYPCYJp2p-bT-",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Equipment.eqp",
+						"id": "eLyGRC58ZGZLqShrT"
+					},
+					"description": "DNA Repair",
+					"reference": "BT166",
+					"local_notes": "Lasts one day to two weeks; Takes effect in one hour",
+					"tech_level": "11",
+					"legality_class": "4",
+					"tags": [
+						"Drug"
+					],
+					"base_value": "300",
+					"quantity": 2,
+					"equipped": true,
+					"calc": {
+						"value": 300,
+						"extended_value": 600,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				},
+				{
+					"id": "eW9zd3yp5dM3B2yHR",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Equipment.eqp",
+						"id": "eXldRcqZXNoGxgjlN"
+					},
+					"description": "Respirocytes",
+					"reference": "BT166",
+					"local_notes": "Lasts one day to two weeks; Takes effect in one hour",
+					"tech_level": "11",
+					"legality_class": "4",
+					"tags": [
+						"Drug"
+					],
+					"base_value": "300",
+					"quantity": 2,
+					"equipped": true,
+					"calc": {
+						"value": 300,
+						"extended_value": 600,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				},
+				{
+					"id": "E3Esme82uRZwQ-5Ce",
+					"description": "If expecting combat, add:",
+					"legality_class": "4",
+					"quantity": 1,
+					"equipped": true,
+					"children": [
+						{
+							"id": "eZfPaUsInR-tIp-Nr",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Bio-Tech/Bio-Tech Equipment.eqp",
+								"id": "enI-8-6ZfJxo8Stl1"
+							},
+							"description": "Basic",
+							"reference": "BT156",
+							"local_notes": "Lasts (25-HT)/4 minutes",
+							"tech_level": "10",
+							"legality_class": "1",
+							"tags": [
+								"Drug"
+							],
+							"base_value": "12",
+							"quantity": 5,
+							"equipped": true,
+							"calc": {
+								"value": 12,
+								"extended_value": 60,
+								"weight": "0 lb",
+								"extended_weight": "0 lb"
+							}
+						}
+					],
+					"calc": {
+						"value": 0,
+						"extended_value": 60,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 0,
+				"extended_value": 2520,
+				"weight": "0 lb",
+				"extended_weight": "0.1 lb"
+			}
+		}
+	]
+}

--- a/Library/Loadouts/Starship Crew/TL11/Chef.gct
+++ b/Library/Loadouts/Starship Crew/TL11/Chef.gct
@@ -1,0 +1,52 @@
+{
+	"version": 5,
+	"id": "BRnQn36eoIJfPDmbW",
+	"equipment": [
+		{
+			"id": "EJzw5g9Z9zRqs-2S0",
+			"description": "Stored in vehicle",
+			"legality_class": "4",
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "esv5ZTllm8omu6MgJ",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eLWOuFmvLCY2RzzZR"
+					},
+					"description": "Kitchen Foodfac",
+					"reference": "UT70",
+					"local_notes": "D/300 meals, or external power.",
+					"tech_level": "11",
+					"tags": [
+						"Housing and Food"
+					],
+					"base_value": "40000",
+					"base_weight": "25 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 40000,
+						"extended_value": 40000,
+						"weight": "25 lb",
+						"extended_weight": "25 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 0,
+				"extended_value": 40000,
+				"weight": "0 lb",
+				"extended_weight": "25 lb"
+			}
+		}
+	],
+	"notes": [
+		{
+			"id": "nW9sMnnlruk_jNcyU",
+			"markdown": "Remove survival foodfac and foodfac additive packets from the TL11 steward lens"
+		}
+	]
+}

--- a/Library/Loadouts/Starship Crew/TL11/Commander.gct
+++ b/Library/Loadouts/Starship Crew/TL11/Commander.gct
@@ -1,0 +1,231 @@
+{
+	"version": 5,
+	"id": "BZj4HTRDmw4CcyjVQ",
+	"equipment": [
+		{
+			"id": "EIulEVRtPd65Jt_EE",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+				"id": "etnuIe2XE5-Od7F9K"
+			},
+			"description": "Attaché Case",
+			"reference": "UT38",
+			"local_notes": "DR16",
+			"tech_level": "11",
+			"base_value": "80",
+			"base_weight": "2 lb",
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "eeJxyXGNKixTgscne",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eqkk8jZ1L80OKm5qF"
+					},
+					"description": "Biometric Scanlock",
+					"reference": "UT104",
+					"local_notes": "Scans finger, retina, DNA or voice in 1 second; A/1 day.",
+					"tech_level": "10",
+					"tags": [
+						"Security and Surveillance"
+					],
+					"base_value": "1000",
+					"base_weight": "1 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 1000,
+						"extended_value": 1000,
+						"weight": "1 lb",
+						"extended_weight": "1 lb"
+					}
+				},
+				{
+					"id": "ep_or6OVso8FhNE83",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "ekAiQd4wsNBsLJLIX"
+					},
+					"description": "Handheld Biometric Scanner",
+					"reference": "UT104",
+					"local_notes": "Scans finger, retina, DNA or voice in 1 second; A/1 day.",
+					"tech_level": "10",
+					"tags": [
+						"Security and Surveillance"
+					],
+					"base_value": "1000",
+					"base_weight": "1 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 1000,
+						"extended_value": 1000,
+						"weight": "1 lb",
+						"extended_weight": "1 lb"
+					}
+				},
+				{
+					"id": "eYriTbGv0RHQV67-W",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "e-o3HXIwsn4rgBZP2"
+					},
+					"description": "Small Radio Communicator",
+					"reference": "UT44",
+					"local_notes": "50-mile range. 2B/10hr.",
+					"tech_level": "11",
+					"tags": [
+						"Communication and Interface"
+					],
+					"base_value": "200",
+					"base_weight": "0.5 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 200,
+						"extended_value": 200,
+						"weight": "0.5 lb",
+						"extended_weight": "0.5 lb"
+					}
+				},
+				{
+					"id": "e-uVb3fvyirYVgPVH",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eX0kgO_ql2q6_WTpL"
+					},
+					"description": "Sonic Screen",
+					"reference": "UT96",
+					"local_notes": "C/1hr.",
+					"tech_level": "10",
+					"legality_class": "3",
+					"tags": [
+						"Deception and Intrusion"
+					],
+					"base_value": "5000",
+					"base_weight": "2.5 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 5000,
+						"extended_value": 5000,
+						"weight": "2.5 lb",
+						"extended_weight": "2.5 lb"
+					}
+				},
+				{
+					"id": "eWTGzG1xz7hsFcWPV",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "High Tech/High Tech Equipment.eqp",
+						"id": "eC-SMnDjklwF1Hse8"
+					},
+					"description": "\"Space\" Pen",
+					"reference": "HT19",
+					"tech_level": "7",
+					"tags": [
+						"Information Technology"
+					],
+					"base_value": "25",
+					"modifiers": [
+						{
+							"id": "fkiHLD3RTXJHEZceY",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "High Tech/High Tech Equipment Modifiers.eqm",
+								"id": "f3V81LEv4EYs_NisP"
+							},
+							"name": "Rugged",
+							"reference": "HT10",
+							"cost_type": "to_base_cost",
+							"weight_type": "to_base_weight",
+							"cost": "+1 CF",
+							"weight": "x1.2"
+						},
+						{
+							"id": "fneyrSvKbDd9HZreL",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "High Tech/High Tech Equipment Modifiers.eqm",
+								"id": "f_ndNuZ49l0QMOrJn"
+							},
+							"name": "Styling",
+							"reference": "HT10",
+							"local_notes": "+1 Reaction",
+							"cost_type": "to_base_cost",
+							"cost": "+1 CF"
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 75,
+						"extended_value": 75,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				},
+				{
+					"id": "eIlYD6j1B_U0RlHrA",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "enQNM0RB6euc5mo7i"
+					},
+					"description": "B cell",
+					"reference": "UT19",
+					"tech_level": "9",
+					"tags": [
+						"Power"
+					],
+					"base_value": "3",
+					"base_weight": "0.05 lb",
+					"quantity": 2,
+					"equipped": true,
+					"calc": {
+						"value": 3,
+						"extended_value": 6,
+						"weight": "0.05 lb",
+						"extended_weight": "0.1 lb"
+					}
+				},
+				{
+					"id": "e11hWd_6kqqMke43U",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "ev80WwcnBpiGFrkol"
+					},
+					"description": "C cell",
+					"reference": "UT19",
+					"tech_level": "9",
+					"tags": [
+						"Power"
+					],
+					"base_value": "10",
+					"base_weight": "0.5 lb",
+					"quantity": 2,
+					"equipped": true,
+					"calc": {
+						"value": 10,
+						"extended_value": 20,
+						"weight": "0.5 lb",
+						"extended_weight": "1 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 80,
+				"extended_value": 7381,
+				"weight": "2 lb",
+				"extended_weight": "8.1 lb"
+			}
+		}
+	]
+}

--- a/Library/Loadouts/Starship Crew/TL11/Computer Workhorse.gct
+++ b/Library/Loadouts/Starship Crew/TL11/Computer Workhorse.gct
@@ -1,0 +1,193 @@
+{
+	"version": 5,
+	"id": "BwWmkRhjDdj0Txm1v",
+	"equipment": [
+		{
+			"id": "E-4vBZSY6WYWoYxqi",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Basic Set/Basic Set Equipment.eqp",
+				"id": "ESjtIfyzScVP49ity"
+			},
+			"description": "Backpack, Small",
+			"reference": "B288",
+			"tech_level": "1",
+			"tags": [
+				"Camping and Survival Gear"
+			],
+			"base_value": "60",
+			"base_weight": "3 lb",
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "contained_weight_prereq",
+						"has": true,
+						"qualifier": {
+							"compare": "at_most",
+							"qualifier": "40 lb"
+						}
+					}
+				]
+			},
+			"modifiers": [
+				{
+					"id": "f6-1-bY8pBahQtsIT",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+						"id": "f3AMg_F7eHdJ-u_bX"
+					},
+					"name": "Expensive",
+					"reference": "UT15",
+					"cost_type": "to_base_cost",
+					"weight_type": "to_base_weight",
+					"cost": "+1 CF",
+					"weight": "x2/3"
+				}
+			],
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "EpqF0schelaSlHiq6",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "ezaCp1IvHG3JS8HOH"
+					},
+					"description": "Personal Computer",
+					"reference": "UT22",
+					"local_notes": "Complexity 8. 100EB. 2C/20hr or external power.",
+					"tech_level": "11",
+					"tags": [
+						"Computers"
+					],
+					"base_value": "1000",
+					"base_weight": "5 lb",
+					"modifiers": [
+						{
+							"id": "fCC1zGFfzwyjWT6GE",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+								"id": "ftp3XhCDqI3Lan38o"
+							},
+							"name": "Rugged",
+							"reference": "UT15",
+							"cost_type": "to_base_cost",
+							"weight_type": "to_base_weight",
+							"cost": "+1 CF",
+							"weight": "x1.2"
+						},
+						{
+							"id": "feJlbvk9bTzgixIDh",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+								"id": "fvamx4np-59rr96di"
+							},
+							"name": "Compact",
+							"reference": "UT23",
+							"local_notes": "Using multipliers",
+							"cost_type": "to_base_cost",
+							"weight_type": "to_base_weight",
+							"tech_level": "9",
+							"cost": "+1 CF",
+							"weight": "x0.5"
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"children": [
+						{
+							"id": "ey60XiT263g7p1rVV",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "eSMEpeCwHrfGzvkx9"
+							},
+							"description": "Portable Terminal",
+							"reference": "UT24",
+							"local_notes": "2B/20hr.",
+							"tech_level": "9",
+							"tags": [
+								"Computers"
+							],
+							"base_value": "50",
+							"base_weight": "0.5 lb",
+							"modifiers": [
+								{
+									"id": "fceKhdOEWS3j59USC",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "ftp3XhCDqI3Lan38o"
+									},
+									"name": "Rugged",
+									"reference": "UT15",
+									"cost_type": "to_base_cost",
+									"weight_type": "to_base_weight",
+									"cost": "+1 CF",
+									"weight": "x1.2"
+								},
+								{
+									"id": "fu3LgXpvHJh7Dkk54",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fbXG-SurLpMjqzf1Z"
+									},
+									"name": "Combination Gadget weight, multiple work at a time",
+									"reference": "UT16",
+									"weight_type": "to_final_weight",
+									"cost": "+0",
+									"weight": "x0.8"
+								},
+								{
+									"id": "fU1UQm37pCGw0Ixph",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fZK5VWsvzMBCRHwkA"
+									},
+									"name": "Combination Gadget cost, multiple work at a time",
+									"reference": "UT16",
+									"cost_type": "to_final_cost",
+									"cost": "x0.8"
+								}
+							],
+							"quantity": 1,
+							"equipped": true,
+							"calc": {
+								"value": 80,
+								"extended_value": 80,
+								"weight": "0.48 lb",
+								"extended_weight": "0.48 lb"
+							}
+						}
+					],
+					"calc": {
+						"value": 3000,
+						"extended_value": 3080,
+						"weight": "3 lb",
+						"extended_weight": "3.48 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 120,
+				"extended_value": 3200,
+				"weight": "2 lb",
+				"extended_weight": "5.48 lb"
+			}
+		}
+	],
+	"notes": [
+		{
+			"id": "nyFkhKBEQ70xjRxmV",
+			"markdown": "Remove rugged combination small computer from Spacer Basic Kit"
+		}
+	]
+}

--- a/Library/Loadouts/Starship Crew/TL11/Demolition.gct
+++ b/Library/Loadouts/Starship Crew/TL11/Demolition.gct
@@ -1,0 +1,94 @@
+{
+	"version": 5,
+	"id": "BbkiALLMbdwFTLit5",
+	"equipment": [
+		{
+			"id": "ELggKIjgYUEizFU39",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Basic Set/Basic Set Equipment.eqp",
+				"id": "ESjtIfyzScVP49ity"
+			},
+			"description": "Backpack, Small",
+			"reference": "B288",
+			"tech_level": "1",
+			"tags": [
+				"Camping and Survival Gear"
+			],
+			"base_value": "60",
+			"base_weight": "3 lb",
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "contained_weight_prereq",
+						"has": true,
+						"qualifier": {
+							"compare": "at_most",
+							"qualifier": "40 lb"
+						}
+					}
+				]
+			},
+			"modifiers": [
+				{
+					"id": "fx4UZ24O4sqe98iGZ",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+						"id": "f3AMg_F7eHdJ-u_bX"
+					},
+					"name": "Expensive",
+					"reference": "UT15",
+					"cost_type": "to_base_cost",
+					"weight_type": "to_base_weight",
+					"cost": "+1 CF",
+					"weight": "x2/3"
+				}
+			],
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "egHr1g4issj3Ainaf",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "ea58EHxoFEH2MNuyO"
+					},
+					"description": "Plasma Explosive",
+					"reference": "UT88",
+					"local_notes": "REF10",
+					"tech_level": "11",
+					"legality_class": "2",
+					"tags": [
+						"Expedition Gear"
+					],
+					"base_value": "100",
+					"base_weight": "1 lb",
+					"quantity": 5,
+					"equipped": true,
+					"calc": {
+						"value": 100,
+						"extended_value": 500,
+						"weight": "1 lb",
+						"extended_weight": "5 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 120,
+				"extended_value": 620,
+				"weight": "2 lb",
+				"extended_weight": "7 lb"
+			}
+		}
+	],
+	"notes": [
+		{
+			"id": "nThmyydjYiMoFO1o6",
+			"markdown": "Requires Explosives (Demolition)"
+		}
+	]
+}

--- a/Library/Loadouts/Starship Crew/TL11/Engineer.gct
+++ b/Library/Loadouts/Starship Crew/TL11/Engineer.gct
@@ -1,0 +1,1651 @@
+{
+	"version": 5,
+	"id": "B5F_2HG122S_k_lYI",
+	"equipment": [
+		{
+			"id": "Eo7PMsdf7Ki9xg5q6",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Basic Set/Basic Set Equipment.eqp",
+				"id": "EwSOT_Sl-CS9v-TgB"
+			},
+			"description": "Backpack, Frame",
+			"reference": "B288",
+			"tech_level": "1",
+			"tags": [
+				"Camping and Survival Gear"
+			],
+			"base_value": "100",
+			"base_weight": "10 lb",
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "contained_weight_prereq",
+						"has": true,
+						"qualifier": {
+							"compare": "at_most",
+							"qualifier": "100 lb"
+						}
+					}
+				]
+			},
+			"modifiers": [
+				{
+					"id": "fxz82EcXENVouxTCp",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+						"id": "f3AMg_F7eHdJ-u_bX"
+					},
+					"name": "Expensive",
+					"reference": "UT15",
+					"cost_type": "to_base_cost",
+					"weight_type": "to_base_weight",
+					"cost": "+1 CF",
+					"weight": "x2/3"
+				}
+			],
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "EUSMGnojVmItxTS8Y",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "es7M7etnnIm5wPDiU"
+					},
+					"description": "Electronics Repair (@Specialization@) Toolkit",
+					"reference": "UT82",
+					"local_notes": "10A/10hr.",
+					"tech_level": "9",
+					"tags": [
+						"Expedition Gear"
+					],
+					"base_value": "1200",
+					"base_weight": "10 lb",
+					"replacements": {
+						"Specialization": "Comm"
+					},
+					"modifiers": [
+						{
+							"id": "fS8BngQLkvHXIOxK8",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+								"id": "f8HaZ0LuUFvHUnXtt"
+							},
+							"name": "Combination Gadget weight, one works at a time",
+							"reference": "UT16",
+							"weight_type": "to_final_weight",
+							"cost": "+0",
+							"weight": "x0.5"
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"children": [
+						{
+							"id": "epCGnJpX5sdcXpgRB",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "e30HAzR77Eg5Bwtxw"
+							},
+							"description": "Electrician Toolkit",
+							"reference": "UT82",
+							"local_notes": "10B/10hr.",
+							"tech_level": "9",
+							"tags": [
+								"Expedition Gear"
+							],
+							"base_value": "600",
+							"base_weight": "20 lb",
+							"modifiers": [
+								{
+									"id": "fMTrZHIx6Tsf-aa1K",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fte-9FKj95fCsgBZP"
+									},
+									"name": "Combination Gadget cost, one works at a time",
+									"reference": "UT16",
+									"cost_type": "to_final_cost",
+									"cost": "x0.5"
+								}
+							],
+							"quantity": 1,
+							"equipped": true,
+							"calc": {
+								"value": 300,
+								"extended_value": 300,
+								"weight": "20 lb",
+								"extended_weight": "20 lb"
+							}
+						},
+						{
+							"id": "exc86yyGA4CnUcxUX",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "es7M7etnnIm5wPDiU"
+							},
+							"description": "Electronics Repair (@Specialization@) Toolkit",
+							"reference": "UT82",
+							"local_notes": "10A/10hr.",
+							"tech_level": "9",
+							"tags": [
+								"Expedition Gear"
+							],
+							"base_value": "1200",
+							"base_weight": "10 lb",
+							"replacements": {
+								"Specialization": "Sensors"
+							},
+							"modifiers": [
+								{
+									"id": "fbkAwHooqyYaCE0jM",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "f8HaZ0LuUFvHUnXtt"
+									},
+									"name": "Combination Gadget weight, one works at a time",
+									"reference": "UT16",
+									"weight_type": "to_final_weight",
+									"cost": "+0",
+									"weight": "x0.5"
+								},
+								{
+									"id": "fI_6F8aIHmwrXk-QN",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fte-9FKj95fCsgBZP"
+									},
+									"name": "Combination Gadget cost, one works at a time",
+									"reference": "UT16",
+									"cost_type": "to_final_cost",
+									"cost": "x0.5"
+								}
+							],
+							"quantity": 1,
+							"equipped": true,
+							"calc": {
+								"value": 600,
+								"extended_value": 600,
+								"weight": "5 lb",
+								"extended_weight": "5 lb"
+							}
+						}
+					],
+					"calc": {
+						"value": 1200,
+						"extended_value": 2100,
+						"weight": "5 lb",
+						"extended_weight": "30 lb"
+					}
+				},
+				{
+					"id": "E8xoG498WwSnPDSm2",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "emOuk952nQYYl-mdN"
+					},
+					"description": "Mechanic (@Specialization@) Toolkit",
+					"reference": "UT82",
+					"local_notes": "10B/10hr.",
+					"tech_level": "9",
+					"tags": [
+						"Expedition Gear"
+					],
+					"base_value": "600",
+					"base_weight": "20 lb",
+					"replacements": {
+						"Specialization": "@Vehicle Type@"
+					},
+					"quantity": 1,
+					"equipped": true,
+					"children": [
+						{
+							"id": "eF3vBCpD4JBlOL3jY",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "emOuk952nQYYl-mdN"
+							},
+							"description": "Mechanic (@Specialization@) Toolkit",
+							"reference": "UT82",
+							"local_notes": "10B/10hr.",
+							"tech_level": "9",
+							"tags": [
+								"Expedition Gear"
+							],
+							"base_value": "600",
+							"base_weight": "20 lb",
+							"replacements": {
+								"Specialization": "@FTL Motive System@"
+							},
+							"modifiers": [
+								{
+									"id": "fIJclYWB2_N0zbTaB",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fte-9FKj95fCsgBZP"
+									},
+									"name": "Combination Gadget cost, one works at a time",
+									"reference": "UT16",
+									"cost_type": "to_final_cost",
+									"cost": "x0.5"
+								},
+								{
+									"id": "fwvuksQBG8HeF-ycy",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "f8HaZ0LuUFvHUnXtt"
+									},
+									"name": "Combination Gadget weight, one works at a time",
+									"reference": "UT16",
+									"weight_type": "to_final_weight",
+									"cost": "+0",
+									"weight": "x0.5"
+								}
+							],
+							"quantity": 1,
+							"equipped": true,
+							"calc": {
+								"value": 300,
+								"extended_value": 300,
+								"weight": "10 lb",
+								"extended_weight": "10 lb"
+							}
+						},
+						{
+							"id": "eN9YbdO4IALLCpV6Y",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "emOuk952nQYYl-mdN"
+							},
+							"description": "Mechanic (@Specialization@) Toolkit",
+							"reference": "UT82",
+							"local_notes": "10B/10hr.",
+							"tech_level": "9",
+							"tags": [
+								"Expedition Gear"
+							],
+							"base_value": "600",
+							"base_weight": "20 lb",
+							"replacements": {
+								"Specialization": "@Power Plant Type@"
+							},
+							"modifiers": [
+								{
+									"id": "fM8EDtXYcVRce7SUN",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fte-9FKj95fCsgBZP"
+									},
+									"name": "Combination Gadget cost, one works at a time",
+									"reference": "UT16",
+									"cost_type": "to_final_cost",
+									"cost": "x0.5"
+								},
+								{
+									"id": "fSkPqN84D4XNLsvJF",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "f8HaZ0LuUFvHUnXtt"
+									},
+									"name": "Combination Gadget weight, one works at a time",
+									"reference": "UT16",
+									"weight_type": "to_final_weight",
+									"cost": "+0",
+									"weight": "x0.5"
+								}
+							],
+							"quantity": 1,
+							"equipped": true,
+							"calc": {
+								"value": 300,
+								"extended_value": 300,
+								"weight": "10 lb",
+								"extended_weight": "10 lb"
+							}
+						},
+						{
+							"id": "eO-x4dTeunBf-MwaO",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "emOuk952nQYYl-mdN"
+							},
+							"description": "Mechanic (@Specialization@) Toolkit",
+							"reference": "UT82",
+							"local_notes": "10B/10hr.",
+							"tech_level": "9",
+							"tags": [
+								"Expedition Gear"
+							],
+							"base_value": "600",
+							"base_weight": "20 lb",
+							"replacements": {
+								"Specialization": "@STL Motive System@"
+							},
+							"modifiers": [
+								{
+									"id": "fgL3Cmttav3x3uBdT",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fte-9FKj95fCsgBZP"
+									},
+									"name": "Combination Gadget cost, one works at a time",
+									"reference": "UT16",
+									"cost_type": "to_final_cost",
+									"cost": "x0.5"
+								},
+								{
+									"id": "fxC0oJKHpSeiMl_D0",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "f8HaZ0LuUFvHUnXtt"
+									},
+									"name": "Combination Gadget weight, one works at a time",
+									"reference": "UT16",
+									"weight_type": "to_final_weight",
+									"cost": "+0",
+									"weight": "x0.5"
+								}
+							],
+							"quantity": 1,
+							"equipped": true,
+							"calc": {
+								"value": 300,
+								"extended_value": 300,
+								"weight": "10 lb",
+								"extended_weight": "10 lb"
+							}
+						}
+					],
+					"calc": {
+						"value": 600,
+						"extended_value": 1500,
+						"weight": "20 lb",
+						"extended_weight": "50 lb"
+					}
+				},
+				{
+					"id": "efDnBIQsDnBSFbmCB",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "enQNM0RB6euc5mo7i"
+					},
+					"description": "B cell",
+					"reference": "UT19",
+					"tech_level": "9",
+					"tags": [
+						"Power"
+					],
+					"base_value": "3",
+					"base_weight": "0.05 lb",
+					"quantity": 4,
+					"equipped": true,
+					"calc": {
+						"value": 3,
+						"extended_value": 12,
+						"weight": "0.05 lb",
+						"extended_weight": "0.2 lb"
+					}
+				},
+				{
+					"id": "e0y1QRK21K2pt2vRa",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "ev80WwcnBpiGFrkol"
+					},
+					"description": "C cell",
+					"reference": "UT19",
+					"tech_level": "9",
+					"tags": [
+						"Power"
+					],
+					"base_value": "10",
+					"base_weight": "0.5 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 10,
+						"extended_value": 10,
+						"weight": "0.5 lb",
+						"extended_weight": "0.5 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 200,
+				"extended_value": 3822,
+				"weight": "6.6666 lb",
+				"extended_weight": "87.3666 lb"
+			}
+		},
+		{
+			"id": "Eos3wOo0f_kgDWKqI",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "High Tech/High Tech Equipment.eqp",
+				"id": "EAnRAyVUrDmAJPOXQ"
+			},
+			"description": "Travel Bag",
+			"reference": "HT54",
+			"local_notes": "Holds 100lbs.",
+			"tech_level": "5",
+			"tags": [
+				"General Equipment"
+			],
+			"base_value": "60",
+			"base_weight": "10 lb",
+			"modifiers": [
+				{
+					"id": "f4KnzJJF2YoQMxTSj",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+						"id": "f3AMg_F7eHdJ-u_bX"
+					},
+					"name": "Expensive",
+					"reference": "UT15",
+					"cost_type": "to_base_cost",
+					"weight_type": "to_base_weight",
+					"cost": "+1 CF",
+					"weight": "x2/3"
+				}
+			],
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "er2g4ZlmRadeNAf5n",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "e08fat3kJF1_6Abg-"
+					},
+					"description": "Sonic Probe",
+					"reference": "UT84",
+					"local_notes": "B/12hr.",
+					"tech_level": "10",
+					"tags": [
+						"Expedition Gear"
+					],
+					"base_value": "500",
+					"base_weight": "0.25 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 500,
+						"extended_value": 500,
+						"weight": "0.25 lb",
+						"extended_weight": "0.25 lb"
+					}
+				},
+				{
+					"id": "eMzxX9uXBmjbvYhfo",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eumSJJ4VioXWyFiaR"
+					},
+					"description": "Portable Robofac",
+					"reference": "UT90",
+					"local_notes": "0.1lbs. or $10 finished product per hour. C/8hrs.",
+					"tech_level": "11",
+					"legality_class": "2",
+					"tags": [
+						"Manufacturing"
+					],
+					"base_value": "10000",
+					"base_weight": "10 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 10000,
+						"extended_value": 10000,
+						"weight": "10 lb",
+						"extended_weight": "10 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 120,
+				"extended_value": 10620,
+				"weight": "6.6666 lb",
+				"extended_weight": "16.9166 lb"
+			}
+		},
+		{
+			"id": "EemtwrgHV_cZSwhY6",
+			"description": "Stored in Vehicle",
+			"legality_class": "4",
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "EoRYapwSEAHn4LZ88",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "efeekclqs54nOsbVN"
+					},
+					"description": "Swarmbot Hive",
+					"reference": "UT37",
+					"tech_level": "10",
+					"base_value": "200",
+					"base_weight": "10 lb",
+					"quantity": 2,
+					"equipped": true,
+					"children": [
+						{
+							"id": "e6pRolx1gYIHlO6fo",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "eRd4HdGkY3padXW2c"
+							},
+							"description": "@Microbot/Nanobot Type@ Swarm",
+							"reference": "UT35",
+							"tech_level": "10",
+							"tags": [
+								"Swarmbots"
+							],
+							"base_weight": "2 lb",
+							"replacements": {
+								"Equipment": "Vehicle",
+								"Microbot/Nanobot Type": "Repair"
+							},
+							"modifiers": [
+								{
+									"id": "F8jmx5G4ebSP0wMKa",
+									"name": "Swarm Type",
+									"reference": "UT37",
+									"local_notes": "at TL11 microbots can have two types, at TL12 nanobots can have two types",
+									"children": [
+										{
+											"id": "fFidOlAjmoVbA0C5h",
+											"name": "Bughunter",
+											"reference": "UT106",
+											"local_notes": "LC3",
+											"tags": [
+												"Counter-Surveillance and ECM",
+												"Security and Surveillance",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+4000",
+											"disabled": true
+										},
+										{
+											"id": "f8t-9zFawM7vBR_vQ",
+											"name": "Cannibal",
+											"reference": "UT169",
+											"local_notes": "LC1",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "12",
+											"cost": "+15000",
+											"disabled": true
+										},
+										{
+											"id": "fXpMO9ec3zrm9Z-7_",
+											"name": "Cleaning",
+											"reference": "UT69",
+											"local_notes": "LC4",
+											"tags": [
+												"Domestic Equipment and Appliances",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "f7lM8yCCUwlns_WEd",
+											"name": "Construction",
+											"reference": "UT86",
+											"local_notes": "LC4",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fyyh-rwKWAzuMHwtW",
+											"name": "Decontamination (@Hazard Type@)",
+											"reference": "UT87",
+											"local_notes": "LC3; Hazardous Materials (@Hazard Type@)-12",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fcNIiYJVqXwTNxgbT",
+											"name": "Decontamination (@Hazard Type@)",
+											"reference": "UT87",
+											"local_notes": "LC3; Hazardous Materials (@Hazard Type@)-13",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "11",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fJGdt1-scZIOw-Obi",
+											"name": "Decontamination (@Hazard Type@)",
+											"reference": "UT87",
+											"local_notes": "LC3; Hazardous Materials (@Hazard Type@)-14",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "12",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fEZ6ECXAhBmdn_g2N",
+											"name": "Defoliator",
+											"reference": "UT87",
+											"local_notes": "LC3",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fkfAac8qsKWRMbKJs",
+											"name": "Devourer",
+											"reference": "UT169",
+											"local_notes": "LC1",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "10",
+											"cost": "+8000",
+											"disabled": true
+										},
+										{
+											"id": "ftUDq65TP2Vnoocnj",
+											"name": "Disassembler",
+											"reference": "UT169",
+											"local_notes": "LC1",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "11",
+											"cost": "+10000",
+											"disabled": true
+										},
+										{
+											"id": "fQPdMHcu5Nk4eVyat",
+											"name": "Explorer",
+											"reference": "UT80",
+											"local_notes": "LC4",
+											"tags": [
+												"Expedition Gear",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+500",
+											"disabled": true
+										},
+										{
+											"id": "fc76DUmILHDK5wohn",
+											"name": "Firefly",
+											"reference": "UT74",
+											"local_notes": "LC4",
+											"tags": [
+												"Domestic Equipment and Appliances",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+100",
+											"disabled": true
+										},
+										{
+											"id": "fK929MUtGA9VXsb5t",
+											"name": "Forensic",
+											"reference": "UT107",
+											"local_notes": "LC3",
+											"tags": [
+												"Enforcement and Coercion",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+4000",
+											"disabled": true
+										},
+										{
+											"id": "ffe76dh3WtXDCBPve",
+											"name": "Gremlin",
+											"reference": "UT169",
+											"local_notes": "LC2",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "10",
+											"cost": "+2000",
+											"disabled": true
+										},
+										{
+											"id": "fezPbNcosLDFCkXMs",
+											"name": "Harvester",
+											"reference": "UT87",
+											"local_notes": "LC4",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+2000",
+											"disabled": true
+										},
+										{
+											"id": "fahZMYo-cHJ7mE0CZ",
+											"name": "Massage",
+											"reference": "UT41",
+											"local_notes": "LC4",
+											"tags": [
+												"Robots",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+200",
+											"disabled": true
+										},
+										{
+											"id": "fv6dFInqrquaFOAew",
+											"name": "Painter",
+											"reference": "UT87",
+											"local_notes": "LC4",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+500",
+											"disabled": true
+										},
+										{
+											"id": "f-2Sm1xeUd9cKKrQd",
+											"name": "Paramedical",
+											"reference": "UT201",
+											"local_notes": "LC3; Diagnosis-10, First Aid-10",
+											"tags": [
+												"Medical",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+6000",
+											"disabled": true
+										},
+										{
+											"id": "fgKLq4lY925FTL0Ro",
+											"name": "Paramedical",
+											"reference": "UT201",
+											"local_notes": "LC3; Diagnosis-11, First Aid-11",
+											"tags": [
+												"Medical",
+												"Swarmbots"
+											],
+											"tech_level": "11",
+											"cost": "+6000",
+											"disabled": true
+										},
+										{
+											"id": "f1mhRNv-rej-Cbrqp",
+											"name": "Paramedical",
+											"reference": "UT201",
+											"local_notes": "LC3; Diagnosis-12, First Aid-12",
+											"tags": [
+												"Medical",
+												"Swarmbots"
+											],
+											"tech_level": "12",
+											"cost": "+6000",
+											"disabled": true
+										},
+										{
+											"id": "fFL8gC09JOYtTolQi",
+											"name": "Pesticide",
+											"reference": "UT87",
+											"local_notes": "LC3",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fo_dvGZb6MRCwgoq9",
+											"name": "Play",
+											"reference": "UT41",
+											"local_notes": "LC4",
+											"tags": [
+												"Robots",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+200",
+											"disabled": true
+										},
+										{
+											"id": "frgc3ABvQEcsxSIbP",
+											"name": "Pollinator",
+											"reference": "UT87",
+											"local_notes": "LC4",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fQm9WtVG4iPrG9Tt6",
+											"name": "Repair (@Equipment@)",
+											"reference": "UT87",
+											"local_notes": "LC4; Repair Skill-12",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+500",
+											"disabled": true
+										},
+										{
+											"id": "fnqK-lnSkBgAsLzYo",
+											"name": "Repair (@Equipment@)",
+											"reference": "UT87",
+											"local_notes": "LC4; Repair Skill-13",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "11",
+											"cost": "+500"
+										},
+										{
+											"id": "fAjpUj_E36OJNdgp0",
+											"name": "Repair (@Other Equipment 1@)",
+											"reference": "UT87",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+250",
+											"disabled": true
+										},
+										{
+											"id": "fvW3J0-H2ZOtjNFrT",
+											"name": "Repair (@Other Equipment 2@)",
+											"reference": "UT87",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+250",
+											"disabled": true
+										},
+										{
+											"id": "foO9IniAQHcdodcYs",
+											"name": "Repair (@Other Equipment 3@)",
+											"reference": "UT87",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+250",
+											"disabled": true
+										},
+										{
+											"id": "fOG2A938USCNQHnJz",
+											"name": "Security",
+											"reference": "UT104",
+											"local_notes": "LC3",
+											"tags": [
+												"Security and Surveillance",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fYx79ReRxrWvQjTJ1",
+											"name": "Sentry",
+											"reference": "UT169",
+											"local_notes": "LC3",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "10",
+											"cost": "+5000",
+											"disabled": true
+										},
+										{
+											"id": "fOKtEWUt9BIiAlymj",
+											"name": "Stinger",
+											"reference": "UT169",
+											"local_notes": "LC2",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "10",
+											"cost": "+1500",
+											"disabled": true
+										},
+										{
+											"id": "fn10ep0w90f22Z7H8",
+											"name": "Surveillance",
+											"reference": "UT106",
+											"local_notes": "LC3",
+											"tags": [
+												"Security and Surveillance",
+												"Surveillance and Tracking Devices",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+500",
+											"disabled": true
+										},
+										{
+											"id": "flLyd25P0KHj7X44g",
+											"name": "Terminator",
+											"reference": "UT169",
+											"local_notes": "LC1",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "10",
+											"cost": "+1500",
+											"disabled": true
+										}
+									]
+								},
+								{
+									"id": "fVBHmQMx2cFyoCZWI",
+									"name": "Self-Replicating",
+									"reference": "UT37",
+									"local_notes": "only for defoliator, devourer or pesticide",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_base_cost",
+									"cost": "x10",
+									"disabled": true
+								},
+								{
+									"id": "FFXfkKFu_SSQgSayR",
+									"name": "Chassis",
+									"local_notes": "choose one microbot or nanobot chassis",
+									"children": [
+										{
+											"id": "FY5urhUqXdUJ1BEr3",
+											"name": "Microbot Chassis",
+											"children": [
+												{
+													"id": "fubO3558DyVql2HZQ",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "f7eMKwMF7BTYFbxhq"
+													},
+													"name": "Microbot Aerostat",
+													"reference": "UT36",
+													"local_notes": "Air Move 2",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "10"
+												},
+												{
+													"id": "f4DfJOf1J9TnQLFKH",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fcVKEB14BedQI1jGA"
+													},
+													"name": "Microbot Crawler",
+													"reference": "UT36",
+													"local_notes": "Move 3; Water Move 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "10",
+													"disabled": true
+												},
+												{
+													"id": "fMKsyL9AzqkA1EIkh",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fScgdTYLwKE9CEYfl"
+													},
+													"name": "Microbot Crawler, Armored",
+													"reference": "UT36",
+													"local_notes": "Move 2, 2x HP",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "10",
+													"cost": "+100%",
+													"disabled": true
+												},
+												{
+													"id": "f_rr9XIHLqA4b6dag",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fpAVv9yE3m3t0Egt_"
+													},
+													"name": "Microbot Flier",
+													"reference": "UT36",
+													"local_notes": "Move 1; Air Move 6",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "10",
+													"cost": "+100%",
+													"disabled": true
+												},
+												{
+													"id": "f2W5Dl0NIDnrgOqdw",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "ffHj2SBngzuewdrbB"
+													},
+													"name": "Microbot Hopper",
+													"reference": "UT36",
+													"local_notes": "Move 4; Super Jump 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "10",
+													"cost": "+50%",
+													"disabled": true
+												},
+												{
+													"id": "f4pbmnIa4GYoQzDlW",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fr6wQjKaUic-BpBCO"
+													},
+													"name": "Microbot Space",
+													"reference": "UT36",
+													"local_notes": "Move 1; 0.0001G solar sail",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "10",
+													"cost": "+0",
+													"disabled": true
+												},
+												{
+													"id": "fv4g6dCu4HMhJI9BJ",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fsL5rGqz66ht8cVvg"
+													},
+													"name": "Microbot Swimmer",
+													"reference": "UT36",
+													"local_notes": "Water Move 4",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "10",
+													"cost": "+0",
+													"disabled": true
+												},
+												{
+													"id": "f5W7rtVTxC-DW9mgS",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fvVo7_8gzuQpK50fc"
+													},
+													"name": "Microbot Contragrav (CG) Flier",
+													"reference": "UT36",
+													"local_notes": "Move 1; Air Move 20",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11^",
+													"cost": "+200%",
+													"disabled": true
+												}
+											]
+										},
+										{
+											"id": "FBh4xOq-7tuhNw3K_",
+											"name": "Nanobot Chassis",
+											"children": [
+												{
+													"id": "f3wOGy12UVIS4dZ-a",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "f6RvvKoBN0DqIjBjQ"
+													},
+													"name": "Nanobot Aerostat",
+													"reference": "UT36",
+													"local_notes": "Air Move 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "11",
+													"disabled": true
+												},
+												{
+													"id": "frc4Y22C4agmFZMb8",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "f1OLvlafFuNITe6na"
+													},
+													"name": "Nanobot Crawler",
+													"reference": "UT36",
+													"local_notes": "Move 3; Water Move 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "11",
+													"disabled": true
+												},
+												{
+													"id": "fbcBZkH8m4PyRkcoc",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fASzj6iYz6hUA-TBB"
+													},
+													"name": "Nanobot Crawler, Armored",
+													"reference": "UT36",
+													"local_notes": "Move 2, 2x HP",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11",
+													"cost": "+100%",
+													"disabled": true
+												},
+												{
+													"id": "fJ8SFPRKb06-igYG3",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fLuL-pD4o6s0lREJs"
+													},
+													"name": "Nanobot Dust",
+													"reference": "UT36",
+													"local_notes": "Immobile",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11",
+													"cost": "-80%",
+													"disabled": true
+												},
+												{
+													"id": "fnAt2Ux0Sxhgfr3cc",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fKeArqcSSvcPk5QTp"
+													},
+													"name": "Nanobot Flier",
+													"reference": "UT36",
+													"local_notes": "Move 1; Air Move 3",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11",
+													"cost": "+100%",
+													"disabled": true
+												},
+												{
+													"id": "f3qP91K-29XgQOp9t",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fyATVIBpOaRfq3tKe"
+													},
+													"name": "Nanobot Hopper",
+													"reference": "UT36",
+													"local_notes": "Move 4; Super Jump 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11",
+													"cost": "+50%",
+													"disabled": true
+												},
+												{
+													"id": "fgDk3fbbR-yoURNkw",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "f80KO0VZYaEJb9hbs"
+													},
+													"name": "Nanobot Space",
+													"reference": "UT36",
+													"local_notes": "Move 1; 0.0001G solar sail",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "11",
+													"cost": "+0",
+													"disabled": true
+												},
+												{
+													"id": "f5JLcVVUv4ExqlpCM",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fa36bUxm5RcsG_mOk"
+													},
+													"name": "Nanobot Swimmer",
+													"reference": "UT36",
+													"local_notes": "Water Move 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "11",
+													"cost": "+0",
+													"disabled": true
+												},
+												{
+													"id": "f3X11NoxWx-Vb6o8r",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fPgd1Z13foKJXxTND"
+													},
+													"name": "Nanobot Contragrav (CG) Flier",
+													"reference": "UT36",
+													"local_notes": "Move 1; Air Move 10",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11^",
+													"cost": "+200%",
+													"disabled": true
+												}
+											]
+										}
+									]
+								},
+								{
+									"id": "FO8qpWCbgpffTC2wH",
+									"name": "Stealth",
+									"children": [
+										{
+											"id": "fHNgiaZ1Ligi6s5lv",
+											"name": "Disguise",
+											"reference": "UT36",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_cost",
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fcfwZYDLM1JLJ2yVc",
+											"name": "Thermo-Optic Chameleon Surface",
+											"reference": "UT37, UT98",
+											"local_notes": "LC3",
+											"tags": [
+												"Deception and Intrusion",
+												"Swarmbots"
+											],
+											"cost_type": "to_final_cost",
+											"tech_level": "9",
+											"cost": "+4000",
+											"weight": "+4 lb",
+											"disabled": true
+										},
+										{
+											"id": "fkHb_nahLpIwdBYZU",
+											"name": "Multispectral Chameleon Surface",
+											"reference": "UT37, UT99",
+											"local_notes": "LC3",
+											"tags": [
+												"Deception and Intrusion",
+												"Swarmbots"
+											],
+											"cost_type": "to_final_cost",
+											"tech_level": "10",
+											"cost": "+6000",
+											"weight": "+4 lb",
+											"disabled": true
+										},
+										{
+											"id": "fiUvK0MCo4l10lUgX",
+											"name": "Dynamic Multispectral Chameleon Surface",
+											"reference": "UT37, UT99",
+											"local_notes": "LC3",
+											"tags": [
+												"Deception and Intrusion",
+												"Swarmbots"
+											],
+											"cost_type": "to_final_cost",
+											"tech_level": "11",
+											"cost": "+8000",
+											"weight": "+4 lb",
+											"disabled": true
+										},
+										{
+											"id": "fFy3jXoR9oslf1WjK",
+											"name": "Ultimate Chameleon Surface",
+											"reference": "UT37, UT99",
+											"local_notes": "LC3",
+											"tags": [
+												"Deception and Intrusion",
+												"Swarmbots"
+											],
+											"cost_type": "to_final_cost",
+											"tech_level": "12",
+											"cost": "+10000",
+											"weight": "+4 lb",
+											"disabled": true
+										}
+									]
+								},
+								{
+									"id": "FnfGjEzJCkKGpFmJ1",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "F5Q7h4gAuvWsoUiFV"
+									},
+									"name": "Power Supply",
+									"children": [
+										{
+											"id": "f4Wr7kElPW-NUOfKO",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "faj6YgnYeEKAy39jw"
+											},
+											"name": "Power Cells",
+											"reference": "UT36",
+											"local_notes": "Recharges in a Hive; C/12hr.",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"disabled": true
+										},
+										{
+											"id": "f6hj2igEu6dSFOeqG",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fCJ9sdOXfXoLN594u"
+											},
+											"name": "Power Cells",
+											"reference": "UT36",
+											"local_notes": "Recharges in a Hive; C/72hr.",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "11"
+										},
+										{
+											"id": "fjjXTek6xWfP6qHdA",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f7WMm14XwVJyvz2NQ"
+											},
+											"name": "Power Cells",
+											"reference": "UT36",
+											"local_notes": "Recharges in a Hive; C/5 days.",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "12",
+											"disabled": true
+										},
+										{
+											"id": "fYDc6Rp1aETiyGfEr",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fGv5njL67i7rODIpL"
+											},
+											"name": "Beamed Power",
+											"reference": "UT36",
+											"local_notes": "C cell receiver",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "fTW4PezQZq4f6n5Pz",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fS-7nLrwLytJp5mLZ"
+											},
+											"name": "Gastrobot",
+											"reference": "UT36",
+											"local_notes": "Consumes 0.1lbs./hr. of biomass",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+100%",
+											"disabled": true
+										},
+										{
+											"id": "fIng4qjB7PRTKKAtX",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fhT3sMtcrOGbTzLku"
+											},
+											"name": "Radio-Thermal Generator (RTG)",
+											"reference": "UT36",
+											"local_notes": "Lasts 1 year; LC1",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+100%",
+											"disabled": true
+										},
+										{
+											"id": "fr-C-8TwITiK4KGyg",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "faJkuSBjewuh2TdLg"
+											},
+											"name": "Solar Cell",
+											"reference": "UT36",
+											"local_notes": "Recharges 3 hours' activity in 1 hour",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "fHNR4lq5LAyKzs7kn",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f2u0xwoaeDxGjxCRq"
+											},
+											"name": "Solar Cell",
+											"reference": "UT36",
+											"local_notes": "Recharges 4 hours' activity in 1 hour",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "fLovQ3tkoBLr01LHe",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "ff9wLL0l7uzB0IRXf"
+											},
+											"name": "Solar Cell",
+											"reference": "UT36",
+											"local_notes": "Recharges 5 hours' activity in 1 hour",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "12",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "fKstN9rMbPMK7e0ar",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f4SVyLNBYhfPgNZC0"
+											},
+											"name": "Organovore",
+											"reference": "UT36",
+											"local_notes": "Consumes 0.1-0.5 lbs./hr. of carbon-based matter; LC3",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11",
+											"cost": "+200%",
+											"disabled": true
+										},
+										{
+											"id": "fyQKsoXsjoGjxQqIh",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fi-Vh6iRVAbMGaOiO"
+											},
+											"name": "Broadcast Power",
+											"reference": "UT37",
+											"local_notes": "C cell receiver",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11^",
+											"cost": "+100%",
+											"disabled": true
+										}
+									]
+								}
+							],
+							"quantity": 2,
+							"equipped": true,
+							"calc": {
+								"value": 500,
+								"extended_value": 1000,
+								"weight": "2 lb",
+								"extended_weight": "4 lb"
+							}
+						}
+					],
+					"calc": {
+						"value": 200,
+						"extended_value": 2400,
+						"weight": "10 lb",
+						"extended_weight": "28 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 0,
+				"extended_value": 2400,
+				"weight": "0 lb",
+				"extended_weight": "28 lb"
+			}
+		}
+	]
+}

--- a/Library/Loadouts/Starship Crew/TL11/Hacker.gct
+++ b/Library/Loadouts/Starship Crew/TL11/Hacker.gct
@@ -1,0 +1,266 @@
+{
+	"version": 5,
+	"id": "BWyWotKolFLj1gHwv",
+	"equipment": [
+		{
+			"id": "EHpR6kqmgObcpdFh7",
+			"description": "Stored in Backpack",
+			"legality_class": "4",
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "EsvQdRBQElwB-cN9L",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "ezaCp1IvHG3JS8HOH"
+					},
+					"description": "Personal Computer",
+					"reference": "UT22",
+					"local_notes": "Complexity 8. 100EB. 2C/20hr or external power.",
+					"tech_level": "11",
+					"tags": [
+						"Computers"
+					],
+					"base_value": "1000",
+					"base_weight": "5 lb",
+					"modifiers": [
+						{
+							"id": "fKgSEzu9QCNUBzIes",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+								"id": "ftp3XhCDqI3Lan38o"
+							},
+							"name": "Rugged",
+							"reference": "UT15",
+							"cost_type": "to_base_cost",
+							"weight_type": "to_base_weight",
+							"cost": "+1 CF",
+							"weight": "x1.2"
+						},
+						{
+							"id": "fpZdfGqoZtfcnfmBz",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+								"id": "fOdqzWq5hDOqIdQ4O"
+							},
+							"name": "Hardened",
+							"reference": "UT23",
+							"local_notes": "Using multipliers, +3 HT vs. resist electronic pulses, microwaves, etc.",
+							"cost_type": "to_base_cost",
+							"weight_type": "to_base_weight",
+							"tech_level": "9",
+							"cost": "+1 CF",
+							"weight": "x2"
+						},
+						{
+							"id": "fND7V3JmYT-EbluH0",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+								"id": "fvamx4np-59rr96di"
+							},
+							"name": "Compact",
+							"reference": "UT23",
+							"local_notes": "Using multipliers",
+							"cost_type": "to_base_cost",
+							"weight_type": "to_base_weight",
+							"tech_level": "9",
+							"cost": "+1 CF",
+							"weight": "x0.5"
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"children": [
+						{
+							"id": "e73saGu1VPqoty5lC",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "eSMEpeCwHrfGzvkx9"
+							},
+							"description": "Portable Terminal",
+							"reference": "UT24",
+							"local_notes": "2B/20hr.",
+							"tech_level": "9",
+							"tags": [
+								"Computers"
+							],
+							"base_value": "50",
+							"base_weight": "0.5 lb",
+							"modifiers": [
+								{
+									"id": "fRsRy6vlVeQTSFqxy",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "ftp3XhCDqI3Lan38o"
+									},
+									"name": "Rugged",
+									"reference": "UT15",
+									"cost_type": "to_base_cost",
+									"weight_type": "to_base_weight",
+									"cost": "+1 CF",
+									"weight": "x1.2"
+								},
+								{
+									"id": "f6NNL8p6SY0-e4GJ1",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fZK5VWsvzMBCRHwkA"
+									},
+									"name": "Combination Gadget cost, multiple work at a time",
+									"reference": "UT16",
+									"cost_type": "to_final_cost",
+									"cost": "x0.8"
+								},
+								{
+									"id": "fgilY-SisQG1pKfPE",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fbXG-SurLpMjqzf1Z"
+									},
+									"name": "Combination Gadget weight, multiple work at a time",
+									"reference": "UT16",
+									"weight_type": "to_final_weight",
+									"cost": "+0",
+									"weight": "x0.8"
+								}
+							],
+							"quantity": 1,
+							"equipped": true,
+							"calc": {
+								"value": 80,
+								"extended_value": 80,
+								"weight": "0.48 lb",
+								"extended_weight": "0.48 lb"
+							}
+						}
+					],
+					"calc": {
+						"value": 4000,
+						"extended_value": 4080,
+						"weight": "6 lb",
+						"extended_weight": "6.48 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 0,
+				"extended_value": 4080,
+				"weight": "0 lb",
+				"extended_weight": "6.48 lb"
+			}
+		},
+		{
+			"id": "eRd4EdELuUtiKsbe7",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+				"id": "ehY0jh2nfpA-Tu9nZ"
+			},
+			"description": "Long-Range Computer Monitoring Scanner",
+			"reference": "UT100",
+			"local_notes": "1,000-yard range. C/10hr.",
+			"tech_level": "9",
+			"legality_class": "2",
+			"tags": [
+				"Deception and Intrusion"
+			],
+			"base_value": "5000",
+			"base_weight": "5 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"value": 5000,
+				"extended_value": 5000,
+				"weight": "5 lb",
+				"extended_weight": "5 lb"
+			}
+		},
+		{
+			"id": "eN4FfeWeTf6t4TEQE",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+				"id": "eoFtTjEBA4BtvMOKa"
+			},
+			"description": "Keyboard Bug",
+			"reference": "UT100",
+			"tech_level": "9",
+			"legality_class": "3",
+			"tags": [
+				"Deception and Intrusion"
+			],
+			"base_value": "200",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"value": 200,
+				"extended_value": 200,
+				"weight": "0 lb",
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eeWnMxF4DLB4XFvBj",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+				"id": "eZZZEUTGQoaOZ_v0S"
+			},
+			"description": "Emissions Nanobug",
+			"reference": "UT105",
+			"local_notes": "AA/year",
+			"tech_level": "9",
+			"tags": [
+				"Surveillance and Tracking Devices"
+			],
+			"base_value": "100",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"value": 100,
+				"extended_value": 100,
+				"weight": "0 lb",
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eyXx3yZaeDM3F3nia",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+				"id": "ev80WwcnBpiGFrkol"
+			},
+			"description": "C cell",
+			"reference": "UT19",
+			"tech_level": "9",
+			"tags": [
+				"Power"
+			],
+			"base_value": "10",
+			"base_weight": "0.5 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"value": 10,
+				"extended_value": 10,
+				"weight": "0.5 lb",
+				"extended_weight": "0.5 lb"
+			}
+		}
+	],
+	"notes": [
+		{
+			"id": "nsUdZm3S-74TKva5z",
+			"markdown": "Remove rugged combination small computer from the TL11 Spacer Basic Kit"
+		}
+	]
+}

--- a/Library/Loadouts/Starship Crew/TL11/Helmsman.gct
+++ b/Library/Loadouts/Starship Crew/TL11/Helmsman.gct
@@ -1,0 +1,1418 @@
+{
+	"version": 5,
+	"id": "B2E4Tu-6Ag9kEVpHw",
+	"equipment": [
+		{
+			"id": "EiDauLE4RK9mFydM4",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Basic Set/Basic Set Equipment.eqp",
+				"id": "ESjtIfyzScVP49ity"
+			},
+			"description": "Backpack, Small",
+			"reference": "B288",
+			"tech_level": "1",
+			"tags": [
+				"Camping and Survival Gear"
+			],
+			"base_value": "60",
+			"base_weight": "3 lb",
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "contained_weight_prereq",
+						"has": true,
+						"qualifier": {
+							"compare": "at_most",
+							"qualifier": "40 lb"
+						}
+					}
+				]
+			},
+			"modifiers": [
+				{
+					"id": "f5yyt7LvG10d0Igsd",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+						"id": "f3AMg_F7eHdJ-u_bX"
+					},
+					"name": "Expensive",
+					"reference": "UT15",
+					"cost_type": "to_base_cost",
+					"weight_type": "to_base_weight",
+					"cost": "+1 CF",
+					"weight": "x2/3"
+				}
+			],
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "ERgRZ5Zc--e38noqE",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "e5qZTKtVs-q-xQlfS"
+					},
+					"description": "Small Computer",
+					"reference": "UT22",
+					"local_notes": "Complexity 7. 10EB. 2B/20hr.",
+					"tech_level": "11",
+					"tags": [
+						"Computers"
+					],
+					"base_value": "100",
+					"base_weight": "0.5 lb",
+					"modifiers": [
+						{
+							"id": "fX2SRsSX9GXetjW-f",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+								"id": "ftp3XhCDqI3Lan38o"
+							},
+							"name": "Rugged",
+							"reference": "UT15",
+							"cost_type": "to_base_cost",
+							"weight_type": "to_base_weight",
+							"cost": "+1 CF",
+							"weight": "x1.2"
+						},
+						{
+							"id": "fqz5qpeS8dmuJgGk2",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+								"id": "fvamx4np-59rr96di"
+							},
+							"name": "Compact",
+							"reference": "UT23",
+							"local_notes": "Using multipliers",
+							"cost_type": "to_base_cost",
+							"weight_type": "to_base_weight",
+							"tech_level": "9",
+							"cost": "+1 CF",
+							"weight": "x0.5"
+						},
+						{
+							"id": "fF80w9jJkm7F0NgDd",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+								"id": "fbXG-SurLpMjqzf1Z"
+							},
+							"name": "Combination Gadget weight, multiple work at a time",
+							"reference": "UT16",
+							"weight_type": "to_final_weight",
+							"cost": "+0",
+							"weight": "x0.8"
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"children": [
+						{
+							"id": "ez2YtfBaYBFXEAevD",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "eSMEpeCwHrfGzvkx9"
+							},
+							"description": "Portable Terminal",
+							"reference": "UT24",
+							"local_notes": "2B/20hr.",
+							"tech_level": "9",
+							"tags": [
+								"Computers"
+							],
+							"base_value": "50",
+							"base_weight": "0.5 lb",
+							"modifiers": [
+								{
+									"id": "fHzcBGn1zQ4KqveF8",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "ftp3XhCDqI3Lan38o"
+									},
+									"name": "Rugged",
+									"reference": "UT15",
+									"cost_type": "to_base_cost",
+									"weight_type": "to_base_weight",
+									"cost": "+1 CF",
+									"weight": "x1.2"
+								},
+								{
+									"id": "f9YE51L5HWF9qhGLd",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fZK5VWsvzMBCRHwkA"
+									},
+									"name": "Combination Gadget cost, multiple work at a time",
+									"reference": "UT16",
+									"cost_type": "to_final_cost",
+									"cost": "x0.8"
+								}
+							],
+							"quantity": 1,
+							"equipped": true,
+							"calc": {
+								"value": 80,
+								"extended_value": 80,
+								"weight": "0.6 lb",
+								"extended_weight": "0.6 lb"
+							}
+						}
+					],
+					"calc": {
+						"value": 300,
+						"extended_value": 380,
+						"weight": "0.24 lb",
+						"extended_weight": "0.84 lb"
+					}
+				},
+				{
+					"id": "euN0X4UX33dX9iKae",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "ejivvq8TpDx5Annl6"
+					},
+					"description": "Inertial Compass",
+					"reference": "UT75",
+					"local_notes": "A/200hr.",
+					"tech_level": "11",
+					"tags": [
+						"Housing and Food"
+					],
+					"base_value": "30",
+					"base_weight": "0.05 lb",
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Navigation"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Air"
+							},
+							"amount": 3
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Navigation"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Land"
+							},
+							"amount": 3
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Navigation"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Sea"
+							},
+							"amount": 3
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 30,
+						"extended_value": 30,
+						"weight": "0.05 lb",
+						"extended_weight": "0.05 lb"
+					}
+				},
+				{
+					"id": "e4Netyp5IJmrEJv2w",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "efgHn5GrLTMIE3JjS"
+					},
+					"description": "Small Ladar",
+					"reference": "UT64",
+					"local_notes": "50-mile range. B/8hr.",
+					"tech_level": "11",
+					"tags": [
+						"Sensors and Scientific Equipment"
+					],
+					"base_value": "2000",
+					"base_weight": "1 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 2000,
+						"extended_value": 2000,
+						"weight": "1 lb",
+						"extended_weight": "1 lb"
+					}
+				},
+				{
+					"id": "eZ2JkA7f4NTqVmBmZ",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eRd4HdGkY3padXW2c"
+					},
+					"description": "@Microbot/Nanobot Type@ Swarm",
+					"reference": "UT35",
+					"tech_level": "10",
+					"tags": [
+						"Swarmbots"
+					],
+					"base_weight": "2 lb",
+					"replacements": {
+						"Microbot/Nanobot Type": "Explorer"
+					},
+					"modifiers": [
+						{
+							"id": "F2QakwEJEpQ3I42a7",
+							"name": "Swarm Type",
+							"reference": "UT37",
+							"local_notes": "at TL11 microbots can have two types, at TL12 nanobots can have two types",
+							"children": [
+								{
+									"id": "f3PmMGrvzU4lB8zZ-",
+									"name": "Bughunter",
+									"reference": "UT106",
+									"local_notes": "LC3",
+									"tags": [
+										"Counter-Surveillance and ECM",
+										"Security and Surveillance",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+4000",
+									"disabled": true
+								},
+								{
+									"id": "fFRgXlC-f-tYgnxSo",
+									"name": "Cannibal",
+									"reference": "UT169",
+									"local_notes": "LC1",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "12",
+									"cost": "+15000",
+									"disabled": true
+								},
+								{
+									"id": "fDPC9-HuEW3-tyihV",
+									"name": "Cleaning",
+									"reference": "UT69",
+									"local_notes": "LC4",
+									"tags": [
+										"Domestic Equipment and Appliances",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fP8AipjPE4aMx7hof",
+									"name": "Construction",
+									"reference": "UT86",
+									"local_notes": "LC4",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fbuZBARLDs2MRI8Dj",
+									"name": "Decontamination (@Hazard Type@)",
+									"reference": "UT87",
+									"local_notes": "LC3; Hazardous Materials (@Hazard Type@)-12",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fm4Qu0b9wLfzsqLRU",
+									"name": "Decontamination (@Hazard Type@)",
+									"reference": "UT87",
+									"local_notes": "LC3; Hazardous Materials (@Hazard Type@)-13",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "11",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fqzxRvOxy-atlNjwZ",
+									"name": "Decontamination (@Hazard Type@)",
+									"reference": "UT87",
+									"local_notes": "LC3; Hazardous Materials (@Hazard Type@)-14",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "12",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fuIwbwx6PAl8L36qJ",
+									"name": "Defoliator",
+									"reference": "UT87",
+									"local_notes": "LC3",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fZ-kYrF5MtCdkFs-V",
+									"name": "Devourer",
+									"reference": "UT169",
+									"local_notes": "LC1",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "10",
+									"cost": "+8000",
+									"disabled": true
+								},
+								{
+									"id": "fne607rbsW1FO2PSh",
+									"name": "Disassembler",
+									"reference": "UT169",
+									"local_notes": "LC1",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "11",
+									"cost": "+10000",
+									"disabled": true
+								},
+								{
+									"id": "fPMkSMZ5oSmvwEXip",
+									"name": "Explorer",
+									"reference": "UT80",
+									"local_notes": "LC4",
+									"tags": [
+										"Expedition Gear",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+500"
+								},
+								{
+									"id": "f91lSZ-ZXPeuqMgnx",
+									"name": "Firefly",
+									"reference": "UT74",
+									"local_notes": "LC4",
+									"tags": [
+										"Domestic Equipment and Appliances",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+100",
+									"disabled": true
+								},
+								{
+									"id": "f96x10hpH5JSk2Tzz",
+									"name": "Forensic",
+									"reference": "UT107",
+									"local_notes": "LC3",
+									"tags": [
+										"Enforcement and Coercion",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+4000",
+									"disabled": true
+								},
+								{
+									"id": "fN15y7ZdiZ3A5wL3H",
+									"name": "Gremlin",
+									"reference": "UT169",
+									"local_notes": "LC2",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "10",
+									"cost": "+2000",
+									"disabled": true
+								},
+								{
+									"id": "f2003pFO749Wb1Iy_",
+									"name": "Harvester",
+									"reference": "UT87",
+									"local_notes": "LC4",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+2000",
+									"disabled": true
+								},
+								{
+									"id": "f6djecNvKxL18_Po4",
+									"name": "Massage",
+									"reference": "UT41",
+									"local_notes": "LC4",
+									"tags": [
+										"Robots",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+200",
+									"disabled": true
+								},
+								{
+									"id": "fXPqzOs0HKhBCTETm",
+									"name": "Painter",
+									"reference": "UT87",
+									"local_notes": "LC4",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+500",
+									"disabled": true
+								},
+								{
+									"id": "fEUtxr7tWyuZJyOz4",
+									"name": "Paramedical",
+									"reference": "UT201",
+									"local_notes": "LC3; Diagnosis-10, First Aid-10",
+									"tags": [
+										"Medical",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+6000",
+									"disabled": true
+								},
+								{
+									"id": "fEHr0iSpb02ePhg4J",
+									"name": "Paramedical",
+									"reference": "UT201",
+									"local_notes": "LC3; Diagnosis-11, First Aid-11",
+									"tags": [
+										"Medical",
+										"Swarmbots"
+									],
+									"tech_level": "11",
+									"cost": "+6000",
+									"disabled": true
+								},
+								{
+									"id": "fu3FY5QFQSae11KL0",
+									"name": "Paramedical",
+									"reference": "UT201",
+									"local_notes": "LC3; Diagnosis-12, First Aid-12",
+									"tags": [
+										"Medical",
+										"Swarmbots"
+									],
+									"tech_level": "12",
+									"cost": "+6000",
+									"disabled": true
+								},
+								{
+									"id": "fRaaeDxTrnGKhZCHm",
+									"name": "Pesticide",
+									"reference": "UT87",
+									"local_notes": "LC3",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fuuDRkcnC7S1JXYde",
+									"name": "Play",
+									"reference": "UT41",
+									"local_notes": "LC4",
+									"tags": [
+										"Robots",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+200",
+									"disabled": true
+								},
+								{
+									"id": "fBK4YUgAHEYc3S4aN",
+									"name": "Pollinator",
+									"reference": "UT87",
+									"local_notes": "LC4",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fsx-YPYwyug-kpnuK",
+									"name": "Repair (@Equipment@)",
+									"reference": "UT87",
+									"local_notes": "LC4; Repair Skill-12",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+500",
+									"disabled": true
+								},
+								{
+									"id": "fscU0bzJO6Kb95pKe",
+									"name": "Repair (@Equipment@)",
+									"reference": "UT87",
+									"local_notes": "LC4; Repair Skill-13",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "11",
+									"cost": "+500",
+									"disabled": true
+								},
+								{
+									"id": "fWly9poOchgZZljve",
+									"name": "Repair (@Other Equipment 1@)",
+									"reference": "UT87",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+250",
+									"disabled": true
+								},
+								{
+									"id": "fBaAtgrcU5laJ9zR8",
+									"name": "Repair (@Other Equipment 2@)",
+									"reference": "UT87",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+250",
+									"disabled": true
+								},
+								{
+									"id": "fSCEVPfEy4Xra0cNi",
+									"name": "Repair (@Other Equipment 3@)",
+									"reference": "UT87",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+250",
+									"disabled": true
+								},
+								{
+									"id": "flf_QSVElX-oRKfEL",
+									"name": "Security",
+									"reference": "UT104",
+									"local_notes": "LC3",
+									"tags": [
+										"Security and Surveillance",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fUGbImar_hRe7oPXD",
+									"name": "Sentry",
+									"reference": "UT169",
+									"local_notes": "LC3",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "10",
+									"cost": "+5000",
+									"disabled": true
+								},
+								{
+									"id": "fxI9-kF172tmhsiLG",
+									"name": "Stinger",
+									"reference": "UT169",
+									"local_notes": "LC2",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "10",
+									"cost": "+1500",
+									"disabled": true
+								},
+								{
+									"id": "furZLbHsiqTzhKPF-",
+									"name": "Surveillance",
+									"reference": "UT106",
+									"local_notes": "LC3",
+									"tags": [
+										"Security and Surveillance",
+										"Surveillance and Tracking Devices",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+500",
+									"disabled": true
+								},
+								{
+									"id": "f042Q9_1IFXrj5lhp",
+									"name": "Terminator",
+									"reference": "UT169",
+									"local_notes": "LC1",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "10",
+									"cost": "+1500",
+									"disabled": true
+								}
+							]
+						},
+						{
+							"id": "feA7C6q4UIkJij80i",
+							"name": "Self-Replicating",
+							"reference": "UT37",
+							"local_notes": "only for defoliator, devourer or pesticide",
+							"tags": [
+								"Swarmbots"
+							],
+							"cost_type": "to_base_cost",
+							"cost": "x10",
+							"disabled": true
+						},
+						{
+							"id": "FfKzLnmMAZLQPFmlI",
+							"name": "Chassis",
+							"local_notes": "choose one microbot or nanobot chassis",
+							"children": [
+								{
+									"id": "F13pFTBKY2H_36Etl",
+									"name": "Microbot Chassis",
+									"children": [
+										{
+											"id": "fEvg2no6FDvwxnaNb",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f7eMKwMF7BTYFbxhq"
+											},
+											"name": "Microbot Aerostat",
+											"reference": "UT36",
+											"local_notes": "Air Move 2",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "10"
+										},
+										{
+											"id": "fMoRWO7uj0-fVh6En",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fcVKEB14BedQI1jGA"
+											},
+											"name": "Microbot Crawler",
+											"reference": "UT36",
+											"local_notes": "Move 3; Water Move 1",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"disabled": true
+										},
+										{
+											"id": "f8wltq2piig2VMkeg",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fScgdTYLwKE9CEYfl"
+											},
+											"name": "Microbot Crawler, Armored",
+											"reference": "UT36",
+											"local_notes": "Move 2, 2x HP",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+100%",
+											"disabled": true
+										},
+										{
+											"id": "fq1xcTWefwLlxdtaf",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fpAVv9yE3m3t0Egt_"
+											},
+											"name": "Microbot Flier",
+											"reference": "UT36",
+											"local_notes": "Move 1; Air Move 6",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+100%",
+											"disabled": true
+										},
+										{
+											"id": "fUm4XfTevRtkQbXCL",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "ffHj2SBngzuewdrbB"
+											},
+											"name": "Microbot Hopper",
+											"reference": "UT36",
+											"local_notes": "Move 4; Super Jump 1",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "f81pHKzqANhJDTe98",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fr6wQjKaUic-BpBCO"
+											},
+											"name": "Microbot Space",
+											"reference": "UT36",
+											"local_notes": "Move 1; 0.0001G solar sail",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+0",
+											"disabled": true
+										},
+										{
+											"id": "fCVQmB-m4gYSLKBC9",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fsL5rGqz66ht8cVvg"
+											},
+											"name": "Microbot Swimmer",
+											"reference": "UT36",
+											"local_notes": "Water Move 4",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+0",
+											"disabled": true
+										},
+										{
+											"id": "fNdOhaRqe3jffKcvJ",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fvVo7_8gzuQpK50fc"
+											},
+											"name": "Microbot Contragrav (CG) Flier",
+											"reference": "UT36",
+											"local_notes": "Move 1; Air Move 20",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11^",
+											"cost": "+200%",
+											"disabled": true
+										}
+									]
+								},
+								{
+									"id": "FLhNLaWgTN0UwqY_Q",
+									"name": "Nanobot Chassis",
+									"children": [
+										{
+											"id": "fjtlkonGSHeQq413T",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f6RvvKoBN0DqIjBjQ"
+											},
+											"name": "Nanobot Aerostat",
+											"reference": "UT36",
+											"local_notes": "Air Move 1",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "11",
+											"disabled": true
+										},
+										{
+											"id": "fgFdGQc5B_UOoeHu3",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f1OLvlafFuNITe6na"
+											},
+											"name": "Nanobot Crawler",
+											"reference": "UT36",
+											"local_notes": "Move 3; Water Move 1",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "11",
+											"disabled": true
+										},
+										{
+											"id": "fB6T0ofrN7y2HLloY",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fASzj6iYz6hUA-TBB"
+											},
+											"name": "Nanobot Crawler, Armored",
+											"reference": "UT36",
+											"local_notes": "Move 2, 2x HP",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11",
+											"cost": "+100%",
+											"disabled": true
+										},
+										{
+											"id": "fLollG6N5xHCT5opD",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fLuL-pD4o6s0lREJs"
+											},
+											"name": "Nanobot Dust",
+											"reference": "UT36",
+											"local_notes": "Immobile",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11",
+											"cost": "-80%",
+											"disabled": true
+										},
+										{
+											"id": "fx2QSf4clEFZd7Zah",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fKeArqcSSvcPk5QTp"
+											},
+											"name": "Nanobot Flier",
+											"reference": "UT36",
+											"local_notes": "Move 1; Air Move 3",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11",
+											"cost": "+100%",
+											"disabled": true
+										},
+										{
+											"id": "fsDsYyILnuHzM03Er",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fyATVIBpOaRfq3tKe"
+											},
+											"name": "Nanobot Hopper",
+											"reference": "UT36",
+											"local_notes": "Move 4; Super Jump 1",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "foCi5oN-2bw8iEw0b",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f80KO0VZYaEJb9hbs"
+											},
+											"name": "Nanobot Space",
+											"reference": "UT36",
+											"local_notes": "Move 1; 0.0001G solar sail",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "11",
+											"cost": "+0",
+											"disabled": true
+										},
+										{
+											"id": "f-AFsdYD9yPoKXYkN",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fa36bUxm5RcsG_mOk"
+											},
+											"name": "Nanobot Swimmer",
+											"reference": "UT36",
+											"local_notes": "Water Move 1",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "11",
+											"cost": "+0",
+											"disabled": true
+										},
+										{
+											"id": "frbZRWIAUcu63SNSy",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fPgd1Z13foKJXxTND"
+											},
+											"name": "Nanobot Contragrav (CG) Flier",
+											"reference": "UT36",
+											"local_notes": "Move 1; Air Move 10",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11^",
+											"cost": "+200%",
+											"disabled": true
+										}
+									]
+								}
+							]
+						},
+						{
+							"id": "FmRK6Qt9zTXcEMmso",
+							"name": "Stealth",
+							"children": [
+								{
+									"id": "fptqdBlfP2aJNOl2r",
+									"name": "Disguise",
+									"reference": "UT36",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_cost",
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fRYLbq41GVV9cNrS_",
+									"name": "Thermo-Optic Chameleon Surface",
+									"reference": "UT37, UT98",
+									"local_notes": "LC3",
+									"tags": [
+										"Deception and Intrusion",
+										"Swarmbots"
+									],
+									"cost_type": "to_final_cost",
+									"tech_level": "9",
+									"cost": "+4000",
+									"weight": "+4 lb",
+									"disabled": true
+								},
+								{
+									"id": "fJkJO6rszxoZW-XZz",
+									"name": "Multispectral Chameleon Surface",
+									"reference": "UT37, UT99",
+									"local_notes": "LC3",
+									"tags": [
+										"Deception and Intrusion",
+										"Swarmbots"
+									],
+									"cost_type": "to_final_cost",
+									"tech_level": "10",
+									"cost": "+6000",
+									"weight": "+4 lb",
+									"disabled": true
+								},
+								{
+									"id": "fXfI3CTk4s0q1-XBc",
+									"name": "Dynamic Multispectral Chameleon Surface",
+									"reference": "UT37, UT99",
+									"local_notes": "LC3",
+									"tags": [
+										"Deception and Intrusion",
+										"Swarmbots"
+									],
+									"cost_type": "to_final_cost",
+									"tech_level": "11",
+									"cost": "+8000",
+									"weight": "+4 lb",
+									"disabled": true
+								},
+								{
+									"id": "f9n4wkpajO0IYy70y",
+									"name": "Ultimate Chameleon Surface",
+									"reference": "UT37, UT99",
+									"local_notes": "LC3",
+									"tags": [
+										"Deception and Intrusion",
+										"Swarmbots"
+									],
+									"cost_type": "to_final_cost",
+									"tech_level": "12",
+									"cost": "+10000",
+									"weight": "+4 lb",
+									"disabled": true
+								}
+							]
+						},
+						{
+							"id": "FUqe-Tr2SJcmQTw7I",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+								"id": "F5Q7h4gAuvWsoUiFV"
+							},
+							"name": "Power Supply",
+							"children": [
+								{
+									"id": "fHHPpR-y5zZPSIxCU",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "faj6YgnYeEKAy39jw"
+									},
+									"name": "Power Cells",
+									"reference": "UT36",
+									"local_notes": "Recharges in a Hive; C/12hr.",
+									"tags": [
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"disabled": true
+								},
+								{
+									"id": "fKcVfqoIeby7aT-tQ",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fCJ9sdOXfXoLN594u"
+									},
+									"name": "Power Cells",
+									"reference": "UT36",
+									"local_notes": "Recharges in a Hive; C/72hr.",
+									"tags": [
+										"Swarmbots"
+									],
+									"tech_level": "11"
+								},
+								{
+									"id": "f4BXdQ6F0Vq5mCgNB",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "f7WMm14XwVJyvz2NQ"
+									},
+									"name": "Power Cells",
+									"reference": "UT36",
+									"local_notes": "Recharges in a Hive; C/5 days.",
+									"tags": [
+										"Swarmbots"
+									],
+									"tech_level": "12",
+									"disabled": true
+								},
+								{
+									"id": "fueKC8BPXnC-YmVXY",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fGv5njL67i7rODIpL"
+									},
+									"name": "Beamed Power",
+									"reference": "UT36",
+									"local_notes": "C cell receiver",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "10",
+									"cost": "+50%",
+									"disabled": true
+								},
+								{
+									"id": "fTrSjIxsQ4cUwrBI8",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fS-7nLrwLytJp5mLZ"
+									},
+									"name": "Gastrobot",
+									"reference": "UT36",
+									"local_notes": "Consumes 0.1lbs./hr. of biomass",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "10",
+									"cost": "+100%",
+									"disabled": true
+								},
+								{
+									"id": "fIMpxVwboejan6hi2",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fhT3sMtcrOGbTzLku"
+									},
+									"name": "Radio-Thermal Generator (RTG)",
+									"reference": "UT36",
+									"local_notes": "Lasts 1 year; LC1",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "10",
+									"cost": "+100%",
+									"disabled": true
+								},
+								{
+									"id": "fOSrSfdpA9-FWHlRV",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "faJkuSBjewuh2TdLg"
+									},
+									"name": "Solar Cell",
+									"reference": "UT36",
+									"local_notes": "Recharges 3 hours' activity in 1 hour",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "10",
+									"cost": "+50%",
+									"disabled": true
+								},
+								{
+									"id": "f8eDmQe2AraCtJKEt",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "f2u0xwoaeDxGjxCRq"
+									},
+									"name": "Solar Cell",
+									"reference": "UT36",
+									"local_notes": "Recharges 4 hours' activity in 1 hour",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "11",
+									"cost": "+50%",
+									"disabled": true
+								},
+								{
+									"id": "fT5Fq2mMYeFCRBjvc",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "ff9wLL0l7uzB0IRXf"
+									},
+									"name": "Solar Cell",
+									"reference": "UT36",
+									"local_notes": "Recharges 5 hours' activity in 1 hour",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "12",
+									"cost": "+50%",
+									"disabled": true
+								},
+								{
+									"id": "fgXJ5xdbUxmx4CA33",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "f4SVyLNBYhfPgNZC0"
+									},
+									"name": "Organovore",
+									"reference": "UT36",
+									"local_notes": "Consumes 0.1-0.5 lbs./hr. of carbon-based matter; LC3",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "11",
+									"cost": "+200%",
+									"disabled": true
+								},
+								{
+									"id": "fFlG1aTRhPEGmzeWn",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fi-Vh6iRVAbMGaOiO"
+									},
+									"name": "Broadcast Power",
+									"reference": "UT37",
+									"local_notes": "C cell receiver",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "11^",
+									"cost": "+100%",
+									"disabled": true
+								}
+							]
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 500,
+						"extended_value": 500,
+						"weight": "2 lb",
+						"extended_weight": "2 lb"
+					}
+				},
+				{
+					"id": "eCMXKklQ5wd59VXR0",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "enQNM0RB6euc5mo7i"
+					},
+					"description": "B cell",
+					"reference": "UT19",
+					"tech_level": "9",
+					"tags": [
+						"Power"
+					],
+					"base_value": "3",
+					"base_weight": "0.05 lb",
+					"quantity": 3,
+					"equipped": true,
+					"calc": {
+						"value": 3,
+						"extended_value": 9,
+						"weight": "0.05 lb",
+						"extended_weight": "0.15 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 120,
+				"extended_value": 3039,
+				"weight": "2 lb",
+				"extended_weight": "6.04 lb"
+			}
+		},
+		{
+			"id": "EeQIZCBVPUx2P0RVE",
+			"description": "Stored on Vehicle",
+			"legality_class": "4",
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "e0VwA9Vi_sWAWvWa3",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "efeekclqs54nOsbVN"
+					},
+					"description": "Swarmbot Hive",
+					"reference": "UT37",
+					"tech_level": "10",
+					"base_value": "200",
+					"base_weight": "10 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 200,
+						"extended_value": 200,
+						"weight": "10 lb",
+						"extended_weight": "10 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 0,
+				"extended_value": 200,
+				"weight": "0 lb",
+				"extended_weight": "10 lb"
+			}
+		}
+	],
+	"notes": [
+		{
+			"id": "nnS4HABM3eB7rS3Mt",
+			"markdown": "Remove rugged combination small computer from the TL11 Spacer Basic Kit"
+		}
+	]
+}

--- a/Library/Loadouts/Starship Crew/TL11/Loader Operator.gct
+++ b/Library/Loadouts/Starship Crew/TL11/Loader Operator.gct
@@ -1,0 +1,69 @@
+{
+	"version": 5,
+	"id": "BfXvwXD65x50uS583",
+	"equipment": [
+		{
+			"id": "EcCq4TbHn_QJk76VR",
+			"description": "Add to Cybersuit from Spacer Basic Kit",
+			"legality_class": "4",
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "etAAZrVg8moDzCd0X",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "evsN4HEOX7Q30RhBC"
+					},
+					"description": "Rainbow",
+					"reference": "UT189",
+					"local_notes": "For smartsuits and cybersuits.",
+					"tech_level": "10",
+					"tags": [
+						"Defenses"
+					],
+					"base_value": "2000",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 2000,
+						"extended_value": 2000,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				},
+				{
+					"id": "eLlagGI-6hGKu1iym",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "ehfM2kKWZZF2X82hJ"
+					},
+					"description": "Morphwear",
+					"reference": "UT189",
+					"local_notes": "For smartsuits and cybersuits.",
+					"tech_level": "10",
+					"tags": [
+						"Defenses"
+					],
+					"base_value": "5000",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 5000,
+						"extended_value": 5000,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 0,
+				"extended_value": 7000,
+				"weight": "0 lb",
+				"extended_weight": "0 lb"
+			}
+		}
+	]
+}

--- a/Library/Loadouts/Starship Crew/TL11/Loadmaster.gct
+++ b/Library/Loadouts/Starship Crew/TL11/Loadmaster.gct
@@ -1,0 +1,455 @@
+{
+	"version": 5,
+	"id": "BIaTrmjYfkJYBd0Ui",
+	"equipment": [
+		{
+			"id": "EejazdVAZuD7C-nLL",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+				"id": "ecvRbROzGAmUpQg_Y"
+			},
+			"description": "Light Infantry Helmet",
+			"reference": "UT176",
+			"tech_level": "11",
+			"legality_class": "3",
+			"tags": [
+				"Armor",
+				"Defenses"
+			],
+			"base_value": "250",
+			"base_weight": "3 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"skull"
+					],
+					"amount": 36
+				}
+			],
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "e1bSPnZL_dX_LG_cc",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eo6Lb0L-G9bFjuQwS"
+					},
+					"description": "Light Infantry Helmet: Visor",
+					"reference": "UT176",
+					"tech_level": "11",
+					"legality_class": "3",
+					"tags": [
+						"Armor",
+						"Defenses"
+					],
+					"base_value": "100",
+					"base_weight": "3 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"locations": [
+								"eye"
+							],
+							"amount": 30
+						},
+						{
+							"type": "dr_bonus",
+							"locations": [
+								"face"
+							],
+							"amount": 30
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 100,
+						"extended_value": 100,
+						"weight": "3 lb",
+						"extended_weight": "3 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 250,
+				"extended_value": 350,
+				"weight": "3 lb",
+				"extended_weight": "6 lb"
+			}
+		},
+		{
+			"id": "Ew1F78-rEglXFudYQ",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+				"id": "eNxEqbQBIyZOS3rdx"
+			},
+			"description": "VR Gloves",
+			"reference": "UT54",
+			"local_notes": "Requires Complexity 2+.",
+			"tech_level": "9",
+			"tags": [
+				"Media and Education"
+			],
+			"base_value": "20",
+			"base_weight": "0.3 lb",
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "eJV_S_HbwmJ9OZZDh",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "esYKu0HiXEa__XOgo"
+					},
+					"description": "Monocrys Gloves",
+					"reference": "UT172",
+					"local_notes": "Flexible.",
+					"tech_level": "11",
+					"tags": [
+						"Defenses"
+					],
+					"base_value": "30",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"locations": [
+								"hand"
+							],
+							"specialization": "piercing and cutting",
+							"amount": 8
+						},
+						{
+							"type": "dr_bonus",
+							"locations": [
+								"hand"
+							],
+							"amount": 4
+						}
+					],
+					"modifiers": [
+						{
+							"id": "fHlgyNJRTkEBgm3lt",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+								"id": "ftTIP1_K9WPCHFSrz"
+							},
+							"name": "Stylish",
+							"reference": "UT175",
+							"cost_type": "to_base_cost",
+							"cost": "+3 CF"
+						},
+						{
+							"id": "fhuibpiLAsHlvxE-4",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+								"id": "fZK5VWsvzMBCRHwkA"
+							},
+							"name": "Combination Gadget cost, multiple work at a time",
+							"reference": "UT16",
+							"cost_type": "to_final_cost",
+							"cost": "x0.8"
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 96,
+						"extended_value": 96,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				},
+				{
+					"id": "eJnMa7UnTxPLLsJuF",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "ef55nM_NrfAgS_Cam"
+					},
+					"description": "Karatand",
+					"reference": "UT163",
+					"tech_level": "9",
+					"legality_class": "3",
+					"tags": [
+						"Melee Weapon",
+						"Weaponry"
+					],
+					"base_value": "100",
+					"weapons": [
+						{
+							"id": "w8bNm2HPlgISqxa-D",
+							"damage": {
+								"type": "cr",
+								"st": "thr"
+							},
+							"usage": "Punch",
+							"reach": "C",
+							"parry": "0",
+							"defaults": [
+								{
+									"type": "dx"
+								},
+								{
+									"type": "skill",
+									"name": "Boxing"
+								},
+								{
+									"type": "skill",
+									"name": "Brawling"
+								},
+								{
+									"type": "skill",
+									"name": "Karate"
+								}
+							],
+							"calc": {
+								"damage": "thr cr"
+							}
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 100,
+						"extended_value": 100,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 20,
+				"extended_value": 216,
+				"weight": "0.3 lb",
+				"extended_weight": "0.3 lb"
+			}
+		},
+		{
+			"id": "e-BrsbBbkizyKRwKJ",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+				"id": "e46KLPiLrq7durI15"
+			},
+			"description": "Assault Boots",
+			"reference": "UT173",
+			"tech_level": "11",
+			"tags": [
+				"Armor",
+				"Defenses"
+			],
+			"base_value": "150",
+			"base_weight": "3 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"foot"
+					],
+					"specialization": "underside of the foot",
+					"amount": 15
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"foot"
+					],
+					"amount": 15
+				}
+			],
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"value": 150,
+				"extended_value": 150,
+				"weight": "3 lb",
+				"extended_weight": "3 lb"
+			}
+		},
+		{
+			"id": "E0vzohloQs0JVYB-c",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Basic Set/Basic Set Equipment.eqp",
+				"id": "ESjtIfyzScVP49ity"
+			},
+			"description": "Backpack, Small",
+			"reference": "B288",
+			"tech_level": "1",
+			"tags": [
+				"Camping and Survival Gear"
+			],
+			"base_value": "60",
+			"base_weight": "3 lb",
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "contained_weight_prereq",
+						"has": true,
+						"qualifier": {
+							"compare": "at_most",
+							"qualifier": "40 lb"
+						}
+					}
+				]
+			},
+			"modifiers": [
+				{
+					"id": "fxrQ9ElZLCrBo44ok",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+						"id": "f3AMg_F7eHdJ-u_bX"
+					},
+					"name": "Expensive",
+					"reference": "UT15",
+					"cost_type": "to_base_cost",
+					"weight_type": "to_base_weight",
+					"cost": "+1 CF",
+					"weight": "x2/3"
+				}
+			],
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "eYj0XWtrGsw801F6U",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eZzoMHddfrX-iu0W4"
+					},
+					"description": "Small Laser Chemscanner",
+					"reference": "UT64",
+					"local_notes": "100-mile range. B/8hr.",
+					"tech_level": "11",
+					"tags": [
+						"Sensors and Scientific Equipment"
+					],
+					"base_value": "1000",
+					"base_weight": "1 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 1000,
+						"extended_value": 1000,
+						"weight": "1 lb",
+						"extended_weight": "1 lb"
+					}
+				},
+				{
+					"id": "ep88KDPwllpU2EgvQ",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "enQNM0RB6euc5mo7i"
+					},
+					"description": "B cell",
+					"reference": "UT19",
+					"tech_level": "9",
+					"tags": [
+						"Power"
+					],
+					"base_value": "3",
+					"base_weight": "0.05 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 3,
+						"extended_value": 3,
+						"weight": "0.05 lb",
+						"extended_weight": "0.05 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 120,
+				"extended_value": 1123,
+				"weight": "2 lb",
+				"extended_weight": "3.05 lb"
+			}
+		},
+		{
+			"id": "EH-hr7TtDb-3t478w",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+				"id": "EUs50zfUDms3u6wAJ"
+			},
+			"description": "Hovercart",
+			"reference": "UT75",
+			"local_notes": "C/12hr.",
+			"tech_level": "9",
+			"tags": [
+				"Expedition Gear"
+			],
+			"base_value": "300",
+			"base_weight": "4 lb",
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "contained_weight_prereq",
+						"has": true,
+						"qualifier": {
+							"compare": "at_most",
+							"qualifier": "500 lb"
+						}
+					}
+				]
+			},
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "Egdav8KmzaVTIj2JN",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "EMSqL1RxmX--SIXfv"
+					},
+					"description": "Pressure Box",
+					"reference": "UT75",
+					"local_notes": "2'x1'x1'. 2C/2wk.",
+					"tech_level": "11",
+					"tags": [
+						"Expedition Gear"
+					],
+					"base_value": "450",
+					"base_weight": "5 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 450,
+						"extended_value": 450,
+						"weight": "5 lb",
+						"extended_weight": "5 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 300,
+				"extended_value": 750,
+				"weight": "4 lb",
+				"extended_weight": "9 lb"
+			}
+		}
+	],
+	"notes": [
+		{
+			"id": "nxfTX9UYK4Vn1GaV4",
+			"markdown": "Remove VR gloves from the TL11 Spacer Basic Kit"
+		}
+	]
+}

--- a/Library/Loadouts/Starship Crew/TL11/Medical Officer.gct
+++ b/Library/Loadouts/Starship Crew/TL11/Medical Officer.gct
@@ -1,0 +1,1737 @@
+{
+	"version": 5,
+	"id": "BXv735vEX8GDi6hzY",
+	"equipment": [
+		{
+			"id": "EeJ8PLPCBbaDgGsWj",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Basic Set/Basic Set Equipment.eqp",
+				"id": "EwSOT_Sl-CS9v-TgB"
+			},
+			"description": "Backpack, Frame",
+			"reference": "B288",
+			"tech_level": "1",
+			"tags": [
+				"Camping and Survival Gear"
+			],
+			"base_value": "100",
+			"base_weight": "10 lb",
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "contained_weight_prereq",
+						"has": true,
+						"qualifier": {
+							"compare": "at_most",
+							"qualifier": "100 lb"
+						}
+					}
+				]
+			},
+			"modifiers": [
+				{
+					"id": "fg9TSIPENPSZl0_3_",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+						"id": "f3AMg_F7eHdJ-u_bX"
+					},
+					"name": "Expensive",
+					"reference": "UT15",
+					"cost_type": "to_base_cost",
+					"weight_type": "to_base_weight",
+					"cost": "+1 CF",
+					"weight": "x2/3"
+				}
+			],
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "eRrN59l1YbO9q6ScF",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "e08RZFtTDrlYGoRwG"
+					},
+					"description": "Crash Kit",
+					"reference": "UT198",
+					"local_notes": "Surgery -5.",
+					"tech_level": "9",
+					"tags": [
+						"Medical"
+					],
+					"base_value": "200",
+					"base_weight": "10 lb",
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "First Aid"
+							},
+							"amount": 2
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 200,
+						"extended_value": 200,
+						"weight": "10 lb",
+						"extended_weight": "10 lb"
+					}
+				},
+				{
+					"id": "e4uUehUlrpsTTKDxc",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "em9ZRPPzEh54KNqXX"
+					},
+					"description": "Pneumohypo",
+					"reference": "UT199",
+					"tech_level": "9",
+					"tags": [
+						"Medical"
+					],
+					"base_value": "20",
+					"base_weight": "0.1 lb",
+					"weapons": [
+						{
+							"id": "w_CZEimWlebe9OLWz",
+							"damage": {
+								"type": "Spec"
+							},
+							"usage": "Stab",
+							"reach": "C",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Knife"
+								},
+								{
+									"type": "dx",
+									"modifier": -4
+								}
+							],
+							"calc": {
+								"damage": "Spec"
+							}
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 20,
+						"extended_value": 20,
+						"weight": "0.1 lb",
+						"extended_weight": "0.1 lb"
+					}
+				},
+				{
+					"id": "eGcrtm1dYIG4zc9RV",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Equipment.eqp",
+						"id": "etXcdY09RGaOSNceE"
+					},
+					"description": "Analgine",
+					"reference": "BT149",
+					"tech_level": "9",
+					"legality_class": "3",
+					"tags": [
+						"Drug"
+					],
+					"base_value": "2",
+					"quantity": 10,
+					"equipped": true,
+					"calc": {
+						"value": 2,
+						"extended_value": 20,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				},
+				{
+					"id": "eWNnthob5xe30o1al",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Equipment.eqp",
+						"id": "eiVH5MDuE6qyc6g8P"
+					},
+					"description": "Antirad",
+					"reference": "BT152",
+					"local_notes": "gives Radiation Tolerance 5",
+					"tech_level": "10",
+					"legality_class": "3",
+					"tags": [
+						"Drug"
+					],
+					"base_value": "50",
+					"quantity": 10,
+					"equipped": true,
+					"calc": {
+						"value": 50,
+						"extended_value": 500,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				},
+				{
+					"id": "eWcxslrJrzSSdlsJS",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Equipment.eqp",
+						"id": "eB7_ilqmGWA-73ELo"
+					},
+					"description": "Antitox",
+					"reference": "BT161",
+					"local_notes": "Lasts for 24 hours",
+					"tech_level": "10",
+					"legality_class": "4",
+					"tags": [
+						"Drug"
+					],
+					"base_value": "400",
+					"quantity": 10,
+					"equipped": true,
+					"calc": {
+						"value": 400,
+						"extended_value": 4000,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				},
+				{
+					"id": "eMcNQgCShtK8or0Uy",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Equipment.eqp",
+						"id": "eOyt3JvGkE7D6mtz_"
+					},
+					"description": "Focus",
+					"reference": "BT162",
+					"local_notes": "Lasts (25-HT)/4 hours",
+					"tech_level": "10",
+					"legality_class": "4",
+					"tags": [
+						"Drug"
+					],
+					"base_value": "160",
+					"quantity": 10,
+					"equipped": true,
+					"calc": {
+						"value": 160,
+						"extended_value": 1600,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				},
+				{
+					"id": "elkyFV6PrhXiXI52n",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Equipment.eqp",
+						"id": "ebYW3BnTrClUkFpWZ"
+					},
+					"description": "Genericillin",
+					"reference": "BT150",
+					"local_notes": "one dose lasts a week",
+					"tech_level": "10",
+					"legality_class": "4",
+					"tags": [
+						"Drug"
+					],
+					"base_value": "25",
+					"quantity": 10,
+					"equipped": true,
+					"calc": {
+						"value": 25,
+						"extended_value": 250,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				},
+				{
+					"id": "e02SGiN_rXeb_aWeT",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Equipment.eqp",
+						"id": "eGs4XHNjDsonXprZW"
+					},
+					"description": "Hepaclean",
+					"reference": "BT162",
+					"local_notes": "Takes effect after 30 minutes",
+					"tech_level": "10",
+					"legality_class": "4",
+					"tags": [
+						"Drug"
+					],
+					"base_value": "30",
+					"quantity": 10,
+					"equipped": true,
+					"calc": {
+						"value": 30,
+						"extended_value": 300,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				},
+				{
+					"id": "e8mgzO8XjmBhn9yGo",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "ejWG4-R2Q6OIoEzw9"
+					},
+					"description": "Quickheal",
+					"reference": "UT206",
+					"tech_level": "11",
+					"tags": [
+						"Biotech",
+						"Drug"
+					],
+					"base_value": "100",
+					"quantity": 10,
+					"equipped": true,
+					"calc": {
+						"value": 100,
+						"extended_value": 1000,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				},
+				{
+					"id": "ebiWXEACdgCgjkOXb",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Equipment.eqp",
+						"id": "eV0phB_Gd2_Aisi3o"
+					},
+					"description": "Ursaline",
+					"reference": "BT151",
+					"tech_level": "9",
+					"legality_class": "4",
+					"tags": [
+						"Drug"
+					],
+					"base_value": "25",
+					"quantity": 20,
+					"equipped": true,
+					"calc": {
+						"value": 25,
+						"extended_value": 500,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				},
+				{
+					"id": "eCwfrZY7IqxnokvB8",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Equipment.eqp",
+						"id": "eXwZ2RaEg1NstR3cG"
+					},
+					"description": "Wideawake",
+					"reference": "BT152",
+					"local_notes": "one dose lasts a week",
+					"tech_level": "10",
+					"legality_class": "4",
+					"tags": [
+						"Drug"
+					],
+					"base_value": "20",
+					"quantity": 10,
+					"equipped": true,
+					"calc": {
+						"value": 20,
+						"extended_value": 200,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				},
+				{
+					"id": "eQx3p_1RT2csqV8pI",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Equipment.eqp",
+						"id": "ez3FTS57Y4pXAqK-o"
+					},
+					"description": "Panimmunity (Level 2)",
+					"reference": "BT165",
+					"local_notes": "Lasts one day to two weeks; Takes effect in one hour",
+					"tech_level": "10",
+					"legality_class": "4",
+					"tags": [
+						"Drug"
+					],
+					"base_value": "250",
+					"quantity": 10,
+					"equipped": true,
+					"calc": {
+						"value": 250,
+						"extended_value": 2500,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				},
+				{
+					"id": "eflSLOnAD6wMt_Swx",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Equipment.eqp",
+						"id": "ebc3OFJE8Blffjmbe"
+					},
+					"description": "Guardians",
+					"reference": "BT165",
+					"local_notes": "Lasts one day to two weeks; Takes effect in one hour",
+					"tech_level": "10",
+					"legality_class": "3",
+					"tags": [
+						"Drug"
+					],
+					"base_value": "100",
+					"quantity": 10,
+					"equipped": true,
+					"calc": {
+						"value": 100,
+						"extended_value": 1000,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				},
+				{
+					"id": "eOFwr_rVEAQLqstLG",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Equipment.eqp",
+						"id": "eXldRcqZXNoGxgjlN"
+					},
+					"description": "Respirocytes",
+					"reference": "BT166",
+					"local_notes": "Lasts one day to two weeks; Takes effect in one hour",
+					"tech_level": "11",
+					"legality_class": "4",
+					"tags": [
+						"Drug"
+					],
+					"base_value": "300",
+					"quantity": 4,
+					"equipped": true,
+					"calc": {
+						"value": 300,
+						"extended_value": 1200,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				},
+				{
+					"id": "eUPkgEiM676j8Ops9",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "evrDbhiCwpYYWInFr"
+					},
+					"description": "Medical Supplies",
+					"reference": "UT199",
+					"local_notes": "Lasts 100 patient-days.",
+					"tech_level": "11",
+					"tags": [
+						"Medical"
+					],
+					"base_value": "500",
+					"base_weight": "5 lb",
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Surgery"
+							},
+							"amount": 1
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 500,
+						"extended_value": 500,
+						"weight": "5 lb",
+						"extended_weight": "5 lb"
+					}
+				},
+				{
+					"id": "eK801bFXF6ChlUPha",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eOIlRaMxDh-fmcyra"
+					},
+					"description": "Surgical Instruments",
+					"reference": "UT199",
+					"local_notes": "5B/20hr.",
+					"tech_level": "9",
+					"tags": [
+						"Medical"
+					],
+					"base_value": "300",
+					"base_weight": "15 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 300,
+						"extended_value": 300,
+						"weight": "15 lb",
+						"extended_weight": "15 lb"
+					}
+				},
+				{
+					"id": "eAumalu0-ojipcDGU",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "ecd5hwLKXPL9OvO8w"
+					},
+					"description": "Neural Inhibitor",
+					"reference": "UT201",
+					"local_notes": "First Aid +1 (quality) to treat shock.",
+					"tech_level": "10",
+					"legality_class": "3",
+					"tags": [
+						"Medical"
+					],
+					"base_value": "200",
+					"base_weight": "0.1 lb",
+					"weapons": [
+						{
+							"id": "wVV3I9DdDiehVPHrb",
+							"damage": {
+								"type": "HT-6 aff"
+							},
+							"usage": "Paralyze",
+							"reach": "C",
+							"defaults": [
+								{
+									"type": "dx"
+								},
+								{
+									"type": "skill",
+									"name": "Brawling"
+								}
+							],
+							"calc": {
+								"damage": "HT-6 aff"
+							}
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 200,
+						"extended_value": 200,
+						"weight": "0.1 lb",
+						"extended_weight": "0.1 lb"
+					}
+				},
+				{
+					"id": "e02duN6g0Rrg7pRCI",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "emOuk952nQYYl-mdN"
+					},
+					"description": "Mechanic (@Specialization@) Toolkit",
+					"reference": "UT82",
+					"local_notes": "10B/10hr.",
+					"tech_level": "9",
+					"tags": [
+						"Expedition Gear"
+					],
+					"base_value": "600",
+					"base_weight": "20 lb",
+					"replacements": {
+						"Specialization": "Life Support"
+					},
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 600,
+						"extended_value": 600,
+						"weight": "20 lb",
+						"extended_weight": "20 lb"
+					}
+				},
+				{
+					"id": "eiappRguD4aGJE2PX",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eRd4HdGkY3padXW2c"
+					},
+					"description": "@Microbot/Nanobot Type@ Swarm",
+					"reference": "UT35",
+					"tech_level": "10",
+					"tags": [
+						"Swarmbots"
+					],
+					"base_weight": "2 lb",
+					"replacements": {
+						"Microbot/Nanobot Type": "Paramedical"
+					},
+					"modifiers": [
+						{
+							"id": "FwNySobdgRA3cXrBJ",
+							"name": "Swarm Type",
+							"reference": "UT37",
+							"local_notes": "at TL11 microbots can have two types, at TL12 nanobots can have two types",
+							"children": [
+								{
+									"id": "fsuAVNUQFVMh4__L3",
+									"name": "Bughunter",
+									"reference": "UT106",
+									"local_notes": "LC3",
+									"tags": [
+										"Counter-Surveillance and ECM",
+										"Security and Surveillance",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+4000",
+									"disabled": true
+								},
+								{
+									"id": "fKxd7Oz_ESTqXyg2i",
+									"name": "Cannibal",
+									"reference": "UT169",
+									"local_notes": "LC1",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "12",
+									"cost": "+15000",
+									"disabled": true
+								},
+								{
+									"id": "fVF02JsCK_7Y0prI8",
+									"name": "Cleaning",
+									"reference": "UT69",
+									"local_notes": "LC4",
+									"tags": [
+										"Domestic Equipment and Appliances",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fNPKZq1GANBjxykLJ",
+									"name": "Construction",
+									"reference": "UT86",
+									"local_notes": "LC4",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fOnwzs9uqkaTX5CGx",
+									"name": "Decontamination (@Hazard Type@)",
+									"reference": "UT87",
+									"local_notes": "LC3; Hazardous Materials (@Hazard Type@)-12",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fARUELbIqVKqa_KDm",
+									"name": "Decontamination (@Hazard Type@)",
+									"reference": "UT87",
+									"local_notes": "LC3; Hazardous Materials (@Hazard Type@)-13",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "11",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fEnRsMHNvzeyBlgdO",
+									"name": "Decontamination (@Hazard Type@)",
+									"reference": "UT87",
+									"local_notes": "LC3; Hazardous Materials (@Hazard Type@)-14",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "12",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fwMN_aGrhD415Y3Qd",
+									"name": "Defoliator",
+									"reference": "UT87",
+									"local_notes": "LC3",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "f1Nlt6jJbTx2eUMzk",
+									"name": "Devourer",
+									"reference": "UT169",
+									"local_notes": "LC1",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "10",
+									"cost": "+8000",
+									"disabled": true
+								},
+								{
+									"id": "flrMmbId0wkyYrEwN",
+									"name": "Disassembler",
+									"reference": "UT169",
+									"local_notes": "LC1",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "11",
+									"cost": "+10000",
+									"disabled": true
+								},
+								{
+									"id": "fIh_JmlOUMLOZ7KAn",
+									"name": "Explorer",
+									"reference": "UT80",
+									"local_notes": "LC4",
+									"tags": [
+										"Expedition Gear",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+500",
+									"disabled": true
+								},
+								{
+									"id": "f5RQqCkXGKh6tjEA3",
+									"name": "Firefly",
+									"reference": "UT74",
+									"local_notes": "LC4",
+									"tags": [
+										"Domestic Equipment and Appliances",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+100",
+									"disabled": true
+								},
+								{
+									"id": "fZn1HWC_IIuL2KAGJ",
+									"name": "Forensic",
+									"reference": "UT107",
+									"local_notes": "LC3",
+									"tags": [
+										"Enforcement and Coercion",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+4000",
+									"disabled": true
+								},
+								{
+									"id": "fFhbXCWvSEj5N2RbG",
+									"name": "Gremlin",
+									"reference": "UT169",
+									"local_notes": "LC2",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "10",
+									"cost": "+2000",
+									"disabled": true
+								},
+								{
+									"id": "fQBoF4lUh6tp_ZO3E",
+									"name": "Harvester",
+									"reference": "UT87",
+									"local_notes": "LC4",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+2000",
+									"disabled": true
+								},
+								{
+									"id": "ffIi28mgud0710E0P",
+									"name": "Massage",
+									"reference": "UT41",
+									"local_notes": "LC4",
+									"tags": [
+										"Robots",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+200",
+									"disabled": true
+								},
+								{
+									"id": "fpIi8WnnV4kqhG2l3",
+									"name": "Painter",
+									"reference": "UT87",
+									"local_notes": "LC4",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+500",
+									"disabled": true
+								},
+								{
+									"id": "fqaATmTlhkEmYEob9",
+									"name": "Paramedical",
+									"reference": "UT201",
+									"local_notes": "LC3; Diagnosis-10, First Aid-10",
+									"tags": [
+										"Medical",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+6000",
+									"disabled": true
+								},
+								{
+									"id": "frmBxM6Iux8pc9MEE",
+									"name": "Paramedical",
+									"reference": "UT201",
+									"local_notes": "LC3; Diagnosis-11, First Aid-11",
+									"tags": [
+										"Medical",
+										"Swarmbots"
+									],
+									"tech_level": "11",
+									"cost": "+6000",
+									"disabled": true
+								},
+								{
+									"id": "fxfxjXovn_y4rEwIk",
+									"name": "Paramedical",
+									"reference": "UT201",
+									"local_notes": "LC3; Diagnosis-12, First Aid-12",
+									"tags": [
+										"Medical",
+										"Swarmbots"
+									],
+									"tech_level": "12",
+									"cost": "+6000"
+								},
+								{
+									"id": "f00m_IvTHvyqHTt0L",
+									"name": "Pesticide",
+									"reference": "UT87",
+									"local_notes": "LC3",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fPy1lNgZ2dIQ12E2j",
+									"name": "Play",
+									"reference": "UT41",
+									"local_notes": "LC4",
+									"tags": [
+										"Robots",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+200",
+									"disabled": true
+								},
+								{
+									"id": "fLdApiGKYR1_kVbOI",
+									"name": "Pollinator",
+									"reference": "UT87",
+									"local_notes": "LC4",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fnzpnRj869OuH686G",
+									"name": "Repair (@Equipment@)",
+									"reference": "UT87",
+									"local_notes": "LC4; Repair Skill-12",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+500",
+									"disabled": true
+								},
+								{
+									"id": "fKaL7z46meTNjUehY",
+									"name": "Repair (@Equipment@)",
+									"reference": "UT87",
+									"local_notes": "LC4; Repair Skill-13",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "11",
+									"cost": "+500",
+									"disabled": true
+								},
+								{
+									"id": "fFVTWr-VEvxfxZDNp",
+									"name": "Repair (@Other Equipment 1@)",
+									"reference": "UT87",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+250",
+									"disabled": true
+								},
+								{
+									"id": "ftL25Umhs6Y2W237t",
+									"name": "Repair (@Other Equipment 2@)",
+									"reference": "UT87",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+250",
+									"disabled": true
+								},
+								{
+									"id": "fMCqfgGZV3tCCQw3M",
+									"name": "Repair (@Other Equipment 3@)",
+									"reference": "UT87",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+250",
+									"disabled": true
+								},
+								{
+									"id": "f-FWhAUbbH4HJQGUI",
+									"name": "Security",
+									"reference": "UT104",
+									"local_notes": "LC3",
+									"tags": [
+										"Security and Surveillance",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fUupKKtcvnkilHFfh",
+									"name": "Sentry",
+									"reference": "UT169",
+									"local_notes": "LC3",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "10",
+									"cost": "+5000",
+									"disabled": true
+								},
+								{
+									"id": "fcp2CoA4T9Ctd7hCz",
+									"name": "Stinger",
+									"reference": "UT169",
+									"local_notes": "LC2",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "10",
+									"cost": "+1500",
+									"disabled": true
+								},
+								{
+									"id": "fppDa8JD9lVW6HoMk",
+									"name": "Surveillance",
+									"reference": "UT106",
+									"local_notes": "LC3",
+									"tags": [
+										"Security and Surveillance",
+										"Surveillance and Tracking Devices",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+500",
+									"disabled": true
+								},
+								{
+									"id": "fZERTCGnW5WFbWXpH",
+									"name": "Terminator",
+									"reference": "UT169",
+									"local_notes": "LC1",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "10",
+									"cost": "+1500",
+									"disabled": true
+								}
+							]
+						},
+						{
+							"id": "fQNpbf1Ly1rtSNOyO",
+							"name": "Self-Replicating",
+							"reference": "UT37",
+							"local_notes": "only for defoliator, devourer or pesticide",
+							"tags": [
+								"Swarmbots"
+							],
+							"cost_type": "to_base_cost",
+							"cost": "x10",
+							"disabled": true
+						},
+						{
+							"id": "FLDZsPbNdqdFZeR5d",
+							"name": "Chassis",
+							"local_notes": "choose one microbot or nanobot chassis",
+							"children": [
+								{
+									"id": "FjWPjKa63PK0PQyGD",
+									"name": "Microbot Chassis",
+									"children": [
+										{
+											"id": "fyFI9YdJeyOFmfqYq",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f7eMKwMF7BTYFbxhq"
+											},
+											"name": "Microbot Aerostat",
+											"reference": "UT36",
+											"local_notes": "Air Move 2",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "10"
+										},
+										{
+											"id": "fYJvijjfmKuGKe_Fl",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fcVKEB14BedQI1jGA"
+											},
+											"name": "Microbot Crawler",
+											"reference": "UT36",
+											"local_notes": "Move 3; Water Move 1",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"disabled": true
+										},
+										{
+											"id": "fmCqLN1wppJr2XOPW",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fScgdTYLwKE9CEYfl"
+											},
+											"name": "Microbot Crawler, Armored",
+											"reference": "UT36",
+											"local_notes": "Move 2, 2x HP",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+100%",
+											"disabled": true
+										},
+										{
+											"id": "f_yVA1h1te6PKObQU",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fpAVv9yE3m3t0Egt_"
+											},
+											"name": "Microbot Flier",
+											"reference": "UT36",
+											"local_notes": "Move 1; Air Move 6",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+100%",
+											"disabled": true
+										},
+										{
+											"id": "fJeRThoxRNf4Hszp9",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "ffHj2SBngzuewdrbB"
+											},
+											"name": "Microbot Hopper",
+											"reference": "UT36",
+											"local_notes": "Move 4; Super Jump 1",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "fatmCT9hpzOSjm73A",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fr6wQjKaUic-BpBCO"
+											},
+											"name": "Microbot Space",
+											"reference": "UT36",
+											"local_notes": "Move 1; 0.0001G solar sail",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+0",
+											"disabled": true
+										},
+										{
+											"id": "fIAz3uaUSu8VKmt6n",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fsL5rGqz66ht8cVvg"
+											},
+											"name": "Microbot Swimmer",
+											"reference": "UT36",
+											"local_notes": "Water Move 4",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+0",
+											"disabled": true
+										},
+										{
+											"id": "fQ1xeF1I6rL4SIi4x",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fvVo7_8gzuQpK50fc"
+											},
+											"name": "Microbot Contragrav (CG) Flier",
+											"reference": "UT36",
+											"local_notes": "Move 1; Air Move 20",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11^",
+											"cost": "+200%",
+											"disabled": true
+										}
+									]
+								},
+								{
+									"id": "FrzRec-ElP1rTVWxw",
+									"name": "Nanobot Chassis",
+									"children": [
+										{
+											"id": "f2YLLXj0dWAtdhYNv",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f6RvvKoBN0DqIjBjQ"
+											},
+											"name": "Nanobot Aerostat",
+											"reference": "UT36",
+											"local_notes": "Air Move 1",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "11",
+											"disabled": true
+										},
+										{
+											"id": "fs9JNaIIjKICiO_KS",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f1OLvlafFuNITe6na"
+											},
+											"name": "Nanobot Crawler",
+											"reference": "UT36",
+											"local_notes": "Move 3; Water Move 1",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "11",
+											"disabled": true
+										},
+										{
+											"id": "fmZ08ePoYjJFebhYa",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fASzj6iYz6hUA-TBB"
+											},
+											"name": "Nanobot Crawler, Armored",
+											"reference": "UT36",
+											"local_notes": "Move 2, 2x HP",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11",
+											"cost": "+100%",
+											"disabled": true
+										},
+										{
+											"id": "fhFEuKNg6Tu6ISTtw",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fLuL-pD4o6s0lREJs"
+											},
+											"name": "Nanobot Dust",
+											"reference": "UT36",
+											"local_notes": "Immobile",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11",
+											"cost": "-80%",
+											"disabled": true
+										},
+										{
+											"id": "fq7FH9MGXRGjB6a1e",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fKeArqcSSvcPk5QTp"
+											},
+											"name": "Nanobot Flier",
+											"reference": "UT36",
+											"local_notes": "Move 1; Air Move 3",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11",
+											"cost": "+100%",
+											"disabled": true
+										},
+										{
+											"id": "f6Ur09lWSOxE5iZkk",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fyATVIBpOaRfq3tKe"
+											},
+											"name": "Nanobot Hopper",
+											"reference": "UT36",
+											"local_notes": "Move 4; Super Jump 1",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "f6_Adn6gp22KIz_d3",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f80KO0VZYaEJb9hbs"
+											},
+											"name": "Nanobot Space",
+											"reference": "UT36",
+											"local_notes": "Move 1; 0.0001G solar sail",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "11",
+											"cost": "+0",
+											"disabled": true
+										},
+										{
+											"id": "f75fo03ke8UoEjnYi",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fa36bUxm5RcsG_mOk"
+											},
+											"name": "Nanobot Swimmer",
+											"reference": "UT36",
+											"local_notes": "Water Move 1",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "11",
+											"cost": "+0",
+											"disabled": true
+										},
+										{
+											"id": "fKllkb_nN-fM6osgS",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fPgd1Z13foKJXxTND"
+											},
+											"name": "Nanobot Contragrav (CG) Flier",
+											"reference": "UT36",
+											"local_notes": "Move 1; Air Move 10",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11^",
+											"cost": "+200%",
+											"disabled": true
+										}
+									]
+								}
+							]
+						},
+						{
+							"id": "FkfV-FxUNzEeAxBJY",
+							"name": "Stealth",
+							"children": [
+								{
+									"id": "f0V9_Oii5Gs-5P5kS",
+									"name": "Disguise",
+									"reference": "UT36",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_cost",
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fm45rTJhbybPCSXKO",
+									"name": "Thermo-Optic Chameleon Surface",
+									"reference": "UT37, UT98",
+									"local_notes": "LC3",
+									"tags": [
+										"Deception and Intrusion",
+										"Swarmbots"
+									],
+									"cost_type": "to_final_cost",
+									"tech_level": "9",
+									"cost": "+4000",
+									"weight": "+4 lb",
+									"disabled": true
+								},
+								{
+									"id": "fc1kfezZWCWWDK9bh",
+									"name": "Multispectral Chameleon Surface",
+									"reference": "UT37, UT99",
+									"local_notes": "LC3",
+									"tags": [
+										"Deception and Intrusion",
+										"Swarmbots"
+									],
+									"cost_type": "to_final_cost",
+									"tech_level": "10",
+									"cost": "+6000",
+									"weight": "+4 lb",
+									"disabled": true
+								},
+								{
+									"id": "fiyem7dTrOKIMEEME",
+									"name": "Dynamic Multispectral Chameleon Surface",
+									"reference": "UT37, UT99",
+									"local_notes": "LC3",
+									"tags": [
+										"Deception and Intrusion",
+										"Swarmbots"
+									],
+									"cost_type": "to_final_cost",
+									"tech_level": "11",
+									"cost": "+8000",
+									"weight": "+4 lb",
+									"disabled": true
+								},
+								{
+									"id": "f1qnJYZqzPVQV3HYh",
+									"name": "Ultimate Chameleon Surface",
+									"reference": "UT37, UT99",
+									"local_notes": "LC3",
+									"tags": [
+										"Deception and Intrusion",
+										"Swarmbots"
+									],
+									"cost_type": "to_final_cost",
+									"tech_level": "12",
+									"cost": "+10000",
+									"weight": "+4 lb",
+									"disabled": true
+								}
+							]
+						},
+						{
+							"id": "FXlhLGB-vR_cSeu8q",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+								"id": "F5Q7h4gAuvWsoUiFV"
+							},
+							"name": "Power Supply",
+							"children": [
+								{
+									"id": "fwlIDa9v2H2dOKkpZ",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "faj6YgnYeEKAy39jw"
+									},
+									"name": "Power Cells",
+									"reference": "UT36",
+									"local_notes": "Recharges in a Hive; C/12hr.",
+									"tags": [
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"disabled": true
+								},
+								{
+									"id": "fyu2V6xEk2ONclWc1",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fCJ9sdOXfXoLN594u"
+									},
+									"name": "Power Cells",
+									"reference": "UT36",
+									"local_notes": "Recharges in a Hive; C/72hr.",
+									"tags": [
+										"Swarmbots"
+									],
+									"tech_level": "11"
+								},
+								{
+									"id": "f4A1Pw2Uz00rH1LJr",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "f7WMm14XwVJyvz2NQ"
+									},
+									"name": "Power Cells",
+									"reference": "UT36",
+									"local_notes": "Recharges in a Hive; C/5 days.",
+									"tags": [
+										"Swarmbots"
+									],
+									"tech_level": "12",
+									"disabled": true
+								},
+								{
+									"id": "f_QkmQ7Hw30QLQqar",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fGv5njL67i7rODIpL"
+									},
+									"name": "Beamed Power",
+									"reference": "UT36",
+									"local_notes": "C cell receiver",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "10",
+									"cost": "+50%",
+									"disabled": true
+								},
+								{
+									"id": "fQLQ9HR4OHuOGEj4x",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fS-7nLrwLytJp5mLZ"
+									},
+									"name": "Gastrobot",
+									"reference": "UT36",
+									"local_notes": "Consumes 0.1lbs./hr. of biomass",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "10",
+									"cost": "+100%",
+									"disabled": true
+								},
+								{
+									"id": "fn3p7w7ShMfE6gia5",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fhT3sMtcrOGbTzLku"
+									},
+									"name": "Radio-Thermal Generator (RTG)",
+									"reference": "UT36",
+									"local_notes": "Lasts 1 year; LC1",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "10",
+									"cost": "+100%",
+									"disabled": true
+								},
+								{
+									"id": "f9H9xGrpXlzk1RI_u",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "faJkuSBjewuh2TdLg"
+									},
+									"name": "Solar Cell",
+									"reference": "UT36",
+									"local_notes": "Recharges 3 hours' activity in 1 hour",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "10",
+									"cost": "+50%",
+									"disabled": true
+								},
+								{
+									"id": "fvHz7g_6pnZLWq_GA",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "f2u0xwoaeDxGjxCRq"
+									},
+									"name": "Solar Cell",
+									"reference": "UT36",
+									"local_notes": "Recharges 4 hours' activity in 1 hour",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "11",
+									"cost": "+50%",
+									"disabled": true
+								},
+								{
+									"id": "fJN_B7Yeml01fq6Sw",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "ff9wLL0l7uzB0IRXf"
+									},
+									"name": "Solar Cell",
+									"reference": "UT36",
+									"local_notes": "Recharges 5 hours' activity in 1 hour",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "12",
+									"cost": "+50%",
+									"disabled": true
+								},
+								{
+									"id": "fZ28LsSin3GWP9mPb",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "f4SVyLNBYhfPgNZC0"
+									},
+									"name": "Organovore",
+									"reference": "UT36",
+									"local_notes": "Consumes 0.1-0.5 lbs./hr. of carbon-based matter; LC3",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "11",
+									"cost": "+200%",
+									"disabled": true
+								},
+								{
+									"id": "foWFDSN2pkSfIW0Bg",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fi-Vh6iRVAbMGaOiO"
+									},
+									"name": "Broadcast Power",
+									"reference": "UT37",
+									"local_notes": "C cell receiver",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "11^",
+									"cost": "+100%",
+									"disabled": true
+								}
+							]
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 6000,
+						"extended_value": 6000,
+						"weight": "2 lb",
+						"extended_weight": "2 lb"
+					}
+				},
+				{
+					"id": "ev5A_IQpbBJFjCG-4",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "epRXtbtPNVTPIqIdo"
+					},
+					"description": "A cell",
+					"reference": "UT19",
+					"tech_level": "9",
+					"tags": [
+						"Power"
+					],
+					"base_value": "2",
+					"base_weight": "0.005 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 2,
+						"extended_value": 2,
+						"weight": "0.005 lb",
+						"extended_weight": "0.005 lb"
+					}
+				},
+				{
+					"id": "ehMJ5jCM0icyXzaMf",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "enQNM0RB6euc5mo7i"
+					},
+					"description": "B cell",
+					"reference": "UT19",
+					"tech_level": "9",
+					"tags": [
+						"Power"
+					],
+					"base_value": "3",
+					"base_weight": "0.05 lb",
+					"quantity": 10,
+					"equipped": true,
+					"calc": {
+						"value": 3,
+						"extended_value": 30,
+						"weight": "0.05 lb",
+						"extended_weight": "0.5 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 200,
+				"extended_value": 21122,
+				"weight": "6.6666 lb",
+				"extended_weight": "59.3716 lb"
+			}
+		},
+		{
+			"id": "EPMcwRZ3OifVpV-zc",
+			"description": "Stored in Vehicle",
+			"legality_class": "4",
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "eWm7EXEZGN47DFfQ6",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "efeekclqs54nOsbVN"
+					},
+					"description": "Swarmbot Hive",
+					"reference": "UT37",
+					"tech_level": "10",
+					"base_value": "200",
+					"base_weight": "10 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 200,
+						"extended_value": 200,
+						"weight": "10 lb",
+						"extended_weight": "10 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 0,
+				"extended_value": 200,
+				"weight": "0 lb",
+				"extended_weight": "10 lb"
+			}
+		}
+	]
+}

--- a/Library/Loadouts/Starship Crew/TL11/Multi-Role Commander.gct
+++ b/Library/Loadouts/Starship Crew/TL11/Multi-Role Commander.gct
@@ -1,0 +1,55 @@
+{
+	"version": 5,
+	"id": "BrHYdO-9tbFu98Mm9",
+	"equipment": [
+		{
+			"id": "EGjxZ70IMuzdAMpcJ",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+				"id": "etnuIe2XE5-Od7F9K"
+			},
+			"description": "Attaché Case",
+			"reference": "UT38",
+			"local_notes": "DR16",
+			"tech_level": "11",
+			"base_value": "80",
+			"base_weight": "2 lb",
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "e_5uGyPW9bEF1zCSb",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "ekAiQd4wsNBsLJLIX"
+					},
+					"description": "Handheld Biometric Scanner",
+					"reference": "UT104",
+					"local_notes": "Scans finger, retina, DNA or voice in 1 second; A/1 day.",
+					"tech_level": "10",
+					"tags": [
+						"Security and Surveillance"
+					],
+					"base_value": "1000",
+					"base_weight": "1 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 1000,
+						"extended_value": 1000,
+						"weight": "1 lb",
+						"extended_weight": "1 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 80,
+				"extended_value": 1080,
+				"weight": "2 lb",
+				"extended_weight": "3 lb"
+			}
+		}
+	]
+}

--- a/Library/Loadouts/Starship Crew/TL11/Multi-Role Engineer.gct
+++ b/Library/Loadouts/Starship Crew/TL11/Multi-Role Engineer.gct
@@ -1,0 +1,360 @@
+{
+	"version": 5,
+	"id": "BnE79Cl9hzw9dGeyt",
+	"equipment": [
+		{
+			"id": "Er4hYyHlxKm5QZeNT",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Basic Set/Basic Set Equipment.eqp",
+				"id": "EwSOT_Sl-CS9v-TgB"
+			},
+			"description": "Backpack, Frame",
+			"reference": "B288",
+			"tech_level": "1",
+			"tags": [
+				"Camping and Survival Gear"
+			],
+			"base_value": "100",
+			"base_weight": "10 lb",
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "contained_weight_prereq",
+						"has": true,
+						"qualifier": {
+							"compare": "at_most",
+							"qualifier": "100 lb"
+						}
+					}
+				]
+			},
+			"modifiers": [
+				{
+					"id": "f6gZVBTCUgo3V01ic",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+						"id": "f3AMg_F7eHdJ-u_bX"
+					},
+					"name": "Expensive",
+					"reference": "UT15",
+					"cost_type": "to_base_cost",
+					"weight_type": "to_base_weight",
+					"cost": "+1 CF",
+					"weight": "x2/3"
+				}
+			],
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "eXMIItb-nUdtzV_av",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eT5uvj7QE4-YaURLs"
+					},
+					"description": "Electrician Mini-Toolkit",
+					"reference": "UT82",
+					"local_notes": "-2 (quality). 5B/10hr.",
+					"tech_level": "9",
+					"tags": [
+						"Expedition Gear"
+					],
+					"base_value": "200",
+					"base_weight": "4 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 200,
+						"extended_value": 200,
+						"weight": "4 lb",
+						"extended_weight": "4 lb"
+					}
+				},
+				{
+					"id": "EyIkVQeFQHnfVfTFn",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "es7M7etnnIm5wPDiU"
+					},
+					"description": "Electronics Repair (@Specialization@) Toolkit",
+					"reference": "UT82",
+					"local_notes": "10A/10hr.",
+					"tech_level": "9",
+					"tags": [
+						"Expedition Gear"
+					],
+					"base_value": "1200",
+					"base_weight": "10 lb",
+					"replacements": {
+						"Specialization": "Comm"
+					},
+					"quantity": 1,
+					"equipped": true,
+					"children": [
+						{
+							"id": "eE-8y-flE4LzAcYNf",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "es7M7etnnIm5wPDiU"
+							},
+							"description": "Electronics Repair (@Specialization@) Toolkit",
+							"reference": "UT82",
+							"local_notes": "10A/10hr.",
+							"tech_level": "9",
+							"tags": [
+								"Expedition Gear"
+							],
+							"base_value": "1200",
+							"base_weight": "10 lb",
+							"replacements": {
+								"Specialization": "Sensors"
+							},
+							"modifiers": [
+								{
+									"id": "fs__QM__rxslT83rE",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fte-9FKj95fCsgBZP"
+									},
+									"name": "Combination Gadget cost, one works at a time",
+									"reference": "UT16",
+									"cost_type": "to_final_cost",
+									"cost": "x0.5"
+								},
+								{
+									"id": "f7coo-BLzio9gASZP",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "f8HaZ0LuUFvHUnXtt"
+									},
+									"name": "Combination Gadget weight, one works at a time",
+									"reference": "UT16",
+									"weight_type": "to_final_weight",
+									"cost": "+0",
+									"weight": "x0.5"
+								}
+							],
+							"quantity": 1,
+							"equipped": true,
+							"calc": {
+								"value": 600,
+								"extended_value": 600,
+								"weight": "5 lb",
+								"extended_weight": "5 lb"
+							}
+						}
+					],
+					"calc": {
+						"value": 1200,
+						"extended_value": 1800,
+						"weight": "10 lb",
+						"extended_weight": "15 lb"
+					}
+				},
+				{
+					"id": "EkUFS-yKUm91TZEzU",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "emOuk952nQYYl-mdN"
+					},
+					"description": "Mechanic (@Specialization@) Toolkit",
+					"reference": "UT82",
+					"local_notes": "10B/10hr.",
+					"tech_level": "9",
+					"tags": [
+						"Expedition Gear"
+					],
+					"base_value": "600",
+					"base_weight": "20 lb",
+					"replacements": {
+						"Specialization": "@Power Plant Type@"
+					},
+					"quantity": 1,
+					"equipped": true,
+					"children": [
+						{
+							"id": "eG-6iP0f-e5SOxnGw",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "emOuk952nQYYl-mdN"
+							},
+							"description": "Mechanic (@Specialization@) Toolkit",
+							"reference": "UT82",
+							"local_notes": "10B/10hr.",
+							"tech_level": "9",
+							"tags": [
+								"Expedition Gear"
+							],
+							"base_value": "600",
+							"base_weight": "20 lb",
+							"replacements": {
+								"Specialization": "@FTL Motive System@"
+							},
+							"modifiers": [
+								{
+									"id": "fhWHKjHeBuDJSKdc9",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fte-9FKj95fCsgBZP"
+									},
+									"name": "Combination Gadget cost, one works at a time",
+									"reference": "UT16",
+									"cost_type": "to_final_cost",
+									"cost": "x0.5"
+								},
+								{
+									"id": "feBjqSEU1GLBSw0c5",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "f8HaZ0LuUFvHUnXtt"
+									},
+									"name": "Combination Gadget weight, one works at a time",
+									"reference": "UT16",
+									"weight_type": "to_final_weight",
+									"cost": "+0",
+									"weight": "x0.5"
+								}
+							],
+							"quantity": 1,
+							"equipped": true,
+							"calc": {
+								"value": 300,
+								"extended_value": 300,
+								"weight": "10 lb",
+								"extended_weight": "10 lb"
+							}
+						},
+						{
+							"id": "e2xMs5md18iZZzti9",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "emOuk952nQYYl-mdN"
+							},
+							"description": "Mechanic (@Specialization@) Toolkit",
+							"reference": "UT82",
+							"local_notes": "10B/10hr.",
+							"tech_level": "9",
+							"tags": [
+								"Expedition Gear"
+							],
+							"base_value": "600",
+							"base_weight": "20 lb",
+							"replacements": {
+								"Specialization": "@STL Motive System@"
+							},
+							"modifiers": [
+								{
+									"id": "fbbpJkBdd0oWQ7Ikq",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fte-9FKj95fCsgBZP"
+									},
+									"name": "Combination Gadget cost, one works at a time",
+									"reference": "UT16",
+									"cost_type": "to_final_cost",
+									"cost": "x0.5"
+								},
+								{
+									"id": "fw7K4_RvM793aqz93",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "f8HaZ0LuUFvHUnXtt"
+									},
+									"name": "Combination Gadget weight, one works at a time",
+									"reference": "UT16",
+									"weight_type": "to_final_weight",
+									"cost": "+0",
+									"weight": "x0.5"
+								}
+							],
+							"quantity": 1,
+							"equipped": true,
+							"calc": {
+								"value": 300,
+								"extended_value": 300,
+								"weight": "10 lb",
+								"extended_weight": "10 lb"
+							}
+						}
+					],
+					"calc": {
+						"value": 600,
+						"extended_value": 1200,
+						"weight": "20 lb",
+						"extended_weight": "40 lb"
+					}
+				},
+				{
+					"id": "eA-h47Y307KKV0Jn6",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "epRXtbtPNVTPIqIdo"
+					},
+					"description": "A cell",
+					"reference": "UT19",
+					"tech_level": "9",
+					"tags": [
+						"Power"
+					],
+					"base_value": "2",
+					"base_weight": "0.005 lb",
+					"quantity": 10,
+					"equipped": true,
+					"calc": {
+						"value": 2,
+						"extended_value": 20,
+						"weight": "0.005 lb",
+						"extended_weight": "0.05 lb"
+					}
+				},
+				{
+					"id": "e4jLK1_eAFq85nuuT",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "enQNM0RB6euc5mo7i"
+					},
+					"description": "B cell",
+					"reference": "UT19",
+					"tech_level": "9",
+					"tags": [
+						"Power"
+					],
+					"base_value": "3",
+					"base_weight": "0.05 lb",
+					"quantity": 15,
+					"equipped": true,
+					"calc": {
+						"value": 3,
+						"extended_value": 45,
+						"weight": "0.05 lb",
+						"extended_weight": "0.75 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 200,
+				"extended_value": 3465,
+				"weight": "6.6666 lb",
+				"extended_weight": "66.4666 lb"
+			}
+		}
+	]
+}

--- a/Library/Loadouts/Starship Crew/TL11/Multi-Role Helmsman.gct
+++ b/Library/Loadouts/Starship Crew/TL11/Multi-Role Helmsman.gct
@@ -1,0 +1,283 @@
+{
+	"version": 5,
+	"id": "BxxDijcQHzlm6Egif",
+	"equipment": [
+		{
+			"id": "EUpht9N8bFtXFcY-d",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Basic Set/Basic Set Equipment.eqp",
+				"id": "ESjtIfyzScVP49ity"
+			},
+			"description": "Backpack, Small",
+			"reference": "B288",
+			"tech_level": "1",
+			"tags": [
+				"Camping and Survival Gear"
+			],
+			"base_value": "60",
+			"base_weight": "3 lb",
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "contained_weight_prereq",
+						"has": true,
+						"qualifier": {
+							"compare": "at_most",
+							"qualifier": "40 lb"
+						}
+					}
+				]
+			},
+			"modifiers": [
+				{
+					"id": "frfMHubyINtDfd4Xn",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+						"id": "f3AMg_F7eHdJ-u_bX"
+					},
+					"name": "Expensive",
+					"reference": "UT15",
+					"cost_type": "to_base_cost",
+					"weight_type": "to_base_weight",
+					"cost": "+1 CF",
+					"weight": "x2/3"
+				}
+			],
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "Eq2HUODikVUeXYIIs",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "e5qZTKtVs-q-xQlfS"
+					},
+					"description": "Small Computer",
+					"reference": "UT22",
+					"local_notes": "Complexity 7. 10EB. 2B/20hr.",
+					"tech_level": "11",
+					"tags": [
+						"Computers"
+					],
+					"base_value": "100",
+					"base_weight": "0.5 lb",
+					"modifiers": [
+						{
+							"id": "faljVFsamhns04ihd",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+								"id": "ftp3XhCDqI3Lan38o"
+							},
+							"name": "Rugged",
+							"reference": "UT15",
+							"cost_type": "to_base_cost",
+							"weight_type": "to_base_weight",
+							"cost": "+1 CF",
+							"weight": "x1.2"
+						},
+						{
+							"id": "fqembNqmoLLfPXBBt",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+								"id": "fvamx4np-59rr96di"
+							},
+							"name": "Compact",
+							"reference": "UT23",
+							"local_notes": "Using multipliers",
+							"cost_type": "to_base_cost",
+							"weight_type": "to_base_weight",
+							"tech_level": "9",
+							"cost": "+1 CF",
+							"weight": "x0.5"
+						},
+						{
+							"id": "fw1nF-1zahLrgkCwL",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+								"id": "fbXG-SurLpMjqzf1Z"
+							},
+							"name": "Combination Gadget weight, multiple work at a time",
+							"reference": "UT16",
+							"weight_type": "to_final_weight",
+							"cost": "+0",
+							"weight": "x0.8"
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"children": [
+						{
+							"id": "e_dtjV-upmSK9PcXg",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "eSMEpeCwHrfGzvkx9"
+							},
+							"description": "Portable Terminal",
+							"reference": "UT24",
+							"local_notes": "2B/20hr.",
+							"tech_level": "9",
+							"tags": [
+								"Computers"
+							],
+							"base_value": "50",
+							"base_weight": "0.5 lb",
+							"modifiers": [
+								{
+									"id": "fdVyPZtRy84KVc218",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "ftp3XhCDqI3Lan38o"
+									},
+									"name": "Rugged",
+									"reference": "UT15",
+									"cost_type": "to_base_cost",
+									"weight_type": "to_base_weight",
+									"cost": "+1 CF",
+									"weight": "x1.2"
+								},
+								{
+									"id": "fFJNjF9xVg5niiIRY",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fZK5VWsvzMBCRHwkA"
+									},
+									"name": "Combination Gadget cost, multiple work at a time",
+									"reference": "UT16",
+									"cost_type": "to_final_cost",
+									"cost": "x0.8"
+								}
+							],
+							"quantity": 1,
+							"equipped": true,
+							"calc": {
+								"value": 80,
+								"extended_value": 80,
+								"weight": "0.6 lb",
+								"extended_weight": "0.6 lb"
+							}
+						}
+					],
+					"calc": {
+						"value": 300,
+						"extended_value": 380,
+						"weight": "0.24 lb",
+						"extended_weight": "0.84 lb"
+					}
+				},
+				{
+					"id": "e_d8FC6XbR3ZF9ZR-",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "ejivvq8TpDx5Annl6"
+					},
+					"description": "Inertial Compass",
+					"reference": "UT75",
+					"local_notes": "A/200hr.",
+					"tech_level": "11",
+					"tags": [
+						"Housing and Food"
+					],
+					"base_value": "30",
+					"base_weight": "0.05 lb",
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Navigation"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Air"
+							},
+							"amount": 3
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Navigation"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Land"
+							},
+							"amount": 3
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Navigation"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Sea"
+							},
+							"amount": 3
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 30,
+						"extended_value": 30,
+						"weight": "0.05 lb",
+						"extended_weight": "0.05 lb"
+					}
+				},
+				{
+					"id": "eqLZk4PSdiSsiSUo9",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "enQNM0RB6euc5mo7i"
+					},
+					"description": "B cell",
+					"reference": "UT19",
+					"tech_level": "9",
+					"tags": [
+						"Power"
+					],
+					"base_value": "3",
+					"base_weight": "0.05 lb",
+					"quantity": 2,
+					"equipped": true,
+					"calc": {
+						"value": 3,
+						"extended_value": 6,
+						"weight": "0.05 lb",
+						"extended_weight": "0.1 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 120,
+				"extended_value": 536,
+				"weight": "2 lb",
+				"extended_weight": "2.99 lb"
+			}
+		}
+	],
+	"notes": [
+		{
+			"id": "np1s4bxdo4fe_27xy",
+			"markdown": "Remove rugged combination small computer from the TL11 Spacer Basic Kit"
+		}
+	]
+}

--- a/Library/Loadouts/Starship Crew/TL11/Multi-Role Loadmaster.gct
+++ b/Library/Loadouts/Starship Crew/TL11/Multi-Role Loadmaster.gct
@@ -1,0 +1,284 @@
+{
+	"version": 5,
+	"id": "B6_kE2EOhnNqO78Aq",
+	"equipment": [
+		{
+			"id": "ExC8dOvO5Hn9123qR",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+				"id": "ecvRbROzGAmUpQg_Y"
+			},
+			"description": "Light Infantry Helmet",
+			"reference": "UT176",
+			"tech_level": "11",
+			"legality_class": "3",
+			"tags": [
+				"Armor",
+				"Defenses"
+			],
+			"base_value": "250",
+			"base_weight": "3 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"skull"
+					],
+					"amount": 36
+				}
+			],
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "eQwtBqDztZvCDhNoo",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eo6Lb0L-G9bFjuQwS"
+					},
+					"description": "Light Infantry Helmet: Visor",
+					"reference": "UT176",
+					"tech_level": "11",
+					"legality_class": "3",
+					"tags": [
+						"Armor",
+						"Defenses"
+					],
+					"base_value": "100",
+					"base_weight": "3 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"locations": [
+								"eye"
+							],
+							"amount": 30
+						},
+						{
+							"type": "dr_bonus",
+							"locations": [
+								"face"
+							],
+							"amount": 30
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 100,
+						"extended_value": 100,
+						"weight": "3 lb",
+						"extended_weight": "3 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 250,
+				"extended_value": 350,
+				"weight": "3 lb",
+				"extended_weight": "6 lb"
+			}
+		},
+		{
+			"id": "Ep1h6-s8K605rP8kl",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+				"id": "eNxEqbQBIyZOS3rdx"
+			},
+			"description": "VR Gloves",
+			"reference": "UT54",
+			"local_notes": "Requires Complexity 2+.",
+			"tech_level": "9",
+			"tags": [
+				"Media and Education"
+			],
+			"base_value": "20",
+			"base_weight": "0.3 lb",
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "ejW7p4GsS2lnrO4yh",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "esYKu0HiXEa__XOgo"
+					},
+					"description": "Monocrys Gloves",
+					"reference": "UT172",
+					"local_notes": "Flexible.",
+					"tech_level": "11",
+					"tags": [
+						"Defenses"
+					],
+					"base_value": "30",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"locations": [
+								"hand"
+							],
+							"specialization": "piercing and cutting",
+							"amount": 8
+						},
+						{
+							"type": "dr_bonus",
+							"locations": [
+								"hand"
+							],
+							"amount": 4
+						}
+					],
+					"modifiers": [
+						{
+							"id": "fByfjuc7kNJmEzAYM",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+								"id": "ftTIP1_K9WPCHFSrz"
+							},
+							"name": "Stylish",
+							"reference": "UT175",
+							"cost_type": "to_base_cost",
+							"cost": "+3 CF"
+						},
+						{
+							"id": "f2VttfwKmxzndn_CL",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+								"id": "fZK5VWsvzMBCRHwkA"
+							},
+							"name": "Combination Gadget cost, multiple work at a time",
+							"reference": "UT16",
+							"cost_type": "to_final_cost",
+							"cost": "x0.8"
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 96,
+						"extended_value": 96,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				},
+				{
+					"id": "eQ-mRWatOMwW-DDjE",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "ef55nM_NrfAgS_Cam"
+					},
+					"description": "Karatand",
+					"reference": "UT163",
+					"tech_level": "9",
+					"legality_class": "3",
+					"tags": [
+						"Melee Weapon",
+						"Weaponry"
+					],
+					"base_value": "100",
+					"weapons": [
+						{
+							"id": "wVO4U8N6ZjLyRqp3h",
+							"damage": {
+								"type": "cr",
+								"st": "thr"
+							},
+							"usage": "Punch",
+							"reach": "C",
+							"parry": "0",
+							"defaults": [
+								{
+									"type": "dx"
+								},
+								{
+									"type": "skill",
+									"name": "Boxing"
+								},
+								{
+									"type": "skill",
+									"name": "Brawling"
+								},
+								{
+									"type": "skill",
+									"name": "Karate"
+								}
+							],
+							"calc": {
+								"damage": "thr cr"
+							}
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 100,
+						"extended_value": 100,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 20,
+				"extended_value": 216,
+				"weight": "0.3 lb",
+				"extended_weight": "0.3 lb"
+			}
+		},
+		{
+			"id": "eJRKHtAxAdBlYnFwm",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+				"id": "e46KLPiLrq7durI15"
+			},
+			"description": "Assault Boots",
+			"reference": "UT173",
+			"tech_level": "11",
+			"tags": [
+				"Armor",
+				"Defenses"
+			],
+			"base_value": "150",
+			"base_weight": "3 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"foot"
+					],
+					"specialization": "underside of the foot",
+					"amount": 15
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"foot"
+					],
+					"amount": 15
+				}
+			],
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"value": 150,
+				"extended_value": 150,
+				"weight": "3 lb",
+				"extended_weight": "3 lb"
+			}
+		}
+	],
+	"notes": [
+		{
+			"id": "ne59GYHCDTYKu1ojO",
+			"markdown": "Remove VR gloves from the TL11 Spacer Basic Kit"
+		}
+	]
+}

--- a/Library/Loadouts/Starship Crew/TL11/Multi-Role Medical Officer.gct
+++ b/Library/Loadouts/Starship Crew/TL11/Multi-Role Medical Officer.gct
@@ -1,0 +1,475 @@
+{
+	"version": 5,
+	"id": "B_t2qwX9Ylv5PymV2",
+	"equipment": [
+		{
+			"id": "EObJ8qW2j5ykA5QIS",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Basic Set/Basic Set Equipment.eqp",
+				"id": "ESjtIfyzScVP49ity"
+			},
+			"description": "Backpack, Small",
+			"reference": "B288",
+			"tech_level": "1",
+			"tags": [
+				"Camping and Survival Gear"
+			],
+			"base_value": "60",
+			"base_weight": "3 lb",
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "contained_weight_prereq",
+						"has": true,
+						"qualifier": {
+							"compare": "at_most",
+							"qualifier": "40 lb"
+						}
+					}
+				]
+			},
+			"modifiers": [
+				{
+					"id": "fLGWyStgk7dIsHkZv",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+						"id": "f3AMg_F7eHdJ-u_bX"
+					},
+					"name": "Expensive",
+					"reference": "UT15",
+					"cost_type": "to_base_cost",
+					"weight_type": "to_base_weight",
+					"cost": "+1 CF",
+					"weight": "x2/3"
+				}
+			],
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "esvEASOTL0Sv4-iXz",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "e08RZFtTDrlYGoRwG"
+					},
+					"description": "Crash Kit",
+					"reference": "UT198",
+					"local_notes": "Surgery -5.",
+					"tech_level": "9",
+					"tags": [
+						"Medical"
+					],
+					"base_value": "200",
+					"base_weight": "10 lb",
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "First Aid"
+							},
+							"amount": 2
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 200,
+						"extended_value": 200,
+						"weight": "10 lb",
+						"extended_weight": "10 lb"
+					}
+				},
+				{
+					"id": "e3ZS-Mk2XgCrPft5I",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "em9ZRPPzEh54KNqXX"
+					},
+					"description": "Pneumohypo",
+					"reference": "UT199",
+					"tech_level": "9",
+					"tags": [
+						"Medical"
+					],
+					"base_value": "20",
+					"base_weight": "0.1 lb",
+					"weapons": [
+						{
+							"id": "w6-Ho6qygjm2YGx9O",
+							"damage": {
+								"type": "Spec"
+							},
+							"usage": "Stab",
+							"reach": "C",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Knife"
+								},
+								{
+									"type": "dx",
+									"modifier": -4
+								}
+							],
+							"calc": {
+								"damage": "Spec"
+							}
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 20,
+						"extended_value": 20,
+						"weight": "0.1 lb",
+						"extended_weight": "0.1 lb"
+					}
+				},
+				{
+					"id": "eljB831LOLMOyHFvY",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Equipment.eqp",
+						"id": "etXcdY09RGaOSNceE"
+					},
+					"description": "Analgine",
+					"reference": "BT149",
+					"tech_level": "9",
+					"legality_class": "3",
+					"tags": [
+						"Drug"
+					],
+					"base_value": "2",
+					"quantity": 10,
+					"equipped": true,
+					"calc": {
+						"value": 2,
+						"extended_value": 20,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				},
+				{
+					"id": "eO9yOzGrY1v9eHaPm",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Equipment.eqp",
+						"id": "eiVH5MDuE6qyc6g8P"
+					},
+					"description": "Antirad",
+					"reference": "BT152",
+					"local_notes": "gives Radiation Tolerance 5",
+					"tech_level": "10",
+					"legality_class": "3",
+					"tags": [
+						"Drug"
+					],
+					"base_value": "50",
+					"quantity": 4,
+					"equipped": true,
+					"calc": {
+						"value": 50,
+						"extended_value": 200,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				},
+				{
+					"id": "eLOmebmx9f65jP130",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Equipment.eqp",
+						"id": "eB7_ilqmGWA-73ELo"
+					},
+					"description": "Antitox",
+					"reference": "BT161",
+					"local_notes": "Lasts for 24 hours",
+					"tech_level": "10",
+					"legality_class": "4",
+					"tags": [
+						"Drug"
+					],
+					"base_value": "400",
+					"quantity": 2,
+					"equipped": true,
+					"calc": {
+						"value": 400,
+						"extended_value": 800,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				},
+				{
+					"id": "eZRH4mgr5aUVwxogm",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Equipment.eqp",
+						"id": "ebYW3BnTrClUkFpWZ"
+					},
+					"description": "Genericillin",
+					"reference": "BT150",
+					"local_notes": "one dose lasts a week",
+					"tech_level": "10",
+					"legality_class": "4",
+					"tags": [
+						"Drug"
+					],
+					"base_value": "25",
+					"quantity": 10,
+					"equipped": true,
+					"calc": {
+						"value": 25,
+						"extended_value": 250,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				},
+				{
+					"id": "eH-QsjgE2rYpHm1QQ",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Equipment.eqp",
+						"id": "eGs4XHNjDsonXprZW"
+					},
+					"description": "Hepaclean",
+					"reference": "BT162",
+					"local_notes": "Takes effect after 30 minutes",
+					"tech_level": "10",
+					"legality_class": "4",
+					"tags": [
+						"Drug"
+					],
+					"base_value": "30",
+					"quantity": 10,
+					"equipped": true,
+					"calc": {
+						"value": 30,
+						"extended_value": 300,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				},
+				{
+					"id": "eKZfSw_pRYK5Px3Fi",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Equipment.eqp",
+						"id": "epVNfjTeOFkjbX8Ke"
+					},
+					"description": "Revive Capsule",
+					"reference": "BT152",
+					"tech_level": "9",
+					"legality_class": "4",
+					"tags": [
+						"Drug"
+					],
+					"base_value": "5",
+					"quantity": 10,
+					"equipped": true,
+					"calc": {
+						"value": 5,
+						"extended_value": 50,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				},
+				{
+					"id": "eJ_fBj8Izwcnm3bg2",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Equipment.eqp",
+						"id": "eV0phB_Gd2_Aisi3o"
+					},
+					"description": "Ursaline",
+					"reference": "BT151",
+					"tech_level": "9",
+					"legality_class": "4",
+					"tags": [
+						"Drug"
+					],
+					"base_value": "25",
+					"quantity": 8,
+					"equipped": true,
+					"calc": {
+						"value": 25,
+						"extended_value": 200,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				},
+				{
+					"id": "eQK5deNa0zUXcnbPB",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Equipment.eqp",
+						"id": "eXwZ2RaEg1NstR3cG"
+					},
+					"description": "Wideawake",
+					"reference": "BT152",
+					"local_notes": "one dose lasts a week",
+					"tech_level": "10",
+					"legality_class": "4",
+					"tags": [
+						"Drug"
+					],
+					"base_value": "20",
+					"quantity": 5,
+					"equipped": true,
+					"calc": {
+						"value": 20,
+						"extended_value": 100,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				},
+				{
+					"id": "ezsRokU5SZM6Ueqeg",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Equipment.eqp",
+						"id": "ebc3OFJE8Blffjmbe"
+					},
+					"description": "Guardians",
+					"reference": "BT165",
+					"local_notes": "Lasts one day to two weeks; Takes effect in one hour",
+					"tech_level": "10",
+					"legality_class": "3",
+					"tags": [
+						"Drug"
+					],
+					"base_value": "100",
+					"quantity": 4,
+					"equipped": true,
+					"calc": {
+						"value": 100,
+						"extended_value": 400,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				},
+				{
+					"id": "eRkO-mmdLPPdWHoTe",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "evrDbhiCwpYYWInFr"
+					},
+					"description": "Medical Supplies",
+					"reference": "UT199",
+					"local_notes": "Lasts 40 patient-days.",
+					"tech_level": "11",
+					"tags": [
+						"Medical"
+					],
+					"base_value": "200",
+					"base_weight": "2 lb",
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Surgery"
+							},
+							"amount": 1
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 200,
+						"extended_value": 200,
+						"weight": "2 lb",
+						"extended_weight": "2 lb"
+					}
+				},
+				{
+					"id": "ePdNfhBtPoz02tfCx",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "ecd5hwLKXPL9OvO8w"
+					},
+					"description": "Neural Inhibitor",
+					"reference": "UT201",
+					"local_notes": "First Aid +1 (quality) to treat shock.",
+					"tech_level": "10",
+					"legality_class": "3",
+					"tags": [
+						"Medical"
+					],
+					"base_value": "200",
+					"base_weight": "0.1 lb",
+					"weapons": [
+						{
+							"id": "wK-AwAaHMbSPC7lFR",
+							"damage": {
+								"type": "HT-6 aff"
+							},
+							"usage": "Paralyze",
+							"reach": "C",
+							"defaults": [
+								{
+									"type": "dx"
+								},
+								{
+									"type": "skill",
+									"name": "Brawling"
+								}
+							],
+							"calc": {
+								"damage": "HT-6 aff"
+							}
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 200,
+						"extended_value": 200,
+						"weight": "0.1 lb",
+						"extended_weight": "0.1 lb"
+					}
+				},
+				{
+					"id": "eYIY0ySmnuT6TjOd5",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "epRXtbtPNVTPIqIdo"
+					},
+					"description": "A cell",
+					"reference": "UT19",
+					"tech_level": "9",
+					"tags": [
+						"Power"
+					],
+					"base_value": "2",
+					"base_weight": "0.005 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 2,
+						"extended_value": 2,
+						"weight": "0.005 lb",
+						"extended_weight": "0.005 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 120,
+				"extended_value": 3062,
+				"weight": "2 lb",
+				"extended_weight": "14.205 lb"
+			}
+		}
+	]
+}

--- a/Library/Loadouts/Starship Crew/TL11/Multi-Role Operations Officer.gct
+++ b/Library/Loadouts/Starship Crew/TL11/Multi-Role Operations Officer.gct
@@ -1,0 +1,226 @@
+{
+	"version": 5,
+	"id": "B5Z7t35jZBglGXqQn",
+	"equipment": [
+		{
+			"id": "E-QARxQfhQlyq70-X",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Basic Set/Basic Set Equipment.eqp",
+				"id": "ESjtIfyzScVP49ity"
+			},
+			"description": "Backpack, Small",
+			"reference": "B288",
+			"tech_level": "1",
+			"tags": [
+				"Camping and Survival Gear"
+			],
+			"base_value": "60",
+			"base_weight": "3 lb",
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "contained_weight_prereq",
+						"has": true,
+						"qualifier": {
+							"compare": "at_most",
+							"qualifier": "40 lb"
+						}
+					}
+				]
+			},
+			"modifiers": [
+				{
+					"id": "fkHnV8hJo9GN3Fwjb",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+						"id": "f3AMg_F7eHdJ-u_bX"
+					},
+					"name": "Expensive",
+					"reference": "UT15",
+					"cost_type": "to_base_cost",
+					"weight_type": "to_base_weight",
+					"cost": "+1 CF",
+					"weight": "x2/3"
+				}
+			],
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "E4Lol5dLnB9KL4Oc8",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "en3ky8jIp2VteORsI"
+					},
+					"description": "Electronics Repair (@Specialization@) Mini-Toolkit",
+					"reference": "UT82",
+					"local_notes": "-2 (quality). 5A/10hr.",
+					"tech_level": "9",
+					"tags": [
+						"Expedition Gear"
+					],
+					"base_value": "400",
+					"base_weight": "2 lb",
+					"replacements": {
+						"Specialization": "Comm"
+					},
+					"quantity": 1,
+					"equipped": true,
+					"children": [
+						{
+							"id": "esVaaa2Ib23CvA9Pk",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "en3ky8jIp2VteORsI"
+							},
+							"description": "Electronics Repair (@Specialization@) Mini-Toolkit",
+							"reference": "UT82",
+							"local_notes": "-2 (quality). 5A/10hr.",
+							"tech_level": "9",
+							"tags": [
+								"Expedition Gear"
+							],
+							"base_value": "400",
+							"base_weight": "2 lb",
+							"replacements": {
+								"Specialization": "Computers"
+							},
+							"modifiers": [
+								{
+									"id": "ffoHfkrOssA-VE4dy",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fte-9FKj95fCsgBZP"
+									},
+									"name": "Combination Gadget cost, one works at a time",
+									"reference": "UT16",
+									"cost_type": "to_final_cost",
+									"cost": "x0.5"
+								},
+								{
+									"id": "fDhpMlRqBw7K6cbn5",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "f8HaZ0LuUFvHUnXtt"
+									},
+									"name": "Combination Gadget weight, one works at a time",
+									"reference": "UT16",
+									"weight_type": "to_final_weight",
+									"cost": "+0",
+									"weight": "x0.5"
+								}
+							],
+							"quantity": 1,
+							"equipped": true,
+							"calc": {
+								"value": 200,
+								"extended_value": 200,
+								"weight": "1 lb",
+								"extended_weight": "1 lb"
+							}
+						},
+						{
+							"id": "eZE59eIfY2rDTmVKp",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "en3ky8jIp2VteORsI"
+							},
+							"description": "Electronics Repair (@Specialization@) Mini-Toolkit",
+							"reference": "UT82",
+							"local_notes": "-2 (quality). 5A/10hr.",
+							"tech_level": "9",
+							"tags": [
+								"Expedition Gear"
+							],
+							"base_value": "400",
+							"base_weight": "2 lb",
+							"replacements": {
+								"Specialization": "Sensors"
+							},
+							"modifiers": [
+								{
+									"id": "fHPuVIkVgI8NTKd2B",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fte-9FKj95fCsgBZP"
+									},
+									"name": "Combination Gadget cost, one works at a time",
+									"reference": "UT16",
+									"cost_type": "to_final_cost",
+									"cost": "x0.5"
+								},
+								{
+									"id": "fZGn8s_B9IdA4Be1L",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "f8HaZ0LuUFvHUnXtt"
+									},
+									"name": "Combination Gadget weight, one works at a time",
+									"reference": "UT16",
+									"weight_type": "to_final_weight",
+									"cost": "+0",
+									"weight": "x0.5"
+								}
+							],
+							"quantity": 1,
+							"equipped": true,
+							"calc": {
+								"value": 200,
+								"extended_value": 200,
+								"weight": "1 lb",
+								"extended_weight": "1 lb"
+							}
+						}
+					],
+					"calc": {
+						"value": 400,
+						"extended_value": 800,
+						"weight": "2 lb",
+						"extended_weight": "4 lb"
+					}
+				},
+				{
+					"id": "eP0MVZWU2Hc5dAyMJ",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "epRXtbtPNVTPIqIdo"
+					},
+					"description": "A cell",
+					"reference": "UT19",
+					"tech_level": "9",
+					"tags": [
+						"Power"
+					],
+					"base_value": "2",
+					"base_weight": "0.005 lb",
+					"quantity": 5,
+					"equipped": true,
+					"calc": {
+						"value": 2,
+						"extended_value": 10,
+						"weight": "0.005 lb",
+						"extended_weight": "0.025 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 120,
+				"extended_value": 930,
+				"weight": "2 lb",
+				"extended_weight": "6.025 lb"
+			}
+		}
+	]
+}

--- a/Library/Loadouts/Starship Crew/TL11/Multi-Role Science Officer.gct
+++ b/Library/Loadouts/Starship Crew/TL11/Multi-Role Science Officer.gct
@@ -1,0 +1,226 @@
+{
+	"version": 5,
+	"id": "BoXm4gGiuzPRbvivy",
+	"equipment": [
+		{
+			"id": "EtrHI49UI3PWE4YYA",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Basic Set/Basic Set Equipment.eqp",
+				"id": "ESjtIfyzScVP49ity"
+			},
+			"description": "Backpack, Small",
+			"reference": "B288",
+			"tech_level": "1",
+			"tags": [
+				"Camping and Survival Gear"
+			],
+			"base_value": "60",
+			"base_weight": "3 lb",
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "contained_weight_prereq",
+						"has": true,
+						"qualifier": {
+							"compare": "at_most",
+							"qualifier": "40 lb"
+						}
+					}
+				]
+			},
+			"modifiers": [
+				{
+					"id": "fbSSM22aWBcoGBHts",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+						"id": "f3AMg_F7eHdJ-u_bX"
+					},
+					"name": "Expensive",
+					"reference": "UT15",
+					"cost_type": "to_base_cost",
+					"weight_type": "to_base_weight",
+					"cost": "+1 CF",
+					"weight": "x2/3"
+				}
+			],
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "ESJ392i-jUThtv6Rg",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eW1L1x-daNSUlpGMD"
+					},
+					"description": "Pocket Analyzer (@Scientific Skill@)",
+					"reference": "UT67",
+					"local_notes": "2B/5hr.",
+					"tech_level": "9",
+					"tags": [
+						"Sensors and Scientific Equipment"
+					],
+					"base_value": "500",
+					"base_weight": "0.6 lb",
+					"replacements": {
+						"Scientific Skill": "Biology(@Chosen Biology Speciality@)"
+					},
+					"quantity": 1,
+					"equipped": true,
+					"children": [
+						{
+							"id": "et55kPhZa18nTGChf",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "eW1L1x-daNSUlpGMD"
+							},
+							"description": "Pocket Analyzer (@Scientific Skill@)",
+							"reference": "UT67",
+							"local_notes": "2B/5hr.",
+							"tech_level": "9",
+							"tags": [
+								"Sensors and Scientific Equipment"
+							],
+							"base_value": "500",
+							"base_weight": "0.6 lb",
+							"replacements": {
+								"Scientific Skill": "Chemistry"
+							},
+							"modifiers": [
+								{
+									"id": "f13VNNybP88ga4W2J",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fte-9FKj95fCsgBZP"
+									},
+									"name": "Combination Gadget cost, one works at a time",
+									"reference": "UT16",
+									"cost_type": "to_final_cost",
+									"cost": "x0.5"
+								},
+								{
+									"id": "fKUBrkpKsAibIXCj2",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "f8HaZ0LuUFvHUnXtt"
+									},
+									"name": "Combination Gadget weight, one works at a time",
+									"reference": "UT16",
+									"weight_type": "to_final_weight",
+									"cost": "+0",
+									"weight": "x0.5"
+								}
+							],
+							"quantity": 1,
+							"equipped": true,
+							"calc": {
+								"value": 250,
+								"extended_value": 250,
+								"weight": "0.3 lb",
+								"extended_weight": "0.3 lb"
+							}
+						},
+						{
+							"id": "eErfIP1iHodaK-KJM",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "eW1L1x-daNSUlpGMD"
+							},
+							"description": "Pocket Analyzer (@Scientific Skill@)",
+							"reference": "UT67",
+							"local_notes": "2B/5hr.",
+							"tech_level": "9",
+							"tags": [
+								"Sensors and Scientific Equipment"
+							],
+							"base_value": "500",
+							"base_weight": "0.6 lb",
+							"replacements": {
+								"Scientific Skill": "Geology(@Chosen Geology Speciality@)"
+							},
+							"modifiers": [
+								{
+									"id": "fUKSIPEPCXhYMW1H7",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fte-9FKj95fCsgBZP"
+									},
+									"name": "Combination Gadget cost, one works at a time",
+									"reference": "UT16",
+									"cost_type": "to_final_cost",
+									"cost": "x0.5"
+								},
+								{
+									"id": "fceaWFzB4_xGZ7QIF",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "f8HaZ0LuUFvHUnXtt"
+									},
+									"name": "Combination Gadget weight, one works at a time",
+									"reference": "UT16",
+									"weight_type": "to_final_weight",
+									"cost": "+0",
+									"weight": "x0.5"
+								}
+							],
+							"quantity": 1,
+							"equipped": true,
+							"calc": {
+								"value": 250,
+								"extended_value": 250,
+								"weight": "0.3 lb",
+								"extended_weight": "0.3 lb"
+							}
+						}
+					],
+					"calc": {
+						"value": 500,
+						"extended_value": 1000,
+						"weight": "0.6 lb",
+						"extended_weight": "1.2 lb"
+					}
+				},
+				{
+					"id": "eumIFi1ELRg5ehSIB",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "enQNM0RB6euc5mo7i"
+					},
+					"description": "B cell",
+					"reference": "UT19",
+					"tech_level": "9",
+					"tags": [
+						"Power"
+					],
+					"base_value": "3",
+					"base_weight": "0.05 lb",
+					"quantity": 4,
+					"equipped": true,
+					"calc": {
+						"value": 3,
+						"extended_value": 12,
+						"weight": "0.05 lb",
+						"extended_weight": "0.2 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 120,
+				"extended_value": 1132,
+				"weight": "2 lb",
+				"extended_weight": "3.4 lb"
+			}
+		}
+	]
+}

--- a/Library/Loadouts/Starship Crew/TL11/Multi-Role Security Officer.gct
+++ b/Library/Loadouts/Starship Crew/TL11/Multi-Role Security Officer.gct
@@ -1,0 +1,417 @@
+{
+	"version": 5,
+	"id": "BoLbQbOEKZycgnWTr",
+	"equipment": [
+		{
+			"id": "Ecj4_kGQG9L1bwKan",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+				"id": "ecvRbROzGAmUpQg_Y"
+			},
+			"description": "Light Infantry Helmet",
+			"reference": "UT176",
+			"tech_level": "11",
+			"legality_class": "3",
+			"tags": [
+				"Armor",
+				"Defenses"
+			],
+			"base_value": "250",
+			"base_weight": "3 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"skull"
+					],
+					"amount": 36
+				}
+			],
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "eAOBrIPpCJBf5hFJV",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eo6Lb0L-G9bFjuQwS"
+					},
+					"description": "Light Infantry Helmet: Visor",
+					"reference": "UT176",
+					"tech_level": "11",
+					"legality_class": "3",
+					"tags": [
+						"Armor",
+						"Defenses"
+					],
+					"base_value": "100",
+					"base_weight": "3 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"locations": [
+								"eye"
+							],
+							"amount": 30
+						},
+						{
+							"type": "dr_bonus",
+							"locations": [
+								"face"
+							],
+							"amount": 30
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 100,
+						"extended_value": 100,
+						"weight": "3 lb",
+						"extended_weight": "3 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 250,
+				"extended_value": 350,
+				"weight": "3 lb",
+				"extended_weight": "6 lb"
+			}
+		},
+		{
+			"id": "eXO65a9CTHA6j4d7l",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+				"id": "eKE5jFzR3r8QPFLhD"
+			},
+			"description": "Monocrys Jacket",
+			"reference": "UT172",
+			"local_notes": "Flexible.",
+			"tech_level": "11",
+			"legality_class": "3",
+			"tags": [
+				"Defenses"
+			],
+			"base_value": "450",
+			"base_weight": "3 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"arm",
+						"torso",
+						"vitals"
+					],
+					"amount": 8
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"arm",
+						"torso",
+						"vitals"
+					],
+					"specialization": "piercing and cutting",
+					"amount": 16
+				}
+			],
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"value": 450,
+				"extended_value": 450,
+				"weight": "3 lb",
+				"extended_weight": "3 lb"
+			}
+		},
+		{
+			"id": "ErF_6aecRx0lc41Y4",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+				"id": "eNxEqbQBIyZOS3rdx"
+			},
+			"description": "VR Gloves",
+			"reference": "UT54",
+			"local_notes": "Requires Complexity 2+.",
+			"tech_level": "9",
+			"tags": [
+				"Media and Education"
+			],
+			"base_value": "20",
+			"base_weight": "0.3 lb",
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "eERdtJEtrAjlNt2wI",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "esYKu0HiXEa__XOgo"
+					},
+					"description": "Monocrys Gloves",
+					"reference": "UT172",
+					"local_notes": "Flexible.",
+					"tech_level": "11",
+					"tags": [
+						"Defenses"
+					],
+					"base_value": "30",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"locations": [
+								"hand"
+							],
+							"specialization": "piercing and cutting",
+							"amount": 8
+						},
+						{
+							"type": "dr_bonus",
+							"locations": [
+								"hand"
+							],
+							"amount": 4
+						}
+					],
+					"modifiers": [
+						{
+							"id": "feUnay7lgQO9WW0zQ",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+								"id": "ftTIP1_K9WPCHFSrz"
+							},
+							"name": "Stylish",
+							"reference": "UT175",
+							"cost_type": "to_base_cost",
+							"cost": "+3 CF"
+						},
+						{
+							"id": "fLGXTAThStVCJPqqa",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+								"id": "fZK5VWsvzMBCRHwkA"
+							},
+							"name": "Combination Gadget cost, multiple work at a time",
+							"reference": "UT16",
+							"cost_type": "to_final_cost",
+							"cost": "x0.8"
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 96,
+						"extended_value": 96,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				},
+				{
+					"id": "eCFXBSuLZBSVrBGaw",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "ef55nM_NrfAgS_Cam"
+					},
+					"description": "Karatand",
+					"reference": "UT163",
+					"tech_level": "9",
+					"legality_class": "3",
+					"tags": [
+						"Melee Weapon",
+						"Weaponry"
+					],
+					"base_value": "100",
+					"weapons": [
+						{
+							"id": "ww4BbAdXGlwob-_1R",
+							"damage": {
+								"type": "cr",
+								"st": "thr"
+							},
+							"usage": "Punch",
+							"reach": "C",
+							"parry": "0",
+							"defaults": [
+								{
+									"type": "dx"
+								},
+								{
+									"type": "skill",
+									"name": "Boxing"
+								},
+								{
+									"type": "skill",
+									"name": "Brawling"
+								},
+								{
+									"type": "skill",
+									"name": "Karate"
+								}
+							],
+							"calc": {
+								"damage": "thr cr"
+							}
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 100,
+						"extended_value": 100,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 20,
+				"extended_value": 216,
+				"weight": "0.3 lb",
+				"extended_weight": "0.3 lb"
+			}
+		},
+		{
+			"id": "eSnooZ8SSz_rJY64n",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+				"id": "ehdRbUenpNRCpUTtS"
+			},
+			"description": "Monocrys Trousers",
+			"reference": "UT172",
+			"local_notes": "Flexible.",
+			"tech_level": "11",
+			"legality_class": "3",
+			"tags": [
+				"Defenses"
+			],
+			"base_value": "280",
+			"base_weight": "2.8 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"groin",
+						"leg"
+					],
+					"amount": 8
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"groin",
+						"leg"
+					],
+					"specialization": "piercing and cutting",
+					"amount": 16
+				}
+			],
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"value": 280,
+				"extended_value": 280,
+				"weight": "2.8 lb",
+				"extended_weight": "2.8 lb"
+			}
+		},
+		{
+			"id": "e94SYufv1diANYVWQ",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+				"id": "e46KLPiLrq7durI15"
+			},
+			"description": "Assault Boots",
+			"reference": "UT173",
+			"tech_level": "11",
+			"tags": [
+				"Armor",
+				"Defenses"
+			],
+			"base_value": "150",
+			"base_weight": "3 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"foot"
+					],
+					"specialization": "underside of the foot",
+					"amount": 15
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"foot"
+					],
+					"amount": 15
+				}
+			],
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"value": 150,
+				"extended_value": 150,
+				"weight": "3 lb",
+				"extended_weight": "3 lb"
+			}
+		},
+		{
+			"id": "EvRL4m_Wp8CC7DOoa",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "High Tech/High Tech Equipment.eqp",
+				"id": "EC9nP-WpcnxfOUAj5"
+			},
+			"description": "Load-Bearing Vest",
+			"reference": "HT54",
+			"local_notes": "Holds 20-30lbs.",
+			"tech_level": "7",
+			"tags": [
+				"General Equipment"
+			],
+			"base_value": "30",
+			"base_weight": "2 lb",
+			"modifiers": [
+				{
+					"id": "f_K22xkj5OhEpIqYb",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+						"id": "fWUQh1AyC_6CUS9Ui"
+					},
+					"name": "Expensive",
+					"reference": "UT15",
+					"cost_type": "to_final_base_cost",
+					"weight_type": "to_base_weight",
+					"cost": "x2",
+					"weight": "x2/3"
+				}
+			],
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"value": 60,
+				"extended_value": 60,
+				"weight": "1.3333 lb",
+				"extended_weight": "1.3333 lb"
+			}
+		}
+	],
+	"notes": [
+		{
+			"id": "n_fHDvUqrF_4rblS_",
+			"markdown": "Remove VR gloves from the TL11 Spacer Basic Kit"
+		}
+	]
+}

--- a/Library/Loadouts/Starship Crew/TL11/Multi-Role Steward.gct
+++ b/Library/Loadouts/Starship Crew/TL11/Multi-Role Steward.gct
@@ -1,0 +1,232 @@
+{
+	"version": 5,
+	"id": "BQYZ985e22Qt5aCv7",
+	"equipment": [
+		{
+			"id": "E2rItIJLF1-MoNB0i",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Basic Set/Basic Set Equipment.eqp",
+				"id": "ESjtIfyzScVP49ity"
+			},
+			"description": "Backpack, Small",
+			"reference": "B288",
+			"tech_level": "1",
+			"tags": [
+				"Camping and Survival Gear"
+			],
+			"base_value": "60",
+			"base_weight": "3 lb",
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "contained_weight_prereq",
+						"has": true,
+						"qualifier": {
+							"compare": "at_most",
+							"qualifier": "40 lb"
+						}
+					}
+				]
+			},
+			"modifiers": [
+				{
+					"id": "fbttFo3apAT8N0i-a",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+						"id": "f3AMg_F7eHdJ-u_bX"
+					},
+					"name": "Expensive",
+					"reference": "UT15",
+					"cost_type": "to_base_cost",
+					"weight_type": "to_base_weight",
+					"cost": "+1 CF",
+					"weight": "x2/3"
+				}
+			],
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "eJQH898YtrAEFzDzv",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "etxU8iNoLgecfWNd7"
+					},
+					"description": "Sleep Set",
+					"reference": "UT69",
+					"local_notes": "A/3 days.",
+					"tech_level": "11",
+					"tags": [
+						"Housing and Food"
+					],
+					"base_value": "200",
+					"base_weight": "0.1 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 200,
+						"extended_value": 200,
+						"weight": "0.1 lb",
+						"extended_weight": "0.1 lb"
+					}
+				},
+				{
+					"id": "e9wRNPdEq6xcG_RIT",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eznc-kmysZ8i10fqA"
+					},
+					"description": "Fire Extinguisher Tube",
+					"reference": "UT87",
+					"local_notes": "8-second discharge. 2-yard range.",
+					"tech_level": "11",
+					"tags": [
+						"Expedition Gear"
+					],
+					"base_value": "10",
+					"base_weight": "1 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 10,
+						"extended_value": 10,
+						"weight": "1 lb",
+						"extended_weight": "1 lb"
+					}
+				},
+				{
+					"id": "eFAf_5MBjwqqcYuxv",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "High Tech/High Tech Equipment.eqp",
+						"id": "exRH86foJfRv3fZaX"
+					},
+					"description": "Alcohol",
+					"reference": "HT34",
+					"tags": [
+						"General Equipment"
+					],
+					"base_value": "5",
+					"base_weight": "2.5 lb",
+					"quantity": 4,
+					"equipped": true,
+					"calc": {
+						"value": 5,
+						"extended_value": 20,
+						"weight": "2.5 lb",
+						"extended_weight": "10 lb"
+					}
+				},
+				{
+					"id": "e0awSBY_Fy21KczvE",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "e5oTYQKsrgnYRkwST"
+					},
+					"description": "Domestic Nanocleanser",
+					"reference": "UT69",
+					"local_notes": "1 week of routine cleaning or one major cleaning job",
+					"tech_level": "11",
+					"tags": [
+						"Housing and Food"
+					],
+					"base_value": "10",
+					"base_weight": "0.5 lb",
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "Housekeeping rolls to clean up things",
+							"amount": 6
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 10,
+						"extended_value": 10,
+						"weight": "0.5 lb",
+						"extended_weight": "0.5 lb"
+					}
+				},
+				{
+					"id": "eeZgYU8D-CGerUtg6",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eX5RNhIyHO3rGNWpR"
+					},
+					"description": "Odor Synthesizer",
+					"reference": "UT52",
+					"local_notes": "100 mixes. B/100hr.",
+					"tech_level": "9",
+					"tags": [
+						"Media and Education"
+					],
+					"base_value": "500",
+					"base_weight": "1 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 500,
+						"extended_value": 500,
+						"weight": "1 lb",
+						"extended_weight": "1 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 120,
+				"extended_value": 860,
+				"weight": "2 lb",
+				"extended_weight": "14.6 lb"
+			}
+		},
+		{
+			"id": "EelUeqwNTE2qApmWY",
+			"description": "Stored in Vehicle",
+			"legality_class": "4",
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "eBfy7K20UFwdKULpA",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eWlSx57LtaAZLHzVy"
+					},
+					"description": "Entertainment Console",
+					"reference": "UT51",
+					"local_notes": "Complexity 8. 4B/5hr. or external power.",
+					"tech_level": "11",
+					"tags": [
+						"Media and Education"
+					],
+					"base_value": "500",
+					"base_weight": "1 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 500,
+						"extended_value": 500,
+						"weight": "1 lb",
+						"extended_weight": "1 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 0,
+				"extended_value": 500,
+				"weight": "0 lb",
+				"extended_weight": "1 lb"
+			}
+		}
+	]
+}

--- a/Library/Loadouts/Starship Crew/TL11/Multi-Role Tactical Officer.gct
+++ b/Library/Loadouts/Starship Crew/TL11/Multi-Role Tactical Officer.gct
@@ -1,0 +1,169 @@
+{
+	"version": 5,
+	"id": "Bx2Lvazkxxn511Ts8",
+	"equipment": [
+		{
+			"id": "EpEX355TYSABrlhhW",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Basic Set/Basic Set Equipment.eqp",
+				"id": "ESjtIfyzScVP49ity"
+			},
+			"description": "Backpack, Small",
+			"reference": "B288",
+			"tech_level": "1",
+			"tags": [
+				"Camping and Survival Gear"
+			],
+			"base_value": "60",
+			"base_weight": "3 lb",
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "contained_weight_prereq",
+						"has": true,
+						"qualifier": {
+							"compare": "at_most",
+							"qualifier": "40 lb"
+						}
+					}
+				]
+			},
+			"modifiers": [
+				{
+					"id": "fi5aK7BE7202VpEF7",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+						"id": "f3AMg_F7eHdJ-u_bX"
+					},
+					"name": "Expensive",
+					"reference": "UT15",
+					"cost_type": "to_base_cost",
+					"weight_type": "to_base_weight",
+					"cost": "+1 CF",
+					"weight": "x2/3"
+				}
+			],
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "E8KJCb3S2xCE1x4Y8",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eSMEpeCwHrfGzvkx9"
+					},
+					"description": "Portable Terminal",
+					"reference": "UT24",
+					"local_notes": "2B/20hr.",
+					"tech_level": "9",
+					"tags": [
+						"Computers"
+					],
+					"base_value": "50",
+					"base_weight": "0.5 lb",
+					"modifiers": [
+						{
+							"id": "f_YFh-bkwYbsxBXik",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+								"id": "ftp3XhCDqI3Lan38o"
+							},
+							"name": "Rugged",
+							"reference": "UT15",
+							"cost_type": "to_base_cost",
+							"weight_type": "to_base_weight",
+							"cost": "+1 CF",
+							"weight": "x1.2"
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"children": [
+						{
+							"id": "emZnTJ51ijOAjYaDy",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "emOmFGTZEbRVE2qhf"
+							},
+							"description": "Cable Jack",
+							"reference": "UT42",
+							"tech_level": "9",
+							"tags": [
+								"Communication and Interface"
+							],
+							"base_value": "5",
+							"modifiers": [
+								{
+									"id": "fwhfiTIys-zZCQgO_",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "ftp3XhCDqI3Lan38o"
+									},
+									"name": "Rugged",
+									"reference": "UT15",
+									"cost_type": "to_base_cost",
+									"weight_type": "to_base_weight",
+									"cost": "+1 CF",
+									"weight": "x1.2"
+								}
+							],
+							"quantity": 1,
+							"equipped": true,
+							"calc": {
+								"value": 10,
+								"extended_value": 10,
+								"weight": "0 lb",
+								"extended_weight": "0 lb"
+							}
+						}
+					],
+					"calc": {
+						"value": 100,
+						"extended_value": 110,
+						"weight": "0.6 lb",
+						"extended_weight": "0.6 lb"
+					}
+				},
+				{
+					"id": "eRCxDSlA7M_Yq38Gm",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "e5BC-pEfofU28HHzf"
+					},
+					"description": "Optical Cable",
+					"reference": "UT43",
+					"local_notes": "\"Quantity\" represents yards.",
+					"tech_level": "9",
+					"tags": [
+						"Communication and Interface"
+					],
+					"base_value": "0.1",
+					"base_weight": "0.01 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 0.1,
+						"extended_value": 0.1,
+						"weight": "0.01 lb",
+						"extended_weight": "0.01 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 120,
+				"extended_value": 230.1,
+				"weight": "2 lb",
+				"extended_weight": "2.61 lb"
+			}
+		}
+	]
+}

--- a/Library/Loadouts/Starship Crew/TL11/Operations Officer.gct
+++ b/Library/Loadouts/Starship Crew/TL11/Operations Officer.gct
@@ -1,0 +1,1339 @@
+{
+	"version": 5,
+	"id": "Bocrp_L-yejjBl9sC",
+	"equipment": [
+		{
+			"id": "EQbR-k7uAN8fxsKPC",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Basic Set/Basic Set Equipment.eqp",
+				"id": "ESjtIfyzScVP49ity"
+			},
+			"description": "Backpack, Small",
+			"reference": "B288",
+			"tech_level": "1",
+			"tags": [
+				"Camping and Survival Gear"
+			],
+			"base_value": "60",
+			"base_weight": "3 lb",
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "contained_weight_prereq",
+						"has": true,
+						"qualifier": {
+							"compare": "at_most",
+							"qualifier": "40 lb"
+						}
+					}
+				]
+			},
+			"modifiers": [
+				{
+					"id": "f-PJ1pEvHpMCpLgvp",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+						"id": "f3AMg_F7eHdJ-u_bX"
+					},
+					"name": "Expensive",
+					"reference": "UT15",
+					"cost_type": "to_base_cost",
+					"weight_type": "to_base_weight",
+					"cost": "+1 CF",
+					"weight": "x2/3"
+				}
+			],
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "E6VoolUAsVErNSiJo",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "es7M7etnnIm5wPDiU"
+					},
+					"description": "Electronics Repair (@Specialization@) Toolkit",
+					"reference": "UT82",
+					"local_notes": "10A/10hr.",
+					"tech_level": "9",
+					"tags": [
+						"Expedition Gear"
+					],
+					"base_value": "1200",
+					"base_weight": "10 lb",
+					"replacements": {
+						"Specialization": "Comm"
+					},
+					"quantity": 1,
+					"equipped": true,
+					"children": [
+						{
+							"id": "eIzVbBpD_VxPjvSqi",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "es7M7etnnIm5wPDiU"
+							},
+							"description": "Electronics Repair (@Specialization@) Toolkit",
+							"reference": "UT82",
+							"local_notes": "10A/10hr.",
+							"tech_level": "9",
+							"tags": [
+								"Expedition Gear"
+							],
+							"base_value": "1200",
+							"base_weight": "10 lb",
+							"replacements": {
+								"Specialization": "Computers"
+							},
+							"modifiers": [
+								{
+									"id": "fomf7Gau3Pw4nMt5a",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fte-9FKj95fCsgBZP"
+									},
+									"name": "Combination Gadget cost, one works at a time",
+									"reference": "UT16",
+									"cost_type": "to_final_cost",
+									"cost": "x0.5"
+								},
+								{
+									"id": "fQOb_kd2J4vRWiXoP",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "f8HaZ0LuUFvHUnXtt"
+									},
+									"name": "Combination Gadget weight, one works at a time",
+									"reference": "UT16",
+									"weight_type": "to_final_weight",
+									"cost": "+0",
+									"weight": "x0.5"
+								}
+							],
+							"quantity": 1,
+							"equipped": true,
+							"calc": {
+								"value": 600,
+								"extended_value": 600,
+								"weight": "5 lb",
+								"extended_weight": "5 lb"
+							}
+						},
+						{
+							"id": "eDB_4T-fW_hH8x_Rz",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "es7M7etnnIm5wPDiU"
+							},
+							"description": "Electronics Repair (@Specialization@) Toolkit",
+							"reference": "UT82",
+							"local_notes": "10A/10hr.",
+							"tech_level": "9",
+							"tags": [
+								"Expedition Gear"
+							],
+							"base_value": "1200",
+							"base_weight": "10 lb",
+							"replacements": {
+								"Specialization": "Sensors"
+							},
+							"modifiers": [
+								{
+									"id": "fcibPwPOgUWWHC0rC",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fte-9FKj95fCsgBZP"
+									},
+									"name": "Combination Gadget cost, one works at a time",
+									"reference": "UT16",
+									"cost_type": "to_final_cost",
+									"cost": "x0.5"
+								},
+								{
+									"id": "fKDj3ELFD5GJgtdsO",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "f8HaZ0LuUFvHUnXtt"
+									},
+									"name": "Combination Gadget weight, one works at a time",
+									"reference": "UT16",
+									"weight_type": "to_final_weight",
+									"cost": "+0",
+									"weight": "x0.5"
+								}
+							],
+							"quantity": 1,
+							"equipped": true,
+							"calc": {
+								"value": 600,
+								"extended_value": 600,
+								"weight": "5 lb",
+								"extended_weight": "5 lb"
+							}
+						}
+					],
+					"calc": {
+						"value": 1200,
+						"extended_value": 2400,
+						"weight": "10 lb",
+						"extended_weight": "20 lb"
+					}
+				},
+				{
+					"id": "eHXUhL2RdcVy-OUuG",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "epRXtbtPNVTPIqIdo"
+					},
+					"description": "A cell",
+					"reference": "UT19",
+					"tech_level": "9",
+					"tags": [
+						"Power"
+					],
+					"base_value": "2",
+					"base_weight": "0.005 lb",
+					"quantity": 10,
+					"equipped": true,
+					"calc": {
+						"value": 2,
+						"extended_value": 20,
+						"weight": "0.005 lb",
+						"extended_weight": "0.05 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 120,
+				"extended_value": 2540,
+				"weight": "2 lb",
+				"extended_weight": "22.05 lb"
+			}
+		},
+		{
+			"id": "ELKkuyz-gGoTcgD-R",
+			"description": "Stored in vehicle",
+			"legality_class": "4",
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "E84wmMwEWI7hc5723",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "efeekclqs54nOsbVN"
+					},
+					"description": "Swarmbot Hive",
+					"reference": "UT37",
+					"tech_level": "10",
+					"base_value": "200",
+					"base_weight": "10 lb",
+					"quantity": 1,
+					"equipped": true,
+					"children": [
+						{
+							"id": "et52Tlw04JAZhEFJ_",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "eRd4HdGkY3padXW2c"
+							},
+							"description": "@Microbot/Nanobot Type@ Swarm",
+							"reference": "UT35",
+							"tech_level": "10",
+							"tags": [
+								"Swarmbots"
+							],
+							"base_weight": "2 lb",
+							"replacements": {
+								"Equipment": "Ship Comm",
+								"Microbot/Nanobot Type": "Repair",
+								"Other Equipment 1": "Ship Computers",
+								"Other Equipment 2": "Ship Sensors"
+							},
+							"modifiers": [
+								{
+									"id": "FylYn8CjNAabKbzfK",
+									"name": "Swarm Type",
+									"reference": "UT37",
+									"local_notes": "at TL11 microbots can have two types, at TL12 nanobots can have two types",
+									"children": [
+										{
+											"id": "fc891YHCVjCi3vlyh",
+											"name": "Bughunter",
+											"reference": "UT106",
+											"local_notes": "LC3",
+											"tags": [
+												"Counter-Surveillance and ECM",
+												"Security and Surveillance",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+4000",
+											"disabled": true
+										},
+										{
+											"id": "fUoK1uYOeEpXcj0tT",
+											"name": "Cannibal",
+											"reference": "UT169",
+											"local_notes": "LC1",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "12",
+											"cost": "+15000",
+											"disabled": true
+										},
+										{
+											"id": "fhB97cZCKKt4Oazb1",
+											"name": "Cleaning",
+											"reference": "UT69",
+											"local_notes": "LC4",
+											"tags": [
+												"Domestic Equipment and Appliances",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "f1SHoWnD9i6UAo1_0",
+											"name": "Construction",
+											"reference": "UT86",
+											"local_notes": "LC4",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "f9ZFTKJpiCes5xjUy",
+											"name": "Decontamination (@Hazard Type@)",
+											"reference": "UT87",
+											"local_notes": "LC3; Hazardous Materials (@Hazard Type@)-12",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fttEmMNPw113vCtO5",
+											"name": "Decontamination (@Hazard Type@)",
+											"reference": "UT87",
+											"local_notes": "LC3; Hazardous Materials (@Hazard Type@)-13",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "11",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fpbYXpdkQ8_1SvNTG",
+											"name": "Decontamination (@Hazard Type@)",
+											"reference": "UT87",
+											"local_notes": "LC3; Hazardous Materials (@Hazard Type@)-14",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "12",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fxB-xCcKa5GawCaXm",
+											"name": "Defoliator",
+											"reference": "UT87",
+											"local_notes": "LC3",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fZBsqfGyKckknGohK",
+											"name": "Devourer",
+											"reference": "UT169",
+											"local_notes": "LC1",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "10",
+											"cost": "+8000",
+											"disabled": true
+										},
+										{
+											"id": "fDYiXANeAU5VAaAOt",
+											"name": "Disassembler",
+											"reference": "UT169",
+											"local_notes": "LC1",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "11",
+											"cost": "+10000",
+											"disabled": true
+										},
+										{
+											"id": "fXo0t5QDsd5xkuqdO",
+											"name": "Explorer",
+											"reference": "UT80",
+											"local_notes": "LC4",
+											"tags": [
+												"Expedition Gear",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+500",
+											"disabled": true
+										},
+										{
+											"id": "fl4z1pPFSS5O4sSd1",
+											"name": "Firefly",
+											"reference": "UT74",
+											"local_notes": "LC4",
+											"tags": [
+												"Domestic Equipment and Appliances",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+100",
+											"disabled": true
+										},
+										{
+											"id": "fIsSUAhCvAv8zJK_Z",
+											"name": "Forensic",
+											"reference": "UT107",
+											"local_notes": "LC3",
+											"tags": [
+												"Enforcement and Coercion",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+4000",
+											"disabled": true
+										},
+										{
+											"id": "fKFWOhKL72uGqi-XI",
+											"name": "Gremlin",
+											"reference": "UT169",
+											"local_notes": "LC2",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "10",
+											"cost": "+2000",
+											"disabled": true
+										},
+										{
+											"id": "f-5ozOtr5jQvUTF79",
+											"name": "Harvester",
+											"reference": "UT87",
+											"local_notes": "LC4",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+2000",
+											"disabled": true
+										},
+										{
+											"id": "fOHtCYf860j-mJSK1",
+											"name": "Massage",
+											"reference": "UT41",
+											"local_notes": "LC4",
+											"tags": [
+												"Robots",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+200",
+											"disabled": true
+										},
+										{
+											"id": "f2oE0Lphna7Lt8EqC",
+											"name": "Painter",
+											"reference": "UT87",
+											"local_notes": "LC4",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+500",
+											"disabled": true
+										},
+										{
+											"id": "fyS4f5M-OBjUlSZ3-",
+											"name": "Paramedical",
+											"reference": "UT201",
+											"local_notes": "LC3; Diagnosis-10, First Aid-10",
+											"tags": [
+												"Medical",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+6000",
+											"disabled": true
+										},
+										{
+											"id": "fjGMiYBk1SLtagZDi",
+											"name": "Paramedical",
+											"reference": "UT201",
+											"local_notes": "LC3; Diagnosis-11, First Aid-11",
+											"tags": [
+												"Medical",
+												"Swarmbots"
+											],
+											"tech_level": "11",
+											"cost": "+6000",
+											"disabled": true
+										},
+										{
+											"id": "fH6kMYEp2MG8uiNZe",
+											"name": "Paramedical",
+											"reference": "UT201",
+											"local_notes": "LC3; Diagnosis-12, First Aid-12",
+											"tags": [
+												"Medical",
+												"Swarmbots"
+											],
+											"tech_level": "12",
+											"cost": "+6000",
+											"disabled": true
+										},
+										{
+											"id": "fixSaEeKLaCA43X3Z",
+											"name": "Pesticide",
+											"reference": "UT87",
+											"local_notes": "LC3",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fpINd5j7Mav2XyuVH",
+											"name": "Play",
+											"reference": "UT41",
+											"local_notes": "LC4",
+											"tags": [
+												"Robots",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+200",
+											"disabled": true
+										},
+										{
+											"id": "f0XTExfpPriZB5f0D",
+											"name": "Pollinator",
+											"reference": "UT87",
+											"local_notes": "LC4",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fBiS00qcT3zR-j6_m",
+											"name": "Repair (@Equipment@)",
+											"reference": "UT87",
+											"local_notes": "LC4; Repair Skill-12",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+500",
+											"disabled": true
+										},
+										{
+											"id": "fkxBGYffwSl2UrNcv",
+											"name": "Repair (@Equipment@)",
+											"reference": "UT87",
+											"local_notes": "LC4; Repair Skill-13",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "11",
+											"cost": "+500"
+										},
+										{
+											"id": "fQuCvU2WzUen4uvBr",
+											"name": "Repair (@Other Equipment 1@)",
+											"reference": "UT87",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+250"
+										},
+										{
+											"id": "fTxUZHf7t7OqHtaub",
+											"name": "Repair (@Other Equipment 2@)",
+											"reference": "UT87",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+250"
+										},
+										{
+											"id": "fF42cSGqy_g8ebvsA",
+											"name": "Repair (@Other Equipment 3@)",
+											"reference": "UT87",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+250",
+											"disabled": true
+										},
+										{
+											"id": "fanqFPrbGLbvK9nGC",
+											"name": "Security",
+											"reference": "UT104",
+											"local_notes": "LC3",
+											"tags": [
+												"Security and Surveillance",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "f4SFXEp4MkD2II3cf",
+											"name": "Sentry",
+											"reference": "UT169",
+											"local_notes": "LC3",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "10",
+											"cost": "+5000",
+											"disabled": true
+										},
+										{
+											"id": "fp6It_B5XbeGvO868",
+											"name": "Stinger",
+											"reference": "UT169",
+											"local_notes": "LC2",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "10",
+											"cost": "+1500",
+											"disabled": true
+										},
+										{
+											"id": "fthcls3nR_MT4IB5r",
+											"name": "Surveillance",
+											"reference": "UT106",
+											"local_notes": "LC3",
+											"tags": [
+												"Security and Surveillance",
+												"Surveillance and Tracking Devices",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+500",
+											"disabled": true
+										},
+										{
+											"id": "ffWcpF1mpSgnVZjcZ",
+											"name": "Terminator",
+											"reference": "UT169",
+											"local_notes": "LC1",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "10",
+											"cost": "+1500",
+											"disabled": true
+										}
+									]
+								},
+								{
+									"id": "fWare3mlVtTcSe79S",
+									"name": "Self-Replicating",
+									"reference": "UT37",
+									"local_notes": "only for defoliator, devourer or pesticide",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_base_cost",
+									"cost": "x10",
+									"disabled": true
+								},
+								{
+									"id": "FR8u4JuSO3sCfEjw_",
+									"name": "Chassis",
+									"local_notes": "choose one microbot or nanobot chassis",
+									"children": [
+										{
+											"id": "FP-0BKXnEBKzrydyb",
+											"name": "Microbot Chassis",
+											"children": [
+												{
+													"id": "fv1if5DkhawumErL2",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "f7eMKwMF7BTYFbxhq"
+													},
+													"name": "Microbot Aerostat",
+													"reference": "UT36",
+													"local_notes": "Air Move 2",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "10",
+													"disabled": true
+												},
+												{
+													"id": "fJr0Vpx5AE0-dLwrZ",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fcVKEB14BedQI1jGA"
+													},
+													"name": "Microbot Crawler",
+													"reference": "UT36",
+													"local_notes": "Move 3; Water Move 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "10"
+												},
+												{
+													"id": "fnngT4l8pOteNfFk0",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fScgdTYLwKE9CEYfl"
+													},
+													"name": "Microbot Crawler, Armored",
+													"reference": "UT36",
+													"local_notes": "Move 2, 2x HP",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "10",
+													"cost": "+100%",
+													"disabled": true
+												},
+												{
+													"id": "f-nwAFBq53YNwjq4-",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fpAVv9yE3m3t0Egt_"
+													},
+													"name": "Microbot Flier",
+													"reference": "UT36",
+													"local_notes": "Move 1; Air Move 6",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "10",
+													"cost": "+100%",
+													"disabled": true
+												},
+												{
+													"id": "f1eTpFjwMSi9xqFIS",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "ffHj2SBngzuewdrbB"
+													},
+													"name": "Microbot Hopper",
+													"reference": "UT36",
+													"local_notes": "Move 4; Super Jump 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "10",
+													"cost": "+50%",
+													"disabled": true
+												},
+												{
+													"id": "fN9wrOQAHroUwqIvd",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fr6wQjKaUic-BpBCO"
+													},
+													"name": "Microbot Space",
+													"reference": "UT36",
+													"local_notes": "Move 1; 0.0001G solar sail",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "10",
+													"cost": "+0",
+													"disabled": true
+												},
+												{
+													"id": "fk-KOjXCb8VJ2cDKy",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fsL5rGqz66ht8cVvg"
+													},
+													"name": "Microbot Swimmer",
+													"reference": "UT36",
+													"local_notes": "Water Move 4",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "10",
+													"cost": "+0",
+													"disabled": true
+												},
+												{
+													"id": "f_63WEyGz6FBfuxwU",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fvVo7_8gzuQpK50fc"
+													},
+													"name": "Microbot Contragrav (CG) Flier",
+													"reference": "UT36",
+													"local_notes": "Move 1; Air Move 20",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11^",
+													"cost": "+200%",
+													"disabled": true
+												}
+											]
+										},
+										{
+											"id": "Fqd29t_5M4xY-pEID",
+											"name": "Nanobot Chassis",
+											"children": [
+												{
+													"id": "fOBuMNlen4qJdrtUf",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "f6RvvKoBN0DqIjBjQ"
+													},
+													"name": "Nanobot Aerostat",
+													"reference": "UT36",
+													"local_notes": "Air Move 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "11",
+													"disabled": true
+												},
+												{
+													"id": "fcibuACO8n1K8bp1I",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "f1OLvlafFuNITe6na"
+													},
+													"name": "Nanobot Crawler",
+													"reference": "UT36",
+													"local_notes": "Move 3; Water Move 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "11",
+													"disabled": true
+												},
+												{
+													"id": "fjjHdgxkpjYPbhLI_",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fASzj6iYz6hUA-TBB"
+													},
+													"name": "Nanobot Crawler, Armored",
+													"reference": "UT36",
+													"local_notes": "Move 2, 2x HP",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11",
+													"cost": "+100%",
+													"disabled": true
+												},
+												{
+													"id": "fN27nJLukUQaORnwW",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fLuL-pD4o6s0lREJs"
+													},
+													"name": "Nanobot Dust",
+													"reference": "UT36",
+													"local_notes": "Immobile",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11",
+													"cost": "-80%",
+													"disabled": true
+												},
+												{
+													"id": "fWmO1AfBzeVLC4Vwq",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fKeArqcSSvcPk5QTp"
+													},
+													"name": "Nanobot Flier",
+													"reference": "UT36",
+													"local_notes": "Move 1; Air Move 3",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11",
+													"cost": "+100%",
+													"disabled": true
+												},
+												{
+													"id": "fQuJeqZ5Milgrxj-A",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fyATVIBpOaRfq3tKe"
+													},
+													"name": "Nanobot Hopper",
+													"reference": "UT36",
+													"local_notes": "Move 4; Super Jump 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11",
+													"cost": "+50%",
+													"disabled": true
+												},
+												{
+													"id": "fBnziGimO0lSw1JmF",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "f80KO0VZYaEJb9hbs"
+													},
+													"name": "Nanobot Space",
+													"reference": "UT36",
+													"local_notes": "Move 1; 0.0001G solar sail",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "11",
+													"cost": "+0",
+													"disabled": true
+												},
+												{
+													"id": "f5ftloua7iyL9pXjp",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fa36bUxm5RcsG_mOk"
+													},
+													"name": "Nanobot Swimmer",
+													"reference": "UT36",
+													"local_notes": "Water Move 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "11",
+													"cost": "+0",
+													"disabled": true
+												},
+												{
+													"id": "fQ7LrX5U7B6WVERue",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fPgd1Z13foKJXxTND"
+													},
+													"name": "Nanobot Contragrav (CG) Flier",
+													"reference": "UT36",
+													"local_notes": "Move 1; Air Move 10",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11^",
+													"cost": "+200%",
+													"disabled": true
+												}
+											]
+										}
+									]
+								},
+								{
+									"id": "FuieArjZE6vxydv3H",
+									"name": "Stealth",
+									"children": [
+										{
+											"id": "fjboLZKPKv6HEVB8R",
+											"name": "Disguise",
+											"reference": "UT36",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_cost",
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fXyNlb_tz2LEFAZep",
+											"name": "Thermo-Optic Chameleon Surface",
+											"reference": "UT37, UT98",
+											"local_notes": "LC3",
+											"tags": [
+												"Deception and Intrusion",
+												"Swarmbots"
+											],
+											"cost_type": "to_final_cost",
+											"tech_level": "9",
+											"cost": "+4000",
+											"weight": "+4 lb",
+											"disabled": true
+										},
+										{
+											"id": "fV5HtBWQXCcbzMOm0",
+											"name": "Multispectral Chameleon Surface",
+											"reference": "UT37, UT99",
+											"local_notes": "LC3",
+											"tags": [
+												"Deception and Intrusion",
+												"Swarmbots"
+											],
+											"cost_type": "to_final_cost",
+											"tech_level": "10",
+											"cost": "+6000",
+											"weight": "+4 lb",
+											"disabled": true
+										},
+										{
+											"id": "fVvdvD_qrTTJWjLHr",
+											"name": "Dynamic Multispectral Chameleon Surface",
+											"reference": "UT37, UT99",
+											"local_notes": "LC3",
+											"tags": [
+												"Deception and Intrusion",
+												"Swarmbots"
+											],
+											"cost_type": "to_final_cost",
+											"tech_level": "11",
+											"cost": "+8000",
+											"weight": "+4 lb",
+											"disabled": true
+										},
+										{
+											"id": "fKAmQfkHOWfs8YHcS",
+											"name": "Ultimate Chameleon Surface",
+											"reference": "UT37, UT99",
+											"local_notes": "LC3",
+											"tags": [
+												"Deception and Intrusion",
+												"Swarmbots"
+											],
+											"cost_type": "to_final_cost",
+											"tech_level": "12",
+											"cost": "+10000",
+											"weight": "+4 lb",
+											"disabled": true
+										}
+									]
+								},
+								{
+									"id": "FQXaOBoak9USnjbKt",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "F5Q7h4gAuvWsoUiFV"
+									},
+									"name": "Power Supply",
+									"children": [
+										{
+											"id": "fX-kQn_5PKqKcmae4",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "faj6YgnYeEKAy39jw"
+											},
+											"name": "Power Cells",
+											"reference": "UT36",
+											"local_notes": "Recharges in a Hive; C/12hr.",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"disabled": true
+										},
+										{
+											"id": "fPMdEv3g54FYgfPrr",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fCJ9sdOXfXoLN594u"
+											},
+											"name": "Power Cells",
+											"reference": "UT36",
+											"local_notes": "Recharges in a Hive; C/72hr.",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "11"
+										},
+										{
+											"id": "f_ptKHAaOTNo3Kw8x",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f7WMm14XwVJyvz2NQ"
+											},
+											"name": "Power Cells",
+											"reference": "UT36",
+											"local_notes": "Recharges in a Hive; C/5 days.",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "12",
+											"disabled": true
+										},
+										{
+											"id": "feRKPpmwEdxSzTCZQ",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fGv5njL67i7rODIpL"
+											},
+											"name": "Beamed Power",
+											"reference": "UT36",
+											"local_notes": "C cell receiver",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "fDnLiG7CUJ_rRIUy2",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fS-7nLrwLytJp5mLZ"
+											},
+											"name": "Gastrobot",
+											"reference": "UT36",
+											"local_notes": "Consumes 0.1lbs./hr. of biomass",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+100%",
+											"disabled": true
+										},
+										{
+											"id": "fnGX4nWvCicV7Z-uK",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fhT3sMtcrOGbTzLku"
+											},
+											"name": "Radio-Thermal Generator (RTG)",
+											"reference": "UT36",
+											"local_notes": "Lasts 1 year; LC1",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+100%",
+											"disabled": true
+										},
+										{
+											"id": "fsVWqN0BbKfKyZv_7",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "faJkuSBjewuh2TdLg"
+											},
+											"name": "Solar Cell",
+											"reference": "UT36",
+											"local_notes": "Recharges 3 hours' activity in 1 hour",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "fS0GE25exiaL-AS2W",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f2u0xwoaeDxGjxCRq"
+											},
+											"name": "Solar Cell",
+											"reference": "UT36",
+											"local_notes": "Recharges 4 hours' activity in 1 hour",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "fZAGtd7TWFEHmlx7q",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "ff9wLL0l7uzB0IRXf"
+											},
+											"name": "Solar Cell",
+											"reference": "UT36",
+											"local_notes": "Recharges 5 hours' activity in 1 hour",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "12",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "fnr21tY6oGFmvnNDI",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f4SVyLNBYhfPgNZC0"
+											},
+											"name": "Organovore",
+											"reference": "UT36",
+											"local_notes": "Consumes 0.1-0.5 lbs./hr. of carbon-based matter; LC3",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11",
+											"cost": "+200%",
+											"disabled": true
+										},
+										{
+											"id": "f39-e36cwPmQ3r3OZ",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fi-Vh6iRVAbMGaOiO"
+											},
+											"name": "Broadcast Power",
+											"reference": "UT37",
+											"local_notes": "C cell receiver",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11^",
+											"cost": "+100%",
+											"disabled": true
+										}
+									]
+								}
+							],
+							"quantity": 1,
+							"equipped": true,
+							"calc": {
+								"value": 1000,
+								"extended_value": 1000,
+								"weight": "2 lb",
+								"extended_weight": "2 lb"
+							}
+						}
+					],
+					"calc": {
+						"value": 200,
+						"extended_value": 1200,
+						"weight": "10 lb",
+						"extended_weight": "12 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 0,
+				"extended_value": 1200,
+				"weight": "0 lb",
+				"extended_weight": "12 lb"
+			}
+		}
+	]
+}

--- a/Library/Loadouts/Starship Crew/TL11/Planetary Survival.gct
+++ b/Library/Loadouts/Starship Crew/TL11/Planetary Survival.gct
@@ -1,0 +1,347 @@
+{
+	"version": 5,
+	"id": "BFUBfJECdIaWu0VIv",
+	"equipment": [
+		{
+			"id": "EqF6WcmIJ-m4Mlh_T",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Basic Set/Basic Set Equipment.eqp",
+				"id": "ESjtIfyzScVP49ity"
+			},
+			"description": "Backpack, Small",
+			"reference": "B288",
+			"tech_level": "1",
+			"tags": [
+				"Camping and Survival Gear"
+			],
+			"base_value": "60",
+			"base_weight": "3 lb",
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "contained_weight_prereq",
+						"has": true,
+						"qualifier": {
+							"compare": "at_most",
+							"qualifier": "40 lb"
+						}
+					}
+				]
+			},
+			"modifiers": [
+				{
+					"id": "fg1gWV8r24eXkTOoE",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+						"id": "f3AMg_F7eHdJ-u_bX"
+					},
+					"name": "Expensive",
+					"reference": "UT15",
+					"cost_type": "to_base_cost",
+					"weight_type": "to_base_weight",
+					"cost": "+1 CF",
+					"weight": "x2/3"
+				}
+			],
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "ecU6ourVZ_zUDwY2W",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eKHGCFojAFhq-L3PW"
+					},
+					"description": "Envirobag",
+					"reference": "UT75",
+					"local_notes": "C/10 days.",
+					"tech_level": "11",
+					"tags": [
+						"Expedition Gear"
+					],
+					"base_value": "40",
+					"base_weight": "1.5 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 40,
+						"extended_value": 40,
+						"weight": "1.5 lb",
+						"extended_weight": "1.5 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 120,
+				"extended_value": 160,
+				"weight": "2 lb",
+				"extended_weight": "3.5 lb"
+			}
+		},
+		{
+			"id": "eWjzvJilw0pdHQorE",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+				"id": "eYnqYsOiIPeJ4eWhH"
+			},
+			"description": "Filtration Canteen",
+			"reference": "UT75",
+			"local_notes": "3lbs. full.",
+			"tech_level": "9",
+			"tags": [
+				"Expedition Gear"
+			],
+			"base_value": "180",
+			"base_weight": "1 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"value": 180,
+				"extended_value": 180,
+				"weight": "1 lb",
+				"extended_weight": "1 lb"
+			}
+		},
+		{
+			"id": "ej-8p8ovwQivUACPg",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+				"id": "eLTzEWr6_5NZpJldi"
+			},
+			"description": "Smart Piton",
+			"reference": "UT76",
+			"tech_level": "9",
+			"tags": [
+				"Expedition Gear"
+			],
+			"base_value": "10",
+			"base_weight": "0.1 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"value": 10,
+				"extended_value": 10,
+				"weight": "0.1 lb",
+				"extended_weight": "0.1 lb"
+			}
+		},
+		{
+			"id": "eUeHUv7qgmndJ9oKB",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+				"id": "emqqi-fRzDkL2CI2n"
+			},
+			"description": "Bioplas Pressure Tent (for one)",
+			"reference": "UT77",
+			"local_notes": "D/6wk.",
+			"tech_level": "11",
+			"tags": [
+				"Expedition Gear"
+			],
+			"base_value": "3000",
+			"base_weight": "10 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"value": 3000,
+				"extended_value": 3000,
+				"weight": "10 lb",
+				"extended_weight": "10 lb"
+			}
+		},
+		{
+			"id": "e3lmBbumYtqxWMURw",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+				"id": "eZnSkabiAi4plvxxt"
+			},
+			"description": "Morph Axe",
+			"reference": "UT83",
+			"tech_level": "10",
+			"tags": [
+				"Expedition Gear",
+				"Melee Weapon",
+				"Missile Weapon"
+			],
+			"base_value": "500",
+			"base_weight": "2 lb",
+			"weapons": [
+				{
+					"id": "wKLyEV6nT7DEl8-TO",
+					"damage": {
+						"type": "",
+						"st": "sw",
+						"base": "1"
+					},
+					"strength": "8",
+					"usage": "Swung",
+					"reach": "1",
+					"parry": "0",
+					"defaults": [
+						{
+							"type": "dx",
+							"modifier": -5
+						},
+						{
+							"type": "skill",
+							"name": "Axe/Mace"
+						},
+						{
+							"type": "skill",
+							"name": "Flail",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Two-Handed Axe/Mace",
+							"modifier": -3
+						}
+					],
+					"calc": {
+						"damage": "sw+1"
+					}
+				},
+				{
+					"id": "WGb2I0A7mbmQWIszo",
+					"damage": {
+						"type": "",
+						"st": "sw",
+						"base": "1"
+					},
+					"strength": "8",
+					"usage": "Thrown",
+					"accuracy": "1",
+					"range": "x1.5/x2.5",
+					"rate_of_fire": "1",
+					"shots": "T",
+					"bulk": "-2",
+					"defaults": [
+						{
+							"type": "dx",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Thrown Weapon",
+							"specialization": "Axe/Mace"
+						}
+					],
+					"calc": {
+						"damage": "sw+1"
+					}
+				}
+			],
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"value": 500,
+				"extended_value": 500,
+				"weight": "2 lb",
+				"extended_weight": "2 lb"
+			}
+		},
+		{
+			"id": "eCiSK6XGHSz9ZnlB-",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+				"id": "eNEACFkp88ouc3hjG"
+			},
+			"description": "Survival Watch",
+			"reference": "UT77",
+			"local_notes": "B/3mo.",
+			"tech_level": "10",
+			"tags": [
+				"Expedition Gear"
+			],
+			"base_value": "300",
+			"base_weight": "0.5 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"value": 300,
+				"extended_value": 300,
+				"weight": "0.5 lb",
+				"extended_weight": "0.5 lb"
+			}
+		},
+		{
+			"id": "eYltQGeQekmACtewY",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+				"id": "e4GAp7wAVkNfpGv16"
+			},
+			"description": "Gripboots",
+			"reference": "UT75,UT173",
+			"tech_level": "11",
+			"legality_class": "4",
+			"tags": [
+				"Expedition Gear"
+			],
+			"base_value": "500",
+			"base_weight": "2 lb",
+			"features": [
+				{
+					"type": "conditional_modifier",
+					"situation": "Climbing Ice",
+					"amount": 1
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Climbing"
+					},
+					"amount": 1
+				},
+				{
+					"type": "weapon_bonus",
+					"selection_type": "weapons_with_required_skill",
+					"level": {
+						"compare": "at_least"
+					},
+					"usage": {
+						"compare": "is",
+						"qualifier": "Kick"
+					},
+					"amount": 1,
+					"per_die": true
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"foot"
+					],
+					"specialization": "underside of the foot",
+					"amount": 15
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"foot"
+					],
+					"amount": 15
+				}
+			],
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"value": 500,
+				"extended_value": 500,
+				"weight": "2 lb",
+				"extended_weight": "2 lb"
+			}
+		}
+	]
+}

--- a/Library/Loadouts/Starship Crew/TL11/Science Officer.gct
+++ b/Library/Loadouts/Starship Crew/TL11/Science Officer.gct
@@ -1,0 +1,2537 @@
+{
+	"version": 5,
+	"id": "B_WCpWZLne2psx69g",
+	"equipment": [
+		{
+			"id": "etwYV2ma5gxTSwYzV",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+				"id": "eVM7yw2CsJmXIImcZ"
+			},
+			"description": "Sensor Glove (left)",
+			"reference": "UT67",
+			"local_notes": "A/2wk.",
+			"tech_level": "10",
+			"tags": [
+				"Sensors and Scientific Equipment"
+			],
+			"base_value": "1000",
+			"base_weight": "0.2 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"value": 1000,
+				"extended_value": 1000,
+				"weight": "0.2 lb",
+				"extended_weight": "0.2 lb"
+			}
+		},
+		{
+			"id": "e9RlPJlGyFzUpOe9Y",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+				"id": "eq1ZKfCmzSINGjE1u"
+			},
+			"description": "Sensor Glove (right)",
+			"reference": "UT67",
+			"local_notes": "A/2wk.",
+			"tech_level": "10",
+			"tags": [
+				"Sensors and Scientific Equipment"
+			],
+			"base_value": "1000",
+			"base_weight": "0.2 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"value": 1000,
+				"extended_value": 1000,
+				"weight": "0.2 lb",
+				"extended_weight": "0.2 lb"
+			}
+		},
+		{
+			"id": "E_TJvDksiYXPQKPZ-",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Basic Set/Basic Set Equipment.eqp",
+				"id": "ESjtIfyzScVP49ity"
+			},
+			"description": "Backpack, Small",
+			"reference": "B288",
+			"tech_level": "1",
+			"tags": [
+				"Camping and Survival Gear"
+			],
+			"base_value": "60",
+			"base_weight": "3 lb",
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "contained_weight_prereq",
+						"has": true,
+						"qualifier": {
+							"compare": "at_most",
+							"qualifier": "40 lb"
+						}
+					}
+				]
+			},
+			"modifiers": [
+				{
+					"id": "fkHprM-hC2FxVLVAZ",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+						"id": "f3AMg_F7eHdJ-u_bX"
+					},
+					"name": "Expensive",
+					"reference": "UT15",
+					"cost_type": "to_base_cost",
+					"weight_type": "to_base_weight",
+					"cost": "+1 CF",
+					"weight": "x2/3"
+				}
+			],
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "EQCzRixlfkOjinC4W",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "euXn8gma6FZbaGtoF"
+					},
+					"description": "Suitcase Lab (@Scientific Skill@)",
+					"reference": "UT67",
+					"local_notes": "4C/10hr.",
+					"tech_level": "9",
+					"tags": [
+						"Sensors and Scientific Equipment"
+					],
+					"base_value": "3000",
+					"base_weight": "10 lb",
+					"replacements": {
+						"Scientific Skill": "Biology (@Chosen Biology Speciality@)"
+					},
+					"quantity": 1,
+					"equipped": true,
+					"children": [
+						{
+							"id": "elcnkWH9FoHthLQGM",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "euXn8gma6FZbaGtoF"
+							},
+							"description": "Suitcase Lab (@Scientific Skill@)",
+							"reference": "UT67",
+							"local_notes": "4C/10hr.",
+							"tech_level": "9",
+							"tags": [
+								"Sensors and Scientific Equipment"
+							],
+							"base_value": "3000",
+							"base_weight": "10 lb",
+							"replacements": {
+								"Scientific Skill": "Chemistry"
+							},
+							"modifiers": [
+								{
+									"id": "fuNq-pwBKj_0D2UkI",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fte-9FKj95fCsgBZP"
+									},
+									"name": "Combination Gadget cost, one works at a time",
+									"reference": "UT16",
+									"cost_type": "to_final_cost",
+									"cost": "x0.5"
+								},
+								{
+									"id": "ffoaP7tcLeM7gUp2C",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "f8HaZ0LuUFvHUnXtt"
+									},
+									"name": "Combination Gadget weight, one works at a time",
+									"reference": "UT16",
+									"weight_type": "to_final_weight",
+									"cost": "+0",
+									"weight": "x0.5"
+								}
+							],
+							"quantity": 1,
+							"equipped": true,
+							"calc": {
+								"value": 1500,
+								"extended_value": 1500,
+								"weight": "5 lb",
+								"extended_weight": "5 lb"
+							}
+						},
+						{
+							"id": "ewrt7eG8H4aIvk2BK",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "euXn8gma6FZbaGtoF"
+							},
+							"description": "Suitcase Lab (@Scientific Skill@)",
+							"reference": "UT67",
+							"local_notes": "4C/10hr.",
+							"tech_level": "9",
+							"tags": [
+								"Sensors and Scientific Equipment"
+							],
+							"base_value": "3000",
+							"base_weight": "10 lb",
+							"replacements": {
+								"Scientific Skill": "Geology(@Chosen Geology Speciality@)"
+							},
+							"modifiers": [
+								{
+									"id": "fMGdHsaymJnjo-ZUf",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fte-9FKj95fCsgBZP"
+									},
+									"name": "Combination Gadget cost, one works at a time",
+									"reference": "UT16",
+									"cost_type": "to_final_cost",
+									"cost": "x0.5"
+								},
+								{
+									"id": "fKXk5MFeyc_KNYG_R",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "f8HaZ0LuUFvHUnXtt"
+									},
+									"name": "Combination Gadget weight, one works at a time",
+									"reference": "UT16",
+									"weight_type": "to_final_weight",
+									"cost": "+0",
+									"weight": "x0.5"
+								}
+							],
+							"quantity": 1,
+							"equipped": true,
+							"calc": {
+								"value": 1500,
+								"extended_value": 1500,
+								"weight": "5 lb",
+								"extended_weight": "5 lb"
+							}
+						}
+					],
+					"calc": {
+						"value": 3000,
+						"extended_value": 6000,
+						"weight": "10 lb",
+						"extended_weight": "20 lb"
+					}
+				},
+				{
+					"id": "ec2tOR5fA3dNv2hDT",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "ed734PLwmUGjrCUnI"
+					},
+					"description": "Spider Cage",
+					"reference": "UT76",
+					"local_notes": "For SM0",
+					"tech_level": "9",
+					"tags": [
+						"Expedition Gear"
+					],
+					"base_value": "2000",
+					"base_weight": "10 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 2000,
+						"extended_value": 2000,
+						"weight": "10 lb",
+						"extended_weight": "10 lb"
+					}
+				},
+				{
+					"id": "ep6Uvrj5ww99HUn5F",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eRd4HdGkY3padXW2c"
+					},
+					"description": "@Microbot/Nanobot Type@ Swarm",
+					"reference": "UT35",
+					"tech_level": "10",
+					"tags": [
+						"Swarmbots"
+					],
+					"base_weight": "2 lb",
+					"replacements": {
+						"Hazard Type": "Biological",
+						"Hazard Type 2": "Nanotech",
+						"Microbot/Nanobot Type": "Biological \u0026 Nanotech Decontamination"
+					},
+					"modifiers": [
+						{
+							"id": "FSC8IF48vDLcf4Lih",
+							"name": "Swarm Type",
+							"reference": "UT37",
+							"local_notes": "at TL11 microbots can have two types, at TL12 nanobots can have two types",
+							"children": [
+								{
+									"id": "f0bD5g_o9ll9ZU4xQ",
+									"name": "Bughunter",
+									"reference": "UT106",
+									"local_notes": "LC3",
+									"tags": [
+										"Counter-Surveillance and ECM",
+										"Security and Surveillance",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+4000",
+									"disabled": true
+								},
+								{
+									"id": "f2CaPq1-sQYAzRvHs",
+									"name": "Cannibal",
+									"reference": "UT169",
+									"local_notes": "LC1",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "12",
+									"cost": "+15000",
+									"disabled": true
+								},
+								{
+									"id": "f-sBoFtmFeWtedHgi",
+									"name": "Cleaning",
+									"reference": "UT69",
+									"local_notes": "LC4",
+									"tags": [
+										"Domestic Equipment and Appliances",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fXsjof0sSIvXqwSf3",
+									"name": "Construction",
+									"reference": "UT86",
+									"local_notes": "LC4",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fbXx9DvdkewpFLnFE",
+									"name": "Decontamination (@Hazard Type@)",
+									"reference": "UT87",
+									"local_notes": "LC3; Hazardous Materials (@Hazard Type@)-12",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true,
+									"calc": {
+										"resolved_notes": "LC3; Hazardous Materials (Biological)-12"
+									}
+								},
+								{
+									"id": "fgtKP1VwWKoauutIi",
+									"name": "Decontamination (@Hazard Type@)",
+									"reference": "UT87",
+									"local_notes": "LC3; Hazardous Materials (@Hazard Type@)-13",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "11",
+									"cost": "+1000",
+									"calc": {
+										"resolved_notes": "LC3; Hazardous Materials (Biological)-13"
+									}
+								},
+								{
+									"id": "faYKZeOy-Z17FLHJT",
+									"name": "Decontamination (@Hazard Type@)",
+									"reference": "UT87",
+									"local_notes": "LC3; Hazardous Materials (@Hazard Type 2@)-13",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "11",
+									"cost": "+1000",
+									"calc": {
+										"resolved_notes": "LC3; Hazardous Materials (Nanotech)-13"
+									}
+								},
+								{
+									"id": "fDGIFdbR_taY0BNHR",
+									"name": "Decontamination (@Hazard Type@)",
+									"reference": "UT87",
+									"local_notes": "LC3; Hazardous Materials (@Hazard Type@)-14",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "12",
+									"cost": "+1000",
+									"disabled": true,
+									"calc": {
+										"resolved_notes": "LC3; Hazardous Materials (Biological)-14"
+									}
+								},
+								{
+									"id": "fD-WJVjkHbpGiW1EG",
+									"name": "Defoliator",
+									"reference": "UT87",
+									"local_notes": "LC3",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fkdmMgzK1lnefpQmB",
+									"name": "Devourer",
+									"reference": "UT169",
+									"local_notes": "LC1",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "10",
+									"cost": "+8000",
+									"disabled": true
+								},
+								{
+									"id": "f67pmOmsJabaeXUBk",
+									"name": "Disassembler",
+									"reference": "UT169",
+									"local_notes": "LC1",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "11",
+									"cost": "+10000",
+									"disabled": true
+								},
+								{
+									"id": "f8iBi0yObXID0_8-r",
+									"name": "Explorer",
+									"reference": "UT80",
+									"local_notes": "LC4",
+									"tags": [
+										"Expedition Gear",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+500",
+									"disabled": true
+								},
+								{
+									"id": "fX7tO4JySsQ52-WLu",
+									"name": "Firefly",
+									"reference": "UT74",
+									"local_notes": "LC4",
+									"tags": [
+										"Domestic Equipment and Appliances",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+100",
+									"disabled": true
+								},
+								{
+									"id": "fIYRkLNulWAzqqYK7",
+									"name": "Forensic",
+									"reference": "UT107",
+									"local_notes": "LC3",
+									"tags": [
+										"Enforcement and Coercion",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+4000",
+									"disabled": true
+								},
+								{
+									"id": "fP2Fr8Cmi2dzLxBcB",
+									"name": "Gremlin",
+									"reference": "UT169",
+									"local_notes": "LC2",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "10",
+									"cost": "+2000",
+									"disabled": true
+								},
+								{
+									"id": "fdZieqwom7t8qYxo_",
+									"name": "Harvester",
+									"reference": "UT87",
+									"local_notes": "LC4",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+2000",
+									"disabled": true
+								},
+								{
+									"id": "fprNJznfco-PmQsEO",
+									"name": "Massage",
+									"reference": "UT41",
+									"local_notes": "LC4",
+									"tags": [
+										"Robots",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+200",
+									"disabled": true
+								},
+								{
+									"id": "fmBIY0qVFuiupEYhd",
+									"name": "Painter",
+									"reference": "UT87",
+									"local_notes": "LC4",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+500",
+									"disabled": true
+								},
+								{
+									"id": "fjmwfT5hiHkcJ6RQM",
+									"name": "Paramedical",
+									"reference": "UT201",
+									"local_notes": "LC3; Diagnosis-10, First Aid-10",
+									"tags": [
+										"Medical",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+6000",
+									"disabled": true
+								},
+								{
+									"id": "f4Tjs-pt1JjtIZ5A_",
+									"name": "Paramedical",
+									"reference": "UT201",
+									"local_notes": "LC3; Diagnosis-11, First Aid-11",
+									"tags": [
+										"Medical",
+										"Swarmbots"
+									],
+									"tech_level": "11",
+									"cost": "+6000",
+									"disabled": true
+								},
+								{
+									"id": "fsFMN5_kYvhAx4rMQ",
+									"name": "Paramedical",
+									"reference": "UT201",
+									"local_notes": "LC3; Diagnosis-12, First Aid-12",
+									"tags": [
+										"Medical",
+										"Swarmbots"
+									],
+									"tech_level": "12",
+									"cost": "+6000",
+									"disabled": true
+								},
+								{
+									"id": "fDjc9btrgDVMSfdjC",
+									"name": "Pesticide",
+									"reference": "UT87",
+									"local_notes": "LC3",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "f9VxAl8rfHtsBNhIU",
+									"name": "Play",
+									"reference": "UT41",
+									"local_notes": "LC4",
+									"tags": [
+										"Robots",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+200",
+									"disabled": true
+								},
+								{
+									"id": "fjzhIPgOdIizlEd4D",
+									"name": "Pollinator",
+									"reference": "UT87",
+									"local_notes": "LC4",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fqjhCpsjFpIc-Ez83",
+									"name": "Repair (@Equipment@)",
+									"reference": "UT87",
+									"local_notes": "LC4; Repair Skill-12",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+500",
+									"disabled": true
+								},
+								{
+									"id": "fRQnSOPvK-qkQQG_1",
+									"name": "Repair (@Equipment@)",
+									"reference": "UT87",
+									"local_notes": "LC4; Repair Skill-13",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "11",
+									"cost": "+500",
+									"disabled": true
+								},
+								{
+									"id": "fh2zR-Pl38xcOMHxC",
+									"name": "Repair (@Other Equipment 1@)",
+									"reference": "UT87",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+250",
+									"disabled": true
+								},
+								{
+									"id": "fUtIoHxcxIpIIiJCn",
+									"name": "Repair (@Other Equipment 2@)",
+									"reference": "UT87",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+250",
+									"disabled": true
+								},
+								{
+									"id": "fQ7DBnw4iJO9uK7Sd",
+									"name": "Repair (@Other Equipment 3@)",
+									"reference": "UT87",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+250",
+									"disabled": true
+								},
+								{
+									"id": "f1dxjLlccOLvi_M1p",
+									"name": "Security",
+									"reference": "UT104",
+									"local_notes": "LC3",
+									"tags": [
+										"Security and Surveillance",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "f4G7leiYau1z5dzhg",
+									"name": "Sentry",
+									"reference": "UT169",
+									"local_notes": "LC3",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "10",
+									"cost": "+5000",
+									"disabled": true
+								},
+								{
+									"id": "fHF1uob1ZSG0INjmP",
+									"name": "Stinger",
+									"reference": "UT169",
+									"local_notes": "LC2",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "10",
+									"cost": "+1500",
+									"disabled": true
+								},
+								{
+									"id": "fK5BjG9jiV0fgr0I-",
+									"name": "Surveillance",
+									"reference": "UT106",
+									"local_notes": "LC3",
+									"tags": [
+										"Security and Surveillance",
+										"Surveillance and Tracking Devices",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+500",
+									"disabled": true
+								},
+								{
+									"id": "f5-SD2GLzRPD7H0zt",
+									"name": "Terminator",
+									"reference": "UT169",
+									"local_notes": "LC1",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "10",
+									"cost": "+1500",
+									"disabled": true
+								}
+							]
+						},
+						{
+							"id": "f_3SVHM2fBs5e-SK2",
+							"name": "Self-Replicating",
+							"reference": "UT37",
+							"local_notes": "only for defoliator, devourer or pesticide",
+							"tags": [
+								"Swarmbots"
+							],
+							"cost_type": "to_base_cost",
+							"cost": "x10",
+							"disabled": true
+						},
+						{
+							"id": "FiFRrQFWDckBWOYBd",
+							"name": "Chassis",
+							"local_notes": "choose one microbot or nanobot chassis",
+							"children": [
+								{
+									"id": "FxMmJLkU6L2hDyz5x",
+									"name": "Microbot Chassis",
+									"children": [
+										{
+											"id": "foNnPhFwzqAKnpE9u",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f7eMKwMF7BTYFbxhq"
+											},
+											"name": "Microbot Aerostat",
+											"reference": "UT36",
+											"local_notes": "Air Move 2",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"disabled": true
+										},
+										{
+											"id": "f4_Ew6w5nIi2E3ilx",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fcVKEB14BedQI1jGA"
+											},
+											"name": "Microbot Crawler",
+											"reference": "UT36",
+											"local_notes": "Move 3; Water Move 1",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "10"
+										},
+										{
+											"id": "fkFKjTaq3mgD-tg-m",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fScgdTYLwKE9CEYfl"
+											},
+											"name": "Microbot Crawler, Armored",
+											"reference": "UT36",
+											"local_notes": "Move 2, 2x HP",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+100%",
+											"disabled": true
+										},
+										{
+											"id": "fkvfLrnswMmk9tB-W",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fpAVv9yE3m3t0Egt_"
+											},
+											"name": "Microbot Flier",
+											"reference": "UT36",
+											"local_notes": "Move 1; Air Move 6",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+100%",
+											"disabled": true
+										},
+										{
+											"id": "fe1Ijh1N4jsTe9G2i",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "ffHj2SBngzuewdrbB"
+											},
+											"name": "Microbot Hopper",
+											"reference": "UT36",
+											"local_notes": "Move 4; Super Jump 1",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "fynFVer1aG8SmX3-g",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fr6wQjKaUic-BpBCO"
+											},
+											"name": "Microbot Space",
+											"reference": "UT36",
+											"local_notes": "Move 1; 0.0001G solar sail",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+0",
+											"disabled": true
+										},
+										{
+											"id": "fKaSHc1p8F8suEy6G",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fsL5rGqz66ht8cVvg"
+											},
+											"name": "Microbot Swimmer",
+											"reference": "UT36",
+											"local_notes": "Water Move 4",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+0",
+											"disabled": true
+										},
+										{
+											"id": "fA_pNDWQXfKDYRuDe",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fvVo7_8gzuQpK50fc"
+											},
+											"name": "Microbot Contragrav (CG) Flier",
+											"reference": "UT36",
+											"local_notes": "Move 1; Air Move 20",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11^",
+											"cost": "+200%",
+											"disabled": true
+										}
+									]
+								},
+								{
+									"id": "FpZ05qeOr5CyJ6aTJ",
+									"name": "Nanobot Chassis",
+									"children": [
+										{
+											"id": "fp_2LVPW5yNG6iFk_",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f6RvvKoBN0DqIjBjQ"
+											},
+											"name": "Nanobot Aerostat",
+											"reference": "UT36",
+											"local_notes": "Air Move 1",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "11",
+											"disabled": true
+										},
+										{
+											"id": "fbnLQUPr_wRmSzaqC",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f1OLvlafFuNITe6na"
+											},
+											"name": "Nanobot Crawler",
+											"reference": "UT36",
+											"local_notes": "Move 3; Water Move 1",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "11",
+											"disabled": true
+										},
+										{
+											"id": "fQPWQ1iJhy1UIQ9XW",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fASzj6iYz6hUA-TBB"
+											},
+											"name": "Nanobot Crawler, Armored",
+											"reference": "UT36",
+											"local_notes": "Move 2, 2x HP",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11",
+											"cost": "+100%",
+											"disabled": true
+										},
+										{
+											"id": "f6xxedb0eRhSaxlcW",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fLuL-pD4o6s0lREJs"
+											},
+											"name": "Nanobot Dust",
+											"reference": "UT36",
+											"local_notes": "Immobile",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11",
+											"cost": "-80%",
+											"disabled": true
+										},
+										{
+											"id": "fG0Cw1J8vSNns7N1E",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fKeArqcSSvcPk5QTp"
+											},
+											"name": "Nanobot Flier",
+											"reference": "UT36",
+											"local_notes": "Move 1; Air Move 3",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11",
+											"cost": "+100%",
+											"disabled": true
+										},
+										{
+											"id": "fbmjOqrTm7bSPhPeT",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fyATVIBpOaRfq3tKe"
+											},
+											"name": "Nanobot Hopper",
+											"reference": "UT36",
+											"local_notes": "Move 4; Super Jump 1",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "fk_Qvw6_-ohy6AvET",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f80KO0VZYaEJb9hbs"
+											},
+											"name": "Nanobot Space",
+											"reference": "UT36",
+											"local_notes": "Move 1; 0.0001G solar sail",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "11",
+											"cost": "+0",
+											"disabled": true
+										},
+										{
+											"id": "fpgRuRQC92aKUAYY9",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fa36bUxm5RcsG_mOk"
+											},
+											"name": "Nanobot Swimmer",
+											"reference": "UT36",
+											"local_notes": "Water Move 1",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "11",
+											"cost": "+0",
+											"disabled": true
+										},
+										{
+											"id": "fzA0KEdNAi10xyv7b",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fPgd1Z13foKJXxTND"
+											},
+											"name": "Nanobot Contragrav (CG) Flier",
+											"reference": "UT36",
+											"local_notes": "Move 1; Air Move 10",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11^",
+											"cost": "+200%",
+											"disabled": true
+										}
+									]
+								}
+							]
+						},
+						{
+							"id": "FWhstaDMhfX2finy2",
+							"name": "Stealth",
+							"children": [
+								{
+									"id": "fiF_fKiDEIMe5D7Ed",
+									"name": "Disguise",
+									"reference": "UT36",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_cost",
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fU9KBOVMl0ycwW7U5",
+									"name": "Thermo-Optic Chameleon Surface",
+									"reference": "UT37, UT98",
+									"local_notes": "LC3",
+									"tags": [
+										"Deception and Intrusion",
+										"Swarmbots"
+									],
+									"cost_type": "to_final_cost",
+									"tech_level": "9",
+									"cost": "+4000",
+									"weight": "+4 lb",
+									"disabled": true
+								},
+								{
+									"id": "fOssg9YwWntAVELl3",
+									"name": "Multispectral Chameleon Surface",
+									"reference": "UT37, UT99",
+									"local_notes": "LC3",
+									"tags": [
+										"Deception and Intrusion",
+										"Swarmbots"
+									],
+									"cost_type": "to_final_cost",
+									"tech_level": "10",
+									"cost": "+6000",
+									"weight": "+4 lb",
+									"disabled": true
+								},
+								{
+									"id": "fvVE6-z3R0wWn1ZTf",
+									"name": "Dynamic Multispectral Chameleon Surface",
+									"reference": "UT37, UT99",
+									"local_notes": "LC3",
+									"tags": [
+										"Deception and Intrusion",
+										"Swarmbots"
+									],
+									"cost_type": "to_final_cost",
+									"tech_level": "11",
+									"cost": "+8000",
+									"weight": "+4 lb",
+									"disabled": true
+								},
+								{
+									"id": "f1oK_VCH-h0_X64i0",
+									"name": "Ultimate Chameleon Surface",
+									"reference": "UT37, UT99",
+									"local_notes": "LC3",
+									"tags": [
+										"Deception and Intrusion",
+										"Swarmbots"
+									],
+									"cost_type": "to_final_cost",
+									"tech_level": "12",
+									"cost": "+10000",
+									"weight": "+4 lb",
+									"disabled": true
+								}
+							]
+						},
+						{
+							"id": "FVFV9rNrxLZKZdE93",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+								"id": "F5Q7h4gAuvWsoUiFV"
+							},
+							"name": "Power Supply",
+							"children": [
+								{
+									"id": "fBslQt0IqTdLFB2uE",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "faj6YgnYeEKAy39jw"
+									},
+									"name": "Power Cells",
+									"reference": "UT36",
+									"local_notes": "Recharges in a Hive; C/12hr.",
+									"tags": [
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"disabled": true
+								},
+								{
+									"id": "fHgYpOB4mgUP7yRl8",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fCJ9sdOXfXoLN594u"
+									},
+									"name": "Power Cells",
+									"reference": "UT36",
+									"local_notes": "Recharges in a Hive; C/72hr.",
+									"tags": [
+										"Swarmbots"
+									],
+									"tech_level": "11"
+								},
+								{
+									"id": "fVnJ0h63p3h163G6h",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "f7WMm14XwVJyvz2NQ"
+									},
+									"name": "Power Cells",
+									"reference": "UT36",
+									"local_notes": "Recharges in a Hive; C/5 days.",
+									"tags": [
+										"Swarmbots"
+									],
+									"tech_level": "12",
+									"disabled": true
+								},
+								{
+									"id": "fE_rm1wdl-9OlTgey",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fGv5njL67i7rODIpL"
+									},
+									"name": "Beamed Power",
+									"reference": "UT36",
+									"local_notes": "C cell receiver",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "10",
+									"cost": "+50%",
+									"disabled": true
+								},
+								{
+									"id": "f3QVservZm6Xi0FQu",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fS-7nLrwLytJp5mLZ"
+									},
+									"name": "Gastrobot",
+									"reference": "UT36",
+									"local_notes": "Consumes 0.1lbs./hr. of biomass",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "10",
+									"cost": "+100%",
+									"disabled": true
+								},
+								{
+									"id": "fBfMDyJolEXlbCeOt",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fhT3sMtcrOGbTzLku"
+									},
+									"name": "Radio-Thermal Generator (RTG)",
+									"reference": "UT36",
+									"local_notes": "Lasts 1 year; LC1",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "10",
+									"cost": "+100%",
+									"disabled": true
+								},
+								{
+									"id": "fAkGeyk35jIhOSm7e",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "faJkuSBjewuh2TdLg"
+									},
+									"name": "Solar Cell",
+									"reference": "UT36",
+									"local_notes": "Recharges 3 hours' activity in 1 hour",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "10",
+									"cost": "+50%",
+									"disabled": true
+								},
+								{
+									"id": "fUx60b1jawFvNKmSV",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "f2u0xwoaeDxGjxCRq"
+									},
+									"name": "Solar Cell",
+									"reference": "UT36",
+									"local_notes": "Recharges 4 hours' activity in 1 hour",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "11",
+									"cost": "+50%",
+									"disabled": true
+								},
+								{
+									"id": "fAHMrlUS3-dThbKHr",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "ff9wLL0l7uzB0IRXf"
+									},
+									"name": "Solar Cell",
+									"reference": "UT36",
+									"local_notes": "Recharges 5 hours' activity in 1 hour",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "12",
+									"cost": "+50%",
+									"disabled": true
+								},
+								{
+									"id": "fhHGElHOqkHV7QTFC",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "f4SVyLNBYhfPgNZC0"
+									},
+									"name": "Organovore",
+									"reference": "UT36",
+									"local_notes": "Consumes 0.1-0.5 lbs./hr. of carbon-based matter; LC3",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "11",
+									"cost": "+200%",
+									"disabled": true
+								},
+								{
+									"id": "fmCNlxUvgBBO02Bfi",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fi-Vh6iRVAbMGaOiO"
+									},
+									"name": "Broadcast Power",
+									"reference": "UT37",
+									"local_notes": "C cell receiver",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "11^",
+									"cost": "+100%",
+									"disabled": true
+								}
+							]
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 2000,
+						"extended_value": 2000,
+						"weight": "2 lb",
+						"extended_weight": "2 lb"
+					}
+				},
+				{
+					"id": "eikyuCGfy8kBaI-PS",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eRd4HdGkY3padXW2c"
+					},
+					"description": "@Microbot/Nanobot Type@ Swarm",
+					"reference": "UT35",
+					"tech_level": "10",
+					"tags": [
+						"Swarmbots"
+					],
+					"base_weight": "2 lb",
+					"replacements": {
+						"Hazard Type": "Chemical",
+						"Hazard Type 2": "Radioactive",
+						"Microbot/Nanobot Type": "Chemical \u0026 Radioactive Decontamination"
+					},
+					"modifiers": [
+						{
+							"id": "FAVpGBLkKj5AdeNbu",
+							"name": "Swarm Type",
+							"reference": "UT37",
+							"local_notes": "at TL11 microbots can have two types, at TL12 nanobots can have two types",
+							"children": [
+								{
+									"id": "fEwLBIe3pWtGNaZlX",
+									"name": "Bughunter",
+									"reference": "UT106",
+									"local_notes": "LC3",
+									"tags": [
+										"Counter-Surveillance and ECM",
+										"Security and Surveillance",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+4000",
+									"disabled": true
+								},
+								{
+									"id": "fEWfDcAZs9TMb5_H4",
+									"name": "Cannibal",
+									"reference": "UT169",
+									"local_notes": "LC1",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "12",
+									"cost": "+15000",
+									"disabled": true
+								},
+								{
+									"id": "fEDntCbHFv8IrPRig",
+									"name": "Cleaning",
+									"reference": "UT69",
+									"local_notes": "LC4",
+									"tags": [
+										"Domestic Equipment and Appliances",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fACiEoRWkEsAmtQVJ",
+									"name": "Construction",
+									"reference": "UT86",
+									"local_notes": "LC4",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fQGcGZbq4ijdDTzEz",
+									"name": "Decontamination (@Hazard Type@)",
+									"reference": "UT87",
+									"local_notes": "LC3; Hazardous Materials (@Hazard Type@)-12",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true,
+									"calc": {
+										"resolved_notes": "LC3; Hazardous Materials (Chemical)-12"
+									}
+								},
+								{
+									"id": "ftBFHe-Ba_co_c6B6",
+									"name": "Decontamination (@Hazard Type@)",
+									"reference": "UT87",
+									"local_notes": "LC3; Hazardous Materials (@Hazard Type@)-13",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "11",
+									"cost": "+1000",
+									"calc": {
+										"resolved_notes": "LC3; Hazardous Materials (Chemical)-13"
+									}
+								},
+								{
+									"id": "fMuVukAmM4oXl5F1y",
+									"name": "Decontamination (@Hazard Type@)",
+									"reference": "UT87",
+									"local_notes": "LC3; Hazardous Materials (@Hazard Type 2@)-13",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "11",
+									"cost": "+1000",
+									"calc": {
+										"resolved_notes": "LC3; Hazardous Materials (Radioactive)-13"
+									}
+								},
+								{
+									"id": "fkd-1ONyFe6eut_Aj",
+									"name": "Decontamination (@Hazard Type@)",
+									"reference": "UT87",
+									"local_notes": "LC3; Hazardous Materials (@Hazard Type@)-14",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "12",
+									"cost": "+1000",
+									"disabled": true,
+									"calc": {
+										"resolved_notes": "LC3; Hazardous Materials (Chemical)-14"
+									}
+								},
+								{
+									"id": "fzW37sbv3sbLO0C-B",
+									"name": "Defoliator",
+									"reference": "UT87",
+									"local_notes": "LC3",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fCHsGsbfzRS6N2oro",
+									"name": "Devourer",
+									"reference": "UT169",
+									"local_notes": "LC1",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "10",
+									"cost": "+8000",
+									"disabled": true
+								},
+								{
+									"id": "fEcNp-6ErPcU6f9PI",
+									"name": "Disassembler",
+									"reference": "UT169",
+									"local_notes": "LC1",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "11",
+									"cost": "+10000",
+									"disabled": true
+								},
+								{
+									"id": "ftGxh3i-z0umPtqJH",
+									"name": "Explorer",
+									"reference": "UT80",
+									"local_notes": "LC4",
+									"tags": [
+										"Expedition Gear",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+500",
+									"disabled": true
+								},
+								{
+									"id": "fOdRoIzPBLrh5ABFJ",
+									"name": "Firefly",
+									"reference": "UT74",
+									"local_notes": "LC4",
+									"tags": [
+										"Domestic Equipment and Appliances",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+100",
+									"disabled": true
+								},
+								{
+									"id": "fW5wXtOcYJFoJiVki",
+									"name": "Forensic",
+									"reference": "UT107",
+									"local_notes": "LC3",
+									"tags": [
+										"Enforcement and Coercion",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+4000",
+									"disabled": true
+								},
+								{
+									"id": "fikf1kfSopVWVn_tJ",
+									"name": "Gremlin",
+									"reference": "UT169",
+									"local_notes": "LC2",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "10",
+									"cost": "+2000",
+									"disabled": true
+								},
+								{
+									"id": "f10wY7UHHjtpXrIzq",
+									"name": "Harvester",
+									"reference": "UT87",
+									"local_notes": "LC4",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+2000",
+									"disabled": true
+								},
+								{
+									"id": "fIPYIgolM4Q6zbDOM",
+									"name": "Massage",
+									"reference": "UT41",
+									"local_notes": "LC4",
+									"tags": [
+										"Robots",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+200",
+									"disabled": true
+								},
+								{
+									"id": "fb-Jv8RaV_vRKoUeX",
+									"name": "Painter",
+									"reference": "UT87",
+									"local_notes": "LC4",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+500",
+									"disabled": true
+								},
+								{
+									"id": "fFrO541fwgpsH6kLl",
+									"name": "Paramedical",
+									"reference": "UT201",
+									"local_notes": "LC3; Diagnosis-10, First Aid-10",
+									"tags": [
+										"Medical",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+6000",
+									"disabled": true
+								},
+								{
+									"id": "f6ZJUqKU4vvBoGQ27",
+									"name": "Paramedical",
+									"reference": "UT201",
+									"local_notes": "LC3; Diagnosis-11, First Aid-11",
+									"tags": [
+										"Medical",
+										"Swarmbots"
+									],
+									"tech_level": "11",
+									"cost": "+6000",
+									"disabled": true
+								},
+								{
+									"id": "ftge_oVxZ1cQEpzol",
+									"name": "Paramedical",
+									"reference": "UT201",
+									"local_notes": "LC3; Diagnosis-12, First Aid-12",
+									"tags": [
+										"Medical",
+										"Swarmbots"
+									],
+									"tech_level": "12",
+									"cost": "+6000",
+									"disabled": true
+								},
+								{
+									"id": "fAiAZDbaEMyPwRTP8",
+									"name": "Pesticide",
+									"reference": "UT87",
+									"local_notes": "LC3",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "f216niesrog4CEdbF",
+									"name": "Play",
+									"reference": "UT41",
+									"local_notes": "LC4",
+									"tags": [
+										"Robots",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+200",
+									"disabled": true
+								},
+								{
+									"id": "fgLRAW7KiVEWxMCGj",
+									"name": "Pollinator",
+									"reference": "UT87",
+									"local_notes": "LC4",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fbmodOQKT_Q5KoExB",
+									"name": "Repair (@Equipment@)",
+									"reference": "UT87",
+									"local_notes": "LC4; Repair Skill-12",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+500",
+									"disabled": true
+								},
+								{
+									"id": "fcz-ZJ2OL2fkgkVeB",
+									"name": "Repair (@Equipment@)",
+									"reference": "UT87",
+									"local_notes": "LC4; Repair Skill-13",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "11",
+									"cost": "+500",
+									"disabled": true
+								},
+								{
+									"id": "f_IZF1Zm-6RjTrtET",
+									"name": "Repair (@Other Equipment 1@)",
+									"reference": "UT87",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+250",
+									"disabled": true
+								},
+								{
+									"id": "fsckcwL9EGJSZYa4w",
+									"name": "Repair (@Other Equipment 2@)",
+									"reference": "UT87",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+250",
+									"disabled": true
+								},
+								{
+									"id": "fSAqbuPzf3tHNAyZa",
+									"name": "Repair (@Other Equipment 3@)",
+									"reference": "UT87",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+250",
+									"disabled": true
+								},
+								{
+									"id": "fQ_aFBTx2i2WKmGkK",
+									"name": "Security",
+									"reference": "UT104",
+									"local_notes": "LC3",
+									"tags": [
+										"Security and Surveillance",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "ffix4tKT3UWpFNMDZ",
+									"name": "Sentry",
+									"reference": "UT169",
+									"local_notes": "LC3",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "10",
+									"cost": "+5000",
+									"disabled": true
+								},
+								{
+									"id": "f3Hn-fGhkQHvQehMM",
+									"name": "Stinger",
+									"reference": "UT169",
+									"local_notes": "LC2",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "10",
+									"cost": "+1500",
+									"disabled": true
+								},
+								{
+									"id": "fi7C-f-OJkcpIUteS",
+									"name": "Surveillance",
+									"reference": "UT106",
+									"local_notes": "LC3",
+									"tags": [
+										"Security and Surveillance",
+										"Surveillance and Tracking Devices",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+500",
+									"disabled": true
+								},
+								{
+									"id": "f2NKA0K0WbfF8aArI",
+									"name": "Terminator",
+									"reference": "UT169",
+									"local_notes": "LC1",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "10",
+									"cost": "+1500",
+									"disabled": true
+								}
+							]
+						},
+						{
+							"id": "fEUuPNrqXArgIE8kU",
+							"name": "Self-Replicating",
+							"reference": "UT37",
+							"local_notes": "only for defoliator, devourer or pesticide",
+							"tags": [
+								"Swarmbots"
+							],
+							"cost_type": "to_base_cost",
+							"cost": "x10",
+							"disabled": true
+						},
+						{
+							"id": "FoImPKtf5wCthP8UJ",
+							"name": "Chassis",
+							"local_notes": "choose one microbot or nanobot chassis",
+							"children": [
+								{
+									"id": "Fe0kD1Xf1zijpV5PO",
+									"name": "Microbot Chassis",
+									"children": [
+										{
+											"id": "fnI_rDlnz-rVwda88",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f7eMKwMF7BTYFbxhq"
+											},
+											"name": "Microbot Aerostat",
+											"reference": "UT36",
+											"local_notes": "Air Move 2",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"disabled": true
+										},
+										{
+											"id": "fZVJBemY4yUJe7Yl4",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fcVKEB14BedQI1jGA"
+											},
+											"name": "Microbot Crawler",
+											"reference": "UT36",
+											"local_notes": "Move 3; Water Move 1",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "10"
+										},
+										{
+											"id": "fCNOIQsN3b4iZ1uL4",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fScgdTYLwKE9CEYfl"
+											},
+											"name": "Microbot Crawler, Armored",
+											"reference": "UT36",
+											"local_notes": "Move 2, 2x HP",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+100%",
+											"disabled": true
+										},
+										{
+											"id": "f5zg41RzB2ZppYtnD",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fpAVv9yE3m3t0Egt_"
+											},
+											"name": "Microbot Flier",
+											"reference": "UT36",
+											"local_notes": "Move 1; Air Move 6",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+100%",
+											"disabled": true
+										},
+										{
+											"id": "fagXajIoszmMlhjS4",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "ffHj2SBngzuewdrbB"
+											},
+											"name": "Microbot Hopper",
+											"reference": "UT36",
+											"local_notes": "Move 4; Super Jump 1",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "fWHURE6qQ9UQankbg",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fr6wQjKaUic-BpBCO"
+											},
+											"name": "Microbot Space",
+											"reference": "UT36",
+											"local_notes": "Move 1; 0.0001G solar sail",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+0",
+											"disabled": true
+										},
+										{
+											"id": "fi6SxZWY3lIbd1q-e",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fsL5rGqz66ht8cVvg"
+											},
+											"name": "Microbot Swimmer",
+											"reference": "UT36",
+											"local_notes": "Water Move 4",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+0",
+											"disabled": true
+										},
+										{
+											"id": "fr_xqTN6t044AxHIg",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fvVo7_8gzuQpK50fc"
+											},
+											"name": "Microbot Contragrav (CG) Flier",
+											"reference": "UT36",
+											"local_notes": "Move 1; Air Move 20",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11^",
+											"cost": "+200%",
+											"disabled": true
+										}
+									]
+								},
+								{
+									"id": "FXqI2WG7c6jmwbV7d",
+									"name": "Nanobot Chassis",
+									"children": [
+										{
+											"id": "flugI6UK3F12uVVZp",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f6RvvKoBN0DqIjBjQ"
+											},
+											"name": "Nanobot Aerostat",
+											"reference": "UT36",
+											"local_notes": "Air Move 1",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "11",
+											"disabled": true
+										},
+										{
+											"id": "f848DlKe6c-FjRInG",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f1OLvlafFuNITe6na"
+											},
+											"name": "Nanobot Crawler",
+											"reference": "UT36",
+											"local_notes": "Move 3; Water Move 1",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "11",
+											"disabled": true
+										},
+										{
+											"id": "f7W94EJlId_ef73nb",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fASzj6iYz6hUA-TBB"
+											},
+											"name": "Nanobot Crawler, Armored",
+											"reference": "UT36",
+											"local_notes": "Move 2, 2x HP",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11",
+											"cost": "+100%",
+											"disabled": true
+										},
+										{
+											"id": "fRcbnCDenSfTqj1oW",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fLuL-pD4o6s0lREJs"
+											},
+											"name": "Nanobot Dust",
+											"reference": "UT36",
+											"local_notes": "Immobile",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11",
+											"cost": "-80%",
+											"disabled": true
+										},
+										{
+											"id": "fzDJB2KCQve_3jxOd",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fKeArqcSSvcPk5QTp"
+											},
+											"name": "Nanobot Flier",
+											"reference": "UT36",
+											"local_notes": "Move 1; Air Move 3",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11",
+											"cost": "+100%",
+											"disabled": true
+										},
+										{
+											"id": "fqZRbZazWZopPRz31",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fyATVIBpOaRfq3tKe"
+											},
+											"name": "Nanobot Hopper",
+											"reference": "UT36",
+											"local_notes": "Move 4; Super Jump 1",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "fMuKtWkoyv8Is-Y0E",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f80KO0VZYaEJb9hbs"
+											},
+											"name": "Nanobot Space",
+											"reference": "UT36",
+											"local_notes": "Move 1; 0.0001G solar sail",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "11",
+											"cost": "+0",
+											"disabled": true
+										},
+										{
+											"id": "fs9HZmdeYOclkDmSq",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fa36bUxm5RcsG_mOk"
+											},
+											"name": "Nanobot Swimmer",
+											"reference": "UT36",
+											"local_notes": "Water Move 1",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "11",
+											"cost": "+0",
+											"disabled": true
+										},
+										{
+											"id": "fjtnD4X_61fTIdJ51",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fPgd1Z13foKJXxTND"
+											},
+											"name": "Nanobot Contragrav (CG) Flier",
+											"reference": "UT36",
+											"local_notes": "Move 1; Air Move 10",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11^",
+											"cost": "+200%",
+											"disabled": true
+										}
+									]
+								}
+							]
+						},
+						{
+							"id": "Fe6xbUbHfBKBe82WY",
+							"name": "Stealth",
+							"children": [
+								{
+									"id": "fO12B742cPUVVQRyf",
+									"name": "Disguise",
+									"reference": "UT36",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_cost",
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fRu9doG7VqjaEkTGG",
+									"name": "Thermo-Optic Chameleon Surface",
+									"reference": "UT37, UT98",
+									"local_notes": "LC3",
+									"tags": [
+										"Deception and Intrusion",
+										"Swarmbots"
+									],
+									"cost_type": "to_final_cost",
+									"tech_level": "9",
+									"cost": "+4000",
+									"weight": "+4 lb",
+									"disabled": true
+								},
+								{
+									"id": "fyBoOHfUipXGm8o6r",
+									"name": "Multispectral Chameleon Surface",
+									"reference": "UT37, UT99",
+									"local_notes": "LC3",
+									"tags": [
+										"Deception and Intrusion",
+										"Swarmbots"
+									],
+									"cost_type": "to_final_cost",
+									"tech_level": "10",
+									"cost": "+6000",
+									"weight": "+4 lb",
+									"disabled": true
+								},
+								{
+									"id": "fc3oFGc_K_J8NchJa",
+									"name": "Dynamic Multispectral Chameleon Surface",
+									"reference": "UT37, UT99",
+									"local_notes": "LC3",
+									"tags": [
+										"Deception and Intrusion",
+										"Swarmbots"
+									],
+									"cost_type": "to_final_cost",
+									"tech_level": "11",
+									"cost": "+8000",
+									"weight": "+4 lb",
+									"disabled": true
+								},
+								{
+									"id": "fD1qsGfxwXJ6rZeGP",
+									"name": "Ultimate Chameleon Surface",
+									"reference": "UT37, UT99",
+									"local_notes": "LC3",
+									"tags": [
+										"Deception and Intrusion",
+										"Swarmbots"
+									],
+									"cost_type": "to_final_cost",
+									"tech_level": "12",
+									"cost": "+10000",
+									"weight": "+4 lb",
+									"disabled": true
+								}
+							]
+						},
+						{
+							"id": "FzJAVsO8o8emivZ39",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+								"id": "F5Q7h4gAuvWsoUiFV"
+							},
+							"name": "Power Supply",
+							"children": [
+								{
+									"id": "fN-_CnkghIEa9Z94F",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "faj6YgnYeEKAy39jw"
+									},
+									"name": "Power Cells",
+									"reference": "UT36",
+									"local_notes": "Recharges in a Hive; C/12hr.",
+									"tags": [
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"disabled": true
+								},
+								{
+									"id": "fS7vRtRJNh2KdsXfJ",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fCJ9sdOXfXoLN594u"
+									},
+									"name": "Power Cells",
+									"reference": "UT36",
+									"local_notes": "Recharges in a Hive; C/72hr.",
+									"tags": [
+										"Swarmbots"
+									],
+									"tech_level": "11"
+								},
+								{
+									"id": "fWvntv1liurWFi7uF",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "f7WMm14XwVJyvz2NQ"
+									},
+									"name": "Power Cells",
+									"reference": "UT36",
+									"local_notes": "Recharges in a Hive; C/5 days.",
+									"tags": [
+										"Swarmbots"
+									],
+									"tech_level": "12",
+									"disabled": true
+								},
+								{
+									"id": "fa6c0BUB3cUVDUfrX",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fGv5njL67i7rODIpL"
+									},
+									"name": "Beamed Power",
+									"reference": "UT36",
+									"local_notes": "C cell receiver",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "10",
+									"cost": "+50%",
+									"disabled": true
+								},
+								{
+									"id": "fNmHMY8lGofENNZ3c",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fS-7nLrwLytJp5mLZ"
+									},
+									"name": "Gastrobot",
+									"reference": "UT36",
+									"local_notes": "Consumes 0.1lbs./hr. of biomass",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "10",
+									"cost": "+100%",
+									"disabled": true
+								},
+								{
+									"id": "f1ACeBIwr6L7DUtYg",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fhT3sMtcrOGbTzLku"
+									},
+									"name": "Radio-Thermal Generator (RTG)",
+									"reference": "UT36",
+									"local_notes": "Lasts 1 year; LC1",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "10",
+									"cost": "+100%",
+									"disabled": true
+								},
+								{
+									"id": "fIsAR9tdm1f00hNK3",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "faJkuSBjewuh2TdLg"
+									},
+									"name": "Solar Cell",
+									"reference": "UT36",
+									"local_notes": "Recharges 3 hours' activity in 1 hour",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "10",
+									"cost": "+50%",
+									"disabled": true
+								},
+								{
+									"id": "fNDcctxHe6dMh6MJm",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "f2u0xwoaeDxGjxCRq"
+									},
+									"name": "Solar Cell",
+									"reference": "UT36",
+									"local_notes": "Recharges 4 hours' activity in 1 hour",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "11",
+									"cost": "+50%",
+									"disabled": true
+								},
+								{
+									"id": "fE4vjmhyzdt3D1vDG",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "ff9wLL0l7uzB0IRXf"
+									},
+									"name": "Solar Cell",
+									"reference": "UT36",
+									"local_notes": "Recharges 5 hours' activity in 1 hour",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "12",
+									"cost": "+50%",
+									"disabled": true
+								},
+								{
+									"id": "f_C-xe5wz3JWjtZeM",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "f4SVyLNBYhfPgNZC0"
+									},
+									"name": "Organovore",
+									"reference": "UT36",
+									"local_notes": "Consumes 0.1-0.5 lbs./hr. of carbon-based matter; LC3",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "11",
+									"cost": "+200%",
+									"disabled": true
+								},
+								{
+									"id": "fq6_FQfUcIaOsZX98",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fi-Vh6iRVAbMGaOiO"
+									},
+									"name": "Broadcast Power",
+									"reference": "UT37",
+									"local_notes": "C cell receiver",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "11^",
+									"cost": "+100%",
+									"disabled": true
+								}
+							]
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 2000,
+						"extended_value": 2000,
+						"weight": "2 lb",
+						"extended_weight": "2 lb"
+					}
+				},
+				{
+					"id": "eBskdo39Znu2Oo2rD",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "ev80WwcnBpiGFrkol"
+					},
+					"description": "C cell",
+					"reference": "UT19",
+					"tech_level": "9",
+					"tags": [
+						"Power"
+					],
+					"base_value": "10",
+					"base_weight": "0.5 lb",
+					"quantity": 4,
+					"equipped": true,
+					"calc": {
+						"value": 10,
+						"extended_value": 40,
+						"weight": "0.5 lb",
+						"extended_weight": "2 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 120,
+				"extended_value": 12160,
+				"weight": "2 lb",
+				"extended_weight": "38 lb"
+			}
+		},
+		{
+			"id": "EfP7tWhQrh1LCEP0M",
+			"description": "Stored in Vehicle",
+			"legality_class": "4",
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "ezt--i8w8iaRxDjev",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "efeekclqs54nOsbVN"
+					},
+					"description": "Swarmbot Hive",
+					"reference": "UT37",
+					"tech_level": "10",
+					"base_value": "200",
+					"base_weight": "10 lb",
+					"quantity": 2,
+					"equipped": true,
+					"calc": {
+						"value": 200,
+						"extended_value": 400,
+						"weight": "10 lb",
+						"extended_weight": "20 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 0,
+				"extended_value": 400,
+				"weight": "0 lb",
+				"extended_weight": "20 lb"
+			}
+		}
+	]
+}

--- a/Library/Loadouts/Starship Crew/TL11/Security Officer.gct
+++ b/Library/Loadouts/Starship Crew/TL11/Security Officer.gct
@@ -1,0 +1,2949 @@
+{
+	"version": 5,
+	"id": "BFFuaqmKZi9h7FkxV",
+	"equipment": [
+		{
+			"id": "ERYu-j0E7eJZs7ErK",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+				"id": "ecvRbROzGAmUpQg_Y"
+			},
+			"description": "Light Infantry Helmet",
+			"reference": "UT176",
+			"tech_level": "11",
+			"legality_class": "3",
+			"tags": [
+				"Armor",
+				"Defenses"
+			],
+			"base_value": "250",
+			"base_weight": "3 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"skull"
+					],
+					"amount": 36
+				}
+			],
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "eVlhqra8GD6aipF7s",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eo6Lb0L-G9bFjuQwS"
+					},
+					"description": "Light Infantry Helmet: Visor",
+					"reference": "UT176",
+					"tech_level": "11",
+					"legality_class": "3",
+					"tags": [
+						"Armor",
+						"Defenses"
+					],
+					"base_value": "100",
+					"base_weight": "3 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"locations": [
+								"eye"
+							],
+							"amount": 30
+						},
+						{
+							"type": "dr_bonus",
+							"locations": [
+								"face"
+							],
+							"amount": 30
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 100,
+						"extended_value": 100,
+						"weight": "3 lb",
+						"extended_weight": "3 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 250,
+				"extended_value": 350,
+				"weight": "3 lb",
+				"extended_weight": "6 lb"
+			}
+		},
+		{
+			"id": "eASXJzBXQf_vGA9N3",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+				"id": "eKE5jFzR3r8QPFLhD"
+			},
+			"description": "Monocrys Jacket",
+			"reference": "UT172",
+			"local_notes": "Flexible.",
+			"tech_level": "11",
+			"legality_class": "3",
+			"tags": [
+				"Defenses"
+			],
+			"base_value": "450",
+			"base_weight": "3 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"arm",
+						"torso",
+						"vitals"
+					],
+					"amount": 8
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"arm",
+						"torso",
+						"vitals"
+					],
+					"specialization": "piercing and cutting",
+					"amount": 16
+				}
+			],
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"value": 450,
+				"extended_value": 450,
+				"weight": "3 lb",
+				"extended_weight": "3 lb"
+			}
+		},
+		{
+			"id": "Ed50WsZivKvlkct2X",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+				"id": "eNxEqbQBIyZOS3rdx"
+			},
+			"description": "VR Gloves",
+			"reference": "UT54",
+			"local_notes": "Requires Complexity 2+.",
+			"tech_level": "9",
+			"tags": [
+				"Media and Education"
+			],
+			"base_value": "20",
+			"base_weight": "0.3 lb",
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "eOWaOPPfOUT18v-3A",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "esYKu0HiXEa__XOgo"
+					},
+					"description": "Monocrys Gloves",
+					"reference": "UT172",
+					"local_notes": "Flexible.",
+					"tech_level": "11",
+					"tags": [
+						"Defenses"
+					],
+					"base_value": "30",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"locations": [
+								"hand"
+							],
+							"specialization": "piercing and cutting",
+							"amount": 8
+						},
+						{
+							"type": "dr_bonus",
+							"locations": [
+								"hand"
+							],
+							"amount": 4
+						}
+					],
+					"modifiers": [
+						{
+							"id": "fYpXSGxyx3oGUvkSH",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+								"id": "ftTIP1_K9WPCHFSrz"
+							},
+							"name": "Stylish",
+							"reference": "UT175",
+							"cost_type": "to_base_cost",
+							"cost": "+3 CF"
+						},
+						{
+							"id": "fm1XjjxFGogKs7WBA",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+								"id": "fZK5VWsvzMBCRHwkA"
+							},
+							"name": "Combination Gadget cost, multiple work at a time",
+							"reference": "UT16",
+							"cost_type": "to_final_cost",
+							"cost": "x0.8"
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 96,
+						"extended_value": 96,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				},
+				{
+					"id": "e3lxbM0OqpdLheq4F",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "ef55nM_NrfAgS_Cam"
+					},
+					"description": "Karatand",
+					"reference": "UT163",
+					"tech_level": "9",
+					"legality_class": "3",
+					"tags": [
+						"Melee Weapon",
+						"Weaponry"
+					],
+					"base_value": "100",
+					"weapons": [
+						{
+							"id": "wrtRasJccf0lOuNP2",
+							"damage": {
+								"type": "cr",
+								"st": "thr"
+							},
+							"usage": "Punch",
+							"reach": "C",
+							"parry": "0",
+							"defaults": [
+								{
+									"type": "dx"
+								},
+								{
+									"type": "skill",
+									"name": "Boxing"
+								},
+								{
+									"type": "skill",
+									"name": "Brawling"
+								},
+								{
+									"type": "skill",
+									"name": "Karate"
+								}
+							],
+							"calc": {
+								"damage": "thr cr"
+							}
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 100,
+						"extended_value": 100,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 20,
+				"extended_value": 216,
+				"weight": "0.3 lb",
+				"extended_weight": "0.3 lb"
+			}
+		},
+		{
+			"id": "eeznlPjBphQWKgaRg",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+				"id": "ehdRbUenpNRCpUTtS"
+			},
+			"description": "Monocrys Trousers",
+			"reference": "UT172",
+			"local_notes": "Flexible.",
+			"tech_level": "11",
+			"legality_class": "3",
+			"tags": [
+				"Defenses"
+			],
+			"base_value": "280",
+			"base_weight": "2.8 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"groin",
+						"leg"
+					],
+					"amount": 8
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"groin",
+						"leg"
+					],
+					"specialization": "piercing and cutting",
+					"amount": 16
+				}
+			],
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"value": 280,
+				"extended_value": 280,
+				"weight": "2.8 lb",
+				"extended_weight": "2.8 lb"
+			}
+		},
+		{
+			"id": "e2N0hNB-bkAm3YqvB",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+				"id": "e46KLPiLrq7durI15"
+			},
+			"description": "Assault Boots",
+			"reference": "UT173",
+			"tech_level": "11",
+			"tags": [
+				"Armor",
+				"Defenses"
+			],
+			"base_value": "150",
+			"base_weight": "3 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"foot"
+					],
+					"specialization": "underside of the foot",
+					"amount": 15
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"foot"
+					],
+					"amount": 15
+				}
+			],
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"value": 150,
+				"extended_value": 150,
+				"weight": "3 lb",
+				"extended_weight": "3 lb"
+			}
+		},
+		{
+			"id": "E7T5VicuxiW9bnw9d",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "High Tech/High Tech Equipment.eqp",
+				"id": "EC9nP-WpcnxfOUAj5"
+			},
+			"description": "Load-Bearing Vest",
+			"reference": "HT54",
+			"local_notes": "Holds 20-30lbs.",
+			"tech_level": "7",
+			"tags": [
+				"General Equipment"
+			],
+			"base_value": "30",
+			"base_weight": "2 lb",
+			"modifiers": [
+				{
+					"id": "fsQAaIjNBB75LDqld",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+						"id": "fWUQh1AyC_6CUS9Ui"
+					},
+					"name": "Expensive",
+					"reference": "UT15",
+					"cost_type": "to_final_base_cost",
+					"weight_type": "to_base_weight",
+					"cost": "x2",
+					"weight": "x2/3"
+				}
+			],
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "eWxbj2410RaScxeCA",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eRArfUwOeI_v9CrIX"
+					},
+					"description": "Heavy Flashlight",
+					"reference": "UT74",
+					"local_notes": "50-yard beam. 2B/24hr.",
+					"tech_level": "9",
+					"tags": [
+						"Housing and Food",
+						"Melee Weapon"
+					],
+					"base_value": "20",
+					"base_weight": "1 lb",
+					"weapons": [
+						{
+							"id": "w4AywoPWcBrTV6XWp",
+							"damage": {
+								"type": "cr",
+								"st": "sw"
+							},
+							"strength": "6",
+							"usage": "Swung",
+							"reach": "1",
+							"parry": "0",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Shortsword"
+								},
+								{
+									"type": "skill",
+									"name": "Broadsword",
+									"modifier": -2
+								},
+								{
+									"type": "skill",
+									"name": "Force Sword",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Jitte/Sai",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Knife",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Saber",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Smallsword",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Tonfa",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Sword!"
+								}
+							],
+							"calc": {
+								"damage": "sw cr"
+							}
+						},
+						{
+							"id": "wUB9bjNAArxow97r1",
+							"damage": {
+								"type": "cr",
+								"st": "thr"
+							},
+							"strength": "6",
+							"usage": "Thrust",
+							"reach": "1",
+							"parry": "0",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": "Shortsword"
+								},
+								{
+									"type": "skill",
+									"name": "Broadsword",
+									"modifier": -2
+								},
+								{
+									"type": "skill",
+									"name": "Force Sword",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Jitte/Sai",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Knife",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Saber",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Smallsword",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Tonfa",
+									"modifier": -3
+								},
+								{
+									"type": "skill",
+									"name": "Sword!"
+								}
+							],
+							"calc": {
+								"damage": "thr cr"
+							}
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 20,
+						"extended_value": 20,
+						"weight": "1 lb",
+						"extended_weight": "1 lb"
+					}
+				},
+				{
+					"id": "eqV_wgHZZT5bespFt",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "e4mc_Vt5XqdsQ-gW2"
+					},
+					"description": "Homing Beacon",
+					"reference": "UT105",
+					"local_notes": "AA/100 hours - 1 year in \"sleeper\" mode",
+					"tech_level": "9",
+					"tags": [
+						"Surveillance and Tracking Devices"
+					],
+					"base_value": "40",
+					"quantity": 5,
+					"equipped": true,
+					"calc": {
+						"value": 40,
+						"extended_value": 200,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				},
+				{
+					"id": "ex6wBVXAR0Y1fd-BQ",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "ehD6CkIi5UiGPo_NW"
+					},
+					"description": "RF Bug Detector",
+					"reference": "UT106",
+					"local_notes": "A/10 hours",
+					"tech_level": "9",
+					"tags": [
+						"Counter-Surveillance and ECM"
+					],
+					"base_value": "200",
+					"base_weight": "0.1 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 200,
+						"extended_value": 200,
+						"weight": "0.1 lb",
+						"extended_weight": "0.1 lb"
+					}
+				},
+				{
+					"id": "eMFdNWJXLbbTW_3TW",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eJBKye1tzZ_euHPmG"
+					},
+					"description": "Electronic Lockpick",
+					"reference": "UT95",
+					"local_notes": "A/2hr.",
+					"tech_level": "9",
+					"legality_class": "2",
+					"tags": [
+						"Deception and Intrusion"
+					],
+					"base_value": "1500",
+					"base_weight": "0.2 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 1500,
+						"extended_value": 1500,
+						"weight": "0.2 lb",
+						"extended_weight": "0.2 lb"
+					}
+				},
+				{
+					"id": "e8ZMr-CgaiyyjlXRf",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eKEcwXsM1zBOvmezR"
+					},
+					"description": "Biometric Cracker Tools",
+					"reference": "UT95",
+					"local_notes": "A/2hr.",
+					"tech_level": "9",
+					"legality_class": "2",
+					"tags": [
+						"Deception and Intrusion"
+					],
+					"base_value": "4000",
+					"base_weight": "10 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 4000,
+						"extended_value": 4000,
+						"weight": "10 lb",
+						"extended_weight": "10 lb"
+					}
+				},
+				{
+					"id": "eDUn9sDJYXD90bi3N",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "e-yGWy1_ZJcfaiaoW"
+					},
+					"description": "Cufftape",
+					"reference": "UT107",
+					"local_notes": "100-foot spool. DR 1. HP 6. ST 20.",
+					"tech_level": "9",
+					"legality_class": "3",
+					"tags": [
+						"Enforcement and Coercion"
+					],
+					"base_value": "10",
+					"base_weight": "0.5 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 10,
+						"extended_value": 10,
+						"weight": "0.5 lb",
+						"extended_weight": "0.5 lb"
+					}
+				},
+				{
+					"id": "eOcx4WG08qfKhd8GS",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "etdtE7-9DZQ3M_1cI"
+					},
+					"description": "Smart Blindfold",
+					"reference": "UT108",
+					"local_notes": "+1 (quality) to Interrogation vs. wearer. C/100hr.",
+					"tech_level": "9",
+					"legality_class": "2",
+					"tags": [
+						"Enforcement and Coercion"
+					],
+					"base_value": "100",
+					"base_weight": "1.5 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 100,
+						"extended_value": 100,
+						"weight": "1.5 lb",
+						"extended_weight": "1.5 lb"
+					}
+				},
+				{
+					"id": "eRtJLmH1aAdippV-Z",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eRd4HdGkY3padXW2c"
+					},
+					"description": "@Microbot/Nanobot Type@ Swarm",
+					"reference": "UT35",
+					"tech_level": "10",
+					"tags": [
+						"Swarmbots"
+					],
+					"base_weight": "2 lb",
+					"replacements": {
+						"Microbot/Nanobot Type": "Security"
+					},
+					"modifiers": [
+						{
+							"id": "F-nm7zXioyOQSl3RV",
+							"name": "Swarm Type",
+							"reference": "UT37",
+							"local_notes": "at TL11 microbots can have two types, at TL12 nanobots can have two types",
+							"children": [
+								{
+									"id": "f7SqXfVqVsQXSDlNl",
+									"name": "Bughunter",
+									"reference": "UT106",
+									"local_notes": "LC3",
+									"tags": [
+										"Counter-Surveillance and ECM",
+										"Security and Surveillance",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+4000",
+									"disabled": true
+								},
+								{
+									"id": "f41Is-E-geViZ5Nej",
+									"name": "Cannibal",
+									"reference": "UT169",
+									"local_notes": "LC1",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "12",
+									"cost": "+15000",
+									"disabled": true
+								},
+								{
+									"id": "fbiIVXprUtKdWvZK_",
+									"name": "Cleaning",
+									"reference": "UT69",
+									"local_notes": "LC4",
+									"tags": [
+										"Domestic Equipment and Appliances",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fUMxQBLW-UsgUx6hD",
+									"name": "Construction",
+									"reference": "UT86",
+									"local_notes": "LC4",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "ftQ-Et3M3cRDrUtIo",
+									"name": "Decontamination (@Hazard Type@)",
+									"reference": "UT87",
+									"local_notes": "LC3; Hazardous Materials (@Hazard Type@)-12",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "f-FduSpO7IhxbJp5U",
+									"name": "Decontamination (@Hazard Type@)",
+									"reference": "UT87",
+									"local_notes": "LC3; Hazardous Materials (@Hazard Type@)-13",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "11",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fkS-G1Li03wiY3Fks",
+									"name": "Decontamination (@Hazard Type@)",
+									"reference": "UT87",
+									"local_notes": "LC3; Hazardous Materials (@Hazard Type@)-14",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "12",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fuiISh5MIM8RfcTe-",
+									"name": "Defoliator",
+									"reference": "UT87",
+									"local_notes": "LC3",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fZlycU4g9dZip7Zvg",
+									"name": "Devourer",
+									"reference": "UT169",
+									"local_notes": "LC1",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "10",
+									"cost": "+8000",
+									"disabled": true
+								},
+								{
+									"id": "ftaYG5on2K9Hzzq1y",
+									"name": "Disassembler",
+									"reference": "UT169",
+									"local_notes": "LC1",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "11",
+									"cost": "+10000",
+									"disabled": true
+								},
+								{
+									"id": "fiOFpkY9PCW339whQ",
+									"name": "Explorer",
+									"reference": "UT80",
+									"local_notes": "LC4",
+									"tags": [
+										"Expedition Gear",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+500",
+									"disabled": true
+								},
+								{
+									"id": "fA-GmXAGAUdJvaY_X",
+									"name": "Firefly",
+									"reference": "UT74",
+									"local_notes": "LC4",
+									"tags": [
+										"Domestic Equipment and Appliances",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+100",
+									"disabled": true
+								},
+								{
+									"id": "fnIF7tl0U4yf7hMqY",
+									"name": "Forensic",
+									"reference": "UT107",
+									"local_notes": "LC3",
+									"tags": [
+										"Enforcement and Coercion",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+4000",
+									"disabled": true
+								},
+								{
+									"id": "fukbA7Cy-59x2E8zI",
+									"name": "Gremlin",
+									"reference": "UT169",
+									"local_notes": "LC2",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "10",
+									"cost": "+2000",
+									"disabled": true
+								},
+								{
+									"id": "fetUPbpL3A7B4vEjC",
+									"name": "Harvester",
+									"reference": "UT87",
+									"local_notes": "LC4",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+2000",
+									"disabled": true
+								},
+								{
+									"id": "fdDLTiJ7VQDqwoHMS",
+									"name": "Massage",
+									"reference": "UT41",
+									"local_notes": "LC4",
+									"tags": [
+										"Robots",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+200",
+									"disabled": true
+								},
+								{
+									"id": "fujCHccHN2fIROw2X",
+									"name": "Painter",
+									"reference": "UT87",
+									"local_notes": "LC4",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+500",
+									"disabled": true
+								},
+								{
+									"id": "fgj8A_pC9X4rGuV4H",
+									"name": "Paramedical",
+									"reference": "UT201",
+									"local_notes": "LC3; Diagnosis-10, First Aid-10",
+									"tags": [
+										"Medical",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+6000",
+									"disabled": true
+								},
+								{
+									"id": "fwwDFn_3iDEIfnMKA",
+									"name": "Paramedical",
+									"reference": "UT201",
+									"local_notes": "LC3; Diagnosis-11, First Aid-11",
+									"tags": [
+										"Medical",
+										"Swarmbots"
+									],
+									"tech_level": "11",
+									"cost": "+6000",
+									"disabled": true
+								},
+								{
+									"id": "fwQBeQnKAk7bDY8tl",
+									"name": "Paramedical",
+									"reference": "UT201",
+									"local_notes": "LC3; Diagnosis-12, First Aid-12",
+									"tags": [
+										"Medical",
+										"Swarmbots"
+									],
+									"tech_level": "12",
+									"cost": "+6000",
+									"disabled": true
+								},
+								{
+									"id": "fyricLhVoXf0Rr--W",
+									"name": "Pesticide",
+									"reference": "UT87",
+									"local_notes": "LC3",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fg-wNUN0Gl2-i_zx5",
+									"name": "Play",
+									"reference": "UT41",
+									"local_notes": "LC4",
+									"tags": [
+										"Robots",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+200",
+									"disabled": true
+								},
+								{
+									"id": "for5Z2E9Y8TlzLMhP",
+									"name": "Pollinator",
+									"reference": "UT87",
+									"local_notes": "LC4",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "f7J-DTYfh4RRP7G56",
+									"name": "Repair (@Equipment@)",
+									"reference": "UT87",
+									"local_notes": "LC4; Repair Skill-12",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+500",
+									"disabled": true
+								},
+								{
+									"id": "f4dNtSD3IrAbiWnfD",
+									"name": "Repair (@Equipment@)",
+									"reference": "UT87",
+									"local_notes": "LC4; Repair Skill-13",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "11",
+									"cost": "+500",
+									"disabled": true
+								},
+								{
+									"id": "f9rP7nUBHcTszhp2L",
+									"name": "Repair (@Other Equipment 1@)",
+									"reference": "UT87",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+250",
+									"disabled": true
+								},
+								{
+									"id": "fLmXcc1topC5k6ecG",
+									"name": "Repair (@Other Equipment 2@)",
+									"reference": "UT87",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+250",
+									"disabled": true
+								},
+								{
+									"id": "fO3E6tlQNDabqobpz",
+									"name": "Repair (@Other Equipment 3@)",
+									"reference": "UT87",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+250",
+									"disabled": true
+								},
+								{
+									"id": "f_QJ6UAI9LnGkUKG3",
+									"name": "Security",
+									"reference": "UT104",
+									"local_notes": "LC3",
+									"tags": [
+										"Security and Surveillance",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+1000"
+								},
+								{
+									"id": "fBh-b6YPQ1EfHl2ZU",
+									"name": "Sentry",
+									"reference": "UT169",
+									"local_notes": "LC3",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "10",
+									"cost": "+5000",
+									"disabled": true
+								},
+								{
+									"id": "fQYWn2_Gkw0YkZhBD",
+									"name": "Stinger",
+									"reference": "UT169",
+									"local_notes": "LC2",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "10",
+									"cost": "+1500",
+									"disabled": true
+								},
+								{
+									"id": "fIx3bbEItOFoyCT0q",
+									"name": "Surveillance",
+									"reference": "UT106",
+									"local_notes": "LC3",
+									"tags": [
+										"Security and Surveillance",
+										"Surveillance and Tracking Devices",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+500",
+									"disabled": true
+								},
+								{
+									"id": "fI6ZKMyT3sB5sDa7s",
+									"name": "Terminator",
+									"reference": "UT169",
+									"local_notes": "LC1",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "10",
+									"cost": "+1500",
+									"disabled": true
+								}
+							]
+						},
+						{
+							"id": "fUuo6j3CapYMb_NNP",
+							"name": "Self-Replicating",
+							"reference": "UT37",
+							"local_notes": "only for defoliator, devourer or pesticide",
+							"tags": [
+								"Swarmbots"
+							],
+							"cost_type": "to_base_cost",
+							"cost": "x10",
+							"disabled": true
+						},
+						{
+							"id": "F5Mt-dWkaodI5WH2I",
+							"name": "Chassis",
+							"local_notes": "choose one microbot or nanobot chassis",
+							"children": [
+								{
+									"id": "FckhGdPObAE6FJ4yq",
+									"name": "Microbot Chassis",
+									"children": [
+										{
+											"id": "fMxfX27_kv2TwcUlP",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f7eMKwMF7BTYFbxhq"
+											},
+											"name": "Microbot Aerostat",
+											"reference": "UT36",
+											"local_notes": "Air Move 2",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "10"
+										},
+										{
+											"id": "fKpCOxODvv-tX5ez6",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fcVKEB14BedQI1jGA"
+											},
+											"name": "Microbot Crawler",
+											"reference": "UT36",
+											"local_notes": "Move 3; Water Move 1",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"disabled": true
+										},
+										{
+											"id": "fBXa95txowu-OUKoo",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fScgdTYLwKE9CEYfl"
+											},
+											"name": "Microbot Crawler, Armored",
+											"reference": "UT36",
+											"local_notes": "Move 2, 2x HP",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+100%",
+											"disabled": true
+										},
+										{
+											"id": "fia66ci5K-QjeYl0s",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fpAVv9yE3m3t0Egt_"
+											},
+											"name": "Microbot Flier",
+											"reference": "UT36",
+											"local_notes": "Move 1; Air Move 6",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+100%",
+											"disabled": true
+										},
+										{
+											"id": "fWqZl9uq2VdKF8CQ_",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "ffHj2SBngzuewdrbB"
+											},
+											"name": "Microbot Hopper",
+											"reference": "UT36",
+											"local_notes": "Move 4; Super Jump 1",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "ftGmnWqpjeKJKgVz8",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fr6wQjKaUic-BpBCO"
+											},
+											"name": "Microbot Space",
+											"reference": "UT36",
+											"local_notes": "Move 1; 0.0001G solar sail",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+0",
+											"disabled": true
+										},
+										{
+											"id": "fwFwSxuG180Z8fWWL",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fsL5rGqz66ht8cVvg"
+											},
+											"name": "Microbot Swimmer",
+											"reference": "UT36",
+											"local_notes": "Water Move 4",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+0",
+											"disabled": true
+										},
+										{
+											"id": "fhO4KiaIjJypo6mTz",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fvVo7_8gzuQpK50fc"
+											},
+											"name": "Microbot Contragrav (CG) Flier",
+											"reference": "UT36",
+											"local_notes": "Move 1; Air Move 20",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11^",
+											"cost": "+200%",
+											"disabled": true
+										}
+									]
+								},
+								{
+									"id": "F_5hShA8zAMfwVMuJ",
+									"name": "Nanobot Chassis",
+									"children": [
+										{
+											"id": "ft7V3mYJYHX68nDGi",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f6RvvKoBN0DqIjBjQ"
+											},
+											"name": "Nanobot Aerostat",
+											"reference": "UT36",
+											"local_notes": "Air Move 1",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "11",
+											"disabled": true
+										},
+										{
+											"id": "fo6Vj4cDEuK7dhw-9",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f1OLvlafFuNITe6na"
+											},
+											"name": "Nanobot Crawler",
+											"reference": "UT36",
+											"local_notes": "Move 3; Water Move 1",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "11",
+											"disabled": true
+										},
+										{
+											"id": "fKklvg2fGrmgBPGes",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fASzj6iYz6hUA-TBB"
+											},
+											"name": "Nanobot Crawler, Armored",
+											"reference": "UT36",
+											"local_notes": "Move 2, 2x HP",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11",
+											"cost": "+100%",
+											"disabled": true
+										},
+										{
+											"id": "fedbz-Ws-lTSxfiuk",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fLuL-pD4o6s0lREJs"
+											},
+											"name": "Nanobot Dust",
+											"reference": "UT36",
+											"local_notes": "Immobile",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11",
+											"cost": "-80%",
+											"disabled": true
+										},
+										{
+											"id": "fCiwx28bvDR55kf5z",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fKeArqcSSvcPk5QTp"
+											},
+											"name": "Nanobot Flier",
+											"reference": "UT36",
+											"local_notes": "Move 1; Air Move 3",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11",
+											"cost": "+100%",
+											"disabled": true
+										},
+										{
+											"id": "f4zp2naMgCl3XzhKv",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fyATVIBpOaRfq3tKe"
+											},
+											"name": "Nanobot Hopper",
+											"reference": "UT36",
+											"local_notes": "Move 4; Super Jump 1",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "fXqJ7YOUi2tPIoyeI",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f80KO0VZYaEJb9hbs"
+											},
+											"name": "Nanobot Space",
+											"reference": "UT36",
+											"local_notes": "Move 1; 0.0001G solar sail",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "11",
+											"cost": "+0",
+											"disabled": true
+										},
+										{
+											"id": "f0f4-vvM2aK_R4Ets",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fa36bUxm5RcsG_mOk"
+											},
+											"name": "Nanobot Swimmer",
+											"reference": "UT36",
+											"local_notes": "Water Move 1",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "11",
+											"cost": "+0",
+											"disabled": true
+										},
+										{
+											"id": "fz_nAOZGtClHa3jIm",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fPgd1Z13foKJXxTND"
+											},
+											"name": "Nanobot Contragrav (CG) Flier",
+											"reference": "UT36",
+											"local_notes": "Move 1; Air Move 10",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11^",
+											"cost": "+200%",
+											"disabled": true
+										}
+									]
+								}
+							]
+						},
+						{
+							"id": "Fv7miKE4A2p94l5ze",
+							"name": "Stealth",
+							"children": [
+								{
+									"id": "fjsnuHLsUmU-bRaul",
+									"name": "Disguise",
+									"reference": "UT36",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_cost",
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "flU2T2ERCtivEs5uZ",
+									"name": "Thermo-Optic Chameleon Surface",
+									"reference": "UT37, UT98",
+									"local_notes": "LC3",
+									"tags": [
+										"Deception and Intrusion",
+										"Swarmbots"
+									],
+									"cost_type": "to_final_cost",
+									"tech_level": "9",
+									"cost": "+4000",
+									"weight": "+4 lb",
+									"disabled": true
+								},
+								{
+									"id": "fi5TqcMUaDrmCdpKO",
+									"name": "Multispectral Chameleon Surface",
+									"reference": "UT37, UT99",
+									"local_notes": "LC3",
+									"tags": [
+										"Deception and Intrusion",
+										"Swarmbots"
+									],
+									"cost_type": "to_final_cost",
+									"tech_level": "10",
+									"cost": "+6000",
+									"weight": "+4 lb",
+									"disabled": true
+								},
+								{
+									"id": "f1tCrfabPK9CusBhg",
+									"name": "Dynamic Multispectral Chameleon Surface",
+									"reference": "UT37, UT99",
+									"local_notes": "LC3",
+									"tags": [
+										"Deception and Intrusion",
+										"Swarmbots"
+									],
+									"cost_type": "to_final_cost",
+									"tech_level": "11",
+									"cost": "+8000",
+									"weight": "+4 lb",
+									"disabled": true
+								},
+								{
+									"id": "fXqARkYkGHSocomcv",
+									"name": "Ultimate Chameleon Surface",
+									"reference": "UT37, UT99",
+									"local_notes": "LC3",
+									"tags": [
+										"Deception and Intrusion",
+										"Swarmbots"
+									],
+									"cost_type": "to_final_cost",
+									"tech_level": "12",
+									"cost": "+10000",
+									"weight": "+4 lb",
+									"disabled": true
+								}
+							]
+						},
+						{
+							"id": "FYn8ihTEwGOLx1UUg",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+								"id": "F5Q7h4gAuvWsoUiFV"
+							},
+							"name": "Power Supply",
+							"children": [
+								{
+									"id": "f70VYiIm86TBJatWY",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "faj6YgnYeEKAy39jw"
+									},
+									"name": "Power Cells",
+									"reference": "UT36",
+									"local_notes": "Recharges in a Hive; C/12hr.",
+									"tags": [
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"disabled": true
+								},
+								{
+									"id": "f4c1H1WEix_D-6t-y",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fCJ9sdOXfXoLN594u"
+									},
+									"name": "Power Cells",
+									"reference": "UT36",
+									"local_notes": "Recharges in a Hive; C/72hr.",
+									"tags": [
+										"Swarmbots"
+									],
+									"tech_level": "11"
+								},
+								{
+									"id": "fpLeYuj6H01U2M0Iw",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "f7WMm14XwVJyvz2NQ"
+									},
+									"name": "Power Cells",
+									"reference": "UT36",
+									"local_notes": "Recharges in a Hive; C/5 days.",
+									"tags": [
+										"Swarmbots"
+									],
+									"tech_level": "12",
+									"disabled": true
+								},
+								{
+									"id": "fet7V05d_8iiAhf0C",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fGv5njL67i7rODIpL"
+									},
+									"name": "Beamed Power",
+									"reference": "UT36",
+									"local_notes": "C cell receiver",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "10",
+									"cost": "+50%",
+									"disabled": true
+								},
+								{
+									"id": "f5jdaoQZraLWKJXWh",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fS-7nLrwLytJp5mLZ"
+									},
+									"name": "Gastrobot",
+									"reference": "UT36",
+									"local_notes": "Consumes 0.1lbs./hr. of biomass",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "10",
+									"cost": "+100%",
+									"disabled": true
+								},
+								{
+									"id": "f-Ekps-Eb81OtOtuV",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fhT3sMtcrOGbTzLku"
+									},
+									"name": "Radio-Thermal Generator (RTG)",
+									"reference": "UT36",
+									"local_notes": "Lasts 1 year; LC1",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "10",
+									"cost": "+100%",
+									"disabled": true
+								},
+								{
+									"id": "f7R-Hu01hW8WIG8py",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "faJkuSBjewuh2TdLg"
+									},
+									"name": "Solar Cell",
+									"reference": "UT36",
+									"local_notes": "Recharges 3 hours' activity in 1 hour",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "10",
+									"cost": "+50%",
+									"disabled": true
+								},
+								{
+									"id": "f-JdTStdnHa4M-vgz",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "f2u0xwoaeDxGjxCRq"
+									},
+									"name": "Solar Cell",
+									"reference": "UT36",
+									"local_notes": "Recharges 4 hours' activity in 1 hour",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "11",
+									"cost": "+50%",
+									"disabled": true
+								},
+								{
+									"id": "fzcbGxIafBw4HXaIb",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "ff9wLL0l7uzB0IRXf"
+									},
+									"name": "Solar Cell",
+									"reference": "UT36",
+									"local_notes": "Recharges 5 hours' activity in 1 hour",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "12",
+									"cost": "+50%",
+									"disabled": true
+								},
+								{
+									"id": "fyO0r9vAIHHYnEjTR",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "f4SVyLNBYhfPgNZC0"
+									},
+									"name": "Organovore",
+									"reference": "UT36",
+									"local_notes": "Consumes 0.1-0.5 lbs./hr. of carbon-based matter; LC3",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "11",
+									"cost": "+200%",
+									"disabled": true
+								},
+								{
+									"id": "fkn6I9qyBnmEaaX8W",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fi-Vh6iRVAbMGaOiO"
+									},
+									"name": "Broadcast Power",
+									"reference": "UT37",
+									"local_notes": "C cell receiver",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "11^",
+									"cost": "+100%",
+									"disabled": true
+								}
+							]
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 1000,
+						"extended_value": 1000,
+						"weight": "2 lb",
+						"extended_weight": "2 lb"
+					}
+				},
+				{
+					"id": "ePJOlvbf-CldgqLDl",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eRd4HdGkY3padXW2c"
+					},
+					"description": "@Microbot/Nanobot Type@ Swarm",
+					"reference": "UT35",
+					"tech_level": "10",
+					"tags": [
+						"Swarmbots"
+					],
+					"base_weight": "2 lb",
+					"replacements": {
+						"Microbot/Nanobot Type": "Forensic"
+					},
+					"modifiers": [
+						{
+							"id": "FWDKOJnwrGyBH3CLi",
+							"name": "Swarm Type",
+							"reference": "UT37",
+							"local_notes": "at TL11 microbots can have two types, at TL12 nanobots can have two types",
+							"children": [
+								{
+									"id": "fILXen4JXVSMUfMft",
+									"name": "Bughunter",
+									"reference": "UT106",
+									"local_notes": "LC3",
+									"tags": [
+										"Counter-Surveillance and ECM",
+										"Security and Surveillance",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+4000",
+									"disabled": true
+								},
+								{
+									"id": "fUM_g9BKR-UTJBrT6",
+									"name": "Cannibal",
+									"reference": "UT169",
+									"local_notes": "LC1",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "12",
+									"cost": "+15000",
+									"disabled": true
+								},
+								{
+									"id": "fyifZwMdC-hneL7rO",
+									"name": "Cleaning",
+									"reference": "UT69",
+									"local_notes": "LC4",
+									"tags": [
+										"Domestic Equipment and Appliances",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fSwaXgJY15U9Nt8Ag",
+									"name": "Construction",
+									"reference": "UT86",
+									"local_notes": "LC4",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fcknOcWA_23SCnyR2",
+									"name": "Decontamination (@Hazard Type@)",
+									"reference": "UT87",
+									"local_notes": "LC3; Hazardous Materials (@Hazard Type@)-12",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fWvW03uwrJnzf-q1b",
+									"name": "Decontamination (@Hazard Type@)",
+									"reference": "UT87",
+									"local_notes": "LC3; Hazardous Materials (@Hazard Type@)-13",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "11",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fDgU-e2H8-kLpz3eD",
+									"name": "Decontamination (@Hazard Type@)",
+									"reference": "UT87",
+									"local_notes": "LC3; Hazardous Materials (@Hazard Type@)-14",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "12",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fSxOKNKzjXhQrDWH4",
+									"name": "Defoliator",
+									"reference": "UT87",
+									"local_notes": "LC3",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "f_uh9Yj6cuN-oeBop",
+									"name": "Devourer",
+									"reference": "UT169",
+									"local_notes": "LC1",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "10",
+									"cost": "+8000",
+									"disabled": true
+								},
+								{
+									"id": "f9SQvNL2gG-X3haIF",
+									"name": "Disassembler",
+									"reference": "UT169",
+									"local_notes": "LC1",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "11",
+									"cost": "+10000",
+									"disabled": true
+								},
+								{
+									"id": "fZ2SAdF75cK5vDdiM",
+									"name": "Explorer",
+									"reference": "UT80",
+									"local_notes": "LC4",
+									"tags": [
+										"Expedition Gear",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+500",
+									"disabled": true
+								},
+								{
+									"id": "fwXVAiZLgEZFceNEO",
+									"name": "Firefly",
+									"reference": "UT74",
+									"local_notes": "LC4",
+									"tags": [
+										"Domestic Equipment and Appliances",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+100",
+									"disabled": true
+								},
+								{
+									"id": "fZ46DnFMoK3FfOUoK",
+									"name": "Forensic",
+									"reference": "UT107",
+									"local_notes": "LC3",
+									"tags": [
+										"Enforcement and Coercion",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+4000"
+								},
+								{
+									"id": "f6VqyboKpRKLCpm11",
+									"name": "Gremlin",
+									"reference": "UT169",
+									"local_notes": "LC2",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "10",
+									"cost": "+2000",
+									"disabled": true
+								},
+								{
+									"id": "fzj2ygkm9Or2RLBHI",
+									"name": "Harvester",
+									"reference": "UT87",
+									"local_notes": "LC4",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+2000",
+									"disabled": true
+								},
+								{
+									"id": "fW6yp7Ia9A3uUIllj",
+									"name": "Massage",
+									"reference": "UT41",
+									"local_notes": "LC4",
+									"tags": [
+										"Robots",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+200",
+									"disabled": true
+								},
+								{
+									"id": "fk27jFGDlfqH9VJfi",
+									"name": "Painter",
+									"reference": "UT87",
+									"local_notes": "LC4",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+500",
+									"disabled": true
+								},
+								{
+									"id": "f9QiftYZ2ZR9LR7dB",
+									"name": "Paramedical",
+									"reference": "UT201",
+									"local_notes": "LC3; Diagnosis-10, First Aid-10",
+									"tags": [
+										"Medical",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+6000",
+									"disabled": true
+								},
+								{
+									"id": "fQemSjn0RzrPz4NXu",
+									"name": "Paramedical",
+									"reference": "UT201",
+									"local_notes": "LC3; Diagnosis-11, First Aid-11",
+									"tags": [
+										"Medical",
+										"Swarmbots"
+									],
+									"tech_level": "11",
+									"cost": "+6000",
+									"disabled": true
+								},
+								{
+									"id": "fiere82HaPcfOuulf",
+									"name": "Paramedical",
+									"reference": "UT201",
+									"local_notes": "LC3; Diagnosis-12, First Aid-12",
+									"tags": [
+										"Medical",
+										"Swarmbots"
+									],
+									"tech_level": "12",
+									"cost": "+6000",
+									"disabled": true
+								},
+								{
+									"id": "f1iPbc7vhpJnZV8lN",
+									"name": "Pesticide",
+									"reference": "UT87",
+									"local_notes": "LC3",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "f5qtqymMuGVRZLXtX",
+									"name": "Play",
+									"reference": "UT41",
+									"local_notes": "LC4",
+									"tags": [
+										"Robots",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+200",
+									"disabled": true
+								},
+								{
+									"id": "fjf1Qk8RlBAcU7gLE",
+									"name": "Pollinator",
+									"reference": "UT87",
+									"local_notes": "LC4",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "f_e74fAQsJ-28EFak",
+									"name": "Repair (@Equipment@)",
+									"reference": "UT87",
+									"local_notes": "LC4; Repair Skill-12",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+500",
+									"disabled": true
+								},
+								{
+									"id": "feJmi29ihnoBLypWY",
+									"name": "Repair (@Equipment@)",
+									"reference": "UT87",
+									"local_notes": "LC4; Repair Skill-13",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "11",
+									"cost": "+500",
+									"disabled": true
+								},
+								{
+									"id": "fDXbjIxiWxN8mLy69",
+									"name": "Repair (@Other Equipment 1@)",
+									"reference": "UT87",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+250",
+									"disabled": true
+								},
+								{
+									"id": "ffny-YpVoqT490HWo",
+									"name": "Repair (@Other Equipment 2@)",
+									"reference": "UT87",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+250",
+									"disabled": true
+								},
+								{
+									"id": "fUryMBCqxVBCLydXy",
+									"name": "Repair (@Other Equipment 3@)",
+									"reference": "UT87",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+250",
+									"disabled": true
+								},
+								{
+									"id": "fvxIr5L5oePf5klHR",
+									"name": "Security",
+									"reference": "UT104",
+									"local_notes": "LC3",
+									"tags": [
+										"Security and Surveillance",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fwiur5OV3k0xyBD5k",
+									"name": "Sentry",
+									"reference": "UT169",
+									"local_notes": "LC3",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "10",
+									"cost": "+5000",
+									"disabled": true
+								},
+								{
+									"id": "fRJ0EG-xm59S-OB3O",
+									"name": "Stinger",
+									"reference": "UT169",
+									"local_notes": "LC2",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "10",
+									"cost": "+1500",
+									"disabled": true
+								},
+								{
+									"id": "fSIQqeFURlNYuLrNi",
+									"name": "Surveillance",
+									"reference": "UT106",
+									"local_notes": "LC3",
+									"tags": [
+										"Security and Surveillance",
+										"Surveillance and Tracking Devices",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+500",
+									"disabled": true
+								},
+								{
+									"id": "floGWrHfTITl0qdyh",
+									"name": "Terminator",
+									"reference": "UT169",
+									"local_notes": "LC1",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "10",
+									"cost": "+1500",
+									"disabled": true
+								}
+							]
+						},
+						{
+							"id": "fW6VCRAzSTfIl1hAs",
+							"name": "Self-Replicating",
+							"reference": "UT37",
+							"local_notes": "only for defoliator, devourer or pesticide",
+							"tags": [
+								"Swarmbots"
+							],
+							"cost_type": "to_base_cost",
+							"cost": "x10",
+							"disabled": true
+						},
+						{
+							"id": "F4Ls_ZmxpXWiu4OTr",
+							"name": "Chassis",
+							"local_notes": "choose one microbot or nanobot chassis",
+							"children": [
+								{
+									"id": "FVI-3Tuv8x4zdTuRt",
+									"name": "Microbot Chassis",
+									"children": [
+										{
+											"id": "fZWf0WH5O9F4FLord",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f7eMKwMF7BTYFbxhq"
+											},
+											"name": "Microbot Aerostat",
+											"reference": "UT36",
+											"local_notes": "Air Move 2",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "10"
+										},
+										{
+											"id": "f1psf3_qCjr3DN6vg",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fcVKEB14BedQI1jGA"
+											},
+											"name": "Microbot Crawler",
+											"reference": "UT36",
+											"local_notes": "Move 3; Water Move 1",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"disabled": true
+										},
+										{
+											"id": "fckTbH7fM-mlsjKwO",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fScgdTYLwKE9CEYfl"
+											},
+											"name": "Microbot Crawler, Armored",
+											"reference": "UT36",
+											"local_notes": "Move 2, 2x HP",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+100%",
+											"disabled": true
+										},
+										{
+											"id": "fu2ORJTITB0iXeQAf",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fpAVv9yE3m3t0Egt_"
+											},
+											"name": "Microbot Flier",
+											"reference": "UT36",
+											"local_notes": "Move 1; Air Move 6",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+100%",
+											"disabled": true
+										},
+										{
+											"id": "ffPPjUhQALRWho6MG",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "ffHj2SBngzuewdrbB"
+											},
+											"name": "Microbot Hopper",
+											"reference": "UT36",
+											"local_notes": "Move 4; Super Jump 1",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "fHJB0cps3ZHxf7pwY",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fr6wQjKaUic-BpBCO"
+											},
+											"name": "Microbot Space",
+											"reference": "UT36",
+											"local_notes": "Move 1; 0.0001G solar sail",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+0",
+											"disabled": true
+										},
+										{
+											"id": "fBLnE3dhVCmZkNCF-",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fsL5rGqz66ht8cVvg"
+											},
+											"name": "Microbot Swimmer",
+											"reference": "UT36",
+											"local_notes": "Water Move 4",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+0",
+											"disabled": true
+										},
+										{
+											"id": "f5omLkPLAkk-TJoub",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fvVo7_8gzuQpK50fc"
+											},
+											"name": "Microbot Contragrav (CG) Flier",
+											"reference": "UT36",
+											"local_notes": "Move 1; Air Move 20",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11^",
+											"cost": "+200%",
+											"disabled": true
+										}
+									]
+								},
+								{
+									"id": "FqtYqCV6hV27vrNbH",
+									"name": "Nanobot Chassis",
+									"children": [
+										{
+											"id": "fzQcKm9zftirH1cz3",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f6RvvKoBN0DqIjBjQ"
+											},
+											"name": "Nanobot Aerostat",
+											"reference": "UT36",
+											"local_notes": "Air Move 1",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "11",
+											"disabled": true
+										},
+										{
+											"id": "fTKDrEFBsCdB6YG7a",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f1OLvlafFuNITe6na"
+											},
+											"name": "Nanobot Crawler",
+											"reference": "UT36",
+											"local_notes": "Move 3; Water Move 1",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "11",
+											"disabled": true
+										},
+										{
+											"id": "fVYgdk5nW1LdSzpnu",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fASzj6iYz6hUA-TBB"
+											},
+											"name": "Nanobot Crawler, Armored",
+											"reference": "UT36",
+											"local_notes": "Move 2, 2x HP",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11",
+											"cost": "+100%",
+											"disabled": true
+										},
+										{
+											"id": "flX5bEWnVi0FUYAHT",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fLuL-pD4o6s0lREJs"
+											},
+											"name": "Nanobot Dust",
+											"reference": "UT36",
+											"local_notes": "Immobile",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11",
+											"cost": "-80%",
+											"disabled": true
+										},
+										{
+											"id": "frMRR3xpQHqVaQuI0",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fKeArqcSSvcPk5QTp"
+											},
+											"name": "Nanobot Flier",
+											"reference": "UT36",
+											"local_notes": "Move 1; Air Move 3",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11",
+											"cost": "+100%",
+											"disabled": true
+										},
+										{
+											"id": "fwv_oxXxpNrMVqI5A",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fyATVIBpOaRfq3tKe"
+											},
+											"name": "Nanobot Hopper",
+											"reference": "UT36",
+											"local_notes": "Move 4; Super Jump 1",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "fY-L978s-v5Z5Lh7D",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f80KO0VZYaEJb9hbs"
+											},
+											"name": "Nanobot Space",
+											"reference": "UT36",
+											"local_notes": "Move 1; 0.0001G solar sail",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "11",
+											"cost": "+0",
+											"disabled": true
+										},
+										{
+											"id": "fzYFZY84hxGUWbV1c",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fa36bUxm5RcsG_mOk"
+											},
+											"name": "Nanobot Swimmer",
+											"reference": "UT36",
+											"local_notes": "Water Move 1",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "11",
+											"cost": "+0",
+											"disabled": true
+										},
+										{
+											"id": "fAZmNX9NES3zxjYPl",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fPgd1Z13foKJXxTND"
+											},
+											"name": "Nanobot Contragrav (CG) Flier",
+											"reference": "UT36",
+											"local_notes": "Move 1; Air Move 10",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11^",
+											"cost": "+200%",
+											"disabled": true
+										}
+									]
+								}
+							]
+						},
+						{
+							"id": "Fmo7p3nOjr-J18qg4",
+							"name": "Stealth",
+							"children": [
+								{
+									"id": "fIMy2WMHZpMd-qndC",
+									"name": "Disguise",
+									"reference": "UT36",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_cost",
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fg0FnTAsb0tJq4VPL",
+									"name": "Thermo-Optic Chameleon Surface",
+									"reference": "UT37, UT98",
+									"local_notes": "LC3",
+									"tags": [
+										"Deception and Intrusion",
+										"Swarmbots"
+									],
+									"cost_type": "to_final_cost",
+									"tech_level": "9",
+									"cost": "+4000",
+									"weight": "+4 lb",
+									"disabled": true
+								},
+								{
+									"id": "f0YYebU6G8zMUCwa-",
+									"name": "Multispectral Chameleon Surface",
+									"reference": "UT37, UT99",
+									"local_notes": "LC3",
+									"tags": [
+										"Deception and Intrusion",
+										"Swarmbots"
+									],
+									"cost_type": "to_final_cost",
+									"tech_level": "10",
+									"cost": "+6000",
+									"weight": "+4 lb",
+									"disabled": true
+								},
+								{
+									"id": "fZDMP1PhjVY14yVxL",
+									"name": "Dynamic Multispectral Chameleon Surface",
+									"reference": "UT37, UT99",
+									"local_notes": "LC3",
+									"tags": [
+										"Deception and Intrusion",
+										"Swarmbots"
+									],
+									"cost_type": "to_final_cost",
+									"tech_level": "11",
+									"cost": "+8000",
+									"weight": "+4 lb",
+									"disabled": true
+								},
+								{
+									"id": "flSJWhheTpNTM2oTk",
+									"name": "Ultimate Chameleon Surface",
+									"reference": "UT37, UT99",
+									"local_notes": "LC3",
+									"tags": [
+										"Deception and Intrusion",
+										"Swarmbots"
+									],
+									"cost_type": "to_final_cost",
+									"tech_level": "12",
+									"cost": "+10000",
+									"weight": "+4 lb",
+									"disabled": true
+								}
+							]
+						},
+						{
+							"id": "FXp3q625Cjcu5Ib45",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+								"id": "F5Q7h4gAuvWsoUiFV"
+							},
+							"name": "Power Supply",
+							"children": [
+								{
+									"id": "fISDD5zoy-9PLwPrD",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "faj6YgnYeEKAy39jw"
+									},
+									"name": "Power Cells",
+									"reference": "UT36",
+									"local_notes": "Recharges in a Hive; C/12hr.",
+									"tags": [
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"disabled": true
+								},
+								{
+									"id": "fk7RlAeiqWrKPxsA1",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fCJ9sdOXfXoLN594u"
+									},
+									"name": "Power Cells",
+									"reference": "UT36",
+									"local_notes": "Recharges in a Hive; C/72hr.",
+									"tags": [
+										"Swarmbots"
+									],
+									"tech_level": "11"
+								},
+								{
+									"id": "fiXL3O14TrDhLoZTG",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "f7WMm14XwVJyvz2NQ"
+									},
+									"name": "Power Cells",
+									"reference": "UT36",
+									"local_notes": "Recharges in a Hive; C/5 days.",
+									"tags": [
+										"Swarmbots"
+									],
+									"tech_level": "12",
+									"disabled": true
+								},
+								{
+									"id": "fdnjhpkXISL35mOE5",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fGv5njL67i7rODIpL"
+									},
+									"name": "Beamed Power",
+									"reference": "UT36",
+									"local_notes": "C cell receiver",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "10",
+									"cost": "+50%",
+									"disabled": true
+								},
+								{
+									"id": "fLyDqabJ5T3mBY0K9",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fS-7nLrwLytJp5mLZ"
+									},
+									"name": "Gastrobot",
+									"reference": "UT36",
+									"local_notes": "Consumes 0.1lbs./hr. of biomass",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "10",
+									"cost": "+100%",
+									"disabled": true
+								},
+								{
+									"id": "ftP4Xhqt8XsQuiPQH",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fhT3sMtcrOGbTzLku"
+									},
+									"name": "Radio-Thermal Generator (RTG)",
+									"reference": "UT36",
+									"local_notes": "Lasts 1 year; LC1",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "10",
+									"cost": "+100%",
+									"disabled": true
+								},
+								{
+									"id": "fUrJ24R-qx7M85vYb",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "faJkuSBjewuh2TdLg"
+									},
+									"name": "Solar Cell",
+									"reference": "UT36",
+									"local_notes": "Recharges 3 hours' activity in 1 hour",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "10",
+									"cost": "+50%",
+									"disabled": true
+								},
+								{
+									"id": "f7kL3Hxv_l62dmLTE",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "f2u0xwoaeDxGjxCRq"
+									},
+									"name": "Solar Cell",
+									"reference": "UT36",
+									"local_notes": "Recharges 4 hours' activity in 1 hour",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "11",
+									"cost": "+50%",
+									"disabled": true
+								},
+								{
+									"id": "f7-0pS0kU67wt9pkW",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "ff9wLL0l7uzB0IRXf"
+									},
+									"name": "Solar Cell",
+									"reference": "UT36",
+									"local_notes": "Recharges 5 hours' activity in 1 hour",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "12",
+									"cost": "+50%",
+									"disabled": true
+								},
+								{
+									"id": "fkbF09LjO-MfngtVs",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "f4SVyLNBYhfPgNZC0"
+									},
+									"name": "Organovore",
+									"reference": "UT36",
+									"local_notes": "Consumes 0.1-0.5 lbs./hr. of carbon-based matter; LC3",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "11",
+									"cost": "+200%",
+									"disabled": true
+								},
+								{
+									"id": "fWR-lUxQtikqaKg-m",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fi-Vh6iRVAbMGaOiO"
+									},
+									"name": "Broadcast Power",
+									"reference": "UT37",
+									"local_notes": "C cell receiver",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "11^",
+									"cost": "+100%",
+									"disabled": true
+								}
+							]
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 4000,
+						"extended_value": 4000,
+						"weight": "2 lb",
+						"extended_weight": "2 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 60,
+				"extended_value": 11090,
+				"weight": "1.3333 lb",
+				"extended_weight": "18.6333 lb"
+			}
+		},
+		{
+			"id": "EuwyBfB6_ZMRbtst1",
+			"description": "Stored in Vehicle",
+			"legality_class": "4",
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "e6RCLEuVv82e1sw3n",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "efeekclqs54nOsbVN"
+					},
+					"description": "Swarmbot Hive",
+					"reference": "UT37",
+					"tech_level": "10",
+					"base_value": "200",
+					"base_weight": "10 lb",
+					"quantity": 2,
+					"equipped": true,
+					"calc": {
+						"value": 200,
+						"extended_value": 400,
+						"weight": "10 lb",
+						"extended_weight": "20 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 0,
+				"extended_value": 400,
+				"weight": "0 lb",
+				"extended_weight": "20 lb"
+			}
+		},
+		{
+			"id": "EDW7cSLRNAcsJjpLI",
+			"description": "Stored in Backpack",
+			"legality_class": "4",
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "ecGPqe7EDY9tqtGTi",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "epRXtbtPNVTPIqIdo"
+					},
+					"description": "A cell",
+					"reference": "UT19",
+					"tech_level": "9",
+					"tags": [
+						"Power"
+					],
+					"base_value": "2",
+					"base_weight": "0.005 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 2,
+						"extended_value": 2,
+						"weight": "0.005 lb",
+						"extended_weight": "0.005 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 0,
+				"extended_value": 2,
+				"weight": "0 lb",
+				"extended_weight": "0.005 lb"
+			}
+		}
+	],
+	"notes": [
+		{
+			"id": "na4SMMQSjRRDl73tj",
+			"markdown": "Remove VR gloves from the TL11 Spacer Basic Kit"
+		}
+	]
+}

--- a/Library/Loadouts/Starship Crew/TL11/Security Officer.gct
+++ b/Library/Loadouts/Starship Crew/TL11/Security Officer.gct
@@ -2855,13 +2855,37 @@
 						"weight": "2 lb",
 						"extended_weight": "2 lb"
 					}
+				},
+				{
+					"id": "ecGPqe7EDY9tqtGTi",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "epRXtbtPNVTPIqIdo"
+					},
+					"description": "A cell",
+					"reference": "UT19",
+					"tech_level": "9",
+					"tags": [
+						"Power"
+					],
+					"base_value": "2",
+					"base_weight": "0.005 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 2,
+						"extended_value": 2,
+						"weight": "0.005 lb",
+						"extended_weight": "0.005 lb"
+					}
 				}
 			],
 			"calc": {
 				"value": 60,
-				"extended_value": 11090,
+				"extended_value": 11092,
 				"weight": "1.3333 lb",
-				"extended_weight": "18.6333 lb"
+				"extended_weight": "18.6383 lb"
 			}
 		},
 		{
@@ -2898,45 +2922,6 @@
 				"extended_value": 400,
 				"weight": "0 lb",
 				"extended_weight": "20 lb"
-			}
-		},
-		{
-			"id": "EDW7cSLRNAcsJjpLI",
-			"description": "Stored in Backpack",
-			"legality_class": "4",
-			"quantity": 1,
-			"equipped": true,
-			"children": [
-				{
-					"id": "ecGPqe7EDY9tqtGTi",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
-						"id": "epRXtbtPNVTPIqIdo"
-					},
-					"description": "A cell",
-					"reference": "UT19",
-					"tech_level": "9",
-					"tags": [
-						"Power"
-					],
-					"base_value": "2",
-					"base_weight": "0.005 lb",
-					"quantity": 1,
-					"equipped": true,
-					"calc": {
-						"value": 2,
-						"extended_value": 2,
-						"weight": "0.005 lb",
-						"extended_weight": "0.005 lb"
-					}
-				}
-			],
-			"calc": {
-				"value": 0,
-				"extended_value": 2,
-				"weight": "0 lb",
-				"extended_weight": "0.005 lb"
 			}
 		}
 	],

--- a/Library/Loadouts/Starship Crew/TL11/Ship's Counselor.gct
+++ b/Library/Loadouts/Starship Crew/TL11/Ship's Counselor.gct
@@ -1,0 +1,235 @@
+{
+	"version": 5,
+	"id": "BU2CRpa1Jxrlv4iKW",
+	"equipment": [
+		{
+			"id": "Exyxr0xI0PVREsYyA",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Basic Set/Basic Set Equipment.eqp",
+				"id": "ESjtIfyzScVP49ity"
+			},
+			"description": "Backpack, Small",
+			"reference": "B288",
+			"tech_level": "1",
+			"tags": [
+				"Camping and Survival Gear"
+			],
+			"base_value": "60",
+			"base_weight": "3 lb",
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "contained_weight_prereq",
+						"has": true,
+						"qualifier": {
+							"compare": "at_most",
+							"qualifier": "40 lb"
+						}
+					}
+				]
+			},
+			"modifiers": [
+				{
+					"id": "f-1mgjTS0-RQ7-A23",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+						"id": "f3AMg_F7eHdJ-u_bX"
+					},
+					"name": "Expensive",
+					"reference": "UT15",
+					"cost_type": "to_base_cost",
+					"weight_type": "to_base_weight",
+					"cost": "+1 CF",
+					"weight": "x2/3"
+				}
+			],
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "eYI7rBAOhBbg34fld",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eVTeRAyFoRbvOEa6F"
+					},
+					"description": "Scanning Net",
+					"reference": "UT204",
+					"local_notes": "External power.",
+					"tech_level": "9",
+					"tags": [
+						"Biotech"
+					],
+					"base_value": "6000",
+					"base_weight": "4 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 6000,
+						"extended_value": 6000,
+						"weight": "4 lb",
+						"extended_weight": "4 lb"
+					}
+				},
+				{
+					"id": "eFNCKqi3IOyNOWUV0",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Equipment.eqp",
+						"id": "eRYg42Ausa4gwc7qU"
+					},
+					"description": "Suitcase Genetics Lab",
+					"reference": "BT16",
+					"local_notes": "10 minutes to pack or unpack; Improvised equipment for all but the most simple tasks",
+					"tech_level": "8",
+					"legality_class": "4",
+					"tags": [
+						"Biotech Facilities",
+						"Genetic Engineering"
+					],
+					"base_value": "12000",
+					"base_weight": "20 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 12000,
+						"extended_value": 12000,
+						"weight": "20 lb",
+						"extended_weight": "20 lb"
+					}
+				},
+				{
+					"id": "epNRKmZIzj2Dfwlk-",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "em9ZRPPzEh54KNqXX"
+					},
+					"description": "Pneumohypo",
+					"reference": "UT199",
+					"tech_level": "9",
+					"tags": [
+						"Medical"
+					],
+					"base_value": "20",
+					"base_weight": "0.1 lb",
+					"weapons": [
+						{
+							"id": "wM9-ftJo7QxpeBczs",
+							"damage": {
+								"type": "Spec"
+							},
+							"usage": "Stab",
+							"reach": "C",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Knife"
+								},
+								{
+									"type": "dx",
+									"modifier": -4
+								}
+							],
+							"calc": {
+								"damage": "Spec"
+							}
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 20,
+						"extended_value": 20,
+						"weight": "0.1 lb",
+						"extended_weight": "0.1 lb"
+					}
+				},
+				{
+					"id": "eFTiqtPi_bEb2rFQG",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Equipment.eqp",
+						"id": "ezb3U8AkhKqoR_pe-"
+					},
+					"description": "Crediline",
+					"reference": "BT157",
+					"local_notes": "Lasts (25-HT) minutes",
+					"tech_level": "9",
+					"legality_class": "2",
+					"tags": [
+						"Drug"
+					],
+					"base_value": "24",
+					"quantity": 5,
+					"equipped": true,
+					"calc": {
+						"value": 24,
+						"extended_value": 120,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				},
+				{
+					"id": "e06IWn6-CrHCSYA7u",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Equipment.eqp",
+						"id": "erjApvib8BnlDe6I5"
+					},
+					"description": "Deep-Sleep",
+					"reference": "BT158",
+					"tech_level": "10",
+					"legality_class": "4",
+					"tags": [
+						"Drug"
+					],
+					"base_value": "5",
+					"quantity": 10,
+					"equipped": true,
+					"calc": {
+						"value": 5,
+						"extended_value": 50,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				},
+				{
+					"id": "eY0MF2aBoc_51Sdhk",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eIX4rnrCFnUG7ewTr"
+					},
+					"description": "Memory-Beta",
+					"reference": "UT205",
+					"tech_level": "10",
+					"legality_class": "3",
+					"tags": [
+						"Biotech",
+						"Drug"
+					],
+					"base_value": "250",
+					"quantity": 4,
+					"equipped": true,
+					"calc": {
+						"value": 250,
+						"extended_value": 1000,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 120,
+				"extended_value": 19310,
+				"weight": "2 lb",
+				"extended_weight": "26.1 lb"
+			}
+		}
+	]
+}

--- a/Library/Loadouts/Starship Crew/TL11/Spacer Basic Kit.gct
+++ b/Library/Loadouts/Starship Crew/TL11/Spacer Basic Kit.gct
@@ -1,0 +1,2120 @@
+{
+	"version": 5,
+	"id": "B7d9aAgXpI44BZ4op",
+	"equipment": [
+		{
+			"id": "EBfVtQxI8Vqr8Rn3h",
+			"description": "Spacer Basic Kit",
+			"legality_class": "4",
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "E8JnupbWC6OGhv1KV",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eteEKk9yMz9Q9La4o"
+					},
+					"description": "Cybersuit",
+					"reference": "UT186",
+					"local_notes": "Super Jump 1. Flexible. D/1wk.",
+					"tech_level": "11",
+					"legality_class": "3",
+					"tags": [
+						"Armor",
+						"Defenses"
+					],
+					"base_value": "35000",
+					"base_weight": "30 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"locations": [
+								"all"
+							],
+							"amount": 40
+						},
+						{
+							"type": "attribute_bonus",
+							"limitation": "lifting_only",
+							"attribute": "st",
+							"amount": 5
+						},
+						{
+							"type": "attribute_bonus",
+							"limitation": "striking_only",
+							"attribute": "st",
+							"amount": 5
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"children": [
+						{
+							"id": "e33fjaEFlYCF6GSXU",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "e3ndgVXcnUultfit9"
+							},
+							"description": "Magnetized Plates",
+							"reference": "UT187",
+							"tech_level": "9",
+							"tags": [
+								"Defenses"
+							],
+							"base_value": "100",
+							"base_weight": "0.5 lb",
+							"quantity": 1,
+							"equipped": true,
+							"calc": {
+								"value": 100,
+								"extended_value": 100,
+								"weight": "0.5 lb",
+								"extended_weight": "0.5 lb"
+							}
+						},
+						{
+							"id": "eWeJzT0knG6kUMH32",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "euCVhRYMuK7QZVmpw"
+							},
+							"description": "Microbot Arteries",
+							"reference": "UT189",
+							"local_notes": "For battlesuits. Maximum of two per suit.",
+							"tech_level": "10",
+							"tags": [
+								"Defenses"
+							],
+							"base_value": "500",
+							"quantity": 1,
+							"equipped": true,
+							"calc": {
+								"value": 500,
+								"extended_value": 500,
+								"weight": "0 lb",
+								"extended_weight": "0 lb"
+							}
+						},
+						{
+							"id": "ernGEpo8iOKNPvVxN",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "eRd4HdGkY3padXW2c"
+							},
+							"description": "@Microbot/Nanobot Type@ Swarm",
+							"reference": "UT35",
+							"tech_level": "10",
+							"tags": [
+								"Swarmbots"
+							],
+							"base_weight": "2 lb",
+							"replacements": {
+								"Equipment": "Cybersuit",
+								"Microbot/Nanobot Type": "Repair"
+							},
+							"modifiers": [
+								{
+									"id": "FvcxwgK06Tw1QvoIg",
+									"name": "Swarm Type",
+									"reference": "UT37",
+									"local_notes": "at TL11 microbots can have two types, at TL12 nanobots can have two types",
+									"children": [
+										{
+											"id": "fNATyb4XZzKfzDkj4",
+											"name": "Bughunter",
+											"reference": "UT106",
+											"local_notes": "LC3",
+											"tags": [
+												"Counter-Surveillance and ECM",
+												"Security and Surveillance",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+4000",
+											"disabled": true
+										},
+										{
+											"id": "f2UaEC5Yb8a3HJ4xv",
+											"name": "Cannibal",
+											"reference": "UT169",
+											"local_notes": "LC1",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "12",
+											"cost": "+15000",
+											"disabled": true
+										},
+										{
+											"id": "fFT46p4d03foPc8IQ",
+											"name": "Cleaning",
+											"reference": "UT69",
+											"local_notes": "LC4",
+											"tags": [
+												"Domestic Equipment and Appliances",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fC-ZG38r6C35EATJJ",
+											"name": "Construction",
+											"reference": "UT86",
+											"local_notes": "LC4",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "f9_vOe07sZyQgwPMb",
+											"name": "Decontamination (@Hazard Type@)",
+											"reference": "UT87",
+											"local_notes": "LC3; Hazardous Materials (@Hazard Type@)-12",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "ftDXdiT0yEuvj1NFq",
+											"name": "Decontamination (@Hazard Type@)",
+											"reference": "UT87",
+											"local_notes": "LC3; Hazardous Materials (@Hazard Type@)-13",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "11",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fhTEnS_O8KHtGsUGX",
+											"name": "Decontamination (@Hazard Type@)",
+											"reference": "UT87",
+											"local_notes": "LC3; Hazardous Materials (@Hazard Type@)-14",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "12",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "ffLrjrnnF9b0cKBR8",
+											"name": "Defoliator",
+											"reference": "UT87",
+											"local_notes": "LC3",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "f6PP4WDLOBkJErJ3V",
+											"name": "Devourer",
+											"reference": "UT169",
+											"local_notes": "LC1",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "10",
+											"cost": "+8000",
+											"disabled": true
+										},
+										{
+											"id": "ffgwdEsUGngKoUlmW",
+											"name": "Disassembler",
+											"reference": "UT169",
+											"local_notes": "LC1",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "11",
+											"cost": "+10000",
+											"disabled": true
+										},
+										{
+											"id": "fmCRzcmOoxx3C29EX",
+											"name": "Explorer",
+											"reference": "UT80",
+											"local_notes": "LC4",
+											"tags": [
+												"Expedition Gear",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+500",
+											"disabled": true
+										},
+										{
+											"id": "f8SJTqdr0GQR62NEb",
+											"name": "Firefly",
+											"reference": "UT74",
+											"local_notes": "LC4",
+											"tags": [
+												"Domestic Equipment and Appliances",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+100",
+											"disabled": true
+										},
+										{
+											"id": "fp9ZljfwA37gu-iOV",
+											"name": "Forensic",
+											"reference": "UT107",
+											"local_notes": "LC3",
+											"tags": [
+												"Enforcement and Coercion",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+4000",
+											"disabled": true
+										},
+										{
+											"id": "fX3kPCb07C5TuBQHN",
+											"name": "Gremlin",
+											"reference": "UT169",
+											"local_notes": "LC2",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "10",
+											"cost": "+2000",
+											"disabled": true
+										},
+										{
+											"id": "fly_vMn6fy0wuCNE4",
+											"name": "Harvester",
+											"reference": "UT87",
+											"local_notes": "LC4",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+2000",
+											"disabled": true
+										},
+										{
+											"id": "fRaGpiNKbIrKoB8Qp",
+											"name": "Massage",
+											"reference": "UT41",
+											"local_notes": "LC4",
+											"tags": [
+												"Robots",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+200",
+											"disabled": true
+										},
+										{
+											"id": "fTN6biXY_jsXjePon",
+											"name": "Painter",
+											"reference": "UT87",
+											"local_notes": "LC4",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+500",
+											"disabled": true
+										},
+										{
+											"id": "fwoqbTg6UPvi71IKc",
+											"name": "Paramedical",
+											"reference": "UT201",
+											"local_notes": "LC3; Diagnosis-10, First Aid-10",
+											"tags": [
+												"Medical",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+6000",
+											"disabled": true
+										},
+										{
+											"id": "fP9nZrdeBIY4-roTH",
+											"name": "Paramedical",
+											"reference": "UT201",
+											"local_notes": "LC3; Diagnosis-11, First Aid-11",
+											"tags": [
+												"Medical",
+												"Swarmbots"
+											],
+											"tech_level": "11",
+											"cost": "+6000",
+											"disabled": true
+										},
+										{
+											"id": "fupa114BIFCp8R0eP",
+											"name": "Paramedical",
+											"reference": "UT201",
+											"local_notes": "LC3; Diagnosis-12, First Aid-12",
+											"tags": [
+												"Medical",
+												"Swarmbots"
+											],
+											"tech_level": "12",
+											"cost": "+6000",
+											"disabled": true
+										},
+										{
+											"id": "fIY6BPLs7aT48XOSi",
+											"name": "Pesticide",
+											"reference": "UT87",
+											"local_notes": "LC3",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fe2k2yClW3YSkblbX",
+											"name": "Play",
+											"reference": "UT41",
+											"local_notes": "LC4",
+											"tags": [
+												"Robots",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+200",
+											"disabled": true
+										},
+										{
+											"id": "fqziaDpNQs120zZLs",
+											"name": "Pollinator",
+											"reference": "UT87",
+											"local_notes": "LC4",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "f2tEZTSLpOnztxK_S",
+											"name": "Repair (@Equipment@)",
+											"reference": "UT87",
+											"local_notes": "LC4; Repair Skill-12",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+500",
+											"disabled": true
+										},
+										{
+											"id": "feCmlWzDQ14KRNL1e",
+											"name": "Repair (@Equipment@)",
+											"reference": "UT87",
+											"local_notes": "LC4; Repair Skill-13",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "11",
+											"cost": "+500"
+										},
+										{
+											"id": "fZZrupp_kO0TjEJeO",
+											"name": "Repair (@Other Equipment 1@)",
+											"reference": "UT87",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+250",
+											"disabled": true
+										},
+										{
+											"id": "f9kQX8tUaeQigYvMF",
+											"name": "Repair (@Other Equipment 2@)",
+											"reference": "UT87",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+250",
+											"disabled": true
+										},
+										{
+											"id": "fZCMESqfPGfFs2VKE",
+											"name": "Repair (@Other Equipment 3@)",
+											"reference": "UT87",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+250",
+											"disabled": true
+										},
+										{
+											"id": "fKt_RV1RnCXqVGhMq",
+											"name": "Security",
+											"reference": "UT104",
+											"local_notes": "LC3",
+											"tags": [
+												"Security and Surveillance",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fmaxQpQEQaAC_u9SP",
+											"name": "Sentry",
+											"reference": "UT169",
+											"local_notes": "LC3",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "10",
+											"cost": "+5000",
+											"disabled": true
+										},
+										{
+											"id": "fb2NFhX62Wi4tmNtw",
+											"name": "Stinger",
+											"reference": "UT169",
+											"local_notes": "LC2",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "10",
+											"cost": "+1500",
+											"disabled": true
+										},
+										{
+											"id": "fgQbRQFrjjS7zo_O9",
+											"name": "Surveillance",
+											"reference": "UT106",
+											"local_notes": "LC3",
+											"tags": [
+												"Security and Surveillance",
+												"Surveillance and Tracking Devices",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+500",
+											"disabled": true
+										},
+										{
+											"id": "f8OeWlvFCUj4HSUjN",
+											"name": "Terminator",
+											"reference": "UT169",
+											"local_notes": "LC1",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "10",
+											"cost": "+1500",
+											"disabled": true
+										}
+									]
+								},
+								{
+									"id": "f1Dh12i5rucYKc_IX",
+									"name": "Self-Replicating",
+									"reference": "UT37",
+									"local_notes": "only for defoliator, devourer or pesticide",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_base_cost",
+									"cost": "x10",
+									"disabled": true
+								},
+								{
+									"id": "FCMX47v6NfdCIrN3w",
+									"name": "Chassis",
+									"local_notes": "choose one microbot or nanobot chassis",
+									"children": [
+										{
+											"id": "FzphWP19cbNooFFWA",
+											"name": "Microbot Chassis",
+											"children": [
+												{
+													"id": "fsmUwEl3X5ndNttgM",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "f7eMKwMF7BTYFbxhq"
+													},
+													"name": "Microbot Aerostat",
+													"reference": "UT36",
+													"local_notes": "Air Move 2",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "10",
+													"disabled": true
+												},
+												{
+													"id": "fSBnEvpvhQXGIJVRU",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fcVKEB14BedQI1jGA"
+													},
+													"name": "Microbot Crawler",
+													"reference": "UT36",
+													"local_notes": "Move 3; Water Move 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "10",
+													"disabled": true
+												},
+												{
+													"id": "f97U4tXIamvKb30BN",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fScgdTYLwKE9CEYfl"
+													},
+													"name": "Microbot Crawler, Armored",
+													"reference": "UT36",
+													"local_notes": "Move 2, 2x HP",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "10",
+													"cost": "+100%",
+													"disabled": true
+												},
+												{
+													"id": "fDaNUFci3EAOcHBYP",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fpAVv9yE3m3t0Egt_"
+													},
+													"name": "Microbot Flier",
+													"reference": "UT36",
+													"local_notes": "Move 1; Air Move 6",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "10",
+													"cost": "+100%",
+													"disabled": true
+												},
+												{
+													"id": "fM7bJoRiPxZLg3EZF",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "ffHj2SBngzuewdrbB"
+													},
+													"name": "Microbot Hopper",
+													"reference": "UT36",
+													"local_notes": "Move 4; Super Jump 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "10",
+													"cost": "+50%",
+													"disabled": true
+												},
+												{
+													"id": "fLHUfr08GBh-4NXXl",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fr6wQjKaUic-BpBCO"
+													},
+													"name": "Microbot Space",
+													"reference": "UT36",
+													"local_notes": "Move 1; 0.0001G solar sail",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "10",
+													"cost": "+0",
+													"disabled": true
+												},
+												{
+													"id": "fnE4NY8n8eQXLyAYL",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fsL5rGqz66ht8cVvg"
+													},
+													"name": "Microbot Swimmer",
+													"reference": "UT36",
+													"local_notes": "Water Move 4",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "10",
+													"cost": "+0",
+													"disabled": true
+												},
+												{
+													"id": "fBzJMLls2PGrMo0oG",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fvVo7_8gzuQpK50fc"
+													},
+													"name": "Microbot Contragrav (CG) Flier",
+													"reference": "UT36",
+													"local_notes": "Move 1; Air Move 20",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11^",
+													"cost": "+200%",
+													"disabled": true
+												}
+											]
+										},
+										{
+											"id": "FJJzFViWTXMSI-Z8n",
+											"name": "Nanobot Chassis",
+											"children": [
+												{
+													"id": "fWl5IevhZBjH_PVLu",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "f6RvvKoBN0DqIjBjQ"
+													},
+													"name": "Nanobot Aerostat",
+													"reference": "UT36",
+													"local_notes": "Air Move 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "11",
+													"disabled": true
+												},
+												{
+													"id": "f6l05cAkf7SdvKjkB",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "f1OLvlafFuNITe6na"
+													},
+													"name": "Nanobot Crawler",
+													"reference": "UT36",
+													"local_notes": "Move 3; Water Move 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "11"
+												},
+												{
+													"id": "f4DsvQLZX3lEDQSbS",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fASzj6iYz6hUA-TBB"
+													},
+													"name": "Nanobot Crawler, Armored",
+													"reference": "UT36",
+													"local_notes": "Move 2, 2x HP",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11",
+													"cost": "+100%",
+													"disabled": true
+												},
+												{
+													"id": "fZsB9Df7CZL0CFi4P",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fLuL-pD4o6s0lREJs"
+													},
+													"name": "Nanobot Dust",
+													"reference": "UT36",
+													"local_notes": "Immobile",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11",
+													"cost": "-80%",
+													"disabled": true
+												},
+												{
+													"id": "fLnu5p08ZnugiGIya",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fKeArqcSSvcPk5QTp"
+													},
+													"name": "Nanobot Flier",
+													"reference": "UT36",
+													"local_notes": "Move 1; Air Move 3",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11",
+													"cost": "+100%",
+													"disabled": true
+												},
+												{
+													"id": "fDpEWUgZyFwWXbCzn",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fyATVIBpOaRfq3tKe"
+													},
+													"name": "Nanobot Hopper",
+													"reference": "UT36",
+													"local_notes": "Move 4; Super Jump 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11",
+													"cost": "+50%",
+													"disabled": true
+												},
+												{
+													"id": "fWHux4R7-GIh1JoOU",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "f80KO0VZYaEJb9hbs"
+													},
+													"name": "Nanobot Space",
+													"reference": "UT36",
+													"local_notes": "Move 1; 0.0001G solar sail",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "11",
+													"cost": "+0",
+													"disabled": true
+												},
+												{
+													"id": "f_ufMHr4ySlM7KulS",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fa36bUxm5RcsG_mOk"
+													},
+													"name": "Nanobot Swimmer",
+													"reference": "UT36",
+													"local_notes": "Water Move 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "11",
+													"cost": "+0",
+													"disabled": true
+												},
+												{
+													"id": "fYFToNZrLhoXTX5wF",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fPgd1Z13foKJXxTND"
+													},
+													"name": "Nanobot Contragrav (CG) Flier",
+													"reference": "UT36",
+													"local_notes": "Move 1; Air Move 10",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11^",
+													"cost": "+200%",
+													"disabled": true
+												}
+											]
+										}
+									]
+								},
+								{
+									"id": "Fu-qaGeTKqdx63_A8",
+									"name": "Stealth",
+									"children": [
+										{
+											"id": "fReIbV66J5f_Tkh8o",
+											"name": "Disguise",
+											"reference": "UT36",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_cost",
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fml0vOUn0NYgRvNRD",
+											"name": "Thermo-Optic Chameleon Surface",
+											"reference": "UT37, UT98",
+											"local_notes": "LC3",
+											"tags": [
+												"Deception and Intrusion",
+												"Swarmbots"
+											],
+											"cost_type": "to_final_cost",
+											"tech_level": "9",
+											"cost": "+4000",
+											"weight": "+4 lb",
+											"disabled": true
+										},
+										{
+											"id": "f8ZiI6tut0hNvKlN-",
+											"name": "Multispectral Chameleon Surface",
+											"reference": "UT37, UT99",
+											"local_notes": "LC3",
+											"tags": [
+												"Deception and Intrusion",
+												"Swarmbots"
+											],
+											"cost_type": "to_final_cost",
+											"tech_level": "10",
+											"cost": "+6000",
+											"weight": "+4 lb",
+											"disabled": true
+										},
+										{
+											"id": "fzrhSiGsD2wnhKoTJ",
+											"name": "Dynamic Multispectral Chameleon Surface",
+											"reference": "UT37, UT99",
+											"local_notes": "LC3",
+											"tags": [
+												"Deception and Intrusion",
+												"Swarmbots"
+											],
+											"cost_type": "to_final_cost",
+											"tech_level": "11",
+											"cost": "+8000",
+											"weight": "+4 lb",
+											"disabled": true
+										},
+										{
+											"id": "fWKgpcC6AUXPXxiPQ",
+											"name": "Ultimate Chameleon Surface",
+											"reference": "UT37, UT99",
+											"local_notes": "LC3",
+											"tags": [
+												"Deception and Intrusion",
+												"Swarmbots"
+											],
+											"cost_type": "to_final_cost",
+											"tech_level": "12",
+											"cost": "+10000",
+											"weight": "+4 lb",
+											"disabled": true
+										}
+									]
+								},
+								{
+									"id": "FDoqWtkSH1jNPXTpu",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "F5Q7h4gAuvWsoUiFV"
+									},
+									"name": "Power Supply",
+									"children": [
+										{
+											"id": "fTZ7EgJ3KrlxHmfr6",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "faj6YgnYeEKAy39jw"
+											},
+											"name": "Power Cells",
+											"reference": "UT36",
+											"local_notes": "Recharges in a Hive; C/12hr.",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"disabled": true
+										},
+										{
+											"id": "fHxCj7b_kUyxSiiUs",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fCJ9sdOXfXoLN594u"
+											},
+											"name": "Power Cells",
+											"reference": "UT36",
+											"local_notes": "Recharges in a Hive; C/72hr.",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "11"
+										},
+										{
+											"id": "fCDyEra7pWjutNXGC",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f7WMm14XwVJyvz2NQ"
+											},
+											"name": "Power Cells",
+											"reference": "UT36",
+											"local_notes": "Recharges in a Hive; C/5 days.",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "12",
+											"disabled": true
+										},
+										{
+											"id": "fr50FJYt1A8UFta3t",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fGv5njL67i7rODIpL"
+											},
+											"name": "Beamed Power",
+											"reference": "UT36",
+											"local_notes": "C cell receiver",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "fAO9n76EezeV0rupl",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fS-7nLrwLytJp5mLZ"
+											},
+											"name": "Gastrobot",
+											"reference": "UT36",
+											"local_notes": "Consumes 0.1lbs./hr. of biomass",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+100%",
+											"disabled": true
+										},
+										{
+											"id": "fPyINd9ZpuyGVIYUE",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fhT3sMtcrOGbTzLku"
+											},
+											"name": "Radio-Thermal Generator (RTG)",
+											"reference": "UT36",
+											"local_notes": "Lasts 1 year; LC1",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+100%",
+											"disabled": true
+										},
+										{
+											"id": "ftD5mTwIillieCm6y",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "faJkuSBjewuh2TdLg"
+											},
+											"name": "Solar Cell",
+											"reference": "UT36",
+											"local_notes": "Recharges 3 hours' activity in 1 hour",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "f3wVipI_Lmwwfajfa",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f2u0xwoaeDxGjxCRq"
+											},
+											"name": "Solar Cell",
+											"reference": "UT36",
+											"local_notes": "Recharges 4 hours' activity in 1 hour",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "f942Uf3zCFYPF08h5",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "ff9wLL0l7uzB0IRXf"
+											},
+											"name": "Solar Cell",
+											"reference": "UT36",
+											"local_notes": "Recharges 5 hours' activity in 1 hour",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "12",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "fN8xX7QxhK0Py39AD",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f4SVyLNBYhfPgNZC0"
+											},
+											"name": "Organovore",
+											"reference": "UT36",
+											"local_notes": "Consumes 0.1-0.5 lbs./hr. of carbon-based matter; LC3",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11",
+											"cost": "+200%",
+											"disabled": true
+										},
+										{
+											"id": "f80HZ5x6w2rSAJbbs",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fi-Vh6iRVAbMGaOiO"
+											},
+											"name": "Broadcast Power",
+											"reference": "UT37",
+											"local_notes": "C cell receiver",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11^",
+											"cost": "+100%",
+											"disabled": true
+										}
+									]
+								}
+							],
+							"quantity": 1,
+							"equipped": true,
+							"calc": {
+								"value": 500,
+								"extended_value": 500,
+								"weight": "2 lb",
+								"extended_weight": "2 lb"
+							}
+						}
+					],
+					"calc": {
+						"value": 35000,
+						"extended_value": 36100,
+						"weight": "30 lb",
+						"extended_weight": "32.5 lb"
+					}
+				},
+				{
+					"id": "equ6cXhIlzDMSot-7",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "edU4hHKFQZtZ4ElU1"
+					},
+					"description": "Tiny Radio Communicator",
+					"reference": "UT44",
+					"local_notes": "5-mile range. 2A/10hr.",
+					"tech_level": "11",
+					"tags": [
+						"Communication and Interface"
+					],
+					"base_value": "50",
+					"base_weight": "0.05 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 50,
+						"extended_value": 50,
+						"weight": "0.05 lb",
+						"extended_weight": "0.05 lb"
+					}
+				},
+				{
+					"id": "etHPsKz8xk4LN4iZC",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eQtg4HMer2ptEf7cp"
+					},
+					"description": "Hyperspectral Contacts",
+					"reference": "UT61",
+					"local_notes": "1x magnification.",
+					"tech_level": "11",
+					"tags": [
+						"Sensors and Scientific Equipment"
+					],
+					"base_value": "1200",
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "spot hidden clues or objects with Forensics, Observation or Search",
+							"amount": 3
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "vision",
+							"amount": 3
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Tracking"
+							},
+							"amount": 3
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 1200,
+						"extended_value": 1200,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				},
+				{
+					"id": "eDG_BeQGUGobHB8m0",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Equipment.eqp",
+						"id": "eLpY_lV7JPT_Srj5A"
+					},
+					"description": "Ordinary Clothes",
+					"reference": "B266",
+					"local_notes": "Status 0",
+					"tags": [
+						"Clothing"
+					],
+					"base_value": "120",
+					"base_weight": "4 lb",
+					"modifiers": [
+						{
+							"id": "fAf9TgL5hbdPwejDM",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+								"id": "fLY2N6xYndg7V6SpV"
+							},
+							"name": "Responsive Fabric",
+							"reference": "UT39",
+							"cost_type": "to_base_cost",
+							"tech_level": "10",
+							"cost": "+2 CF"
+						},
+						{
+							"id": "fMLq53qAVX75UxuWR",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+								"id": "ffYgtFc-xzY7zhAQd"
+							},
+							"name": "Buzz Fabric",
+							"reference": "UT39",
+							"cost_type": "to_base_cost",
+							"tech_level": "10",
+							"cost": "+1 CF"
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 480,
+						"extended_value": 480,
+						"weight": "4 lb",
+						"extended_weight": "4 lb"
+					}
+				},
+				{
+					"id": "e_1QJ3SAg2Pxg9JVx",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eT3f4c4tSQXzONaiV"
+					},
+					"description": "Space Biosuit",
+					"reference": "UT179",
+					"local_notes": "Flexible. 2C/6wk.",
+					"tech_level": "10",
+					"legality_class": "3",
+					"tags": [
+						"Armor",
+						"Defenses"
+					],
+					"base_value": "10000",
+					"base_weight": "5 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"locations": [
+								"all"
+							],
+							"specialization": "corrosion, crushing and toxic",
+							"amount": -12
+						},
+						{
+							"type": "dr_bonus",
+							"locations": [
+								"all"
+							],
+							"amount": 15
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 10000,
+						"extended_value": 10000,
+						"weight": "5 lb",
+						"extended_weight": "5 lb"
+					}
+				},
+				{
+					"id": "e4lNjHkgoOk1Ksvyg",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eyvIWpyu_ZL2Mu5zP"
+					},
+					"description": "Wristwatch Rad Counter",
+					"reference": "UT67",
+					"local_notes": "A/6mo.",
+					"tech_level": "9",
+					"tags": [
+						"Sensors and Scientific Equipment"
+					],
+					"base_value": "100",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 100,
+						"extended_value": 100,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				},
+				{
+					"id": "eOCfjPrrKqMVL8PMG",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "edeuZPVHHNIu1RLQd"
+					},
+					"description": "Biomonitor Bracelet",
+					"reference": "UT197",
+					"local_notes": "+1 (quality) to diagnose the wearer.",
+					"tech_level": "9",
+					"tags": [
+						"Medical"
+					],
+					"base_value": "50",
+					"base_weight": "0.1 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 50,
+						"extended_value": 50,
+						"weight": "0.1 lb",
+						"extended_weight": "0.1 lb"
+					}
+				},
+				{
+					"id": "EMDyU46NLU0kjz_ve",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eNxEqbQBIyZOS3rdx"
+					},
+					"description": "VR Gloves",
+					"reference": "UT54",
+					"local_notes": "Requires Complexity 2+.",
+					"tech_level": "9",
+					"tags": [
+						"Media and Education"
+					],
+					"base_value": "20",
+					"base_weight": "0.3 lb",
+					"quantity": 1,
+					"equipped": true,
+					"children": [
+						{
+							"id": "eQly_0OvbKZETJY7_",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "ef55nM_NrfAgS_Cam"
+							},
+							"description": "Karatand",
+							"reference": "UT163",
+							"tech_level": "9",
+							"legality_class": "3",
+							"tags": [
+								"Melee Weapon",
+								"Weaponry"
+							],
+							"base_value": "100",
+							"weapons": [
+								{
+									"id": "wFUwQBexMe7910AGU",
+									"damage": {
+										"type": "cr",
+										"st": "thr"
+									},
+									"usage": "Punch",
+									"reach": "C",
+									"parry": "0",
+									"defaults": [
+										{
+											"type": "dx"
+										},
+										{
+											"type": "skill",
+											"name": "Boxing"
+										},
+										{
+											"type": "skill",
+											"name": "Brawling"
+										},
+										{
+											"type": "skill",
+											"name": "Karate"
+										}
+									],
+									"calc": {
+										"damage": "thr cr"
+									}
+								}
+							],
+							"quantity": 1,
+							"equipped": true,
+							"calc": {
+								"value": 100,
+								"extended_value": 100,
+								"weight": "0 lb",
+								"extended_weight": "0 lb"
+							}
+						}
+					],
+					"calc": {
+						"value": 20,
+						"extended_value": 120,
+						"weight": "0.3 lb",
+						"extended_weight": "0.3 lb"
+					}
+				},
+				{
+					"id": "Eb-xP9LleYtac7AvB",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "High Tech/High Tech Equipment.eqp",
+						"id": "EqiOPn9i8xyh2a7jy"
+					},
+					"description": "Waist Pack",
+					"reference": "HT54",
+					"local_notes": "Holds 10lbs.",
+					"tech_level": "5",
+					"tags": [
+						"General Equipment"
+					],
+					"base_value": "10",
+					"base_weight": "1 lb",
+					"quantity": 1,
+					"equipped": true,
+					"children": [
+						{
+							"id": "EUwP5UFpmG7ljrgHv",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "e5qZTKtVs-q-xQlfS"
+							},
+							"description": "Small Computer",
+							"reference": "UT22",
+							"local_notes": "Complexity 7. 10EB. 2B/20hr.",
+							"tech_level": "11",
+							"tags": [
+								"Computers"
+							],
+							"base_value": "100",
+							"base_weight": "0.5 lb",
+							"modifiers": [
+								{
+									"id": "fWKjX47PT4oF8TJum",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "ftp3XhCDqI3Lan38o"
+									},
+									"name": "Rugged",
+									"reference": "UT15",
+									"cost_type": "to_base_cost",
+									"weight_type": "to_base_weight",
+									"cost": "+1 CF",
+									"weight": "x1.2"
+								}
+							],
+							"quantity": 1,
+							"equipped": true,
+							"children": [
+								{
+									"id": "ePTQdA6u0S18qgYsm",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+										"id": "eC1DrHF8oqmYt-rRT"
+									},
+									"description": "Datapad",
+									"reference": "UT23",
+									"local_notes": "2A/20hr.",
+									"tech_level": "9",
+									"tags": [
+										"Computers"
+									],
+									"base_value": "10",
+									"base_weight": "0.05 lb",
+									"modifiers": [
+										{
+											"id": "fFh1yQx9HqoqMzDTS",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fZK5VWsvzMBCRHwkA"
+											},
+											"name": "Combination Gadget cost, multiple work at a time",
+											"reference": "UT16",
+											"cost_type": "to_final_cost",
+											"cost": "x0.8"
+										},
+										{
+											"id": "fy0oH-mh4cRkmH011",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fbXG-SurLpMjqzf1Z"
+											},
+											"name": "Combination Gadget weight, multiple work at a time",
+											"reference": "UT16",
+											"weight_type": "to_final_weight",
+											"cost": "+0",
+											"weight": "x0.8"
+										},
+										{
+											"id": "fixafw7O_OuDsrS_b",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "ftp3XhCDqI3Lan38o"
+											},
+											"name": "Rugged",
+											"reference": "UT15",
+											"cost_type": "to_base_cost",
+											"weight_type": "to_base_weight",
+											"cost": "+1 CF",
+											"weight": "x1.2"
+										}
+									],
+									"quantity": 1,
+									"equipped": true,
+									"calc": {
+										"value": 16,
+										"extended_value": 16,
+										"weight": "0.048 lb",
+										"extended_weight": "0.048 lb"
+									}
+								}
+							],
+							"calc": {
+								"value": 200,
+								"extended_value": 216,
+								"weight": "0.6 lb",
+								"extended_weight": "0.648 lb"
+							}
+						},
+						{
+							"id": "eitAfg57X1uePSkdf",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "e5BC-pEfofU28HHzf"
+							},
+							"description": "Optical Cable",
+							"reference": "UT43",
+							"local_notes": "\"Quantity\" represents yards.",
+							"tech_level": "9",
+							"tags": [
+								"Communication and Interface"
+							],
+							"base_value": "0.1",
+							"base_weight": "0.01 lb",
+							"quantity": 1,
+							"equipped": true,
+							"calc": {
+								"value": 0.1,
+								"extended_value": 0.1,
+								"weight": "0.01 lb",
+								"extended_weight": "0.01 lb"
+							}
+						},
+						{
+							"id": "EMayb0QFtEVRGJ_WC",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "EJckJM_hH4F4xKfwh"
+							},
+							"description": "Hand Thruster",
+							"reference": "UT231",
+							"local_notes": "0.1G acceleration",
+							"tech_level": "9",
+							"tags": [
+								"Expedition Gear"
+							],
+							"base_value": "50",
+							"base_weight": "3 lb",
+							"quantity": 1,
+							"equipped": true,
+							"children": [
+								{
+									"id": "eFQ17NEcrzzHeuZLm",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+										"id": "e1AvdwPjgAi5wr6LM"
+									},
+									"description": "Hand Thruster Cartridge",
+									"reference": "UT231",
+									"local_notes": "30 seconds of 0.1G acceleration",
+									"tags": [
+										"Expedition Gear"
+									],
+									"base_value": "10",
+									"base_weight": "1 lb",
+									"quantity": 1,
+									"equipped": true,
+									"calc": {
+										"value": 10,
+										"extended_value": 10,
+										"weight": "1 lb",
+										"extended_weight": "1 lb"
+									}
+								}
+							],
+							"calc": {
+								"value": 50,
+								"extended_value": 60,
+								"weight": "3 lb",
+								"extended_weight": "4 lb"
+							}
+						},
+						{
+							"id": "eBk6vlhbuxHwo3GnL",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "e80GXy2r6Vc2kTw5i"
+							},
+							"description": "3/16\" Smart Rope",
+							"reference": "UT76",
+							"local_notes": "Per yard. Supports 2,000lbs. Can be ordered by radio to be flexible or rigid, unable to be untied.",
+							"tech_level": "11",
+							"tags": [
+								"Tools and Construction Materials"
+							],
+							"base_value": "1",
+							"base_weight": "0.025 lb",
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Knot-Tying"
+									},
+									"amount": 3
+								}
+							],
+							"quantity": 10,
+							"equipped": true,
+							"calc": {
+								"value": 1,
+								"extended_value": 10,
+								"weight": "0.025 lb",
+								"extended_weight": "0.25 lb"
+							}
+						},
+						{
+							"id": "eiN9CXgo0KxBgj6kX",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "ebCNh87klNSzFt1m6"
+							},
+							"description": "Splat Piton",
+							"reference": "UT76",
+							"tech_level": "9",
+							"tags": [
+								"Expedition Gear"
+							],
+							"base_value": "10",
+							"base_weight": "0.05 lb",
+							"quantity": 1,
+							"equipped": true,
+							"calc": {
+								"value": 10,
+								"extended_value": 10,
+								"weight": "0.05 lb",
+								"extended_weight": "0.05 lb"
+							}
+						},
+						{
+							"id": "EnNy6j7_ftRnjxHB9",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "Ez-VClz8l8_6V0LaR"
+							},
+							"description": "Pocket Pack",
+							"reference": "UT38",
+							"tech_level": "9",
+							"quantity": 1,
+							"equipped": true,
+							"children": [
+								{
+									"id": "edcu8i-5mIcLE6Xx4",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+										"id": "euI8dEYRdnmx6Rmcc"
+									},
+									"description": "Candy bar",
+									"reference": "UT38",
+									"tech_level": "9",
+									"base_value": "1",
+									"base_weight": "0.125 lb",
+									"quantity": 1,
+									"equipped": true,
+									"calc": {
+										"value": 1,
+										"extended_value": 1,
+										"weight": "0.125 lb",
+										"extended_weight": "0.125 lb"
+									}
+								},
+								{
+									"id": "eqNubdcUDDtPLgULt",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+										"id": "eGBSENKNFt4VCspzv"
+									},
+									"description": "Food tablets",
+									"reference": "UT38",
+									"tech_level": "9",
+									"base_value": "5",
+									"base_weight": "0.25 lb",
+									"quantity": 1,
+									"equipped": true,
+									"calc": {
+										"value": 5,
+										"extended_value": 5,
+										"weight": "0.25 lb",
+										"extended_weight": "0.25 lb"
+									}
+								},
+								{
+									"id": "e6TA_rYV_3cFXCWAZ",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+										"id": "e6rO2q_UIV-CCt9W9"
+									},
+									"description": "Marking pen",
+									"reference": "UT38",
+									"tech_level": "9",
+									"base_value": "4",
+									"base_weight": "0.0625 lb",
+									"quantity": 1,
+									"equipped": true,
+									"calc": {
+										"value": 4,
+										"extended_value": 4,
+										"weight": "0.0625 lb",
+										"extended_weight": "0.0625 lb"
+									}
+								},
+								{
+									"id": "eLp25d_4XEmY8Qmis",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+										"id": "emMylxg9qt-HrZ8IA"
+									},
+									"description": "Penlight",
+									"reference": "UT74",
+									"local_notes": "5-yard beam. 2A/24hr.",
+									"tech_level": "9",
+									"tags": [
+										"Housing Tools and Survival Gear"
+									],
+									"base_value": "3",
+									"base_weight": "0.1 lb",
+									"quantity": 1,
+									"equipped": true,
+									"calc": {
+										"value": 3,
+										"extended_value": 3,
+										"weight": "0.1 lb",
+										"extended_weight": "0.1 lb"
+									}
+								},
+								{
+									"id": "exSfcLndFODDJZguP",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+										"id": "eBABd92qd4qkfnZcI"
+									},
+									"description": "Swiss army knife",
+									"reference": "UT38",
+									"tech_level": "9",
+									"base_value": "10",
+									"base_weight": "0.125 lb",
+									"quantity": 1,
+									"equipped": true,
+									"calc": {
+										"value": 10,
+										"extended_value": 10,
+										"weight": "0.125 lb",
+										"extended_weight": "0.125 lb"
+									}
+								},
+								{
+									"id": "eEB828ISh_bQjvgu_",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+										"id": "e2RWOzDuPgwBqEtaY"
+									},
+									"description": "Vacuum-proof sticky tape",
+									"reference": "UT38",
+									"local_notes": "150yd. x 2\"",
+									"tech_level": "9",
+									"base_value": "2",
+									"base_weight": "0.125 lb",
+									"quantity": 1,
+									"equipped": true,
+									"calc": {
+										"value": 2,
+										"extended_value": 2,
+										"weight": "0.125 lb",
+										"extended_weight": "0.125 lb"
+									}
+								}
+							],
+							"calc": {
+								"value": 0,
+								"extended_value": 25,
+								"weight": "0 lb",
+								"extended_weight": "0.7875 lb"
+							}
+						},
+						{
+							"id": "eAGIcMTO1tJJCgEyH",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Equipment.eqp",
+								"id": "e0z9DCZj3jzgLmFSf"
+							},
+							"description": "Personal Basics",
+							"reference": "B288",
+							"local_notes": "Minimum gear for camping: -2 to any Survival roll without it. Includes utensils, tinderbox or flint and steel, towel, etc., as TL permits.",
+							"tech_level": "0",
+							"tags": [
+								"Camping and Survival Gear"
+							],
+							"base_value": "5",
+							"base_weight": "1 lb",
+							"quantity": 1,
+							"equipped": true,
+							"calc": {
+								"value": 5,
+								"extended_value": 5,
+								"weight": "1 lb",
+								"extended_weight": "1 lb"
+							}
+						},
+						{
+							"id": "erk0HgdUIWxTxU2jM",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "eSHT4XG9bbuomFm-i"
+							},
+							"description": "Cleaning Gel",
+							"reference": "UT38",
+							"local_notes": "7 applications.",
+							"tech_level": "9",
+							"base_value": "7",
+							"base_weight": "1.5 lb",
+							"quantity": 1,
+							"equipped": true,
+							"calc": {
+								"value": 7,
+								"extended_value": 7,
+								"weight": "1.5 lb",
+								"extended_weight": "1.5 lb"
+							}
+						},
+						{
+							"id": "e_9kcUsfA8ODIGiAx",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "eihpHx6SKfL_XBqyj"
+							},
+							"description": "Smart Brush",
+							"reference": "UT38",
+							"local_notes": "B/24hr.",
+							"tech_level": "9",
+							"base_value": "50",
+							"base_weight": "0.5 lb",
+							"quantity": 1,
+							"equipped": true,
+							"calc": {
+								"value": 50,
+								"extended_value": 50,
+								"weight": "0.5 lb",
+								"extended_weight": "0.5 lb"
+							}
+						},
+						{
+							"id": "eWO9cFb9TY3IfPIyy",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "edNt6ts8chLmfoPXz"
+							},
+							"description": "Grooming Spray",
+							"reference": "UT38",
+							"local_notes": "30 uses.",
+							"tech_level": "10",
+							"base_value": "10",
+							"base_weight": "0.1 lb",
+							"quantity": 1,
+							"equipped": true,
+							"calc": {
+								"value": 10,
+								"extended_value": 10,
+								"weight": "0.1 lb",
+								"extended_weight": "0.1 lb"
+							}
+						},
+						{
+							"id": "ehG1u010bU5jgpBQl",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Bio-Tech/Bio-Tech Equipment.eqp",
+								"id": "eSAwPI3aJT6KqrIXA"
+							},
+							"description": "Pore Cleaners",
+							"reference": "BT165",
+							"local_notes": "Lasts one day to two weeks; Takes effect in one hour",
+							"tech_level": "10",
+							"legality_class": "4",
+							"tags": [
+								"Drug"
+							],
+							"base_value": "50",
+							"quantity": 1,
+							"equipped": true,
+							"calc": {
+								"value": 50,
+								"extended_value": 50,
+								"weight": "0 lb",
+								"extended_weight": "0 lb"
+							}
+						},
+						{
+							"id": "etm1Oa8CDhFNARb91",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "eQPgEdhO7JoJjyJLr"
+							},
+							"description": "Nasal Filter Plugs",
+							"reference": "UT188",
+							"tech_level": "9",
+							"tags": [
+								"Defenses"
+							],
+							"base_value": "100",
+							"quantity": 1,
+							"equipped": true,
+							"calc": {
+								"value": 100,
+								"extended_value": 100,
+								"weight": "0 lb",
+								"extended_weight": "0 lb"
+							}
+						},
+						{
+							"id": "eM4bRms2nQ03KoWXD",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "epRXtbtPNVTPIqIdo"
+							},
+							"description": "A cell",
+							"reference": "UT19",
+							"tech_level": "9",
+							"tags": [
+								"Power"
+							],
+							"base_value": "2",
+							"base_weight": "0.005 lb",
+							"quantity": 2,
+							"equipped": true,
+							"calc": {
+								"value": 2,
+								"extended_value": 4,
+								"weight": "0.005 lb",
+								"extended_weight": "0.01 lb"
+							}
+						}
+					],
+					"calc": {
+						"value": 10,
+						"extended_value": 557.1,
+						"weight": "1 lb",
+						"extended_weight": "9.8555 lb"
+					}
+				},
+				{
+					"id": "ESM2_sCMDibkjWmFu",
+					"description": "Stored in vehicle",
+					"legality_class": "4",
+					"features": [
+						{
+							"type": "contained_weight_reduction",
+							"reduction": "100%"
+						}
+					],
+					"quantity": 1,
+					"children": [
+						{
+							"id": "ec8dX0fotAkgxbGkp",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "efeekclqs54nOsbVN"
+							},
+							"description": "Swarmbot Hive",
+							"reference": "UT37",
+							"tech_level": "10",
+							"base_value": "200",
+							"base_weight": "10 lb",
+							"quantity": 1,
+							"calc": {
+								"value": 200,
+								"extended_value": 200,
+								"weight": "10 lb",
+								"extended_weight": "10 lb"
+							}
+						}
+					],
+					"calc": {
+						"value": 0,
+						"extended_value": 200,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 0,
+				"extended_value": 48857.1,
+				"weight": "0 lb",
+				"extended_weight": "51.8055 lb"
+			}
+		}
+	]
+}

--- a/Library/Loadouts/Starship Crew/TL11/Steward.gct
+++ b/Library/Loadouts/Starship Crew/TL11/Steward.gct
@@ -1,0 +1,2557 @@
+{
+	"version": 5,
+	"id": "BfZAHr9GxyUBxiRvr",
+	"equipment": [
+		{
+			"id": "eNma77ALgtQsL3EQE",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+				"id": "eF0azadW_ikOXi7pu"
+			},
+			"description": "Cybervox",
+			"reference": "UT40",
+			"local_notes": "C/10hr.",
+			"tech_level": "9",
+			"base_value": "200",
+			"base_weight": "2.5 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"value": 200,
+				"extended_value": 200,
+				"weight": "2.5 lb",
+				"extended_weight": "2.5 lb"
+			}
+		},
+		{
+			"id": "EbjbdunPQdm3Wc13B",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Basic Set/Basic Set Equipment.eqp",
+				"id": "ESjtIfyzScVP49ity"
+			},
+			"description": "Backpack, Small",
+			"reference": "B288",
+			"tech_level": "1",
+			"tags": [
+				"Camping and Survival Gear"
+			],
+			"base_value": "60",
+			"base_weight": "3 lb",
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "contained_weight_prereq",
+						"has": true,
+						"qualifier": {
+							"compare": "at_most",
+							"qualifier": "40 lb"
+						}
+					}
+				]
+			},
+			"modifiers": [
+				{
+					"id": "f3qnB7UNg258oUchV",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+						"id": "f3AMg_F7eHdJ-u_bX"
+					},
+					"name": "Expensive",
+					"reference": "UT15",
+					"cost_type": "to_base_cost",
+					"weight_type": "to_base_weight",
+					"cost": "+1 CF",
+					"weight": "x2/3"
+				}
+			],
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "eJI1LDQOynqoik6vn",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eFggKMtx9D-27k-tV"
+					},
+					"description": "First Aid Kit",
+					"reference": "UT198",
+					"tech_level": "9",
+					"tags": [
+						"Medical"
+					],
+					"base_value": "50",
+					"base_weight": "2 lb",
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "First Aid"
+							},
+							"amount": 1
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 50,
+						"extended_value": 50,
+						"weight": "2 lb",
+						"extended_weight": "2 lb"
+					}
+				},
+				{
+					"id": "egy5CvjBeVnhJ8DVC",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "etxU8iNoLgecfWNd7"
+					},
+					"description": "Sleep Set",
+					"reference": "UT69",
+					"local_notes": "A/3 days.",
+					"tech_level": "11",
+					"tags": [
+						"Housing and Food"
+					],
+					"base_value": "200",
+					"base_weight": "0.1 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 200,
+						"extended_value": 200,
+						"weight": "0.1 lb",
+						"extended_weight": "0.1 lb"
+					}
+				},
+				{
+					"id": "en55h1_1PX-tA-NCm",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eznc-kmysZ8i10fqA"
+					},
+					"description": "Fire Extinguisher Tube",
+					"reference": "UT87",
+					"local_notes": "8-second discharge. 2-yard range.",
+					"tech_level": "11",
+					"tags": [
+						"Expedition Gear"
+					],
+					"base_value": "10",
+					"base_weight": "1 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 10,
+						"extended_value": 10,
+						"weight": "1 lb",
+						"extended_weight": "1 lb"
+					}
+				},
+				{
+					"id": "ey3RTfhvmhY6cmS2R",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "High Tech/High Tech Equipment.eqp",
+						"id": "exRH86foJfRv3fZaX"
+					},
+					"description": "Alcohol",
+					"reference": "HT34",
+					"tags": [
+						"General Equipment"
+					],
+					"base_value": "5",
+					"base_weight": "2.5 lb",
+					"quantity": 4,
+					"equipped": true,
+					"calc": {
+						"value": 5,
+						"extended_value": 20,
+						"weight": "2.5 lb",
+						"extended_weight": "10 lb"
+					}
+				},
+				{
+					"id": "el88uAhJHpmIFgkRb",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "e5oTYQKsrgnYRkwST"
+					},
+					"description": "Domestic Nanocleanser",
+					"reference": "UT69",
+					"local_notes": "1 week of routine cleaning or one major cleaning job",
+					"tech_level": "11",
+					"tags": [
+						"Housing and Food"
+					],
+					"base_value": "10",
+					"base_weight": "0.5 lb",
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "Housekeeping rolls to clean up things",
+							"amount": 6
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 10,
+						"extended_value": 10,
+						"weight": "0.5 lb",
+						"extended_weight": "0.5 lb"
+					}
+				},
+				{
+					"id": "e3A3BYyCvZu2WGSS-",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eX5RNhIyHO3rGNWpR"
+					},
+					"description": "Odor Synthesizer",
+					"reference": "UT52",
+					"local_notes": "100 mixes. B/100hr.",
+					"tech_level": "9",
+					"tags": [
+						"Media and Education"
+					],
+					"base_value": "500",
+					"base_weight": "1 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 500,
+						"extended_value": 500,
+						"weight": "1 lb",
+						"extended_weight": "1 lb"
+					}
+				},
+				{
+					"id": "eA-CvmxiP2vUOlEn8",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eYXl6o2QMoLbB34Y9"
+					},
+					"description": "Survival Foodfac",
+					"reference": "UT70",
+					"local_notes": "C/30 meals.",
+					"tech_level": "11",
+					"tags": [
+						"Housing and Food"
+					],
+					"base_value": "10000",
+					"base_weight": "10 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 10000,
+						"extended_value": 10000,
+						"weight": "10 lb",
+						"extended_weight": "10 lb"
+					}
+				},
+				{
+					"id": "epqzsOGbgRjZE0Sr_",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "e_czMbwML4nRphM6I"
+					},
+					"description": "Survival Foodfac Flavor Packets",
+					"reference": "UT70",
+					"tech_level": "11",
+					"tags": [
+						"Housing and Food"
+					],
+					"base_value": "0.1",
+					"base_weight": "0.05 lb",
+					"quantity": 100,
+					"equipped": true,
+					"calc": {
+						"value": 0.1,
+						"extended_value": 10,
+						"weight": "0.05 lb",
+						"extended_weight": "5 lb"
+					}
+				},
+				{
+					"id": "ecUGjIouOSqV9mNWj",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "enQNM0RB6euc5mo7i"
+					},
+					"description": "B cell",
+					"reference": "UT19",
+					"tech_level": "9",
+					"tags": [
+						"Power"
+					],
+					"base_value": "3",
+					"base_weight": "0.05 lb",
+					"quantity": 8,
+					"equipped": true,
+					"calc": {
+						"value": 3,
+						"extended_value": 24,
+						"weight": "0.05 lb",
+						"extended_weight": "0.4 lb"
+					}
+				},
+				{
+					"id": "eB1GKBudwC9-nuHPo",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "ev80WwcnBpiGFrkol"
+					},
+					"description": "C cell",
+					"reference": "UT19",
+					"tech_level": "9",
+					"tags": [
+						"Power"
+					],
+					"base_value": "10",
+					"base_weight": "0.5 lb",
+					"quantity": 2,
+					"equipped": true,
+					"calc": {
+						"value": 10,
+						"extended_value": 20,
+						"weight": "0.5 lb",
+						"extended_weight": "1 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 120,
+				"extended_value": 10964,
+				"weight": "2 lb",
+				"extended_weight": "33 lb"
+			}
+		},
+		{
+			"id": "EP5D1lb3Wa-onHUG5",
+			"description": "Stored in Vehicle",
+			"legality_class": "4",
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "eXZV5AWbsLMmS8uYM",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eWlSx57LtaAZLHzVy"
+					},
+					"description": "Entertainment Console",
+					"reference": "UT51",
+					"local_notes": "Complexity 8. 4B/5hr. or external power.",
+					"tech_level": "11",
+					"tags": [
+						"Media and Education"
+					],
+					"base_value": "500",
+					"base_weight": "1 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 500,
+						"extended_value": 500,
+						"weight": "1 lb",
+						"extended_weight": "1 lb"
+					}
+				},
+				{
+					"id": "EGzfGQJXWha6nx2dn",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "efeekclqs54nOsbVN"
+					},
+					"description": "Swarmbot Hive",
+					"reference": "UT37",
+					"tech_level": "10",
+					"base_value": "200",
+					"base_weight": "10 lb",
+					"quantity": 2,
+					"equipped": true,
+					"children": [
+						{
+							"id": "eu6zTLXzT8kYt6hVs",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "eRd4HdGkY3padXW2c"
+							},
+							"description": "@Microbot/Nanobot Type@ Swarm",
+							"reference": "UT35",
+							"tech_level": "10",
+							"tags": [
+								"Swarmbots"
+							],
+							"base_weight": "2 lb",
+							"replacements": {
+								"Microbot/Nanobot Type": "Cleaning"
+							},
+							"modifiers": [
+								{
+									"id": "F-S8QxkK1rjrMPW6a",
+									"name": "Swarm Type",
+									"reference": "UT37",
+									"local_notes": "at TL11 microbots can have two types, at TL12 nanobots can have two types",
+									"children": [
+										{
+											"id": "ffhVF4dChFlfChHPC",
+											"name": "Bughunter",
+											"reference": "UT106",
+											"local_notes": "LC3",
+											"tags": [
+												"Counter-Surveillance and ECM",
+												"Security and Surveillance",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+4000",
+											"disabled": true
+										},
+										{
+											"id": "fdzj0CD30DVaKhwpi",
+											"name": "Cannibal",
+											"reference": "UT169",
+											"local_notes": "LC1",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "12",
+											"cost": "+15000",
+											"disabled": true
+										},
+										{
+											"id": "fIpLx5wEYUPcOPifb",
+											"name": "Cleaning",
+											"reference": "UT69",
+											"local_notes": "LC4",
+											"tags": [
+												"Domestic Equipment and Appliances",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+1000"
+										},
+										{
+											"id": "f8gGn3gG648e1vihm",
+											"name": "Construction",
+											"reference": "UT86",
+											"local_notes": "LC4",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fBkcbNqaUZQY3Q0u9",
+											"name": "Decontamination (@Hazard Type@)",
+											"reference": "UT87",
+											"local_notes": "LC3; Hazardous Materials (@Hazard Type@)-12",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fcbDp69iXo5Ei9RL3",
+											"name": "Decontamination (@Hazard Type@)",
+											"reference": "UT87",
+											"local_notes": "LC3; Hazardous Materials (@Hazard Type@)-13",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "11",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fsSwBnL2rOUwID3Ix",
+											"name": "Decontamination (@Hazard Type@)",
+											"reference": "UT87",
+											"local_notes": "LC3; Hazardous Materials (@Hazard Type@)-14",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "12",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fUIYgu4tbcjkvGS8u",
+											"name": "Defoliator",
+											"reference": "UT87",
+											"local_notes": "LC3",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fFW3W1NeIaFaKA7zF",
+											"name": "Devourer",
+											"reference": "UT169",
+											"local_notes": "LC1",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "10",
+											"cost": "+8000",
+											"disabled": true
+										},
+										{
+											"id": "f9Q0Y6aZtic8LMXy5",
+											"name": "Disassembler",
+											"reference": "UT169",
+											"local_notes": "LC1",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "11",
+											"cost": "+10000",
+											"disabled": true
+										},
+										{
+											"id": "fVWfqau3zT7SykBPu",
+											"name": "Explorer",
+											"reference": "UT80",
+											"local_notes": "LC4",
+											"tags": [
+												"Expedition Gear",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+500",
+											"disabled": true
+										},
+										{
+											"id": "fKy0bPEePr7W8OpT_",
+											"name": "Firefly",
+											"reference": "UT74",
+											"local_notes": "LC4",
+											"tags": [
+												"Domestic Equipment and Appliances",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+100",
+											"disabled": true
+										},
+										{
+											"id": "foFj5fKtBO-utHRRp",
+											"name": "Forensic",
+											"reference": "UT107",
+											"local_notes": "LC3",
+											"tags": [
+												"Enforcement and Coercion",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+4000",
+											"disabled": true
+										},
+										{
+											"id": "f-_HKROf0iC-D2d_H",
+											"name": "Gremlin",
+											"reference": "UT169",
+											"local_notes": "LC2",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "10",
+											"cost": "+2000",
+											"disabled": true
+										},
+										{
+											"id": "fnD5tpEnOWJBnSugm",
+											"name": "Harvester",
+											"reference": "UT87",
+											"local_notes": "LC4",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+2000",
+											"disabled": true
+										},
+										{
+											"id": "f-M2xMItgkE3qKQR0",
+											"name": "Massage",
+											"reference": "UT41",
+											"local_notes": "LC4",
+											"tags": [
+												"Robots",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+200",
+											"disabled": true
+										},
+										{
+											"id": "fJEAaqLSn8h4DJEhm",
+											"name": "Painter",
+											"reference": "UT87",
+											"local_notes": "LC4",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+500",
+											"disabled": true
+										},
+										{
+											"id": "fTDG9ukYPlcMM1hAA",
+											"name": "Paramedical",
+											"reference": "UT201",
+											"local_notes": "LC3; Diagnosis-10, First Aid-10",
+											"tags": [
+												"Medical",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+6000",
+											"disabled": true
+										},
+										{
+											"id": "fm_Kz7d0ezLdcMoRi",
+											"name": "Paramedical",
+											"reference": "UT201",
+											"local_notes": "LC3; Diagnosis-11, First Aid-11",
+											"tags": [
+												"Medical",
+												"Swarmbots"
+											],
+											"tech_level": "11",
+											"cost": "+6000",
+											"disabled": true
+										},
+										{
+											"id": "fTumf0GoNFnuPLYsZ",
+											"name": "Paramedical",
+											"reference": "UT201",
+											"local_notes": "LC3; Diagnosis-12, First Aid-12",
+											"tags": [
+												"Medical",
+												"Swarmbots"
+											],
+											"tech_level": "12",
+											"cost": "+6000",
+											"disabled": true
+										},
+										{
+											"id": "fueT0CChCC9d7QLb_",
+											"name": "Pesticide",
+											"reference": "UT87",
+											"local_notes": "LC3",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fWrz10jWrtdR1bi5M",
+											"name": "Play",
+											"reference": "UT41",
+											"local_notes": "LC4",
+											"tags": [
+												"Robots",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+200",
+											"disabled": true
+										},
+										{
+											"id": "fNZfPAS_ei-6rLfiP",
+											"name": "Pollinator",
+											"reference": "UT87",
+											"local_notes": "LC4",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fvyTbfs3U2y8Y7ODt",
+											"name": "Repair (@Equipment@)",
+											"reference": "UT87",
+											"local_notes": "LC4; Repair Skill-12",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+500",
+											"disabled": true
+										},
+										{
+											"id": "f8gAV7gmb41KV01j6",
+											"name": "Repair (@Equipment@)",
+											"reference": "UT87",
+											"local_notes": "LC4; Repair Skill-13",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "11",
+											"cost": "+500",
+											"disabled": true
+										},
+										{
+											"id": "f8zk6CGqN66B4sk9Y",
+											"name": "Repair (@Other Equipment 1@)",
+											"reference": "UT87",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+250",
+											"disabled": true
+										},
+										{
+											"id": "faKDnSNchXzZ58KCS",
+											"name": "Repair (@Other Equipment 2@)",
+											"reference": "UT87",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+250",
+											"disabled": true
+										},
+										{
+											"id": "fy8Rw_0PPDcBoYUFX",
+											"name": "Repair (@Other Equipment 3@)",
+											"reference": "UT87",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+250",
+											"disabled": true
+										},
+										{
+											"id": "fXEU_VtXMsQrKXRyk",
+											"name": "Security",
+											"reference": "UT104",
+											"local_notes": "LC3",
+											"tags": [
+												"Security and Surveillance",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fTHKPO9ETgnUbGt0D",
+											"name": "Sentry",
+											"reference": "UT169",
+											"local_notes": "LC3",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "10",
+											"cost": "+5000",
+											"disabled": true
+										},
+										{
+											"id": "futr_Xjg5tcXzhIHZ",
+											"name": "Stinger",
+											"reference": "UT169",
+											"local_notes": "LC2",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "10",
+											"cost": "+1500",
+											"disabled": true
+										},
+										{
+											"id": "feVfiOI_cr2E2foUy",
+											"name": "Surveillance",
+											"reference": "UT106",
+											"local_notes": "LC3",
+											"tags": [
+												"Security and Surveillance",
+												"Surveillance and Tracking Devices",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+500",
+											"disabled": true
+										},
+										{
+											"id": "f-9-pZULmiKhy5KyW",
+											"name": "Terminator",
+											"reference": "UT169",
+											"local_notes": "LC1",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "10",
+											"cost": "+1500",
+											"disabled": true
+										}
+									]
+								},
+								{
+									"id": "fN6kjSM0ffz3Aynq_",
+									"name": "Self-Replicating",
+									"reference": "UT37",
+									"local_notes": "only for defoliator, devourer or pesticide",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_base_cost",
+									"cost": "x10",
+									"disabled": true
+								},
+								{
+									"id": "FOVXRjT4JXdhTL-Uu",
+									"name": "Chassis",
+									"local_notes": "choose one microbot or nanobot chassis",
+									"children": [
+										{
+											"id": "FZ97_QCq8Sov5U6ho",
+											"name": "Microbot Chassis",
+											"children": [
+												{
+													"id": "fsB_XCBIQJ0s-2zVl",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "f7eMKwMF7BTYFbxhq"
+													},
+													"name": "Microbot Aerostat",
+													"reference": "UT36",
+													"local_notes": "Air Move 2",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "10"
+												},
+												{
+													"id": "fvjSdj4ZVAIFiTQ35",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fcVKEB14BedQI1jGA"
+													},
+													"name": "Microbot Crawler",
+													"reference": "UT36",
+													"local_notes": "Move 3; Water Move 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "10",
+													"disabled": true
+												},
+												{
+													"id": "f60Yz3khtWnkVbajy",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fScgdTYLwKE9CEYfl"
+													},
+													"name": "Microbot Crawler, Armored",
+													"reference": "UT36",
+													"local_notes": "Move 2, 2x HP",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "10",
+													"cost": "+100%",
+													"disabled": true
+												},
+												{
+													"id": "fd_HUlb2ODcW_v9Pv",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fpAVv9yE3m3t0Egt_"
+													},
+													"name": "Microbot Flier",
+													"reference": "UT36",
+													"local_notes": "Move 1; Air Move 6",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "10",
+													"cost": "+100%",
+													"disabled": true
+												},
+												{
+													"id": "fLgJRcoDM94KXsAAL",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "ffHj2SBngzuewdrbB"
+													},
+													"name": "Microbot Hopper",
+													"reference": "UT36",
+													"local_notes": "Move 4; Super Jump 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "10",
+													"cost": "+50%",
+													"disabled": true
+												},
+												{
+													"id": "fCxtPFboWhAKaT6-D",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fr6wQjKaUic-BpBCO"
+													},
+													"name": "Microbot Space",
+													"reference": "UT36",
+													"local_notes": "Move 1; 0.0001G solar sail",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "10",
+													"cost": "+0",
+													"disabled": true
+												},
+												{
+													"id": "fX45bUl6GyJITCRDy",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fsL5rGqz66ht8cVvg"
+													},
+													"name": "Microbot Swimmer",
+													"reference": "UT36",
+													"local_notes": "Water Move 4",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "10",
+													"cost": "+0",
+													"disabled": true
+												},
+												{
+													"id": "fWtIlb2k9SeuDxmce",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fvVo7_8gzuQpK50fc"
+													},
+													"name": "Microbot Contragrav (CG) Flier",
+													"reference": "UT36",
+													"local_notes": "Move 1; Air Move 20",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11^",
+													"cost": "+200%",
+													"disabled": true
+												}
+											]
+										},
+										{
+											"id": "FFxA8BmoZVv0WQ40A",
+											"name": "Nanobot Chassis",
+											"children": [
+												{
+													"id": "fZi7La3GAWU3hBIqe",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "f6RvvKoBN0DqIjBjQ"
+													},
+													"name": "Nanobot Aerostat",
+													"reference": "UT36",
+													"local_notes": "Air Move 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "11",
+													"disabled": true
+												},
+												{
+													"id": "fCwPC1UjDhdROcZP1",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "f1OLvlafFuNITe6na"
+													},
+													"name": "Nanobot Crawler",
+													"reference": "UT36",
+													"local_notes": "Move 3; Water Move 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "11",
+													"disabled": true
+												},
+												{
+													"id": "fbwK8kGeF3YpTJl8J",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fASzj6iYz6hUA-TBB"
+													},
+													"name": "Nanobot Crawler, Armored",
+													"reference": "UT36",
+													"local_notes": "Move 2, 2x HP",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11",
+													"cost": "+100%",
+													"disabled": true
+												},
+												{
+													"id": "ffldavBTt4_acUdXj",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fLuL-pD4o6s0lREJs"
+													},
+													"name": "Nanobot Dust",
+													"reference": "UT36",
+													"local_notes": "Immobile",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11",
+													"cost": "-80%",
+													"disabled": true
+												},
+												{
+													"id": "foiSEvAXkhutliCKg",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fKeArqcSSvcPk5QTp"
+													},
+													"name": "Nanobot Flier",
+													"reference": "UT36",
+													"local_notes": "Move 1; Air Move 3",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11",
+													"cost": "+100%",
+													"disabled": true
+												},
+												{
+													"id": "fD0bR24uUCQh3_PhZ",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fyATVIBpOaRfq3tKe"
+													},
+													"name": "Nanobot Hopper",
+													"reference": "UT36",
+													"local_notes": "Move 4; Super Jump 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11",
+													"cost": "+50%",
+													"disabled": true
+												},
+												{
+													"id": "fGjmsZ3f82TLN8lp_",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "f80KO0VZYaEJb9hbs"
+													},
+													"name": "Nanobot Space",
+													"reference": "UT36",
+													"local_notes": "Move 1; 0.0001G solar sail",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "11",
+													"cost": "+0",
+													"disabled": true
+												},
+												{
+													"id": "fjZ_gpYqeBXG6xCXA",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fa36bUxm5RcsG_mOk"
+													},
+													"name": "Nanobot Swimmer",
+													"reference": "UT36",
+													"local_notes": "Water Move 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "11",
+													"cost": "+0",
+													"disabled": true
+												},
+												{
+													"id": "fnrnkKPnG_eF7AK7t",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fPgd1Z13foKJXxTND"
+													},
+													"name": "Nanobot Contragrav (CG) Flier",
+													"reference": "UT36",
+													"local_notes": "Move 1; Air Move 10",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11^",
+													"cost": "+200%",
+													"disabled": true
+												}
+											]
+										}
+									]
+								},
+								{
+									"id": "F3rfnas1aQj8QdC-Q",
+									"name": "Stealth",
+									"children": [
+										{
+											"id": "fOJnFGesmVLfce3XL",
+											"name": "Disguise",
+											"reference": "UT36",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_cost",
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "f8esO4P-Fs51o_E4m",
+											"name": "Thermo-Optic Chameleon Surface",
+											"reference": "UT37, UT98",
+											"local_notes": "LC3",
+											"tags": [
+												"Deception and Intrusion",
+												"Swarmbots"
+											],
+											"cost_type": "to_final_cost",
+											"tech_level": "9",
+											"cost": "+4000",
+											"weight": "+4 lb",
+											"disabled": true
+										},
+										{
+											"id": "fTmxjh7drARpI3_vf",
+											"name": "Multispectral Chameleon Surface",
+											"reference": "UT37, UT99",
+											"local_notes": "LC3",
+											"tags": [
+												"Deception and Intrusion",
+												"Swarmbots"
+											],
+											"cost_type": "to_final_cost",
+											"tech_level": "10",
+											"cost": "+6000",
+											"weight": "+4 lb",
+											"disabled": true
+										},
+										{
+											"id": "f2LVFH28yYWBcvhbO",
+											"name": "Dynamic Multispectral Chameleon Surface",
+											"reference": "UT37, UT99",
+											"local_notes": "LC3",
+											"tags": [
+												"Deception and Intrusion",
+												"Swarmbots"
+											],
+											"cost_type": "to_final_cost",
+											"tech_level": "11",
+											"cost": "+8000",
+											"weight": "+4 lb",
+											"disabled": true
+										},
+										{
+											"id": "fbsv-eW-UUYXSIi_t",
+											"name": "Ultimate Chameleon Surface",
+											"reference": "UT37, UT99",
+											"local_notes": "LC3",
+											"tags": [
+												"Deception and Intrusion",
+												"Swarmbots"
+											],
+											"cost_type": "to_final_cost",
+											"tech_level": "12",
+											"cost": "+10000",
+											"weight": "+4 lb",
+											"disabled": true
+										}
+									]
+								},
+								{
+									"id": "FYHcVUpykdbqv8Jwi",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "F5Q7h4gAuvWsoUiFV"
+									},
+									"name": "Power Supply",
+									"children": [
+										{
+											"id": "f3rUMH_lvOXE2PyUY",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "faj6YgnYeEKAy39jw"
+											},
+											"name": "Power Cells",
+											"reference": "UT36",
+											"local_notes": "Recharges in a Hive; C/12hr.",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"disabled": true
+										},
+										{
+											"id": "fcln3jzBh1QIKrbWP",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fCJ9sdOXfXoLN594u"
+											},
+											"name": "Power Cells",
+											"reference": "UT36",
+											"local_notes": "Recharges in a Hive; C/72hr.",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "11"
+										},
+										{
+											"id": "fgqvrWoYt0rfnmUtA",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f7WMm14XwVJyvz2NQ"
+											},
+											"name": "Power Cells",
+											"reference": "UT36",
+											"local_notes": "Recharges in a Hive; C/5 days.",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "12",
+											"disabled": true
+										},
+										{
+											"id": "fL_qVBRHj8rfjIeJg",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fGv5njL67i7rODIpL"
+											},
+											"name": "Beamed Power",
+											"reference": "UT36",
+											"local_notes": "C cell receiver",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "fkXdXDF1qGsm_wA1a",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fS-7nLrwLytJp5mLZ"
+											},
+											"name": "Gastrobot",
+											"reference": "UT36",
+											"local_notes": "Consumes 0.1lbs./hr. of biomass",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+100%",
+											"disabled": true
+										},
+										{
+											"id": "fpiC5QmqmeX-rALkC",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fhT3sMtcrOGbTzLku"
+											},
+											"name": "Radio-Thermal Generator (RTG)",
+											"reference": "UT36",
+											"local_notes": "Lasts 1 year; LC1",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+100%",
+											"disabled": true
+										},
+										{
+											"id": "fSjbfHo4Jeiw2YXE2",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "faJkuSBjewuh2TdLg"
+											},
+											"name": "Solar Cell",
+											"reference": "UT36",
+											"local_notes": "Recharges 3 hours' activity in 1 hour",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "fCuo5XRpZhsXHIjUY",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f2u0xwoaeDxGjxCRq"
+											},
+											"name": "Solar Cell",
+											"reference": "UT36",
+											"local_notes": "Recharges 4 hours' activity in 1 hour",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "fL04l-CFVultfMDz_",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "ff9wLL0l7uzB0IRXf"
+											},
+											"name": "Solar Cell",
+											"reference": "UT36",
+											"local_notes": "Recharges 5 hours' activity in 1 hour",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "12",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "f30r-SeQ8YG9YGsEA",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f4SVyLNBYhfPgNZC0"
+											},
+											"name": "Organovore",
+											"reference": "UT36",
+											"local_notes": "Consumes 0.1-0.5 lbs./hr. of carbon-based matter; LC3",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11",
+											"cost": "+200%",
+											"disabled": true
+										},
+										{
+											"id": "fP2LjAGt3M-ipoiVZ",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fi-Vh6iRVAbMGaOiO"
+											},
+											"name": "Broadcast Power",
+											"reference": "UT37",
+											"local_notes": "C cell receiver",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11^",
+											"cost": "+100%",
+											"disabled": true
+										}
+									]
+								}
+							],
+							"quantity": 1,
+							"equipped": true,
+							"calc": {
+								"value": 1000,
+								"extended_value": 1000,
+								"weight": "2 lb",
+								"extended_weight": "2 lb"
+							}
+						},
+						{
+							"id": "eRnx3YQRdUdYu26qT",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "eRd4HdGkY3padXW2c"
+							},
+							"description": "@Microbot/Nanobot Type@ Swarm",
+							"reference": "UT35",
+							"tech_level": "10",
+							"tags": [
+								"Swarmbots"
+							],
+							"base_weight": "2 lb",
+							"replacements": {
+								"Microbot/Nanobot Type": "Massage"
+							},
+							"modifiers": [
+								{
+									"id": "F_JSqzhhJQxzVji5S",
+									"name": "Swarm Type",
+									"reference": "UT37",
+									"local_notes": "at TL11 microbots can have two types, at TL12 nanobots can have two types",
+									"children": [
+										{
+											"id": "fynrfA-MtqaRitsbk",
+											"name": "Bughunter",
+											"reference": "UT106",
+											"local_notes": "LC3",
+											"tags": [
+												"Counter-Surveillance and ECM",
+												"Security and Surveillance",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+4000",
+											"disabled": true
+										},
+										{
+											"id": "fyyKxWNDi4kdmPbY6",
+											"name": "Cannibal",
+											"reference": "UT169",
+											"local_notes": "LC1",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "12",
+											"cost": "+15000",
+											"disabled": true
+										},
+										{
+											"id": "fxqmpxTskOApcLKg8",
+											"name": "Cleaning",
+											"reference": "UT69",
+											"local_notes": "LC4",
+											"tags": [
+												"Domestic Equipment and Appliances",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fYID14H0S6QpCZfjP",
+											"name": "Construction",
+											"reference": "UT86",
+											"local_notes": "LC4",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fmawAPANGl-EpGmTt",
+											"name": "Decontamination (@Hazard Type@)",
+											"reference": "UT87",
+											"local_notes": "LC3; Hazardous Materials (@Hazard Type@)-12",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fO3GKJPGnFaSyzwMV",
+											"name": "Decontamination (@Hazard Type@)",
+											"reference": "UT87",
+											"local_notes": "LC3; Hazardous Materials (@Hazard Type@)-13",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "11",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "f47BdsI5aiqiLIE5e",
+											"name": "Decontamination (@Hazard Type@)",
+											"reference": "UT87",
+											"local_notes": "LC3; Hazardous Materials (@Hazard Type@)-14",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "12",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fJMhwpYJmaZ1zI7jV",
+											"name": "Defoliator",
+											"reference": "UT87",
+											"local_notes": "LC3",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fqHsEEOhjClJh0-qe",
+											"name": "Devourer",
+											"reference": "UT169",
+											"local_notes": "LC1",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "10",
+											"cost": "+8000",
+											"disabled": true
+										},
+										{
+											"id": "fIbGLxEG2ujCXjxKd",
+											"name": "Disassembler",
+											"reference": "UT169",
+											"local_notes": "LC1",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "11",
+											"cost": "+10000",
+											"disabled": true
+										},
+										{
+											"id": "frwClmg1wc-FIrkTc",
+											"name": "Explorer",
+											"reference": "UT80",
+											"local_notes": "LC4",
+											"tags": [
+												"Expedition Gear",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+500",
+											"disabled": true
+										},
+										{
+											"id": "fyOt_DV4tlqZSHlXU",
+											"name": "Firefly",
+											"reference": "UT74",
+											"local_notes": "LC4",
+											"tags": [
+												"Domestic Equipment and Appliances",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+100",
+											"disabled": true
+										},
+										{
+											"id": "fAYr1tLvdbyePUPfM",
+											"name": "Forensic",
+											"reference": "UT107",
+											"local_notes": "LC3",
+											"tags": [
+												"Enforcement and Coercion",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+4000",
+											"disabled": true
+										},
+										{
+											"id": "fK5MXyBTXtvE7WQcE",
+											"name": "Gremlin",
+											"reference": "UT169",
+											"local_notes": "LC2",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "10",
+											"cost": "+2000",
+											"disabled": true
+										},
+										{
+											"id": "fTdhxR4araSo2aunz",
+											"name": "Harvester",
+											"reference": "UT87",
+											"local_notes": "LC4",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+2000",
+											"disabled": true
+										},
+										{
+											"id": "fFc_CJJ1V4V8eYs7b",
+											"name": "Massage",
+											"reference": "UT41",
+											"local_notes": "LC4",
+											"tags": [
+												"Robots",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+200"
+										},
+										{
+											"id": "fQUk4IDpBB0n5wlY3",
+											"name": "Painter",
+											"reference": "UT87",
+											"local_notes": "LC4",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+500",
+											"disabled": true
+										},
+										{
+											"id": "fgXBZYZeXC7-S3Z1b",
+											"name": "Paramedical",
+											"reference": "UT201",
+											"local_notes": "LC3; Diagnosis-10, First Aid-10",
+											"tags": [
+												"Medical",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+6000",
+											"disabled": true
+										},
+										{
+											"id": "fsnhFfq-7GymxDj6b",
+											"name": "Paramedical",
+											"reference": "UT201",
+											"local_notes": "LC3; Diagnosis-11, First Aid-11",
+											"tags": [
+												"Medical",
+												"Swarmbots"
+											],
+											"tech_level": "11",
+											"cost": "+6000",
+											"disabled": true
+										},
+										{
+											"id": "fE0ubOKErzdUrwmzq",
+											"name": "Paramedical",
+											"reference": "UT201",
+											"local_notes": "LC3; Diagnosis-12, First Aid-12",
+											"tags": [
+												"Medical",
+												"Swarmbots"
+											],
+											"tech_level": "12",
+											"cost": "+6000",
+											"disabled": true
+										},
+										{
+											"id": "faxYTzVokeKAczgQH",
+											"name": "Pesticide",
+											"reference": "UT87",
+											"local_notes": "LC3",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fAElkvrJQqAG5fvoL",
+											"name": "Play",
+											"reference": "UT41",
+											"local_notes": "LC4",
+											"tags": [
+												"Robots",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+200",
+											"disabled": true
+										},
+										{
+											"id": "f-SXUGG1DKBYhd6Dd",
+											"name": "Pollinator",
+											"reference": "UT87",
+											"local_notes": "LC4",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fYesn-G1cj-gVg8iQ",
+											"name": "Repair (@Equipment@)",
+											"reference": "UT87",
+											"local_notes": "LC4; Repair Skill-12",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+500",
+											"disabled": true
+										},
+										{
+											"id": "ficcOxA73-EtxWSU2",
+											"name": "Repair (@Equipment@)",
+											"reference": "UT87",
+											"local_notes": "LC4; Repair Skill-13",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "11",
+											"cost": "+500",
+											"disabled": true
+										},
+										{
+											"id": "fHLrucAB9Ilp1EVGV",
+											"name": "Repair (@Other Equipment 1@)",
+											"reference": "UT87",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+250",
+											"disabled": true
+										},
+										{
+											"id": "fOzMVDbCGONsVPxkm",
+											"name": "Repair (@Other Equipment 2@)",
+											"reference": "UT87",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+250",
+											"disabled": true
+										},
+										{
+											"id": "f9Bn3KCPw4CypqU-M",
+											"name": "Repair (@Other Equipment 3@)",
+											"reference": "UT87",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+250",
+											"disabled": true
+										},
+										{
+											"id": "fTG5KzAix1oMo0kgD",
+											"name": "Security",
+											"reference": "UT104",
+											"local_notes": "LC3",
+											"tags": [
+												"Security and Surveillance",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fjmuSB6cmlGvXzdp_",
+											"name": "Sentry",
+											"reference": "UT169",
+											"local_notes": "LC3",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "10",
+											"cost": "+5000",
+											"disabled": true
+										},
+										{
+											"id": "fJc-QgbmnKd5YKSVA",
+											"name": "Stinger",
+											"reference": "UT169",
+											"local_notes": "LC2",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "10",
+											"cost": "+1500",
+											"disabled": true
+										},
+										{
+											"id": "fruLYGM4Ke9QGEQVy",
+											"name": "Surveillance",
+											"reference": "UT106",
+											"local_notes": "LC3",
+											"tags": [
+												"Security and Surveillance",
+												"Surveillance and Tracking Devices",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+500",
+											"disabled": true
+										},
+										{
+											"id": "fJY5CR9Mz3B0Z0cvd",
+											"name": "Terminator",
+											"reference": "UT169",
+											"local_notes": "LC1",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "10",
+											"cost": "+1500",
+											"disabled": true
+										}
+									]
+								},
+								{
+									"id": "ftZeHS8jymAw9TtaU",
+									"name": "Self-Replicating",
+									"reference": "UT37",
+									"local_notes": "only for defoliator, devourer or pesticide",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_base_cost",
+									"cost": "x10",
+									"disabled": true
+								},
+								{
+									"id": "FkrIsaNGmRfWxM5i6",
+									"name": "Chassis",
+									"local_notes": "choose one microbot or nanobot chassis",
+									"children": [
+										{
+											"id": "FZKcTh_M7d0Q3KCNR",
+											"name": "Microbot Chassis",
+											"children": [
+												{
+													"id": "fFk3Bj3TOFyEi8d3h",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "f7eMKwMF7BTYFbxhq"
+													},
+													"name": "Microbot Aerostat",
+													"reference": "UT36",
+													"local_notes": "Air Move 2",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "10",
+													"disabled": true
+												},
+												{
+													"id": "f2pc64QD8torJnKLR",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fcVKEB14BedQI1jGA"
+													},
+													"name": "Microbot Crawler",
+													"reference": "UT36",
+													"local_notes": "Move 3; Water Move 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "10"
+												},
+												{
+													"id": "f7IVurg9rTPzHQIKP",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fScgdTYLwKE9CEYfl"
+													},
+													"name": "Microbot Crawler, Armored",
+													"reference": "UT36",
+													"local_notes": "Move 2, 2x HP",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "10",
+													"cost": "+100%",
+													"disabled": true
+												},
+												{
+													"id": "fiFzyECGFUjTOJGdf",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fpAVv9yE3m3t0Egt_"
+													},
+													"name": "Microbot Flier",
+													"reference": "UT36",
+													"local_notes": "Move 1; Air Move 6",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "10",
+													"cost": "+100%",
+													"disabled": true
+												},
+												{
+													"id": "f-6_QTfjK6_sz37RN",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "ffHj2SBngzuewdrbB"
+													},
+													"name": "Microbot Hopper",
+													"reference": "UT36",
+													"local_notes": "Move 4; Super Jump 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "10",
+													"cost": "+50%",
+													"disabled": true
+												},
+												{
+													"id": "fAWtU2Tc322t0NzEt",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fr6wQjKaUic-BpBCO"
+													},
+													"name": "Microbot Space",
+													"reference": "UT36",
+													"local_notes": "Move 1; 0.0001G solar sail",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "10",
+													"cost": "+0",
+													"disabled": true
+												},
+												{
+													"id": "fRdO4lbIwYIMpsckA",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fsL5rGqz66ht8cVvg"
+													},
+													"name": "Microbot Swimmer",
+													"reference": "UT36",
+													"local_notes": "Water Move 4",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "10",
+													"cost": "+0",
+													"disabled": true
+												},
+												{
+													"id": "fMsRmgjJGi2phCg7z",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fvVo7_8gzuQpK50fc"
+													},
+													"name": "Microbot Contragrav (CG) Flier",
+													"reference": "UT36",
+													"local_notes": "Move 1; Air Move 20",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11^",
+													"cost": "+200%",
+													"disabled": true
+												}
+											]
+										},
+										{
+											"id": "FsVQO4QEHg2Gy0h3-",
+											"name": "Nanobot Chassis",
+											"children": [
+												{
+													"id": "f5ILkLcOAP60bf85Z",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "f6RvvKoBN0DqIjBjQ"
+													},
+													"name": "Nanobot Aerostat",
+													"reference": "UT36",
+													"local_notes": "Air Move 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "11",
+													"disabled": true
+												},
+												{
+													"id": "f4PAl0lQFmhL-JbUX",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "f1OLvlafFuNITe6na"
+													},
+													"name": "Nanobot Crawler",
+													"reference": "UT36",
+													"local_notes": "Move 3; Water Move 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "11",
+													"disabled": true
+												},
+												{
+													"id": "fFKKb7ooodQw2aO9J",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fASzj6iYz6hUA-TBB"
+													},
+													"name": "Nanobot Crawler, Armored",
+													"reference": "UT36",
+													"local_notes": "Move 2, 2x HP",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11",
+													"cost": "+100%",
+													"disabled": true
+												},
+												{
+													"id": "fOucBG8z7Ma25kYpq",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fLuL-pD4o6s0lREJs"
+													},
+													"name": "Nanobot Dust",
+													"reference": "UT36",
+													"local_notes": "Immobile",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11",
+													"cost": "-80%",
+													"disabled": true
+												},
+												{
+													"id": "fppqfPQ3Si36pfrak",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fKeArqcSSvcPk5QTp"
+													},
+													"name": "Nanobot Flier",
+													"reference": "UT36",
+													"local_notes": "Move 1; Air Move 3",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11",
+													"cost": "+100%",
+													"disabled": true
+												},
+												{
+													"id": "ffIU9XMwN1EbgRo-S",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fyATVIBpOaRfq3tKe"
+													},
+													"name": "Nanobot Hopper",
+													"reference": "UT36",
+													"local_notes": "Move 4; Super Jump 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11",
+													"cost": "+50%",
+													"disabled": true
+												},
+												{
+													"id": "fA9ShmZZ02rjzneC-",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "f80KO0VZYaEJb9hbs"
+													},
+													"name": "Nanobot Space",
+													"reference": "UT36",
+													"local_notes": "Move 1; 0.0001G solar sail",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "11",
+													"cost": "+0",
+													"disabled": true
+												},
+												{
+													"id": "fvB9DDMp6_vljZaW0",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fa36bUxm5RcsG_mOk"
+													},
+													"name": "Nanobot Swimmer",
+													"reference": "UT36",
+													"local_notes": "Water Move 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "11",
+													"cost": "+0",
+													"disabled": true
+												},
+												{
+													"id": "f5eHiXfnaKyLp-AYt",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fPgd1Z13foKJXxTND"
+													},
+													"name": "Nanobot Contragrav (CG) Flier",
+													"reference": "UT36",
+													"local_notes": "Move 1; Air Move 10",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11^",
+													"cost": "+200%",
+													"disabled": true
+												}
+											]
+										}
+									]
+								},
+								{
+									"id": "F9yf0U55ZG8dnFQeu",
+									"name": "Stealth",
+									"children": [
+										{
+											"id": "fdVmkeM1HE1WNXPe7",
+											"name": "Disguise",
+											"reference": "UT36",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_cost",
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fzoo_eQoqwLotdSXl",
+											"name": "Thermo-Optic Chameleon Surface",
+											"reference": "UT37, UT98",
+											"local_notes": "LC3",
+											"tags": [
+												"Deception and Intrusion",
+												"Swarmbots"
+											],
+											"cost_type": "to_final_cost",
+											"tech_level": "9",
+											"cost": "+4000",
+											"weight": "+4 lb",
+											"disabled": true
+										},
+										{
+											"id": "fIahAgBl5jEMcUxgk",
+											"name": "Multispectral Chameleon Surface",
+											"reference": "UT37, UT99",
+											"local_notes": "LC3",
+											"tags": [
+												"Deception and Intrusion",
+												"Swarmbots"
+											],
+											"cost_type": "to_final_cost",
+											"tech_level": "10",
+											"cost": "+6000",
+											"weight": "+4 lb",
+											"disabled": true
+										},
+										{
+											"id": "fjTt91V0TSboWC5ex",
+											"name": "Dynamic Multispectral Chameleon Surface",
+											"reference": "UT37, UT99",
+											"local_notes": "LC3",
+											"tags": [
+												"Deception and Intrusion",
+												"Swarmbots"
+											],
+											"cost_type": "to_final_cost",
+											"tech_level": "11",
+											"cost": "+8000",
+											"weight": "+4 lb",
+											"disabled": true
+										},
+										{
+											"id": "fk72YOsLvS43_YpMM",
+											"name": "Ultimate Chameleon Surface",
+											"reference": "UT37, UT99",
+											"local_notes": "LC3",
+											"tags": [
+												"Deception and Intrusion",
+												"Swarmbots"
+											],
+											"cost_type": "to_final_cost",
+											"tech_level": "12",
+											"cost": "+10000",
+											"weight": "+4 lb",
+											"disabled": true
+										}
+									]
+								},
+								{
+									"id": "FcJ-mXDlVlXVr3vGw",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "F5Q7h4gAuvWsoUiFV"
+									},
+									"name": "Power Supply",
+									"children": [
+										{
+											"id": "fXwC1d68j42ssSOPT",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "faj6YgnYeEKAy39jw"
+											},
+											"name": "Power Cells",
+											"reference": "UT36",
+											"local_notes": "Recharges in a Hive; C/12hr.",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"disabled": true
+										},
+										{
+											"id": "fqaWVTuLJNspa5MsV",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fCJ9sdOXfXoLN594u"
+											},
+											"name": "Power Cells",
+											"reference": "UT36",
+											"local_notes": "Recharges in a Hive; C/72hr.",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "11"
+										},
+										{
+											"id": "fYHvcc90Y-SrByRx6",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f7WMm14XwVJyvz2NQ"
+											},
+											"name": "Power Cells",
+											"reference": "UT36",
+											"local_notes": "Recharges in a Hive; C/5 days.",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "12",
+											"disabled": true
+										},
+										{
+											"id": "fPsP_B7gZzBNACtdc",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fGv5njL67i7rODIpL"
+											},
+											"name": "Beamed Power",
+											"reference": "UT36",
+											"local_notes": "C cell receiver",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "fP8idcQckg2y9BsFj",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fS-7nLrwLytJp5mLZ"
+											},
+											"name": "Gastrobot",
+											"reference": "UT36",
+											"local_notes": "Consumes 0.1lbs./hr. of biomass",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+100%",
+											"disabled": true
+										},
+										{
+											"id": "fTIKyji8VCEKI1_g8",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fhT3sMtcrOGbTzLku"
+											},
+											"name": "Radio-Thermal Generator (RTG)",
+											"reference": "UT36",
+											"local_notes": "Lasts 1 year; LC1",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+100%",
+											"disabled": true
+										},
+										{
+											"id": "f6gTKaCj07KDiD-lH",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "faJkuSBjewuh2TdLg"
+											},
+											"name": "Solar Cell",
+											"reference": "UT36",
+											"local_notes": "Recharges 3 hours' activity in 1 hour",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "fVPCcg4YIS38PJ_FN",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f2u0xwoaeDxGjxCRq"
+											},
+											"name": "Solar Cell",
+											"reference": "UT36",
+											"local_notes": "Recharges 4 hours' activity in 1 hour",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "fwsUbQWy7oqVYncyI",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "ff9wLL0l7uzB0IRXf"
+											},
+											"name": "Solar Cell",
+											"reference": "UT36",
+											"local_notes": "Recharges 5 hours' activity in 1 hour",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "12",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "fHZUesdnS-ooglkhR",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f4SVyLNBYhfPgNZC0"
+											},
+											"name": "Organovore",
+											"reference": "UT36",
+											"local_notes": "Consumes 0.1-0.5 lbs./hr. of carbon-based matter; LC3",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11",
+											"cost": "+200%",
+											"disabled": true
+										},
+										{
+											"id": "f76haMQqttqdlj5PU",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fi-Vh6iRVAbMGaOiO"
+											},
+											"name": "Broadcast Power",
+											"reference": "UT37",
+											"local_notes": "C cell receiver",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11^",
+											"cost": "+100%",
+											"disabled": true
+										}
+									]
+								}
+							],
+							"quantity": 1,
+							"equipped": true,
+							"calc": {
+								"value": 200,
+								"extended_value": 200,
+								"weight": "2 lb",
+								"extended_weight": "2 lb"
+							}
+						}
+					],
+					"calc": {
+						"value": 200,
+						"extended_value": 2800,
+						"weight": "10 lb",
+						"extended_weight": "28 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 0,
+				"extended_value": 3300,
+				"weight": "0 lb",
+				"extended_weight": "29 lb"
+			}
+		}
+	]
+}

--- a/Library/Loadouts/Starship Crew/TL11/Superscience Hacker.gct
+++ b/Library/Loadouts/Starship Crew/TL11/Superscience Hacker.gct
@@ -1,0 +1,104 @@
+{
+	"version": 5,
+	"id": "BJCPyLqJX8EyyNhSG",
+	"equipment": [
+		{
+			"id": "ETrQYN5v_gxZXesFv",
+			"description": "Stored in backpack",
+			"legality_class": "4",
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "e_rRFqJqnnxROHVgg",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "erxnl_BHDpebstnig"
+					},
+					"description": "Small Ultrascanner",
+					"reference": "UT66",
+					"local_notes": "2,000-yard range. +6 to detection. B/4hrs.",
+					"tech_level": "11^",
+					"legality_class": "3",
+					"tags": [
+						"Sensors and Scientific Equipment"
+					],
+					"base_value": "2000",
+					"base_weight": "1 lb",
+					"modifiers": [
+						{
+							"id": "fqyKbfmhiX8jrQSfB",
+							"name": "Memory Scan",
+							"reference": "UT100",
+							"local_notes": "can scan computer memory; LC2",
+							"tags": [
+								"Deception and Intrusion"
+							],
+							"tech_level": "10^",
+							"cost": "+200%"
+						},
+						{
+							"id": "fl3qNvuOdtS5GQMMZ",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+								"id": "ftp3XhCDqI3Lan38o"
+							},
+							"name": "Rugged",
+							"reference": "UT15",
+							"cost_type": "to_base_cost",
+							"weight_type": "to_base_weight",
+							"cost": "+1 CF",
+							"weight": "x1.2"
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 12000,
+						"extended_value": 12000,
+						"weight": "1.2 lb",
+						"extended_weight": "1.2 lb"
+					}
+				},
+				{
+					"id": "exgy8VjDoNebeLOP8",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "enQNM0RB6euc5mo7i"
+					},
+					"description": "B cell",
+					"reference": "UT19",
+					"tech_level": "9",
+					"tags": [
+						"Power"
+					],
+					"base_value": "3",
+					"base_weight": "0.05 lb",
+					"quantity": 4,
+					"equipped": true,
+					"calc": {
+						"value": 3,
+						"extended_value": 12,
+						"weight": "0.05 lb",
+						"extended_weight": "0.2 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 0,
+				"extended_value": 12012,
+				"weight": "0 lb",
+				"extended_weight": "1.4 lb"
+			}
+		}
+	],
+	"notes": [
+		{
+			"id": "nYWTrrknxSMce4Qb4",
+			"markdown": "Remove long-range computer monitoring scanner from the TL11 Hacker lens"
+		}
+	]
+}

--- a/Library/Loadouts/Starship Crew/TL11/Superscience Loadmaster.gct
+++ b/Library/Loadouts/Starship Crew/TL11/Superscience Loadmaster.gct
@@ -1,0 +1,31 @@
+{
+	"version": 5,
+	"id": "B82G7IFw_u5c4unw2",
+	"equipment": [
+		{
+			"id": "ECmJM5WxY4FjzGBmT",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+				"id": "E5k6QJZHsjFoFEGiY"
+			},
+			"description": "Gravpack",
+			"reference": "UT75",
+			"local_notes": "C/12hr.",
+			"tech_level": "11^",
+			"tags": [
+				"Expedition Gear"
+			],
+			"base_value": "15000",
+			"base_weight": "15 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"value": 15000,
+				"extended_value": 15000,
+				"weight": "15 lb",
+				"extended_weight": "15 lb"
+			}
+		}
+	]
+}

--- a/Library/Loadouts/Starship Crew/TL11/Superscience Medical Officer.gct
+++ b/Library/Loadouts/Starship Crew/TL11/Superscience Medical Officer.gct
@@ -1,0 +1,81 @@
+{
+	"version": 5,
+	"id": "BJMQWWNSlYUBK67WU",
+	"equipment": [
+		{
+			"id": "E2KMX22U6mHe64HI5",
+			"description": "Stored in Backpack",
+			"legality_class": "4",
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "emXF6rHrWPBO33eoR",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "e_i5GdrpupUcERZMC"
+					},
+					"description": "Medscanner",
+					"reference": "UT200",
+					"local_notes": "B/10hr.",
+					"tech_level": "10^",
+					"tags": [
+						"Medical"
+					],
+					"base_value": "1000",
+					"base_weight": "0.25 lb",
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Diagnosis"
+							},
+							"amount": 3
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 1000,
+						"extended_value": 1000,
+						"weight": "0.25 lb",
+						"extended_weight": "0.25 lb"
+					}
+				},
+				{
+					"id": "evI7wpih03NgmXSAJ",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "enQNM0RB6euc5mo7i"
+					},
+					"description": "B cell",
+					"reference": "UT19",
+					"tech_level": "9",
+					"tags": [
+						"Power"
+					],
+					"base_value": "3",
+					"base_weight": "0.05 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 3,
+						"extended_value": 3,
+						"weight": "0.05 lb",
+						"extended_weight": "0.05 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 0,
+				"extended_value": 1003,
+				"weight": "0 lb",
+				"extended_weight": "0.3 lb"
+			}
+		}
+	]
+}

--- a/Library/Loadouts/Starship Crew/TL11/Superscience Science Officer.gct
+++ b/Library/Loadouts/Starship Crew/TL11/Superscience Science Officer.gct
@@ -1,0 +1,99 @@
+{
+	"version": 5,
+	"id": "BOyRN2w5v-Ci27uXd",
+	"equipment": [
+		{
+			"id": "E0Ga8Lsmfav1nEVz3",
+			"description": "Stored in Backpack",
+			"legality_class": "4",
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "e1ZxEUDO838549zXA",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "erxnl_BHDpebstnig"
+					},
+					"description": "Small Ultrascanner",
+					"reference": "UT66",
+					"local_notes": "2,000-yard range. +6 to detection. B/4hrs.",
+					"tech_level": "11^",
+					"legality_class": "3",
+					"tags": [
+						"Sensors and Scientific Equipment"
+					],
+					"base_value": "2000",
+					"base_weight": "1 lb",
+					"modifiers": [
+						{
+							"id": "f_E_JDMgcML4ShyvU",
+							"name": "Memory Scan",
+							"reference": "UT100",
+							"local_notes": "can scan computer memory; LC2",
+							"tags": [
+								"Deception and Intrusion"
+							],
+							"tech_level": "10^",
+							"cost": "+200%",
+							"disabled": true
+						},
+						{
+							"id": "fdPZnW1Q-PNUAmIWm",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+								"id": "ftp3XhCDqI3Lan38o"
+							},
+							"name": "Rugged",
+							"reference": "UT15",
+							"cost_type": "to_base_cost",
+							"weight_type": "to_base_weight",
+							"cost": "+1 CF",
+							"weight": "x1.2"
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 4000,
+						"extended_value": 4000,
+						"weight": "1.2 lb",
+						"extended_weight": "1.2 lb"
+					}
+				},
+				{
+					"id": "exkM1O7yu6o4ZvKnM",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "enQNM0RB6euc5mo7i"
+					},
+					"description": "B cell",
+					"reference": "UT19",
+					"tech_level": "9",
+					"tags": [
+						"Power"
+					],
+					"base_value": "3",
+					"base_weight": "0.05 lb",
+					"quantity": 2,
+					"equipped": true,
+					"calc": {
+						"value": 3,
+						"extended_value": 6,
+						"weight": "0.05 lb",
+						"extended_weight": "0.1 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 0,
+				"extended_value": 4006,
+				"weight": "0 lb",
+				"extended_weight": "1.3 lb"
+			}
+		}
+	]
+}

--- a/Library/Loadouts/Starship Crew/TL11/Superscience Tactical Officer.gct
+++ b/Library/Loadouts/Starship Crew/TL11/Superscience Tactical Officer.gct
@@ -1,0 +1,1271 @@
+{
+	"version": 5,
+	"id": "BaXGiiYiTqoetBVsT",
+	"equipment": [
+		{
+			"id": "EWk_QY5JKp1nmg-Zb",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Basic Set/Basic Set Equipment.eqp",
+				"id": "EwSOT_Sl-CS9v-TgB"
+			},
+			"description": "Backpack, Frame",
+			"reference": "B288",
+			"tech_level": "1",
+			"tags": [
+				"Camping and Survival Gear"
+			],
+			"base_value": "100",
+			"base_weight": "10 lb",
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "contained_weight_prereq",
+						"has": true,
+						"qualifier": {
+							"compare": "at_most",
+							"qualifier": "100 lb"
+						}
+					}
+				]
+			},
+			"modifiers": [
+				{
+					"id": "fQuVMtlDmcHpkJitX",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+						"id": "f3AMg_F7eHdJ-u_bX"
+					},
+					"name": "Expensive",
+					"reference": "UT15",
+					"cost_type": "to_base_cost",
+					"weight_type": "to_base_weight",
+					"cost": "+1 CF",
+					"weight": "x2/3"
+				}
+			],
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "eyK4ZFF1zSQAyRH7X",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eolfoSjDZrWRDXA6e"
+					},
+					"description": "Armoury (@Specialization@) Toolkit",
+					"reference": "UT82",
+					"local_notes": "10B/10hr.",
+					"tech_level": "9",
+					"tags": [
+						"Expedition Gear"
+					],
+					"base_value": "600",
+					"base_weight": "20 lb",
+					"replacements": {
+						"Specialization": "Force Shields"
+					},
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 600,
+						"extended_value": 600,
+						"weight": "20 lb",
+						"extended_weight": "20 lb"
+					}
+				},
+				{
+					"id": "edowiYv4HcqNfw88V",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "e7TE6SF7jxlBKNKsE"
+					},
+					"description": "Light Force Screen",
+					"reference": "UT191",
+					"local_notes": "DR200.",
+					"tech_level": "11^",
+					"legality_class": "3",
+					"tags": [
+						"Defenses"
+					],
+					"base_value": "25000",
+					"base_weight": "25 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 25000,
+						"extended_value": 25000,
+						"weight": "25 lb",
+						"extended_weight": "25 lb"
+					}
+				},
+				{
+					"id": "eo21GRQ0muwYcynYW",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eBNtuKd7TaJyiCvvo"
+					},
+					"description": "Portable Fusion Reactor",
+					"reference": "UT20",
+					"tech_level": "11",
+					"legality_class": "2",
+					"tags": [
+						"Power"
+					],
+					"base_value": "100000",
+					"base_weight": "50 lb",
+					"modifiers": [
+						{
+							"id": "fOEOKquXxf0ENTJS0",
+							"name": "Superscience",
+							"weight_type": "to_base_weight",
+							"tech_level": "11^",
+							"cost": "x0.2",
+							"weight": "x0.1"
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 20000,
+						"extended_value": 20000,
+						"weight": "5 lb",
+						"extended_weight": "5 lb"
+					}
+				},
+				{
+					"id": "erJ33ZeNKnRRg9G-C",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "epRXtbtPNVTPIqIdo"
+					},
+					"description": "A cell",
+					"reference": "UT19",
+					"tech_level": "9",
+					"tags": [
+						"Power"
+					],
+					"base_value": "2",
+					"base_weight": "0.005 lb",
+					"quantity": 10,
+					"equipped": true,
+					"calc": {
+						"value": 2,
+						"extended_value": 20,
+						"weight": "0.005 lb",
+						"extended_weight": "0.05 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 200,
+				"extended_value": 45820,
+				"weight": "6.6666 lb",
+				"extended_weight": "56.7166 lb"
+			}
+		},
+		{
+			"id": "E7UIk2k2LKcZpUop0",
+			"description": "Inside Swarmbot Hive",
+			"legality_class": "4",
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "e1kQ9UncCXy8Aro3R",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eRd4HdGkY3padXW2c"
+					},
+					"description": "@Microbot/Nanobot Type@ Swarm",
+					"reference": "UT35",
+					"tech_level": "10",
+					"tags": [
+						"Swarmbots"
+					],
+					"base_weight": "2 lb",
+					"replacements": {
+						"Equipment": "Light Force Screen",
+						"Microbot/Nanobot Type": "Repair"
+					},
+					"modifiers": [
+						{
+							"id": "FqCPU8DkVsSJ7iQIR",
+							"name": "Swarm Type",
+							"reference": "UT37",
+							"local_notes": "at TL11 microbots can have two types, at TL12 nanobots can have two types",
+							"children": [
+								{
+									"id": "fHo-OcSRRxbfmNKPQ",
+									"name": "Bughunter",
+									"reference": "UT106",
+									"local_notes": "LC3",
+									"tags": [
+										"Counter-Surveillance and ECM",
+										"Security and Surveillance",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+4000",
+									"disabled": true
+								},
+								{
+									"id": "fgHxV54h4H9NWAi1E",
+									"name": "Cannibal",
+									"reference": "UT169",
+									"local_notes": "LC1",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "12",
+									"cost": "+15000",
+									"disabled": true
+								},
+								{
+									"id": "fH3ZSD-a9_Mcjy4ws",
+									"name": "Cleaning",
+									"reference": "UT69",
+									"local_notes": "LC4",
+									"tags": [
+										"Domestic Equipment and Appliances",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "f6OahFihJ0ieQcrCQ",
+									"name": "Construction",
+									"reference": "UT86",
+									"local_notes": "LC4",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fpKQz1-NJ_njbsgaw",
+									"name": "Decontamination (@Hazard Type@)",
+									"reference": "UT87",
+									"local_notes": "LC3; Hazardous Materials (@Hazard Type@)-12",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fDtTc566_siL9Ucop",
+									"name": "Decontamination (@Hazard Type@)",
+									"reference": "UT87",
+									"local_notes": "LC3; Hazardous Materials (@Hazard Type@)-13",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "11",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fmXB2uliwa7BfEOx6",
+									"name": "Decontamination (@Hazard Type@)",
+									"reference": "UT87",
+									"local_notes": "LC3; Hazardous Materials (@Hazard Type@)-14",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "12",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fH0owvb3ES6AU2nxM",
+									"name": "Defoliator",
+									"reference": "UT87",
+									"local_notes": "LC3",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fNDNOEOAMyDHflVlm",
+									"name": "Devourer",
+									"reference": "UT169",
+									"local_notes": "LC1",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "10",
+									"cost": "+8000",
+									"disabled": true
+								},
+								{
+									"id": "fT6qPPTwxfFQwkWOv",
+									"name": "Disassembler",
+									"reference": "UT169",
+									"local_notes": "LC1",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "11",
+									"cost": "+10000",
+									"disabled": true
+								},
+								{
+									"id": "f0FI4RGhi_s7wajYu",
+									"name": "Explorer",
+									"reference": "UT80",
+									"local_notes": "LC4",
+									"tags": [
+										"Expedition Gear",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+500",
+									"disabled": true
+								},
+								{
+									"id": "f9jLUae6nAL06pHq0",
+									"name": "Firefly",
+									"reference": "UT74",
+									"local_notes": "LC4",
+									"tags": [
+										"Domestic Equipment and Appliances",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+100",
+									"disabled": true
+								},
+								{
+									"id": "fmuR7Pu7whyAUC6BP",
+									"name": "Forensic",
+									"reference": "UT107",
+									"local_notes": "LC3",
+									"tags": [
+										"Enforcement and Coercion",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+4000",
+									"disabled": true
+								},
+								{
+									"id": "fsvnqCZ4SLbG1wbP-",
+									"name": "Gremlin",
+									"reference": "UT169",
+									"local_notes": "LC2",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "10",
+									"cost": "+2000",
+									"disabled": true
+								},
+								{
+									"id": "f3c4U9ruzEHiBNHfM",
+									"name": "Harvester",
+									"reference": "UT87",
+									"local_notes": "LC4",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+2000",
+									"disabled": true
+								},
+								{
+									"id": "fc-TlMa7-LJuCfsMK",
+									"name": "Massage",
+									"reference": "UT41",
+									"local_notes": "LC4",
+									"tags": [
+										"Robots",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+200",
+									"disabled": true
+								},
+								{
+									"id": "fTp_Ry0OARMEvce_n",
+									"name": "Painter",
+									"reference": "UT87",
+									"local_notes": "LC4",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+500",
+									"disabled": true
+								},
+								{
+									"id": "fzwcnt5tisrpUgoVA",
+									"name": "Paramedical",
+									"reference": "UT201",
+									"local_notes": "LC3; Diagnosis-10, First Aid-10",
+									"tags": [
+										"Medical",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+6000",
+									"disabled": true
+								},
+								{
+									"id": "foAm0Yp0Vg28rtzSn",
+									"name": "Paramedical",
+									"reference": "UT201",
+									"local_notes": "LC3; Diagnosis-11, First Aid-11",
+									"tags": [
+										"Medical",
+										"Swarmbots"
+									],
+									"tech_level": "11",
+									"cost": "+6000",
+									"disabled": true
+								},
+								{
+									"id": "feio7qFCSY_W1lWQW",
+									"name": "Paramedical",
+									"reference": "UT201",
+									"local_notes": "LC3; Diagnosis-12, First Aid-12",
+									"tags": [
+										"Medical",
+										"Swarmbots"
+									],
+									"tech_level": "12",
+									"cost": "+6000",
+									"disabled": true
+								},
+								{
+									"id": "fCNMBUwIsIW438i-F",
+									"name": "Pesticide",
+									"reference": "UT87",
+									"local_notes": "LC3",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "feDPcBJ0vX2m2hWt0",
+									"name": "Play",
+									"reference": "UT41",
+									"local_notes": "LC4",
+									"tags": [
+										"Robots",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+200",
+									"disabled": true
+								},
+								{
+									"id": "fs6_NBToSAKfnIlLh",
+									"name": "Pollinator",
+									"reference": "UT87",
+									"local_notes": "LC4",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "f06vj-XP_Str4eP_5",
+									"name": "Repair (@Equipment@)",
+									"reference": "UT87",
+									"local_notes": "LC4; Repair Skill-12",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+500",
+									"disabled": true
+								},
+								{
+									"id": "fAsnyfYCnnmYTMJT8",
+									"name": "Repair (@Equipment@)",
+									"reference": "UT87",
+									"local_notes": "LC4; Repair Skill-13",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "11",
+									"cost": "+500"
+								},
+								{
+									"id": "fSsOcNun_w1Z_41MD",
+									"name": "Repair (@Other Equipment 1@)",
+									"reference": "UT87",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+250",
+									"disabled": true
+								},
+								{
+									"id": "fEyPtOPz6Nug_9ttJ",
+									"name": "Repair (@Other Equipment 2@)",
+									"reference": "UT87",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+250",
+									"disabled": true
+								},
+								{
+									"id": "fWvMq4Bf28tHipKmo",
+									"name": "Repair (@Other Equipment 3@)",
+									"reference": "UT87",
+									"tags": [
+										"Swarmbots",
+										"Tools and Construction Materials"
+									],
+									"tech_level": "10",
+									"cost": "+250",
+									"disabled": true
+								},
+								{
+									"id": "f7zJhky7YTnIhjfBq",
+									"name": "Security",
+									"reference": "UT104",
+									"local_notes": "LC3",
+									"tags": [
+										"Security and Surveillance",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "fHo9MBmU49O7ieKrn",
+									"name": "Sentry",
+									"reference": "UT169",
+									"local_notes": "LC3",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "10",
+									"cost": "+5000",
+									"disabled": true
+								},
+								{
+									"id": "fRQLIPFnPbKjfXWrj",
+									"name": "Stinger",
+									"reference": "UT169",
+									"local_notes": "LC2",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "10",
+									"cost": "+1500",
+									"disabled": true
+								},
+								{
+									"id": "fDvLyPxC6LGZyw3XO",
+									"name": "Surveillance",
+									"reference": "UT106",
+									"local_notes": "LC3",
+									"tags": [
+										"Security and Surveillance",
+										"Surveillance and Tracking Devices",
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"cost": "+500",
+									"disabled": true
+								},
+								{
+									"id": "fPL8FXV_ZYuvZjRi-",
+									"name": "Terminator",
+									"reference": "UT169",
+									"local_notes": "LC1",
+									"tags": [
+										"Combat Robots",
+										"Swarmbots",
+										"Weaponry"
+									],
+									"tech_level": "10",
+									"cost": "+1500",
+									"disabled": true
+								}
+							]
+						},
+						{
+							"id": "fzyHva5kSmhID0Kne",
+							"name": "Self-Replicating",
+							"reference": "UT37",
+							"local_notes": "only for defoliator, devourer or pesticide",
+							"tags": [
+								"Swarmbots"
+							],
+							"cost_type": "to_base_cost",
+							"cost": "x10",
+							"disabled": true
+						},
+						{
+							"id": "FD9euAikddiD5ijLU",
+							"name": "Chassis",
+							"local_notes": "choose one microbot or nanobot chassis",
+							"children": [
+								{
+									"id": "F9JvRreuxL91lGJYn",
+									"name": "Microbot Chassis",
+									"children": [
+										{
+											"id": "fzTOYopVzrEG5JUQV",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f7eMKwMF7BTYFbxhq"
+											},
+											"name": "Microbot Aerostat",
+											"reference": "UT36",
+											"local_notes": "Air Move 2",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"disabled": true
+										},
+										{
+											"id": "fvTv_nWh7N_x1Wo2M",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fcVKEB14BedQI1jGA"
+											},
+											"name": "Microbot Crawler",
+											"reference": "UT36",
+											"local_notes": "Move 3; Water Move 1",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "10"
+										},
+										{
+											"id": "fk20tpbot5VTpmRJ9",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fScgdTYLwKE9CEYfl"
+											},
+											"name": "Microbot Crawler, Armored",
+											"reference": "UT36",
+											"local_notes": "Move 2, 2x HP",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+100%",
+											"disabled": true
+										},
+										{
+											"id": "fDO6vk6fRacuSPG05",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fpAVv9yE3m3t0Egt_"
+											},
+											"name": "Microbot Flier",
+											"reference": "UT36",
+											"local_notes": "Move 1; Air Move 6",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+100%",
+											"disabled": true
+										},
+										{
+											"id": "fapT5ZVG8N_Y7ler_",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "ffHj2SBngzuewdrbB"
+											},
+											"name": "Microbot Hopper",
+											"reference": "UT36",
+											"local_notes": "Move 4; Super Jump 1",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "fAF1OhHbb9CWsgKjk",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fr6wQjKaUic-BpBCO"
+											},
+											"name": "Microbot Space",
+											"reference": "UT36",
+											"local_notes": "Move 1; 0.0001G solar sail",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+0",
+											"disabled": true
+										},
+										{
+											"id": "f4GTB71bIxJcXdLea",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fsL5rGqz66ht8cVvg"
+											},
+											"name": "Microbot Swimmer",
+											"reference": "UT36",
+											"local_notes": "Water Move 4",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+0",
+											"disabled": true
+										},
+										{
+											"id": "fbcrz4GGiz50m_FYG",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fvVo7_8gzuQpK50fc"
+											},
+											"name": "Microbot Contragrav (CG) Flier",
+											"reference": "UT36",
+											"local_notes": "Move 1; Air Move 20",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11^",
+											"cost": "+200%",
+											"disabled": true
+										}
+									]
+								},
+								{
+									"id": "FesM_7NyHUtHHKAfp",
+									"name": "Nanobot Chassis",
+									"children": [
+										{
+											"id": "fPh4Uj8vCJFYoPX3d",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f6RvvKoBN0DqIjBjQ"
+											},
+											"name": "Nanobot Aerostat",
+											"reference": "UT36",
+											"local_notes": "Air Move 1",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "11",
+											"disabled": true
+										},
+										{
+											"id": "fwisj8tRoJSAEpBOx",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f1OLvlafFuNITe6na"
+											},
+											"name": "Nanobot Crawler",
+											"reference": "UT36",
+											"local_notes": "Move 3; Water Move 1",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "11",
+											"disabled": true
+										},
+										{
+											"id": "f2kanYKAEg_h2MktW",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fASzj6iYz6hUA-TBB"
+											},
+											"name": "Nanobot Crawler, Armored",
+											"reference": "UT36",
+											"local_notes": "Move 2, 2x HP",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11",
+											"cost": "+100%",
+											"disabled": true
+										},
+										{
+											"id": "f_KzYtxQI00xFkoRQ",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fLuL-pD4o6s0lREJs"
+											},
+											"name": "Nanobot Dust",
+											"reference": "UT36",
+											"local_notes": "Immobile",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11",
+											"cost": "-80%",
+											"disabled": true
+										},
+										{
+											"id": "fLEbYlIf2ul5avDYX",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fKeArqcSSvcPk5QTp"
+											},
+											"name": "Nanobot Flier",
+											"reference": "UT36",
+											"local_notes": "Move 1; Air Move 3",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11",
+											"cost": "+100%",
+											"disabled": true
+										},
+										{
+											"id": "fgaO1o7hhnK4ENG4h",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fyATVIBpOaRfq3tKe"
+											},
+											"name": "Nanobot Hopper",
+											"reference": "UT36",
+											"local_notes": "Move 4; Super Jump 1",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "fdHhlaz2Md24locYy",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f80KO0VZYaEJb9hbs"
+											},
+											"name": "Nanobot Space",
+											"reference": "UT36",
+											"local_notes": "Move 1; 0.0001G solar sail",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "11",
+											"cost": "+0",
+											"disabled": true
+										},
+										{
+											"id": "fXZAj6wgrnJScRuWk",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fa36bUxm5RcsG_mOk"
+											},
+											"name": "Nanobot Swimmer",
+											"reference": "UT36",
+											"local_notes": "Water Move 1",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "11",
+											"cost": "+0",
+											"disabled": true
+										},
+										{
+											"id": "f9dJl1LUxCFfKXoqk",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fPgd1Z13foKJXxTND"
+											},
+											"name": "Nanobot Contragrav (CG) Flier",
+											"reference": "UT36",
+											"local_notes": "Move 1; Air Move 10",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11^",
+											"cost": "+200%",
+											"disabled": true
+										}
+									]
+								}
+							]
+						},
+						{
+							"id": "F-cl0rcr0FKjV6YP7",
+							"name": "Stealth",
+							"children": [
+								{
+									"id": "fZjN8mu8VqwAKfpxc",
+									"name": "Disguise",
+									"reference": "UT36",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_cost",
+									"tech_level": "10",
+									"cost": "+1000",
+									"disabled": true
+								},
+								{
+									"id": "f5KtpuNCwPYX38V-m",
+									"name": "Thermo-Optic Chameleon Surface",
+									"reference": "UT37, UT98",
+									"local_notes": "LC3",
+									"tags": [
+										"Deception and Intrusion",
+										"Swarmbots"
+									],
+									"cost_type": "to_final_cost",
+									"tech_level": "9",
+									"cost": "+4000",
+									"weight": "+4 lb",
+									"disabled": true
+								},
+								{
+									"id": "fF2anz4fJwYkjYL26",
+									"name": "Multispectral Chameleon Surface",
+									"reference": "UT37, UT99",
+									"local_notes": "LC3",
+									"tags": [
+										"Deception and Intrusion",
+										"Swarmbots"
+									],
+									"cost_type": "to_final_cost",
+									"tech_level": "10",
+									"cost": "+6000",
+									"weight": "+4 lb",
+									"disabled": true
+								},
+								{
+									"id": "fSxo1b2MzwkCNQbzB",
+									"name": "Dynamic Multispectral Chameleon Surface",
+									"reference": "UT37, UT99",
+									"local_notes": "LC3",
+									"tags": [
+										"Deception and Intrusion",
+										"Swarmbots"
+									],
+									"cost_type": "to_final_cost",
+									"tech_level": "11",
+									"cost": "+8000",
+									"weight": "+4 lb",
+									"disabled": true
+								},
+								{
+									"id": "fXHJ2ieZXA2sMsLJv",
+									"name": "Ultimate Chameleon Surface",
+									"reference": "UT37, UT99",
+									"local_notes": "LC3",
+									"tags": [
+										"Deception and Intrusion",
+										"Swarmbots"
+									],
+									"cost_type": "to_final_cost",
+									"tech_level": "12",
+									"cost": "+10000",
+									"weight": "+4 lb",
+									"disabled": true
+								}
+							]
+						},
+						{
+							"id": "F_utqSIzxrv73W0jJ",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+								"id": "F5Q7h4gAuvWsoUiFV"
+							},
+							"name": "Power Supply",
+							"children": [
+								{
+									"id": "fedtRIwFGN_AsuHPY",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "faj6YgnYeEKAy39jw"
+									},
+									"name": "Power Cells",
+									"reference": "UT36",
+									"local_notes": "Recharges in a Hive; C/12hr.",
+									"tags": [
+										"Swarmbots"
+									],
+									"tech_level": "10",
+									"disabled": true
+								},
+								{
+									"id": "f3PHwg9MqEWI0CWkQ",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fCJ9sdOXfXoLN594u"
+									},
+									"name": "Power Cells",
+									"reference": "UT36",
+									"local_notes": "Recharges in a Hive; C/72hr.",
+									"tags": [
+										"Swarmbots"
+									],
+									"tech_level": "11"
+								},
+								{
+									"id": "fx_Yja849JmoN1rKD",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "f7WMm14XwVJyvz2NQ"
+									},
+									"name": "Power Cells",
+									"reference": "UT36",
+									"local_notes": "Recharges in a Hive; C/5 days.",
+									"tags": [
+										"Swarmbots"
+									],
+									"tech_level": "12",
+									"disabled": true
+								},
+								{
+									"id": "fo1fkVfo6g0yQlb3H",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fGv5njL67i7rODIpL"
+									},
+									"name": "Beamed Power",
+									"reference": "UT36",
+									"local_notes": "C cell receiver",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "10",
+									"cost": "+50%",
+									"disabled": true
+								},
+								{
+									"id": "fDUt4_R9akealNpUU",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fS-7nLrwLytJp5mLZ"
+									},
+									"name": "Gastrobot",
+									"reference": "UT36",
+									"local_notes": "Consumes 0.1lbs./hr. of biomass",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "10",
+									"cost": "+100%",
+									"disabled": true
+								},
+								{
+									"id": "fWg1QDwK3prlYmUlN",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fhT3sMtcrOGbTzLku"
+									},
+									"name": "Radio-Thermal Generator (RTG)",
+									"reference": "UT36",
+									"local_notes": "Lasts 1 year; LC1",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "10",
+									"cost": "+100%",
+									"disabled": true
+								},
+								{
+									"id": "fzDvcSAbwRjimKrrG",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "faJkuSBjewuh2TdLg"
+									},
+									"name": "Solar Cell",
+									"reference": "UT36",
+									"local_notes": "Recharges 3 hours' activity in 1 hour",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "10",
+									"cost": "+50%",
+									"disabled": true
+								},
+								{
+									"id": "fzvGNiGihsx_wrcGX",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "f2u0xwoaeDxGjxCRq"
+									},
+									"name": "Solar Cell",
+									"reference": "UT36",
+									"local_notes": "Recharges 4 hours' activity in 1 hour",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "11",
+									"cost": "+50%",
+									"disabled": true
+								},
+								{
+									"id": "fWYvofuoBoq6hpU4F",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "ff9wLL0l7uzB0IRXf"
+									},
+									"name": "Solar Cell",
+									"reference": "UT36",
+									"local_notes": "Recharges 5 hours' activity in 1 hour",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "12",
+									"cost": "+50%",
+									"disabled": true
+								},
+								{
+									"id": "fhCOtxzHy2bjTNIDP",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "f4SVyLNBYhfPgNZC0"
+									},
+									"name": "Organovore",
+									"reference": "UT36",
+									"local_notes": "Consumes 0.1-0.5 lbs./hr. of carbon-based matter; LC3",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "11",
+									"cost": "+200%",
+									"disabled": true
+								},
+								{
+									"id": "fV2ucIMah_C6H8CRG",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fi-Vh6iRVAbMGaOiO"
+									},
+									"name": "Broadcast Power",
+									"reference": "UT37",
+									"local_notes": "C cell receiver",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_final_base_cost",
+									"tech_level": "11^",
+									"cost": "+100%",
+									"disabled": true
+								}
+							]
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 500,
+						"extended_value": 500,
+						"weight": "2 lb",
+						"extended_weight": "2 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 0,
+				"extended_value": 500,
+				"weight": "0 lb",
+				"extended_weight": "2 lb"
+			}
+		}
+	],
+	"notes": [
+		{
+			"id": "nDmsrTSBsWChbffl9",
+			"markdown": "Remove Expensive Small Backpack, Portable Toolkit, Microbot Swarm and B cells from the TL11 Tactical Officer lens"
+		}
+	]
+}

--- a/Library/Loadouts/Starship Crew/TL11/Tactical Officer.gct
+++ b/Library/Loadouts/Starship Crew/TL11/Tactical Officer.gct
@@ -1,0 +1,1334 @@
+{
+	"version": 5,
+	"id": "BA2Yv-RLtxLxVZJWO",
+	"equipment": [
+		{
+			"id": "EuVSfNKvwBmQx_G3n",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Basic Set/Basic Set Equipment.eqp",
+				"id": "ESjtIfyzScVP49ity"
+			},
+			"description": "Backpack, Small",
+			"reference": "B288",
+			"tech_level": "1",
+			"tags": [
+				"Camping and Survival Gear"
+			],
+			"base_value": "60",
+			"base_weight": "3 lb",
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "contained_weight_prereq",
+						"has": true,
+						"qualifier": {
+							"compare": "at_most",
+							"qualifier": "40 lb"
+						}
+					}
+				]
+			},
+			"modifiers": [
+				{
+					"id": "fUHitV4X2TAcj6DZJ",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+						"id": "f3AMg_F7eHdJ-u_bX"
+					},
+					"name": "Expensive",
+					"reference": "UT15",
+					"cost_type": "to_base_cost",
+					"weight_type": "to_base_weight",
+					"cost": "+1 CF",
+					"weight": "x2/3"
+				}
+			],
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "e1oLk4VhStOlhFZHj",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eolfoSjDZrWRDXA6e"
+					},
+					"description": "Armoury (@Specialization@) Toolkit",
+					"reference": "UT82",
+					"local_notes": "10B/10hr.",
+					"tech_level": "9",
+					"tags": [
+						"Expedition Gear"
+					],
+					"base_value": "600",
+					"base_weight": "20 lb",
+					"replacements": {
+						"Specialization": "Vehicular Armor"
+					},
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 600,
+						"extended_value": 600,
+						"weight": "20 lb",
+						"extended_weight": "20 lb"
+					}
+				},
+				{
+					"id": "EppnYybqopX6RLr0J",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eSMEpeCwHrfGzvkx9"
+					},
+					"description": "Portable Terminal",
+					"reference": "UT24",
+					"local_notes": "2B/20hr.",
+					"tech_level": "9",
+					"tags": [
+						"Computers"
+					],
+					"base_value": "50",
+					"base_weight": "0.5 lb",
+					"modifiers": [
+						{
+							"id": "fZm6-zjXCAWpqWbMt",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+								"id": "ftp3XhCDqI3Lan38o"
+							},
+							"name": "Rugged",
+							"reference": "UT15",
+							"cost_type": "to_base_cost",
+							"weight_type": "to_base_weight",
+							"cost": "+1 CF",
+							"weight": "x1.2"
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"children": [
+						{
+							"id": "eP2f0eWFuHGrBCmt2",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "emOmFGTZEbRVE2qhf"
+							},
+							"description": "Cable Jack",
+							"reference": "UT42",
+							"tech_level": "9",
+							"tags": [
+								"Communication and Interface"
+							],
+							"base_value": "5",
+							"modifiers": [
+								{
+									"id": "frVjBpKlwxQ3Bwqht",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "ftp3XhCDqI3Lan38o"
+									},
+									"name": "Rugged",
+									"reference": "UT15",
+									"cost_type": "to_base_cost",
+									"weight_type": "to_base_weight",
+									"cost": "+1 CF",
+									"weight": "x1.2"
+								}
+							],
+							"quantity": 1,
+							"equipped": true,
+							"calc": {
+								"value": 10,
+								"extended_value": 10,
+								"weight": "0 lb",
+								"extended_weight": "0 lb"
+							}
+						}
+					],
+					"calc": {
+						"value": 100,
+						"extended_value": 110,
+						"weight": "0.6 lb",
+						"extended_weight": "0.6 lb"
+					}
+				},
+				{
+					"id": "eoqTxjbubBUVxm1v-",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "e5BC-pEfofU28HHzf"
+					},
+					"description": "Optical Cable",
+					"reference": "UT43",
+					"local_notes": "\"Quantity\" represents yards.",
+					"tech_level": "9",
+					"tags": [
+						"Communication and Interface"
+					],
+					"base_value": "0.1",
+					"base_weight": "0.01 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 0.1,
+						"extended_value": 0.1,
+						"weight": "0.01 lb",
+						"extended_weight": "0.01 lb"
+					}
+				},
+				{
+					"id": "eicGCpVZZzM-bi39U",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "enQNM0RB6euc5mo7i"
+					},
+					"description": "B cell",
+					"reference": "UT19",
+					"tech_level": "9",
+					"tags": [
+						"Power"
+					],
+					"base_value": "3",
+					"base_weight": "0.05 lb",
+					"quantity": 10,
+					"equipped": true,
+					"calc": {
+						"value": 3,
+						"extended_value": 30,
+						"weight": "0.05 lb",
+						"extended_weight": "0.5 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 120,
+				"extended_value": 860.1,
+				"weight": "2 lb",
+				"extended_weight": "23.11 lb"
+			}
+		},
+		{
+			"id": "EH80nP_ZBDakYAfAZ",
+			"description": "Stored in Vehicle",
+			"legality_class": "4",
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "EXYAyauOTa-ybOEdS",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "efeekclqs54nOsbVN"
+					},
+					"description": "Swarmbot Hive",
+					"reference": "UT37",
+					"tech_level": "10",
+					"base_value": "200",
+					"base_weight": "10 lb",
+					"quantity": 1,
+					"equipped": true,
+					"children": [
+						{
+							"id": "eu2VOnHmqU-Nhpdvh",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "eRd4HdGkY3padXW2c"
+							},
+							"description": "@Microbot/Nanobot Type@ Swarm",
+							"reference": "UT35",
+							"tech_level": "10",
+							"tags": [
+								"Swarmbots"
+							],
+							"base_weight": "2 lb",
+							"replacements": {
+								"Equipment": "Ship Armor",
+								"Microbot/Nanobot Type": "Repair"
+							},
+							"modifiers": [
+								{
+									"id": "FxDh3viioErhTpkEM",
+									"name": "Swarm Type",
+									"reference": "UT37",
+									"local_notes": "at TL11 microbots can have two types, at TL12 nanobots can have two types",
+									"children": [
+										{
+											"id": "fU3l-kN6FyYNB05O_",
+											"name": "Bughunter",
+											"reference": "UT106",
+											"local_notes": "LC3",
+											"tags": [
+												"Counter-Surveillance and ECM",
+												"Security and Surveillance",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+4000",
+											"disabled": true
+										},
+										{
+											"id": "f9AwX2XS4znVIAOox",
+											"name": "Cannibal",
+											"reference": "UT169",
+											"local_notes": "LC1",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "12",
+											"cost": "+15000",
+											"disabled": true
+										},
+										{
+											"id": "fxZsPD33qS-vnNuwo",
+											"name": "Cleaning",
+											"reference": "UT69",
+											"local_notes": "LC4",
+											"tags": [
+												"Domestic Equipment and Appliances",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fmHCux_uoPgh6WV5f",
+											"name": "Construction",
+											"reference": "UT86",
+											"local_notes": "LC4",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fP8VOUiD9AgY_91wG",
+											"name": "Decontamination (@Hazard Type@)",
+											"reference": "UT87",
+											"local_notes": "LC3; Hazardous Materials (@Hazard Type@)-12",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "f68-xA1MKhwuJ-FpS",
+											"name": "Decontamination (@Hazard Type@)",
+											"reference": "UT87",
+											"local_notes": "LC3; Hazardous Materials (@Hazard Type@)-13",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "11",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "f0uZKDaAtLyckbdVg",
+											"name": "Decontamination (@Hazard Type@)",
+											"reference": "UT87",
+											"local_notes": "LC3; Hazardous Materials (@Hazard Type@)-14",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "12",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fr8h1ASIVGvkT1-l4",
+											"name": "Defoliator",
+											"reference": "UT87",
+											"local_notes": "LC3",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fsnyUNG9FzFG5qcMe",
+											"name": "Devourer",
+											"reference": "UT169",
+											"local_notes": "LC1",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "10",
+											"cost": "+8000",
+											"disabled": true
+										},
+										{
+											"id": "fREClR3fk5pyll7tN",
+											"name": "Disassembler",
+											"reference": "UT169",
+											"local_notes": "LC1",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "11",
+											"cost": "+10000",
+											"disabled": true
+										},
+										{
+											"id": "fDE6ZYQh045cOar7n",
+											"name": "Explorer",
+											"reference": "UT80",
+											"local_notes": "LC4",
+											"tags": [
+												"Expedition Gear",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+500",
+											"disabled": true
+										},
+										{
+											"id": "fS1TSZshw_Pu9U_nJ",
+											"name": "Firefly",
+											"reference": "UT74",
+											"local_notes": "LC4",
+											"tags": [
+												"Domestic Equipment and Appliances",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+100",
+											"disabled": true
+										},
+										{
+											"id": "f1RUfUSIpXybTeMP6",
+											"name": "Forensic",
+											"reference": "UT107",
+											"local_notes": "LC3",
+											"tags": [
+												"Enforcement and Coercion",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+4000",
+											"disabled": true
+										},
+										{
+											"id": "fqMM-IhjHaj-8WIkB",
+											"name": "Gremlin",
+											"reference": "UT169",
+											"local_notes": "LC2",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "10",
+											"cost": "+2000",
+											"disabled": true
+										},
+										{
+											"id": "fbcFUudoGBj7oXs6-",
+											"name": "Harvester",
+											"reference": "UT87",
+											"local_notes": "LC4",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+2000",
+											"disabled": true
+										},
+										{
+											"id": "fZVCbma4D_u2RoYJP",
+											"name": "Massage",
+											"reference": "UT41",
+											"local_notes": "LC4",
+											"tags": [
+												"Robots",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+200",
+											"disabled": true
+										},
+										{
+											"id": "fiKUwSDie_U1Lc_2e",
+											"name": "Painter",
+											"reference": "UT87",
+											"local_notes": "LC4",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+500",
+											"disabled": true
+										},
+										{
+											"id": "fvk9RCkA9OhfaQFSg",
+											"name": "Paramedical",
+											"reference": "UT201",
+											"local_notes": "LC3; Diagnosis-10, First Aid-10",
+											"tags": [
+												"Medical",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+6000",
+											"disabled": true
+										},
+										{
+											"id": "fn8UQNDbqwQAjBKGD",
+											"name": "Paramedical",
+											"reference": "UT201",
+											"local_notes": "LC3; Diagnosis-11, First Aid-11",
+											"tags": [
+												"Medical",
+												"Swarmbots"
+											],
+											"tech_level": "11",
+											"cost": "+6000",
+											"disabled": true
+										},
+										{
+											"id": "fYNELNBM9rdjRHXfx",
+											"name": "Paramedical",
+											"reference": "UT201",
+											"local_notes": "LC3; Diagnosis-12, First Aid-12",
+											"tags": [
+												"Medical",
+												"Swarmbots"
+											],
+											"tech_level": "12",
+											"cost": "+6000",
+											"disabled": true
+										},
+										{
+											"id": "fsprakXYB2Gvbcie3",
+											"name": "Pesticide",
+											"reference": "UT87",
+											"local_notes": "LC3",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fVWIghYAvhOvgyu2G",
+											"name": "Play",
+											"reference": "UT41",
+											"local_notes": "LC4",
+											"tags": [
+												"Robots",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+200",
+											"disabled": true
+										},
+										{
+											"id": "fLReDzsnUqUi3gPvq",
+											"name": "Pollinator",
+											"reference": "UT87",
+											"local_notes": "LC4",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fBD-oNY875JlBD561",
+											"name": "Repair (@Equipment@)",
+											"reference": "UT87",
+											"local_notes": "LC4; Repair Skill-12",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+500",
+											"disabled": true
+										},
+										{
+											"id": "f6Knq4FpoGXo295S_",
+											"name": "Repair (@Equipment@)",
+											"reference": "UT87",
+											"local_notes": "LC4; Repair Skill-13",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "11",
+											"cost": "+500"
+										},
+										{
+											"id": "f9RaB3nrJ1v2rqpmA",
+											"name": "Repair (@Other Equipment 1@)",
+											"reference": "UT87",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+250",
+											"disabled": true
+										},
+										{
+											"id": "fgdK9Ne2Xpz13Nw5Q",
+											"name": "Repair (@Other Equipment 2@)",
+											"reference": "UT87",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+250",
+											"disabled": true
+										},
+										{
+											"id": "fXfpuw6Tj69kyTzea",
+											"name": "Repair (@Other Equipment 3@)",
+											"reference": "UT87",
+											"tags": [
+												"Swarmbots",
+												"Tools and Construction Materials"
+											],
+											"tech_level": "10",
+											"cost": "+250",
+											"disabled": true
+										},
+										{
+											"id": "fAIbki3yAMtRe5NFi",
+											"name": "Security",
+											"reference": "UT104",
+											"local_notes": "LC3",
+											"tags": [
+												"Security and Surveillance",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fAzNAHeKjBsrFCIs7",
+											"name": "Sentry",
+											"reference": "UT169",
+											"local_notes": "LC3",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "10",
+											"cost": "+5000",
+											"disabled": true
+										},
+										{
+											"id": "fEQwcjEQtfUOgAuq4",
+											"name": "Stinger",
+											"reference": "UT169",
+											"local_notes": "LC2",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "10",
+											"cost": "+1500",
+											"disabled": true
+										},
+										{
+											"id": "f7XpYmZDeSQfjIzuM",
+											"name": "Surveillance",
+											"reference": "UT106",
+											"local_notes": "LC3",
+											"tags": [
+												"Security and Surveillance",
+												"Surveillance and Tracking Devices",
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"cost": "+500",
+											"disabled": true
+										},
+										{
+											"id": "f2xoSVSRx9c9W1n3C",
+											"name": "Terminator",
+											"reference": "UT169",
+											"local_notes": "LC1",
+											"tags": [
+												"Combat Robots",
+												"Swarmbots",
+												"Weaponry"
+											],
+											"tech_level": "10",
+											"cost": "+1500",
+											"disabled": true
+										}
+									]
+								},
+								{
+									"id": "fgJS6tdCzU4bSmO9K",
+									"name": "Self-Replicating",
+									"reference": "UT37",
+									"local_notes": "only for defoliator, devourer or pesticide",
+									"tags": [
+										"Swarmbots"
+									],
+									"cost_type": "to_base_cost",
+									"cost": "x10",
+									"disabled": true
+								},
+								{
+									"id": "FQuCMKEHikkdoey9c",
+									"name": "Chassis",
+									"local_notes": "choose one microbot or nanobot chassis",
+									"children": [
+										{
+											"id": "Fx7yGvTTrRV2rVLg4",
+											"name": "Microbot Chassis",
+											"children": [
+												{
+													"id": "fz2sH4ZUakHr_0nNx",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "f7eMKwMF7BTYFbxhq"
+													},
+													"name": "Microbot Aerostat",
+													"reference": "UT36",
+													"local_notes": "Air Move 2",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "10",
+													"disabled": true
+												},
+												{
+													"id": "fV8xWY7ZmRgFya6Ou",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fcVKEB14BedQI1jGA"
+													},
+													"name": "Microbot Crawler",
+													"reference": "UT36",
+													"local_notes": "Move 3; Water Move 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "10"
+												},
+												{
+													"id": "fd48IDzs9RN3r2yUk",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fScgdTYLwKE9CEYfl"
+													},
+													"name": "Microbot Crawler, Armored",
+													"reference": "UT36",
+													"local_notes": "Move 2, 2x HP",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "10",
+													"cost": "+100%",
+													"disabled": true
+												},
+												{
+													"id": "fxwyG1Yo8WgK5d6HQ",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fpAVv9yE3m3t0Egt_"
+													},
+													"name": "Microbot Flier",
+													"reference": "UT36",
+													"local_notes": "Move 1; Air Move 6",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "10",
+													"cost": "+100%",
+													"disabled": true
+												},
+												{
+													"id": "fRX8lJwXMneLZo1Fh",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "ffHj2SBngzuewdrbB"
+													},
+													"name": "Microbot Hopper",
+													"reference": "UT36",
+													"local_notes": "Move 4; Super Jump 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "10",
+													"cost": "+50%",
+													"disabled": true
+												},
+												{
+													"id": "f3BCShV83vuSxjAbr",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fr6wQjKaUic-BpBCO"
+													},
+													"name": "Microbot Space",
+													"reference": "UT36",
+													"local_notes": "Move 1; 0.0001G solar sail",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "10",
+													"cost": "+0",
+													"disabled": true
+												},
+												{
+													"id": "fY6anJsHtybFnxuAk",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fsL5rGqz66ht8cVvg"
+													},
+													"name": "Microbot Swimmer",
+													"reference": "UT36",
+													"local_notes": "Water Move 4",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "10",
+													"cost": "+0",
+													"disabled": true
+												},
+												{
+													"id": "fql4OXavQ0DhnlYlC",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fvVo7_8gzuQpK50fc"
+													},
+													"name": "Microbot Contragrav (CG) Flier",
+													"reference": "UT36",
+													"local_notes": "Move 1; Air Move 20",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11^",
+													"cost": "+200%",
+													"disabled": true
+												}
+											]
+										},
+										{
+											"id": "Fn3fUDBqDeb0CFIO1",
+											"name": "Nanobot Chassis",
+											"children": [
+												{
+													"id": "fNlwk6-RMC9MuD9-k",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "f6RvvKoBN0DqIjBjQ"
+													},
+													"name": "Nanobot Aerostat",
+													"reference": "UT36",
+													"local_notes": "Air Move 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "11",
+													"disabled": true
+												},
+												{
+													"id": "fTXamBKjFOMwL51Bn",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "f1OLvlafFuNITe6na"
+													},
+													"name": "Nanobot Crawler",
+													"reference": "UT36",
+													"local_notes": "Move 3; Water Move 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "11",
+													"disabled": true
+												},
+												{
+													"id": "fcyJI8CoUU5__ibHZ",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fASzj6iYz6hUA-TBB"
+													},
+													"name": "Nanobot Crawler, Armored",
+													"reference": "UT36",
+													"local_notes": "Move 2, 2x HP",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11",
+													"cost": "+100%",
+													"disabled": true
+												},
+												{
+													"id": "fSyLP3ktrWMngmmyQ",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fLuL-pD4o6s0lREJs"
+													},
+													"name": "Nanobot Dust",
+													"reference": "UT36",
+													"local_notes": "Immobile",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11",
+													"cost": "-80%",
+													"disabled": true
+												},
+												{
+													"id": "fYOYbBFFpBRmhtGeo",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fKeArqcSSvcPk5QTp"
+													},
+													"name": "Nanobot Flier",
+													"reference": "UT36",
+													"local_notes": "Move 1; Air Move 3",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11",
+													"cost": "+100%",
+													"disabled": true
+												},
+												{
+													"id": "f0IP21DH-AbAcZSs2",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fyATVIBpOaRfq3tKe"
+													},
+													"name": "Nanobot Hopper",
+													"reference": "UT36",
+													"local_notes": "Move 4; Super Jump 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11",
+													"cost": "+50%",
+													"disabled": true
+												},
+												{
+													"id": "fJBv2Qh-HMOXUTkHz",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "f80KO0VZYaEJb9hbs"
+													},
+													"name": "Nanobot Space",
+													"reference": "UT36",
+													"local_notes": "Move 1; 0.0001G solar sail",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "11",
+													"cost": "+0",
+													"disabled": true
+												},
+												{
+													"id": "fOa96twjVvVD1Abrn",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fa36bUxm5RcsG_mOk"
+													},
+													"name": "Nanobot Swimmer",
+													"reference": "UT36",
+													"local_notes": "Water Move 1",
+													"tags": [
+														"Swarmbots"
+													],
+													"tech_level": "11",
+													"cost": "+0",
+													"disabled": true
+												},
+												{
+													"id": "fH8j80DFt-CgZt77K",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+														"id": "fPgd1Z13foKJXxTND"
+													},
+													"name": "Nanobot Contragrav (CG) Flier",
+													"reference": "UT36",
+													"local_notes": "Move 1; Air Move 10",
+													"tags": [
+														"Swarmbots"
+													],
+													"cost_type": "to_final_base_cost",
+													"tech_level": "11^",
+													"cost": "+200%",
+													"disabled": true
+												}
+											]
+										}
+									]
+								},
+								{
+									"id": "F3BBhNKn88XRdUbNg",
+									"name": "Stealth",
+									"children": [
+										{
+											"id": "fUDMfH8GJo2mhWtTz",
+											"name": "Disguise",
+											"reference": "UT36",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_cost",
+											"tech_level": "10",
+											"cost": "+1000",
+											"disabled": true
+										},
+										{
+											"id": "fYxp4BzB9B_hzdoKx",
+											"name": "Thermo-Optic Chameleon Surface",
+											"reference": "UT37, UT98",
+											"local_notes": "LC3",
+											"tags": [
+												"Deception and Intrusion",
+												"Swarmbots"
+											],
+											"cost_type": "to_final_cost",
+											"tech_level": "9",
+											"cost": "+4000",
+											"weight": "+4 lb",
+											"disabled": true
+										},
+										{
+											"id": "fAG3MoFvMNUD3HSeH",
+											"name": "Multispectral Chameleon Surface",
+											"reference": "UT37, UT99",
+											"local_notes": "LC3",
+											"tags": [
+												"Deception and Intrusion",
+												"Swarmbots"
+											],
+											"cost_type": "to_final_cost",
+											"tech_level": "10",
+											"cost": "+6000",
+											"weight": "+4 lb",
+											"disabled": true
+										},
+										{
+											"id": "fmB0CLcsNx4Q-d4wm",
+											"name": "Dynamic Multispectral Chameleon Surface",
+											"reference": "UT37, UT99",
+											"local_notes": "LC3",
+											"tags": [
+												"Deception and Intrusion",
+												"Swarmbots"
+											],
+											"cost_type": "to_final_cost",
+											"tech_level": "11",
+											"cost": "+8000",
+											"weight": "+4 lb",
+											"disabled": true
+										},
+										{
+											"id": "fCioclmcMFprc8HYa",
+											"name": "Ultimate Chameleon Surface",
+											"reference": "UT37, UT99",
+											"local_notes": "LC3",
+											"tags": [
+												"Deception and Intrusion",
+												"Swarmbots"
+											],
+											"cost_type": "to_final_cost",
+											"tech_level": "12",
+											"cost": "+10000",
+											"weight": "+4 lb",
+											"disabled": true
+										}
+									]
+								},
+								{
+									"id": "FRpMJ-VB2izC1L-fR",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "F5Q7h4gAuvWsoUiFV"
+									},
+									"name": "Power Supply",
+									"children": [
+										{
+											"id": "fuwWXIYCO4DA5ub1p",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "faj6YgnYeEKAy39jw"
+											},
+											"name": "Power Cells",
+											"reference": "UT36",
+											"local_notes": "Recharges in a Hive; C/12hr.",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "10",
+											"disabled": true
+										},
+										{
+											"id": "f-5yNCe_IzkZ_aAQK",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fCJ9sdOXfXoLN594u"
+											},
+											"name": "Power Cells",
+											"reference": "UT36",
+											"local_notes": "Recharges in a Hive; C/72hr.",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "11"
+										},
+										{
+											"id": "f3A5bGoy_QR5aSoDJ",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f7WMm14XwVJyvz2NQ"
+											},
+											"name": "Power Cells",
+											"reference": "UT36",
+											"local_notes": "Recharges in a Hive; C/5 days.",
+											"tags": [
+												"Swarmbots"
+											],
+											"tech_level": "12",
+											"disabled": true
+										},
+										{
+											"id": "frfHvwh9qRMhpgcpO",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fGv5njL67i7rODIpL"
+											},
+											"name": "Beamed Power",
+											"reference": "UT36",
+											"local_notes": "C cell receiver",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "fIxHlVSBG2-3vmrbZ",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fS-7nLrwLytJp5mLZ"
+											},
+											"name": "Gastrobot",
+											"reference": "UT36",
+											"local_notes": "Consumes 0.1lbs./hr. of biomass",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+100%",
+											"disabled": true
+										},
+										{
+											"id": "f0vXwmB_1AbdiZxsz",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fhT3sMtcrOGbTzLku"
+											},
+											"name": "Radio-Thermal Generator (RTG)",
+											"reference": "UT36",
+											"local_notes": "Lasts 1 year; LC1",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+100%",
+											"disabled": true
+										},
+										{
+											"id": "fVNYbPW6iIncGoCkg",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "faJkuSBjewuh2TdLg"
+											},
+											"name": "Solar Cell",
+											"reference": "UT36",
+											"local_notes": "Recharges 3 hours' activity in 1 hour",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "10",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "f86OpD3YfIIbhNo91",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f2u0xwoaeDxGjxCRq"
+											},
+											"name": "Solar Cell",
+											"reference": "UT36",
+											"local_notes": "Recharges 4 hours' activity in 1 hour",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "fi8iOk2EgTgJJJom7",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "ff9wLL0l7uzB0IRXf"
+											},
+											"name": "Solar Cell",
+											"reference": "UT36",
+											"local_notes": "Recharges 5 hours' activity in 1 hour",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "12",
+											"cost": "+50%",
+											"disabled": true
+										},
+										{
+											"id": "f2uZZxyASyRnhSpLH",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "f4SVyLNBYhfPgNZC0"
+											},
+											"name": "Organovore",
+											"reference": "UT36",
+											"local_notes": "Consumes 0.1-0.5 lbs./hr. of carbon-based matter; LC3",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11",
+											"cost": "+200%",
+											"disabled": true
+										},
+										{
+											"id": "fP8OnX7pK1T-JUJhu",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+												"id": "fi-Vh6iRVAbMGaOiO"
+											},
+											"name": "Broadcast Power",
+											"reference": "UT37",
+											"local_notes": "C cell receiver",
+											"tags": [
+												"Swarmbots"
+											],
+											"cost_type": "to_final_base_cost",
+											"tech_level": "11^",
+											"cost": "+100%",
+											"disabled": true
+										}
+									]
+								}
+							],
+							"quantity": 1,
+							"equipped": true,
+							"calc": {
+								"value": 500,
+								"extended_value": 500,
+								"weight": "2 lb",
+								"extended_weight": "2 lb"
+							}
+						}
+					],
+					"calc": {
+						"value": 200,
+						"extended_value": 700,
+						"weight": "10 lb",
+						"extended_weight": "12 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 0,
+				"extended_value": 700,
+				"weight": "0 lb",
+				"extended_weight": "12 lb"
+			}
+		}
+	]
+}

--- a/Library/Loadouts/Starship Crew/TL11/Wealthy Captain.gct
+++ b/Library/Loadouts/Starship Crew/TL11/Wealthy Captain.gct
@@ -1,0 +1,610 @@
+{
+	"version": 5,
+	"id": "B0M_jgKmrPMrkRVKm",
+	"equipment": [
+		{
+			"id": "Ey6_spWiabOqcLvIQ",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+				"id": "eV2zXo4IunNijS-Ql"
+			},
+			"description": "Hyperspectral Video Glasses",
+			"reference": "UT61",
+			"local_notes": "1x magnification. A/10hr.",
+			"tech_level": "11",
+			"tags": [
+				"Sensors and Scientific Equipment"
+			],
+			"base_value": "1000",
+			"base_weight": "0.1 lb",
+			"features": [
+				{
+					"type": "conditional_modifier",
+					"situation": "spot hidden clues or objects with Forensics, Observation or Search",
+					"amount": 3
+				},
+				{
+					"type": "attribute_bonus",
+					"attribute": "vision",
+					"amount": 3
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Tracking"
+					},
+					"amount": 3
+				}
+			],
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "e5SpG8HZvcBxJHx7O",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "e9kAbJ50xjO8yX0UI"
+					},
+					"description": "Armored Shades",
+					"reference": "UT176",
+					"tech_level": "11",
+					"tags": [
+						"Armor",
+						"Defenses"
+					],
+					"base_value": "100",
+					"base_weight": "0.1 lb",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"locations": [
+								"eye"
+							],
+							"amount": 20
+						}
+					],
+					"modifiers": [
+						{
+							"id": "fXm8iEv5suMXihvqv",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+								"id": "fZK5VWsvzMBCRHwkA"
+							},
+							"name": "Combination Gadget cost, multiple work at a time",
+							"reference": "UT16",
+							"cost_type": "to_final_cost",
+							"cost": "x0.8"
+						},
+						{
+							"id": "fH7w6h6QmoRSq3EF1",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+								"id": "fbXG-SurLpMjqzf1Z"
+							},
+							"name": "Combination Gadget weight, multiple work at a time",
+							"reference": "UT16",
+							"weight_type": "to_final_weight",
+							"cost": "+0",
+							"weight": "x0.8"
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 80,
+						"extended_value": 80,
+						"weight": "0.08 lb",
+						"extended_weight": "0.08 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 1000,
+				"extended_value": 1080,
+				"weight": "0.1 lb",
+				"extended_weight": "0.18 lb"
+			}
+		},
+		{
+			"id": "EUONK7qePm-Qmezk2",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+				"id": "eraqQxZI24RXWz89d"
+			},
+			"description": "Monocrys Bodysuit",
+			"reference": "UT172",
+			"local_notes": "Flexible.",
+			"tech_level": "11",
+			"legality_class": "3",
+			"tags": [
+				"Defenses"
+			],
+			"base_value": "900",
+			"base_weight": "6 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"arm",
+						"groin",
+						"leg",
+						"torso",
+						"vitals"
+					],
+					"specialization": "piercing and cutting",
+					"amount": 16
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"arm",
+						"groin",
+						"leg",
+						"torso",
+						"vitals"
+					],
+					"amount": 8
+				}
+			],
+			"modifiers": [
+				{
+					"id": "fCYSNGd3go-FMqjt7",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+						"id": "fqbI9o_MAPf9QouwA"
+					},
+					"name": "Fashion Original",
+					"reference": "UT175",
+					"cost_type": "to_base_cost",
+					"cost": "+19 CF"
+				}
+			],
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "EKa2czCr2SGkISzO4",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "e5qZTKtVs-q-xQlfS"
+					},
+					"description": "Small Computer",
+					"reference": "UT22",
+					"local_notes": "Complexity 7. 10EB. 2B/20hr.",
+					"tech_level": "11",
+					"tags": [
+						"Computers"
+					],
+					"base_value": "100",
+					"base_weight": "0.5 lb",
+					"modifiers": [
+						{
+							"id": "fiOMc_qd9Y4kUpPmC",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+								"id": "fCGs6y2MHu5bT_3Rs"
+							},
+							"name": "Printed (-1 Complexity)",
+							"reference": "UT23",
+							"local_notes": "Using multipliers, -1 Complexity, divide data storage by 1,000",
+							"cost_type": "to_base_cost",
+							"weight_type": "to_base_weight",
+							"tech_level": "TL9",
+							"cost": "+0 CF",
+							"weight": "+0 lb"
+						},
+						{
+							"id": "f6ExFfwKrTNghsFe5",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+								"id": "fORPlSDsTOr2fk5Wz"
+							},
+							"name": "Fast (+1 Complexity)",
+							"reference": "UT23",
+							"local_notes": "Using multipliers",
+							"cost_type": "to_base_cost",
+							"weight_type": "to_base_weight",
+							"tech_level": "9",
+							"cost": "+19 CF",
+							"weight": "+0 lb"
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"children": [
+						{
+							"id": "eQy0r6GIZmbaz3_uF",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "ewqK_8JnrLhbFAq4b"
+							},
+							"description": "Sleeve Display",
+							"reference": "UT24",
+							"local_notes": "A/10hr.",
+							"tech_level": "9",
+							"tags": [
+								"Computers"
+							],
+							"base_value": "50",
+							"modifiers": [
+								{
+									"id": "fOZfqGrYIrZo1DAav",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fbXG-SurLpMjqzf1Z"
+									},
+									"name": "Combination Gadget weight, multiple work at a time",
+									"reference": "UT16",
+									"weight_type": "to_final_weight",
+									"cost": "+0",
+									"weight": "x0.8"
+								},
+								{
+									"id": "f07At04zxg7t1wy-k",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+										"id": "fZK5VWsvzMBCRHwkA"
+									},
+									"name": "Combination Gadget cost, multiple work at a time",
+									"reference": "UT16",
+									"cost_type": "to_final_cost",
+									"cost": "x0.8"
+								}
+							],
+							"quantity": 1,
+							"equipped": true,
+							"calc": {
+								"value": 40,
+								"extended_value": 40,
+								"weight": "0 lb",
+								"extended_weight": "0 lb"
+							}
+						}
+					],
+					"calc": {
+						"value": 2000,
+						"extended_value": 2040,
+						"weight": "0.5 lb",
+						"extended_weight": "0.5 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 18000,
+				"extended_value": 20040,
+				"weight": "6 lb",
+				"extended_weight": "6.5 lb"
+			}
+		},
+		{
+			"id": "eIiLvRnIR278Domou",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+				"id": "eNEACFkp88ouc3hjG"
+			},
+			"description": "Survival Watch",
+			"reference": "UT77",
+			"local_notes": "B/3mo.",
+			"tech_level": "10",
+			"tags": [
+				"Expedition Gear"
+			],
+			"base_value": "300",
+			"base_weight": "0.5 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"value": 300,
+				"extended_value": 300,
+				"weight": "0.5 lb",
+				"extended_weight": "0.5 lb"
+			}
+		},
+		{
+			"id": "EXq6qK1RVrcJgLPja",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+				"id": "eNxEqbQBIyZOS3rdx"
+			},
+			"description": "VR Gloves",
+			"reference": "UT54",
+			"local_notes": "Requires Complexity 2+.",
+			"tech_level": "9",
+			"tags": [
+				"Media and Education"
+			],
+			"base_value": "20",
+			"base_weight": "0.3 lb",
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "enDeO7UZW7DUjlhec",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "esYKu0HiXEa__XOgo"
+					},
+					"description": "Monocrys Gloves",
+					"reference": "UT172",
+					"local_notes": "Flexible.",
+					"tech_level": "11",
+					"tags": [
+						"Defenses"
+					],
+					"base_value": "30",
+					"features": [
+						{
+							"type": "dr_bonus",
+							"locations": [
+								"hand"
+							],
+							"specialization": "piercing and cutting",
+							"amount": 8
+						},
+						{
+							"type": "dr_bonus",
+							"locations": [
+								"hand"
+							],
+							"amount": 4
+						}
+					],
+					"modifiers": [
+						{
+							"id": "f-v7zlAkmcUYa4Zt4",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+								"id": "ftTIP1_K9WPCHFSrz"
+							},
+							"name": "Stylish",
+							"reference": "UT175",
+							"cost_type": "to_base_cost",
+							"cost": "+3 CF"
+						},
+						{
+							"id": "fl_z3jkwwGxMjVGh3",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+								"id": "fZK5VWsvzMBCRHwkA"
+							},
+							"name": "Combination Gadget cost, multiple work at a time",
+							"reference": "UT16",
+							"cost_type": "to_final_cost",
+							"cost": "x0.8"
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 96,
+						"extended_value": 96,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				},
+				{
+					"id": "e3vmRIAAYaTToF1Fc",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "ef55nM_NrfAgS_Cam"
+					},
+					"description": "Karatand",
+					"reference": "UT163",
+					"tech_level": "9",
+					"legality_class": "3",
+					"tags": [
+						"Melee Weapon",
+						"Weaponry"
+					],
+					"base_value": "100",
+					"weapons": [
+						{
+							"id": "wKzwBMtBpcCZCsrp6",
+							"damage": {
+								"type": "cr",
+								"st": "thr"
+							},
+							"usage": "Punch",
+							"reach": "C",
+							"parry": "0",
+							"defaults": [
+								{
+									"type": "dx"
+								},
+								{
+									"type": "skill",
+									"name": "Boxing"
+								},
+								{
+									"type": "skill",
+									"name": "Brawling"
+								},
+								{
+									"type": "skill",
+									"name": "Karate"
+								}
+							],
+							"calc": {
+								"damage": "thr cr"
+							}
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 100,
+						"extended_value": 100,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 20,
+				"extended_value": 216,
+				"weight": "0.3 lb",
+				"extended_weight": "0.3 lb"
+			}
+		},
+		{
+			"id": "echRNuz27GcmnXIup",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+				"id": "e46KLPiLrq7durI15"
+			},
+			"description": "Assault Boots",
+			"reference": "UT173",
+			"tech_level": "11",
+			"tags": [
+				"Armor",
+				"Defenses"
+			],
+			"base_value": "150",
+			"base_weight": "3 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"foot"
+					],
+					"specialization": "underside of the foot",
+					"amount": 15
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"foot"
+					],
+					"amount": 15
+				}
+			],
+			"modifiers": [
+				{
+					"id": "fyUkJP2lxzk23TdPs",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+						"id": "ftTIP1_K9WPCHFSrz"
+					},
+					"name": "Stylish",
+					"reference": "UT175",
+					"cost_type": "to_base_cost",
+					"cost": "+3 CF"
+				}
+			],
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"value": 600,
+				"extended_value": 600,
+				"weight": "3 lb",
+				"extended_weight": "3 lb"
+			}
+		},
+		{
+			"id": "Excljg84gfDpkbPIW",
+			"description": "Add to Waist Pack",
+			"legality_class": "4",
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "earuDeEJdkYMu9bjy",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "e4mc_Vt5XqdsQ-gW2"
+					},
+					"description": "Homing Beacon",
+					"reference": "UT105",
+					"local_notes": "AA/100 hours - 1 year in \"sleeper\" mode",
+					"tech_level": "9",
+					"tags": [
+						"Surveillance and Tracking Devices"
+					],
+					"base_value": "40",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 40,
+						"extended_value": 40,
+						"weight": "0 lb",
+						"extended_weight": "0 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 0,
+				"extended_value": 40,
+				"weight": "0 lb",
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "E5PcE7b9_-sy9pFFg",
+			"description": "Add to Attache Case",
+			"legality_class": "4",
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "e8IheBCuHPVFuZ1od",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "epRXtbtPNVTPIqIdo"
+					},
+					"description": "A cell",
+					"reference": "UT19",
+					"tech_level": "9",
+					"tags": [
+						"Power"
+					],
+					"base_value": "2",
+					"base_weight": "0.005 lb",
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 2,
+						"extended_value": 2,
+						"weight": "0.005 lb",
+						"extended_weight": "0.005 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 0,
+				"extended_value": 2,
+				"weight": "0 lb",
+				"extended_weight": "0.005 lb"
+			}
+		}
+	],
+	"notes": [
+		{
+			"id": "nnztr-DoqUpnVAHV1",
+			"markdown": "Remove from the TL11 Basic Spacer Kit:\n* Hyperspectral Contacts\n* Biomonitor Bracelet\n* Responsive Buzz Fabric Clothing\n* VR Gloves"
+		}
+	]
+}

--- a/Library/Loadouts/Starship Crew/TL11/Weapon, Blaster Carbine.gct
+++ b/Library/Loadouts/Starship Crew/TL11/Weapon, Blaster Carbine.gct
@@ -1,0 +1,197 @@
+{
+	"version": 5,
+	"id": "BrGaaxM3hbOoo1y7L",
+	"equipment": [
+		{
+			"id": "EASLNS2pUogDi1ncp",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "High Tech/High Tech Equipment.eqp",
+				"id": "EacmJUPcIX3jxUjFy"
+			},
+			"description": "Patrol Sling",
+			"reference": "HT154",
+			"local_notes": "+1 Fast-Draw (Long Arm).",
+			"tech_level": "7",
+			"tags": [
+				"Firearm Accessories"
+			],
+			"base_value": "50",
+			"base_weight": "1 lb",
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "ebvgjJ--39oTrja85",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eTNjwDleQndep59WO"
+					},
+					"description": "Blaster Carbine",
+					"reference": "UT123",
+					"local_notes": "2C/17 shots.",
+					"tech_level": "11",
+					"legality_class": "2",
+					"tags": [
+						"Missile Weapon",
+						"Weaponry"
+					],
+					"base_value": "9200",
+					"base_weight": "5.6 lb",
+					"weapons": [
+						{
+							"id": "WaJRSSu8fY2WoQETH",
+							"damage": {
+								"type": "burn, sur",
+								"base": "5d",
+								"armor_divisor": 5
+							},
+							"strength": "5†",
+							"accuracy": "10+1",
+							"range": "500/1,500",
+							"rate_of_fire": "3",
+							"shots": "17(3)",
+							"bulk": "-3",
+							"recoil": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Beam Weapons",
+									"specialization": "Rifle"
+								},
+								{
+									"type": "skill",
+									"name": "Beam Weapons",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Guns",
+									"specialization": "Rifle",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -4
+								}
+							],
+							"calc": {
+								"damage": "5d(5) burn, sur"
+							}
+						},
+						{
+							"id": "WCkR4l9krPg5ac-Hx",
+							"damage": {
+								"type": "HT-5 aff",
+								"armor_divisor": 3
+							},
+							"strength": "5†",
+							"usage": "Omni-Blaster Stun",
+							"accuracy": "10+1",
+							"range": "500/1,500",
+							"rate_of_fire": "3",
+							"shots": "17(3)",
+							"bulk": "-3",
+							"recoil": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Beam Weapons",
+									"specialization": "Rifle"
+								},
+								{
+									"type": "skill",
+									"name": "Beam Weapons",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Guns",
+									"specialization": "Rifle",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -4
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "(3) HT-5 aff"
+							}
+						}
+					],
+					"modifiers": [
+						{
+							"id": "f7Mt_y3xz12qyjDzu",
+							"name": "Omni-Blaster",
+							"local_notes": "note: manually unhide Omni-Blaster Stun",
+							"cost": "+100%",
+							"disabled": true
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"calc": {
+						"value": 9200,
+						"extended_value": 9200,
+						"weight": "5.6 lb",
+						"extended_weight": "5.6 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 50,
+				"extended_value": 9250,
+				"weight": "1 lb",
+				"extended_weight": "6.6 lb"
+			}
+		},
+		{
+			"id": "ErN_ul0ZatsPtGMhH",
+			"description": "Add to Load-Bearing Vest",
+			"legality_class": "4",
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "eDIdWhcC2Vpokm63Y",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "ev80WwcnBpiGFrkol"
+					},
+					"description": "C cell",
+					"reference": "UT19",
+					"tech_level": "9",
+					"tags": [
+						"Power"
+					],
+					"base_value": "10",
+					"base_weight": "0.5 lb",
+					"quantity": 4,
+					"equipped": true,
+					"calc": {
+						"value": 10,
+						"extended_value": 40,
+						"weight": "0.5 lb",
+						"extended_weight": "2 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 0,
+				"extended_value": 40,
+				"weight": "0 lb",
+				"extended_weight": "2 lb"
+			}
+		}
+	],
+	"notes": [
+		{
+			"id": "nSdUGHBEk-fMJg--F",
+			"markdown": "Requires Beam Weapons (Rifle)"
+		}
+	]
+}

--- a/Library/Loadouts/Starship Crew/TL11/Weapon, Grenades.gct
+++ b/Library/Loadouts/Starship Crew/TL11/Weapon, Grenades.gct
@@ -1,0 +1,4905 @@
+{
+	"version": 5,
+	"id": "B64qz9eiF80gguBjv",
+	"equipment": [
+		{
+			"id": "EmYI6n61j8EyHJy2E",
+			"description": "Add to Load-Bearing Vest",
+			"legality_class": "4",
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "EnqVkKqysSv3xH9YY",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "e9JMu0uwKXD9-qQ6_"
+					},
+					"description": "Mini Hand Grenade",
+					"reference": "UT146",
+					"local_notes": "Manually add a warhead equipment modifier then unhide the relevant ranged weapon usages",
+					"tags": [
+						"Weaponry"
+					],
+					"base_value": "10",
+					"base_weight": "0.25 lb",
+					"weapons": [
+						{
+							"id": "WVOqa-m37r3wHZW98",
+							"damage": {
+								"type": "spec. 4yds 40 doses",
+								"base": "0"
+							},
+							"usage": "Biochemical Aerosol",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"calc": {
+								"damage": "spec. 4yds 40 doses"
+							}
+						},
+						{
+							"id": "WAKEh13LS22AzrzLR",
+							"damage": {
+								"type": "spec. 4yds 16 doses",
+								"base": "0"
+							},
+							"usage": "Biochemical Liquid",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "spec. 4yds 16 doses"
+							}
+						},
+						{
+							"id": "WsS5CaH1Yuqra9f9i",
+							"damage": {
+								"type": "spec. 400 yds",
+								"base": "0"
+							},
+							"usage": "Flare",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "spec. 400 yds"
+							}
+						},
+						{
+							"id": "WPG7WFtqc3AoQ_Ot_",
+							"damage": {
+								"type": "cr ex",
+								"base": "8d",
+								"fragmentation": "2d",
+								"fragmentation_type": " cut"
+							},
+							"usage": "High Explosive (TL9)",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "8d cr ex [2d  cut]"
+							}
+						},
+						{
+							"id": "Wsen5cfnZqX7cNFoY",
+							"damage": {
+								"type": "cr ex",
+								"base": "8d",
+								"fragmentation": "2d",
+								"fragmentation_type": " cut",
+								"modifier_per_die": 1
+							},
+							"usage": "High Explosive (TL10)",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "8d (+1 per die) cr ex [2d  cut]"
+							}
+						},
+						{
+							"id": "Wrh6WRU5oeXZd7et2",
+							"damage": {
+								"type": "cr ex",
+								"base": "8d"
+							},
+							"usage": "High Explosive Concussion (TL9)",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "8d cr ex"
+							}
+						},
+						{
+							"id": "WAbFqDtWWwYkPSfmH",
+							"damage": {
+								"type": "cr ex",
+								"base": "8d",
+								"modifier_per_die": 1
+							},
+							"usage": "High Explosive Concussion (TL10)",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "8d (+1 per die) cr ex"
+							}
+						},
+						{
+							"id": "WUMc_FqONphM5Iqam",
+							"damage": {
+								"type": "cr inc",
+								"base": "6dx4",
+								"armor_divisor": 10
+							},
+							"usage": "Shaped Charge (TL9) jet",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx4(10) cr inc"
+							}
+						},
+						{
+							"id": "WoFEM_6FcyC7jawVd",
+							"damage": {
+								"type": "cr inc",
+								"base": "6dx4",
+								"armor_divisor": 10,
+								"modifier_per_die": 1
+							},
+							"usage": "Shaped Charge (TL10) jet",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx4(10) (+1 per die) cr inc"
+							}
+						},
+						{
+							"id": "WyGY4PEqh5q0AH1Ae",
+							"damage": {
+								"type": "cr ex",
+								"base": "4d",
+								"fragmentation": "2d",
+								"fragmentation_type": "cut"
+							},
+							"usage": "Shaped Charge linked explosion",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"hide": true,
+							"calc": {
+								"damage": "4d cr ex [2d cut]"
+							}
+						},
+						{
+							"id": "W1c29GU8XwWHOCVMr",
+							"damage": {
+								"type": "spec. ST 24 (+2 per additional layer)"
+							},
+							"usage": "Tangler",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "spec. ST 24 (+2 per additional layer)"
+							}
+						},
+						{
+							"id": "WtF9hZFfQ2z922NsX",
+							"damage": {
+								"type": "cr ex inc",
+								"base": "8dx2"
+							},
+							"usage": "Thermobaric (TL9)",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "8dx2 cr ex inc"
+							}
+						},
+						{
+							"id": "WGIJ1CllFiTyresCX",
+							"damage": {
+								"type": "cr ex inc",
+								"base": "8dx2",
+								"modifier_per_die": 1
+							},
+							"usage": "Thermobaric (TL10)",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "8dx2 (+1 per die) cr ex inc"
+							}
+						},
+						{
+							"id": "WAxJTJvE4y-LqwMR_",
+							"damage": {
+								"type": "cr inc",
+								"base": "6dx5",
+								"armor_divisor": 10
+							},
+							"usage": "High Explosive Multi-Purpose (TL10) jet",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx5(10) cr inc"
+							}
+						},
+						{
+							"id": "W-uirj-a1XDwTj7K7",
+							"damage": {
+								"type": "cr inc",
+								"base": "6dx5",
+								"armor_divisor": 10,
+								"modifier_per_die": 1
+							},
+							"usage": "High Explosive Multi-Purpose (TL11) jet",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx5(10) (+1 per die) cr inc"
+							}
+						},
+						{
+							"id": "WNqp9NC44RvI8f0qN",
+							"damage": {
+								"type": "cr ex",
+								"base": "4d",
+								"fragmentation": "2d",
+								"fragmentation_type": "cut"
+							},
+							"usage": "High Explosive Multi-Purpose linked explosion",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"hide": true,
+							"calc": {
+								"damage": "4d cr ex [2d cut]"
+							}
+						},
+						{
+							"id": "W1PmnODd2Lks0V19K",
+							"damage": {
+								"type": "burn sur",
+								"base": "2d"
+							},
+							"usage": "Stingray",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "2d burn sur"
+							}
+						},
+						{
+							"id": "WAAs7wRKdUzfvhfAj",
+							"damage": {
+								"type": "spec. 1sq yd"
+							},
+							"usage": "Swarm",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "spec. 1sq yd"
+							}
+						},
+						{
+							"id": "WBNquO4HtRXIzJeOM",
+							"damage": {
+								"type": "cr ex",
+								"base": "6dx200"
+							},
+							"usage": "0.01kT Mininuke blast",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx200 cr ex"
+							}
+						},
+						{
+							"id": "WBfbWSzpS8DHXSpGY",
+							"damage": {
+								"type": "burn ex* rad sur",
+								"base": "4dx200"
+							},
+							"usage": "0.01kT Mininuke linked radiation",
+							"usage_notes": "divide by distance rather than 3x distance; to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"hide": true,
+							"calc": {
+								"damage": "4dx200 burn ex* rad sur"
+							}
+						},
+						{
+							"id": "WEe-2mZ7PZDdWAAym",
+							"damage": {
+								"type": "cr ex",
+								"base": "6dx600"
+							},
+							"usage": "0.1kT Mininuke blast",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx600 cr ex"
+							}
+						},
+						{
+							"id": "WiTRE5yQd5pW2MQ-0",
+							"damage": {
+								"type": "burn ex* rad sur",
+								"base": "6dx400"
+							},
+							"usage": "0.1kT Mininuke linked radiation",
+							"usage_notes": "divide by distance rather than 3x distance; to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"hide": true,
+							"calc": {
+								"damage": "6dx400 burn ex* rad sur"
+							}
+						},
+						{
+							"id": "WGmGD0GZdPf48IFdr",
+							"damage": {
+								"type": "cr ex",
+								"base": "6dx2000"
+							},
+							"usage": "1kT Mininuke blast",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx2000 cr ex"
+							}
+						},
+						{
+							"id": "W1E54MN9Co2-eXcSh",
+							"damage": {
+								"type": "burn ex* rad sur",
+								"base": "4dx2000"
+							},
+							"usage": "1kT Mininuke linked radiation",
+							"usage_notes": "divide by distance rather than 3x distance; to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"hide": true,
+							"calc": {
+								"damage": "4dx2000 burn ex* rad sur"
+							}
+						},
+						{
+							"id": "W1Nfr3Bbh7_N4QBZN",
+							"damage": {
+								"type": "burn ex sur*",
+								"base": "6dx4"
+							},
+							"usage": "0.1μg Antimatter Explosion",
+							"usage_notes": "divide by distance rather than 3x distance; to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx4 burn ex sur*"
+							}
+						},
+						{
+							"id": "WCKy5soHI6_5FktnG",
+							"damage": {
+								"type": "tox rad†",
+								"base": "6dx10000"
+							},
+							"usage": "0.1μg Antimatter linked radiation",
+							"usage_notes": "divide by square of distance rather than 3x distance; to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"hide": true,
+							"calc": {
+								"damage": "6dx10000 tox rad†"
+							}
+						},
+						{
+							"id": "Wv4HwDu6vTaL3ZCIi",
+							"damage": {
+								"type": "burn ex sur*",
+								"base": "6dx12"
+							},
+							"usage": "1μg Antimatter Explosion",
+							"usage_notes": "divide by distance rather than 3x distance; to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx12 burn ex sur*"
+							}
+						},
+						{
+							"id": "WbHEtfrThpYmXhCFO",
+							"damage": {
+								"type": "tox rad†",
+								"base": "6dx100000"
+							},
+							"usage": "1μg Antimatter linked radiation",
+							"usage_notes": "divide by square of distance rather than 3x distance; to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"hide": true,
+							"calc": {
+								"damage": "6dx100000 tox rad†"
+							}
+						},
+						{
+							"id": "WBGWMtG9KfnOdLHf-",
+							"damage": {
+								"type": "burn ex sur*",
+								"base": "6dx40"
+							},
+							"usage": "10μg Antimatter Explosion",
+							"usage_notes": "divide by distance rather than 3x distance; to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx40 burn ex sur*"
+							}
+						},
+						{
+							"id": "WBdZezyCypopXqBW3",
+							"damage": {
+								"type": "tox rad†",
+								"base": "6dx1000000"
+							},
+							"usage": "10μg Antimatter linked radiation",
+							"usage_notes": "divide by square of distance rather than 3x distance; to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"hide": true,
+							"calc": {
+								"damage": "6dx1000000 tox rad†"
+							}
+						},
+						{
+							"id": "WilIAkg5aDHMHPdIL",
+							"damage": {
+								"type": "spec. 4yds"
+							},
+							"usage": "EMP",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "spec. 4yds"
+							}
+						},
+						{
+							"id": "WEjw_mJNgffJuC34Y",
+							"damage": {
+								"type": "cr ex",
+								"base": "1d"
+							},
+							"usage": "EMP linked explosion",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"hide": true,
+							"calc": {
+								"damage": "1d cr ex"
+							}
+						},
+						{
+							"id": "WPGhCrf5zWw1bTxMq",
+							"damage": {
+								"type": "spec. 40yd radius"
+							},
+							"usage": "Expendable Jammer",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "spec. 40yd radius"
+							}
+						},
+						{
+							"id": "WcVCIkwlUMr8mzqL_",
+							"damage": {
+								"type": "HT-4 aff. 4yd radius"
+							},
+							"usage": "Strobe",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "HT-4 aff. 4yd radius"
+							}
+						},
+						{
+							"id": "WaFVubc2cQ_NLjMHL",
+							"damage": {
+								"type": "HT-4 aff. 4yd radius"
+							},
+							"usage": "Warbler",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "HT-4 aff. 4yd radius"
+							}
+						},
+						{
+							"id": "WErvJJHIQK5HAoiSp",
+							"damage": {
+								"type": "cr dkb ex",
+								"base": "8d"
+							},
+							"usage": "Force",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "8d cr dkb ex"
+							}
+						},
+						{
+							"id": "WFOzx8-w9v_4hcbku",
+							"damage": {
+								"type": "burn ex sur",
+								"base": "6dx2"
+							},
+							"usage": "Plasma",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx2 burn ex sur"
+							}
+						},
+						{
+							"id": "WU9KGtbJ9uTFmO8Mf",
+							"damage": {
+								"type": "cr dkb ex",
+								"base": "6dx25"
+							},
+							"usage": "Implosion pull",
+							"usage_notes": "knockback pulls victims inwards; to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx25 cr dkb ex"
+							}
+						},
+						{
+							"id": "W4BqeaAhSXhpgX7xW",
+							"damage": {
+								"type": "tox rad ex",
+								"base": "6dx40"
+							},
+							"usage": "Implosion linked radiation",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"hide": true,
+							"calc": {
+								"damage": "6dx40 tox rad ex"
+							}
+						},
+						{
+							"id": "WH9yTGfHEoLH6__v9",
+							"damage": {
+								"type": "spec. 4yd radius"
+							},
+							"usage": "Psi-Bomb",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "spec. 4yd radius"
+							}
+						},
+						{
+							"id": "WHQa_FqdnPM32LvMP",
+							"damage": {
+								"type": "spec. 2yd radius"
+							},
+							"usage": "Stasis",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "spec. 2yd radius"
+							}
+						},
+						{
+							"id": "WXRyY7nxnKAIXmJKM",
+							"damage": {
+								"type": "spec. 2yd radius"
+							},
+							"usage": "Vortex",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "spec. 2yd radius"
+							}
+						}
+					],
+					"modifiers": [
+						{
+							"id": "fwBFwozW0OE5BeIt2",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+								"id": "fKtVH_SHC4e-tHTIe"
+							},
+							"name": "Biochemical Aerosol",
+							"reference": "UT153",
+							"local_notes": "Cost Plus Filler x # of Doses",
+							"cost_type": "to_base_cost",
+							"tech_level": "9",
+							"cost": "+0 CF"
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"children": [
+						{
+							"id": "ewW30ESOTJtnR8eXQ",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "eA9DiGibooMm0moad"
+							},
+							"description": "Paralysis Gas",
+							"reference": "UT160",
+							"tech_level": "10",
+							"legality_class": "2",
+							"tags": [
+								"Biochemical and Nanotech Weapons",
+								"Weaponry"
+							],
+							"base_value": "10",
+							"quantity": 40,
+							"equipped": true,
+							"calc": {
+								"value": 10,
+								"extended_value": 400,
+								"weight": "0 lb",
+								"extended_weight": "0 lb"
+							}
+						}
+					],
+					"calc": {
+						"value": 10,
+						"extended_value": 410,
+						"weight": "0.25 lb",
+						"extended_weight": "0.25 lb"
+					}
+				},
+				{
+					"id": "EPbVmznXU7OclOXPa",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "e9JMu0uwKXD9-qQ6_"
+					},
+					"description": "Mini Hand Grenade",
+					"reference": "UT146",
+					"local_notes": "Manually add a warhead equipment modifier then unhide the relevant ranged weapon usages",
+					"tags": [
+						"Weaponry"
+					],
+					"base_value": "10",
+					"base_weight": "0.25 lb",
+					"weapons": [
+						{
+							"id": "WaK3ra_PeQZOBzirJ",
+							"damage": {
+								"type": "spec. 4yds 40 doses",
+								"base": "0"
+							},
+							"usage": "Biochemical Aerosol",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"calc": {
+								"damage": "spec. 4yds 40 doses"
+							}
+						},
+						{
+							"id": "Wf2Mfzt-azk0UKXo_",
+							"damage": {
+								"type": "spec. 4yds 16 doses",
+								"base": "0"
+							},
+							"usage": "Biochemical Liquid",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "spec. 4yds 16 doses"
+							}
+						},
+						{
+							"id": "WmwJoFTB0OyuWhTUi",
+							"damage": {
+								"type": "spec. 400 yds",
+								"base": "0"
+							},
+							"usage": "Flare",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "spec. 400 yds"
+							}
+						},
+						{
+							"id": "WKyn6JwaLxXPutgTw",
+							"damage": {
+								"type": "cr ex",
+								"base": "8d",
+								"fragmentation": "2d",
+								"fragmentation_type": " cut"
+							},
+							"usage": "High Explosive (TL9)",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "8d cr ex [2d  cut]"
+							}
+						},
+						{
+							"id": "Wkp6TRI1TuDRadoFm",
+							"damage": {
+								"type": "cr ex",
+								"base": "8d",
+								"fragmentation": "2d",
+								"fragmentation_type": " cut",
+								"modifier_per_die": 1
+							},
+							"usage": "High Explosive (TL10)",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "8d (+1 per die) cr ex [2d  cut]"
+							}
+						},
+						{
+							"id": "Wvb59CrkldzR3s66o",
+							"damage": {
+								"type": "cr ex",
+								"base": "8d"
+							},
+							"usage": "High Explosive Concussion (TL9)",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "8d cr ex"
+							}
+						},
+						{
+							"id": "WW4nIoea93mx2YdhQ",
+							"damage": {
+								"type": "cr ex",
+								"base": "8d",
+								"modifier_per_die": 1
+							},
+							"usage": "High Explosive Concussion (TL10)",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "8d (+1 per die) cr ex"
+							}
+						},
+						{
+							"id": "WrSDkZgfG7K8HiB5e",
+							"damage": {
+								"type": "cr inc",
+								"base": "6dx4",
+								"armor_divisor": 10
+							},
+							"usage": "Shaped Charge (TL9) jet",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx4(10) cr inc"
+							}
+						},
+						{
+							"id": "WAHQ-8epcvj8Hz7ZK",
+							"damage": {
+								"type": "cr inc",
+								"base": "6dx4",
+								"armor_divisor": 10,
+								"modifier_per_die": 1
+							},
+							"usage": "Shaped Charge (TL10) jet",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx4(10) (+1 per die) cr inc"
+							}
+						},
+						{
+							"id": "WhwirgfAIFouYHKCH",
+							"damage": {
+								"type": "cr ex",
+								"base": "4d",
+								"fragmentation": "2d",
+								"fragmentation_type": "cut"
+							},
+							"usage": "Shaped Charge linked explosion",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"hide": true,
+							"calc": {
+								"damage": "4d cr ex [2d cut]"
+							}
+						},
+						{
+							"id": "WrE9AZ8ypHmlk8d0c",
+							"damage": {
+								"type": "spec. ST 24 (+2 per additional layer)"
+							},
+							"usage": "Tangler",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "spec. ST 24 (+2 per additional layer)"
+							}
+						},
+						{
+							"id": "W8H2wWhmeCjN9tdXB",
+							"damage": {
+								"type": "cr ex inc",
+								"base": "8dx2"
+							},
+							"usage": "Thermobaric (TL9)",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "8dx2 cr ex inc"
+							}
+						},
+						{
+							"id": "W39SvlP9YiZDuYz1E",
+							"damage": {
+								"type": "cr ex inc",
+								"base": "8dx2",
+								"modifier_per_die": 1
+							},
+							"usage": "Thermobaric (TL10)",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "8dx2 (+1 per die) cr ex inc"
+							}
+						},
+						{
+							"id": "WWLY-cwjPGFt7jFLd",
+							"damage": {
+								"type": "cr inc",
+								"base": "6dx5",
+								"armor_divisor": 10
+							},
+							"usage": "High Explosive Multi-Purpose (TL10) jet",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx5(10) cr inc"
+							}
+						},
+						{
+							"id": "WIlseaxXyoyNaUvgn",
+							"damage": {
+								"type": "cr inc",
+								"base": "6dx5",
+								"armor_divisor": 10,
+								"modifier_per_die": 1
+							},
+							"usage": "High Explosive Multi-Purpose (TL11) jet",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx5(10) (+1 per die) cr inc"
+							}
+						},
+						{
+							"id": "WqMpC4IviCikjmGG6",
+							"damage": {
+								"type": "cr ex",
+								"base": "4d",
+								"fragmentation": "2d",
+								"fragmentation_type": "cut"
+							},
+							"usage": "High Explosive Multi-Purpose linked explosion",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"hide": true,
+							"calc": {
+								"damage": "4d cr ex [2d cut]"
+							}
+						},
+						{
+							"id": "WF1_M0UHJyBEYIn45",
+							"damage": {
+								"type": "burn sur",
+								"base": "2d"
+							},
+							"usage": "Stingray",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "2d burn sur"
+							}
+						},
+						{
+							"id": "WFQ85kidS0fJiAU17",
+							"damage": {
+								"type": "spec. 1sq yd"
+							},
+							"usage": "Swarm",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "spec. 1sq yd"
+							}
+						},
+						{
+							"id": "W_zpAWOZdgJrAKPIV",
+							"damage": {
+								"type": "cr ex",
+								"base": "6dx200"
+							},
+							"usage": "0.01kT Mininuke blast",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx200 cr ex"
+							}
+						},
+						{
+							"id": "WXx1_tiRhmfLuFm7g",
+							"damage": {
+								"type": "burn ex* rad sur",
+								"base": "4dx200"
+							},
+							"usage": "0.01kT Mininuke linked radiation",
+							"usage_notes": "divide by distance rather than 3x distance; to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"hide": true,
+							"calc": {
+								"damage": "4dx200 burn ex* rad sur"
+							}
+						},
+						{
+							"id": "WGDhleIGXf99qZMCL",
+							"damage": {
+								"type": "cr ex",
+								"base": "6dx600"
+							},
+							"usage": "0.1kT Mininuke blast",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx600 cr ex"
+							}
+						},
+						{
+							"id": "Wou9oO_ZbI0xuAQqN",
+							"damage": {
+								"type": "burn ex* rad sur",
+								"base": "6dx400"
+							},
+							"usage": "0.1kT Mininuke linked radiation",
+							"usage_notes": "divide by distance rather than 3x distance; to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"hide": true,
+							"calc": {
+								"damage": "6dx400 burn ex* rad sur"
+							}
+						},
+						{
+							"id": "WIxoG7RlKFA4j2HOD",
+							"damage": {
+								"type": "cr ex",
+								"base": "6dx2000"
+							},
+							"usage": "1kT Mininuke blast",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx2000 cr ex"
+							}
+						},
+						{
+							"id": "W9MlBjLFZXu0B7ZzW",
+							"damage": {
+								"type": "burn ex* rad sur",
+								"base": "4dx2000"
+							},
+							"usage": "1kT Mininuke linked radiation",
+							"usage_notes": "divide by distance rather than 3x distance; to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"hide": true,
+							"calc": {
+								"damage": "4dx2000 burn ex* rad sur"
+							}
+						},
+						{
+							"id": "WVCbKoF7op-Of_PHJ",
+							"damage": {
+								"type": "burn ex sur*",
+								"base": "6dx4"
+							},
+							"usage": "0.1μg Antimatter Explosion",
+							"usage_notes": "divide by distance rather than 3x distance; to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx4 burn ex sur*"
+							}
+						},
+						{
+							"id": "WnY6OYcCpzsjL2HG8",
+							"damage": {
+								"type": "tox rad†",
+								"base": "6dx10000"
+							},
+							"usage": "0.1μg Antimatter linked radiation",
+							"usage_notes": "divide by square of distance rather than 3x distance; to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"hide": true,
+							"calc": {
+								"damage": "6dx10000 tox rad†"
+							}
+						},
+						{
+							"id": "WkyAei8n8sZi4MmkK",
+							"damage": {
+								"type": "burn ex sur*",
+								"base": "6dx12"
+							},
+							"usage": "1μg Antimatter Explosion",
+							"usage_notes": "divide by distance rather than 3x distance; to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx12 burn ex sur*"
+							}
+						},
+						{
+							"id": "WDTL56Oug2Qgw7qXA",
+							"damage": {
+								"type": "tox rad†",
+								"base": "6dx100000"
+							},
+							"usage": "1μg Antimatter linked radiation",
+							"usage_notes": "divide by square of distance rather than 3x distance; to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"hide": true,
+							"calc": {
+								"damage": "6dx100000 tox rad†"
+							}
+						},
+						{
+							"id": "WTiUoj8p6Tq0S8EYg",
+							"damage": {
+								"type": "burn ex sur*",
+								"base": "6dx40"
+							},
+							"usage": "10μg Antimatter Explosion",
+							"usage_notes": "divide by distance rather than 3x distance; to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx40 burn ex sur*"
+							}
+						},
+						{
+							"id": "WIJnUohWttvgjdwbu",
+							"damage": {
+								"type": "tox rad†",
+								"base": "6dx1000000"
+							},
+							"usage": "10μg Antimatter linked radiation",
+							"usage_notes": "divide by square of distance rather than 3x distance; to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"hide": true,
+							"calc": {
+								"damage": "6dx1000000 tox rad†"
+							}
+						},
+						{
+							"id": "WP3Gga72SPu9FS57C",
+							"damage": {
+								"type": "spec. 4yds"
+							},
+							"usage": "EMP",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "spec. 4yds"
+							}
+						},
+						{
+							"id": "WG2S6suxigM5EjgLz",
+							"damage": {
+								"type": "cr ex",
+								"base": "1d"
+							},
+							"usage": "EMP linked explosion",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"hide": true,
+							"calc": {
+								"damage": "1d cr ex"
+							}
+						},
+						{
+							"id": "WUPPILtrycQWJDVUj",
+							"damage": {
+								"type": "spec. 40yd radius"
+							},
+							"usage": "Expendable Jammer",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "spec. 40yd radius"
+							}
+						},
+						{
+							"id": "W8XAayva0-Z8gUu7j",
+							"damage": {
+								"type": "HT-4 aff. 4yd radius"
+							},
+							"usage": "Strobe",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "HT-4 aff. 4yd radius"
+							}
+						},
+						{
+							"id": "WlL1JuSMq75cI60tf",
+							"damage": {
+								"type": "HT-4 aff. 4yd radius"
+							},
+							"usage": "Warbler",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "HT-4 aff. 4yd radius"
+							}
+						},
+						{
+							"id": "WeCu437RkTqHxkgon",
+							"damage": {
+								"type": "cr dkb ex",
+								"base": "8d"
+							},
+							"usage": "Force",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "8d cr dkb ex"
+							}
+						},
+						{
+							"id": "Wc6CKRWAuMUPNapOq",
+							"damage": {
+								"type": "burn ex sur",
+								"base": "6dx2"
+							},
+							"usage": "Plasma",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx2 burn ex sur"
+							}
+						},
+						{
+							"id": "WH9ICv_KYJYXXTqRi",
+							"damage": {
+								"type": "cr dkb ex",
+								"base": "6dx25"
+							},
+							"usage": "Implosion pull",
+							"usage_notes": "knockback pulls victims inwards; to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx25 cr dkb ex"
+							}
+						},
+						{
+							"id": "WGY4C3jvG_z4LEQx6",
+							"damage": {
+								"type": "tox rad ex",
+								"base": "6dx40"
+							},
+							"usage": "Implosion linked radiation",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"hide": true,
+							"calc": {
+								"damage": "6dx40 tox rad ex"
+							}
+						},
+						{
+							"id": "WWciIwVufcpoBNfs0",
+							"damage": {
+								"type": "spec. 4yd radius"
+							},
+							"usage": "Psi-Bomb",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "spec. 4yd radius"
+							}
+						},
+						{
+							"id": "WM_mVPTqMEwaqksWo",
+							"damage": {
+								"type": "spec. 2yd radius"
+							},
+							"usage": "Stasis",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "spec. 2yd radius"
+							}
+						},
+						{
+							"id": "Wakb2bwwc9pjFdcYD",
+							"damage": {
+								"type": "spec. 2yd radius"
+							},
+							"usage": "Vortex",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "spec. 2yd radius"
+							}
+						}
+					],
+					"modifiers": [
+						{
+							"id": "fYgQ0-VACOJvo0rPQ",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+								"id": "fKtVH_SHC4e-tHTIe"
+							},
+							"name": "Biochemical Aerosol",
+							"reference": "UT153",
+							"local_notes": "Cost Plus Filler x # of Doses",
+							"cost_type": "to_base_cost",
+							"tech_level": "9",
+							"cost": "+0 CF"
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"children": [
+						{
+							"id": "eFIQktrs75ZBFuQDZ",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "eA9DiGibooMm0moad"
+							},
+							"description": "Paralysis Gas",
+							"reference": "UT160",
+							"tech_level": "10",
+							"legality_class": "2",
+							"tags": [
+								"Biochemical and Nanotech Weapons",
+								"Weaponry"
+							],
+							"base_value": "10",
+							"quantity": 40,
+							"equipped": true,
+							"calc": {
+								"value": 10,
+								"extended_value": 400,
+								"weight": "0 lb",
+								"extended_weight": "0 lb"
+							}
+						}
+					],
+					"calc": {
+						"value": 10,
+						"extended_value": 410,
+						"weight": "0.25 lb",
+						"extended_weight": "0.25 lb"
+					}
+				},
+				{
+					"id": "EsR_8autiAq9iWrdL",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "e9JMu0uwKXD9-qQ6_"
+					},
+					"description": "Mini Hand Grenade",
+					"reference": "UT146",
+					"local_notes": "Manually add a warhead equipment modifier then unhide the relevant ranged weapon usages",
+					"tags": [
+						"Weaponry"
+					],
+					"base_value": "10",
+					"base_weight": "0.25 lb",
+					"weapons": [
+						{
+							"id": "WFLJEkfiM7u3_DV_l",
+							"damage": {
+								"type": "spec. 4yds 40 doses",
+								"base": "0"
+							},
+							"usage": "Biochemical Aerosol",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"calc": {
+								"damage": "spec. 4yds 40 doses"
+							}
+						},
+						{
+							"id": "WfKxJ-NcoJDEP1HaP",
+							"damage": {
+								"type": "spec. 4yds 16 doses",
+								"base": "0"
+							},
+							"usage": "Biochemical Liquid",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "spec. 4yds 16 doses"
+							}
+						},
+						{
+							"id": "WDGdV7TI8tHvGLdqs",
+							"damage": {
+								"type": "spec. 400 yds",
+								"base": "0"
+							},
+							"usage": "Flare",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "spec. 400 yds"
+							}
+						},
+						{
+							"id": "WYkzVD2lx2Wwy2ykN",
+							"damage": {
+								"type": "cr ex",
+								"base": "8d",
+								"fragmentation": "2d",
+								"fragmentation_type": " cut"
+							},
+							"usage": "High Explosive (TL9)",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "8d cr ex [2d  cut]"
+							}
+						},
+						{
+							"id": "W0TQ4WismzW6YxFu3",
+							"damage": {
+								"type": "cr ex",
+								"base": "8d",
+								"fragmentation": "2d",
+								"fragmentation_type": " cut",
+								"modifier_per_die": 1
+							},
+							"usage": "High Explosive (TL10)",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "8d (+1 per die) cr ex [2d  cut]"
+							}
+						},
+						{
+							"id": "W3wPSDBvUMhfEVpNq",
+							"damage": {
+								"type": "cr ex",
+								"base": "8d"
+							},
+							"usage": "High Explosive Concussion (TL9)",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "8d cr ex"
+							}
+						},
+						{
+							"id": "WvdLM7dXKrjrlqSpY",
+							"damage": {
+								"type": "cr ex",
+								"base": "8d",
+								"modifier_per_die": 1
+							},
+							"usage": "High Explosive Concussion (TL10)",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "8d (+1 per die) cr ex"
+							}
+						},
+						{
+							"id": "W5ID_DpX_qH3kSzwO",
+							"damage": {
+								"type": "cr inc",
+								"base": "6dx4",
+								"armor_divisor": 10
+							},
+							"usage": "Shaped Charge (TL9) jet",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx4(10) cr inc"
+							}
+						},
+						{
+							"id": "WvJgCS-sUNrFrEY6I",
+							"damage": {
+								"type": "cr inc",
+								"base": "6dx4",
+								"armor_divisor": 10,
+								"modifier_per_die": 1
+							},
+							"usage": "Shaped Charge (TL10) jet",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx4(10) (+1 per die) cr inc"
+							}
+						},
+						{
+							"id": "Wn-kvfxi4lr8lAw13",
+							"damage": {
+								"type": "cr ex",
+								"base": "4d",
+								"fragmentation": "2d",
+								"fragmentation_type": "cut"
+							},
+							"usage": "Shaped Charge linked explosion",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"hide": true,
+							"calc": {
+								"damage": "4d cr ex [2d cut]"
+							}
+						},
+						{
+							"id": "WaiGzbTVcf2PdcTFt",
+							"damage": {
+								"type": "spec. ST 24 (+2 per additional layer)"
+							},
+							"usage": "Tangler",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "spec. ST 24 (+2 per additional layer)"
+							}
+						},
+						{
+							"id": "Wq4WzkA7vqMNPUino",
+							"damage": {
+								"type": "cr ex inc",
+								"base": "8dx2"
+							},
+							"usage": "Thermobaric (TL9)",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "8dx2 cr ex inc"
+							}
+						},
+						{
+							"id": "W47_17kp_OGyMRRVH",
+							"damage": {
+								"type": "cr ex inc",
+								"base": "8dx2",
+								"modifier_per_die": 1
+							},
+							"usage": "Thermobaric (TL10)",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "8dx2 (+1 per die) cr ex inc"
+							}
+						},
+						{
+							"id": "WcW1GhHBuKZRsgIFz",
+							"damage": {
+								"type": "cr inc",
+								"base": "6dx5",
+								"armor_divisor": 10
+							},
+							"usage": "High Explosive Multi-Purpose (TL10) jet",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx5(10) cr inc"
+							}
+						},
+						{
+							"id": "WxIfp4hgTyXIeqvdu",
+							"damage": {
+								"type": "cr inc",
+								"base": "6dx5",
+								"armor_divisor": 10,
+								"modifier_per_die": 1
+							},
+							"usage": "High Explosive Multi-Purpose (TL11) jet",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx5(10) (+1 per die) cr inc"
+							}
+						},
+						{
+							"id": "WlNvPEHefGF9ryiMi",
+							"damage": {
+								"type": "cr ex",
+								"base": "4d",
+								"fragmentation": "2d",
+								"fragmentation_type": "cut"
+							},
+							"usage": "High Explosive Multi-Purpose linked explosion",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"hide": true,
+							"calc": {
+								"damage": "4d cr ex [2d cut]"
+							}
+						},
+						{
+							"id": "We4iA0Plq6vvVyOyz",
+							"damage": {
+								"type": "burn sur",
+								"base": "2d"
+							},
+							"usage": "Stingray",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "2d burn sur"
+							}
+						},
+						{
+							"id": "WF2HDQe7oZe4mJktF",
+							"damage": {
+								"type": "spec. 1sq yd"
+							},
+							"usage": "Swarm",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "spec. 1sq yd"
+							}
+						},
+						{
+							"id": "W-GZciryCcZDD4cS3",
+							"damage": {
+								"type": "cr ex",
+								"base": "6dx200"
+							},
+							"usage": "0.01kT Mininuke blast",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx200 cr ex"
+							}
+						},
+						{
+							"id": "WQEpAfOmxIFidd6I7",
+							"damage": {
+								"type": "burn ex* rad sur",
+								"base": "4dx200"
+							},
+							"usage": "0.01kT Mininuke linked radiation",
+							"usage_notes": "divide by distance rather than 3x distance; to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"hide": true,
+							"calc": {
+								"damage": "4dx200 burn ex* rad sur"
+							}
+						},
+						{
+							"id": "WT4KTQ4WL2SDQKDVU",
+							"damage": {
+								"type": "cr ex",
+								"base": "6dx600"
+							},
+							"usage": "0.1kT Mininuke blast",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx600 cr ex"
+							}
+						},
+						{
+							"id": "WEIdS9odNcuIOXrPR",
+							"damage": {
+								"type": "burn ex* rad sur",
+								"base": "6dx400"
+							},
+							"usage": "0.1kT Mininuke linked radiation",
+							"usage_notes": "divide by distance rather than 3x distance; to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"hide": true,
+							"calc": {
+								"damage": "6dx400 burn ex* rad sur"
+							}
+						},
+						{
+							"id": "Wxi9tFB7J4VWR6lbI",
+							"damage": {
+								"type": "cr ex",
+								"base": "6dx2000"
+							},
+							"usage": "1kT Mininuke blast",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx2000 cr ex"
+							}
+						},
+						{
+							"id": "WmeIRik6acYWqHm_C",
+							"damage": {
+								"type": "burn ex* rad sur",
+								"base": "4dx2000"
+							},
+							"usage": "1kT Mininuke linked radiation",
+							"usage_notes": "divide by distance rather than 3x distance; to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"hide": true,
+							"calc": {
+								"damage": "4dx2000 burn ex* rad sur"
+							}
+						},
+						{
+							"id": "WbYeQN6DFqqITdr-2",
+							"damage": {
+								"type": "burn ex sur*",
+								"base": "6dx4"
+							},
+							"usage": "0.1μg Antimatter Explosion",
+							"usage_notes": "divide by distance rather than 3x distance; to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx4 burn ex sur*"
+							}
+						},
+						{
+							"id": "Wm_f1NGRhLM6FtWl-",
+							"damage": {
+								"type": "tox rad†",
+								"base": "6dx10000"
+							},
+							"usage": "0.1μg Antimatter linked radiation",
+							"usage_notes": "divide by square of distance rather than 3x distance; to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"hide": true,
+							"calc": {
+								"damage": "6dx10000 tox rad†"
+							}
+						},
+						{
+							"id": "WVAuaDX1nFdbMnP04",
+							"damage": {
+								"type": "burn ex sur*",
+								"base": "6dx12"
+							},
+							"usage": "1μg Antimatter Explosion",
+							"usage_notes": "divide by distance rather than 3x distance; to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx12 burn ex sur*"
+							}
+						},
+						{
+							"id": "WUbe43XZ36nvi0vEg",
+							"damage": {
+								"type": "tox rad†",
+								"base": "6dx100000"
+							},
+							"usage": "1μg Antimatter linked radiation",
+							"usage_notes": "divide by square of distance rather than 3x distance; to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"hide": true,
+							"calc": {
+								"damage": "6dx100000 tox rad†"
+							}
+						},
+						{
+							"id": "WTKVsNyjZ8XQXbQqT",
+							"damage": {
+								"type": "burn ex sur*",
+								"base": "6dx40"
+							},
+							"usage": "10μg Antimatter Explosion",
+							"usage_notes": "divide by distance rather than 3x distance; to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx40 burn ex sur*"
+							}
+						},
+						{
+							"id": "WW4wnYSoAdwrdUZD1",
+							"damage": {
+								"type": "tox rad†",
+								"base": "6dx1000000"
+							},
+							"usage": "10μg Antimatter linked radiation",
+							"usage_notes": "divide by square of distance rather than 3x distance; to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"hide": true,
+							"calc": {
+								"damage": "6dx1000000 tox rad†"
+							}
+						},
+						{
+							"id": "W7erPPeOPLPQTweqN",
+							"damage": {
+								"type": "spec. 4yds"
+							},
+							"usage": "EMP",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "spec. 4yds"
+							}
+						},
+						{
+							"id": "WqigShSi8HNCBsFqC",
+							"damage": {
+								"type": "cr ex",
+								"base": "1d"
+							},
+							"usage": "EMP linked explosion",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"hide": true,
+							"calc": {
+								"damage": "1d cr ex"
+							}
+						},
+						{
+							"id": "WHDHHzVdTYWxyoou6",
+							"damage": {
+								"type": "spec. 40yd radius"
+							},
+							"usage": "Expendable Jammer",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "spec. 40yd radius"
+							}
+						},
+						{
+							"id": "WC_5v-pywkB4T9sqm",
+							"damage": {
+								"type": "HT-4 aff. 4yd radius"
+							},
+							"usage": "Strobe",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "HT-4 aff. 4yd radius"
+							}
+						},
+						{
+							"id": "WL_wJ84D3H75wV5wg",
+							"damage": {
+								"type": "HT-4 aff. 4yd radius"
+							},
+							"usage": "Warbler",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "HT-4 aff. 4yd radius"
+							}
+						},
+						{
+							"id": "WtpQYovkJgpK1zLmL",
+							"damage": {
+								"type": "cr dkb ex",
+								"base": "8d"
+							},
+							"usage": "Force",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "8d cr dkb ex"
+							}
+						},
+						{
+							"id": "Wm00ChGnkYHUJwwpv",
+							"damage": {
+								"type": "burn ex sur",
+								"base": "6dx2"
+							},
+							"usage": "Plasma",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx2 burn ex sur"
+							}
+						},
+						{
+							"id": "WgqEnwyodjQ3Bf9Tk",
+							"damage": {
+								"type": "cr dkb ex",
+								"base": "6dx25"
+							},
+							"usage": "Implosion pull",
+							"usage_notes": "knockback pulls victims inwards; to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx25 cr dkb ex"
+							}
+						},
+						{
+							"id": "WUCzn727hoHpLzCrX",
+							"damage": {
+								"type": "tox rad ex",
+								"base": "6dx40"
+							},
+							"usage": "Implosion linked radiation",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"hide": true,
+							"calc": {
+								"damage": "6dx40 tox rad ex"
+							}
+						},
+						{
+							"id": "WXJyLfpoenwOgnkQP",
+							"damage": {
+								"type": "spec. 4yd radius"
+							},
+							"usage": "Psi-Bomb",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "spec. 4yd radius"
+							}
+						},
+						{
+							"id": "W7CCuxE3zQO4LHMJV",
+							"damage": {
+								"type": "spec. 2yd radius"
+							},
+							"usage": "Stasis",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "spec. 2yd radius"
+							}
+						},
+						{
+							"id": "WJLYCbysbUnMLU3wm",
+							"damage": {
+								"type": "spec. 2yd radius"
+							},
+							"usage": "Vortex",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "spec. 2yd radius"
+							}
+						}
+					],
+					"modifiers": [
+						{
+							"id": "fCXO71DJnTFr9_oM9",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+								"id": "fKtVH_SHC4e-tHTIe"
+							},
+							"name": "Biochemical Aerosol",
+							"reference": "UT153",
+							"local_notes": "Cost Plus Filler x # of Doses",
+							"cost_type": "to_base_cost",
+							"tech_level": "9",
+							"cost": "+0 CF"
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"children": [
+						{
+							"id": "eHhPGLZOZ5TaDomr4",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "eA9DiGibooMm0moad"
+							},
+							"description": "Paralysis Gas",
+							"reference": "UT160",
+							"tech_level": "10",
+							"legality_class": "2",
+							"tags": [
+								"Biochemical and Nanotech Weapons",
+								"Weaponry"
+							],
+							"base_value": "10",
+							"quantity": 40,
+							"equipped": true,
+							"calc": {
+								"value": 10,
+								"extended_value": 400,
+								"weight": "0 lb",
+								"extended_weight": "0 lb"
+							}
+						}
+					],
+					"calc": {
+						"value": 10,
+						"extended_value": 410,
+						"weight": "0.25 lb",
+						"extended_weight": "0.25 lb"
+					}
+				},
+				{
+					"id": "e4hxEVkH6tmzguQ2Y",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "e9JMu0uwKXD9-qQ6_"
+					},
+					"description": "Mini Hand Grenade",
+					"reference": "UT146",
+					"local_notes": "Manually add a warhead equipment modifier then unhide the relevant ranged weapon usages",
+					"tags": [
+						"Weaponry"
+					],
+					"base_value": "10",
+					"base_weight": "0.25 lb",
+					"weapons": [
+						{
+							"id": "WQrLzl4o0uX7IfDua",
+							"damage": {
+								"type": "spec. 4yds 40 doses",
+								"base": "0"
+							},
+							"usage": "Biochemical Aerosol",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "spec. 4yds 40 doses"
+							}
+						},
+						{
+							"id": "WtnVKowPCTOxXQ3au",
+							"damage": {
+								"type": "spec. 4yds 16 doses",
+								"base": "0"
+							},
+							"usage": "Biochemical Liquid",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "spec. 4yds 16 doses"
+							}
+						},
+						{
+							"id": "WTYd5IZpvAnZU_kVx",
+							"damage": {
+								"type": "spec. 400 yds",
+								"base": "0"
+							},
+							"usage": "Flare",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "spec. 400 yds"
+							}
+						},
+						{
+							"id": "WtyzSbLrg78jnl8X7",
+							"damage": {
+								"type": "cr ex",
+								"base": "8d",
+								"fragmentation": "2d",
+								"fragmentation_type": " cut"
+							},
+							"usage": "High Explosive (TL9)",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "8d cr ex [2d  cut]"
+							}
+						},
+						{
+							"id": "WtkgHxwgCizg2zXVx",
+							"damage": {
+								"type": "cr ex",
+								"base": "8d",
+								"fragmentation": "2d",
+								"fragmentation_type": " cut",
+								"modifier_per_die": 1
+							},
+							"usage": "High Explosive (TL10)",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "8d (+1 per die) cr ex [2d  cut]"
+							}
+						},
+						{
+							"id": "WxOkxLlwL-_FP_pfO",
+							"damage": {
+								"type": "cr ex",
+								"base": "8d"
+							},
+							"usage": "High Explosive Concussion (TL9)",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "8d cr ex"
+							}
+						},
+						{
+							"id": "W29wvBjPEV9k1RT7P",
+							"damage": {
+								"type": "cr ex",
+								"base": "8d",
+								"modifier_per_die": 1
+							},
+							"usage": "High Explosive Concussion (TL10)",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "8d (+1 per die) cr ex"
+							}
+						},
+						{
+							"id": "WX-_gzeJQAvkZQQ23",
+							"damage": {
+								"type": "cr inc",
+								"base": "6dx4",
+								"armor_divisor": 10
+							},
+							"usage": "Shaped Charge (TL9) jet",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx4(10) cr inc"
+							}
+						},
+						{
+							"id": "WBcMFytn4BePlRQZT",
+							"damage": {
+								"type": "cr inc",
+								"base": "6dx4",
+								"armor_divisor": 10,
+								"modifier_per_die": 1
+							},
+							"usage": "Shaped Charge (TL10) jet",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx4(10) (+1 per die) cr inc"
+							}
+						},
+						{
+							"id": "Wneb_mS-uLV6ztrBE",
+							"damage": {
+								"type": "cr ex",
+								"base": "4d",
+								"fragmentation": "2d",
+								"fragmentation_type": "cut"
+							},
+							"usage": "Shaped Charge linked explosion",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"hide": true,
+							"calc": {
+								"damage": "4d cr ex [2d cut]"
+							}
+						},
+						{
+							"id": "W81guhwJGAjZzpe9E",
+							"damage": {
+								"type": "spec. ST 24 (+2 per additional layer)"
+							},
+							"usage": "Tangler",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"calc": {
+								"damage": "spec. ST 24 (+2 per additional layer)"
+							}
+						},
+						{
+							"id": "WBmftgrNppitU_6da",
+							"damage": {
+								"type": "cr ex inc",
+								"base": "8dx2"
+							},
+							"usage": "Thermobaric (TL9)",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "8dx2 cr ex inc"
+							}
+						},
+						{
+							"id": "Wmhb3fpLg5EA-0z6T",
+							"damage": {
+								"type": "cr ex inc",
+								"base": "8dx2",
+								"modifier_per_die": 1
+							},
+							"usage": "Thermobaric (TL10)",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "8dx2 (+1 per die) cr ex inc"
+							}
+						},
+						{
+							"id": "WiwaxScZMqFQIaAsK",
+							"damage": {
+								"type": "cr inc",
+								"base": "6dx5",
+								"armor_divisor": 10
+							},
+							"usage": "High Explosive Multi-Purpose (TL10) jet",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx5(10) cr inc"
+							}
+						},
+						{
+							"id": "W6ZH6GHSjJK4dRUG_",
+							"damage": {
+								"type": "cr inc",
+								"base": "6dx5",
+								"armor_divisor": 10,
+								"modifier_per_die": 1
+							},
+							"usage": "High Explosive Multi-Purpose (TL11) jet",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx5(10) (+1 per die) cr inc"
+							}
+						},
+						{
+							"id": "WrRMZ_sxU6aNHX2Rd",
+							"damage": {
+								"type": "cr ex",
+								"base": "4d",
+								"fragmentation": "2d",
+								"fragmentation_type": "cut"
+							},
+							"usage": "High Explosive Multi-Purpose linked explosion",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"hide": true,
+							"calc": {
+								"damage": "4d cr ex [2d cut]"
+							}
+						},
+						{
+							"id": "WH_ZvrC5sV53AZYfo",
+							"damage": {
+								"type": "burn sur",
+								"base": "2d"
+							},
+							"usage": "Stingray",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "2d burn sur"
+							}
+						},
+						{
+							"id": "WoYGRxh1bTiKeiYAN",
+							"damage": {
+								"type": "spec. 1sq yd"
+							},
+							"usage": "Swarm",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "spec. 1sq yd"
+							}
+						},
+						{
+							"id": "WE1ERlvXY7kbSEN7p",
+							"damage": {
+								"type": "cr ex",
+								"base": "6dx200"
+							},
+							"usage": "0.01kT Mininuke blast",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx200 cr ex"
+							}
+						},
+						{
+							"id": "WAbS13fB9PNtk4mBh",
+							"damage": {
+								"type": "burn ex* rad sur",
+								"base": "4dx200"
+							},
+							"usage": "0.01kT Mininuke linked radiation",
+							"usage_notes": "divide by distance rather than 3x distance; to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"hide": true,
+							"calc": {
+								"damage": "4dx200 burn ex* rad sur"
+							}
+						},
+						{
+							"id": "W9u31LxHqdUD9G33C",
+							"damage": {
+								"type": "cr ex",
+								"base": "6dx600"
+							},
+							"usage": "0.1kT Mininuke blast",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx600 cr ex"
+							}
+						},
+						{
+							"id": "WTV6CBfmE4nzQEKEm",
+							"damage": {
+								"type": "burn ex* rad sur",
+								"base": "6dx400"
+							},
+							"usage": "0.1kT Mininuke linked radiation",
+							"usage_notes": "divide by distance rather than 3x distance; to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"hide": true,
+							"calc": {
+								"damage": "6dx400 burn ex* rad sur"
+							}
+						},
+						{
+							"id": "We53qd2xkHMagIyaI",
+							"damage": {
+								"type": "cr ex",
+								"base": "6dx2000"
+							},
+							"usage": "1kT Mininuke blast",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx2000 cr ex"
+							}
+						},
+						{
+							"id": "WGJK1sJqKKHBgbmD-",
+							"damage": {
+								"type": "burn ex* rad sur",
+								"base": "4dx2000"
+							},
+							"usage": "1kT Mininuke linked radiation",
+							"usage_notes": "divide by distance rather than 3x distance; to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"hide": true,
+							"calc": {
+								"damage": "4dx2000 burn ex* rad sur"
+							}
+						},
+						{
+							"id": "WAm_jEiiiDDrT7sNh",
+							"damage": {
+								"type": "burn ex sur*",
+								"base": "6dx4"
+							},
+							"usage": "0.1μg Antimatter Explosion",
+							"usage_notes": "divide by distance rather than 3x distance; to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx4 burn ex sur*"
+							}
+						},
+						{
+							"id": "W0chZPa44POzI8eKu",
+							"damage": {
+								"type": "tox rad†",
+								"base": "6dx10000"
+							},
+							"usage": "0.1μg Antimatter linked radiation",
+							"usage_notes": "divide by square of distance rather than 3x distance; to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"hide": true,
+							"calc": {
+								"damage": "6dx10000 tox rad†"
+							}
+						},
+						{
+							"id": "W0G1YosMx2uFGq4lk",
+							"damage": {
+								"type": "burn ex sur*",
+								"base": "6dx12"
+							},
+							"usage": "1μg Antimatter Explosion",
+							"usage_notes": "divide by distance rather than 3x distance; to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx12 burn ex sur*"
+							}
+						},
+						{
+							"id": "W0ljG7e-4IwtS0aKC",
+							"damage": {
+								"type": "tox rad†",
+								"base": "6dx100000"
+							},
+							"usage": "1μg Antimatter linked radiation",
+							"usage_notes": "divide by square of distance rather than 3x distance; to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"hide": true,
+							"calc": {
+								"damage": "6dx100000 tox rad†"
+							}
+						},
+						{
+							"id": "WM74wcN1XqMheS2BZ",
+							"damage": {
+								"type": "burn ex sur*",
+								"base": "6dx40"
+							},
+							"usage": "10μg Antimatter Explosion",
+							"usage_notes": "divide by distance rather than 3x distance; to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx40 burn ex sur*"
+							}
+						},
+						{
+							"id": "WfgcHAwlZNPrFhPfY",
+							"damage": {
+								"type": "tox rad†",
+								"base": "6dx1000000"
+							},
+							"usage": "10μg Antimatter linked radiation",
+							"usage_notes": "divide by square of distance rather than 3x distance; to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"hide": true,
+							"calc": {
+								"damage": "6dx1000000 tox rad†"
+							}
+						},
+						{
+							"id": "WV6e2S-2O4ZkgkMvr",
+							"damage": {
+								"type": "spec. 4yds"
+							},
+							"usage": "EMP",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "spec. 4yds"
+							}
+						},
+						{
+							"id": "WqYq6__C-SIcGdxBc",
+							"damage": {
+								"type": "cr ex",
+								"base": "1d"
+							},
+							"usage": "EMP linked explosion",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"hide": true,
+							"calc": {
+								"damage": "1d cr ex"
+							}
+						},
+						{
+							"id": "Wo5C1qlUkumln48SR",
+							"damage": {
+								"type": "spec. 40yd radius"
+							},
+							"usage": "Expendable Jammer",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "spec. 40yd radius"
+							}
+						},
+						{
+							"id": "W8tDuJphsDkwi2KBG",
+							"damage": {
+								"type": "HT-4 aff. 4yd radius"
+							},
+							"usage": "Strobe",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "HT-4 aff. 4yd radius"
+							}
+						},
+						{
+							"id": "WMCKMzLv26MmLIRoV",
+							"damage": {
+								"type": "HT-4 aff. 4yd radius"
+							},
+							"usage": "Warbler",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "HT-4 aff. 4yd radius"
+							}
+						},
+						{
+							"id": "WfZ8YSGo-2GEc-6cX",
+							"damage": {
+								"type": "cr dkb ex",
+								"base": "8d"
+							},
+							"usage": "Force",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "8d cr dkb ex"
+							}
+						},
+						{
+							"id": "WazNu_5SASh5wcmZP",
+							"damage": {
+								"type": "burn ex sur",
+								"base": "6dx2"
+							},
+							"usage": "Plasma",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx2 burn ex sur"
+							}
+						},
+						{
+							"id": "W8AL4SuTEtf95NtR1",
+							"damage": {
+								"type": "cr dkb ex",
+								"base": "6dx25"
+							},
+							"usage": "Implosion pull",
+							"usage_notes": "knockback pulls victims inwards; to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "6dx25 cr dkb ex"
+							}
+						},
+						{
+							"id": "WBNMonKalXmNqI7mt",
+							"damage": {
+								"type": "tox rad ex",
+								"base": "6dx40"
+							},
+							"usage": "Implosion linked radiation",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"hide": true,
+							"calc": {
+								"damage": "6dx40 tox rad ex"
+							}
+						},
+						{
+							"id": "WhR3EIm4j4wwGBokx",
+							"damage": {
+								"type": "spec. 4yd radius"
+							},
+							"usage": "Psi-Bomb",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "spec. 4yd radius"
+							}
+						},
+						{
+							"id": "WtwYtKK0CwBsXweGS",
+							"damage": {
+								"type": "spec. 2yd radius"
+							},
+							"usage": "Stasis",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "spec. 2yd radius"
+							}
+						},
+						{
+							"id": "W2cwGsve6vdapBwOo",
+							"damage": {
+								"type": "spec. 2yd radius"
+							},
+							"usage": "Vortex",
+							"usage_notes": "to be used with the relevant Equipment Modifier",
+							"range": "x3.5",
+							"rate_of_fire": "1",
+							"shots": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Throwing"
+								},
+								{
+									"type": "skill",
+									"name": "Dropping",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -3
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "spec. 2yd radius"
+							}
+						}
+					],
+					"modifiers": [
+						{
+							"id": "fPz5O8jpm4fa52QYa",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
+								"id": "fQ_qI191B1O4XuDmX"
+							},
+							"name": "Tangler",
+							"reference": "UT155",
+							"cost_type": "to_base_cost",
+							"tech_level": "9",
+							"cost": "+1 CF"
+						}
+					],
+					"quantity": 4,
+					"equipped": true,
+					"calc": {
+						"value": 20,
+						"extended_value": 80,
+						"weight": "0.25 lb",
+						"extended_weight": "1 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 0,
+				"extended_value": 1310,
+				"weight": "0 lb",
+				"extended_weight": "1.75 lb"
+			}
+		}
+	]
+}

--- a/Library/Loadouts/Starship Crew/TL11/Weapon, Omni-Blaster Pistol.gct
+++ b/Library/Loadouts/Starship Crew/TL11/Weapon, Omni-Blaster Pistol.gct
@@ -1,0 +1,276 @@
+{
+	"version": 5,
+	"id": "BWRaJ4p1zPPX_bUZp",
+	"equipment": [
+		{
+			"id": "EzWgUqxE6Kwh-6tO2",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "High Tech/High Tech Equipment.eqp",
+				"id": "E73yMX2SGu09jndtY"
+			},
+			"description": "Retention Holster",
+			"reference": "HT154",
+			"local_notes": "+2 Retain Weapon.",
+			"tech_level": "7",
+			"tags": [
+				"Firearm Accessories"
+			],
+			"base_value": "100",
+			"base_weight": "0.5 lb",
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "ExjA9juUW6kmoo7Ib",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "eLdup3xMnqKVMq5Hu"
+					},
+					"description": "Blaster Pistol",
+					"reference": "UT123",
+					"local_notes": "C/40 shots.",
+					"tech_level": "11",
+					"legality_class": "3",
+					"tags": [
+						"Missile Weapon",
+						"Weaponry"
+					],
+					"base_value": "2200",
+					"base_weight": "1.6 lb",
+					"weapons": [
+						{
+							"id": "W2WT5qpsr9YDG63FI",
+							"damage": {
+								"type": "burn, sur",
+								"base": "3d",
+								"armor_divisor": 5
+							},
+							"strength": "4",
+							"accuracy": "5",
+							"range": "300/900",
+							"rate_of_fire": "3",
+							"shots": "40(3)",
+							"bulk": "-2",
+							"recoil": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Beam Weapons",
+									"specialization": "Pistol"
+								},
+								{
+									"type": "skill",
+									"name": "Beam Weapons",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Guns",
+									"specialization": "Pistol",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -4
+								}
+							],
+							"calc": {
+								"damage": "3d(5) burn, sur"
+							}
+						},
+						{
+							"id": "W2rEe3-rsYqVb44l3",
+							"damage": {
+								"type": "HT-3 aff",
+								"armor_divisor": 3
+							},
+							"strength": "4",
+							"usage": "Omni-Blaster Stun",
+							"accuracy": "5",
+							"range": "300/900",
+							"rate_of_fire": "3",
+							"shots": "40(3)",
+							"bulk": "-2",
+							"recoil": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Beam Weapons",
+									"specialization": "Pistol"
+								},
+								{
+									"type": "skill",
+									"name": "Beam Weapons",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Guns",
+									"specialization": "Pistol",
+									"modifier": -4
+								},
+								{
+									"type": "dx",
+									"modifier": -4
+								}
+							],
+							"calc": {
+								"damage": "(3) HT-3 aff"
+							}
+						}
+					],
+					"modifiers": [
+						{
+							"id": "fIxZ5qEBf3p-4wSnG",
+							"name": "Omni-Blaster",
+							"local_notes": "note: manually unhide Omni-Blaster Stun",
+							"cost": "+100%"
+						},
+						{
+							"id": "fEMwAZhvAvyTTLd60",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Equipment Modifiers.eqm",
+								"id": "fKVVvHu0-Mgu2jotm"
+							},
+							"name": "Fine Quality",
+							"reference": "B280",
+							"local_notes": "+1 to Malf",
+							"cost_type": "to_base_cost",
+							"cost": "+1 CF",
+							"features": [
+								{
+									"type": "weapon_acc_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							]
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"children": [
+						{
+							"id": "Eog-kBKPkmQqMsQYt",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "e5DIbfpp4o2Sdu7tY"
+							},
+							"description": "Accessory Rail",
+							"reference": "UT150",
+							"tech_level": "9",
+							"tags": [
+								"Firearm Accessories",
+								"Weaponry"
+							],
+							"base_value": "100",
+							"base_weight": "2 lb",
+							"quantity": 1,
+							"equipped": true,
+							"children": [
+								{
+									"id": "egjY2Ns8_aHVuiIMN",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+										"id": "eL55XD_2gh5v1kg6u"
+									},
+									"description": "Compact Targeting Scope",
+									"reference": "UT149",
+									"local_notes": "+3 to aimed shots. A/100hr.",
+									"tech_level": "11",
+									"tags": [
+										"Firearm Accessories",
+										"Weaponry"
+									],
+									"base_value": "1000",
+									"base_weight": "0.5 lb",
+									"quantity": 1,
+									"equipped": true,
+									"calc": {
+										"value": 1000,
+										"extended_value": 1000,
+										"weight": "0.5 lb",
+										"extended_weight": "0.5 lb"
+									}
+								}
+							],
+							"calc": {
+								"value": 100,
+								"extended_value": 1100,
+								"weight": "2 lb",
+								"extended_weight": "2.5 lb"
+							}
+						}
+					],
+					"calc": {
+						"value": 8800,
+						"extended_value": 9900,
+						"weight": "1.6 lb",
+						"extended_weight": "4.1 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 100,
+				"extended_value": 10000,
+				"weight": "0.5 lb",
+				"extended_weight": "4.6 lb"
+			}
+		},
+		{
+			"id": "EEE1McRIJ3cnLBZOf",
+			"description": "Add to Load-Bearing Vest",
+			"legality_class": "4",
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "et-Ljd-9nIba8ih4H",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "ev80WwcnBpiGFrkol"
+					},
+					"description": "C cell",
+					"reference": "UT19",
+					"tech_level": "9",
+					"tags": [
+						"Power"
+					],
+					"base_value": "10",
+					"base_weight": "0.5 lb",
+					"quantity": 2,
+					"equipped": true,
+					"calc": {
+						"value": 10,
+						"extended_value": 20,
+						"weight": "0.5 lb",
+						"extended_weight": "1 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 0,
+				"extended_value": 20,
+				"weight": "0 lb",
+				"extended_weight": "1 lb"
+			}
+		}
+	],
+	"notes": [
+		{
+			"id": "nRmnSFwChgBmw2ogj",
+			"markdown": "Requires Beam Weapons (Pistol)"
+		}
+	]
+}

--- a/Library/Loadouts/Starship Crew/TL11/Weapon, X-Ray Laser Rifle.gct
+++ b/Library/Loadouts/Starship Crew/TL11/Weapon, X-Ray Laser Rifle.gct
@@ -1,0 +1,196 @@
+{
+	"version": 5,
+	"id": "BCgHA-VzOr2p7UJ4E",
+	"equipment": [
+		{
+			"id": "Ex8nDpCgAGzUbx3qa",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "High Tech/High Tech Equipment.eqp",
+				"id": "EacmJUPcIX3jxUjFy"
+			},
+			"description": "Patrol Sling",
+			"reference": "HT154",
+			"local_notes": "+1 Fast-Draw (Long Arm).",
+			"tech_level": "7",
+			"tags": [
+				"Firearm Accessories"
+			],
+			"base_value": "50",
+			"base_weight": "1 lb",
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "E_S0wy_oHNwcEC-B1",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "e4sbsa7hJQmfyNlA2"
+					},
+					"description": "X-Ray Laser Rifle",
+					"reference": "UT118",
+					"local_notes": "External D-cell.",
+					"tech_level": "11",
+					"legality_class": "2",
+					"tags": [
+						"Missile Weapon",
+						"Weaponry"
+					],
+					"base_value": "16000",
+					"base_weight": "8 lb",
+					"weapons": [
+						{
+							"id": "WftwtsjX3x_Ao6g7Z",
+							"damage": {
+								"type": "burn, sur",
+								"base": "6d",
+								"armor_divisor": 5
+							},
+							"strength": "7†",
+							"accuracy": "12",
+							"range": "40/120 mi",
+							"rate_of_fire": "10",
+							"shots": "83(5)",
+							"bulk": "-4",
+							"recoil": "1",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Beam Weapons",
+									"specialization": "Rifle"
+								},
+								{
+									"type": "skill",
+									"name": "Beam Weapons",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Guns",
+									"specialization": "Rifle",
+									"modifier": -4
+								}
+							],
+							"calc": {
+								"damage": "6d(5) burn, sur"
+							}
+						}
+					],
+					"quantity": 1,
+					"equipped": true,
+					"children": [
+						{
+							"id": "EGY5MDccWLX-Nb4qA",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+								"id": "e5DIbfpp4o2Sdu7tY"
+							},
+							"description": "Accessory Rail",
+							"reference": "UT150",
+							"tech_level": "9",
+							"tags": [
+								"Firearm Accessories",
+								"Weaponry"
+							],
+							"base_value": "100",
+							"base_weight": "2 lb",
+							"quantity": 1,
+							"equipped": true,
+							"children": [
+								{
+									"id": "eMtq29_6RplfC_qSP",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+										"id": "eL55XD_2gh5v1kg6u"
+									},
+									"description": "Compact Targeting Scope",
+									"reference": "UT149",
+									"local_notes": "+3 to aimed shots. A/100hr.",
+									"tech_level": "11",
+									"tags": [
+										"Firearm Accessories",
+										"Weaponry"
+									],
+									"base_value": "1000",
+									"base_weight": "0.5 lb",
+									"quantity": 1,
+									"equipped": true,
+									"calc": {
+										"value": 1000,
+										"extended_value": 1000,
+										"weight": "0.5 lb",
+										"extended_weight": "0.5 lb"
+									}
+								}
+							],
+							"calc": {
+								"value": 100,
+								"extended_value": 1100,
+								"weight": "2 lb",
+								"extended_weight": "2.5 lb"
+							}
+						}
+					],
+					"calc": {
+						"value": 16000,
+						"extended_value": 17100,
+						"weight": "8 lb",
+						"extended_weight": "10.5 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 50,
+				"extended_value": 17150,
+				"weight": "1 lb",
+				"extended_weight": "11.5 lb"
+			}
+		},
+		{
+			"id": "ECDjKv8GOdXHKpNza",
+			"description": "Add to Load-Bearing Vest",
+			"legality_class": "4",
+			"quantity": 1,
+			"equipped": true,
+			"children": [
+				{
+					"id": "eeHf-2fFP47GA6u00",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Ultra Tech/Ultra Tech Equipment.eqp",
+						"id": "e_noIf9v8q1Okb3m9"
+					},
+					"description": "D cell",
+					"reference": "UT19",
+					"tech_level": "9",
+					"tags": [
+						"Power"
+					],
+					"base_value": "100",
+					"base_weight": "5 lb",
+					"quantity": 2,
+					"equipped": true,
+					"calc": {
+						"value": 100,
+						"extended_value": 200,
+						"weight": "5 lb",
+						"extended_weight": "10 lb"
+					}
+				}
+			],
+			"calc": {
+				"value": 0,
+				"extended_value": 200,
+				"weight": "0 lb",
+				"extended_weight": "10 lb"
+			}
+		}
+	]
+}

--- a/Library/Ultra Tech/Ultra Tech Equipment.eqp
+++ b/Library/Ultra Tech/Ultra Tech Equipment.eqp
@@ -54907,11 +54907,6 @@
 		},
 		{
 			"id": "eRd4HdGkY3padXW2c",
-			"source": {
-				"library": "richardwilkes/gcs_master_library",
-				"path": "Ultra Tech/Ultra Tech Equipment.eqp",
-				"id": "eqFME0FUFNk7cR-4s"
-			},
 			"description": "@Microbot/Nanobot Type@ Swarm",
 			"reference": "UT35",
 			"tech_level": "10",
@@ -55386,11 +55381,6 @@
 							"children": [
 								{
 									"id": "fwczZZ75e0KEFyGnB",
-									"source": {
-										"library": "richardwilkes/gcs_master_library",
-										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-										"id": "f7eMKwMF7BTYFbxhq"
-									},
 									"name": "Microbot Aerostat",
 									"reference": "UT36",
 									"local_notes": "Air Move 2",
@@ -55402,11 +55392,6 @@
 								},
 								{
 									"id": "fLuSGWIZ-3ROuq7kd",
-									"source": {
-										"library": "richardwilkes/gcs_master_library",
-										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-										"id": "fcVKEB14BedQI1jGA"
-									},
 									"name": "Microbot Crawler",
 									"reference": "UT36",
 									"local_notes": "Move 3; Water Move 1",
@@ -55417,11 +55402,6 @@
 								},
 								{
 									"id": "fKG6jBFn5-WOkz0e0",
-									"source": {
-										"library": "richardwilkes/gcs_master_library",
-										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-										"id": "fScgdTYLwKE9CEYfl"
-									},
 									"name": "Microbot Crawler, Armored",
 									"reference": "UT36",
 									"local_notes": "Move 2, 2x HP",
@@ -55435,11 +55415,6 @@
 								},
 								{
 									"id": "fD8wm1mQpwRHAdDMP",
-									"source": {
-										"library": "richardwilkes/gcs_master_library",
-										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-										"id": "fpAVv9yE3m3t0Egt_"
-									},
 									"name": "Microbot Flier",
 									"reference": "UT36",
 									"local_notes": "Move 1; Air Move 6",
@@ -55453,11 +55428,6 @@
 								},
 								{
 									"id": "fgwcSbh5rWFgVtYHk",
-									"source": {
-										"library": "richardwilkes/gcs_master_library",
-										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-										"id": "ffHj2SBngzuewdrbB"
-									},
 									"name": "Microbot Hopper",
 									"reference": "UT36",
 									"local_notes": "Move 4; Super Jump 1",
@@ -55471,11 +55441,6 @@
 								},
 								{
 									"id": "fIZ4FN3qCEnJUd3pr",
-									"source": {
-										"library": "richardwilkes/gcs_master_library",
-										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-										"id": "fr6wQjKaUic-BpBCO"
-									},
 									"name": "Microbot Space",
 									"reference": "UT36",
 									"local_notes": "Move 1; 0.0001G solar sail",
@@ -55488,11 +55453,6 @@
 								},
 								{
 									"id": "fEsm73Uzg9JqD5UyP",
-									"source": {
-										"library": "richardwilkes/gcs_master_library",
-										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-										"id": "fsL5rGqz66ht8cVvg"
-									},
 									"name": "Microbot Swimmer",
 									"reference": "UT36",
 									"local_notes": "Water Move 4",
@@ -55505,11 +55465,6 @@
 								},
 								{
 									"id": "fcefbRQhOwaSTTMkM",
-									"source": {
-										"library": "richardwilkes/gcs_master_library",
-										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-										"id": "fvVo7_8gzuQpK50fc"
-									},
 									"name": "Microbot Contragrav (CG) Flier",
 									"reference": "UT36",
 									"local_notes": "Move 1; Air Move 20",
@@ -55529,11 +55484,6 @@
 							"children": [
 								{
 									"id": "fY_vQx3LPn4QYiW73",
-									"source": {
-										"library": "richardwilkes/gcs_master_library",
-										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-										"id": "f6RvvKoBN0DqIjBjQ"
-									},
 									"name": "Nanobot Aerostat",
 									"reference": "UT36",
 									"local_notes": "Air Move 1",
@@ -55545,11 +55495,6 @@
 								},
 								{
 									"id": "fiGB3LktygwvqcQzR",
-									"source": {
-										"library": "richardwilkes/gcs_master_library",
-										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-										"id": "f1OLvlafFuNITe6na"
-									},
 									"name": "Nanobot Crawler",
 									"reference": "UT36",
 									"local_notes": "Move 3; Water Move 1",
@@ -55561,11 +55506,6 @@
 								},
 								{
 									"id": "fHSAk3wZ0MEKeAnb2",
-									"source": {
-										"library": "richardwilkes/gcs_master_library",
-										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-										"id": "fASzj6iYz6hUA-TBB"
-									},
 									"name": "Nanobot Crawler, Armored",
 									"reference": "UT36",
 									"local_notes": "Move 2, 2x HP",
@@ -55579,11 +55519,6 @@
 								},
 								{
 									"id": "fDjaibB6Pi_wlxp9N",
-									"source": {
-										"library": "richardwilkes/gcs_master_library",
-										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-										"id": "fLuL-pD4o6s0lREJs"
-									},
 									"name": "Nanobot Dust",
 									"reference": "UT36",
 									"local_notes": "Immobile",
@@ -55597,11 +55532,6 @@
 								},
 								{
 									"id": "f4V1zDKdkcJ-MHp00",
-									"source": {
-										"library": "richardwilkes/gcs_master_library",
-										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-										"id": "fKeArqcSSvcPk5QTp"
-									},
 									"name": "Nanobot Flier",
 									"reference": "UT36",
 									"local_notes": "Move 1; Air Move 3",
@@ -55615,11 +55545,6 @@
 								},
 								{
 									"id": "fhBVu7Z_GmGt8aT-G",
-									"source": {
-										"library": "richardwilkes/gcs_master_library",
-										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-										"id": "fyATVIBpOaRfq3tKe"
-									},
 									"name": "Nanobot Hopper",
 									"reference": "UT36",
 									"local_notes": "Move 4; Super Jump 1",
@@ -55633,11 +55558,6 @@
 								},
 								{
 									"id": "fBQNIyUSGjLwei6eG",
-									"source": {
-										"library": "richardwilkes/gcs_master_library",
-										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-										"id": "f80KO0VZYaEJb9hbs"
-									},
 									"name": "Nanobot Space",
 									"reference": "UT36",
 									"local_notes": "Move 1; 0.0001G solar sail",
@@ -55650,11 +55570,6 @@
 								},
 								{
 									"id": "fXHfogWbLem_qElvq",
-									"source": {
-										"library": "richardwilkes/gcs_master_library",
-										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-										"id": "fa36bUxm5RcsG_mOk"
-									},
 									"name": "Nanobot Swimmer",
 									"reference": "UT36",
 									"local_notes": "Water Move 1",
@@ -55667,11 +55582,6 @@
 								},
 								{
 									"id": "fMWrHkMs5QNgHQUNK",
-									"source": {
-										"library": "richardwilkes/gcs_master_library",
-										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-										"id": "fPgd1Z13foKJXxTND"
-									},
 									"name": "Nanobot Contragrav (CG) Flier",
 									"reference": "UT36",
 									"local_notes": "Move 1; Air Move 10",
@@ -55767,20 +55677,10 @@
 				},
 				{
 					"id": "FWdDxbhUqwjnajoaG",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-						"id": "F5Q7h4gAuvWsoUiFV"
-					},
 					"name": "Power Supply",
 					"children": [
 						{
 							"id": "fvigyWNSmn5qh-us_",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-								"id": "faj6YgnYeEKAy39jw"
-							},
 							"name": "Power Cells",
 							"reference": "UT36",
 							"local_notes": "Recharges in a Hive; C/12hr.",
@@ -55791,11 +55691,6 @@
 						},
 						{
 							"id": "fjZJfWkiu3l9qHvg4",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-								"id": "fCJ9sdOXfXoLN594u"
-							},
 							"name": "Power Cells",
 							"reference": "UT36",
 							"local_notes": "Recharges in a Hive; C/72hr.",
@@ -55807,11 +55702,6 @@
 						},
 						{
 							"id": "f5id_gjbX9LeqGhMj",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-								"id": "f7WMm14XwVJyvz2NQ"
-							},
 							"name": "Power Cells",
 							"reference": "UT36",
 							"local_notes": "Recharges in a Hive; C/5 days.",
@@ -55823,11 +55713,6 @@
 						},
 						{
 							"id": "flkNG2XTcybhzZfYU",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-								"id": "fGv5njL67i7rODIpL"
-							},
 							"name": "Beamed Power",
 							"reference": "UT36",
 							"local_notes": "C cell receiver",
@@ -55841,11 +55726,6 @@
 						},
 						{
 							"id": "fRbi8avhwrmJQ1TLZ",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-								"id": "fS-7nLrwLytJp5mLZ"
-							},
 							"name": "Gastrobot",
 							"reference": "UT36",
 							"local_notes": "Consumes 0.1lbs./hr. of biomass",
@@ -55859,11 +55739,6 @@
 						},
 						{
 							"id": "fwLeq-bb3fFRxDym3",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-								"id": "fhT3sMtcrOGbTzLku"
-							},
 							"name": "Radio-Thermal Generator (RTG)",
 							"reference": "UT36",
 							"local_notes": "Lasts 1 year; LC1",
@@ -55877,11 +55752,6 @@
 						},
 						{
 							"id": "fCfEBf_xi2-M4irFc",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-								"id": "faJkuSBjewuh2TdLg"
-							},
 							"name": "Solar Cell",
 							"reference": "UT36",
 							"local_notes": "Recharges 3 hours' activity in 1 hour",
@@ -55895,11 +55765,6 @@
 						},
 						{
 							"id": "fEwkqqvRBm0XvcXVP",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-								"id": "f2u0xwoaeDxGjxCRq"
-							},
 							"name": "Solar Cell",
 							"reference": "UT36",
 							"local_notes": "Recharges 4 hours' activity in 1 hour",
@@ -55913,11 +55778,6 @@
 						},
 						{
 							"id": "fZSxrgasv9cYGZJaR",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-								"id": "ff9wLL0l7uzB0IRXf"
-							},
 							"name": "Solar Cell",
 							"reference": "UT36",
 							"local_notes": "Recharges 5 hours' activity in 1 hour",
@@ -55931,11 +55791,6 @@
 						},
 						{
 							"id": "fdiTnMs0sebuB6MuQ",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-								"id": "f4SVyLNBYhfPgNZC0"
-							},
 							"name": "Organovore",
 							"reference": "UT36",
 							"local_notes": "Consumes 0.1-0.5 lbs./hr. of carbon-based matter; LC3",
@@ -55949,11 +55804,6 @@
 						},
 						{
 							"id": "fHrqYbh9G602-uFp1",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-								"id": "fi-Vh6iRVAbMGaOiO"
-							},
 							"name": "Broadcast Power",
 							"reference": "UT37",
 							"local_notes": "C cell receiver",


### PR DESCRIPTION
This adds all the TL11 loadouts from GURPS Loadouts: Starship Crew.

They're not 100% accurate to the book because:
* They erroneously think that swarmbots are weightless (they weigh 2lbs. I submitted errata).
* They treat the cost and weight of equipment as excluding power cells - I could convert them all to containers and add batteries in, but chose not to because it would be a large change to do for every item in the equipment library that has power cells.
* I'm not certain that they're always applying the cost/weight saving for combination gadgets.
* I don't remove surplus energy cells for combination gadgets.
* They use multiplicative cost modifiers and I use additive ones.

I've done combination gadgets by turning one item into a container and then adding the items its combined with inside it, then applied cost/weight modifiers as appropriate.
It does get slightly confusing that an item could be a combination gadget, have some equipment built-in, or be a container of items that could be removed, and that's all represented by equipment containers.

I haven't done the other tech levels because it's a lot of work and I'm not planning to use them in a campaign yet.

I considered add a Chemscanner and Radscanner to the Science Officer and notes for the Superscience Science Officer that the Ultrascanner replaces them because the TL11 Science Officer lacks scanners without the Superscience lens, but I think that goes a bit further than interpreting the book to the best of my ability.

Potentially, these templates could be combined with the starship crew professional templates, which would be simpler for users, but:
* This is an incomplete set of the equipment options for a professional template (it doesn't include TLs other than 11).
* This would require duplicating the Spacer Basic Kit, Computer Workhorse, Planetary Survival, Better Living Through Chemistry and Armed templates for every professional template.

This also includes:
* Remove the source library data from `@Microbot/Nanobot Type@ Swarm` - it shouldn't have any, and having some causes the checker for changes from the source library to get confused.