### PR TITLE
Ultra Tech Equipment: Fix library sync for swarmbots

### DIFF
--- a/Library/Ultra Tech/Ultra Tech Equipment.eqp
+++ b/Library/Ultra Tech/Ultra Tech Equipment.eqp
@@ -54907,11 +54907,6 @@
 		},
 		{
 			"id": "eRd4HdGkY3padXW2c",
-			"source": {
-				"library": "richardwilkes/gcs_master_library",
-				"path": "Ultra Tech/Ultra Tech Equipment.eqp",
-				"id": "eqFME0FUFNk7cR-4s"
-			},
 			"description": "@Microbot/Nanobot Type@ Swarm",
 			"reference": "UT35",
 			"tech_level": "10",
@@ -55386,11 +55381,6 @@
 							"children": [
 								{
 									"id": "fwczZZ75e0KEFyGnB",
-									"source": {
-										"library": "richardwilkes/gcs_master_library",
-										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-										"id": "f7eMKwMF7BTYFbxhq"
-									},
 									"name": "Microbot Aerostat",
 									"reference": "UT36",
 									"local_notes": "Air Move 2",
@@ -55402,11 +55392,6 @@
 								},
 								{
 									"id": "fLuSGWIZ-3ROuq7kd",
-									"source": {
-										"library": "richardwilkes/gcs_master_library",
-										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-										"id": "fcVKEB14BedQI1jGA"
-									},
 									"name": "Microbot Crawler",
 									"reference": "UT36",
 									"local_notes": "Move 3; Water Move 1",
@@ -55417,11 +55402,6 @@
 								},
 								{
 									"id": "fKG6jBFn5-WOkz0e0",
-									"source": {
-										"library": "richardwilkes/gcs_master_library",
-										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-										"id": "fScgdTYLwKE9CEYfl"
-									},
 									"name": "Microbot Crawler, Armored",
 									"reference": "UT36",
 									"local_notes": "Move 2, 2x HP",
@@ -55435,11 +55415,6 @@
 								},
 								{
 									"id": "fD8wm1mQpwRHAdDMP",
-									"source": {
-										"library": "richardwilkes/gcs_master_library",
-										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-										"id": "fpAVv9yE3m3t0Egt_"
-									},
 									"name": "Microbot Flier",
 									"reference": "UT36",
 									"local_notes": "Move 1; Air Move 6",
@@ -55453,11 +55428,6 @@
 								},
 								{
 									"id": "fgwcSbh5rWFgVtYHk",
-									"source": {
-										"library": "richardwilkes/gcs_master_library",
-										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-										"id": "ffHj2SBngzuewdrbB"
-									},
 									"name": "Microbot Hopper",
 									"reference": "UT36",
 									"local_notes": "Move 4; Super Jump 1",
@@ -55471,11 +55441,6 @@
 								},
 								{
 									"id": "fIZ4FN3qCEnJUd3pr",
-									"source": {
-										"library": "richardwilkes/gcs_master_library",
-										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-										"id": "fr6wQjKaUic-BpBCO"
-									},
 									"name": "Microbot Space",
 									"reference": "UT36",
 									"local_notes": "Move 1; 0.0001G solar sail",
@@ -55488,11 +55453,6 @@
 								},
 								{
 									"id": "fEsm73Uzg9JqD5UyP",
-									"source": {
-										"library": "richardwilkes/gcs_master_library",
-										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-										"id": "fsL5rGqz66ht8cVvg"
-									},
 									"name": "Microbot Swimmer",
 									"reference": "UT36",
 									"local_notes": "Water Move 4",
@@ -55505,11 +55465,6 @@
 								},
 								{
 									"id": "fcefbRQhOwaSTTMkM",
-									"source": {
-										"library": "richardwilkes/gcs_master_library",
-										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-										"id": "fvVo7_8gzuQpK50fc"
-									},
 									"name": "Microbot Contragrav (CG) Flier",
 									"reference": "UT36",
 									"local_notes": "Move 1; Air Move 20",
@@ -55529,11 +55484,6 @@
 							"children": [
 								{
 									"id": "fY_vQx3LPn4QYiW73",
-									"source": {
-										"library": "richardwilkes/gcs_master_library",
-										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-										"id": "f6RvvKoBN0DqIjBjQ"
-									},
 									"name": "Nanobot Aerostat",
 									"reference": "UT36",
 									"local_notes": "Air Move 1",
@@ -55545,11 +55495,6 @@
 								},
 								{
 									"id": "fiGB3LktygwvqcQzR",
-									"source": {
-										"library": "richardwilkes/gcs_master_library",
-										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-										"id": "f1OLvlafFuNITe6na"
-									},
 									"name": "Nanobot Crawler",
 									"reference": "UT36",
 									"local_notes": "Move 3; Water Move 1",
@@ -55561,11 +55506,6 @@
 								},
 								{
 									"id": "fHSAk3wZ0MEKeAnb2",
-									"source": {
-										"library": "richardwilkes/gcs_master_library",
-										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-										"id": "fASzj6iYz6hUA-TBB"
-									},
 									"name": "Nanobot Crawler, Armored",
 									"reference": "UT36",
 									"local_notes": "Move 2, 2x HP",
@@ -55579,11 +55519,6 @@
 								},
 								{
 									"id": "fDjaibB6Pi_wlxp9N",
-									"source": {
-										"library": "richardwilkes/gcs_master_library",
-										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-										"id": "fLuL-pD4o6s0lREJs"
-									},
 									"name": "Nanobot Dust",
 									"reference": "UT36",
 									"local_notes": "Immobile",
@@ -55597,11 +55532,6 @@
 								},
 								{
 									"id": "f4V1zDKdkcJ-MHp00",
-									"source": {
-										"library": "richardwilkes/gcs_master_library",
-										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-										"id": "fKeArqcSSvcPk5QTp"
-									},
 									"name": "Nanobot Flier",
 									"reference": "UT36",
 									"local_notes": "Move 1; Air Move 3",
@@ -55615,11 +55545,6 @@
 								},
 								{
 									"id": "fhBVu7Z_GmGt8aT-G",
-									"source": {
-										"library": "richardwilkes/gcs_master_library",
-										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-										"id": "fyATVIBpOaRfq3tKe"
-									},
 									"name": "Nanobot Hopper",
 									"reference": "UT36",
 									"local_notes": "Move 4; Super Jump 1",
@@ -55633,11 +55558,6 @@
 								},
 								{
 									"id": "fBQNIyUSGjLwei6eG",
-									"source": {
-										"library": "richardwilkes/gcs_master_library",
-										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-										"id": "f80KO0VZYaEJb9hbs"
-									},
 									"name": "Nanobot Space",
 									"reference": "UT36",
 									"local_notes": "Move 1; 0.0001G solar sail",
@@ -55650,11 +55570,6 @@
 								},
 								{
 									"id": "fXHfogWbLem_qElvq",
-									"source": {
-										"library": "richardwilkes/gcs_master_library",
-										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-										"id": "fa36bUxm5RcsG_mOk"
-									},
 									"name": "Nanobot Swimmer",
 									"reference": "UT36",
 									"local_notes": "Water Move 1",
@@ -55667,11 +55582,6 @@
 								},
 								{
 									"id": "fMWrHkMs5QNgHQUNK",
-									"source": {
-										"library": "richardwilkes/gcs_master_library",
-										"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-										"id": "fPgd1Z13foKJXxTND"
-									},
 									"name": "Nanobot Contragrav (CG) Flier",
 									"reference": "UT36",
 									"local_notes": "Move 1; Air Move 10",
@@ -55767,20 +55677,10 @@
 				},
 				{
 					"id": "FWdDxbhUqwjnajoaG",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-						"id": "F5Q7h4gAuvWsoUiFV"
-					},
 					"name": "Power Supply",
 					"children": [
 						{
 							"id": "fvigyWNSmn5qh-us_",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-								"id": "faj6YgnYeEKAy39jw"
-							},
 							"name": "Power Cells",
 							"reference": "UT36",
 							"local_notes": "Recharges in a Hive; C/12hr.",
@@ -55791,11 +55691,6 @@
 						},
 						{
 							"id": "fjZJfWkiu3l9qHvg4",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-								"id": "fCJ9sdOXfXoLN594u"
-							},
 							"name": "Power Cells",
 							"reference": "UT36",
 							"local_notes": "Recharges in a Hive; C/72hr.",
@@ -55807,11 +55702,6 @@
 						},
 						{
 							"id": "f5id_gjbX9LeqGhMj",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-								"id": "f7WMm14XwVJyvz2NQ"
-							},
 							"name": "Power Cells",
 							"reference": "UT36",
 							"local_notes": "Recharges in a Hive; C/5 days.",
@@ -55823,11 +55713,6 @@
 						},
 						{
 							"id": "flkNG2XTcybhzZfYU",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-								"id": "fGv5njL67i7rODIpL"
-							},
 							"name": "Beamed Power",
 							"reference": "UT36",
 							"local_notes": "C cell receiver",
@@ -55841,11 +55726,6 @@
 						},
 						{
 							"id": "fRbi8avhwrmJQ1TLZ",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-								"id": "fS-7nLrwLytJp5mLZ"
-							},
 							"name": "Gastrobot",
 							"reference": "UT36",
 							"local_notes": "Consumes 0.1lbs./hr. of biomass",
@@ -55859,11 +55739,6 @@
 						},
 						{
 							"id": "fwLeq-bb3fFRxDym3",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-								"id": "fhT3sMtcrOGbTzLku"
-							},
 							"name": "Radio-Thermal Generator (RTG)",
 							"reference": "UT36",
 							"local_notes": "Lasts 1 year; LC1",
