### PR TITLE
Add Bio-Tech Meta-Traits

### DIFF
--- a/Library/Basic Set/Basic Set Enhancement Modifiers.adm
+++ b/Library/Basic Set/Basic Set Enhancement Modifiers.adm
@@ -273,9 +273,16 @@
 		},
 		{
 			"id": "mcXN1MCeZnZB4Jz2e",
-			"name": "Follow-Up",
+			"name": "Follow-Up (@Carrier Attack@)",
 			"reference": "B105,P102",
-			"local_notes": "Cost is variable and must be entered manually"
+			"local_notes": "1 point per level",
+			"cost": 1,
+			"levels": 1
+		},
+		{
+			"id": "m1nJdcOiKLxg7pXwe",
+			"name": "Follow-Up (@Carrier Attack@)",
+			"reference": "B105,P102"
 		},
 		{
 			"id": "mwT-SCDV2GwvCcnJ6",
@@ -537,9 +544,11 @@
 		},
 		{
 			"id": "msnycFZUVspQ77fd7",
-			"name": "Side Effect",
+			"name": "Side Effect (@Side Effect Affliction@)",
 			"reference": "B109,P106",
-			"cost": 50
+			"local_notes": "Set level to 50, plus 1 per percentage point of Affliction enhancements included (Stunning is the default, at +0%)",
+			"cost": 1,
+			"levels": 50
 		},
 		{
 			"id": "mzUmNTI_isgbeOkEY",
@@ -549,9 +558,10 @@
 		},
 		{
 			"id": "md0iavn_lCSnS1Xkf",
-			"name": "Symptoms",
+			"name": "Symptoms (@HP Threshold and Effect@)",
 			"reference": "B109",
-			"local_notes": "Cost must be manually entered"
+			"local_notes": "1 point per level",
+			"cost": 1
 		},
 		{
 			"id": "mdFYMCDPzqbAuFeAd",

--- a/Library/Basic Set/Basic Set Limitation Modifiers.adm
+++ b/Library/Basic Set/Basic Set Limitation Modifiers.adm
@@ -3,9 +3,10 @@
 	"rows": [
 		{
 			"id": "m2IwCpU9KwYmjiSSA",
-			"name": "Accessibility",
+			"name": "Accessibility (@Condition@)",
 			"reference": "B110,P99",
-			"local_notes": "Must enter cost manually"
+			"local_notes": "1 point per level",
+			"cost": -1
 		},
 		{
 			"id": "mjuUqIZoOHqvugUN1",
@@ -159,6 +160,14 @@
 			"reference": "B112,P102",
 			"local_notes": "+1/level to Recoil",
 			"cost": -10,
+			"levels": 1
+		},
+		{
+			"id": "mHGpYfPpTxJ8KT7J_",
+			"name": "Follow-Up (@Carrier Attack@)",
+			"reference": "B105,P102",
+			"local_notes": "-1 point per level",
+			"cost": -1,
 			"levels": 1
 		},
 		{
@@ -566,6 +575,13 @@
 			"cost": -20
 		},
 		{
+			"id": "mkm-2zZQLCio_8RYl",
+			"name": "No Incendiary Effect",
+			"reference": "B105",
+			"reference_highlight": "Incendiary (inc)",
+			"cost": -10
+		},
+		{
 			"id": "mE-U_o2GcTPUA8Zsd",
 			"name": "No Knockback (nkb)",
 			"reference": "B111",
@@ -704,7 +720,7 @@
 		},
 		{
 			"id": "mwOn3HOcXabGaSQBP",
-			"name": "Sense-Based (@senses)",
+			"name": "Sense-Based (@senses@)",
 			"reference": "B115",
 			"local_notes": "Manually add -5% for each sense beyond the first",
 			"cost": -20
@@ -739,9 +755,10 @@
 		},
 		{
 			"id": "mdoMyuuoZBbQiTi3L",
-			"name": "Temporary Disadvantage",
+			"name": "Temporary Disadvantage (@Temporary Disadvantage@)",
 			"reference": "B115,P106",
-			"local_notes": "Cost must be entered manually"
+			"local_notes": "1 point per level",
+			"cost": -1
 		},
 		{
 			"id": "mQjsgnm-42rgt94Au",

--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -19599,8 +19599,9 @@
 		},
 		{
 			"id": "t7a13kFVl53ZfbkrK",
-			"name": "Payload (@Load@)",
+			"name": "Payload",
 			"reference": "B74",
+			"local_notes": "\u003cscript\u003e\niff(entity.exists,\n  measure.formatWeight(\n    self.levels * entity.encumbrance().basicLift / 10,\n    entity.displayWeightUnits,\n  ),\n  \"Payload will be calculated when added to a character sheet\")\n\u003c/script\u003e",
 			"tags": [
 				"Advantage",
 				"Exotic",
@@ -19619,7 +19620,8 @@
 			"can_level": true,
 			"levels": 1,
 			"calc": {
-				"points": 1
+				"points": 1,
+				"resolved_notes": "Payload will be calculated when added to a character sheet"
 			}
 		},
 		{

--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -24923,6 +24923,20 @@
 			}
 		},
 		{
+			"id": "tpuWKQ-QR0MKnmxCx",
+			"name": "Taboo Trait (@Trait@)",
+			"reference": "B261",
+			"tags": [
+				"Exotic",
+				"Mental",
+				"Physical",
+				"Taboo Trait"
+			],
+			"calc": {
+				"points": 0
+			}
+		},
+		{
 			"id": "tX9xOWAhCw2TPxJy-",
 			"name": "Talent (@Large@)",
 			"reference": "B89",

--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -7445,6 +7445,100 @@
 			}
 		},
 		{
+			"id": "tOWDg9Tm1ImEUemm8",
+			"name": "Modified Arm",
+			"reference": "B53",
+			"reference_highlight": "Modifying Beings With One or Two Arms",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Physical"
+			],
+			"modifiers": [
+				{
+					"id": "mHw1wsjYwtMYNyOuF",
+					"name": "Extra-Flexible",
+					"reference": "B53",
+					"cost": 5,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "mFw8g3xqq5lg6yxJ7",
+					"name": "Long",
+					"reference": "B53",
+					"cost": 10,
+					"cost_type": "points",
+					"levels": 1,
+					"disabled": true
+				},
+				{
+					"id": "mNnSH8gNmqaUwcdgZ",
+					"name": "Foot Manipulators",
+					"reference": "B53",
+					"cost": -3,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "mXs56UKXB1DL_YbWR",
+					"name": "No Physical Attack",
+					"reference": "B53",
+					"cost": -5,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "mXIk3JnIZvBiuWvFz",
+					"name": "Short",
+					"reference": "B53",
+					"cost": -5,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "m68jB2d_ss3TH4AjE",
+					"name": "Weak",
+					"reference": "B53",
+					"local_notes": "Half body ST",
+					"cost": -2.5,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "mwBDY5stCI5SSvJWC",
+					"name": "Weak",
+					"reference": "B53",
+					"local_notes": "Quarter body ST",
+					"cost": -5,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "m4U3LyoOGDAatD48m",
+					"name": "Weapon Mount",
+					"reference": "B53",
+					"cost": -8,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "mOFX_YWRyU1jGmPc3",
+					"name": "No Grasping Hand",
+					"reference": "MATG28",
+					"cost": -4,
+					"cost_type": "points",
+					"disabled": true
+				}
+			],
+			"points_per_level": 10,
+			"can_level": true,
+			"levels": 1,
+			"calc": {
+				"points": 10
+			}
+		},
+		{
 			"id": "tnoTxbCUvvok5k1Ep",
 			"name": "Extra Attack",
 			"reference": "B53,P49,MA44",
@@ -7642,6 +7736,55 @@
 					"name": "Prehensile Feet",
 					"reference": "MATG28",
 					"cost": 20,
+					"disabled": true
+				}
+			],
+			"calc": {
+				"points": 0
+			}
+		},
+		{
+			"id": "tKQss2MjGVWvj-RaR",
+			"name": "Modified Legs",
+			"reference": "B54",
+			"reference_highlight": "Modifying Beings With Two Legs",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Physical"
+			],
+			"modifiers": [
+				{
+					"id": "mei7A4OuucTdQDJ9P",
+					"name": "Long",
+					"reference": "B55",
+					"cost": 10,
+					"cost_type": "points",
+					"levels": 1,
+					"disabled": true
+				},
+				{
+					"id": "mdR4F1BB8UdVE8UYL",
+					"name": "Cannot Kick",
+					"reference": "B55",
+					"cost": -5,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "mzY7ZT_U9dNSwpTyL",
+					"name": "Extra Flexible",
+					"reference": "MATG27",
+					"cost": 5,
+					"cost_type": "points",
+					"disabled": true
+				},
+				{
+					"id": "mvFMLYK-MyKoQpTJz",
+					"name": "Prehensile Feet",
+					"reference": "MATG28",
+					"cost": 2,
+					"cost_type": "points",
 					"disabled": true
 				}
 			],

--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -5459,6 +5459,29 @@
 			}
 		},
 		{
+			"id": "t9JmDbmYS-RXMN3vt",
+			"name": "Decreased Size Modifier",
+			"reference": "B19",
+			"tags": [
+				"Attribute",
+				"Disadvantage",
+				"Physical"
+			],
+			"features": [
+				{
+					"type": "attribute_bonus",
+					"attribute": "sm",
+					"amount": -1,
+					"per_level": true
+				}
+			],
+			"can_level": true,
+			"levels": 1,
+			"calc": {
+				"points": 0
+			}
+		},
+		{
 			"id": "thI3hK3riuknUwkHF",
 			"name": "Decreased Strength",
 			"reference": "B14",
@@ -10887,6 +10910,29 @@
 			"levels": 1,
 			"calc": {
 				"points": 5
+			}
+		},
+		{
+			"id": "tGpcVbjudWqlXl_xf",
+			"name": "Increased Size Modifier",
+			"reference": "B19",
+			"tags": [
+				"Advantage",
+				"Attribute",
+				"Physical"
+			],
+			"features": [
+				{
+					"type": "attribute_bonus",
+					"attribute": "sm",
+					"amount": 1,
+					"per_level": true
+				}
+			],
+			"can_level": true,
+			"levels": 1,
+			"calc": {
+				"points": 0
 			}
 		},
 		{

--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -557,11 +557,29 @@
 							"disabled": true
 						},
 						{
+							"id": "mnGKJ1gbj6Khm2yb1",
+							"name": "Secondary DX Penalty",
+							"reference": "B36",
+							"local_notes": "Gives -1 to DX per level",
+							"cost": 2,
+							"levels": 1,
+							"disabled": true
+						},
+						{
 							"id": "mGrt_MCkCqYWQsYmf",
 							"name": "HT Penalty",
 							"reference": "B36",
 							"local_notes": "Gives -1 to HT per level",
 							"cost": 5,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "m2GIk38ucceSfU8S6",
+							"name": "Secondary HT Penalty",
+							"reference": "B36",
+							"local_notes": "Gives -1 to HT per level",
+							"cost": 1,
 							"levels": 1,
 							"disabled": true
 						},
@@ -575,11 +593,29 @@
 							"disabled": true
 						},
 						{
+							"id": "mdFcNIPFScETgxCp2",
+							"name": "Secondary IQ Penalty",
+							"reference": "B36",
+							"local_notes": "Gives -1 to IQ per level",
+							"cost": 2,
+							"levels": 1,
+							"disabled": true
+						},
+						{
 							"id": "mRujRofkSR0Qz_6t4",
 							"name": "ST Penalty",
 							"reference": "B36",
 							"local_notes": "Gives -1 to ST per level",
 							"cost": 5,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mD6JfBoVaDwPtaomG",
+							"name": "Secondary ST Penalty",
+							"reference": "B36",
+							"local_notes": "Gives -1 to ST per level",
+							"cost": 1,
 							"levels": 1,
 							"disabled": true
 						}
@@ -613,10 +649,25 @@
 							"disabled": true
 						},
 						{
+							"id": "mYkhH9WMtDvhB6_fo",
+							"name": "Secondary Agony",
+							"reference": "B428",
+							"local_notes": "Lose 1 FP per minute",
+							"cost": 20,
+							"disabled": true
+						},
+						{
 							"id": "mvWxR84PRSUHvkj7J",
 							"name": "Choking",
 							"reference": "B428",
 							"cost": 100,
+							"disabled": true
+						},
+						{
+							"id": "mXyf5Hlv0RPlEkNpg",
+							"name": "Secondary Choking",
+							"reference": "B428",
+							"cost": 20,
 							"disabled": true
 						},
 						{
@@ -627,10 +678,24 @@
 							"disabled": true
 						},
 						{
+							"id": "mPh9x7aqRRZAhlGJq",
+							"name": "Secondary Daze",
+							"reference": "B428",
+							"cost": 10,
+							"disabled": true
+						},
+						{
 							"id": "mrHOK9XTtfJtmZSWi",
 							"name": "Ecstasy",
 							"reference": "B428",
 							"cost": 100,
+							"disabled": true
+						},
+						{
+							"id": "m2xxR4H2k3uRvNK_u",
+							"name": "Secondary Ecstasy",
+							"reference": "B428",
+							"cost": 20,
 							"disabled": true
 						},
 						{
@@ -641,6 +706,13 @@
 							"disabled": true
 						},
 						{
+							"id": "mEnMcsbBq11OS7xkp",
+							"name": "Secondary Hallucination",
+							"reference": "B429",
+							"cost": 10,
+							"disabled": true
+						},
+						{
 							"id": "m_lRu3tKLDJvYSDuA",
 							"name": "Paralysis",
 							"reference": "B429",
@@ -648,10 +720,24 @@
 							"disabled": true
 						},
 						{
+							"id": "md2YoQV3QZfeSZTVI",
+							"name": "Secondary Paralysis",
+							"reference": "B429",
+							"cost": 30,
+							"disabled": true
+						},
+						{
 							"id": "mtLSXY1DP5TNVy47j",
 							"name": "Retching",
 							"reference": "B429",
 							"cost": 50,
+							"disabled": true
+						},
+						{
+							"id": "mteCJ6o6Dmz46epJl",
+							"name": "Secondary Retching",
+							"reference": "B429",
+							"cost": 10,
 							"disabled": true
 						},
 						{
@@ -663,9 +749,23 @@
 							"disabled": true
 						},
 						{
+							"id": "m3tSJQPlZLnd5H8be",
+							"name": "Secondary Seizure",
+							"reference": "B429",
+							"local_notes": "Lose 1d FP at the end of the seizure",
+							"cost": 20,
+							"disabled": true
+						},
+						{
 							"id": "mRzsyEijx7EOZNmFk",
 							"name": "Sleep",
 							"cost": 150,
+							"disabled": true
+						},
+						{
+							"id": "miCyY8lVQMmZDOcx4",
+							"name": "Secondary Sleep",
+							"cost": 30,
 							"disabled": true
 						},
 						{
@@ -673,6 +773,13 @@
 							"name": "Unconsciousness",
 							"reference": "B429",
 							"cost": 200,
+							"disabled": true
+						},
+						{
+							"id": "m92wct_niZWgHViHK",
+							"name": "Secondary Unconsciousness",
+							"reference": "B429",
+							"cost": 40,
 							"disabled": true
 						}
 					]