@@ -55877,11 +55752,6 @@
 						},
 						{
 							"id": "fCfEBf_xi2-M4irFc",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-								"id": "faJkuSBjewuh2TdLg"
-							},
 							"name": "Solar Cell",
 							"reference": "UT36",
 							"local_notes": "Recharges 3 hours' activity in 1 hour",
@@ -55895,11 +55765,6 @@
 						},
 						{
 							"id": "fEwkqqvRBm0XvcXVP",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-								"id": "f2u0xwoaeDxGjxCRq"
-							},
 							"name": "Solar Cell",
 							"reference": "UT36",
 							"local_notes": "Recharges 4 hours' activity in 1 hour",
@@ -55913,11 +55778,6 @@
 						},
 						{
 							"id": "fZSxrgasv9cYGZJaR",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-								"id": "ff9wLL0l7uzB0IRXf"
-							},
 							"name": "Solar Cell",
 							"reference": "UT36",
 							"local_notes": "Recharges 5 hours' activity in 1 hour",
@@ -55931,11 +55791,6 @@
 						},
 						{
 							"id": "fdiTnMs0sebuB6MuQ",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-								"id": "f4SVyLNBYhfPgNZC0"
-							},
 							"name": "Organovore",
 							"reference": "UT36",
 							"local_notes": "Consumes 0.1-0.5 lbs./hr. of carbon-based matter; LC3",
@@ -55949,11 +55804,6 @@
 						},
 						{
 							"id": "fHrqYbh9G602-uFp1",
-							"source": {
-								"library": "richardwilkes/gcs_master_library",
-								"path": "Ultra Tech/Ultra Tech Equipment Modifiers.eqm",
-								"id": "fi-Vh6iRVAbMGaOiO"
-							},
 							"name": "Broadcast Power",
 							"reference": "UT37",
 							"local_notes": "C cell receiver",


### PR DESCRIPTION
Somehow, the swarmbots ended up with source library information saying it came from a nonexistent item in the Ultra Tech Equipment library.

Because of this,  it would always treat swarmbots as being out of sync with the source library.