@@ -691,11 +798,27 @@
 							"disabled": true
 						},
 						{
+							"id": "mafwitAwhQOQZ4QOL",
+							"name": "Secondary Coughing",
+							"reference": "B428",
+							"local_notes": "Gives -3 to DX and -1 to IQ and cannot use Stealth",
+							"cost": 4,
+							"disabled": true
+						},
+						{
 							"id": "mLSxY7lwOpk_Bq-ln",
 							"name": "Drunk",
 							"reference": "B428",
 							"local_notes": "Gives -2 to DX and IQ; -4 to self-control rolls except those to resist Cowardice",
 							"cost": 20,
+							"disabled": true
+						},
+						{
+							"id": "mVJKm5R98VlW71Zkz",
+							"name": "Secondary Drunk",
+							"reference": "B428",
+							"local_notes": "Gives -2 to DX and IQ; -4 to self-control rolls except those to resist Cowardice",
+							"cost": 4,
 							"disabled": true
 						},
 						{
@@ -707,11 +830,27 @@
 							"disabled": true
 						},
 						{
+							"id": "m7tOgc12hHN9-vI4Y",
+							"name": "Secondary Euphoria",
+							"reference": "B428",
+							"local_notes": "Gives -3 to all DX, IQ, skill and self-control rolls",
+							"cost": 6,
+							"disabled": true
+						},
+						{
 							"id": "mBlcOZ2js5HaazxmR",
 							"name": "Moderate Pain",
 							"reference": "B428",
 							"local_notes": "-2 to all DX, IQ, skill and self-control rolls",
 							"cost": 20,
+							"disabled": true
+						},
+						{
+							"id": "mgNrj60xi2iRGkCQD",
+							"name": "Secondary Moderate Pain",
+							"reference": "B428",
+							"local_notes": "-2 to all DX, IQ, skill and self-control rolls",
+							"cost": 4,
 							"disabled": true
 						},
 						{
@@ -723,11 +862,27 @@
 							"disabled": true
 						},
 						{
+							"id": "mIO_hO693Q4KcqFNi",
+							"name": "Secondary Nauseated",
+							"reference": "B428",
+							"local_notes": "-2 to all attribute and skill rolls; -1 to active defenses",
+							"cost": 6,
+							"disabled": true
+						},
+						{
 							"id": "mVriOY0uj42ljk1DZ",
 							"name": "Severe Pain",
 							"reference": "B428",
 							"local_notes": "-4 to all DX, IQ, skill and self-control rolls",
 							"cost": 40,
+							"disabled": true
+						},
+						{
+							"id": "m86St6wM9wu90JDY2",
+							"name": "Secondary Severe Pain",
+							"reference": "B428",
+							"local_notes": "-4 to all DX, IQ, skill and self-control rolls",
+							"cost": 8,
 							"disabled": true
 						},
 						{
@@ -739,11 +894,27 @@
 							"disabled": true
 						},
 						{
+							"id": "mSlHrX9HNeS0rupjU",
+							"name": "Secondary Terrible Pain",
+							"reference": "B428",
+							"local_notes": "-6 to all DX, IQ, skill and self-control rolls",
+							"cost": 12,
+							"disabled": true
+						},
+						{
 							"id": "men3HN0kwXa7TCjU3",
 							"name": "Tipsy",
 							"reference": "B428",
 							"local_notes": "-1 to DX and IQ, -2 to self-control rolls except those to resist Cowardice",
 							"cost": 10,
+							"disabled": true
+						},
+						{
+							"id": "mvbMiqvw8H0Cuz9Vb",
+							"name": "Secondary Tipsy",
+							"reference": "B428",
+							"local_notes": "-1 to DX and IQ, -2 to self-control rolls except those to resist Cowardice",
+							"cost": 2,
 							"disabled": true
 						}
 					]
@@ -760,10 +931,24 @@
 							"disabled": true
 						},
 						{
+							"id": "mAn_DCyTZVYgrOlX1",
+							"name": "Secondary Coma",
+							"reference": "B429",
+							"cost": 50,
+							"disabled": true
+						},
+						{
 							"id": "muwxonMDXdErnB7yT",
 							"name": "Heart Attack",
 							"reference": "B429",
 							"cost": 300,
+							"disabled": true
+						},
+						{
+							"id": "mc6VL3webpenS-wT5",
+							"name": "Secondary Heart Attack",
+							"reference": "B429",
+							"cost": 60,
 							"disabled": true
 						}
 					]
@@ -773,6 +958,13 @@
 					"name": "Stunning",
 					"reference": "B36",
 					"cost": 10,
+					"disabled": true
+				},
+				{
+					"id": "mSuXI8hZTDNF9Sl2p",
+					"name": "Secondary Stunning",
+					"reference": "B36",
+					"cost": 2,
 					"disabled": true
 				},
 				{
@@ -789,6 +981,15 @@
 							"disabled": true
 						},
 						{
+							"id": "mjiP4JePPWOsWbRHW",
+							"name": "Secondary Gives @Advantage@",
+							"reference": "B36",
+							"local_notes": "1 point per level",
+							"cost": 2,
+							"levels": 1,
+							"disabled": true
+						},
+						{
 							"id": "mUTYb66pr3d4JJhy_",
 							"name": "Gives @Disadvantage@",
 							"reference": "B36",
@@ -798,10 +999,28 @@
 							"disabled": true
 						},
 						{
+							"id": "mMMzzxYMQAzbyFA76",
+							"name": "Secondary Gives @Disadvantage@",
+							"reference": "B36",
+							"local_notes": "5 points per level",
+							"cost": 1,
+							"levels": 1,
+							"disabled": true
+						},
+						{
 							"id": "mtfm9VeVSnQ6cYsCt",
 							"name": "Negates @Advantage@",
 							"reference": "B36",
 							"local_notes": "1 point per level",
+							"cost": 1,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mPG5yXUT5pghj9GBx",
+							"name": "Secondary Negates @Advantage@",
+							"reference": "B36",
+							"local_notes": "5 points per level",
 							"cost": 1,
 							"levels": 1,
 							"disabled": true
@@ -4498,6 +4717,22 @@
 						}
 					],
 					"disabled": true
+				},
+				{
+					"id": "m8DkcwceXBb_EhAxw",
+					"name": "Long",
+					"reference": "B88",
+					"cost": 100,
+					"levels": 1,
+					"disabled": true
+				},
+				{
+					"id": "mvP7NlXUddPBQpKZj",
+					"name": "Long, max reach only",
+					"reference": "B88",
+					"cost": 75,
+					"levels": 1,
+					"disabled": true
 				}
 			],
 			"base_points": 5,
@@ -4656,6 +4891,7 @@
 				{
 					"id": "mp9T_OqdzlIPOwCPK",
 					"name": "Weak",
+					"reference": "B88",
 					"cost": -50,
 					"features": [
 						{
@@ -4671,6 +4907,22 @@
 							"per_die": true
 						}
 					],
+					"disabled": true
+				},
+				{
+					"id": "mDh5dATnburPDmvnI",
+					"name": "Long",
+					"reference": "B88",
+					"cost": 100,
+					"levels": 1,
+					"disabled": true
+				},
+				{
+					"id": "mWhsyyIGVCReBytan",
+					"name": "Long, max reach only",
+					"reference": "B88",
+					"cost": 75,
+					"levels": 1,
 					"disabled": true
 				}
 			],
@@ -7132,14 +7384,9 @@
 			"points_per_level": 5,
 			"features": [
 				{
-					"type": "weapon_parry_bonus",
-					"selection_type": "weapons_with_required_skill",
-					"name": {
-						"compare": "is",
-						"qualifier": "@Melee weapon skill@"
-					},
-					"amount": 1,
-					"leveled": true
+					"type": "conditional_modifier",
+					"situation": "to Parry with @Melee weapon skill@",
+					"amount": 1
 				}
 			],
 			"can_level": true,
@@ -7182,21 +7429,9 @@
 			"points_per_level": 5,
 			"features": [
 				{
-					"type": "weapon_parry_bonus",
-					"selection_type": "weapons_with_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "Natural Attacks"
-					},
-					"specialization": {
-						"compare": "is",
-						"qualifier": "Punch"
-					},
-					"level": {
-						"compare": "at_least"
-					},
-					"amount": 1,
-					"leveled": true
+					"type": "conditional_modifier",
+					"situation": "to Parry with bare hands",
+					"amount": 1
 				}
 			],
 			"can_level": true,
@@ -10235,6 +10470,7 @@
 				{
 					"id": "mH7V_TlNnG58l4vx3",
 					"name": "Weak",
+					"reference": "B88",
 					"cost": -50,
 					"features": [
 						{
@@ -10250,6 +10486,22 @@
 							"per_die": true
 						}
 					],
+					"disabled": true
+				},
+				{
+					"id": "mOEGVYfSJ0K0ZBzCT",
+					"name": "Long",
+					"reference": "B88",
+					"cost": 100,
+					"levels": 1,
+					"disabled": true
+				},
+				{
+					"id": "mhQmNYZ4w33UA8OeY",
+					"name": "Long, max reach only",
+					"reference": "B88",
+					"cost": 75,
+					"levels": 1,
 					"disabled": true
 				}
 			],
@@ -14618,6 +14870,7 @@
 				{
 					"id": "m6QYwddKRT6tIEaTY",
 					"name": "Weak",
+					"reference": "B88",
 					"cost": -50,
 					"features": [
 						{
@@ -14633,6 +14886,22 @@
 							"per_die": true
 						}
 					],
+					"disabled": true
+				},
+				{
+					"id": "mcg0LAF7zuAowSQ1u",
+					"name": "Long",
+					"reference": "B88",
+					"cost": 100,
+					"levels": 1,
+					"disabled": true
+				},
+				{
+					"id": "mgMXh5RrHI4jyoBAC",
+					"name": "Long, max reach only",
+					"reference": "B88",
+					"cost": 75,
+					"levels": 1,
 					"disabled": true
 				}
 			],
@@ -19686,6 +19955,7 @@
 				{
 					"id": "mAkX7u-NZi0jADrUG",
 					"name": "Weak",
+					"reference": "B88",
 					"cost": -50,
 					"features": [
 						{
@@ -19701,6 +19971,22 @@
 							"per_die": true
 						}
 					],
+					"disabled": true
+				},
+				{
+					"id": "m9_L_8l4mf-zx5hRx",
+					"name": "Long",
+					"reference": "B88",
+					"cost": 100,
+					"levels": 1,
+					"disabled": true
+				},
+				{
+					"id": "mPD1PmHfr0XcgGKSJ",
+					"name": "Long, max reach only",
+					"reference": "B88",
+					"cost": 75,
+					"levels": 1,
 					"disabled": true
 				}
 			],

--- a/Library/Bio-Tech/Bio-Tech Traits.adq
+++ b/Library/Bio-Tech/Bio-Tech Traits.adq
@@ -2,6 +2,4755 @@
 	"version": 5,
 	"rows": [
 		{
+			"id": "T1JFY5XO6M37RQe0U",
+			"name": "Bioelectric Organ",
+			"reference": "BT45",
+			"local_notes": "TL11",
+			"container_type": "meta_trait",
+			"children": [
+				{
+					"id": "tRWzzvLhqykh7xKrb",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tuvstBu3EtRU0qAa9"
+					},
+					"name": "Innate Attack (Burn)",
+					"reference": "B61,P53,MA45",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"replacements": {
+						"Attack Type": "Attack Type",
+						"Side Effect Affliction": "Stunning"
+					},
+					"modifiers": [
+						{
+							"id": "mk22av6zzSK7cqeTX",
+							"name": "Cyclic",
+							"reference": "B103",
+							"local_notes": "1 sec",
+							"cost": 100,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "m7UWzzpB1Y36OItrS",
+							"name": "Cyclic",
+							"reference": "B103",
+							"local_notes": "10 sec",
+							"cost": 50,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mDle0ELZh28Z3BQoi",
+							"name": "Cyclic",
+							"reference": "B103",
+							"local_notes": "1 min",
+							"cost": 40,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mKAQjJ0XYH0pvqoOD",
+							"name": "Cyclic",
+							"reference": "B103",
+							"local_notes": "1 hr",
+							"cost": 20,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mZRupROQchjSF0LYR",
+							"name": "Cyclic",
+							"reference": "B103",
+							"local_notes": "1 day",
+							"cost": 10,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mq1bRm33dzY3IgjWF",
+							"name": "Cyclic",
+							"reference": "B103",
+							"local_notes": "1 sec; Resistible",
+							"cost": 50,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mCaVft_yg6lDzZJo4",
+							"name": "Cyclic",
+							"reference": "B103",
+							"local_notes": "10 sec; Resistible",
+							"cost": 25,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mvAl8xdezZQFsOmJS",
+							"name": "Cyclic",
+							"reference": "B103",
+							"local_notes": "1 min; Resistible",
+							"cost": 20,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "malmXWC9minTtMmhn",
+							"name": "Cyclic",
+							"reference": "B103",
+							"local_notes": "1 hr; Resistible",
+							"cost": 10,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mOPNbDoyrEUmtV5Od",
+							"name": "Cyclic",
+							"reference": "B103",
+							"local_notes": "1 day; Resistible",
+							"cost": 5,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mWi-OuzIdJN6Ja_SD",
+							"name": "Contagious",
+							"reference": "B103",
+							"local_notes": "Mildly",
+							"cost": 20,
+							"disabled": true
+						},
+						{
+							"id": "m71KnZ7dCZ1fEbXVL",
+							"name": "Contagious",
+							"reference": "B103",
+							"local_notes": "Highly",
+							"cost": 50,
+							"disabled": true
+						},
+						{
+							"id": "mv8R_A1rOM51sfQkF",
+							"name": "Double Blunt Trauma",
+							"reference": "B104",
+							"local_notes": "1HP per 10 dmg",
+							"cost": 20,
+							"disabled": true
+						},
+						{
+							"id": "mCwCiel4gP_9T52Qu",
+							"name": "Explosion",
+							"reference": "B104",
+							"cost": 50,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mGDGIzt7FtlMmG3oX",
+							"name": "Fragmentation",
+							"reference": "B104",
+							"cost": 15,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mezDMZ0uuOK_XKi_1",
+							"name": "Fragmentation",
+							"reference": "B104",
+							"local_notes": "Hot",
+							"cost": 15,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mBsmwWTFj3PZZDUhi",
+							"name": "Radiation",
+							"reference": "B104",
+							"cost": 100,
+							"disabled": true
+						},
+						{
+							"id": "mrjAfQ7I7wpyNjp_o",
+							"name": "Surge",
+							"reference": "B104",
+							"cost": 20,
+							"disabled": true
+						},
+						{
+							"id": "mnQP1KB4BZAQscYd9",
+							"name": "Armor Divisor",
+							"reference": "B102",
+							"local_notes": "2",
+							"cost": 50,
+							"disabled": true
+						},
+						{
+							"id": "mkpWPHpMJXSDbyXZo",
+							"name": "Armor Divisor",
+							"reference": "B102",
+							"local_notes": "3",
+							"cost": 100,
+							"disabled": true
+						},
+						{
+							"id": "mFlnQh_zjUxkW7RiJ",
+							"name": "Armor Divisor",
+							"reference": "B102",
+							"local_notes": "5",
+							"cost": 150,
+							"disabled": true
+						},
+						{
+							"id": "mvjas9KT2ybwmTet8",
+							"name": "Armor Divisor",
+							"reference": "B102",
+							"local_notes": "10",
+							"cost": 200,
+							"disabled": true
+						},
+						{
+							"id": "m5Nc7a5RW1kksldbH",
+							"name": "Side Effect",
+							"reference": "B109",
+							"local_notes": "@Effect@",
+							"disabled": true
+						},
+						{
+							"id": "mlaxpATYe90RULgj4",
+							"name": "Symptoms",
+							"reference": "B109",
+							"local_notes": "@Effect@",
+							"disabled": true
+						},
+						{
+							"id": "mBSshvi1pn8T_90S3",
+							"name": "Armor Divisor",
+							"reference": "B110",
+							"local_notes": "0.5",
+							"cost": -30,
+							"disabled": true
+						},
+						{
+							"id": "m5z71JCmiKXoYZ2xg",
+							"name": "Armor Divisor",
+							"reference": "B110",
+							"local_notes": "0.2",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "mevtrrFHuSLq_HIKS",
+							"name": "Armor Divisor",
+							"reference": "B110",
+							"local_notes": "0.1",
+							"cost": -70,
+							"disabled": true
+						},
+						{
+							"id": "mhagGv12K3B52taLb",
+							"name": "No Wounding",
+							"reference": "B111",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "mXDt3CFaTc7GpKTXu",
+							"name": "Surge, Arcing",
+							"reference": "PSI20",
+							"cost": 100,
+							"disabled": true
+						},
+						{
+							"id": "mxhwF4qM0FnkBs_0u",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+								"id": "mVtDQj3J1f5GAAQ-J"
+							},
+							"name": "Melee Attack",
+							"reference": "B112,P103",
+							"local_notes": "Reach C",
+							"cost": -30
+						},
+						{
+							"id": "m7ujnz43Nsjm_wLVk",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+								"id": "mkm-2zZQLCio_8RYl"
+							},
+							"name": "No Incendiary Effect",
+							"reference": "B105",
+							"reference_highlight": "Incenciarry (inc)",
+							"cost": -10
+						},
+						{
+							"id": "ms8P3_9_wus4h1jf_",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+								"id": "msnycFZUVspQ77fd7"
+							},
+							"name": "Side Effect (@Side Effect Affliction@)",
+							"reference": "B109,P106",
+							"local_notes": "Set level to 50, plus 1 per percentage point of Affliction enhancements included (Stunning is the default, at +0%)",
+							"cost": 1,
+							"levels": 50
+						},
+						{
+							"id": "mSqneaBvPDSeV094v",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+								"id": "mzUmNTI_isgbeOkEY"
+							},
+							"name": "Surge (sur)",
+							"reference": "B105",
+							"cost": 20
+						},
+						{
+							"id": "mA1aQC2I_7rOZWCoU",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+								"id": "myEztjO4DilC6AdoN"
+							},
+							"name": "Takes Recharge",
+							"reference": "B115,P106",
+							"local_notes": "5 seconds between uses, or 2x the time required to use the ability, whichever is longer",
+							"cost": -10
+						},
+						{
+							"id": "mxEfIziDFBfM3wXr3",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+								"id": "mBUqeaOCkjZbdZXTV"
+							},
+							"name": "Variable",
+							"reference": "B109,P107",
+							"cost": 5
+						}
+					],
+					"points_per_level": 5,
+					"weapons": [
+						{
+							"id": "wMgGhsDa70lierIKM",
+							"damage": {
+								"type": "burn",
+								"leveled": true,
+								"base": "1d"
+							},
+							"reach": "1",
+							"defaults": [
+								{
+									"type": "dx"
+								},
+								{
+									"type": "skill",
+									"name": "Brawling"
+								},
+								{
+									"type": "skill",
+									"name": "Boxing"
+								},
+								{
+									"type": "skill",
+									"name": "Karate"
+								}
+							],
+							"calc": {
+								"damage": "1d burn"
+							}
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 7
+					}
+				}
+			],
+			"calc": {
+				"points": 7
+			}
+		},
+		{
+			"id": "TyN19gQQjOgv4sHha",
+			"name": "Prehensile Tongue",
+			"reference": "BT45",
+			"local_notes": "TL10",
+			"container_type": "meta_trait",
+			"children": [
+				{
+					"id": "tAqB16niZN7jY7QPa",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tAZ31tXG_HzDmVCRp"
+					},
+					"name": "Acute Taste \u0026 Smell",
+					"reference": "B35",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"points_per_level": 2,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "taste_smell",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 2
+					}
+				},
+				{
+					"id": "tCBwySJDH-IRj-myE",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tpwIBKlkbnSdcNrWd"
+					},
+					"name": "Racial Skill Bonus - @Skill without a specialization@",
+					"reference": "BX452",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Mental",
+						"Talent"
+					],
+					"replacements": {
+						"Skill without a specialization": "Erotic Art"
+					},
+					"points_per_level": 2,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "@Skill without a specialization@"
+							},
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 2
+					}
+				},
+				{
+					"id": "tgEy9POxMmsa430Sb",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tkCi-pV0exqSyPhyv"
+					},
+					"name": "Extra Arm",
+					"reference": "B53",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "m-xxNzGWy6KqquW-o",
+							"name": "Extra-Flexible",
+							"reference": "B53",
+							"cost": 50
+						},
+						{
+							"id": "mVFhBexUnmQjOAfSL",
+							"name": "Long",
+							"reference": "B53",
+							"cost": 100,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "m2TrsSW3c_zUbKySD",
+							"name": "Foot Manipulators",
+							"reference": "B53",
+							"cost": -30,
+							"disabled": true
+						},
+						{
+							"id": "mnVBOYqIF7tHzHe64",
+							"name": "No Physical Attack",
+							"reference": "B53",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "mYstJbgrangC2nBth",
+							"name": "Short",
+							"reference": "B53",
+							"cost": -50
+						},
+						{
+							"id": "mzOaVwDvwltiGHu1y",
+							"name": "Weak",
+							"reference": "B53",
+							"local_notes": "Half body ST",
+							"cost": -25,
+							"disabled": true
+						},
+						{
+							"id": "mHHAQBQVlZSdhnuyP",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Powers/Powers Modifiers.adm",
+								"id": "mPcdrHEQuuS1KP9kT"
+							},
+							"name": "Switchable",
+							"reference": "P109",
+							"cost": 10
+						},
+						{
+							"id": "mKlrk_iPEF1akEJQM",
+							"name": "Weak",
+							"reference": "B53",
+							"local_notes": "Quarter body ST",
+							"cost": -50
+						},
+						{
+							"id": "mEBmLPv5G8GKwMfZK",
+							"name": "Weapon Mount",
+							"reference": "B53",
+							"cost": -80,
+							"disabled": true
+						},
+						{
+							"id": "m3D6G-10qzAx0zwSt",
+							"name": "No Grasping Hand",
+							"reference": "MATG28",
+							"cost": -40,
+							"disabled": true
+						}
+					],
+					"points_per_level": 10,
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 6
+					}
+				}
+			],
+			"calc": {
+				"points": 10
+			}
+		},
+		{
+			"id": "twlxLezOdicVKFwxJ",
+			"name": "No Appendix",
+			"reference": "BT46",
+			"local_notes": "TL9",
+			"tags": [
+				"Exotic",
+				"Physical"
+			],
+			"calc": {
+				"points": 0
+			}
+		},
+		{
+			"id": "TQx1gGRXhk4dsFPAo",
+			"name": "Burst Reflexes",
+			"reference": "BT48",
+			"local_notes": "TL9",
+			"container_type": "meta_trait",
+			"children": [
+				{
+					"id": "tPU2VxAY12NMR9p89",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tWF1J_Z0Ziz-qJ6pn"
+					},
+					"name": "Increased Basic Speed",
+					"reference": "B17",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mts2Ley65RawaWIes",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+								"id": "mb8dKIbPtFmqDLYaM"
+							},
+							"name": "Costs Fatigue",
+							"reference": "B111,P101",
+							"cost": -5,
+							"levels": 2
+						}
+					],
+					"points_per_level": 5,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "basic_speed",
+							"amount": 0.25,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 4,
+					"calc": {
+						"points": 18
+					}
+				}
+			],
+			"calc": {
+				"points": 18
+			}
+		},
+		{
+			"id": "T1hzWSwn-I1Ob0eW1",
+			"name": "Explosive Strength",
+			"reference": "BT48",
+			"local_notes": "TL9",
+			"container_type": "meta_trait",
+			"children": [
+				{
+					"id": "ThyVm5klwxC70K_-M",
+					"name": "Enhanced Muscles",
+					"reference": "BT213",
+					"modifiers": [
+						{
+							"id": "mH8DDOrTOIMDEmzmR",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+								"id": "m3JXyTOmjIZwhY1_g"
+							},
+							"name": "Costs Fatigue",
+							"reference": "B111,P101",
+							"local_notes": "Has maintenance cost",
+							"cost": -10,
+							"levels": 1
+						},
+						{
+							"id": "mchqAslc_8mOqisha",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+								"id": "m5NmnYfBmmJqwzSnv"
+							},
+							"name": "Emergencies Only",
+							"reference": "B112,P102",
+							"cost": -30
+						}
+					],
+					"container_type": "meta_trait",
+					"children": [
+						{
+							"id": "txjUVzZlqSe-d4ogF",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t6krAE1uo6M0oDJFL"
+							},
+							"name": "Lifting ST",
+							"reference": "B65,P58",
+							"tags": [
+								"Advantage",
+								"Exotic",
+								"Physical"
+							],
+							"modifiers": [
+								{
+									"id": "mIaPSiK047YKDGhBN",
+									"name": "No Fine Manipulators",
+									"reference": "B15",
+									"cost": -40,
+									"disabled": true
+								},
+								{
+									"id": "maP1B0dgzA0NJVrUj",
+									"name": "Size",
+									"reference": "B15",
+									"cost": -10,
+									"levels": 1,
+									"disabled": true
+								},
+								{
+									"id": "mrL8j3_MArQZGVKbH",
+									"name": "Super-Effort",
+									"reference": "P58",
+									"cost": 400,
+									"disabled": true
+								},
+								{
+									"id": "mLvyZwcBUYipBkPN8",
+									"name": "Know Your Own Strength Variant Price",
+									"reference": "PY83:18",
+									"cost": 4,
+									"cost_type": "points",
+									"affects": "levels_only",
+									"disabled": true
+								},
+								{
+									"id": "mI2lDg3y8gyVifdPx",
+									"name": "@Limb@ Grip ST",
+									"reference": "MATG28",
+									"cost": -70,
+									"disabled": true
+								},
+								{
+									"id": "mqPZH9Jum7bXox9La",
+									"name": "Bite ST",
+									"reference": "MATG28",
+									"cost": -70,
+									"disabled": true
+								}
+							],
+							"points_per_level": 3,
+							"features": [
+								{
+									"type": "attribute_bonus",
+									"limitation": "lifting_only",
+									"attribute": "st",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"levels": 5,
+							"calc": {
+								"points": 9
+							}
+						},
+						{
+							"id": "tjCeRO72frSn0UWRB",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t8HajX_K4BDKPuUop"
+							},
+							"name": "Striking ST",
+							"reference": "B88,P78",
+							"tags": [
+								"Advantage",
+								"Exotic",
+								"Physical"
+							],
+							"modifiers": [
+								{
+									"id": "m2oLy0Pn79krZxRHu",
+									"name": "No Fine Manipulators",
+									"cost": -40,
+									"disabled": true
+								},
+								{
+									"id": "mrDYCJq6Z4BAQhNMk",
+									"name": "Size",
+									"cost": -10,
+									"levels": 1,
+									"disabled": true
+								},
+								{
+									"id": "mvZ7g4HVNNbjSgUeA",
+									"name": "Super Effort",
+									"reference": "SU24",
+									"cost": 400,
+									"disabled": true
+								},
+								{
+									"id": "mb4zcNU0uahiQOS5t",
+									"name": "One Attack Only",
+									"reference": "P79",
+									"local_notes": "@Attack@",
+									"cost": -60,
+									"disabled": true
+								},
+								{
+									"id": "mapgwi84T-Jq8Pq8H",
+									"name": "Know Your Own Strength Pricing Variant",
+									"reference": "PY83:18",
+									"cost": -4,
+									"cost_type": "points",
+									"affects": "levels_only",
+									"disabled": true
+								}
+							],
+							"points_per_level": 5,
+							"features": [
+								{
+									"type": "attribute_bonus",
+									"limitation": "striking_only",
+									"attribute": "st",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"levels": 5,
+							"calc": {
+								"points": 15
+							}
+						}
+					],
+					"calc": {
+						"points": 24
+					}
+				}
+			],
+			"calc": {
+				"points": 24
+			}
+		},
+		{
+			"id": "TcVRXc10rugmtWbC4",
+			"name": "Sex Pheromones",
+			"reference": "BT48",
+			"local_notes": "TL10",
+			"container_type": "meta_trait",
+			"children": [
+				{
+					"id": "tlPazttwxnaYhbz5C",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t9fwzDbdQy1S9CHUx"
+					},
+					"name": "Affliction",
+					"reference": "B35,P39,PSI13",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"replacements": {
+						"Condition": "Only on those attracted to your gender",
+						"Disadvantage": "Lecherousness (12)",
+						"senses": "Scent"
+					},
+					"modifiers": [
+						{
+							"id": "MnaPczKcIjMq1hbBo",
+							"name": "Attribute Penalties",
+							"children": [
+								{
+									"id": "mfPlmuztup8MPiA3L",
+									"name": "DX Penalty",
+									"reference": "B36",
+									"local_notes": "Gives -1 to DX per level",
+									"cost": 10,
+									"levels": 1,
+									"disabled": true
+								},
+								{
+									"id": "mnhChqKGgn9XkQ5Gb",
+									"name": "HT Penalty",
+									"reference": "B36",
+									"local_notes": "Gives -1 to HT per level",
+									"cost": 5,
+									"levels": 1,
+									"disabled": true
+								},
+								{
+									"id": "m6-XuBQXwseJ4V5lN",
+									"name": "IQ Penalty",
+									"reference": "B36",
+									"local_notes": "Gives -1 to IQ per level",
+									"cost": 10,
+									"levels": 1,
+									"disabled": true
+								},
+								{
+									"id": "m4Tqg1nAoPFdwJXRT",
+									"name": "ST Penalty",
+									"reference": "B36",
+									"local_notes": "Gives -1 to ST per level",
+									"cost": 5,
+									"levels": 1,
+									"disabled": true
+								}
+							]
+						},
+						{
+							"id": "mhQUMjPvZFj99hveU",
+							"name": "Cancellation",
+							"reference": "PSI13",
+							"cost": 10,
+							"disabled": true
+						},
+						{
+							"id": "mKbPsZ7UG40iQQWKi",
+							"name": "Cumulative",
+							"reference": "B36",
+							"cost": 400,
+							"disabled": true
+						},
+						{
+							"id": "Mai7AiKrOKu4xfieo",
+							"name": "Incapacitation",
+							"reference": "B36",
+							"children": [
+								{
+									"id": "mHeOu_Mcel2ES8vQT",
+									"name": "Agony",
+									"reference": "B428",
+									"local_notes": "Lose 1 FP per minute",
+									"cost": 100,
+									"disabled": true
+								},
+								{
+									"id": "mfueLGLr2KagWjpEI",
+									"name": "Choking",
+									"reference": "B428",
+									"cost": 100,
+									"disabled": true
+								},
+								{
+									"id": "mMl9HUFKlXuseK4pT",
+									"name": "Daze",
+									"reference": "B428",
+									"cost": 50,
+									"disabled": true
+								},
+								{
+									"id": "mD8-44bzeAHIYSu8Y",
+									"name": "Ecstasy",
+									"reference": "B428",
+									"cost": 100,
+									"disabled": true
+								},
+								{
+									"id": "mYN9Sp_Uj6Gf8bBqy",
+									"name": "Hallucination",
+									"reference": "B429",
+									"cost": 50,
+									"disabled": true
+								},
+								{
+									"id": "m727Ge__x0UsKRi5N",
+									"name": "Paralysis",
+									"reference": "B429",
+									"cost": 150,
+									"disabled": true
+								},
+								{
+									"id": "mlLc6vf8Xv9SKP5Jn",
+									"name": "Retching",
+									"reference": "B429",
+									"cost": 50,
+									"disabled": true
+								},
+								{
+									"id": "m3iX_MZJUwFppUFue",
+									"name": "Seizure",
+									"reference": "B429",
+									"local_notes": "Lose 1d FP at the end of the seizure",
+									"cost": 100,
+									"disabled": true
+								},
+								{
+									"id": "ml38xkAnlbl7cBXpN",
+									"name": "Sleep",
+									"cost": 150,
+									"disabled": true
+								},
+								{
+									"id": "mjxmYZL5GKIYWEznc",
+									"name": "Unconsciousness",
+									"reference": "B429",
+									"cost": 200,
+									"disabled": true
+								}
+							]
+						},
+						{
+							"id": "MKEoDcPTx-z4wzqcF",
+							"name": "Irritations",
+							"reference": "B36",
+							"children": [
+								{
+									"id": "mweBG59ZhjK_0OfXN",
+									"name": "Coughing",
+									"reference": "B428",
+									"local_notes": "Gives -3 to DX and -1 to IQ and cannot use Stealth",
+									"cost": 20,
+									"disabled": true
+								},
+								{
+									"id": "musdmr9XGU7_1ZVvM",
+									"name": "Drunk",
+									"reference": "B428",
+									"local_notes": "Gives -2 to DX and IQ; -4 to self-control rolls except those to resist Cowardice",
+									"cost": 20,
+									"disabled": true
+								},
+								{
+									"id": "mdMtwcAtXXDbmIiBy",
+									"name": "Euphoria",
+									"reference": "B428",
+									"local_notes": "Gives -3 to all DX, IQ, skill and self-control rolls",
+									"cost": 30,
+									"disabled": true
+								},
+								{
+									"id": "mWhw0wdBorTS3tvKP",
+									"name": "Moderate Pain",
+									"reference": "B428",
+									"local_notes": "-2 to all DX, IQ, skill and self-control rolls",
+									"cost": 20,
+									"disabled": true
+								},
+								{
+									"id": "mBOOVGmab8g-HG3Ty",
+									"name": "Nauseated",
+									"reference": "B428",
+									"local_notes": "-2 to all attribute and skill rolls; -1 to active defenses",
+									"cost": 30,
+									"disabled": true
+								},
+								{
+									"id": "mSUeLpavIuqLeQA86",
+									"name": "Severe Pain",
+									"reference": "B428",
+									"local_notes": "-4 to all DX, IQ, skill and self-control rolls",
+									"cost": 40,
+									"disabled": true
+								},
+								{
+									"id": "mNnDGDr29Nh-YQxuA",
+									"name": "Terrible Pain",
+									"reference": "B428",
+									"local_notes": "-6 to all DX, IQ, skill and self-control rolls",
+									"cost": 60,
+									"disabled": true
+								},
+								{
+									"id": "m29YttMMV9U3M4ADr",
+									"name": "Tipsy",
+									"reference": "B428",
+									"local_notes": "-1 to DX and IQ, -2 to self-control rolls except those to resist Cowardice",
+									"cost": 10,
+									"disabled": true
+								}
+							]
+						},
+						{
+							"id": "MGqPTRYaC-Ei7BmnE",
+							"name": "Mortal Conditions",
+							"children": [
+								{
+									"id": "mnqGYHuZ9FzYdHcrE",
+									"name": "Coma",
+									"reference": "B429",
+									"cost": 250,
+									"disabled": true
+								},
+								{
+									"id": "mggg6Nd8HnQ0KZuG5",
+									"name": "Heart Attack",
+									"reference": "B429",
+									"cost": 300,
+									"disabled": true
+								}
+							]
+						},
+						{
+							"id": "mFajUAbDf4Q8yjAl4",
+							"name": "Stunning",
+							"reference": "B36",
+							"cost": 10,
+							"disabled": true
+						},
+						{
+							"id": "MQQmiIEqtbHK7cGal",
+							"name": "Traits",
+							"children": [
+								{
+									"id": "mhumlR1J5kwsK408e",
+									"name": "Gives @Advantage@",
+									"reference": "B36",
+									"local_notes": "1 point per level",
+									"cost": 10,
+									"levels": 1,
+									"disabled": true
+								},
+								{
+									"id": "mQVMY-tIyAgtdhxib",
+									"name": "Gives @Disadvantage@",
+									"reference": "B36",
+									"local_notes": "1 point per level",
+									"cost": 1,
+									"levels": 15
+								},
+								{
+									"id": "m67PEpXpHTWRegaq1",
+									"name": "Negates @Advantage@",
+									"reference": "B36",
+									"local_notes": "1 point per level",
+									"cost": 1,
+									"levels": 1,
+									"disabled": true
+								}
+							]
+						},
+						{
+							"id": "mpalScbhSTwl96gYU",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+								"id": "m2IwCpU9KwYmjiSSA"
+							},
+							"name": "Accessibility (@Condition@)",
+							"reference": "B110,P99",
+							"local_notes": "1 point per level",
+							"cost": -1,
+							"levels": 20
+						},
+						{
+							"id": "muKXBwQXSIrzh08Tg",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+								"id": "mbO8GjGu_NuPTLz6e"
+							},
+							"name": "Area Effect",
+							"reference": "B102,P100",
+							"local_notes": "2^level radius",
+							"cost": 50,
+							"levels": 1
+						},
+						{
+							"id": "myZdjlhYZAoQIru3x",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+								"id": "mk76f3SlpNhhWuzRi"
+							},
+							"name": "Emanation",
+							"reference": "B112,P102",
+							"cost": -20
+						},
+						{
+							"id": "mvwh4kEATuGUFAKkQ",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+								"id": "mR2B49Uxlo3jsnYYq"
+							},
+							"name": "Sense-Based (@senses@)",
+							"reference": "B109",
+							"local_notes": "Manually add +50% for each sense beyond the first",
+							"cost": 150
+						}
+					],
+					"points_per_level": 10,
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 28
+					}
+				}
+			],
+			"calc": {
+				"points": 28
+			}
+		},
+		{
+			"id": "TNCS-zcEct6E7nd-1",
+			"name": "Trust Hormones",
+			"reference": "BT48",
+			"local_notes": "TL10",
+			"container_type": "meta_trait",
+			"children": [
+				{
+					"id": "tcX9XuYM5yZQ68nva",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t9fwzDbdQy1S9CHUx"
+					},
+					"name": "Affliction",
+					"reference": "B35,P39,PSI13",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"replacements": {
+						"Disadvantage": "Gullible (12)"
+					},
+					"modifiers": [
+						{
+							"id": "MjuxmtORctwzWh_gq",
+							"name": "Attribute Penalties",
+							"children": [
+								{
+									"id": "mtvzj3mesFiivSdNH",
+									"name": "DX Penalty",
+									"reference": "B36",
+									"local_notes": "Gives -1 to DX per level",
+									"cost": 10,
+									"levels": 1,
+									"disabled": true
+								},
+								{
+									"id": "m9ZTRsmA3j8EzkMEg",
+									"name": "HT Penalty",
+									"reference": "B36",
+									"local_notes": "Gives -1 to HT per level",
+									"cost": 5,
+									"levels": 1,
+									"disabled": true
+								},
+								{
+									"id": "mKjDEU6Q_NRIFlZtr",
+									"name": "IQ Penalty",
+									"reference": "B36",
+									"local_notes": "Gives -1 to IQ per level",
+									"cost": 10,
+									"levels": 1,
+									"disabled": true
+								},
+								{
+									"id": "mpJThvzIPMwI5qtT5",
+									"name": "ST Penalty",
+									"reference": "B36",
+									"local_notes": "Gives -1 to ST per level",
+									"cost": 5,
+									"levels": 1,
+									"disabled": true
+								}
+							]
+						},
+						{
+							"id": "mjTZg_Ylqo66aCM10",
+							"name": "Cancellation",
+							"reference": "PSI13",
+							"cost": 10,
+							"disabled": true
+						},
+						{
+							"id": "mBru_OGF7sLcotNZM",
+							"name": "Cumulative",
+							"reference": "B36",
+							"cost": 400,
+							"disabled": true
+						},
+						{
+							"id": "MNoNLPWFupAFbV0Fn",
+							"name": "Incapacitation",
+							"reference": "B36",
+							"children": [
+								{
+									"id": "mHt4UpAlSJEs35Dvb",
+									"name": "Agony",
+									"reference": "B428",
+									"local_notes": "Lose 1 FP per minute",
+									"cost": 100,
+									"disabled": true
+								},
+								{
+									"id": "m30k3ZnCLZO15iD2H",
+									"name": "Choking",
+									"reference": "B428",
+									"cost": 100,
+									"disabled": true
+								},
+								{
+									"id": "mn9xpJpKPi92dG2Nr",
+									"name": "Daze",
+									"reference": "B428",
+									"cost": 50,
+									"disabled": true
+								},
+								{
+									"id": "moKkpTdsbsTd2Op2d",
+									"name": "Ecstasy",
+									"reference": "B428",
+									"cost": 100,
+									"disabled": true
+								},
+								{
+									"id": "m-mjkwMNGQ77d1vDt",
+									"name": "Hallucination",
+									"reference": "B429",
+									"cost": 50,
+									"disabled": true
+								},
+								{
+									"id": "mRFwiIQS3hb7FcxPb",
+									"name": "Paralysis",
+									"reference": "B429",
+									"cost": 150,
+									"disabled": true
+								},
+								{
+									"id": "mFUEbyn5KCeCPUl2B",
+									"name": "Retching",
+									"reference": "B429",
+									"cost": 50,
+									"disabled": true
+								},
+								{
+									"id": "mxjmJWLlC8_ht6tah",
+									"name": "Seizure",
+									"reference": "B429",
+									"local_notes": "Lose 1d FP at the end of the seizure",
+									"cost": 100,
+									"disabled": true
+								},
+								{
+									"id": "mG1WtJoWQAQXsnN5z",
+									"name": "Sleep",
+									"cost": 150,
+									"disabled": true
+								},
+								{
+									"id": "mabGKeO5GWYKY3Y5t",
+									"name": "Unconsciousness",
+									"reference": "B429",
+									"cost": 200,
+									"disabled": true
+								}
+							]
+						},
+						{
+							"id": "MagBVM5ILJ2PmIg3D",
+							"name": "Irritations",
+							"reference": "B36",
+							"children": [
+								{
+									"id": "mz-paTlH-9dGf_VWx",
+									"name": "Coughing",
+									"reference": "B428",
+									"local_notes": "Gives -3 to DX and -1 to IQ and cannot use Stealth",
+									"cost": 20,
+									"disabled": true
+								},
+								{
+									"id": "mizCiu_EP1J1-vYaO",
+									"name": "Drunk",
+									"reference": "B428",
+									"local_notes": "Gives -2 to DX and IQ; -4 to self-control rolls except those to resist Cowardice",
+									"cost": 20,
+									"disabled": true
+								},
+								{
+									"id": "mXXJgvIPdvmCgALRs",
+									"name": "Euphoria",
+									"reference": "B428",
+									"local_notes": "Gives -3 to all DX, IQ, skill and self-control rolls",
+									"cost": 30,
+									"disabled": true
+								},
+								{
+									"id": "mipJnmggx1o3SnPiC",
+									"name": "Moderate Pain",
+									"reference": "B428",
+									"local_notes": "-2 to all DX, IQ, skill and self-control rolls",
+									"cost": 20,
+									"disabled": true
+								},
+								{
+									"id": "mxA6wOkgJEOXlKAua",
+									"name": "Nauseated",
+									"reference": "B428",
+									"local_notes": "-2 to all attribute and skill rolls; -1 to active defenses",
+									"cost": 30,
+									"disabled": true
+								},
+								{
+									"id": "mDYNjv0yUKTuUfF4q",
+									"name": "Severe Pain",
+									"reference": "B428",
+									"local_notes": "-4 to all DX, IQ, skill and self-control rolls",
+									"cost": 40,
+									"disabled": true
+								},
+								{
+									"id": "mwLJ8rDzMQJH6zzvE",
+									"name": "Terrible Pain",
+									"reference": "B428",
+									"local_notes": "-6 to all DX, IQ, skill and self-control rolls",
+									"cost": 60,
+									"disabled": true
+								},
+								{
+									"id": "mRv3bfpnS9lOrL5FY",
+									"name": "Tipsy",
+									"reference": "B428",
+									"local_notes": "-1 to DX and IQ, -2 to self-control rolls except those to resist Cowardice",
+									"cost": 10,
+									"disabled": true
+								}
+							]
+						},
+						{
+							"id": "Mx-hHOkbnMmG6NEn9",
+							"name": "Mortal Conditions",
+							"children": [
+								{
+									"id": "muZAUbdDX5K1TLEfE",
+									"name": "Coma",
+									"reference": "B429",
+									"cost": 250,
+									"disabled": true
+								},
+								{
+									"id": "mfokLluss4nQewlFF",
+									"name": "Heart Attack",
+									"reference": "B429",
+									"cost": 300,
+									"disabled": true
+								}
+							]
+						},
+						{
+							"id": "mz4yf0BL4dRZsUmHp",
+							"name": "Stunning",
+							"reference": "B36",
+							"cost": 10,
+							"disabled": true
+						},
+						{
+							"id": "MgKXyvMZece_j_lDz",
+							"name": "Traits",
+							"children": [
+								{
+									"id": "m2DMgved20Vwu3pGc",
+									"name": "Gives @Advantage@",
+									"reference": "B36",
+									"local_notes": "1 point per level",
+									"cost": 10,
+									"levels": 1,
+									"disabled": true
+								},
+								{
+									"id": "mOkqiqJEt0FUz8wRL",
+									"name": "Gives @Disadvantage@",
+									"reference": "B36",
+									"local_notes": "1 point per level",
+									"cost": 1,
+									"levels": 10
+								},
+								{
+									"id": "mDVrVN9y3P-U4ggi7",
+									"name": "Negates @Advantage@",
+									"reference": "B36",
+									"local_notes": "1 point per level",
+									"cost": 1,
+									"levels": 1,
+									"disabled": true
+								}
+							]
+						},
+						{
+							"id": "mWisJ0Vx2EIXg_x-Y",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+								"id": "mbO8GjGu_NuPTLz6e"
+							},
+							"name": "Area Effect",
+							"reference": "B102,P100",
+							"local_notes": "2^level radius",
+							"cost": 50,
+							"levels": 1
+						},
+						{
+							"id": "mTyF1OLUiyH0i1eaQ",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+								"id": "mk76f3SlpNhhWuzRi"
+							},
+							"name": "Emanation",
+							"reference": "B112,P102",
+							"cost": -20
+						},
+						{
+							"id": "mQakBm5KsIBPo48K6",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+								"id": "mR2B49Uxlo3jsnYYq"
+							},
+							"name": "Sense-Based (@senses@)",
+							"reference": "B109",
+							"local_notes": "Manually add +50% for each sense beyond the first",
+							"cost": 150
+						}
+					],
+					"points_per_level": 10,
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 29
+					}
+				}
+			],
+			"calc": {
+				"points": 29
+			}
+		},
+		{
+			"id": "TQEZfjQYnJQixPICc",
+			"name": "Xeno-Pheromones",
+			"reference": "BT48",
+			"local_notes": "TL10",
+			"container_type": "meta_trait",
+			"children": [
+				{
+					"id": "tUU9W67yLlZuv3WEC",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t7E-Evy7VZAbL_iQt"
+					},
+					"name": "Talent (Animal Friend)",
+					"reference": "B90,PU3:6",
+					"tags": [
+						"Advantage",
+						"Mental",
+						"Talent"
+					],
+					"replacements": {
+						"Condition": "One species only",
+						"senses": "Scent"
+					},
+					"modifiers": [
+						{
+							"id": "m4AzwQp9htV0wGjM9",
+							"name": "Alternative Cost",
+							"cost": 1,
+							"cost_type": "points",
+							"affects": "levels_only",
+							"disabled": true
+						},
+						{
+							"id": "mAiCu5jm25aQZj5fK",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+								"id": "m2IwCpU9KwYmjiSSA"
+							},
+							"name": "Accessibility (@Condition@)",
+							"reference": "B110,P99",
+							"local_notes": "1 point per level",
+							"cost": -1,
+							"levels": 40
+						},
+						{
+							"id": "mQWEUWi87QtPoTbam",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+								"id": "mwOn3HOcXabGaSQBP"
+							},
+							"name": "Sense-Based (@senses@)",
+							"reference": "B115",
+							"local_notes": "Manually add -5% for each sense beyond the first",
+							"cost": -20
+						}
+					],
+					"points_per_level": 5,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "contains",
+								"qualifier": "animal handling"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "falconry"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "contains",
+								"qualifier": "packing"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "contains",
+								"qualifier": "riding"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "contains",
+								"qualifier": "teamster"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "contains",
+								"qualifier": "veterinary"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "reaction_bonus",
+							"situation": "from ordinary animals",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 2
+					}
+				}
+			],
+			"calc": {
+				"points": 2
+			}
+		},
+		{
+			"id": "TGI6dd0FjmClSF30H",
+			"name": "Dominance Pheromones",
+			"reference": "BT48",
+			"local_notes": "TL11",
+			"container_type": "meta_trait",
+			"children": [
+				{
+					"id": "tHsnqH0_JZjaOKjd_",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tMMQWflrKUPOkyIF9"
+					},
+					"name": "Charisma",
+					"reference": "B41",
+					"tags": [
+						"Advantage",
+						"Mental"
+					],
+					"replacements": {
+						"Condition": "no effect on nonhumans",
+						"senses": "Scent"
+					},
+					"modifiers": [
+						{
+							"id": "mLZu39KUY_-zST441",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+								"id": "m2IwCpU9KwYmjiSSA"
+							},
+							"name": "Accessibility (@Condition@)",
+							"reference": "B110,P99",
+							"local_notes": "1 point per level",
+							"cost": -1,
+							"levels": 5
+						},
+						{
+							"id": "mDibOJI17l-qmyiA9",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+								"id": "mwOn3HOcXabGaSQBP"
+							},
+							"name": "Sense-Based (@senses@)",
+							"reference": "B115",
+							"local_notes": "Manually add -5% for each sense beyond the first",
+							"cost": -20
+						}
+					],
+					"points_per_level": 5,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "fortune-telling"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "leadership"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "panhandling"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "public speaking"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "reaction_bonus",
+							"situation": "from sapient being with whom you actively interact (converse, lecture, etc.)",
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "reaction_bonus",
+							"situation": "to Influence rolls",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 4,
+					"calc": {
+						"points": 15
+					}
+				}
+			],
+			"calc": {
+				"points": 15
+			}
+		},
+		{
+			"id": "TMBQ2QvEUiZiobyxy",
+			"name": "Deadly Venom",
+			"reference": "BT49",
+			"local_notes": "TL9",
+			"container_type": "meta_trait",
+			"children": [
+				{
+					"id": "tayBxn8mS_qqAswvh",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "ttP5n0OVmbu8o50uI"
+					},
+					"name": "Innate Attack (Toxic)",
+					"reference": "B62,P53,MA45",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"replacements": {
+						"Attack Type": "Follow-Up",
+						"Carrier Attack": "Teeth/Striker/Claws",
+						"HP Threshold and Effect": "2/3 HP -2 ST, DX IQ and HT"
+					},
+					"modifiers": [
+						{
+							"id": "man51pbdGlwrCRAHU",
+							"name": "Cyclic",
+							"reference": "B103",
+							"local_notes": "1 sec",
+							"cost": 100,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "msREeN9XEsh_S4gqS",
+							"name": "Cyclic",
+							"reference": "B103",
+							"local_notes": "10 sec",
+							"cost": 50,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mARRp_IB_AaqEMUM0",
+							"name": "Cyclic",
+							"reference": "B103",
+							"local_notes": "1 min",
+							"cost": 40,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mk5G5ey5Xww0Pz8JY",
+							"name": "Cyclic",
+							"reference": "B103",
+							"local_notes": "1 hr",
+							"cost": 20,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "m91cMRgmXoFZ0hga6",
+							"name": "Cyclic",
+							"reference": "B103",
+							"local_notes": "1 day",
+							"cost": 10,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mSrKVAwJC6ZWIxhRF",
+							"name": "Cyclic",
+							"reference": "B103",
+							"local_notes": "1 sec; Resistible",
+							"cost": 50,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "m-EV9SMYAbZ7jbxjF",
+							"name": "Cyclic",
+							"reference": "B103",
+							"local_notes": "10 sec; Resistible",
+							"cost": 25,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mC0x-2zuOujXCbr7T",
+							"name": "Cyclic",
+							"reference": "B103",
+							"local_notes": "1 min; Resistible",
+							"cost": 20,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mVWDY3OKQzFWJhtwK",
+							"name": "Cyclic",
+							"reference": "B103",
+							"local_notes": "1 hr; Resistible",
+							"cost": 10,
+							"levels": 3
+						},
+						{
+							"id": "mkENz_x_JpjhrfJC1",
+							"name": "Cyclic",
+							"reference": "B103",
+							"local_notes": "1 day; Resistible",
+							"cost": 5,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "maMVU0BZmp3fkOGfJ",
+							"name": "Contagious",
+							"reference": "B103",
+							"local_notes": "Mildly",
+							"cost": 20,
+							"disabled": true
+						},
+						{
+							"id": "m-tBqyHY8QnzNTVjU",
+							"name": "Contagious",
+							"reference": "B103",
+							"local_notes": "Highly",
+							"cost": 50,
+							"disabled": true
+						},
+						{
+							"id": "mR6CiuwkQiTS5mz9a",
+							"name": "Double Blunt Trauma",
+							"reference": "B104",
+							"local_notes": "1HP per 10 dmg",
+							"cost": 20,
+							"disabled": true
+						},
+						{
+							"id": "mHRwgv4y3Tl0MxPmb",
+							"name": "Explosion",
+							"reference": "B104",
+							"cost": 50,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "m4SsGNLjHykoc4CjS",
+							"name": "Fragmentation",
+							"reference": "B104",
+							"cost": 15,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mwpZcbl9U3Yxx1Kpb",
+							"name": "Fragmentation",
+							"reference": "B104",
+							"local_notes": "Hot",
+							"cost": 15,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mNJS00Yv3nXOoKx8A",
+							"name": "Radiation",
+							"reference": "B104",
+							"cost": 100,
+							"disabled": true
+						},
+						{
+							"id": "mHpfOkNYW14resD8d",
+							"name": "Surge",
+							"reference": "B104",
+							"cost": 20,
+							"disabled": true
+						},
+						{
+							"id": "moS9CIaD7s72LpbUt",
+							"name": "Armor Divisor",
+							"reference": "B102",
+							"local_notes": "2",
+							"cost": 50,
+							"disabled": true
+						},
+						{
+							"id": "mNcJSOFMgrtgNbPsL",
+							"name": "Armor Divisor",
+							"reference": "B102",
+							"local_notes": "3",
+							"cost": 100,
+							"disabled": true
+						},
+						{
+							"id": "mtyzcKXf2RuRUDuio",
+							"name": "Armor Divisor",
+							"reference": "B102",
+							"local_notes": "5",
+							"cost": 150,
+							"disabled": true
+						},
+						{
+							"id": "mEJeBXyIxSw4FybI3",
+							"name": "Armor Divisor",
+							"reference": "B102",
+							"local_notes": "10",
+							"cost": 200,
+							"disabled": true
+						},
+						{
+							"id": "m0hKciDnADuBz764A",
+							"name": "Side Effect",
+							"reference": "B109",
+							"local_notes": "@Effect@",
+							"disabled": true
+						},
+						{
+							"id": "miRcojafhXQQPgdBi",
+							"name": "Symptoms",
+							"reference": "B109",
+							"local_notes": "@Effect@",
+							"disabled": true
+						},
+						{
+							"id": "mHN_Jg2qcAcy-6Q4Q",
+							"name": "Armor Divisor",
+							"reference": "B110",
+							"local_notes": "0.5",
+							"cost": -30,
+							"disabled": true
+						},
+						{
+							"id": "mRSd4zfTbCmYpkuL4",
+							"name": "Armor Divisor",
+							"reference": "B110",
+							"local_notes": "0.2",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "meNwjq_z1zGSzR9cg",
+							"name": "Armor Divisor",
+							"reference": "B110",
+							"local_notes": "0.1",
+							"cost": -70,
+							"disabled": true
+						},
+						{
+							"id": "mMghkQcB6LniyBN5N",
+							"name": "No Wounding",
+							"reference": "B111",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "moc4a6AsxUvApSL9A",
+							"name": "Incendiary",
+							"reference": "B104",
+							"cost": 10,
+							"disabled": true
+						},
+						{
+							"id": "mhqAJmQg5N_URmuAX",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+								"id": "m1nJdcOiKLxg7pXwe"
+							},
+							"name": "Follow-Up (@Carrier Attack@)",
+							"reference": "B105,P102"
+						},
+						{
+							"id": "m8npP7movGYPkn5QT",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+								"id": "m35mRHt7D1uGCmYeA"
+							},
+							"name": "Onset",
+							"reference": "B113,P104",
+							"local_notes": "1 minute",
+							"cost": -10
+						},
+						{
+							"id": "m12DKTvgezDM8Q3R9",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+								"id": "m-F3ACfcl680ioFta"
+							},
+							"name": "Resistible",
+							"reference": "B115,P105",
+							"local_notes": "HT + (level - 6) to resist",
+							"cost": -5,
+							"levels": 2
+						},
+						{
+							"id": "mejrmBdJoFfoe2tuk",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+								"id": "md0iavn_lCSnS1Xkf"
+							},
+							"name": "Symptoms (@HP Threshold and Effect@)",
+							"reference": "B109",
+							"local_notes": "1 point per level",
+							"cost": 1,
+							"levels": 60
+						}
+					],
+					"points_per_level": 4,
+					"weapons": [
+						{
+							"id": "WKiCwIdnvz-Bn88Ii",
+							"damage": {
+								"type": "tox",
+								"base": "1d"
+							},
+							"accuracy": "3",
+							"range": "10/100",
+							"rate_of_fire": "1",
+							"recoil": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Innate Attack",
+									"specialization": "@Attack Type@"
+								},
+								{
+									"type": "skill",
+									"name": "Innate Attack",
+									"modifier": -2
+								},
+								{
+									"type": "dx",
+									"modifier": -4
+								}
+							],
+							"calc": {
+								"damage": "1d tox"
+							}
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 7
+					}
+				}
+			],
+			"calc": {
+				"points": 7
+			}
+		},
+		{
+			"id": "T-8B5mP1KZTG8hxD2",
+			"name": "Ecstasy Glands",
+			"reference": "BT49",
+			"local_notes": "TL10",
+			"container_type": "meta_trait",
+			"children": [
+				{
+					"id": "taYWZsYpJIgUCZ9J2",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t9fwzDbdQy1S9CHUx"
+					},
+					"name": "Affliction",
+					"reference": "B35,P39,PSI13",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "MxLfh8mUeE4a5-tqr",
+							"name": "Attribute Penalties",
+							"children": [
+								{
+									"id": "mgty5bNRhYLMjb7RU",
+									"name": "DX Penalty",
+									"reference": "B36",
+									"local_notes": "Gives -1 to DX per level",
+									"cost": 10,
+									"levels": 1,
+									"disabled": true
+								},
+								{
+									"id": "m79zJym_EBxZeoADD",
+									"name": "Secondary DX Penalty",
+									"reference": "B36",
+									"local_notes": "Gives -1 to DX per level",
+									"cost": 2,
+									"levels": 1,
+									"disabled": true
+								},
+								{
+									"id": "m1TA0cIw6gGoibXWW",
+									"name": "HT Penalty",
+									"reference": "B36",
+									"local_notes": "Gives -1 to HT per level",
+									"cost": 5,
+									"levels": 1,
+									"disabled": true
+								},
+								{
+									"id": "mpoVlKsktukZRZnTj",
+									"name": "Secondary HT Penalty",
+									"reference": "B36",
+									"local_notes": "Gives -1 to HT per level",
+									"cost": 1,
+									"levels": 1,
+									"disabled": true
+								},
+								{
+									"id": "mVwenw-Bu3YwZVDsi",
+									"name": "IQ Penalty",
+									"reference": "B36",
+									"local_notes": "Gives -1 to IQ per level",
+									"cost": 10,
+									"levels": 1,
+									"disabled": true
+								},
+								{
+									"id": "m1w5HLqsCgSGXMbMZ",
+									"name": "Secondary IQ Penalty",
+									"reference": "B36",
+									"local_notes": "Gives -1 to IQ per level",
+									"cost": 2,
+									"levels": 1,
+									"disabled": true
+								},
+								{
+									"id": "mxU5UTav1TASJ4idp",
+									"name": "Secondary ST Penalty",
+									"reference": "B36",
+									"local_notes": "Gives -1 to ST per level",
+									"cost": 1,
+									"levels": 1,
+									"disabled": true
+								}
+							]
+						},
+						{
+							"id": "mmjZsqhcx_xG4jkZ0",
+							"name": "Cancellation",
+							"reference": "PSI13",
+							"cost": 10,
+							"disabled": true
+						},
+						{
+							"id": "mfVJ_cG0zYKc2Y4V-",
+							"name": "Cumulative",
+							"reference": "B36",
+							"cost": 400,
+							"disabled": true
+						},
+						{
+							"id": "MJbj5URpFtrPexA5U",
+							"name": "Incapacitation",
+							"reference": "B36",
+							"children": [
+								{
+									"id": "m_7JA_dL75drAxGRg",
+									"name": "Agony",
+									"reference": "B428",
+									"local_notes": "Lose 1 FP per minute",
+									"cost": 100,
+									"disabled": true
+								},
+								{
+									"id": "mGdvrVZFCcnb3-n_A",
+									"name": "Secondary Agony",
+									"reference": "B428",
+									"local_notes": "Lose 1 FP per minute",
+									"cost": 20,
+									"disabled": true
+								},
+								{
+									"id": "mMASJkMCAvhE4H_nE",
+									"name": "Choking",
+									"reference": "B428",
+									"cost": 100,
+									"disabled": true
+								},
+								{
+									"id": "m3QNomnQJRNckz7sf",
+									"name": "Secondary Choking",
+									"reference": "B428",
+									"cost": 20,
+									"disabled": true
+								},
+								{
+									"id": "mVZSHplwgbJ4UW3rC",
+									"name": "Daze",
+									"reference": "B428",
+									"cost": 50,
+									"disabled": true
+								},
+								{
+									"id": "m0qokgkwybPeqfSJb",
+									"name": "Secondary Daze",
+									"reference": "B428",
+									"cost": 10,
+									"disabled": true
+								},
+								{
+									"id": "mqJG4-_am87PCoe5L",
+									"name": "Ecstasy",
+									"reference": "B428",
+									"cost": 100
+								},
+								{
+									"id": "mVZNA-ZiOg3yiDE5U",
+									"name": "Secondary Ecstasy",
+									"reference": "B428",
+									"cost": 20,
+									"disabled": true
+								},
+								{
+									"id": "mbD2ha9iWg2bHU8Eq",
+									"name": "Hallucination",
+									"reference": "B429",
+									"cost": 50,
+									"disabled": true
+								},
+								{
+									"id": "mE9uoAW1Nez64nvfd",
+									"name": "Secondary Hallucination",
+									"reference": "B429",
+									"cost": 10,
+									"disabled": true
+								},
+								{
+									"id": "mRnSvL9KQ8VbXOY81",
+									"name": "Paralysis",
+									"reference": "B429",
+									"cost": 150,
+									"disabled": true
+								},
+								{
+									"id": "mce5RsX9JbovAotJ8",
+									"name": "Secondary Paralysis",
+									"reference": "B429",
+									"cost": 30,
+									"disabled": true
+								},
+								{
+									"id": "m___It5fvWanqH9QX",
+									"name": "Retching",
+									"reference": "B429",
+									"cost": 50,
+									"disabled": true
+								},
+								{
+									"id": "mR2SAHX6_fNXXr9rx",
+									"name": "Secondary Retching",
+									"reference": "B429",
+									"cost": 10,
+									"disabled": true
+								},
+								{
+									"id": "mBcC7IUDDPr_wdMzN",
+									"name": "Seizure",
+									"reference": "B429",
+									"local_notes": "Lose 1d FP at the end of the seizure",
+									"cost": 100,
+									"disabled": true
+								},
+								{
+									"id": "mNygTzxab0xaKb5os",
+									"name": "Secondary Seizure",
+									"reference": "B429",
+									"local_notes": "Lose 1d FP at the end of the seizure",
+									"cost": 20,
+									"disabled": true
+								},
+								{
+									"id": "mgt4mJXn60DjUs7o_",
+									"name": "Sleep",
+									"cost": 150,
+									"disabled": true
+								},
+								{
+									"id": "mFzZdnyMHhCLuQw8d",
+									"name": "Secondary Sleep",
+									"cost": 30,
+									"disabled": true
+								},
+								{
+									"id": "mGZDr9K3Vv_BTcffx",
+									"name": "Unconsciousness",
+									"reference": "B429",
+									"cost": 200,
+									"disabled": true
+								},
+								{
+									"id": "mm24Hu9yplfARqnNc",
+									"name": "Secondary Unconsciousness",
+									"reference": "B429",
+									"cost": 40,
+									"disabled": true
+								}
+							]
+						},
+						{
+							"id": "MUzxWfwiEA9rFCuy1",
+							"name": "Irritations",
+							"reference": "B36",
+							"children": [
+								{
+									"id": "m1-tN6iPTwYN60OzW",
+									"name": "Coughing",
+									"reference": "B428",
+									"local_notes": "Gives -3 to DX and -1 to IQ and cannot use Stealth",
+									"cost": 20,
+									"disabled": true
+								},
+								{
+									"id": "moFeD08FeCdjxBt2-",
+									"name": "Secondary Coughing",
+									"reference": "B428",
+									"local_notes": "Gives -3 to DX and -1 to IQ and cannot use Stealth",
+									"cost": 4,
+									"disabled": true
+								},
+								{
+									"id": "mLvwtSUl2p37SrbXx",
+									"name": "Drunk",
+									"reference": "B428",
+									"local_notes": "Gives -2 to DX and IQ; -4 to self-control rolls except those to resist Cowardice",
+									"cost": 20,
+									"disabled": true
+								},
+								{
+									"id": "mSjuSmiyMiwemM2gf",
+									"name": "Secondary Drunk",
+									"reference": "B428",
+									"local_notes": "Gives -2 to DX and IQ; -4 to self-control rolls except those to resist Cowardice",
+									"cost": 4,
+									"disabled": true
+								},
+								{
+									"id": "mv4u8UeW9euKBPi2I",
+									"name": "Euphoria",
+									"reference": "B428",
+									"local_notes": "Gives -3 to all DX, IQ, skill and self-control rolls",
+									"cost": 30,
+									"disabled": true
+								},
+								{
+									"id": "m-uSCwU3c-wHFxAuY",
+									"name": "Secondary Euphoria",
+									"reference": "B428",
+									"local_notes": "Gives -3 to all DX, IQ, skill and self-control rolls",
+									"cost": 6,
+									"disabled": true
+								},
+								{
+									"id": "mkKByPBxzmx8L0t3z",
+									"name": "Moderate Pain",
+									"reference": "B428",
+									"local_notes": "-2 to all DX, IQ, skill and self-control rolls",
+									"cost": 20,
+									"disabled": true
+								},
+								{
+									"id": "mq-vEdEy7EqmhgRbb",
+									"name": "Secondary Moderate Pain",
+									"reference": "B428",
+									"local_notes": "-2 to all DX, IQ, skill and self-control rolls",
+									"cost": 4,
+									"disabled": true
+								},
+								{
+									"id": "mXrbbKXWlIkHUgGWf",
+									"name": "Nauseated",
+									"reference": "B428",
+									"local_notes": "-2 to all attribute and skill rolls; -1 to active defenses",
+									"cost": 30,
+									"disabled": true
+								},
+								{
+									"id": "mbyaNaQNPDK3U0edk",
+									"name": "Secondary Nauseated",
+									"reference": "B428",
+									"local_notes": "-2 to all attribute and skill rolls; -1 to active defenses",
+									"cost": 6,
+									"disabled": true
+								},
+								{
+									"id": "mSsBVxd_3C1Os3wAa",
+									"name": "Severe Pain",
+									"reference": "B428",
+									"local_notes": "-4 to all DX, IQ, skill and self-control rolls",
+									"cost": 40,
+									"disabled": true
+								},
+								{
+									"id": "mbrafx9iczX9TaDgs",
+									"name": "Secondary Severe Pain",
+									"reference": "B428",
+									"local_notes": "-4 to all DX, IQ, skill and self-control rolls",
+									"cost": 8,
+									"disabled": true
+								},
+								{
+									"id": "mX_WdKyiRxsnPnb-s",
+									"name": "Terrible Pain",
+									"reference": "B428",
+									"local_notes": "-6 to all DX, IQ, skill and self-control rolls",
+									"cost": 60,
+									"disabled": true
+								},
+								{
+									"id": "mAuoXtE1QMBWdqVa6",
+									"name": "Secondary Terrible Pain",
+									"reference": "B428",
+									"local_notes": "-6 to all DX, IQ, skill and self-control rolls",
+									"cost": 12,
+									"disabled": true
+								},
+								{
+									"id": "mn8g-xh_Vj9OvfaJI",
+									"name": "Tipsy",
+									"reference": "B428",
+									"local_notes": "-1 to DX and IQ, -2 to self-control rolls except those to resist Cowardice",
+									"cost": 10,
+									"disabled": true
+								},
+								{
+									"id": "m7n8_wm84LCdvz5nJ",
+									"name": "Secondary Tipsy",
+									"reference": "B428",
+									"local_notes": "-1 to DX and IQ, -2 to self-control rolls except those to resist Cowardice",
+									"cost": 2,
+									"disabled": true
+								}
+							]
+						},
+						{
+							"id": "M6LTgVbR0GHw_wT93",
+							"name": "Mortal Conditions",
+							"children": [
+								{
+									"id": "mWJJmvQnLKEDtvZ91",
+									"name": "Coma",
+									"reference": "B429",
+									"cost": 250,
+									"disabled": true
+								},
+								{
+									"id": "m6EhRkLFUCyz_l0OD",
+									"name": "Secondary Coma",
+									"reference": "B429",
+									"cost": 50,
+									"disabled": true
+								},
+								{
+									"id": "mtz8Nwh7cvxFRyP9e",
+									"name": "Heart Attack",
+									"reference": "B429",
+									"cost": 300,
+									"disabled": true
+								},
+								{
+									"id": "mu5v9Kjij8HSV97KN",
+									"name": "Secondary Heart Attack",
+									"reference": "B429",
+									"cost": 60
+								}
+							]
+						},
+						{
+							"id": "mLOnUsz5iVLz9-IBq",
+							"name": "Stunning",
+							"reference": "B36",
+							"cost": 10,
+							"disabled": true
+						},
+						{
+							"id": "m84eZSYUC6-32zUZE",
+							"name": "Secondary Stunning",
+							"reference": "B36",
+							"cost": 2,
+							"disabled": true
+						},
+						{
+							"id": "MqxG-xGaNlGX-6Dsn",
+							"name": "Traits",
+							"children": [
+								{
+									"id": "mBNSIkpzqZ5LLzSZu",
+									"name": "Gives @Advantage@",
+									"reference": "B36",
+									"local_notes": "1 point per level",
+									"cost": 10,
+									"levels": 1,
+									"disabled": true
+								},
+								{
+									"id": "mBixC6TcBbG5R4IDR",
+									"name": "Secondary Gives @Advantage@",
+									"reference": "B36",
+									"local_notes": "1 point per level",
+									"cost": 2,
+									"levels": 1,
+									"disabled": true
+								},
+								{
+									"id": "mo7jULKrCCvbeTdhS",
+									"name": "Gives @Disadvantage@",
+									"reference": "B36",
+									"local_notes": "1 point per level",
+									"cost": 1,
+									"levels": 1,
+									"disabled": true
+								},
+								{
+									"id": "mdxHdgMpEPXdtPsl7",
+									"name": "Secondary Gives @Disadvantage@",
+									"reference": "B36",
+									"local_notes": "5 points per level",
+									"cost": 1,
+									"levels": 1,
+									"disabled": true
+								},
+								{
+									"id": "mdFW6wHs7Q7yYc3TN",
+									"name": "Negates @Advantage@",
+									"reference": "B36",
+									"local_notes": "1 point per level",
+									"cost": 1,
+									"levels": 1,
+									"disabled": true
+								},
+								{
+									"id": "mS9gJVSWiXinzI5Gn",
+									"name": "Secondary Negates @Advantage@",
+									"reference": "B36",
+									"local_notes": "5 points per level",
+									"cost": 1,
+									"levels": 1,
+									"disabled": true
+								}
+							]
+						},
+						{
+							"id": "m8RUqCA1ib_ka-mm5",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+								"id": "m9qu6zy-gjsxl3Jjw"
+							},
+							"name": "Blood Agent",
+							"reference": "B110,P100",
+							"cost": -40
+						},
+						{
+							"id": "mfIHCvPvRRZP19Cb0",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+								"id": "m35mRHt7D1uGCmYeA"
+							},
+							"name": "Onset",
+							"reference": "B113,P104",
+							"local_notes": "1 minute",
+							"cost": -10
+						},
+						{
+							"id": "mca8OL2yxj-uJbuV-",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+								"id": "m5NmnYfBmmJqwzSnv"
+							},
+							"name": "Emergencies Only",
+							"reference": "B112,P102",
+							"cost": -30
+						},
+						{
+							"id": "mx2KNgIOXbaArWCkO",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+								"id": "mVtDQj3J1f5GAAQ-J"
+							},
+							"name": "Melee Attack",
+							"reference": "B112,P103",
+							"local_notes": "Reach C",
+							"cost": -30
+						}
+					],
+					"points_per_level": 10,
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 15
+					}
+				}
+			],
+			"calc": {
+				"points": 15
+			}
+		},
+		{
+			"id": "TLDWTvcFuZmLCN9Ln",
+			"name": "Venomous Spit",
+			"reference": "BT49",
+			"local_notes": "TL10",
+			"container_type": "meta_trait",
+			"children": [
+				{
+					"id": "t5TfAcSLB2ZUaokSo",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "ttP5n0OVmbu8o50uI"
+					},
+					"name": "Innate Attack (Toxic)",
+					"reference": "B62,P53,MA45",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"replacements": {
+						"HP Threshold and Effect": "2/3 HP, -3 DX and IQ"
+					},
+					"modifiers": [
+						{
+							"id": "m9llut402WlPZiv9m",
+							"name": "Cyclic",
+							"reference": "B103",
+							"local_notes": "1 sec",
+							"cost": 100,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mDcy-qJ8w4u-ygU2I",
+							"name": "Cyclic",
+							"reference": "B103",
+							"local_notes": "10 sec",
+							"cost": 50,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mlsJ2i4B6kbbqDbOK",
+							"name": "Cyclic",
+							"reference": "B103",
+							"local_notes": "1 min",
+							"cost": 40,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mVqPRVy_gfluW9OgS",
+							"name": "Cyclic",
+							"reference": "B103",
+							"local_notes": "1 hr",
+							"cost": 20,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mzKImBgHyJN3FhnEj",
+							"name": "Cyclic",
+							"reference": "B103",
+							"local_notes": "1 day",
+							"cost": 10,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mMcdsKV0Q9wqISjf9",
+							"name": "Cyclic",
+							"reference": "B103",
+							"local_notes": "1 sec; Resistible",
+							"cost": 50,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mfmZ-IlRjqpt2F9OL",
+							"name": "Cyclic",
+							"reference": "B103",
+							"local_notes": "10 sec; Resistible",
+							"cost": 25,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mZkWtXrmrJQkUdQ3A",
+							"name": "Cyclic",
+							"reference": "B103",
+							"local_notes": "1 min; Resistible",
+							"cost": 20,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mfljfJp4I_zYrh1ic",
+							"name": "Cyclic",
+							"reference": "B103",
+							"local_notes": "1 hr; Resistible",
+							"cost": 10,
+							"levels": 3
+						},
+						{
+							"id": "mfVL56bZxaEF0RAlb",
+							"name": "Cyclic",
+							"reference": "B103",
+							"local_notes": "1 day; Resistible",
+							"cost": 5,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "moPUTHf-bjkp0DQMZ",
+							"name": "Contagious",
+							"reference": "B103",
+							"local_notes": "Mildly",
+							"cost": 20,
+							"disabled": true
+						},
+						{
+							"id": "m6YTNfYgkhBRQhG2A",
+							"name": "Contagious",
+							"reference": "B103",
+							"local_notes": "Highly",
+							"cost": 50,
+							"disabled": true
+						},
+						{
+							"id": "mHlzTxY04FCyuTFy-",
+							"name": "Double Blunt Trauma",
+							"reference": "B104",
+							"local_notes": "1HP per 10 dmg",
+							"cost": 20,
+							"disabled": true
+						},
+						{
+							"id": "mOi4QgsjTKgNyhL1p",
+							"name": "Explosion",
+							"reference": "B104",
+							"cost": 50,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "myEag2P8WftP0mxPX",
+							"name": "Fragmentation",
+							"reference": "B104",
+							"cost": 15,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "m1zsmYcqgQhmJrxJ_",
+							"name": "Fragmentation",
+							"reference": "B104",
+							"local_notes": "Hot",
+							"cost": 15,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "m2uIkE1amz-bF1j1f",
+							"name": "Radiation",
+							"reference": "B104",
+							"cost": 100,
+							"disabled": true
+						},
+						{
+							"id": "m8e6O0gaEMdaANlv0",
+							"name": "Surge",
+							"reference": "B104",
+							"cost": 20,
+							"disabled": true
+						},
+						{
+							"id": "mH2Wxx9kQHbe4JIr5",
+							"name": "Armor Divisor",
+							"reference": "B102",
+							"local_notes": "2",
+							"cost": 50,
+							"disabled": true
+						},
+						{
+							"id": "ma_qOOQrZFAVQ17kv",
+							"name": "Armor Divisor",
+							"reference": "B102",
+							"local_notes": "3",
+							"cost": 100,
+							"disabled": true
+						},
+						{
+							"id": "mpARtV9nvz_ohvlEX",
+							"name": "Armor Divisor",
+							"reference": "B102",
+							"local_notes": "5",
+							"cost": 150,
+							"disabled": true
+						},
+						{
+							"id": "mFDc0JuoydINcvAr6",
+							"name": "Armor Divisor",
+							"reference": "B102",
+							"local_notes": "10",
+							"cost": 200,
+							"disabled": true
+						},
+						{
+							"id": "mCVpWXTr_IB1cgiwJ",
+							"name": "Side Effect",
+							"reference": "B109",
+							"local_notes": "@Effect@",
+							"disabled": true
+						},
+						{
+							"id": "mVW4fColcKNlsjHeD",
+							"name": "Symptoms",
+							"reference": "B109",
+							"local_notes": "@Effect@",
+							"disabled": true
+						},
+						{
+							"id": "m46C_Z3Es8NfMqj7L",
+							"name": "Armor Divisor",
+							"reference": "B110",
+							"local_notes": "0.5",
+							"cost": -30,
+							"disabled": true
+						},
+						{
+							"id": "m_q4ArpP2gIIgCK5V",
+							"name": "Armor Divisor",
+							"reference": "B110",
+							"local_notes": "0.2",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "mbrIeQmG1-83UD4Mk",
+							"name": "Armor Divisor",
+							"reference": "B110",
+							"local_notes": "0.1",
+							"cost": -70,
+							"disabled": true
+						},
+						{
+							"id": "m8PngcfvMlxyHcjq8",
+							"name": "No Wounding",
+							"reference": "B111",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "mR9F3oD6GiMehqQgb",
+							"name": "Incendiary",
+							"reference": "B104",
+							"cost": 10,
+							"disabled": true
+						},
+						{
+							"id": "mXBy5L1oIYIqaW7th",
+							"name": "+1 damage",
+							"cost": 1.2,
+							"cost_type": "points",
+							"affects": "base_only"
+						},
+						{
+							"id": "m17aUZi1p1U3w_pg7",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+								"id": "m9qu6zy-gjsxl3Jjw"
+							},
+							"name": "Blood Agent",
+							"reference": "B110,P100",
+							"cost": -40
+						},
+						{
+							"id": "mCwJAr86_9ebUSQxm",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+								"id": "m6WObJI1VTU-Wto4A"
+							},
+							"name": "Jet",
+							"reference": "B106,P103"
+						},
+						{
+							"id": "mdn_zkRHh3KjqatqT",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+								"id": "m35mRHt7D1uGCmYeA"
+							},
+							"name": "Onset",
+							"reference": "B113,P104",
+							"local_notes": "1 minute",
+							"cost": -10
+						},
+						{
+							"id": "mlXNAvNNh1HJGxGTl",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+								"id": "muEHnnBcFvKfMCDHp"
+							},
+							"name": "Reduced Range",
+							"reference": "B115,P105",
+							"local_notes": "2 Range Divisor",
+							"cost": -10
+						},
+						{
+							"id": "mdKD4aXTKc2NLJfcl",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+								"id": "m-F3ACfcl680ioFta"
+							},
+							"name": "Resistible",
+							"reference": "B115,P105",
+							"local_notes": "HT + (level - 6) to resist",
+							"cost": -5,
+							"levels": 3
+						},
+						{
+							"id": "mUJhwBoi-dc3hQN1G",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+								"id": "md0iavn_lCSnS1Xkf"
+							},
+							"name": "Symptoms (@HP Threshold and Effect@)",
+							"reference": "B109",
+							"local_notes": "1 point per level",
+							"cost": 1,
+							"levels": 60
+						}
+					],
+					"points_per_level": 4,
+					"weapons": [
+						{
+							"id": "wP5JeCcNbNSEA2o_8",
+							"damage": {
+								"type": "tox",
+								"base": "1d+1"
+							},
+							"usage": "Jet",
+							"reach": "5",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": "Innate Attack",
+									"modifier": -2
+								},
+								{
+									"type": "skill",
+									"name": "Innate Attack",
+									"specialization": "Breath"
+								}
+							],
+							"calc": {
+								"damage": "1d+1 tox"
+							}
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 6
+					}
+				}
+			],
+			"calc": {
+				"points": 6
+			}
+		},
+		{
+			"id": "tIvKV0WjoOE_cDASs",
+			"name": "Digitigrade Posture",
+			"reference": "BT51",
+			"local_notes": "TL9",
+			"calc": {
+				"points": 0
+			}
+		},
+		{
+			"id": "TyRzqRLDFKZJZiCB_",
+			"name": "Prehensile Toes",
+			"reference": "BT51",
+			"local_notes": "TL9",
+			"container_type": "meta_trait",
+			"children": [
+				{
+					"id": "tqJdICYsGUPvCRKkS",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tkCi-pV0exqSyPhyv"
+					},
+					"name": "Extra Arm",
+					"reference": "B53",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "myZAn-1aEupMUraHG",
+							"name": "Extra-Flexible",
+							"reference": "B53",
+							"cost": 50,
+							"disabled": true
+						},
+						{
+							"id": "mOGCuDsKeMzHW1GB-",
+							"name": "Long",
+							"reference": "B53",
+							"cost": 100,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mZnHqiA0IwrARUPur",
+							"name": "Foot Manipulators",
+							"reference": "B53",
+							"cost": -30
+						},
+						{
+							"id": "mV-TKigARqqS092x1",
+							"name": "No Physical Attack",
+							"reference": "B53",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "mI-c_Sxxc7JKVBdOF",
+							"name": "Short",
+							"reference": "B53",
+							"cost": -50
+						},
+						{
+							"id": "mmOg45NPIT0dgROUt",
+							"name": "Weak",
+							"reference": "B53",
+							"local_notes": "Half body ST",
+							"cost": -25,
+							"disabled": true
+						},
+						{
+							"id": "m-XLbqE-142FC99-N",
+							"name": "Weak",
+							"reference": "B53",
+							"local_notes": "Quarter body ST",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "myPbs2iKNbbeKBSEj",
+							"name": "Weapon Mount",
+							"reference": "B53",
+							"cost": -80,
+							"disabled": true
+						},
+						{
+							"id": "m70WwkVIladRXHEZU",
+							"name": "No Grasping Hand",
+							"reference": "MATG28",
+							"cost": -40,
+							"disabled": true
+						}
+					],
+					"points_per_level": 10,
+					"can_level": true,
+					"levels": 2,
+					"calc": {
+						"points": 4
+					}
+				}
+			],
+			"calc": {
+				"points": 4
+			}
+		},
+		{
+			"id": "TNiASAdyio_tM35vm",
+			"name": "Legs to Arms",
+			"reference": "BT51",
+			"local_notes": "TL9",
+			"container_type": "meta_trait",
+			"children": [
+				{
+					"id": "toppL7sAjjF26iWbO",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tkCi-pV0exqSyPhyv"
+					},
+					"name": "Extra Arm",
+					"reference": "B53",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mcY0ai8-2gminFtVZ",
+							"name": "Extra-Flexible",
+							"reference": "B53",
+							"cost": 50,
+							"disabled": true
+						},
+						{
+							"id": "m3PT1WpDehGFn2oME",
+							"name": "Long",
+							"reference": "B53",
+							"cost": 100,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mkJcw6CPKNyjTE3jk",
+							"name": "Foot Manipulators",
+							"reference": "B53",
+							"cost": -30
+						},
+						{
+							"id": "mUxSY5T5HhU7gYcU8",
+							"name": "No Physical Attack",
+							"reference": "B53",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "mcjv1UCesQZBDQP-B",
+							"name": "Short",
+							"reference": "B53",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "mZeQXXlHwpbpjcAFV",
+							"name": "Weak",
+							"reference": "B53",
+							"local_notes": "Half body ST",
+							"cost": -25,
+							"disabled": true
+						},
+						{
+							"id": "m1JoxONlqbjYsnluG",
+							"name": "Weak",
+							"reference": "B53",
+							"local_notes": "Quarter body ST",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "mh17t4Ipr0eM3pIU6",
+							"name": "Weapon Mount",
+							"reference": "B53",
+							"cost": -80,
+							"disabled": true
+						},
+						{
+							"id": "m4b0u35B5I3_-YtqT",
+							"name": "No Grasping Hand",
+							"reference": "MATG28",
+							"cost": -40,
+							"disabled": true
+						}
+					],
+					"points_per_level": 10,
+					"can_level": true,
+					"levels": 2,
+					"calc": {
+						"points": 14
+					}
+				},
+				{
+					"id": "tUt_JWTqNeIp3KIsI",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tWxf5xaLhR2u0HTIG"
+					},
+					"name": "Lame (Crippled Legs)",
+					"reference": "B141",
+					"local_notes": "You must reduce your Basic Move to half your Basic Speed (round down)",
+					"tags": [
+						"Disadvantage",
+						"Physical"
+					],
+					"replacements": {
+						"Condition": "Not in zero-G"
+					},
+					"modifiers": [
+						{
+							"id": "mEATUZ7PEnM6r7-mm",
+							"name": "Mitigator: Flight",
+							"reference": "FFWF13",
+							"reference_highlight": "Lame",
+							"cost": -80,
+							"disabled": true
+						},
+						{
+							"id": "mYUF3qsvT6RPXNXK0",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+								"id": "m2IwCpU9KwYmjiSSA"
+							},
+							"name": "Accessibility (@Condition@)",
+							"reference": "B110,P99",
+							"local_notes": "1 point per level",
+							"cost": -1,
+							"levels": 10
+						}
+					],
+					"base_points": -10,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "to use any skill that requires the use of your legs, including all Melee Weapon and unarmed combat skills (but not ranged combat skills)",
+							"amount": -3
+						}
+					],
+					"calc": {
+						"points": -9
+					}
+				},
+				{
+					"id": "twPOwxhhcOeQRKU8J",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tBBMkYdKxMwhn73fI"
+					},
+					"name": "Decreased Basic Move",
+					"reference": "B17",
+					"tags": [
+						"Attribute",
+						"Disadvantage",
+						"Physical"
+					],
+					"points_per_level": -5,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "basic_move",
+							"amount": -1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "tfLDTzIVQaBoEloXK",
+					"name": "Add levels of Decreased Basic Move until your Basic Move is halved",
+					"calc": {
+						"points": 0
+					}
+				}
+			],
+			"calc": {
+				"points": 5
+			}
+		},
+		{
+			"id": "t1bffFTfNbTChFffc",
+			"name": "Ordinary Tail",
+			"reference": "BT51",
+			"local_notes": "TL9",
+			"calc": {
+				"points": 0
+			}
+		},
+		{
+			"id": "TgANNsBfbQGXiGE27",
+			"name": "Prehensile Tail",
+			"reference": "BT51",
+			"local_notes": "TL10",
+			"container_type": "meta_trait",
+			"children": [
+				{
+					"id": "tf8F8DeEAUVu2ZSfl",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tkCi-pV0exqSyPhyv"
+					},
+					"name": "Extra Arm",
+					"reference": "B53",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mEZfW1raBgIAyUf4L",
+							"name": "Extra-Flexible",
+							"reference": "B53",
+							"cost": 50
+						},
+						{
+							"id": "mdfFl2McWye7kmJtk",
+							"name": "Long",
+							"reference": "B53",
+							"cost": 100,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "m6tkVq0zn6K3s7ScD",
+							"name": "Foot Manipulators",
+							"reference": "B53",
+							"cost": -30,
+							"disabled": true
+						},
+						{
+							"id": "m7Md6cae8bkFj2eIv",
+							"name": "No Physical Attack",
+							"reference": "B53",
+							"cost": -50
+						},
+						{
+							"id": "m_1qNi8YCLtuKH8YV",
+							"name": "Short",
+							"reference": "B53",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "mhs1JCcXNjrfe_pyi",
+							"name": "Weak",
+							"reference": "B53",
+							"local_notes": "Half body ST",
+							"cost": -25,
+							"disabled": true
+						},
+						{
+							"id": "mAHZIH11X0ErYxZje",
+							"name": "Weak",
+							"reference": "B53",
+							"local_notes": "Quarter body ST",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "msDX0xsaVh1zJ5c7T",
+							"name": "Weapon Mount",
+							"reference": "B53",
+							"cost": -80,
+							"disabled": true
+						},
+						{
+							"id": "mFlbGdTNeAIBQa_jl",
+							"name": "No Grasping Hand",
+							"reference": "MATG28",
+							"cost": -40,
+							"disabled": true
+						}
+					],
+					"points_per_level": 10,
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 10
+					}
+				}
+			],
+			"calc": {
+				"points": 10
+			}
+		},
+		{
+			"id": "T1V76K5AbwHAznj9d",
+			"name": "Prehensile Trunk",
+			"reference": "BT51",
+			"local_notes": "TL11",
+			"children": [
+				{
+					"id": "tpz0eV-qwKAboSxLf",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tkCi-pV0exqSyPhyv"
+					},
+					"name": "Extra Arm",
+					"reference": "B53",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mzQwM34K8aXnwUQaf",
+							"name": "Extra-Flexible",
+							"reference": "B53",
+							"cost": 50
+						},
+						{
+							"id": "mHrzkv6Np9RBCrEYp",
+							"name": "Long",
+							"reference": "B53",
+							"cost": 100,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "m9H8LoF9klB9MnGAP",
+							"name": "Foot Manipulators",
+							"reference": "B53",
+							"cost": -30,
+							"disabled": true
+						},
+						{
+							"id": "mvUOfcbCA-Mxrd515",
+							"name": "No Physical Attack",
+							"reference": "B53",
+							"cost": -50
+						},
+						{
+							"id": "mAkERonDPbBU_AyAH",
+							"name": "Short",
+							"reference": "B53",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "mT8d5Ne3YfNVOQKmL",
+							"name": "Weak",
+							"reference": "B53",
+							"local_notes": "Half body ST",
+							"cost": -25,
+							"disabled": true
+						},
+						{
+							"id": "mI65vJZxLsQAfDvAc",
+							"name": "Weak",
+							"reference": "B53",
+							"local_notes": "Quarter body ST",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "m-Sqf7b4uythC4_he",
+							"name": "Weapon Mount",
+							"reference": "B53",
+							"cost": -80,
+							"disabled": true
+						},
+						{
+							"id": "mcnzXS0DpAzkByLzi",
+							"name": "No Grasping Hand",
+							"reference": "MATG28",
+							"cost": -40,
+							"disabled": true
+						}
+					],
+					"points_per_level": 10,
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 10
+					}
+				}
+			],
+			"calc": {
+				"points": 10
+			}
+		},
+		{
+			"id": "THYrwozvUBXEac_ce",
+			"name": "Scorpion Tail",
+			"reference": "BT51",
+			"local_notes": "TL12",
+			"children": [
+				{
+					"id": "tlq4YWLmzObmUCcxA",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tukroad0MSj14lSkd"
+					},
+					"name": "Large Piercing Striker (@Body Part@)",
+					"reference": "B88",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"replacements": {
+						"Body Part": "Tail"
+					},
+					"modifiers": [
+						{
+							"id": "m94Lz8KGzSKGIBuOM",
+							"name": "Cannot Parry",
+							"reference": "B88",
+							"cost": -40,
+							"disabled": true
+						},
+						{
+							"id": "mdKhMUqj034xBmTCj",
+							"name": "Clumsy",
+							"reference": "B88",
+							"cost": -20,
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"amount": -1,
+									"per_level": true
+								}
+							],
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mknZSO7Q4bqrtxcFo",
+							"name": "Limited Arc (@Direction@)",
+							"reference": "B88",
+							"cost": -40,
+							"disabled": true
+						},
+						{
+							"id": "msqg47zJNmVhNa8Hb",
+							"name": "Weak",
+							"reference": "B88",
+							"cost": -50,
+							"features": [
+								{
+									"type": "weapon_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": -1,
+									"per_die": true
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mDRCPu30yHa9W3yVk",
+							"name": "Long",
+							"reference": "B88",
+							"cost": 100,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mo7xXfSJwbaxW1dyE",
+							"name": "Long, max reach only",
+							"reference": "B88",
+							"cost": 75,
+							"levels": 1,
+							"disabled": true
+						}
+					],
+					"base_points": 6,
+					"weapons": [
+						{
+							"id": "wY1kAKXyAtUh8_4HL",
+							"damage": {
+								"type": "pi+",
+								"st": "thr",
+								"modifier_per_die": 1
+							},
+							"reach": "C",
+							"parry": "0",
+							"defaults": [
+								{
+									"type": "dx"
+								},
+								{
+									"type": "skill",
+									"name": "Brawling"
+								}
+							],
+							"calc": {
+								"damage": "thr (+1 per die) pi+"
+							}
+						}
+					],
+					"calc": {
+						"points": 6
+					}
+				},
+				{
+					"id": "tPtdhWe59k1eMwES0",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "ttP5n0OVmbu8o50uI"
+					},
+					"name": "Innate Attack (Toxic)",
+					"reference": "B62,P53,MA45",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"replacements": {
+						"Attack Type": "Follow-Up",
+						"Carrier Attack": "Striker"
+					},
+					"modifiers": [
+						{
+							"id": "m5TrzDmX3Nd-5DOAU",
+							"name": "Cyclic",
+							"reference": "B103",
+							"local_notes": "1 sec",
+							"cost": 100,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "megL58AeaCnskkN_a",
+							"name": "Cyclic",
+							"reference": "B103",
+							"local_notes": "10 sec",
+							"cost": 50,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mWJLdOXhmiFxBL9qV",
+							"name": "Cyclic",
+							"reference": "B103",
+							"local_notes": "1 min",
+							"cost": 40,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mYWtUiRYsbOs-MfNO",
+							"name": "Cyclic",
+							"reference": "B103",
+							"local_notes": "1 hr",
+							"cost": 20,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mLSI4EgBlyMKvevun",
+							"name": "Cyclic",
+							"reference": "B103",
+							"local_notes": "1 day",
+							"cost": 10,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mKju4emkc927OMkES",
+							"name": "Cyclic",
+							"reference": "B103",
+							"local_notes": "1 sec; Resistible",
+							"cost": 50,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "m9sXG1Gm9m8qOZv42",
+							"name": "Cyclic",
+							"reference": "B103",
+							"local_notes": "10 sec; Resistible",
+							"cost": 25,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mjzwwo1vGuHLDUb4y",
+							"name": "Cyclic",
+							"reference": "B103",
+							"local_notes": "1 min; Resistible",
+							"cost": 20,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mmh1Ani3eow-_CDh7",
+							"name": "Cyclic",
+							"reference": "B103",
+							"local_notes": "1 hr; Resistible",
+							"cost": 10,
+							"levels": 4
+						},
+						{
+							"id": "mJCvh4tIMmvW10RHs",
+							"name": "Cyclic",
+							"reference": "B103",
+							"local_notes": "1 day; Resistible",
+							"cost": 5,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "m0A7vD7SAWrVFM8yw",
+							"name": "Contagious",
+							"reference": "B103",
+							"local_notes": "Mildly",
+							"cost": 20,
+							"disabled": true
+						},
+						{
+							"id": "mN8osxbV71zIqu3AE",
+							"name": "Contagious",
+							"reference": "B103",
+							"local_notes": "Highly",
+							"cost": 50,
+							"disabled": true
+						},
+						{
+							"id": "m0OdjyFuM8Dl3RH8Q",
+							"name": "Double Blunt Trauma",
+							"reference": "B104",
+							"local_notes": "1HP per 10 dmg",
+							"cost": 20,
+							"disabled": true
+						},
+						{
+							"id": "meIN7M3_T3nvl670U",
+							"name": "Explosion",
+							"reference": "B104",
+							"cost": 50,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mFsjsNVaCe_FFYOuA",
+							"name": "Fragmentation",
+							"reference": "B104",
+							"cost": 15,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "msDg3H2LT_Li_T5qJ",
+							"name": "Fragmentation",
+							"reference": "B104",
+							"local_notes": "Hot",
+							"cost": 15,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mu6qgPlIG2iTXsSpH",
+							"name": "Radiation",
+							"reference": "B104",
+							"cost": 100,
+							"disabled": true
+						},
+						{
+							"id": "mpBib3qRaDZ7YPRFw",
+							"name": "Surge",
+							"reference": "B104",
+							"cost": 20,
+							"disabled": true
+						},
+						{
+							"id": "mF7PXf7dwYHkJ06vU",
+							"name": "Armor Divisor",
+							"reference": "B102",
+							"local_notes": "2",
+							"cost": 50,
+							"disabled": true
+						},
+						{
+							"id": "maYfpbzUjzmxbpHL2",
+							"name": "Armor Divisor",
+							"reference": "B102",
+							"local_notes": "3",
+							"cost": 100,
+							"disabled": true
+						},
+						{
+							"id": "mRTyPOYwJo6q-HfkU",
+							"name": "Armor Divisor",
+							"reference": "B102",
+							"local_notes": "5",
+							"cost": 150,
+							"disabled": true
+						},
+						{
+							"id": "mw0MjI_WjTZ4Mg7_y",
+							"name": "Armor Divisor",
+							"reference": "B102",
+							"local_notes": "10",
+							"cost": 200,
+							"disabled": true
+						},
+						{
+							"id": "mJhiStQuYwlOgWLb9",
+							"name": "Side Effect",
+							"reference": "B109",
+							"local_notes": "@Effect@",
+							"disabled": true
+						},
+						{
+							"id": "mfVunqle5eSJDmcL2",
+							"name": "Symptoms",
+							"reference": "B109",
+							"local_notes": "@Effect@",
+							"disabled": true
+						},
+						{
+							"id": "mOdkexyv65Vg7uoco",
+							"name": "Armor Divisor",
+							"reference": "B110",
+							"local_notes": "0.5",
+							"cost": -30,
+							"disabled": true
+						},
+						{
+							"id": "mA8cGnw4M68nv0fTL",
+							"name": "Armor Divisor",
+							"reference": "B110",
+							"local_notes": "0.2",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "mOe_bt2KiJNVmJec8",
+							"name": "Armor Divisor",
+							"reference": "B110",
+							"local_notes": "0.1",
+							"cost": -70,
+							"disabled": true
+						},
+						{
+							"id": "mmwA_NmYbDbE_YqOJ",
+							"name": "No Wounding",
+							"reference": "B111",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "mbs94lOyunU5AkuyL",
+							"name": "Incendiary",
+							"reference": "B104",
+							"cost": 10,
+							"disabled": true
+						},
+						{
+							"id": "mZeN0BwaxyFj3G1MG",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+								"id": "m1nJdcOiKLxg7pXwe"
+							},
+							"name": "Follow-Up (@Carrier Attack@)",
+							"reference": "B105,P102"
+						},
+						{
+							"id": "mxY98E5wdUGRjl1R-",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+								"id": "m-F3ACfcl680ioFta"
+							},
+							"name": "Resistible",
+							"reference": "B115,P105",
+							"local_notes": "HT + (level - 6) to resist",
+							"cost": -5,
+							"levels": 3
+						}
+					],
+					"points_per_level": 4,
+					"weapons": [
+						{
+							"id": "W5iQHR4aGnDYnNtaX",
+							"damage": {
+								"type": "tox",
+								"base": "1d"
+							},
+							"accuracy": "3",
+							"range": "10/100",
+							"rate_of_fire": "1",
+							"recoil": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Innate Attack",
+									"specialization": "@Attack Type@"
+								},
+								{
+									"type": "skill",
+									"name": "Innate Attack",
+									"modifier": -2
+								},
+								{
+									"type": "dx",
+									"modifier": -4
+								}
+							],
+							"calc": {
+								"damage": "1d tox"
+							}
+						}
+					],
+					"can_level": true,
+					"levels": 2,
+					"calc": {
+						"points": 10
+					}
+				}
+			],
+			"calc": {
+				"points": 16
+			}
+		},
+		{
+			"id": "t1To3ffVy3zTmUhT_",
+			"name": "Altered Sex Ratio (@Ratio@)",
+			"reference": "BT58",
+			"local_notes": "TL9",
+			"calc": {
+				"points": 0
+			}
+		},
+		{
+			"id": "trw8nSoy0n3fMAXnc",
+			"name": "Cross-Species Surrogacy",
+			"reference": "BT58",
+			"local_notes": "TL10",
+			"base_points": 1,
+			"calc": {
+				"points": 1
+			}
+		},
+		{
+			"id": "ti51X8W0eg4n_lYZ9",
+			"name": "Easy Childbirth",
+			"reference": "BT58",
+			"local_notes": "TL10",
+			"calc": {
+				"points": 0
+			}
+		},
+		{
+			"id": "to-5RJL0cfauvVaSO",
+			"name": "External Development (@Gestation Length@)",
+			"reference": "BT58",
+			"local_notes": "TL10",
+			"calc": {
+				"points": 0
+			}
+		},
+		{
+			"id": "tAxoUhk-hCacq90oj",
+			"name": "Light Menses",
+			"reference": "BT58",
+			"local_notes": "TL9",
+			"calc": {
+				"points": 0
+			}
+		},
+		{
+			"id": "T4I1lKbVAm_JUhoRo",
+			"name": "Estrus",
+			"reference": "BT59",
+			"local_notes": "TL9",
+			"children": [
+				{
+					"id": "T5zT0SaOIgWuqlwxF",
+					"name": "Variant Humans also often have this:",
+					"template_picker": {
+						"type": "count"
+					},
+					"children": [
+						{
+							"id": "tp82IAm8qLJUY1xCc",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tSiOKuvTJkqJhuRrI"
+							},
+							"name": "Lecherousness",
+							"reference": "B142",
+							"local_notes": "Make a self-control roll whenever you have more than the briefest contact with an appealing member of the sex you find attractive, at -5 if this person is Handsome/Beautiful, or at -10 if Very Handsome/Very Beautiful. If you fail, you must make a “pass” using whatever wiles and skills you can bring to bear.",
+							"tags": [
+								"Disadvantage",
+								"Mental"
+							],
+							"replacements": {
+								"Condition": "Only in mating season"
+							},
+							"modifiers": [
+								{
+									"id": "mj83LEBcirQDJm-HC",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+										"id": "m2IwCpU9KwYmjiSSA"
+									},
+									"name": "Accessibility (@Condition@)",
+									"reference": "B110,P99",
+									"local_notes": "1 point per level",
+									"cost": -1,
+									"levels": 80
+								}
+							],
+							"cr": 12,
+							"base_points": -15,
+							"calc": {
+								"points": -3
+							}
+						}
+					],
+					"calc": {
+						"points": -3
+					}
+				}
+			],
+			"calc": {
+				"points": -3
+			}
+		},
+		{
+			"id": "tqoZjoMK01Dz00QE5",
+			"name": "Reproductive Control",
+			"reference": "BT59",
+			"local_notes": "TL9",
+			"base_points": 1,
+			"calc": {
+				"points": 1
+			}
+		},
+		{
+			"id": "t5xD0RWeH3yvce1Br",
+			"name": "Sexual Orientation (@Orientation@)",
+			"reference": "BT59",
+			"local_notes": "TL9",
+			"calc": {
+				"points": 0
+			}
+		},
+		{
+			"id": "t2HX8P_jw03Yf1h1f",
+			"name": "Shorter Gestation (@Gestation Length@)",
+			"reference": "BT59",
+			"local_notes": "TL10",
+			"calc": {
+				"points": 0
+			}
+		},
+		{
+			"id": "tBWeZ90I501SFcH3_",
+			"name": "Extended Fertility (@Fertility Extended To@)",
+			"reference": "BT59",
+			"local_notes": "TL9",
+			"calc": {
+				"points": 0
+			}
+		},
+		{
+			"id": "ttmb3CyN09tIra5GP",
+			"name": "Increased Fecundity (@Litter Size@)",
+			"reference": "BT59",
+			"local_notes": "TL9",
+			"calc": {
+				"points": 0
+			}
+		},
+		{
+			"id": "tbxbxWKLSqheG8ZU2",
+			"name": "Hermaphroditism",
+			"reference": "BT59",
+			"local_notes": "TL10",
+			"calc": {
+				"points": 0
+			}
+		},
+		{
+			"id": "tny2gjhcdhsBVRmXl",
+			"name": "Oviparous (@Gestation Length@)",
+			"reference": "BT59",
+			"local_notes": "TL10",
+			"calc": {
+				"points": 0
+			}
+		},
+		{
+			"id": "tV-sKMFCpL6KwPcgC",
+			"name": "Parthenogenesis",
+			"reference": "BT59",
+			"local_notes": "TL10",
+			"modifiers": [
+				{
+					"id": "m5-Mvxb4d8jzP6a8t",
+					"name": "In addition to sexual reproduction",
+					"cost": 1,
+					"cost_type": "points",
+					"disabled": true
+				}
+			],
+			"calc": {
+				"points": 0
+			}
+		},
+		{
+			"id": "Tv0Y4NZfGnuGNiwiQ",
+			"name": "Exotic Genitalia (@Features@)",
+			"reference": "BT59",
+			"local_notes": "TL9",
+			"children": [
+				{
+					"id": "TJS7OFkRiuuewXa9J",
+					"name": "If it enhances his ability as a lover, this will grant a racial bonus to Erotic Art skill",
+					"template_picker": {
+						"type": "count"
+					},
+					"children": [
+						{
+							"id": "t4ugN6CK3pv_xqsh3",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tpwIBKlkbnSdcNrWd"
+							},
+							"name": "Racial Skill Bonus - @Skill without a specialization@",
+							"reference": "BX452",
+							"tags": [
+								"Advantage",
+								"Exotic",
+								"Mental",
+								"Talent"
+							],
+							"replacements": {
+								"Skill without a specialization": "Erotic Art"
+							},
+							"points_per_level": 2,
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "@Skill without a specialization@"
+									},
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"calc": {
+								"points": 0
+							}
+						}
+					],
+					"calc": {
+						"points": 0
+					}
+				}
+			],
+			"calc": {
+				"points": 0
+			}
+		},
+		{
+			"id": "t0chRUtja4yl-jN91",
+			"name": "Modified Genetic Inheritance (@Gene Inheritance Modification@)",
+			"reference": "BT59",
+			"local_notes": "TL10",
+			"calc": {
+				"points": 0
+			}
+		},
+		{
+			"id": "Tb8rQyD0oDU0_aBE3",
+			"name": "Variant Sexual Schemes (@Sexes@)",
+			"reference": "BT59",
+			"local_notes": "TL10",
+			"children": [
+				{
+					"id": "T-imAaguHik-a32Cb",
+					"name": "A \"drone\" sex may be neutered or sexless",
+					"template_picker": {
+						"type": "count"
+					},
+					"children": [
+						{
+							"id": "tuLU4XuXNnnbtrWR7",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tTq2WezVZouDD4sFe"
+							},
+							"name": "Neutered",
+							"reference": "B165",
+							"local_notes": "Immune to seduction",
+							"tags": [
+								"Physical",
+								"Quirk"
+							],
+							"base_points": -1,
+							"calc": {
+								"points": -1
+							}
+						},
+						{
+							"id": "tYy4pZ3e-9WaDQbZ0",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tSKajHun2ScWfmrCr"
+							},
+							"name": "Sexless",
+							"reference": "B165",
+							"tags": [
+								"Physical",
+								"Quirk"
+							],
+							"base_points": -1,
+							"calc": {
+								"points": -1
+							}
+						}
+					],
+					"calc": {
+						"points": -2
+					}
+				}
+			],
+			"calc": {
+				"points": -2
+			}
+		},
+		{
+			"id": "tLe1-US7YK9twT2zS",
+			"name": "Taboo Trait (Genetic Defects)",
+			"reference": "BT65, B261",
+			"local_notes": "TL8; Also prohibits attributes more than 2 below the average for an adult with that template",
+			"tags": [
+				"Exotic",
+				"Mental",
+				"Physical",
+				"Taboo Trait"
+			],
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Short Attention Span"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Non-Iconographic"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "No Sense of Smell/Taste"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Night Blindness"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Innumerate"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Hemophilia"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Gigantism"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Dyslexia"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Dwarfism"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Colorblindness"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "starts_with",
+							"qualifier": "Bad Sight"
+						}
+					}
+				]
+			},
+			"calc": {
+				"points": 0
+			}
+		},
+		{
+			"id": "tTi0zSDyDA07Ttfvy",
+			"name": "Taboo Trait (Unattractiveness)",
+			"reference": "BT65, B261",
+			"local_notes": "TL9",
+			"tags": [
+				"Exotic",
+				"Physical",
+				"Taboo Trait"
+			],
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Very Unfit"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Very Fat"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Overweight"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Fat"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Bowlegged"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Bad Smell"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Appearance"
+						},
+						"notes": {
+							"compare": "contains",
+							"qualifier": "Horrific"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Appearance"
+						},
+						"notes": {
+							"compare": "contains",
+							"qualifier": "Monstrous"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Appearance"
+						},
+						"notes": {
+							"compare": "contains",
+							"qualifier": "Hideous"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Appearance"
+						},
+						"notes": {
+							"compare": "contains",
+							"qualifier": "Ugly"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Appearance"
+						},
+						"notes": {
+							"compare": "contains",
+							"qualifier": "Unattractive"
+						}
+					}
+				]
+			},
+			"calc": {
+				"points": 0
+			}
+		},
+		{
+			"id": "t020EdMCSbDSrITDv",
+			"name": "Taboo Trait (Aggressiveness)",
+			"reference": "BT65, B261",
+			"local_notes": "TL9",
+			"tags": [
+				"Exotic",
+				"Mental",
+				"Taboo Trait"
+			],
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Bad Temper"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Berserk"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Bully"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Stubbornness"
+						}
+					}
+				]
+			},
+			"calc": {
+				"points": 0
+			}
+		},
+		{
+			"id": "tDhx56D50aegwu4w6",
+			"name": "Taboo Trait (Mental Instability)",
+			"reference": "BT65, B261",
+			"local_notes": "TL9; Also prohibits any Compulsive Behaviour or Phobia worth -10 points or more",
+			"tags": [
+				"Exotic",
+				"Mental",
+				"Taboo Trait"
+			],
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Pyromania"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Phantom Voices"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Paranoia"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "On the Edge"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Obsession"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Megalomania"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Manic-Depressive"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Lunacy"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Low Self-Image"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Kleptomania"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Guilt Complex"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Flashbacks"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Delusion"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "starts_with",
+							"qualifier": "Delusions"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Chronic Depression"
+						}
+					}
+				]
+			},
+			"calc": {
+				"points": 0
+			}
+		},
+		{
 			"id": "TxtxxADYNjHcokGFN",
 			"name": "Panimmunity (Level 1)",
 			"reference": "BT165",

--- a/Library/Powers/Powers Modifiers.adm
+++ b/Library/Powers/Powers Modifiers.adm
@@ -77,6 +77,12 @@
 			"reference": "P29",
 			"local_notes": "Opposed by Anti-powers and weird science gadgets",
 			"cost": -10
+		},
+		{
+			"id": "mPcdrHEQuuS1KP9kT",
+			"name": "Switchable",
+			"reference": "P109",
+			"cost": 10
 		}
 	]
 }


### PR DESCRIPTION
While looking into adding the Bio-Tech racial templates, I found some more traits from Bio-Tech that I hadn't added.

In this Pull Request, I went through Bio-Tech's Gengineered Traits and added the meta-traits and features I found that didn't seem to have an equivalent in Basic Set.

This includes building a few abilities based off innate attacks and afflictions, where I've tried to use the existing traits and modifiers to make most of them syncable with the source library.

Most of the changes are:
* Change modifiers to take substitutions and set its % value by setting its level.
* Add missing modifiers.