### PR TITLE
Bio-Tech: Add Gengineered Human Racial Templates

### DIFF
--- a/Library/Bio-Tech/Races/Alpha.gct
+++ b/Library/Bio-Tech/Races/Alpha.gct
@@ -1,0 +1,1688 @@
+{
+	"version": 5,
+	"id": "BwOehsZslkMOF_6ay",
+	"traits": [
+		{
+			"id": "TMWLyKQrA6irNZ2P9",
+			"name": "Alpha",
+			"reference": "BT66",
+			"local_notes": "TL9. $64000. LC4.",
+			"ancestry": "Human",
+			"container_type": "ancestry",
+			"children": [
+				{
+					"id": "t-7w0z9_Gl5bdGaHB",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tGWOSEE6SmBHACE6Y"
+					},
+					"name": "Increased Dexterity",
+					"reference": "B15",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "m-zAOlLMHIlFgmFxf",
+							"name": "No Fine Manipulators",
+							"cost": -40,
+							"disabled": true
+						}
+					],
+					"points_per_level": 20,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "dx",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 20
+					}
+				},
+				{
+					"id": "tPGgsleSNYtyDhIM_",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tVt3SvdGWNchJ8z4o"
+					},
+					"name": "Increased Health",
+					"reference": "B14",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"points_per_level": 10,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "ht",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 10
+					}
+				},
+				{
+					"id": "tcMj6HsbFgFdlq0F4",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "thdJ55ghf__io9AQa"
+					},
+					"name": "Longevity",
+					"reference": "B66",
+					"local_notes": "You fail aging rolls only on a 17 or 18, or only on an 18 if your modified HT is 17 or better",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"base_points": 2,
+					"calc": {
+						"points": 2
+					}
+				},
+				{
+					"id": "t5r80UvjyY_t9wPsY",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tJTfFdHM7YI5IZR7I"
+					},
+					"name": "Resistant",
+					"reference": "B81,P71,MA47",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"replacements": {
+						"Occasional: Disease, Ingested Poison, etc.": "Disease"
+					},
+					"modifiers": [
+						{
+							"id": "m7xlFzocsXpl05bui",
+							"name": "@Very Common: Metabolic Hazards, etc.@",
+							"reference": "B80",
+							"cost": 30,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mCH0-pf09H9FVRhga",
+							"name": "@Common: Poison, Sickness, etc.@",
+							"reference": "B81",
+							"cost": 15,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "m9lXwGvvBrdLJ-vIK",
+							"name": "@Occasional: Disease, Ingested Poison, etc.@",
+							"reference": "B81",
+							"cost": 10,
+							"cost_type": "points"
+						},
+						{
+							"id": "m-pSVT98G_fIJzngI",
+							"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+							"reference": "B81",
+							"cost": 5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "m_nHAdKPhnojL0EqJ",
+							"name": "Immunity",
+							"reference": "B81",
+							"cost": 1,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "mpPmjm2PaaiC0DrBh",
+							"name": "+8 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.5,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "mngSuThtW5TgFDvBX",
+							"name": "+3 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.33,
+							"cost_type": "multiplier"
+						}
+					],
+					"round_down": true,
+					"calc": {
+						"points": 3
+					}
+				},
+				{
+					"id": "tScojhqRDgQgV_l8m",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "tLe1-US7YK9twT2zS"
+					},
+					"name": "Taboo Trait (Genetic Defects)",
+					"reference": "BT65, B261",
+					"local_notes": "TL8; Also prohibits attributes more than 2 below the average for an adult with that template",
+					"tags": [
+						"Exotic",
+						"Mental",
+						"Physical",
+						"Taboo Trait"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Short Attention Span"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Non-Iconographic"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "No Sense of Smell/Taste"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Night Blindness"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Innumerate"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Hemophilia"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Gigantism"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dyslexia"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dwarfism"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Colorblindness"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "starts_with",
+									"qualifier": "Bad Sight"
+								}
+							}
+						]
+					},
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "tcMPf381wbzlB_dft",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "tDhx56D50aegwu4w6"
+					},
+					"name": "Taboo Trait (Mental Instability)",
+					"reference": "BT65, B261",
+					"local_notes": "TL9; Also prohibits any Compulsive Behaviour or Phobia worth -10 points or more",
+					"tags": [
+						"Exotic",
+						"Mental",
+						"Taboo Trait"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Pyromania"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Phantom Voices"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Paranoia"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "On the Edge"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Obsession"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Megalomania"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Manic-Depressive"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Lunacy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Low Self-Image"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Kleptomania"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Guilt Complex"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Flashbacks"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Delusion"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "starts_with",
+									"qualifier": "Delusions"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Chronic Depression"
+								}
+							}
+						]
+					},
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "TC4zY6CqKsCnyX0sg",
+					"name": "Choose One",
+					"template_picker": {
+						"type": "count",
+						"qualifier": {
+							"compare": "is",
+							"qualifier": 1
+						}
+					},
+					"children": [
+						{
+							"id": "TRIh6bj0fpe9Q2BzV",
+							"name": "Base",
+							"children": [
+								{
+									"id": "tJPlyX2Hg8vYuiACV",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tdlCZw4YB4T7QkOnj"
+									},
+									"name": "Appearance",
+									"reference": "B21",
+									"tags": [
+										"Advantage",
+										"Physical"
+									],
+									"modifiers": [
+										{
+											"id": "mLcb_gsdCIXtvnX0b",
+											"name": "Attractive",
+											"reference": "B21",
+											"cost": 4,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": 1
+												}
+											]
+										},
+										{
+											"id": "mnxXWRt7hTyRYZw1Z",
+											"name": "Average",
+											"reference": "B21",
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "mRBBKMKNwTnIR6gVG",
+											"name": "Beautiful",
+											"reference": "B21",
+											"cost": 12,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from those attracted to members of your sex, +2 from everyone else",
+													"amount": 4
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mvOinJ3Wp1JBYHhal",
+											"name": "Beautiful (Androgynous)",
+											"reference": "B21",
+											"cost": 12,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": 3
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mPXvBQ5wkw_R1-v0a",
+											"name": "Beautiful (Impressive)",
+											"reference": "B21",
+											"cost": 12,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": 3
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mrfpQcStpfwW7Lfwj",
+											"name": "Handsome",
+											"reference": "B21",
+											"cost": 12,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from those attracted to members of your sex, +2 from everyone else",
+													"amount": 4
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mpaz7mIw7VyrzDwOx",
+											"name": "Handsome (Androgynous)",
+											"reference": "B21",
+											"cost": 12,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": 3
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mJNuIpsdWIgfKzqIu",
+											"name": "Handsome (Impressive)",
+											"reference": "B21",
+											"cost": 12,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": 3
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mpc6IaXVMXNWeSp3c",
+											"name": "Hideous",
+											"reference": "B21,B202",
+											"cost": -16,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Intimidation"
+													},
+													"amount": 2
+												},
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": -4
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mtKKxFU4fQt1d4tDH",
+											"name": "Horrific",
+											"reference": "B21,B202",
+											"cost": -24,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Intimidation"
+													},
+													"amount": 4
+												},
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": -6
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mNnF7SExUm5RwwFpp",
+											"name": "Impressive",
+											"reference": "B21",
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "mZVkkNr6qOjR-FbOk",
+											"name": "Monstrous",
+											"reference": "B21,B202",
+											"cost": -20,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Intimidation"
+													},
+													"amount": 3
+												},
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": -5
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "milE4ouqGG_tO45vo",
+											"name": "Off-the-Shelf Looks",
+											"reference": "B21",
+											"local_notes": "Halves the usual reaction bonus - adjust manually",
+											"cost": -50,
+											"disabled": true
+										},
+										{
+											"id": "mVxcduBjeNKwy4q-L",
+											"name": "Transcendent",
+											"reference": "B21",
+											"cost": 20,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+													"amount": 8
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mlp_aDKNaMPCHhpaO",
+											"name": "Transcendent (Androgynous)",
+											"reference": "B21",
+											"cost": 20,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": 5
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mT4GNcJ8lgNGYmrgK",
+											"name": "Transcendent (Impressive)",
+											"reference": "B21",
+											"cost": 20,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": 5
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mDbIujymPNLLonhuY",
+											"name": "Ugly",
+											"reference": "B21",
+											"cost": -8,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": -2
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mL2o1dwN6WlPvlPPM",
+											"name": "Unattractive",
+											"reference": "B21",
+											"cost": -4,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": -1
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "m6ht_BeQLasjPC7da",
+											"name": "Universal",
+											"reference": "B21",
+											"cost": 25,
+											"disabled": true
+										},
+										{
+											"id": "mG-DPBW7lWdYjRPHg",
+											"name": "Very Beautiful",
+											"reference": "B21",
+											"cost": 16,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+													"amount": 6
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "m6D5Cd3hbhFUwPDlA",
+											"name": "Very Beautiful (Androgynous)",
+											"reference": "B21",
+											"cost": 16,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": 4
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mpE8IM5JqzZGo2JQW",
+											"name": "Very Beautiful (Impressive)",
+											"reference": "B21",
+											"cost": 16,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": 4
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mmUSjaTiMW-32Uaw0",
+											"name": "Very Handsome",
+											"reference": "B21",
+											"cost": 16,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+													"amount": 6
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mNFEUq7p33sPE4o1n",
+											"name": "Very Handsome (Androgynous)",
+											"reference": "B21",
+											"cost": 16,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": 4
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mjWJP8SL9rFk2ez10",
+											"name": "Very Handsome (Impressive)",
+											"reference": "B21",
+											"cost": 16,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": 4
+												}
+											],
+											"disabled": true
+										}
+									],
+									"calc": {
+										"points": 4
+									}
+								}
+							],
+							"calc": {
+								"points": 4
+							}
+						},
+						{
+							"id": "T7YSXeVD2TgKEofbP",
+							"name": "Omega",
+							"reference": "BT66",
+							"local_notes": "+$28000. LC3",
+							"children": [
+								{
+									"id": "t8lzjKTh8g7yQ5rjP",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t1w1RFcFceKR2T9_e"
+									},
+									"name": "Increased Intelligence",
+									"reference": "B15",
+									"tags": [
+										"Advantage",
+										"Attribute",
+										"Mental"
+									],
+									"points_per_level": 20,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "iq",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": 20
+									}
+								},
+								{
+									"id": "TteXlcBsroBuuVfUE",
+									"name": "Choose One",
+									"template_picker": {
+										"type": "count",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": 1
+										}
+									},
+									"children": [
+										{
+											"id": "tyf1vJGjcvS2KJ_4-",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tdlCZw4YB4T7QkOnj"
+											},
+											"name": "Appearance",
+											"reference": "B21",
+											"tags": [
+												"Advantage",
+												"Physical"
+											],
+											"modifiers": [
+												{
+													"id": "mc3qmcUMvWoAqXLzF",
+													"name": "Attractive",
+													"reference": "B21",
+													"cost": 4,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 1
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mH7lIF0DOMZGnkVAD",
+													"name": "Average",
+													"reference": "B21",
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mxuXhJAUfcoWbDi-V",
+													"name": "Beautiful",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from those attracted to members of your sex, +2 from everyone else",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mN2wn2wu6D9F7s2AV",
+													"name": "Beautiful (Androgynous)",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 3
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mF7_XDO4fF6wMrmb2",
+													"name": "Beautiful (Impressive)",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 3
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mWFYewuRfw2ZBlKuu",
+													"name": "Handsome",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from those attracted to members of your sex, +2 from everyone else",
+															"amount": 4
+														}
+													]
+												},
+												{
+													"id": "mq9MBi7KXiAAP2Kvy",
+													"name": "Handsome (Androgynous)",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 3
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "msRuBzTCnbsin5eOJ",
+													"name": "Handsome (Impressive)",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 3
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mstUfJKLqN8P2G4LK",
+													"name": "Hideous",
+													"reference": "B21,B202",
+													"cost": -16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "skill_bonus",
+															"selection_type": "skills_with_name",
+															"name": {
+																"compare": "is",
+																"qualifier": "Intimidation"
+															},
+															"amount": 2
+														},
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": -4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "moYwR-WWkM6RSw6S_",
+													"name": "Horrific",
+													"reference": "B21,B202",
+													"cost": -24,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "skill_bonus",
+															"selection_type": "skills_with_name",
+															"name": {
+																"compare": "is",
+																"qualifier": "Intimidation"
+															},
+															"amount": 4
+														},
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": -6
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mGAwAn30yskXY0Eay",
+													"name": "Impressive",
+													"reference": "B21",
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mpOJeaCBnSA6mk0OI",
+													"name": "Monstrous",
+													"reference": "B21,B202",
+													"cost": -20,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "skill_bonus",
+															"selection_type": "skills_with_name",
+															"name": {
+																"compare": "is",
+																"qualifier": "Intimidation"
+															},
+															"amount": 3
+														},
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": -5
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mC4Tno82Os-jvosUL",
+													"name": "Off-the-Shelf Looks",
+													"reference": "B21",
+													"local_notes": "Halves the usual reaction bonus - adjust manually",
+													"cost": -50,
+													"disabled": true
+												},
+												{
+													"id": "m63UOfDrc1Ib13Bzw",
+													"name": "Transcendent",
+													"reference": "B21",
+													"cost": 20,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+															"amount": 8
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "m6UVuy3xk0KOQ357-",
+													"name": "Transcendent (Androgynous)",
+													"reference": "B21",
+													"cost": 20,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 5
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mLKe25x05HIil8lhD",
+													"name": "Transcendent (Impressive)",
+													"reference": "B21",
+													"cost": 20,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 5
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mBub7boHVZuZo8lU7",
+													"name": "Ugly",
+													"reference": "B21",
+													"cost": -8,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": -2
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mGNkGoXqz9TarObSB",
+													"name": "Unattractive",
+													"reference": "B21",
+													"cost": -4,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": -1
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "msQ2l6ZjeSn_-cdyJ",
+													"name": "Universal",
+													"reference": "B21",
+													"cost": 25,
+													"disabled": true
+												},
+												{
+													"id": "mt5aFeC4r5Cuht9ax",
+													"name": "Very Beautiful",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+															"amount": 6
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mCI8GXfU4pWBwqaRO",
+													"name": "Very Beautiful (Androgynous)",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "m00cXB1juPHKwzDwj",
+													"name": "Very Beautiful (Impressive)",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mzTWW8GY3soqhOJ8T",
+													"name": "Very Handsome",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+															"amount": 6
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mf03gY0ODooK2UR9l",
+													"name": "Very Handsome (Androgynous)",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mNb-nNudli4eAh8qV",
+													"name": "Very Handsome (Impressive)",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												}
+											],
+											"calc": {
+												"points": 12
+											}
+										},
+										{
+											"id": "tzhMLr-TaNcpCS1Pq",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tdlCZw4YB4T7QkOnj"
+											},
+											"name": "Appearance",
+											"reference": "B21",
+											"tags": [
+												"Advantage",
+												"Physical"
+											],
+											"modifiers": [
+												{
+													"id": "mF6XoYMpZxnRjJ_W3",
+													"name": "Attractive",
+													"reference": "B21",
+													"cost": 4,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 1
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mt9LaAIYx_vb1t2UV",
+													"name": "Average",
+													"reference": "B21",
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mz6QJY38s4HmbOP7Q",
+													"name": "Beautiful",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from those attracted to members of your sex, +2 from everyone else",
+															"amount": 4
+														}
+													]
+												},
+												{
+													"id": "mZ2lQ_6lnw2Zby9se",
+													"name": "Beautiful (Androgynous)",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 3
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mwjlccEnRBEoL57EL",
+													"name": "Beautiful (Impressive)",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 3
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mmmnv8ONN9bkXmich",
+													"name": "Handsome",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from those attracted to members of your sex, +2 from everyone else",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mlAaVDTCtXHVWfNrh",
+													"name": "Handsome (Androgynous)",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 3
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mrkX2rulkvzbjZu2q",
+													"name": "Handsome (Impressive)",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 3
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mXHgisdOXnvcoU13o",
+													"name": "Hideous",
+													"reference": "B21,B202",
+													"cost": -16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "skill_bonus",
+															"selection_type": "skills_with_name",
+															"name": {
+																"compare": "is",
+																"qualifier": "Intimidation"
+															},
+															"amount": 2
+														},
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": -4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mdzfVRVykYsO-BPBU",
+													"name": "Horrific",
+													"reference": "B21,B202",
+													"cost": -24,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "skill_bonus",
+															"selection_type": "skills_with_name",
+															"name": {
+																"compare": "is",
+																"qualifier": "Intimidation"
+															},
+															"amount": 4
+														},
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": -6
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mOxpmiKljAIDT7Rzu",
+													"name": "Impressive",
+													"reference": "B21",
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mFOxhcUQroi51PWI_",
+													"name": "Monstrous",
+													"reference": "B21,B202",
+													"cost": -20,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "skill_bonus",
+															"selection_type": "skills_with_name",
+															"name": {
+																"compare": "is",
+																"qualifier": "Intimidation"
+															},
+															"amount": 3
+														},
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": -5
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "m70cgsYvrL7xGnirC",
+													"name": "Off-the-Shelf Looks",
+													"reference": "B21",
+													"local_notes": "Halves the usual reaction bonus - adjust manually",
+													"cost": -50,
+													"disabled": true
+												},
+												{
+													"id": "m0YaPD8pIV08z9RcM",
+													"name": "Transcendent",
+													"reference": "B21",
+													"cost": 20,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+															"amount": 8
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "m-MyrwVQVM38GxnV8",
+													"name": "Transcendent (Androgynous)",
+													"reference": "B21",
+													"cost": 20,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 5
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mCVjq3Ns0-UL1SfXq",
+													"name": "Transcendent (Impressive)",
+													"reference": "B21",
+													"cost": 20,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 5
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mjkKrKwbz0x2FFqdh",
+													"name": "Ugly",
+													"reference": "B21",
+													"cost": -8,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": -2
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mN_Zlr8MZLCY4y_Pu",
+													"name": "Unattractive",
+													"reference": "B21",
+													"cost": -4,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": -1
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mMEH9OSqAhhcWKPdP",
+													"name": "Universal",
+													"reference": "B21",
+													"cost": 25,
+													"disabled": true
+												},
+												{
+													"id": "mgrsxI5yE80ZGA3Ks",
+													"name": "Very Beautiful",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+															"amount": 6
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mj8mvzyRZ4_fG1h8c",
+													"name": "Very Beautiful (Androgynous)",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mygHLtHXgCp0YLxCa",
+													"name": "Very Beautiful (Impressive)",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mkzBbCz3WrG7kH_Bi",
+													"name": "Very Handsome",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+															"amount": 6
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "m4JzX8tkkjyZDiLes",
+													"name": "Very Handsome (Androgynous)",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mI764FtVLIFF-5XPS",
+													"name": "Very Handsome (Impressive)",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												}
+											],
+											"calc": {
+												"points": 12
+											}
+										}
+									],
+									"calc": {
+										"points": 24
+									}
+								}
+							],
+							"calc": {
+								"points": 44
+							}
+						}
+					],
+					"calc": {
+						"points": 48
+					}
+				}
+			],
+			"calc": {
+				"points": 83
+			}
+		}
+	]
+}

--- a/Library/Bio-Tech/Races/Avatar.gct
+++ b/Library/Bio-Tech/Races/Avatar.gct
@@ -1,0 +1,1771 @@
+{
+	"version": 5,
+	"id": "B-qhdMSIO6aXOsp-_",
+	"traits": [
+		{
+			"id": "TpgmI4x1f7o-HOEY3",
+			"name": "Avatar",
+			"reference": "BT66",
+			"local_notes": "TL10. $116000. LC3.",
+			"tags": [
+				"Race"
+			],
+			"container_type": "ancestry",
+			"children": [
+				{
+					"id": "tHzSCr6vYXAijFeUV",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tVt3SvdGWNchJ8z4o"
+					},
+					"name": "Increased Health",
+					"reference": "B14",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"points_per_level": 10,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "ht",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 2,
+					"calc": {
+						"points": 20
+					}
+				},
+				{
+					"id": "tcgaOctd_E7A_GWD_",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tJTfFdHM7YI5IZR7I"
+					},
+					"name": "Resistant",
+					"reference": "B81,P71,MA47",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"replacements": {
+						"Occasional: Disease, Ingested Poison, etc.": "Disease"
+					},
+					"modifiers": [
+						{
+							"id": "m3Pt5MW_wI4tCg2p1",
+							"name": "@Very Common: Metabolic Hazards, etc.@",
+							"reference": "B80",
+							"cost": 30,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mOK8S-jVXnF5E2UOv",
+							"name": "@Common: Poison, Sickness, etc.@",
+							"reference": "B81",
+							"cost": 15,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "meloZCObjV1dl_vJz",
+							"name": "@Occasional: Disease, Ingested Poison, etc.@",
+							"reference": "B81",
+							"cost": 10,
+							"cost_type": "points"
+						},
+						{
+							"id": "mABzEfZCV-WnE86Hl",
+							"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+							"reference": "B81",
+							"cost": 5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mXaFb2V9tlIyL39fs",
+							"name": "Immunity",
+							"reference": "B81",
+							"cost": 1,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "mw9uWwPbvdts111EN",
+							"name": "+8 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.5,
+							"cost_type": "multiplier"
+						},
+						{
+							"id": "mSBrXdL_8kGPFNnH2",
+							"name": "+3 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.33,
+							"cost_type": "multiplier",
+							"disabled": true
+						}
+					],
+					"round_down": true,
+					"calc": {
+						"points": 5
+					}
+				},
+				{
+					"id": "txWrgenpv2PBJVnO4",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tpwIBKlkbnSdcNrWd"
+					},
+					"name": "Racial Skill Bonus - @Skill without a specialization@",
+					"reference": "BX452",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Mental",
+						"Talent"
+					],
+					"replacements": {
+						"Skill without a specialization": "Sex Appeal"
+					},
+					"points_per_level": 2,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "@Skill without a specialization@"
+							},
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 3,
+					"calc": {
+						"points": 6
+					}
+				},
+				{
+					"id": "ta3hWrSZHg9Z9XGVl",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Power Ups/Power Ups Traits.adq",
+						"id": "tkr9rivWg8KtK_oDA"
+					},
+					"name": "Distinctive Features",
+					"reference": "PU6:14",
+					"local_notes": "@Subject@",
+					"tags": [
+						"Physical",
+						"Quirk",
+						"Social"
+					],
+					"replacements": {
+						"Subject": "Exaggerated secondary sexual characteristics"
+					},
+					"base_points": -1,
+					"calc": {
+						"points": -1,
+						"resolved_notes": "Exaggerated secondary sexual characteristics"
+					}
+				},
+				{
+					"id": "tEeNwhPZ_UAesIfCS",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "tLe1-US7YK9twT2zS"
+					},
+					"name": "Taboo Trait (Genetic Defects)",
+					"reference": "BT65, B261",
+					"local_notes": "TL8; Also prohibits attributes more than 2 below the average for an adult with that template",
+					"tags": [
+						"Exotic",
+						"Mental",
+						"Physical",
+						"Taboo Trait"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Short Attention Span"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Non-Iconographic"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "No Sense of Smell/Taste"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Night Blindness"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Innumerate"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Hemophilia"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Gigantism"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dyslexia"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dwarfism"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Colorblindness"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "starts_with",
+									"qualifier": "Bad Sight"
+								}
+							}
+						]
+					},
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "tK1jWV5sLD7fJm7Bc",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "tDhx56D50aegwu4w6"
+					},
+					"name": "Taboo Trait (Mental Instability)",
+					"reference": "BT65, B261",
+					"local_notes": "TL9; Also prohibits any Compulsive Behaviour or Phobia worth -10 points or more",
+					"tags": [
+						"Exotic",
+						"Mental",
+						"Taboo Trait"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Pyromania"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Phantom Voices"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Paranoia"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "On the Edge"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Obsession"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Megalomania"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Manic-Depressive"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Lunacy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Low Self-Image"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Kleptomania"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Guilt Complex"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Flashbacks"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Delusion"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "starts_with",
+									"qualifier": "Delusions"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Chronic Depression"
+								}
+							}
+						]
+					},
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "Tb91NSPl3jwS4XxVC",
+					"name": "Choose One",
+					"template_picker": {
+						"type": "count",
+						"qualifier": {
+							"compare": "is",
+							"qualifier": 1
+						}
+					},
+					"children": [
+						{
+							"id": "TjFfa36RSTHCkQv4P",
+							"name": "Male Avatar",
+							"children": [
+								{
+									"id": "t3VvTzRyoMovt9yo9",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tdlCZw4YB4T7QkOnj"
+									},
+									"name": "Appearance",
+									"reference": "B21",
+									"tags": [
+										"Advantage",
+										"Physical"
+									],
+									"modifiers": [
+										{
+											"id": "mMJIDnTPB0QzqfL-Y",
+											"name": "Attractive",
+											"reference": "B21",
+											"cost": 4,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": 1
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mwFXIavPK2hEjz_-i",
+											"name": "Average",
+											"reference": "B21",
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "mnYqknYafUtW7vOyd",
+											"name": "Beautiful",
+											"reference": "B21",
+											"cost": 12,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from those attracted to members of your sex, +2 from everyone else",
+													"amount": 4
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mywxgQCPBLcoU5jGF",
+											"name": "Beautiful (Androgynous)",
+											"reference": "B21",
+											"cost": 12,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": 3
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mOR3S0ORaaeAHUO0Y",
+											"name": "Beautiful (Impressive)",
+											"reference": "B21",
+											"cost": 12,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": 3
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mog5WMsB0-T5ak5d1",
+											"name": "Handsome",
+											"reference": "B21",
+											"cost": 12,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from those attracted to members of your sex, +2 from everyone else",
+													"amount": 4
+												}
+											]
+										},
+										{
+											"id": "mBss9X5X7EThA2zDy",
+											"name": "Handsome (Androgynous)",
+											"reference": "B21",
+											"cost": 12,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": 3
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "m9BZalx0EaFY7BJNh",
+											"name": "Handsome (Impressive)",
+											"reference": "B21",
+											"cost": 12,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": 3
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "m70_DlUOe4i25Dguc",
+											"name": "Hideous",
+											"reference": "B21,B202",
+											"cost": -16,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Intimidation"
+													},
+													"amount": 2
+												},
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": -4
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mnlQPxZifBFPKJ-Fe",
+											"name": "Horrific",
+											"reference": "B21,B202",
+											"cost": -24,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Intimidation"
+													},
+													"amount": 4
+												},
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": -6
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mDOKVT929k7WyqIF2",
+											"name": "Impressive",
+											"reference": "B21",
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "mej_XdED2s24z2PDs",
+											"name": "Monstrous",
+											"reference": "B21,B202",
+											"cost": -20,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Intimidation"
+													},
+													"amount": 3
+												},
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": -5
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mC0gDod1PGXWK9_aQ",
+											"name": "Off-the-Shelf Looks",
+											"reference": "B21",
+											"local_notes": "Halves the usual reaction bonus - adjust manually",
+											"cost": -50,
+											"disabled": true
+										},
+										{
+											"id": "mwrZpVpcDVsxLH_wr",
+											"name": "Transcendent",
+											"reference": "B21",
+											"cost": 20,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+													"amount": 8
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mZIsjvVBY0T8PNeN6",
+											"name": "Transcendent (Androgynous)",
+											"reference": "B21",
+											"cost": 20,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": 5
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mbh9xWj4TOMWoYxBb",
+											"name": "Transcendent (Impressive)",
+											"reference": "B21",
+											"cost": 20,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": 5
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mBrUiA5YFihpmguTl",
+											"name": "Ugly",
+											"reference": "B21",
+											"cost": -8,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": -2
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mL2KUa4I6xGC_aG-Y",
+											"name": "Unattractive",
+											"reference": "B21",
+											"cost": -4,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": -1
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "m496vWJg_duzYmMLD",
+											"name": "Universal",
+											"reference": "B21",
+											"cost": 25,
+											"disabled": true
+										},
+										{
+											"id": "mVAzbsCo1_len1EPp",
+											"name": "Very Beautiful",
+											"reference": "B21",
+											"cost": 16,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+													"amount": 6
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mXNBA6JhunFzl1s5J",
+											"name": "Very Beautiful (Androgynous)",
+											"reference": "B21",
+											"cost": 16,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": 4
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mQBH4Qhfm9O8n1IVi",
+											"name": "Very Beautiful (Impressive)",
+											"reference": "B21",
+											"cost": 16,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": 4
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mnjazja7X9bJGG9pT",
+											"name": "Very Handsome",
+											"reference": "B21",
+											"cost": 16,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+													"amount": 6
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mL4n-mpAwBcUleQrx",
+											"name": "Very Handsome (Androgynous)",
+											"reference": "B21",
+											"cost": 16,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": 4
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mdOT1bH9arw5B_6mJ",
+											"name": "Very Handsome (Impressive)",
+											"reference": "B21",
+											"cost": 16,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": 4
+												}
+											],
+											"disabled": true
+										}
+									],
+									"calc": {
+										"points": 12
+									}
+								},
+								{
+									"id": "tS2U9fXZtgyNR0yxZ",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tqha9GlDBU9P-Wg-6"
+									},
+									"name": "Increased Strength",
+									"reference": "B14",
+									"tags": [
+										"Advantage",
+										"Attribute",
+										"Physical"
+									],
+									"modifiers": [
+										{
+											"id": "mvJrX8Yr_K1GKmNOk",
+											"name": "No Fine Manipulators",
+											"reference": "B15",
+											"cost": -40,
+											"disabled": true
+										},
+										{
+											"id": "mMHp2TtQeAT0XKc4F",
+											"name": "Size",
+											"reference": "B15",
+											"cost": -10,
+											"levels": 1,
+											"disabled": true
+										},
+										{
+											"id": "mScvaWjIMjKoWDmZ4",
+											"name": "Super-Effort",
+											"reference": "SU24",
+											"cost": 300,
+											"disabled": true
+										}
+									],
+									"points_per_level": 10,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "st",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 2,
+									"calc": {
+										"points": 20
+									}
+								},
+								{
+									"id": "t4PPiVz9jD3WCn1bD",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "teRggYn926_I1YeWO"
+									},
+									"name": "High Pain Threshold",
+									"reference": "B59",
+									"local_notes": "Never suffer shock penalties when injured",
+									"tags": [
+										"Advantage",
+										"Physical"
+									],
+									"base_points": 10,
+									"features": [
+										{
+											"type": "conditional_modifier",
+											"situation": "on all HT rolls to avoid knockdown and stunning",
+											"amount": 3
+										},
+										{
+											"type": "conditional_modifier",
+											"situation": "to resist torture",
+											"amount": 3
+										}
+									],
+									"calc": {
+										"points": 10
+									}
+								},
+								{
+									"id": "tT1R5wCw6RXgnY5sq",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tPbL1_rekOzkM86wz"
+									},
+									"name": "Overconfidence",
+									"reference": "B148",
+									"local_notes": "You must make a self-control roll any time the GM feels you show an unreasonable degree of caution. If you fail, you must go ahead as though you were able to handle the situation!",
+									"tags": [
+										"Disadvantage",
+										"Mental"
+									],
+									"cr": 12,
+									"base_points": -5,
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from young or naive individuals who believe you are as good as you say you are",
+											"amount": 2
+										},
+										{
+											"type": "reaction_bonus",
+											"situation": "from experienced NPCs",
+											"amount": -2
+										}
+									],
+									"calc": {
+										"points": -5
+									}
+								},
+								{
+									"id": "tdEtctJRvie6gpYmP",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tkvBzkhf0YNP2cF5j"
+									},
+									"name": "Proud",
+									"reference": "B164",
+									"tags": [
+										"Mental",
+										"Quirk"
+									],
+									"base_points": -1,
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "to orders, insults, or social slights",
+											"amount": -1
+										}
+									],
+									"calc": {
+										"points": -1
+									}
+								}
+							],
+							"calc": {
+								"points": 36
+							}
+						},
+						{
+							"id": "TqkLrrQXhWJgHdaFb",
+							"name": "Female Avatar",
+							"children": [
+								{
+									"id": "tH9jikes_vRCFf8iS",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tdlCZw4YB4T7QkOnj"
+									},
+									"name": "Appearance",
+									"reference": "B21",
+									"tags": [
+										"Advantage",
+										"Physical"
+									],
+									"modifiers": [
+										{
+											"id": "mVskbDWVs0AkejeCA",
+											"name": "Attractive",
+											"reference": "B21",
+											"cost": 4,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": 1
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mrgiyw85XexryGVLi",
+											"name": "Average",
+											"reference": "B21",
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "mOi3ORxhZnEsRPXMY",
+											"name": "Beautiful",
+											"reference": "B21",
+											"cost": 12,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from those attracted to members of your sex, +2 from everyone else",
+													"amount": 4
+												}
+											]
+										},
+										{
+											"id": "m0ErYp2v7xlCeEumQ",
+											"name": "Beautiful (Androgynous)",
+											"reference": "B21",
+											"cost": 12,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": 3
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mXzKpCuSvMFAM0nVX",
+											"name": "Beautiful (Impressive)",
+											"reference": "B21",
+											"cost": 12,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": 3
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mc4bRO16xqAa9nAWE",
+											"name": "Handsome",
+											"reference": "B21",
+											"cost": 12,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from those attracted to members of your sex, +2 from everyone else",
+													"amount": 4
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mTVGpYeLTAKpoS27c",
+											"name": "Handsome (Androgynous)",
+											"reference": "B21",
+											"cost": 12,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": 3
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "moQJ5ux6z7ckaudzx",
+											"name": "Handsome (Impressive)",
+											"reference": "B21",
+											"cost": 12,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": 3
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "m37Dc5GFbwXdOobMk",
+											"name": "Hideous",
+											"reference": "B21,B202",
+											"cost": -16,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Intimidation"
+													},
+													"amount": 2
+												},
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": -4
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "m82Zw0PW9A08YQXYU",
+											"name": "Horrific",
+											"reference": "B21,B202",
+											"cost": -24,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Intimidation"
+													},
+													"amount": 4
+												},
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": -6
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mzM2QVesXnzwBD_QD",
+											"name": "Impressive",
+											"reference": "B21",
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "m4S5dBgRof5KGOJhT",
+											"name": "Monstrous",
+											"reference": "B21,B202",
+											"cost": -20,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Intimidation"
+													},
+													"amount": 3
+												},
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": -5
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mRWDZmFWDgW7YBC6k",
+											"name": "Off-the-Shelf Looks",
+											"reference": "B21",
+											"local_notes": "Halves the usual reaction bonus - adjust manually",
+											"cost": -50,
+											"disabled": true
+										},
+										{
+											"id": "mOyZpanDuyRDaSLJO",
+											"name": "Transcendent",
+											"reference": "B21",
+											"cost": 20,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+													"amount": 8
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "muQEMGaHC1L1EfeXN",
+											"name": "Transcendent (Androgynous)",
+											"reference": "B21",
+											"cost": 20,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": 5
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mrQUalZjkHGeOWNlA",
+											"name": "Transcendent (Impressive)",
+											"reference": "B21",
+											"cost": 20,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": 5
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mt0BIej6ce6cBS9lq",
+											"name": "Ugly",
+											"reference": "B21",
+											"cost": -8,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": -2
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "m90X87_3xnn4shVZN",
+											"name": "Unattractive",
+											"reference": "B21",
+											"cost": -4,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": -1
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mQWIsfdXubr510_fx",
+											"name": "Universal",
+											"reference": "B21",
+											"cost": 25,
+											"disabled": true
+										},
+										{
+											"id": "myK5KqA-XNbULmJ6X",
+											"name": "Very Beautiful",
+											"reference": "B21",
+											"cost": 16,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+													"amount": 6
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mtveNkAymGhcQ7tGt",
+											"name": "Very Beautiful (Androgynous)",
+											"reference": "B21",
+											"cost": 16,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": 4
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mVMkKJ0NDGC93A-TK",
+											"name": "Very Beautiful (Impressive)",
+											"reference": "B21",
+											"cost": 16,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": 4
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mmnQByWSmjW7a4QJ5",
+											"name": "Very Handsome",
+											"reference": "B21",
+											"cost": 16,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+													"amount": 6
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mDqOhbhS9vjYOIxCq",
+											"name": "Very Handsome (Androgynous)",
+											"reference": "B21",
+											"cost": 16,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": 4
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mrerMMzJ9GY9K4xjR",
+											"name": "Very Handsome (Impressive)",
+											"reference": "B21",
+											"cost": 16,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": 4
+												}
+											],
+											"disabled": true
+										}
+									],
+									"calc": {
+										"points": 12
+									}
+								},
+								{
+									"id": "teUa_fnR0RR0ApnJt",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tGWOSEE6SmBHACE6Y"
+									},
+									"name": "Increased Dexterity",
+									"reference": "B15",
+									"tags": [
+										"Advantage",
+										"Attribute",
+										"Physical"
+									],
+									"modifiers": [
+										{
+											"id": "m5tXSnRyFbAkPIQcf",
+											"name": "No Fine Manipulators",
+											"cost": -40,
+											"disabled": true
+										}
+									],
+									"points_per_level": 20,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "dx",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": 20
+									}
+								},
+								{
+									"id": "tE_ZlbEp31pzcDLNh",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t2vba3l0J2mCZM50M"
+									},
+									"name": "Voice",
+									"reference": "B97",
+									"tags": [
+										"Advantage",
+										"Physical"
+									],
+									"base_points": 10,
+									"features": [
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "diplomacy"
+											},
+											"amount": 2
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "fast-talk"
+											},
+											"amount": 2
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "starts_with",
+												"qualifier": "mimicry"
+											},
+											"amount": 2
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "performance"
+											},
+											"amount": 2
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "politics"
+											},
+											"amount": 2
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "public speaking"
+											},
+											"amount": 2
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "sex appeal"
+											},
+											"amount": 2
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "singing"
+											},
+											"amount": 2
+										},
+										{
+											"type": "reaction_bonus",
+											"situation": "from others who can hear your voice",
+											"amount": 2
+										}
+									],
+									"calc": {
+										"points": 10
+									}
+								},
+								{
+									"id": "t2sQJlpkDbrOiEm8B",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tLE3ucdo2fjeiUTav"
+									},
+									"name": "Responsive",
+									"reference": "B164",
+									"tags": [
+										"Mental",
+										"Quirk"
+									],
+									"base_points": -1,
+									"calc": {
+										"points": -1
+									}
+								},
+								{
+									"id": "tJySUgsf2IBY4Y2ID",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tfujsOp4WL4ZholTv"
+									},
+									"name": "Mild Shyness",
+									"reference": "B154",
+									"local_notes": "You are uneasy with strangers, especially assertive or attractive ones.",
+									"tags": [
+										"Disadvantage",
+										"Mental"
+									],
+									"base_points": -5,
+									"features": [
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "Acting"
+											},
+											"amount": -1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "Carousing"
+											},
+											"amount": -1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "Diplomacy"
+											},
+											"amount": -1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "Fast-Talk"
+											},
+											"amount": -1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "Intimidation"
+											},
+											"amount": -1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "Leadership"
+											},
+											"amount": -1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "Merchant"
+											},
+											"amount": -1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "Panhandling"
+											},
+											"amount": -1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "Performance"
+											},
+											"amount": -1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "Politics"
+											},
+											"amount": -1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "Public Speaking"
+											},
+											"amount": -1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "Savoir-Faire"
+											},
+											"amount": -1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "Sex Appeal"
+											},
+											"amount": -1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "Streetwise"
+											},
+											"amount": -1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "Teaching"
+											},
+											"amount": -1
+										}
+									],
+									"calc": {
+										"points": -5
+									}
+								},
+								{
+									"id": "tDjOPJiwOjA3X6AW4",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Bio-Tech/Bio-Tech Traits.adq",
+										"id": "t020EdMCSbDSrITDv"
+									},
+									"name": "Taboo Trait (Aggressiveness)",
+									"reference": "BT65, B261",
+									"local_notes": "TL9",
+									"tags": [
+										"Exotic",
+										"Mental",
+										"Taboo Trait"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Bad Temper"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Berserk"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Bully"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Stubbornness"
+												}
+											}
+										]
+									},
+									"calc": {
+										"points": 0
+									}
+								}
+							],
+							"calc": {
+								"points": 36
+							}
+						}
+					],
+					"calc": {
+						"points": 72
+					}
+				}
+			],
+			"calc": {
+				"points": 102
+			}
+		}
+	],
+	"notes": [
+		{
+			"id": "nK30Y3GMf2yQSfhXN",
+			"markdown": "Females have Taboo Trait Agresssivness\n Both sexes have exaggerated sexual characteristics: Males are blatantly muscular with abun\u0002dant body and facial hair, while females are very curvaceous and have soft, delicate facial features"
+		}
+	]
+}

--- a/Library/Bio-Tech/Races/Brownie.gct
+++ b/Library/Bio-Tech/Races/Brownie.gct
@@ -1,0 +1,1054 @@
+{
+	"version": 5,
+	"id": "BLjlNfsbxUk2gS426",
+	"traits": [
+		{
+			"id": "T53svFpsZeuwD_bRP",
+			"name": "Brownie",
+			"reference": "BT68",
+			"local_notes": "TL9. $65000. LC3.",
+			"tags": [
+				"Race"
+			],
+			"container_type": "ancestry",
+			"children": [
+				{
+					"id": "tLeS3YTfLhzmLNqv-",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "thI3hK3riuknUwkHF"
+					},
+					"name": "Decreased Strength",
+					"reference": "B14",
+					"tags": [
+						"Attribute",
+						"Disadvantage",
+						"Physical"
+					],
+					"points_per_level": -10,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "st",
+							"amount": -1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": -10
+					}
+				},
+				{
+					"id": "tjq-x4m16YW-bpbWI",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tVt3SvdGWNchJ8z4o"
+					},
+					"name": "Increased Health",
+					"reference": "B14",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"points_per_level": 10,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "ht",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 2,
+					"calc": {
+						"points": 20
+					}
+				},
+				{
+					"id": "tJRJZty2V3S7yZrGI",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tBBMkYdKxMwhn73fI"
+					},
+					"name": "Decreased Basic Move",
+					"reference": "B17",
+					"tags": [
+						"Attribute",
+						"Disadvantage",
+						"Physical"
+					],
+					"points_per_level": -5,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "basic_move",
+							"amount": -1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": -5
+					}
+				},
+				{
+					"id": "tmeWTSGQ6__qQYTc-",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tkdGzhkqoMAQbknEc"
+					},
+					"name": "Acute Vision",
+					"reference": "B35",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"points_per_level": 2,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "vision",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 2
+					}
+				},
+				{
+					"id": "tso41Nm8HBr_BDzgN",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t6XtSYhM7yan5_B73"
+					},
+					"name": "Acute Hearing",
+					"reference": "B35",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"points_per_level": 2,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "hearing",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 2,
+					"calc": {
+						"points": 4
+					}
+				},
+				{
+					"id": "t91N8lot9c6zRF757",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tzQQVBRuixCbnRR0w"
+					},
+					"name": "Catfall",
+					"reference": "B41,P43",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mCzOG_H2-IU39UErk",
+							"name": "Feather Fall",
+							"reference": "P43",
+							"cost": 20,
+							"disabled": true
+						},
+						{
+							"id": "mwWV03Y9pK3jul-z4",
+							"name": "Parachute",
+							"reference": "P43",
+							"cost": -30,
+							"disabled": true
+						}
+					],
+					"base_points": 10,
+					"calc": {
+						"points": 10
+					}
+				},
+				{
+					"id": "tWRWBcaV2kCs2CBNi",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tJTfFdHM7YI5IZR7I"
+					},
+					"name": "Resistant",
+					"reference": "B81,P71,MA47",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"replacements": {
+						"Occasional: Disease, Ingested Poison, etc.": "Disease"
+					},
+					"modifiers": [
+						{
+							"id": "miNDq-MtTCaxgY7Gp",
+							"name": "@Very Common: Metabolic Hazards, etc.@",
+							"reference": "B80",
+							"cost": 30,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "micHXaTNlUFgW3gZK",
+							"name": "@Common: Poison, Sickness, etc.@",
+							"reference": "B81",
+							"cost": 15,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mXvrkw-dxquQrk0Ii",
+							"name": "@Occasional: Disease, Ingested Poison, etc.@",
+							"reference": "B81",
+							"cost": 10,
+							"cost_type": "points"
+						},
+						{
+							"id": "mzaBbeWhGCkvJhOoD",
+							"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+							"reference": "B81",
+							"cost": 5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mTBIylKiRw-XOf53w",
+							"name": "Immunity",
+							"reference": "B81",
+							"cost": 1,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "m_G9v3IW1FMUfBbEJ",
+							"name": "+8 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.5,
+							"cost_type": "multiplier"
+						},
+						{
+							"id": "mckrUDjP1ZESC_9a9",
+							"name": "+3 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.33,
+							"cost_type": "multiplier",
+							"disabled": true
+						}
+					],
+					"round_down": true,
+					"calc": {
+						"points": 5
+					}
+				},
+				{
+					"id": "tobIED0OaK04aEqxE",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "thdJ55ghf__io9AQa"
+					},
+					"name": "Longevity",
+					"reference": "B66",
+					"local_notes": "You fail aging rolls only on a 17 or 18, or only on an 18 if your modified HT is 17 or better",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"base_points": 2,
+					"calc": {
+						"points": 2
+					}
+				},
+				{
+					"id": "tWUoaQZ6dfdK-jj2U",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "tcpWN_ZW2kBHtFd_-"
+					},
+					"name": "No Degeneration in Zero-G",
+					"reference": "BT211",
+					"tags": [
+						"Perk"
+					],
+					"base_points": 1,
+					"calc": {
+						"points": 1
+					}
+				},
+				{
+					"id": "tfKWTFjYNClMyeTjB",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tHa_LwEUawGsB_vO2"
+					},
+					"name": "Disturbing Voice",
+					"reference": "B132",
+					"tags": [
+						"Disadvantage",
+						"Physical"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "voice"
+								}
+							}
+						]
+					},
+					"base_points": -10,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "diplomacy"
+							},
+							"amount": -2
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "fast-talk"
+							},
+							"amount": -2
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "performance"
+							},
+							"amount": -2
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "public speaking"
+							},
+							"amount": -2
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "sex appeal"
+							},
+							"amount": -2
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "singing"
+							},
+							"amount": -2
+						}
+					],
+					"calc": {
+						"points": -10
+					}
+				},
+				{
+					"id": "tBTuY57k3EHx6QOUA",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tdlCZw4YB4T7QkOnj"
+					},
+					"name": "Appearance",
+					"reference": "B21",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "m2wFfAA5DjTjpOinA",
+							"name": "Attractive",
+							"reference": "B21",
+							"cost": 4,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mtuHL0mQTqnX8JTFr",
+							"name": "Average",
+							"reference": "B21",
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mqC3-vFxzKDfj3QyA",
+							"name": "Beautiful",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mMZuRZ7dhGHuSWhkF",
+							"name": "Beautiful (Androgynous)",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 3
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mghXfgVB7Lf_FVqd3",
+							"name": "Beautiful (Impressive)",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 3
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "m5Kerh6Qa0Kl4P1uA",
+							"name": "Handsome",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mhlRv0EavdiHsMSuA",
+							"name": "Handsome (Androgynous)",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 3
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mJV0KGkDTz-gG0UGa",
+							"name": "Handsome (Impressive)",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 3
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "m_aw0w9ab6h0qgk94",
+							"name": "Hideous",
+							"reference": "B21,B202",
+							"cost": -16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Intimidation"
+									},
+									"amount": 2
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "msy9zkHt-GzfkkvOj",
+							"name": "Horrific",
+							"reference": "B21,B202",
+							"cost": -24,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Intimidation"
+									},
+									"amount": 4
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -6
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "m1jXvPVUBCmvyQy3z",
+							"name": "Impressive",
+							"reference": "B21",
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mCE9fOd3E4dgLtqM6",
+							"name": "Monstrous",
+							"reference": "B21,B202",
+							"cost": -20,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Intimidation"
+									},
+									"amount": 3
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -5
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "m809b0nzcsaVl4kLQ",
+							"name": "Off-the-Shelf Looks",
+							"reference": "B21",
+							"local_notes": "Halves the usual reaction bonus - adjust manually",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "m-CQCKoILz_-hRqew",
+							"name": "Transcendent",
+							"reference": "B21",
+							"cost": 20,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+									"amount": 8
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mn6gB3Z8mZwE_WsFe",
+							"name": "Transcendent (Androgynous)",
+							"reference": "B21",
+							"cost": 20,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 5
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "my7l0oZlmYtmoJuE0",
+							"name": "Transcendent (Impressive)",
+							"reference": "B21",
+							"cost": 20,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 5
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mmirjKVLFQkGWAkNB",
+							"name": "Ugly",
+							"reference": "B21",
+							"cost": -8,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -2
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mJFD_p6cOmsmHCP27",
+							"name": "Unattractive",
+							"reference": "B21",
+							"cost": -4,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -1
+								}
+							]
+						},
+						{
+							"id": "mucSzCW7HsrkJ-eI0",
+							"name": "Universal",
+							"reference": "B21",
+							"cost": 25,
+							"disabled": true
+						},
+						{
+							"id": "mKxc9XpqOvDmHUYBC",
+							"name": "Very Beautiful",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+									"amount": 6
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "miPgg2zOrMlsWMeve",
+							"name": "Very Beautiful (Androgynous)",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mRmb7MbtxRnvGwwNL",
+							"name": "Very Beautiful (Impressive)",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "m-_pWszf9h3D5e5d0",
+							"name": "Very Handsome",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+									"amount": 6
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "msa866KdBhRpRfTc8",
+							"name": "Very Handsome (Androgynous)",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "myulPT2GyVwLe1VeY",
+							"name": "Very Handsome (Impressive)",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						}
+					],
+					"calc": {
+						"points": -4
+					}
+				},
+				{
+					"id": "tsfvx7x5St1y2vO0y",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "tLe1-US7YK9twT2zS"
+					},
+					"name": "Taboo Trait (Genetic Defects)",
+					"reference": "BT65, B261",
+					"local_notes": "TL8; Also prohibits attributes more than 2 below the average for an adult with that template",
+					"tags": [
+						"Exotic",
+						"Mental",
+						"Physical",
+						"Taboo Trait"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Short Attention Span"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Non-Iconographic"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "No Sense of Smell/Taste"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Night Blindness"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Innumerate"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Hemophilia"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Gigantism"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dyslexia"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dwarfism"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Colorblindness"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "starts_with",
+									"qualifier": "Bad Sight"
+								}
+							}
+						]
+					},
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "tlYVwdZAXMN-ZmbXn",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "tDhx56D50aegwu4w6"
+					},
+					"name": "Taboo Trait (Mental Instability)",
+					"reference": "BT65, B261",
+					"local_notes": "TL9; Also prohibits any Compulsive Behaviour or Phobia worth -10 points or more",
+					"tags": [
+						"Exotic",
+						"Mental",
+						"Taboo Trait"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Pyromania"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Phantom Voices"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Paranoia"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "On the Edge"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Obsession"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Megalomania"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Manic-Depressive"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Lunacy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Low Self-Image"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Kleptomania"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Guilt Complex"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Flashbacks"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Delusion"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "starts_with",
+									"qualifier": "Delusions"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Chronic Depression"
+								}
+							}
+						]
+					},
+					"calc": {
+						"points": 0
+					}
+				}
+			],
+			"calc": {
+				"points": 15
+			}
+		}
+	],
+	"notes": [
+		{
+			"id": "nRT5VQYJaPjZPv3zR",
+			"markdown": "3 Inches sorter then average but 15 pounds heavier then unmoddified humans."
+		}
+	]
+}

--- a/Library/Bio-Tech/Races/Camazotz.gct
+++ b/Library/Bio-Tech/Races/Camazotz.gct
@@ -1,0 +1,1187 @@
+{
+	"version": 5,
+	"id": "B-v4kJGkCUQlU_d-B",
+	"traits": [
+		{
+			"id": "TuxcP31Jf2-TxBRda",
+			"name": "Camatzotz",
+			"reference": "BT71",
+			"local_notes": "TL10. $91000. LC3.",
+			"tags": [
+				"Race"
+			],
+			"container_type": "ancestry",
+			"children": [
+				{
+					"id": "t0FuLiDh5f7my-ku0",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "thI3hK3riuknUwkHF"
+					},
+					"name": "Decreased Strength",
+					"reference": "B14",
+					"tags": [
+						"Attribute",
+						"Disadvantage",
+						"Physical"
+					],
+					"points_per_level": -10,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "st",
+							"amount": -1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 2,
+					"calc": {
+						"points": -20
+					}
+				},
+				{
+					"id": "tJ8ZX9MQ1tZajkCep",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tGWOSEE6SmBHACE6Y"
+					},
+					"name": "Increased Dexterity",
+					"reference": "B15",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mwQRn2KThvNyYcdrU",
+							"name": "No Fine Manipulators",
+							"cost": -40,
+							"disabled": true
+						}
+					],
+					"points_per_level": 20,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "dx",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 20
+					}
+				},
+				{
+					"id": "tZnBvFG2ozJV8uDzy",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tM6z7Mx6e2V4VvUR4"
+					},
+					"name": "Absolute Direction",
+					"reference": "B34",
+					"tags": [
+						"Advantage",
+						"Mental",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mmVPwdE8rs4u-37YM",
+							"name": "Requires signal",
+							"reference": "B34",
+							"cost": -20,
+							"disabled": true
+						},
+						{
+							"id": "mYm-WuBzEoDRWHx74",
+							"name": "3D Spatial Sense",
+							"reference": "B34",
+							"cost": 5,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "starts_with",
+										"qualifier": "piloting"
+									},
+									"amount": 1
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "aerobatics"
+									},
+									"amount": 2
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "free fall"
+									},
+									"amount": 2
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "navigation"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "hyperspace"
+									},
+									"amount": 2
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "navigation"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "space"
+									},
+									"amount": 2
+								}
+							]
+						}
+					],
+					"base_points": 5,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "body sense"
+							},
+							"amount": 3
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "navigation"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "air"
+							},
+							"amount": 3
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "navigation"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "land"
+							},
+							"amount": 3
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "navigation"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "sea"
+							},
+							"amount": 3
+						}
+					],
+					"calc": {
+						"points": 10
+					}
+				},
+				{
+					"id": "twIvj8ZSsWvljwT-m",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t6XtSYhM7yan5_B73"
+					},
+					"name": "Acute Hearing",
+					"reference": "B35",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"points_per_level": 2,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "hearing",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 2,
+					"calc": {
+						"points": 4
+					}
+				},
+				{
+					"id": "t0eplFWWb0neAMAQn",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tAZ31tXG_HzDmVCRp"
+					},
+					"name": "Acute Taste \u0026 Smell",
+					"reference": "B35",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"points_per_level": 2,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "taste_smell",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 2
+					}
+				},
+				{
+					"id": "tphHR0mHpj4oPsUua",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tBp8Q-gJeFHzopeuI"
+					},
+					"name": "Flight",
+					"reference": "B56,P50,PSI14",
+					"local_notes": "Air Move is Basic Speed x 2 (drop all fractions)",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"replacements": {
+						"Condition": "Requires Low Gravity",
+						"Temporary Disadvantage": "No Fine Manipulators"
+					},
+					"modifiers": [
+						{
+							"id": "mgG4gezKMGlD5dHyP",
+							"name": "Newtonian Space Flight",
+							"reference": "B56",
+							"cost": 25,
+							"disabled": true
+						},
+						{
+							"id": "mx44v-Be33aI_XO-k",
+							"name": "Space Flight",
+							"reference": "B56",
+							"cost": 50,
+							"disabled": true
+						},
+						{
+							"id": "mNbUk7-BlJKW2UcnS",
+							"name": "Cannot Hover",
+							"reference": "B56",
+							"cost": -15,
+							"disabled": true
+						},
+						{
+							"id": "mMDcET3-bul61vQew",
+							"name": "Controlled Gliding",
+							"reference": "B56",
+							"cost": -45,
+							"disabled": true
+						},
+						{
+							"id": "mwNY3oZ0IyFCrSOLO",
+							"name": "Gliding",
+							"reference": "B56",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "mLP4R9m79YDuu4FJb",
+							"name": "Lighter Than Air",
+							"reference": "B56",
+							"cost": -10,
+							"disabled": true
+						},
+						{
+							"id": "mdSJWydtKg1jatVyl",
+							"name": "Low Ceiling",
+							"reference": "B56",
+							"local_notes": "30'",
+							"cost": -10,
+							"disabled": true
+						},
+						{
+							"id": "muuXDR11B9mpzS6n4",
+							"name": "Low Ceiling",
+							"reference": "B56",
+							"local_notes": "10'",
+							"cost": -20,
+							"disabled": true
+						},
+						{
+							"id": "mbeHfVnbJl9fh-0jh",
+							"name": "Low Ceiling",
+							"reference": "B56",
+							"local_notes": "5'",
+							"cost": -25,
+							"disabled": true
+						},
+						{
+							"id": "mVIw9yv64AX7JboHR",
+							"name": "Small Wings",
+							"reference": "B56",
+							"cost": -10,
+							"disabled": true
+						},
+						{
+							"id": "mqumQQ0339LcVKlcg",
+							"name": "Space Flight Only",
+							"reference": "B56",
+							"cost": -75,
+							"disabled": true
+						},
+						{
+							"id": "mZI8G1aMl56QBIabg",
+							"name": "Winged",
+							"reference": "B56",
+							"cost": -25
+						},
+						{
+							"id": "mVFUTgMLPupB9zXA0",
+							"name": "Planetary",
+							"reference": "P50",
+							"cost": -5,
+							"disabled": true
+						},
+						{
+							"id": "m7g8HXqKc0EXZVPnp",
+							"name": "Requires Surface",
+							"reference": "P50",
+							"cost": -20,
+							"disabled": true
+						},
+						{
+							"id": "moyzBW5w4nZ-j_74M",
+							"name": "Slow",
+							"reference": "PSI14",
+							"local_notes": "Basic Speed",
+							"cost": -25,
+							"disabled": true
+						},
+						{
+							"id": "mSpF19aB6RabenRmp",
+							"name": "Slow, Move 1",
+							"reference": "PSI14",
+							"cost": -45,
+							"disabled": true
+						},
+						{
+							"id": "maoJjtgAw1N_ej2CV",
+							"name": "Encumbrance-Limited (No encumbrance)",
+							"reference": "FFWF12",
+							"reference_highlight": "Encumbrance-Limited",
+							"local_notes": "Can only glide at best when overburdened",
+							"cost": -15,
+							"disabled": true
+						},
+						{
+							"id": "mgXtydSBWnfm3dYfd",
+							"name": "Encumbrance-Limited (Light encumbrance)",
+							"reference": "FFWF12",
+							"reference_highlight": "Encumbrance-Limited",
+							"local_notes": "Can only glide at best when overburdened",
+							"cost": -10,
+							"disabled": true
+						},
+						{
+							"id": "mthXS0qbJhnVDtGTk",
+							"name": "Encumbrance-Limited (Medium encumbrance)",
+							"reference": "FFWF12",
+							"reference_highlight": "Encumbrance-Limited",
+							"local_notes": "Can only glide at best when overburdened",
+							"cost": -5,
+							"disabled": true
+						},
+						{
+							"id": "m7-caHcuA0KEjz-La",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+								"id": "m2IwCpU9KwYmjiSSA"
+							},
+							"name": "Accessibility (@Condition@)",
+							"reference": "B110,P99",
+							"local_notes": "1 point per level",
+							"cost": -1,
+							"levels": 35
+						},
+						{
+							"id": "moWBEatb7pbgjGg4c",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+								"id": "mdoMyuuoZBbQiTi3L"
+							},
+							"name": "Temporary Disadvantage (@Temporary Disadvantage@)",
+							"reference": "B115,P106",
+							"local_notes": "1 point per level",
+							"cost": -1,
+							"levels": 30
+						}
+					],
+					"base_points": 40,
+					"calc": {
+						"points": 8
+					}
+				},
+				{
+					"id": "tFG4DfA9SRzbCRoTx",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tj66NHKyO_GObgGsj"
+					},
+					"name": "Sharp Claws",
+					"reference": "B42",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"base_points": 5,
+					"weapons": [
+						{
+							"id": "wLIX9orTUsuh1abmA",
+							"damage": {
+								"type": "cut",
+								"st": "thr",
+								"base": "-1"
+							},
+							"usage": "Slash",
+							"reach": "C",
+							"parry": "0",
+							"defaults": [
+								{
+									"type": "dx"
+								},
+								{
+									"type": "skill",
+									"name": "Brawling"
+								},
+								{
+									"type": "skill",
+									"name": "Boxing"
+								},
+								{
+									"type": "skill",
+									"name": "Karate"
+								}
+							],
+							"calc": {
+								"damage": "thr-1 cut"
+							}
+						},
+						{
+							"id": "woRKWU9VD4gJPTg7e",
+							"damage": {
+								"type": "cut",
+								"st": "thr"
+							},
+							"usage": "Kick",
+							"reach": "C,1",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -2
+								},
+								{
+									"type": "skill",
+									"name": "Karate",
+									"modifier": -2
+								},
+								{
+									"type": "skill",
+									"name": "Brawling",
+									"modifier": -2
+								}
+							],
+							"calc": {
+								"damage": "thr cut"
+							}
+						}
+					],
+					"calc": {
+						"points": 5
+					}
+				},
+				{
+					"id": "tjx-ge0kkZbe9Bsl5",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tK9Ov0WtlrhnJFy5n"
+					},
+					"name": "Sharp Teeth",
+					"reference": "B91",
+					"tags": [
+						"Exotic",
+						"Perk",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "m5lbKdC-nQoYSVco2",
+							"name": "Provided by Vampiric Bite",
+							"reference": "B96",
+							"cost": -1,
+							"cost_type": "points",
+							"disabled": true
+						}
+					],
+					"base_points": 1,
+					"weapons": [
+						{
+							"id": "wbvHiFVdyHJ95bXcQ",
+							"damage": {
+								"type": "cut",
+								"st": "thr",
+								"base": "-1"
+							},
+							"usage": "Bite",
+							"reach": "C",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Brawling"
+								},
+								{
+									"type": "dx"
+								}
+							],
+							"calc": {
+								"damage": "thr-1 cut"
+							}
+						}
+					],
+					"calc": {
+						"points": 1
+					}
+				},
+				{
+					"id": "tYGJzYdQ0aSTVlAPv",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t0RpC5DR3ijYx7aYU"
+					},
+					"name": "Scanning Sense",
+					"reference": "B81,P72,PSI17",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mpRgf06upPeHGCBMT",
+							"name": "Imaging Radar",
+							"reference": "B81",
+							"cost": 20,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mepyglKOsyM0EI0tV",
+							"name": "Radar",
+							"reference": "B81",
+							"cost": 20,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mz8PRXl_K6HLD6Mnz",
+							"name": "Ladar",
+							"reference": "B81",
+							"cost": 20,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mTF4pMjB5S7jv_zyA",
+							"name": "Para-Radar",
+							"reference": "B81",
+							"cost": 40,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "m8-4vd3scVzriRLU_",
+							"name": "Sonar",
+							"reference": "B81",
+							"cost": 20,
+							"cost_type": "points"
+						},
+						{
+							"id": "mhIRwgMJAIC_rKtN6",
+							"name": "Extended Arc",
+							"reference": "B82",
+							"local_notes": "240°",
+							"cost": 75,
+							"disabled": true
+						},
+						{
+							"id": "mh5MBbD98DrRnuXCb",
+							"name": "Extended Arc",
+							"reference": "B82",
+							"local_notes": "360°",
+							"cost": 125,
+							"disabled": true
+						},
+						{
+							"id": "muytNa_-zFdqV7hFI",
+							"name": "Low-Probability Intercept",
+							"reference": "B82",
+							"cost": 10,
+							"disabled": true
+						},
+						{
+							"id": "mV-GSwy7cpQMvxXyT",
+							"name": "Multi-Mode",
+							"reference": "B82",
+							"cost": 50,
+							"disabled": true
+						},
+						{
+							"id": "mue2B0dLO7Ip5TRGZ",
+							"name": "Penetrating",
+							"reference": "B82",
+							"cost": 50,
+							"disabled": true
+						},
+						{
+							"id": "mSE5HI5-MR0ppgw-P",
+							"name": "Targeting",
+							"reference": "B82",
+							"cost": 20,
+							"disabled": true
+						},
+						{
+							"id": "mC25ZoBT6eKcbcvKV",
+							"name": "Targeting Only",
+							"reference": "B82",
+							"cost": -40,
+							"disabled": true
+						},
+						{
+							"id": "mHdwNqSqpCEglWvUZ",
+							"name": "Active IR",
+							"reference": "P72",
+							"cost": 20,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mAI5cp8GqYpQrIMhf",
+							"name": "T-Ray Vision",
+							"reference": "P72",
+							"cost": 25,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mhNoe5yFyuyTM2ei3",
+							"name": "Bio-Scan",
+							"reference": "P72",
+							"cost": 50,
+							"disabled": true
+						},
+						{
+							"id": "mkKAkWpEIe_u4urjO",
+							"name": "No Intercept",
+							"reference": "P72",
+							"cost": 50,
+							"disabled": true
+						},
+						{
+							"id": "mGHI6yj0DtG8CkFLM",
+							"name": "Scanner",
+							"reference": "P72",
+							"cost": 50,
+							"disabled": true
+						},
+						{
+							"id": "m3DYyNTiPT3PGIHqS",
+							"name": "Field Sense",
+							"reference": "SU27",
+							"cost": 10,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "m0ENVXkwrWyyaKdo6",
+							"name": "Extra-Sensory Awareness",
+							"reference": "PSI17",
+							"cost": 20,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mxM3qeXBXssn_8qYl",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+								"id": "mBiJCN2DvROTZnYPj"
+							},
+							"name": "Reduced Range",
+							"reference": "B115,P105",
+							"local_notes": "5 Range Divisor",
+							"cost": -20
+						}
+					],
+					"calc": {
+						"points": 16
+					}
+				},
+				{
+					"id": "tNt8WxdH6_Vwj8e3V",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t9SRIvj3a6sg382bW"
+					},
+					"name": "Ultrahearing",
+					"reference": "B94,P51",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "msFn8dtuWrfV_ebQx",
+							"name": "No normal hearing",
+							"reference": "B94",
+							"cost": -5,
+							"cost_type": "points",
+							"disabled": true
+						}
+					],
+					"base_points": 5,
+					"calc": {
+						"points": 5
+					}
+				},
+				{
+					"id": "tG8dcojzWQBraDRzK",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tsPqY8NyZ8sJbkdS-"
+					},
+					"name": "Fur",
+					"reference": "B101",
+					"tags": [
+						"Exotic",
+						"Perk",
+						"Physical"
+					],
+					"base_points": 1,
+					"calc": {
+						"points": 1
+					}
+				},
+				{
+					"id": "tI_z7n2HoNdC04vXg",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "taEdO2Q-RgdH-CiHq"
+					},
+					"name": "Skinny",
+					"reference": "B18",
+					"tags": [
+						"Disadvantage",
+						"Physical"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "attribute_prereq",
+								"has": true,
+								"qualifier": {
+									"compare": "at_most",
+									"qualifier": 14
+								},
+								"which": "ht"
+							}
+						]
+					},
+					"base_points": -5,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "disguise"
+							},
+							"amount": -2
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "shadowing"
+							},
+							"amount": -2
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to ST vs. knockback",
+							"amount": -2
+						}
+					],
+					"calc": {
+						"points": -5
+					}
+				},
+				{
+					"id": "tdaKlAqlt7wcWDbDl",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t_ZUyO0Xhmi2p0Vku"
+					},
+					"name": "Unnatural Features (@Description@)",
+					"reference": "B22",
+					"tags": [
+						"Disadvantage",
+						"Physical"
+					],
+					"replacements": {
+						"Description": "Arms double as Wings"
+					},
+					"points_per_level": -1,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "disguise"
+							},
+							"amount": -1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "shadowing"
+							},
+							"amount": -1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": -1
+					}
+				},
+				{
+					"id": "tuESmojIHkq4bL1Me",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tEYEuzMtxSsWCG7uW"
+					},
+					"name": "Unusual Biochemistry",
+					"reference": "B160",
+					"tags": [
+						"Disadvantage",
+						"Physical"
+					],
+					"base_points": -5,
+					"calc": {
+						"points": -5
+					}
+				},
+				{
+					"id": "TUJJv1sdyWSBnhJWF",
+					"name": "Optionally, choose one",
+					"template_picker": {
+						"type": "count",
+						"qualifier": {
+							"compare": "at_most",
+							"qualifier": 1
+						}
+					},
+					"children": [
+						{
+							"id": "ThWKQ64650YxIRWX0",
+							"name": "Camazotz Bioroid",
+							"local_notes": "-$5000. LC3.",
+							"children": [
+								{
+									"id": "TF3n6sGi4gn2IfkeO",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Bio-Tech/Bio-Tech Traits.adq",
+										"id": "TluHkPSI8BnDWWEZo"
+									},
+									"name": "Bioroid",
+									"reference": "BT214",
+									"container_type": "meta_trait",
+									"children": [
+										{
+											"id": "t2-KqvYevb2vQHYCS",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Bio-Tech/Bio-Tech Traits.adq",
+												"id": "tAgMr2EzmeXfC7Tkg"
+											},
+											"name": "Early Maturation",
+											"reference": "BT212",
+											"local_notes": "may be level 3-5",
+											"tags": [
+												"Feature"
+											],
+											"can_level": true,
+											"levels": 3,
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "tjytrJUhzwFcSdfAU",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Template Toolkit/Template Toolkit 2 - Races/Template Toolkit 2 - Races Traits.adq",
+												"id": "tQY4rjF8t2sAPM9xv"
+											},
+											"name": "Sterile",
+											"reference": "TT2:12",
+											"tags": [
+												"Feature",
+												"Physical"
+											],
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "tWoBLThdgKkMOUqRe",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tEYEuzMtxSsWCG7uW"
+											},
+											"name": "Unusual Biochemistry",
+											"reference": "B160",
+											"tags": [
+												"Disadvantage",
+												"Physical"
+											],
+											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										}
+									],
+									"calc": {
+										"points": -5
+									}
+								}
+							],
+							"calc": {
+								"points": -5
+							}
+						},
+						{
+							"id": "Tgnd_ruYyNUa8OFyc",
+							"name": "Camazotz Chimera",
+							"local_notes": "-$20000. LC3.",
+							"children": [
+								{
+									"id": "TX66IZz_3rJ2oY0tD",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Bio-Tech/Bio-Tech Traits.adq",
+										"id": "To3AVoJByLMnwXPPz"
+									},
+									"name": "Chimera",
+									"reference": "BT214",
+									"container_type": "meta_trait",
+									"children": [
+										{
+											"id": "tQcqNMvRhr8fMr99e",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t8duh7FJvBdSs4NOb"
+											},
+											"name": "Restricted Diet (@Food@)",
+											"reference": "B151",
+											"tags": [
+												"Disadvantage",
+												"Physical"
+											],
+											"modifiers": [
+												{
+													"id": "mE5Ukx_atNTrSvwJK",
+													"name": "Substitution",
+													"reference": "B151",
+													"cost": -50
+												},
+												{
+													"id": "mjrOpXYJ6iSVW9GJ3",
+													"name": "Very Common",
+													"reference": "B151",
+													"cost": -10,
+													"cost_type": "points"
+												},
+												{
+													"id": "muYJyG3bxumpzp9OQ",
+													"name": "Common",
+													"reference": "B151",
+													"cost": -20,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mPD0NEnEtcrWrKNoW",
+													"name": "Occasional",
+													"reference": "B151",
+													"cost": -30,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mxcq9qFhdbxkRI2lq",
+													"name": "Rare",
+													"reference": "B151",
+													"cost": -40,
+													"cost_type": "points",
+													"disabled": true
+												}
+											],
+											"calc": {
+												"points": -5
+											}
+										},
+										{
+											"id": "t9irNAOtmuo2tlkpq",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Template Toolkit/Template Toolkit 2 - Races/Template Toolkit 2 - Races Traits.adq",
+												"id": "tQY4rjF8t2sAPM9xv"
+											},
+											"name": "Sterile",
+											"reference": "TT2:12",
+											"tags": [
+												"Feature",
+												"Physical"
+											],
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "ttPmIKH8Z85Q4xiD3",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tEYEuzMtxSsWCG7uW"
+											},
+											"name": "Unusual Biochemistry",
+											"reference": "B160",
+											"tags": [
+												"Disadvantage",
+												"Physical"
+											],
+											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										}
+									],
+									"calc": {
+										"points": -10
+									}
+								},
+								{
+									"id": "tqXmfPBjd4lAwndmA",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t9nyvI3uvjJi5aqF5"
+									},
+									"name": "Short Lifespan",
+									"reference": "B154",
+									"tags": [
+										"Disadvantage",
+										"Exotic",
+										"Physical"
+									],
+									"points_per_level": -10,
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": -10
+									}
+								}
+							],
+							"calc": {
+								"points": -20
+							}
+						}
+					],
+					"calc": {
+						"points": -25
+					}
+				}
+			],
+			"calc": {
+				"points": 16
+			}
+		}
+	]
+}

--- a/Library/Bio-Tech/Races/Chronos.gct
+++ b/Library/Bio-Tech/Races/Chronos.gct
@@ -1,0 +1,1235 @@
+{
+	"version": 5,
+	"id": "BqBjj7Zg1kexoix3W",
+	"traits": [
+		{
+			"id": "TcoCRS09rsLGdtoZD",
+			"name": "Chronos",
+			"reference": "BT72",
+			"local_notes": "TL10. $144000. LC2.",
+			"tags": [
+				"Race"
+			],
+			"container_type": "ancestry",
+			"children": [
+				{
+					"id": "tKdpiLHRNHp1qlG8e",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tqha9GlDBU9P-Wg-6"
+					},
+					"name": "Increased Strength",
+					"reference": "B14",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mn0LehT054Q7E67dX",
+							"name": "No Fine Manipulators",
+							"reference": "B15",
+							"cost": -40,
+							"disabled": true
+						},
+						{
+							"id": "mws6g_hDb9q3d9s9M",
+							"name": "Size",
+							"reference": "B15",
+							"cost": -10,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mfIAfRpi0kXJqN9_c",
+							"name": "Super-Effort",
+							"reference": "SU24",
+							"cost": 300,
+							"disabled": true
+						}
+					],
+					"points_per_level": 10,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "st",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 2,
+					"calc": {
+						"points": 20
+					}
+				},
+				{
+					"id": "tKGnXrzoFvC331xIi",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tGWOSEE6SmBHACE6Y"
+					},
+					"name": "Increased Dexterity",
+					"reference": "B15",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mQtSe37qWaalN9LcA",
+							"name": "No Fine Manipulators",
+							"cost": -40,
+							"disabled": true
+						}
+					],
+					"points_per_level": 20,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "dx",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 20
+					}
+				},
+				{
+					"id": "th9h0LEhC3agnz7K7",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t50ZzyORV0rTiYwnb"
+					},
+					"name": "Decreased Intelligence",
+					"reference": "B15",
+					"tags": [
+						"Attribute",
+						"Disadvantage",
+						"Mental"
+					],
+					"points_per_level": -20,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "iq",
+							"amount": -1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": -20
+					}
+				},
+				{
+					"id": "tANifqw1WpFYxg2E3",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tVt3SvdGWNchJ8z4o"
+					},
+					"name": "Increased Health",
+					"reference": "B14",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"points_per_level": 10,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "ht",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 10
+					}
+				},
+				{
+					"id": "tu-mWRDQVfYlwIoD3",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tWF1J_Z0Ziz-qJ6pn"
+					},
+					"name": "Increased Basic Speed",
+					"reference": "B17",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "m3x7AuO_4lujl6-S7",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+								"id": "mb8dKIbPtFmqDLYaM"
+							},
+							"name": "Costs Fatigue",
+							"reference": "B111,P101",
+							"cost": -5,
+							"levels": 2
+						}
+					],
+					"points_per_level": 5,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "basic_speed",
+							"amount": 0.25,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 4,
+					"calc": {
+						"points": 18
+					}
+				},
+				{
+					"id": "t8N4DOVYNXRU7b1vD",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tsIfS0jZqdshsDFOM"
+					},
+					"name": "Extra Fatigue Points",
+					"reference": "B16",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"points_per_level": 3,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "fp",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 3,
+					"calc": {
+						"points": 9
+					}
+				},
+				{
+					"id": "t8AEV_0hQjMRKaT4m",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t6XtSYhM7yan5_B73"
+					},
+					"name": "Acute Hearing",
+					"reference": "B35",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"points_per_level": 2,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "hearing",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 2,
+					"calc": {
+						"points": 4
+					}
+				},
+				{
+					"id": "tyrJHbftRJpnm3vXs",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tGjjVtxav9KsrG7Wx"
+					},
+					"name": "Combat Reflexes",
+					"reference": "B43",
+					"local_notes": "Never freeze",
+					"tags": [
+						"Advantage",
+						"Mental"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Enhanced Time Sense"
+								}
+							}
+						]
+					},
+					"base_points": 15,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "starts_with",
+								"qualifier": "fast-draw"
+							},
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "dodge",
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "parry",
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "block",
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "fright_check",
+							"amount": 2
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "on all IQ rolls to wake up or to recover from surprise or mental stun",
+							"amount": 6
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to initiative rolls for your side (+2 if you are the leader)",
+							"amount": 1
+						}
+					],
+					"calc": {
+						"points": 15
+					}
+				},
+				{
+					"id": "tLg_kBX2f7GhAVk5c",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tjKuFiuy3Fs6rm69e"
+					},
+					"name": "Discriminatory Smell",
+					"reference": "B49,P47",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mvKnTuM2TyGzLzAhs",
+							"name": "Emotion Sense",
+							"reference": "B49",
+							"cost": 50,
+							"disabled": true
+						},
+						{
+							"id": "mOPnwZWOUDOn8vq_r",
+							"name": "Profiling",
+							"reference": "P47",
+							"cost": 50,
+							"disabled": true
+						}
+					],
+					"base_points": 15,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Tracking"
+							},
+							"amount": 4
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "on any task that utilizes sense of smell",
+							"amount": 4
+						}
+					],
+					"calc": {
+						"points": 15
+					}
+				},
+				{
+					"id": "tr6E9Bwr_n0QGh87-",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "twweH-N8IVtnf2LnI"
+					},
+					"name": "Fangs",
+					"reference": "B91",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"base_points": 2,
+					"weapons": [
+						{
+							"id": "wRmIKYcFDuT4Gjtb3",
+							"damage": {
+								"type": "imp",
+								"st": "thr",
+								"base": "-1"
+							},
+							"usage": "Bite",
+							"reach": "C",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Brawling"
+								},
+								{
+									"type": "dx"
+								}
+							],
+							"calc": {
+								"damage": "thr-1 imp"
+							}
+						}
+					],
+					"calc": {
+						"points": 2
+					}
+				},
+				{
+					"id": "tmT9gaYfEd9i-VEBV",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "teRggYn926_I1YeWO"
+					},
+					"name": "High Pain Threshold",
+					"reference": "B59",
+					"local_notes": "Never suffer shock penalties when injured",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"base_points": 10,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "on all HT rolls to avoid knockdown and stunning",
+							"amount": 3
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to resist torture",
+							"amount": 3
+						}
+					],
+					"calc": {
+						"points": 10
+					}
+				},
+				{
+					"id": "tBpSPAyN6e9QkALtf",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tUzmcuTXRq35xQ-rB"
+					},
+					"name": "Single-Minded",
+					"reference": "B85",
+					"tags": [
+						"Advantage",
+						"Mental"
+					],
+					"base_points": 5,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "to rolls for any lengthy mental task you concentrate on to the exclusion of other activities, if the GM feels such focus would be beneficial",
+							"amount": 3
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to all rolls to notice interruptions while obsessed with a task",
+							"amount": -5
+						}
+					],
+					"calc": {
+						"points": 5
+					}
+				},
+				{
+					"id": "tK76_oUFPX9AfRquA",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tynHtgvWZmmNOL97D"
+					},
+					"name": "Reduced Consumption",
+					"reference": "B80",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mBlKQ2no7a1bjVJM7",
+							"name": "Cast-Iron Stomach",
+							"reference": "B80",
+							"cost": -50
+						},
+						{
+							"id": "m12KTsr8KhN6FwfCJ",
+							"name": "Food Only",
+							"reference": "B80",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "mJurqB0LYMmfsmNuK",
+							"name": "Water Only",
+							"reference": "B80",
+							"cost": -50,
+							"disabled": true
+						}
+					],
+					"points_per_level": 2,
+					"can_level": true,
+					"levels": 2,
+					"calc": {
+						"points": 2
+					}
+				},
+				{
+					"id": "tVBnfCW_9ujkEGVyn",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tAonFRmR-RtLdMP8e"
+					},
+					"name": "Very Rapid Healing",
+					"reference": "B79",
+					"local_notes": "When you roll to recover lost HP, a successful HT roll means you heal 2 HP, not 1",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "attribute_prereq",
+								"has": true,
+								"qualifier": {
+									"compare": "at_least",
+									"qualifier": 12
+								},
+								"which": "ht"
+							}
+						]
+					},
+					"base_points": 15,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "to effective HT when rolling to recover lost HP or to see if you can get over a crippling injury",
+							"amount": 5
+						}
+					],
+					"calc": {
+						"points": 15
+					}
+				},
+				{
+					"id": "tB8X1sdDEkXmf4-I2",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tsPqY8NyZ8sJbkdS-"
+					},
+					"name": "Fur",
+					"reference": "B101",
+					"tags": [
+						"Exotic",
+						"Perk",
+						"Physical"
+					],
+					"base_points": 1,
+					"calc": {
+						"points": 1
+					}
+				},
+				{
+					"id": "tHvdmLIPnwglKHW1V",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tmRX0o0iO20zWIVyo"
+					},
+					"name": "Bloodlust",
+					"reference": "B125",
+					"local_notes": "You must make a self-control roll whenever you need to accept a surrender, evade a sentry, take a prisoner, etc.",
+					"tags": [
+						"Disadvantage",
+						"Mental"
+					],
+					"cr": 12,
+					"base_points": -10,
+					"calc": {
+						"points": -10
+					}
+				},
+				{
+					"id": "tMtZzHzC5ZQ301L_v",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tHa_LwEUawGsB_vO2"
+					},
+					"name": "Disturbing Voice",
+					"reference": "B132",
+					"tags": [
+						"Disadvantage",
+						"Physical"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "voice"
+								}
+							}
+						]
+					},
+					"base_points": -10,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "diplomacy"
+							},
+							"amount": -2
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "fast-talk"
+							},
+							"amount": -2
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "performance"
+							},
+							"amount": -2
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "public speaking"
+							},
+							"amount": -2
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "sex appeal"
+							},
+							"amount": -2
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "singing"
+							},
+							"amount": -2
+						}
+					],
+					"calc": {
+						"points": -10
+					}
+				},
+				{
+					"id": "tdlZWSqM02DB0UFpo",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t0DUjQv4R20iknQwp"
+					},
+					"name": "Low Empathy",
+					"reference": "B142",
+					"tags": [
+						"Disadvantage",
+						"Mental"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "oblivious"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "callous"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "empathy"
+								}
+							}
+						]
+					},
+					"base_points": -20,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "acting"
+							},
+							"amount": -3
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "carousing"
+							},
+							"amount": -3
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "criminology"
+							},
+							"amount": -3
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "detect lies"
+							},
+							"amount": -3
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "diplomacy"
+							},
+							"amount": -3
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "enthrallment"
+							},
+							"amount": -3
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "fast-talk"
+							},
+							"amount": -3
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "interrogation"
+							},
+							"amount": -3
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "leadership"
+							},
+							"amount": -3
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "merchant"
+							},
+							"amount": -3
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "politics"
+							},
+							"amount": -3
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "contains",
+								"qualifier": "psychology"
+							},
+							"amount": -3
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "contains",
+								"qualifier": "savoir-faire"
+							},
+							"amount": -3
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "sex appeal"
+							},
+							"amount": -3
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "sociology"
+							},
+							"amount": -3
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "streetwise"
+							},
+							"amount": -3
+						}
+					],
+					"calc": {
+						"points": -20
+					}
+				},
+				{
+					"id": "tkckgaAHTOjko1Kb8",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t_ZUyO0Xhmi2p0Vku"
+					},
+					"name": "Unnatural Features (@Description@)",
+					"reference": "B22",
+					"tags": [
+						"Disadvantage",
+						"Physical"
+					],
+					"replacements": {
+						"Description": "Canine muzzle, mouse-like ears and eyes"
+					},
+					"points_per_level": -1,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "disguise"
+							},
+							"amount": -1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "shadowing"
+							},
+							"amount": -1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 2,
+					"calc": {
+						"points": -2
+					}
+				},
+				{
+					"id": "TZGYchxse9izf0r86",
+					"name": "Optionally, choose one",
+					"template_picker": {
+						"type": "count",
+						"qualifier": {
+							"compare": "at_most",
+							"qualifier": 1
+						}
+					},
+					"children": [
+						{
+							"id": "TBi1bmFVglRScQSYX",
+							"name": "Chronos Bioroid",
+							"local_notes": "-$35000. LC1.",
+							"children": [
+								{
+									"id": "TvxiwyMz8NCNGoydX",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Bio-Tech/Bio-Tech Traits.adq",
+										"id": "TluHkPSI8BnDWWEZo"
+									},
+									"name": "Bioroid",
+									"reference": "BT214",
+									"container_type": "meta_trait",
+									"children": [
+										{
+											"id": "t1VCIH-kfa9LnpKte",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Bio-Tech/Bio-Tech Traits.adq",
+												"id": "tAgMr2EzmeXfC7Tkg"
+											},
+											"name": "Early Maturation",
+											"reference": "BT212",
+											"local_notes": "may be level 3-5",
+											"tags": [
+												"Feature"
+											],
+											"can_level": true,
+											"levels": 3,
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "tAaWNKTpjYjK_cDhH",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Template Toolkit/Template Toolkit 2 - Races/Template Toolkit 2 - Races Traits.adq",
+												"id": "tQY4rjF8t2sAPM9xv"
+											},
+											"name": "Sterile",
+											"reference": "TT2:12",
+											"tags": [
+												"Feature",
+												"Physical"
+											],
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "tZVlorX9t83nZcpGw",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tEYEuzMtxSsWCG7uW"
+											},
+											"name": "Unusual Biochemistry",
+											"reference": "B160",
+											"tags": [
+												"Disadvantage",
+												"Physical"
+											],
+											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										}
+									],
+									"calc": {
+										"points": -5
+									}
+								},
+								{
+									"id": "teUZ8LAW1yQVLEY2G",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t9Ayzq0-Ain8oiIM8"
+									},
+									"name": "Self-Destruct",
+									"reference": "B153",
+									"tags": [
+										"Disadvantage",
+										"Exotic",
+										"Physical"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "starts_with",
+													"qualifier": "terminally ill"
+												}
+											}
+										]
+									},
+									"base_points": -10,
+									"calc": {
+										"points": -10
+									}
+								},
+								{
+									"id": "tp4yGwMP4IYA2EDj3",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t9nyvI3uvjJi5aqF5"
+									},
+									"name": "Short Lifespan",
+									"reference": "B154",
+									"tags": [
+										"Disadvantage",
+										"Exotic",
+										"Physical"
+									],
+									"points_per_level": -10,
+									"can_level": true,
+									"levels": 2,
+									"calc": {
+										"points": -20
+									}
+								}
+							],
+							"calc": {
+								"points": -35
+							}
+						},
+						{
+							"id": "TQ1pleXpsTzS3rPTp",
+							"name": "Chronos Chimera",
+							"local_notes": "-$20000. LC1.",
+							"children": [
+								{
+									"id": "T2jU30Ub4IC-hXWHj",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Bio-Tech/Bio-Tech Traits.adq",
+										"id": "To3AVoJByLMnwXPPz"
+									},
+									"name": "Chimera",
+									"reference": "BT214",
+									"container_type": "meta_trait",
+									"children": [
+										{
+											"id": "tx-EfRCcxnuv08EI2",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t8duh7FJvBdSs4NOb"
+											},
+											"name": "Restricted Diet (@Food@)",
+											"reference": "B151",
+											"tags": [
+												"Disadvantage",
+												"Physical"
+											],
+											"modifiers": [
+												{
+													"id": "mkjVReP8GC3-thSvJ",
+													"name": "Substitution",
+													"reference": "B151",
+													"cost": -50
+												},
+												{
+													"id": "mW3ZSQMtGUvtmft5B",
+													"name": "Very Common",
+													"reference": "B151",
+													"cost": -10,
+													"cost_type": "points"
+												},
+												{
+													"id": "mBXa99VWFynoso8P1",
+													"name": "Common",
+													"reference": "B151",
+													"cost": -20,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mjBsoFK1oevcj9tFt",
+													"name": "Occasional",
+													"reference": "B151",
+													"cost": -30,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m4Gz63ksVZ8N7qVDp",
+													"name": "Rare",
+													"reference": "B151",
+													"cost": -40,
+													"cost_type": "points",
+													"disabled": true
+												}
+											],
+											"calc": {
+												"points": -5
+											}
+										},
+										{
+											"id": "t-GJSH_B1w-GzLrtC",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Template Toolkit/Template Toolkit 2 - Races/Template Toolkit 2 - Races Traits.adq",
+												"id": "tQY4rjF8t2sAPM9xv"
+											},
+											"name": "Sterile",
+											"reference": "TT2:12",
+											"tags": [
+												"Feature",
+												"Physical"
+											],
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "tBxgQFtzhUfgA9xyP",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tEYEuzMtxSsWCG7uW"
+											},
+											"name": "Unusual Biochemistry",
+											"reference": "B160",
+											"tags": [
+												"Disadvantage",
+												"Physical"
+											],
+											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										}
+									],
+									"calc": {
+										"points": -10
+									}
+								},
+								{
+									"id": "tiTZnNta1C1zhRZrR",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t9nyvI3uvjJi5aqF5"
+									},
+									"name": "Short Lifespan",
+									"reference": "B154",
+									"tags": [
+										"Disadvantage",
+										"Exotic",
+										"Physical"
+									],
+									"points_per_level": -10,
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": -10
+									}
+								}
+							],
+							"calc": {
+								"points": -20
+							}
+						}
+					],
+					"calc": {
+						"points": -55
+					}
+				}
+			],
+			"calc": {
+				"points": 29
+			}
+		}
+	]
+}

--- a/Library/Bio-Tech/Races/Diana.gct
+++ b/Library/Bio-Tech/Races/Diana.gct
@@ -1,0 +1,1318 @@
+{
+	"version": 5,
+	"id": "BVKcFwxtvYQtBjvpm",
+	"traits": [
+		{
+			"id": "Tfz3B5QGTpvNzTxO8",
+			"name": "Diana",
+			"reference": "BT68",
+			"local_notes": "TL9. $92000. LC3.",
+			"tags": [
+				"Race"
+			],
+			"container_type": "ancestry",
+			"children": [
+				{
+					"id": "tDgQ_gQavJLWpOSlE",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t1w1RFcFceKR2T9_e"
+					},
+					"name": "Increased Intelligence",
+					"reference": "B15",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Mental"
+					],
+					"points_per_level": 20,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "iq",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 20
+					}
+				},
+				{
+					"id": "tQ3r0jGSwzNTRj2Rh",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tVt3SvdGWNchJ8z4o"
+					},
+					"name": "Increased Health",
+					"reference": "B14",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"points_per_level": 10,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "ht",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 10
+					}
+				},
+				{
+					"id": "tGPD-Yj6gcGYBYFJx",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tdlCZw4YB4T7QkOnj"
+					},
+					"name": "Appearance",
+					"reference": "B21",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mLYJxJwZNfGpp7iP5",
+							"name": "Attractive",
+							"reference": "B21",
+							"cost": 4,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 1
+								}
+							]
+						},
+						{
+							"id": "mHIGUh3U-cYGnBqZi",
+							"name": "Average",
+							"reference": "B21",
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "m5CSuORD4KGx9Gmxr",
+							"name": "Beautiful",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mB_dQQTMl60JETCK-",
+							"name": "Beautiful (Androgynous)",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 3
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "meUu-agODyZdoPlqS",
+							"name": "Beautiful (Impressive)",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 3
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mXQ-2c8feSJM8oby2",
+							"name": "Handsome",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "msjAqNdSTXfchO-Hm",
+							"name": "Handsome (Androgynous)",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 3
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mN4bkxv-8a8FmPUHp",
+							"name": "Handsome (Impressive)",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 3
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "ms06_BXodFUF8mub7",
+							"name": "Hideous",
+							"reference": "B21,B202",
+							"cost": -16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Intimidation"
+									},
+									"amount": 2
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mggq9dxRo_PI5rc3u",
+							"name": "Horrific",
+							"reference": "B21,B202",
+							"cost": -24,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Intimidation"
+									},
+									"amount": 4
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -6
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mEe3ifVR2b9WDpsTd",
+							"name": "Impressive",
+							"reference": "B21",
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "maNENWFNIQZmsKzy4",
+							"name": "Monstrous",
+							"reference": "B21,B202",
+							"cost": -20,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Intimidation"
+									},
+									"amount": 3
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -5
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mg3HTIDyEaLIW1VHW",
+							"name": "Off-the-Shelf Looks",
+							"reference": "B21",
+							"local_notes": "Halves the usual reaction bonus - adjust manually",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "m1uYYzkr-4COmPNlx",
+							"name": "Transcendent",
+							"reference": "B21",
+							"cost": 20,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+									"amount": 8
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mNxy9NPIEL2xMlxww",
+							"name": "Transcendent (Androgynous)",
+							"reference": "B21",
+							"cost": 20,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 5
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mQdAUK8KlThRqi_S2",
+							"name": "Transcendent (Impressive)",
+							"reference": "B21",
+							"cost": 20,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 5
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mRAm7un_N2WbfD_LA",
+							"name": "Ugly",
+							"reference": "B21",
+							"cost": -8,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -2
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mnsLZADzCYL24Qrxt",
+							"name": "Unattractive",
+							"reference": "B21",
+							"cost": -4,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "moArpJvKp0itEmt89",
+							"name": "Universal",
+							"reference": "B21",
+							"cost": 25,
+							"disabled": true
+						},
+						{
+							"id": "mYjL8fpPynRxHZZQ0",
+							"name": "Very Beautiful",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+									"amount": 6
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "m0koIV5zYi3OhBDFy",
+							"name": "Very Beautiful (Androgynous)",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mxTdsI8E8mvTtzvlK",
+							"name": "Very Beautiful (Impressive)",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mYL0iSGs3t8vjIhSW",
+							"name": "Very Handsome",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+									"amount": 6
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mAhT7rScULCZMvBBt",
+							"name": "Very Handsome (Androgynous)",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "moRNnQ-bLtdbN1g45",
+							"name": "Very Handsome (Impressive)",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						}
+					],
+					"calc": {
+						"points": 4
+					}
+				},
+				{
+					"id": "ttGU1-o9zotzNbQ5P",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "toTe273Ky82B6YdW5"
+					},
+					"name": "Fit",
+					"reference": "B55",
+					"local_notes": "Recover FP at twice the normal rate (but not FP spent for spells or psi powers)",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"base_points": 5,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "to all HT rolls to stay conscious, avoid death, resist disease, or resist poison",
+							"amount": 1
+						}
+					],
+					"calc": {
+						"points": 5
+					}
+				},
+				{
+					"id": "tP3gC44otdgng3W-r",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tJTfFdHM7YI5IZR7I"
+					},
+					"name": "Resistant",
+					"reference": "B81,P71,MA47",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"replacements": {
+						"Occasional: Disease, Ingested Poison, etc.": "Disease"
+					},
+					"modifiers": [
+						{
+							"id": "mOU833if-pa9PovpH",
+							"name": "@Very Common: Metabolic Hazards, etc.@",
+							"reference": "B80",
+							"cost": 30,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "m4x_GOMuFqbc6TuFo",
+							"name": "@Common: Poison, Sickness, etc.@",
+							"reference": "B81",
+							"cost": 15,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "m7i74OcNEfaJBFarJ",
+							"name": "@Occasional: Disease, Ingested Poison, etc.@",
+							"reference": "B81",
+							"cost": 10,
+							"cost_type": "points"
+						},
+						{
+							"id": "mIEzAFCO-3i295XTF",
+							"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+							"reference": "B81",
+							"cost": 5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mD3qmja4BDkqKFPcN",
+							"name": "Immunity",
+							"reference": "B81",
+							"cost": 1,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "m98yVdgfkpLsfc2eM",
+							"name": "+8 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.5,
+							"cost_type": "multiplier"
+						},
+						{
+							"id": "mdKVZqHtyThz5K2nM",
+							"name": "+3 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.33,
+							"cost_type": "multiplier",
+							"disabled": true
+						}
+					],
+					"round_down": true,
+					"calc": {
+						"points": 5
+					}
+				},
+				{
+					"id": "td63XlgYBteOpoEU4",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "thdJ55ghf__io9AQa"
+					},
+					"name": "Longevity",
+					"reference": "B66",
+					"local_notes": "You fail aging rolls only on a 17 or 18, or only on an 18 if your modified HT is 17 or better",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"base_points": 2,
+					"calc": {
+						"points": 2
+					}
+				},
+				{
+					"id": "tZ5i7_klPEJ50A8Ze",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "tqoZjoMK01Dz00QE5"
+					},
+					"name": "Reproductive Control",
+					"reference": "BT59",
+					"local_notes": "TL9",
+					"base_points": 1,
+					"calc": {
+						"points": 1
+					}
+				},
+				{
+					"id": "tVCQFq_8BYKPQFv05",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "t1To3ffVy3zTmUhT_"
+					},
+					"name": "Altered Sex Ratio (@Ratio@)",
+					"reference": "BT58",
+					"local_notes": "TL9",
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "tE1oSpwxwXWRJatGT",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "twlxLezOdicVKFwxJ"
+					},
+					"name": "No Appendix",
+					"reference": "BT46",
+					"local_notes": "TL9",
+					"tags": [
+						"Exotic",
+						"Physical"
+					],
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "t7DmAHzxRLbbAoPNy",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "t5xD0RWeH3yvce1Br"
+					},
+					"name": "Sexual Orientation (@Orientation@)",
+					"reference": "BT59",
+					"local_notes": "TL9",
+					"replacements": {
+						"Orientation": "Lesbian"
+					},
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "tNkvjvcG-hLGR4zwP",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "tLe1-US7YK9twT2zS"
+					},
+					"name": "Taboo Trait (Genetic Defects)",
+					"reference": "BT65, B261",
+					"local_notes": "TL8; Also prohibits attributes more than 2 below the average for an adult with that template",
+					"tags": [
+						"Exotic",
+						"Mental",
+						"Physical",
+						"Taboo Trait"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Short Attention Span"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Non-Iconographic"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "No Sense of Smell/Taste"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Night Blindness"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Innumerate"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Hemophilia"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Gigantism"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dyslexia"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dwarfism"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Colorblindness"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "starts_with",
+									"qualifier": "Bad Sight"
+								}
+							}
+						]
+					},
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "T6SVET5sNaZkr8G6x",
+					"name": "Optionally, Add",
+					"template_picker": {
+						"type": "count"
+					},
+					"children": [
+						{
+							"id": "TSjaEAvjUYqryAK2X",
+							"name": "Artemis",
+							"local_notes": "+$69000. LC2.",
+							"children": [
+								{
+									"id": "tW-Ou36-SaRW2i4O0",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tqha9GlDBU9P-Wg-6"
+									},
+									"name": "Increased Strength",
+									"reference": "B14",
+									"tags": [
+										"Advantage",
+										"Attribute",
+										"Physical"
+									],
+									"modifiers": [
+										{
+											"id": "mr57cj3JVZFXEW-Xa",
+											"name": "No Fine Manipulators",
+											"reference": "B15",
+											"cost": -40,
+											"disabled": true
+										},
+										{
+											"id": "mlPZYJkr-uemwizqU",
+											"name": "Size",
+											"reference": "B15",
+											"cost": -10,
+											"levels": 1,
+											"disabled": true
+										},
+										{
+											"id": "m320yEJqN-x0lBImX",
+											"name": "Super-Effort",
+											"reference": "SU24",
+											"cost": 300,
+											"disabled": true
+										}
+									],
+									"points_per_level": 10,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "st",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": 10
+									}
+								},
+								{
+									"id": "tHWYvFU602HmDJAA0",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tGWOSEE6SmBHACE6Y"
+									},
+									"name": "Increased Dexterity",
+									"reference": "B15",
+									"tags": [
+										"Advantage",
+										"Attribute",
+										"Physical"
+									],
+									"modifiers": [
+										{
+											"id": "m2G1Rx63Q0TrBsJUY",
+											"name": "No Fine Manipulators",
+											"cost": -40,
+											"disabled": true
+										}
+									],
+									"points_per_level": 20,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "dx",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": 20
+									}
+								},
+								{
+									"id": "taw5-aHE7JqFJnNLq",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tmpxhXmSORakqvrbn"
+									},
+									"name": "Increased Perception",
+									"reference": "B16",
+									"tags": [
+										"Advantage",
+										"Attribute",
+										"Mental",
+										"Physical"
+									],
+									"points_per_level": 5,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "per",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": 5
+									}
+								},
+								{
+									"id": "tgJVwcfCYcDyUbzkg",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tGjjVtxav9KsrG7Wx"
+									},
+									"name": "Combat Reflexes",
+									"reference": "B43",
+									"local_notes": "Never freeze",
+									"tags": [
+										"Advantage",
+										"Mental"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Enhanced Time Sense"
+												}
+											}
+										]
+									},
+									"base_points": 15,
+									"features": [
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "starts_with",
+												"qualifier": "fast-draw"
+											},
+											"amount": 1
+										},
+										{
+											"type": "attribute_bonus",
+											"attribute": "dodge",
+											"amount": 1
+										},
+										{
+											"type": "attribute_bonus",
+											"attribute": "parry",
+											"amount": 1
+										},
+										{
+											"type": "attribute_bonus",
+											"attribute": "block",
+											"amount": 1
+										},
+										{
+											"type": "attribute_bonus",
+											"attribute": "fright_check",
+											"amount": 2
+										},
+										{
+											"type": "conditional_modifier",
+											"situation": "on all IQ rolls to wake up or to recover from surprise or mental stun",
+											"amount": 6
+										},
+										{
+											"type": "conditional_modifier",
+											"situation": "to initiative rolls for your side (+2 if you are the leader)",
+											"amount": 1
+										}
+									],
+									"calc": {
+										"points": 15
+									}
+								},
+								{
+									"id": "TniQHwS5m2Jn_Udza",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Bio-Tech/Bio-Tech Traits.adq",
+										"id": "T1hzWSwn-I1Ob0eW1"
+									},
+									"name": "Explosive Strength",
+									"reference": "BT48",
+									"local_notes": "TL9",
+									"container_type": "meta_trait",
+									"children": [
+										{
+											"id": "TlObJCk5GI6-zp1rO",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Bio-Tech/Bio-Tech Traits.adq",
+												"id": "ThyVm5klwxC70K_-M"
+											},
+											"name": "Enhanced Muscles",
+											"reference": "BT213",
+											"modifiers": [
+												{
+													"id": "m4gbVq3cVgEYIfGra",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+														"id": "m3JXyTOmjIZwhY1_g"
+													},
+													"name": "Costs Fatigue",
+													"reference": "B111,P101",
+													"local_notes": "Has maintenance cost",
+													"cost": -10,
+													"levels": 1
+												},
+												{
+													"id": "mgvF_j7ZUds8TriUF",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+														"id": "m5NmnYfBmmJqwzSnv"
+													},
+													"name": "Emergencies Only",
+													"reference": "B112,P102",
+													"cost": -30
+												}
+											],
+											"container_type": "meta_trait",
+											"children": [
+												{
+													"id": "tCJGm7rqIZAKRPK5g",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Basic Set/Basic Set Traits.adq",
+														"id": "t6krAE1uo6M0oDJFL"
+													},
+													"name": "Lifting ST",
+													"reference": "B65,P58",
+													"tags": [
+														"Advantage",
+														"Exotic",
+														"Physical"
+													],
+													"modifiers": [
+														{
+															"id": "mA3AtZ2R8-jBn8pHR",
+															"name": "No Fine Manipulators",
+															"reference": "B15",
+															"cost": -40,
+															"disabled": true
+														},
+														{
+															"id": "mG2PqHl7nTB4X6C9H",
+															"name": "Size",
+															"reference": "B15",
+															"cost": -10,
+															"levels": 1,
+															"disabled": true
+														},
+														{
+															"id": "mK_vpO9GKZox---YX",
+															"name": "Super-Effort",
+															"reference": "P58",
+															"cost": 400,
+															"disabled": true
+														},
+														{
+															"id": "mfdwNc19jy4JYy8Yn",
+															"name": "Know Your Own Strength Variant Price",
+															"reference": "PY83:18",
+															"cost": 4,
+															"cost_type": "points",
+															"affects": "levels_only",
+															"disabled": true
+														},
+														{
+															"id": "mlKMLSNUFh3ZgMIkP",
+															"name": "@Limb@ Grip ST",
+															"reference": "MATG28",
+															"cost": -70,
+															"disabled": true
+														},
+														{
+															"id": "m3QTTzKvs76wngBxJ",
+															"name": "Bite ST",
+															"reference": "MATG28",
+															"cost": -70,
+															"disabled": true
+														}
+													],
+													"points_per_level": 3,
+													"features": [
+														{
+															"type": "attribute_bonus",
+															"limitation": "lifting_only",
+															"attribute": "st",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"can_level": true,
+													"levels": 5,
+													"calc": {
+														"points": 9
+													}
+												},
+												{
+													"id": "tzD1q0GrZ5BxLn-N-",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Basic Set/Basic Set Traits.adq",
+														"id": "t8HajX_K4BDKPuUop"
+													},
+													"name": "Striking ST",
+													"reference": "B88,P78",
+													"tags": [
+														"Advantage",
+														"Exotic",
+														"Physical"
+													],
+													"modifiers": [
+														{
+															"id": "m_PiZo5e-UZQyKbsO",
+															"name": "No Fine Manipulators",
+															"cost": -40,
+															"disabled": true
+														},
+														{
+															"id": "mV94BGbFHMbL4yrws",
+															"name": "Size",
+															"cost": -10,
+															"levels": 1,
+															"disabled": true
+														},
+														{
+															"id": "m4ngXa23zM9Gb2ovK",
+															"name": "Super Effort",
+															"reference": "SU24",
+															"cost": 400,
+															"disabled": true
+														},
+														{
+															"id": "mico1bDVAuRtpOJv3",
+															"name": "One Attack Only",
+															"reference": "P79",
+															"local_notes": "@Attack@",
+															"cost": -60,
+															"disabled": true
+														},
+														{
+															"id": "mtks4tgQSgzzks88n",
+															"name": "Know Your Own Strength Pricing Variant",
+															"reference": "PY83:18",
+															"cost": -4,
+															"cost_type": "points",
+															"affects": "levels_only",
+															"disabled": true
+														}
+													],
+													"points_per_level": 5,
+													"features": [
+														{
+															"type": "attribute_bonus",
+															"limitation": "striking_only",
+															"attribute": "st",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"can_level": true,
+													"levels": 5,
+													"calc": {
+														"points": 15
+													}
+												}
+											],
+											"calc": {
+												"points": 24
+											}
+										}
+									],
+									"calc": {
+										"points": 24
+									}
+								},
+								{
+									"id": "tkuFPkwiBs4sE_p7K",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tPbL1_rekOzkM86wz"
+									},
+									"name": "Overconfidence",
+									"reference": "B148",
+									"local_notes": "You must make a self-control roll any time the GM feels you show an unreasonable degree of caution. If you fail, you must go ahead as though you were able to handle the situation!",
+									"tags": [
+										"Disadvantage",
+										"Mental"
+									],
+									"cr": 12,
+									"base_points": -5,
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from young or naive individuals who believe you are as good as you say you are",
+											"amount": 2
+										},
+										{
+											"type": "reaction_bonus",
+											"situation": "from experienced NPCs",
+											"amount": -2
+										}
+									],
+									"calc": {
+										"points": -5
+									}
+								}
+							],
+							"calc": {
+								"points": 69
+							}
+						},
+						{
+							"id": "TUB9k8R2Mq02W8eWm",
+							"name": "Athena",
+							"local_notes": "TL10. +$18000. LC3.",
+							"children": [
+								{
+									"id": "tKIYgJhXRuq98ddre",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Bio-Tech/Bio-Tech Traits.adq",
+										"id": "tKvd6bbXhGlQVR8lm"
+									},
+									"name": "Early Maturation",
+									"reference": "BT212",
+									"tags": [
+										"Feature"
+									],
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": 0
+									}
+								},
+								{
+									"id": "twsCmoWLdnLvIbQr_",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tUJz4wvVveMiGDX0R"
+									},
+									"name": "Extended Lifespan",
+									"reference": "B53",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Physical"
+									],
+									"points_per_level": 2,
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": 2
+									}
+								},
+								{
+									"id": "trsEOWEJJRwuK4Sw1",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Bio-Tech/Bio-Tech Traits.adq",
+										"id": "tV-sKMFCpL6KwPcgC"
+									},
+									"name": "Parthenogenesis",
+									"reference": "BT59",
+									"local_notes": "TL10",
+									"modifiers": [
+										{
+											"id": "mm8nbtG-LyxsGMj0S",
+											"name": "In addition to sexual reproduction",
+											"cost": 1,
+											"cost_type": "points",
+											"disabled": true
+										}
+									],
+									"calc": {
+										"points": 0
+									}
+								},
+								{
+									"id": "tswt2-gi9mIYGnWhL",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tDPqnU1ciDF13F4kZ"
+									},
+									"name": "Versatile",
+									"reference": "B96",
+									"tags": [
+										"Advantage",
+										"Mental"
+									],
+									"base_points": 5,
+									"features": [
+										{
+											"type": "conditional_modifier",
+											"situation": "on any task that requires creativity or invention, including most rolls against Artist skill and all Engineer rolls for new inventions",
+											"amount": 1
+										}
+									],
+									"calc": {
+										"points": 5
+									}
+								}
+							],
+							"calc": {
+								"points": 7
+							}
+						}
+					],
+					"calc": {
+						"points": 76
+					}
+				}
+			],
+			"calc": {
+				"points": 123
+			}
+		}
+	]
+}

--- a/Library/Bio-Tech/Races/Drylander.gct
+++ b/Library/Bio-Tech/Races/Drylander.gct
@@ -1,0 +1,337 @@
+{
+	"version": 5,
+	"id": "BDmwAGbNxBjmGIprm",
+	"traits": [
+		{
+			"id": "TXSzG5b0veUn4jnRr",
+			"name": "Drylander",
+			"reference": "BT70",
+			"local_notes": "TL9. $69000. LC3.",
+			"tags": [
+				"Race"
+			],
+			"container_type": "ancestry",
+			"children": [
+				{
+					"id": "tEGBi5Ta9Pop5ELud",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tWNGzCluuu3S1L8jv"
+					},
+					"name": "Nictitating Membrane",
+					"reference": "B71",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"points_per_level": 1,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "to all HT rolls concerned with eye damage",
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "dr_bonus",
+							"locations": [
+								"eye"
+							],
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 1
+					}
+				},
+				{
+					"id": "tg-YBugY4XRtoI9gI",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tk0ZKpvgqpE35AZcM"
+					},
+					"name": "Night Vision",
+					"reference": "B71,P87",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"points_per_level": 1,
+					"can_level": true,
+					"levels": 3,
+					"calc": {
+						"points": 3
+					}
+				},
+				{
+					"id": "tHn91W740PQc7JgC8",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tynHtgvWZmmNOL97D"
+					},
+					"name": "Reduced Consumption",
+					"reference": "B80",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mL7Gnr_retFS7oXW4",
+							"name": "Cast-Iron Stomach",
+							"reference": "B80",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "m4IPzg4GCUIwiGgqb",
+							"name": "Food Only",
+							"reference": "B80",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "mUMy2JSoPbSqLWleE",
+							"name": "Water Only",
+							"reference": "B80",
+							"cost": -50
+						}
+					],
+					"points_per_level": 2,
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 1
+					}
+				},
+				{
+					"id": "tb8O9Jk-p1NHsyN8J",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tJTfFdHM7YI5IZR7I"
+					},
+					"name": "Resistant",
+					"reference": "B81,P71,MA47",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"replacements": {
+						"Common: Poison, Sickness, etc.": "Poison"
+					},
+					"modifiers": [
+						{
+							"id": "mBHQBZ_a55HC0IJTd",
+							"name": "@Very Common: Metabolic Hazards, etc.@",
+							"reference": "B80",
+							"cost": 30,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mcFNiSFt0yV6adocp",
+							"name": "@Common: Poison, Sickness, etc.@",
+							"reference": "B81",
+							"cost": 15,
+							"cost_type": "points"
+						},
+						{
+							"id": "mVoCDCJWnN00-OFvj",
+							"name": "@Occasional: Disease, Ingested Poison, etc.@",
+							"reference": "B81",
+							"cost": 10,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mubbebDosTsMoT-MN",
+							"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+							"reference": "B81",
+							"cost": 5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "m53PYPjg5rDZLZMQM",
+							"name": "Immunity",
+							"reference": "B81",
+							"cost": 1,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "mQNQse25snC0elDhW",
+							"name": "+8 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.5,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "m9ImeEP6looIrOsyq",
+							"name": "+3 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.33,
+							"cost_type": "multiplier"
+						}
+					],
+					"round_down": true,
+					"calc": {
+						"points": 4
+					}
+				},
+				{
+					"id": "t2kTiaO0xmAvzih74",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "touwUIFalnae02BUl"
+					},
+					"name": "Temperature Tolerance",
+					"reference": "B93",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"points_per_level": 1,
+					"can_level": true,
+					"levels": 5,
+					"calc": {
+						"points": 5
+					}
+				},
+				{
+					"id": "t2GqygtDnSQork8P5",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t_ZUyO0Xhmi2p0Vku"
+					},
+					"name": "Unnatural Features (@Description@)",
+					"reference": "B22",
+					"tags": [
+						"Disadvantage",
+						"Physical"
+					],
+					"replacements": {
+						"Description": "Large catlike eyes"
+					},
+					"points_per_level": -1,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "disguise"
+							},
+							"amount": -1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "shadowing"
+							},
+							"amount": -1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": -1
+					}
+				},
+				{
+					"id": "TWpYx3L74Bef3OMH3",
+					"name": "Choose One",
+					"template_picker": {
+						"type": "count",
+						"qualifier": {
+							"compare": "is",
+							"qualifier": 1
+						}
+					},
+					"children": [
+						{
+							"id": "T8tIDDeMqIClbZQ-a",
+							"name": "Base",
+							"children": [
+								{
+									"id": "tQra0lGCRqDjjSt_V",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tFY7tz3BT0k253ky_"
+									},
+									"name": "Filter Lungs",
+									"reference": "B55",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Physical"
+									],
+									"base_points": 5,
+									"calc": {
+										"points": 5
+									}
+								}
+							],
+							"calc": {
+								"points": 5
+							}
+						},
+						{
+							"id": "TDPQdwrMNkY0J9JFx",
+							"name": "Martian Drylander",
+							"reference": "BT70",
+							"local_notes": "-$5000. LC3.",
+							"tags": [
+								"Race"
+							],
+							"container_type": "ancestry",
+							"children": [
+								{
+									"id": "t53xdtLGX_fjIh3HY",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Bio-Tech/Bio-Tech Traits.adq",
+										"id": "tLOAkXsBjj01jYAH0"
+									},
+									"name": "Low-Pressure Lungs",
+									"reference": "BT212",
+									"tags": [
+										"Feature"
+									],
+									"calc": {
+										"points": 0
+									}
+								}
+							],
+							"calc": {
+								"points": 0
+							}
+						}
+					],
+					"calc": {
+						"points": 5
+					}
+				}
+			],
+			"calc": {
+				"points": 18
+			}
+		}
+	]
+}

--- a/Library/Bio-Tech/Races/Eros.gct
+++ b/Library/Bio-Tech/Races/Eros.gct
@@ -1,0 +1,4864 @@
+{
+	"version": 5,
+	"id": "BEfn3zyqPacwwTLO0",
+	"traits": [
+		{
+			"id": "TrH3UniCosMsCvwXh",
+			"name": "Eros",
+			"reference": "BT72",
+			"local_notes": "TL10. $95000. LC3.",
+			"tags": [
+				"Race"
+			],
+			"container_type": "ancestry",
+			"children": [
+				{
+					"id": "tY9XF8rULfxaM32Uv",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "thI3hK3riuknUwkHF"
+					},
+					"name": "Decreased Strength",
+					"reference": "B14",
+					"tags": [
+						"Attribute",
+						"Disadvantage",
+						"Physical"
+					],
+					"points_per_level": -10,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "st",
+							"amount": -1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": -10
+					}
+				},
+				{
+					"id": "t5SsflkJGpvnzlJVT",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tVt3SvdGWNchJ8z4o"
+					},
+					"name": "Increased Health",
+					"reference": "B14",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"points_per_level": 10,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "ht",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 10
+					}
+				},
+				{
+					"id": "tOBkRhS2o4qlJBizp",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tsIfS0jZqdshsDFOM"
+					},
+					"name": "Extra Fatigue Points",
+					"reference": "B16",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"points_per_level": 3,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "fp",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 3
+					}
+				},
+				{
+					"id": "tcHfEuo_h52Lut_5t",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t8o1i_S4Xtjzg7gxR"
+					},
+					"name": "Flexibility (Double-Jointed)",
+					"reference": "B56",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"base_points": 15,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "climbing"
+							},
+							"amount": 5
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "escape"
+							},
+							"amount": 5
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "erotic art"
+							},
+							"amount": 5
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "in penalties may be ignored when due to close quarters",
+							"amount": -5
+						}
+					],
+					"calc": {
+						"points": 15
+					}
+				},
+				{
+					"id": "tef4gg_Vxmoe5oWCE",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tJTfFdHM7YI5IZR7I"
+					},
+					"name": "Resistant",
+					"reference": "B81,P71,MA47",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"replacements": {
+						"Occasional: Disease, Ingested Poison, etc.": "Disease"
+					},
+					"modifiers": [
+						{
+							"id": "m7CGasPqHwvvf7BMU",
+							"name": "@Very Common: Metabolic Hazards, etc.@",
+							"reference": "B80",
+							"cost": 30,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mLATGVvZKSAqYoJh_",
+							"name": "@Common: Poison, Sickness, etc.@",
+							"reference": "B81",
+							"cost": 15,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mvPVlFD9280bQyURx",
+							"name": "@Occasional: Disease, Ingested Poison, etc.@",
+							"reference": "B81",
+							"cost": 10,
+							"cost_type": "points"
+						},
+						{
+							"id": "mPkZ0YCdSKv-N-Z5i",
+							"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+							"reference": "B81",
+							"cost": 5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "m37v2xBT5ZNIZwpFV",
+							"name": "Immunity",
+							"reference": "B81",
+							"cost": 1,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "mVxO6kNJM9ammzWhp",
+							"name": "+8 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.5,
+							"cost_type": "multiplier"
+						},
+						{
+							"id": "mI8YWzaetUGothKW4",
+							"name": "+3 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.33,
+							"cost_type": "multiplier",
+							"disabled": true
+						}
+					],
+					"round_down": true,
+					"calc": {
+						"points": 5
+					}
+				},
+				{
+					"id": "TeSl3kZsmv7IDQwfc",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "TcVRXc10rugmtWbC4"
+					},
+					"name": "Sex Pheromones",
+					"reference": "BT48",
+					"local_notes": "TL10",
+					"container_type": "meta_trait",
+					"children": [
+						{
+							"id": "to6Z4cRBNLMnyKqfJ",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t9fwzDbdQy1S9CHUx"
+							},
+							"name": "Affliction",
+							"reference": "B35,P39,PSI13",
+							"tags": [
+								"Advantage",
+								"Exotic",
+								"Physical"
+							],
+							"replacements": {
+								"Condition": "Only on those attracted to your gender",
+								"Disadvantage": "Lecherousness (12)",
+								"senses": "Scent"
+							},
+							"modifiers": [
+								{
+									"id": "M_zYgaTtE1uPkMtR7",
+									"name": "Attribute Penalties",
+									"children": [
+										{
+											"id": "mwG845-03IckDbsZt",
+											"name": "DX Penalty",
+											"reference": "B36",
+											"local_notes": "Gives -1 to DX per level",
+											"cost": 10,
+											"levels": 1,
+											"disabled": true
+										},
+										{
+											"id": "mE0HufLWSw59pOrCI",
+											"name": "HT Penalty",
+											"reference": "B36",
+											"local_notes": "Gives -1 to HT per level",
+											"cost": 5,
+											"levels": 1,
+											"disabled": true
+										},
+										{
+											"id": "m3RQogrEe_Tq5EZ_Z",
+											"name": "IQ Penalty",
+											"reference": "B36",
+											"local_notes": "Gives -1 to IQ per level",
+											"cost": 10,
+											"levels": 1,
+											"disabled": true
+										},
+										{
+											"id": "mGBQdfgEIuyvfJLju",
+											"name": "ST Penalty",
+											"reference": "B36",
+											"local_notes": "Gives -1 to ST per level",
+											"cost": 5,
+											"levels": 1,
+											"disabled": true
+										}
+									]
+								},
+								{
+									"id": "mvavRMz5mYLJavfVr",
+									"name": "Cancellation",
+									"reference": "PSI13",
+									"cost": 10,
+									"disabled": true
+								},
+								{
+									"id": "mbVzfVT_g-sSLg_Xb",
+									"name": "Cumulative",
+									"reference": "B36",
+									"cost": 400,
+									"disabled": true
+								},
+								{
+									"id": "MwQhVWVGMriptvEtV",
+									"name": "Incapacitation",
+									"reference": "B36",
+									"children": [
+										{
+											"id": "m2Lb4q6RKsaHO3uin",
+											"name": "Agony",
+											"reference": "B428",
+											"local_notes": "Lose 1 FP per minute",
+											"cost": 100,
+											"disabled": true
+										},
+										{
+											"id": "mLstE9hX9_Ft1-hmW",
+											"name": "Choking",
+											"reference": "B428",
+											"cost": 100,
+											"disabled": true
+										},
+										{
+											"id": "mrVEx_QkfEct9D1jJ",
+											"name": "Daze",
+											"reference": "B428",
+											"cost": 50,
+											"disabled": true
+										},
+										{
+											"id": "mEKOoA0g4YmFPEV8J",
+											"name": "Ecstasy",
+											"reference": "B428",
+											"cost": 100,
+											"disabled": true
+										},
+										{
+											"id": "m7YsFWxwL4OCPAp3d",
+											"name": "Hallucination",
+											"reference": "B429",
+											"cost": 50,
+											"disabled": true
+										},
+										{
+											"id": "mHZDscXF2RiwEL6UV",
+											"name": "Paralysis",
+											"reference": "B429",
+											"cost": 150,
+											"disabled": true
+										},
+										{
+											"id": "md1y6ox7oKi8Illdp",
+											"name": "Retching",
+											"reference": "B429",
+											"cost": 50,
+											"disabled": true
+										},
+										{
+											"id": "myHCefgW9gJeawq-6",
+											"name": "Seizure",
+											"reference": "B429",
+											"local_notes": "Lose 1d FP at the end of the seizure",
+											"cost": 100,
+											"disabled": true
+										},
+										{
+											"id": "mX_J4NHSyydTQdRCQ",
+											"name": "Sleep",
+											"cost": 150,
+											"disabled": true
+										},
+										{
+											"id": "mtS7esK9jt7rjSgE3",
+											"name": "Unconsciousness",
+											"reference": "B429",
+											"cost": 200,
+											"disabled": true
+										}
+									]
+								},
+								{
+									"id": "Mu2Qv_d7V92628TXV",
+									"name": "Irritations",
+									"reference": "B36",
+									"children": [
+										{
+											"id": "mZJVwqMmJqevnmLXY",
+											"name": "Coughing",
+											"reference": "B428",
+											"local_notes": "Gives -3 to DX and -1 to IQ and cannot use Stealth",
+											"cost": 20,
+											"disabled": true
+										},
+										{
+											"id": "mymsA2PnBAwhkDSj1",
+											"name": "Drunk",
+											"reference": "B428",
+											"local_notes": "Gives -2 to DX and IQ; -4 to self-control rolls except those to resist Cowardice",
+											"cost": 20,
+											"disabled": true
+										},
+										{
+											"id": "mdFGYKAOWAFqFPprM",
+											"name": "Euphoria",
+											"reference": "B428",
+											"local_notes": "Gives -3 to all DX, IQ, skill and self-control rolls",
+											"cost": 30,
+											"disabled": true
+										},
+										{
+											"id": "mP7gtAU43IGvfMa5Q",
+											"name": "Moderate Pain",
+											"reference": "B428",
+											"local_notes": "-2 to all DX, IQ, skill and self-control rolls",
+											"cost": 20,
+											"disabled": true
+										},
+										{
+											"id": "mJ3qPh_oZ4kjio5G8",
+											"name": "Nauseated",
+											"reference": "B428",
+											"local_notes": "-2 to all attribute and skill rolls; -1 to active defenses",
+											"cost": 30,
+											"disabled": true
+										},
+										{
+											"id": "mNp7ZqVrvlUuy83mN",
+											"name": "Severe Pain",
+											"reference": "B428",
+											"local_notes": "-4 to all DX, IQ, skill and self-control rolls",
+											"cost": 40,
+											"disabled": true
+										},
+										{
+											"id": "mcwzYwtJs1CziEr4L",
+											"name": "Terrible Pain",
+											"reference": "B428",
+											"local_notes": "-6 to all DX, IQ, skill and self-control rolls",
+											"cost": 60,
+											"disabled": true
+										},
+										{
+											"id": "m7E9ygfYWFD_VDd9_",
+											"name": "Tipsy",
+											"reference": "B428",
+											"local_notes": "-1 to DX and IQ, -2 to self-control rolls except those to resist Cowardice",
+											"cost": 10,
+											"disabled": true
+										}
+									]
+								},
+								{
+									"id": "M3xEYYBSVogcbJyPW",
+									"name": "Mortal Conditions",
+									"children": [
+										{
+											"id": "mdssjOSmiHNLmJeI-",
+											"name": "Coma",
+											"reference": "B429",
+											"cost": 250,
+											"disabled": true
+										},
+										{
+											"id": "mqQJ83L3Oh1CnE3Jb",
+											"name": "Heart Attack",
+											"reference": "B429",
+											"cost": 300,
+											"disabled": true
+										}
+									]
+								},
+								{
+									"id": "myytyXvrZLzhJo3rc",
+									"name": "Stunning",
+									"reference": "B36",
+									"cost": 10,
+									"disabled": true
+								},
+								{
+									"id": "M-tjjTFyvYlsNa_uh",
+									"name": "Traits",
+									"children": [
+										{
+											"id": "mqTEb4z-cijHW-iDj",
+											"name": "Gives @Advantage@",
+											"reference": "B36",
+											"local_notes": "1 point per level",
+											"cost": 10,
+											"levels": 1,
+											"disabled": true
+										},
+										{
+											"id": "mhof8x6MVbdt037bk",
+											"name": "Gives @Disadvantage@",
+											"reference": "B36",
+											"local_notes": "1 point per level",
+											"cost": 1,
+											"levels": 15
+										},
+										{
+											"id": "mzxg4xVm1d3rPB3zf",
+											"name": "Negates @Advantage@",
+											"reference": "B36",
+											"local_notes": "1 point per level",
+											"cost": 1,
+											"levels": 1,
+											"disabled": true
+										}
+									]
+								},
+								{
+									"id": "m4JVvENeGIT5xRt2a",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+										"id": "m2IwCpU9KwYmjiSSA"
+									},
+									"name": "Accessibility (@Condition@)",
+									"reference": "B110,P99",
+									"local_notes": "1 point per level",
+									"cost": -1,
+									"levels": 20
+								},
+								{
+									"id": "m7y_0zX86PogZMWs9",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+										"id": "mbO8GjGu_NuPTLz6e"
+									},
+									"name": "Area Effect",
+									"reference": "B102,P100",
+									"local_notes": "2^level radius",
+									"cost": 50,
+									"levels": 1
+								},
+								{
+									"id": "mARsH50ZK-Ao2Wl6k",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+										"id": "mk76f3SlpNhhWuzRi"
+									},
+									"name": "Emanation",
+									"reference": "B112,P102",
+									"cost": -20
+								},
+								{
+									"id": "mpc7IV-3eSL-X1Vmr",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+										"id": "mR2B49Uxlo3jsnYYq"
+									},
+									"name": "Sense-Based (@senses@)",
+									"reference": "B109",
+									"local_notes": "Manually add +50% for each sense beyond the first",
+									"cost": 150
+								}
+							],
+							"points_per_level": 10,
+							"can_level": true,
+							"levels": 1,
+							"calc": {
+								"points": 28
+							}
+						}
+					],
+					"calc": {
+						"points": 28
+					}
+				},
+				{
+					"id": "t4t1zQ1eOnEdRqkNa",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t2vba3l0J2mCZM50M"
+					},
+					"name": "Voice",
+					"reference": "B97",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"base_points": 10,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "diplomacy"
+							},
+							"amount": 2
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "fast-talk"
+							},
+							"amount": 2
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "starts_with",
+								"qualifier": "mimicry"
+							},
+							"amount": 2
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "performance"
+							},
+							"amount": 2
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "politics"
+							},
+							"amount": 2
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "public speaking"
+							},
+							"amount": 2
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "sex appeal"
+							},
+							"amount": 2
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "singing"
+							},
+							"amount": 2
+						},
+						{
+							"type": "reaction_bonus",
+							"situation": "from others who can hear your voice",
+							"amount": 2
+						}
+					],
+					"calc": {
+						"points": 10
+					}
+				},
+				{
+					"id": "t9csPJnABKkIMJ93S",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t59wSfU9kpC1rus5P"
+					},
+					"name": "Alcohol Tolerance",
+					"reference": "B100",
+					"tags": [
+						"Perk",
+						"Physical"
+					],
+					"base_points": 1,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "on all HT rolls related to drinking",
+							"amount": 2
+						}
+					],
+					"calc": {
+						"points": 1
+					}
+				},
+				{
+					"id": "tLS6MN6GDf9OxQclS",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t5j2Ox4jaIV9j0rpz"
+					},
+					"name": "Deep Sleeper",
+					"reference": "B101",
+					"tags": [
+						"Perk",
+						"Physical"
+					],
+					"base_points": 1,
+					"calc": {
+						"points": 1
+					}
+				},
+				{
+					"id": "tmGPqq7iaUEOnmOvr",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tf5DfdQFaNUVbkPV2"
+					},
+					"name": "Sanitized Metabolism",
+					"reference": "B101",
+					"tags": [
+						"Perk",
+						"Physical"
+					],
+					"base_points": 1,
+					"features": [
+						{
+							"type": "reaction_bonus",
+							"situation": "from others in close confines",
+							"amount": 1
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to attempts to track you by scent",
+							"amount": -1
+						}
+					],
+					"calc": {
+						"points": 1
+					}
+				},
+				{
+					"id": "TCWyf35EUWPkap6JV",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "TluHkPSI8BnDWWEZo"
+					},
+					"name": "Bioroid",
+					"reference": "BT214",
+					"container_type": "meta_trait",
+					"children": [
+						{
+							"id": "t1Hy-RTCYPER-f3Dt",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Bio-Tech/Bio-Tech Traits.adq",
+								"id": "tAgMr2EzmeXfC7Tkg"
+							},
+							"name": "Early Maturation",
+							"reference": "BT212",
+							"local_notes": "may be level 3-5",
+							"tags": [
+								"Feature"
+							],
+							"can_level": true,
+							"levels": 3,
+							"calc": {
+								"points": 0
+							}
+						},
+						{
+							"id": "tUqv1UA5nrsyW7_h9",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Bio-Tech/Bio-Tech Traits.adq",
+								"id": "tQqPmMDKWQQ8uP2iY"
+							},
+							"name": "Sterile",
+							"calc": {
+								"points": 0
+							}
+						},
+						{
+							"id": "tIwAAGO06UzcvNGQp",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tEYEuzMtxSsWCG7uW"
+							},
+							"name": "Unusual Biochemistry",
+							"reference": "B160",
+							"tags": [
+								"Disadvantage",
+								"Physical"
+							],
+							"base_points": -5,
+							"calc": {
+								"points": -5
+							}
+						}
+					],
+					"calc": {
+						"points": -5
+					}
+				},
+				{
+					"id": "twmZZk1aPM7Gcf8-3",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tzBDG0xUlT_dh7FuY"
+					},
+					"name": "Chummy",
+					"reference": "B126",
+					"tags": [
+						"Disadvantage",
+						"Mental"
+					],
+					"base_points": -5,
+					"features": [
+						{
+							"type": "reaction_bonus",
+							"situation": "to others",
+							"amount": 2
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to IQ-based skills when alone",
+							"amount": -1
+						}
+					],
+					"calc": {
+						"points": -5
+					}
+				},
+				{
+					"id": "tHSJLwJ5nEpQpZWsK",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tV06LED8bg9xJGF3c"
+					},
+					"name": "Impulsiveness",
+					"reference": "B139",
+					"local_notes": "Make a self-control roll whenever it would be wise to wait and ponder. If you fail, you must act",
+					"tags": [
+						"Disadvantage",
+						"Mental"
+					],
+					"cr": 12,
+					"base_points": -10,
+					"calc": {
+						"points": -10
+					}
+				},
+				{
+					"id": "tDOFG7-axnDQUmFUR",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tSiOKuvTJkqJhuRrI"
+					},
+					"name": "Lecherousness",
+					"reference": "B142",
+					"local_notes": "Make a self-control roll whenever you have more than the briefest contact with an appealing member of the sex you find attractive, at -5 if this person is Handsome/Beautiful, or at -10 if Very Handsome/Very Beautiful. If you fail, you must make a “pass” using whatever wiles and skills you can bring to bear.",
+					"tags": [
+						"Disadvantage",
+						"Mental"
+					],
+					"cr": 12,
+					"base_points": -15,
+					"calc": {
+						"points": -15
+					}
+				},
+				{
+					"id": "t9eEMoSzYX0IPZNaw",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t5Qs23yaRu3D4T_hM"
+					},
+					"name": "Attentive",
+					"reference": "B163",
+					"tags": [
+						"Mental",
+						"Quirk"
+					],
+					"base_points": -1,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "to skill rolls when working on lengthy tasks, but -3 to notice any important interruption",
+							"amount": 1
+						}
+					],
+					"calc": {
+						"points": -1
+					}
+				},
+				{
+					"id": "T0W1ID2HJuhFY6tWS",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "Tv0Y4NZfGnuGNiwiQ"
+					},
+					"name": "Exotic Genitalia (@Features@)",
+					"reference": "BT59",
+					"local_notes": "TL9",
+					"children": [
+						{
+							"id": "tj_N2VP_pFwSwTXIX",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tpwIBKlkbnSdcNrWd"
+							},
+							"name": "Racial Skill Bonus - @Skill without a specialization@",
+							"reference": "BX452",
+							"tags": [
+								"Advantage",
+								"Exotic",
+								"Mental",
+								"Talent"
+							],
+							"replacements": {
+								"Skill without a specialization": "Erotic Art"
+							},
+							"points_per_level": 2,
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "@Skill without a specialization@"
+									},
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"levels": 1,
+							"calc": {
+								"points": 2
+							}
+						}
+					],
+					"calc": {
+						"points": 2
+					}
+				},
+				{
+					"id": "txc0Mtj1xNWmgA37l",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Template Toolkit/Template Toolkit 2 - Races/Template Toolkit 2 - Races Traits.adq",
+						"id": "tQY4rjF8t2sAPM9xv"
+					},
+					"name": "Sterile",
+					"reference": "TT2:12",
+					"tags": [
+						"Feature",
+						"Physical"
+					],
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "tUr5huFP8LFtWiedT",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "tLe1-US7YK9twT2zS"
+					},
+					"name": "Taboo Trait (Genetic Defects)",
+					"reference": "BT65, B261",
+					"local_notes": "TL8; Also prohibits attributes more than 2 below the average for an adult with that template",
+					"tags": [
+						"Exotic",
+						"Mental",
+						"Physical",
+						"Taboo Trait"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Short Attention Span"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Non-Iconographic"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "No Sense of Smell/Taste"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Night Blindness"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Innumerate"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Hemophilia"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Gigantism"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dyslexia"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dwarfism"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Colorblindness"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "starts_with",
+									"qualifier": "Bad Sight"
+								}
+							}
+						]
+					},
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "T5TM5RO6pEYg8ZsqU",
+					"name": "Choose One",
+					"template_picker": {
+						"type": "count",
+						"qualifier": {
+							"compare": "is",
+							"qualifier": 1
+						}
+					},
+					"children": [
+						{
+							"id": "T1WIxJ5YZ4U5Ox3Md",
+							"name": "Base",
+							"children": [
+								{
+									"id": "T-iM_hVvSwpzRqG9I",
+									"name": "Choose One",
+									"template_picker": {
+										"type": "count",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": 1
+										}
+									},
+									"children": [
+										{
+											"id": "txUWaaXpiWduOhtw4",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tdlCZw4YB4T7QkOnj"
+											},
+											"name": "Appearance",
+											"reference": "B21",
+											"tags": [
+												"Advantage",
+												"Physical"
+											],
+											"modifiers": [
+												{
+													"id": "mfJAsA0k11X-qqKTX",
+													"name": "Attractive",
+													"reference": "B21",
+													"cost": 4,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 1
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "meMszXSINhRAX4gHo",
+													"name": "Average",
+													"reference": "B21",
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mAwdPQy8unhQPXFBn",
+													"name": "Beautiful",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from those attracted to members of your sex, +2 from everyone else",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mCjUkGryhWkxX6opQ",
+													"name": "Beautiful (Androgynous)",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 3
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mCzN_V-qtERVQWh2p",
+													"name": "Beautiful (Impressive)",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 3
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mYOnqb4LuACVXZhNQ",
+													"name": "Handsome",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from those attracted to members of your sex, +2 from everyone else",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mdmreOMXUX2yDx6vA",
+													"name": "Handsome (Androgynous)",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 3
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mZ7Vh312ouW5uaNgj",
+													"name": "Handsome (Impressive)",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 3
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mH7Hclsrmp1TGHa9f",
+													"name": "Hideous",
+													"reference": "B21,B202",
+													"cost": -16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "skill_bonus",
+															"selection_type": "skills_with_name",
+															"name": {
+																"compare": "is",
+																"qualifier": "Intimidation"
+															},
+															"amount": 2
+														},
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": -4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "m4SNCCVbr2Dj7lXD0",
+													"name": "Horrific",
+													"reference": "B21,B202",
+													"cost": -24,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "skill_bonus",
+															"selection_type": "skills_with_name",
+															"name": {
+																"compare": "is",
+																"qualifier": "Intimidation"
+															},
+															"amount": 4
+														},
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": -6
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "msLYJ0x7M-pn-rjYq",
+													"name": "Impressive",
+													"reference": "B21",
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mMRwVqMkH8MtT50f_",
+													"name": "Monstrous",
+													"reference": "B21,B202",
+													"cost": -20,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "skill_bonus",
+															"selection_type": "skills_with_name",
+															"name": {
+																"compare": "is",
+																"qualifier": "Intimidation"
+															},
+															"amount": 3
+														},
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": -5
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mNHfnb6d5P5ZhPwJr",
+													"name": "Off-the-Shelf Looks",
+													"reference": "B21",
+													"local_notes": "Halves the usual reaction bonus - adjust manually",
+													"cost": -50,
+													"disabled": true
+												},
+												{
+													"id": "m71UCZuJCTZjuXPY-",
+													"name": "Transcendent",
+													"reference": "B21",
+													"cost": 20,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+															"amount": 8
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mCdlk23v51MQr1-Te",
+													"name": "Transcendent (Androgynous)",
+													"reference": "B21",
+													"cost": 20,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 5
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mGNkhFZsSruuCV5-r",
+													"name": "Transcendent (Impressive)",
+													"reference": "B21",
+													"cost": 20,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 5
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "myPIYBhsspUozgeia",
+													"name": "Ugly",
+													"reference": "B21",
+													"cost": -8,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": -2
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mvrzTpjiK973B_Wbv",
+													"name": "Unattractive",
+													"reference": "B21",
+													"cost": -4,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": -1
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "m2deE6AF0JKXAncZ1",
+													"name": "Universal",
+													"reference": "B21",
+													"cost": 25,
+													"disabled": true
+												},
+												{
+													"id": "mWJ1TxbPnzrtPh6QA",
+													"name": "Very Beautiful",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+															"amount": 6
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "ms79aJAA_CM_S5laQ",
+													"name": "Very Beautiful (Androgynous)",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mQSF6sG1K1NPkTRk9",
+													"name": "Very Beautiful (Impressive)",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "m4fvs5bxmQNSDXeWz",
+													"name": "Very Handsome",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+															"amount": 6
+														}
+													]
+												},
+												{
+													"id": "mfBmZmaHTNLleCeU4",
+													"name": "Very Handsome (Androgynous)",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "miDAmir0KrgQP7ZX1",
+													"name": "Very Handsome (Impressive)",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												}
+											],
+											"calc": {
+												"points": 16
+											}
+										},
+										{
+											"id": "tjBFT_lBASaaxjB1n",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tdlCZw4YB4T7QkOnj"
+											},
+											"name": "Appearance",
+											"reference": "B21",
+											"tags": [
+												"Advantage",
+												"Physical"
+											],
+											"modifiers": [
+												{
+													"id": "mtqrVUGiIxtI1db2q",
+													"name": "Attractive",
+													"reference": "B21",
+													"cost": 4,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 1
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "m9JBzjC5uhWsozfTL",
+													"name": "Average",
+													"reference": "B21",
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m-Pv2DhyBcxqAt6gP",
+													"name": "Beautiful",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from those attracted to members of your sex, +2 from everyone else",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "m6WyMbronDMSiCesa",
+													"name": "Beautiful (Androgynous)",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 3
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mn9r-QQAHnJtxdlUC",
+													"name": "Beautiful (Impressive)",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 3
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mlCoAh3PfvWlghJ3A",
+													"name": "Handsome",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from those attracted to members of your sex, +2 from everyone else",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mbw68qDTfcNfkTF7s",
+													"name": "Handsome (Androgynous)",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 3
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mgVNXgp69cpDE9Qyi",
+													"name": "Handsome (Impressive)",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 3
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mosY2ub2naVhoxqdF",
+													"name": "Hideous",
+													"reference": "B21,B202",
+													"cost": -16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "skill_bonus",
+															"selection_type": "skills_with_name",
+															"name": {
+																"compare": "is",
+																"qualifier": "Intimidation"
+															},
+															"amount": 2
+														},
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": -4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mLRQYAFzhHUhKifQO",
+													"name": "Horrific",
+													"reference": "B21,B202",
+													"cost": -24,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "skill_bonus",
+															"selection_type": "skills_with_name",
+															"name": {
+																"compare": "is",
+																"qualifier": "Intimidation"
+															},
+															"amount": 4
+														},
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": -6
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mp3RKZzl7OGoDYQK8",
+													"name": "Impressive",
+													"reference": "B21",
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m9piAmFtnDuNI6IML",
+													"name": "Monstrous",
+													"reference": "B21,B202",
+													"cost": -20,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "skill_bonus",
+															"selection_type": "skills_with_name",
+															"name": {
+																"compare": "is",
+																"qualifier": "Intimidation"
+															},
+															"amount": 3
+														},
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": -5
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mM53AUWWq2VlNGrhb",
+													"name": "Off-the-Shelf Looks",
+													"reference": "B21",
+													"local_notes": "Halves the usual reaction bonus - adjust manually",
+													"cost": -50,
+													"disabled": true
+												},
+												{
+													"id": "m0dNIJy7RNWInfYSl",
+													"name": "Transcendent",
+													"reference": "B21",
+													"cost": 20,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+															"amount": 8
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mqIgCgJk403Vuc4ue",
+													"name": "Transcendent (Androgynous)",
+													"reference": "B21",
+													"cost": 20,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 5
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mpBiY05QGpURypNaG",
+													"name": "Transcendent (Impressive)",
+													"reference": "B21",
+													"cost": 20,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 5
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mrUtyh0ICTWLEeGUr",
+													"name": "Ugly",
+													"reference": "B21",
+													"cost": -8,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": -2
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "m5qaiSvAIeDKn9Cnt",
+													"name": "Unattractive",
+													"reference": "B21",
+													"cost": -4,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": -1
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mt9_uqgd-7M9JIWaD",
+													"name": "Universal",
+													"reference": "B21",
+													"cost": 25,
+													"disabled": true
+												},
+												{
+													"id": "mE_cAy4_6RTN7ywHK",
+													"name": "Very Beautiful",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+															"amount": 6
+														}
+													]
+												},
+												{
+													"id": "mXaGYGZSiGoNN3tlC",
+													"name": "Very Beautiful (Androgynous)",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mD4qUjtqZ_oUelfkx",
+													"name": "Very Beautiful (Impressive)",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mVL83NwnUbzwRjKkm",
+													"name": "Very Handsome",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+															"amount": 6
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "m3X6NnaDoWKeoWKW4",
+													"name": "Very Handsome (Androgynous)",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mNAxnNHkxBJS3aB3s",
+													"name": "Very Handsome (Impressive)",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												}
+											],
+											"calc": {
+												"points": 16
+											}
+										}
+									],
+									"calc": {
+										"points": 32
+									}
+								},
+								{
+									"id": "tMz4832c5sl2ky6P_",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tkr9rivWg8KtK_oDA"
+									},
+									"name": "Distinctive Features",
+									"reference": "PU6:14",
+									"local_notes": "@Subject@",
+									"tags": [
+										"Physical",
+										"Quirk",
+										"Social"
+									],
+									"replacements": {
+										"Subject": "Exaggerated Sexual Characteristics"
+									},
+									"base_points": -1,
+									"calc": {
+										"points": -1,
+										"resolved_notes": "Exaggerated Sexual Characteristics"
+									}
+								}
+							],
+							"calc": {
+								"points": 31
+							}
+						},
+						{
+							"id": "Tth5H4TjvSAas1htg",
+							"name": "Fugu",
+							"local_notes": "+$15000",
+							"children": [
+								{
+									"id": "T9gAFVT7RpIcgQkwQ",
+									"name": "Choose One",
+									"template_picker": {
+										"type": "count",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": 1
+										}
+									},
+									"children": [
+										{
+											"id": "tRJE4ESl9SVIZCkRP",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tdlCZw4YB4T7QkOnj"
+											},
+											"name": "Appearance",
+											"reference": "B21",
+											"tags": [
+												"Advantage",
+												"Physical"
+											],
+											"modifiers": [
+												{
+													"id": "mqzAhzPK_85VQbcXe",
+													"name": "Attractive",
+													"reference": "B21",
+													"cost": 4,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 1
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mqoJZmTNvJtcqmAQs",
+													"name": "Average",
+													"reference": "B21",
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m4YbdBaJViYraCgrv",
+													"name": "Beautiful",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from those attracted to members of your sex, +2 from everyone else",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mMf5JnI_d0w1DShow",
+													"name": "Beautiful (Androgynous)",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 3
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mS7Rl6FGNW38KQnLS",
+													"name": "Beautiful (Impressive)",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 3
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mR-NE0fa22l701l8r",
+													"name": "Handsome",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from those attracted to members of your sex, +2 from everyone else",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mgU-HQq-ifn7ZZoCC",
+													"name": "Handsome (Androgynous)",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 3
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "m7Ocub_twZzxLsV0z",
+													"name": "Handsome (Impressive)",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 3
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mUGkP9gbCxn2WZg_q",
+													"name": "Hideous",
+													"reference": "B21,B202",
+													"cost": -16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "skill_bonus",
+															"selection_type": "skills_with_name",
+															"name": {
+																"compare": "is",
+																"qualifier": "Intimidation"
+															},
+															"amount": 2
+														},
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": -4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "m5_n-2_Mkp_7oy5P5",
+													"name": "Horrific",
+													"reference": "B21,B202",
+													"cost": -24,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "skill_bonus",
+															"selection_type": "skills_with_name",
+															"name": {
+																"compare": "is",
+																"qualifier": "Intimidation"
+															},
+															"amount": 4
+														},
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": -6
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mZtXim90_S7f8nb7Y",
+													"name": "Impressive",
+													"reference": "B21",
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mhSNQHUIbbqyDxMlB",
+													"name": "Monstrous",
+													"reference": "B21,B202",
+													"cost": -20,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "skill_bonus",
+															"selection_type": "skills_with_name",
+															"name": {
+																"compare": "is",
+																"qualifier": "Intimidation"
+															},
+															"amount": 3
+														},
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": -5
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "m-eIO8QoFGKPmGSaS",
+													"name": "Off-the-Shelf Looks",
+													"reference": "B21",
+													"local_notes": "Halves the usual reaction bonus - adjust manually",
+													"cost": -50,
+													"disabled": true
+												},
+												{
+													"id": "mf0d1CY31C0m-vVof",
+													"name": "Transcendent",
+													"reference": "B21",
+													"cost": 20,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+															"amount": 8
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "m8XCtA5wn0FUgr1bi",
+													"name": "Transcendent (Androgynous)",
+													"reference": "B21",
+													"cost": 20,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 5
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "m5o0zbgdyMs2JOrWG",
+													"name": "Transcendent (Impressive)",
+													"reference": "B21",
+													"cost": 20,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 5
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mfhFpZwAmEk7hTT8w",
+													"name": "Ugly",
+													"reference": "B21",
+													"cost": -8,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": -2
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mLaNz-GX5h23nm5LF",
+													"name": "Unattractive",
+													"reference": "B21",
+													"cost": -4,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": -1
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "m-NJmAIswo710JCpo",
+													"name": "Universal",
+													"reference": "B21",
+													"cost": 25,
+													"disabled": true
+												},
+												{
+													"id": "m-FngdPXF50ihx0wZ",
+													"name": "Very Beautiful",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+															"amount": 6
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mFJz5G1HT4_zpROdj",
+													"name": "Very Beautiful (Androgynous)",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mi0tZu9QvB-TQEp-k",
+													"name": "Very Beautiful (Impressive)",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mjxHTuMVcz6O7Z75F",
+													"name": "Very Handsome",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+															"amount": 6
+														}
+													]
+												},
+												{
+													"id": "m8Pl1FdoGVaLyMXK6",
+													"name": "Very Handsome (Androgynous)",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mkQq8x9lOS7S8AldE",
+													"name": "Very Handsome (Impressive)",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												}
+											],
+											"calc": {
+												"points": 16
+											}
+										},
+										{
+											"id": "t8Xs5ob2McMM9Z1AB",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tdlCZw4YB4T7QkOnj"
+											},
+											"name": "Appearance",
+											"reference": "B21",
+											"tags": [
+												"Advantage",
+												"Physical"
+											],
+											"modifiers": [
+												{
+													"id": "mraeyGC-5ZDCP4o8K",
+													"name": "Attractive",
+													"reference": "B21",
+													"cost": 4,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 1
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mw35Pm2760siWZn6U",
+													"name": "Average",
+													"reference": "B21",
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mO_pOyB8VvWMhibIZ",
+													"name": "Beautiful",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from those attracted to members of your sex, +2 from everyone else",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mWUKBtCUGB1TlVQDu",
+													"name": "Beautiful (Androgynous)",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 3
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "m3_7skMhH_YudQK8a",
+													"name": "Beautiful (Impressive)",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 3
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mkzMOuhlXsCECXQnF",
+													"name": "Handsome",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from those attracted to members of your sex, +2 from everyone else",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mkquEGPcPXhv7s5DM",
+													"name": "Handsome (Androgynous)",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 3
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mwq_IduJudBdD8gIt",
+													"name": "Handsome (Impressive)",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 3
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "m-vm-PwpzxqMh7Log",
+													"name": "Hideous",
+													"reference": "B21,B202",
+													"cost": -16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "skill_bonus",
+															"selection_type": "skills_with_name",
+															"name": {
+																"compare": "is",
+																"qualifier": "Intimidation"
+															},
+															"amount": 2
+														},
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": -4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mcW5mmQdvMJzVjp20",
+													"name": "Horrific",
+													"reference": "B21,B202",
+													"cost": -24,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "skill_bonus",
+															"selection_type": "skills_with_name",
+															"name": {
+																"compare": "is",
+																"qualifier": "Intimidation"
+															},
+															"amount": 4
+														},
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": -6
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mKIB2r5wxuVahz3BG",
+													"name": "Impressive",
+													"reference": "B21",
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mg58xv_edGj3VOnDe",
+													"name": "Monstrous",
+													"reference": "B21,B202",
+													"cost": -20,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "skill_bonus",
+															"selection_type": "skills_with_name",
+															"name": {
+																"compare": "is",
+																"qualifier": "Intimidation"
+															},
+															"amount": 3
+														},
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": -5
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mUComXvEuDX1RdwHR",
+													"name": "Off-the-Shelf Looks",
+													"reference": "B21",
+													"local_notes": "Halves the usual reaction bonus - adjust manually",
+													"cost": -50,
+													"disabled": true
+												},
+												{
+													"id": "m3kZUENrKa8W1j6wS",
+													"name": "Transcendent",
+													"reference": "B21",
+													"cost": 20,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+															"amount": 8
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mAxb076tLZoykFWru",
+													"name": "Transcendent (Androgynous)",
+													"reference": "B21",
+													"cost": 20,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 5
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mLhNeZeWPQ_Fazz7E",
+													"name": "Transcendent (Impressive)",
+													"reference": "B21",
+													"cost": 20,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 5
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mlI-KbtQPOdwSit3f",
+													"name": "Ugly",
+													"reference": "B21",
+													"cost": -8,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": -2
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "misWWY04xk4yi2suT",
+													"name": "Unattractive",
+													"reference": "B21",
+													"cost": -4,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": -1
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mM0SMwTKNfdVSdvA3",
+													"name": "Universal",
+													"reference": "B21",
+													"cost": 25,
+													"disabled": true
+												},
+												{
+													"id": "mEXwNLfJW92B1P50n",
+													"name": "Very Beautiful",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+															"amount": 6
+														}
+													]
+												},
+												{
+													"id": "mf8sqkiL2zbKcsh9x",
+													"name": "Very Beautiful (Androgynous)",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mX9V9zNcMf2x9Zq_1",
+													"name": "Very Beautiful (Impressive)",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "m0nF6457npdjx4qu_",
+													"name": "Very Handsome",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+															"amount": 6
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mYFell5jxve-2NY1T",
+													"name": "Very Handsome (Androgynous)",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mHrTm3v3w--j8mqtc",
+													"name": "Very Handsome (Impressive)",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												}
+											],
+											"calc": {
+												"points": 16
+											}
+										}
+									],
+									"calc": {
+										"points": 32
+									}
+								},
+								{
+									"id": "T46yJRQmlxOERhU6N",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Bio-Tech/Bio-Tech Traits.adq",
+										"id": "T-8B5mP1KZTG8hxD2"
+									},
+									"name": "Ecstasy Glands",
+									"reference": "BT49",
+									"local_notes": "TL10",
+									"container_type": "meta_trait",
+									"children": [
+										{
+											"id": "tjQPkSd6tZB1uR9IT",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t9fwzDbdQy1S9CHUx"
+											},
+											"name": "Affliction",
+											"reference": "B35,P39,PSI13",
+											"tags": [
+												"Advantage",
+												"Exotic",
+												"Physical"
+											],
+											"modifiers": [
+												{
+													"id": "MeP_I1X9RAj37eDCJ",
+													"name": "Attribute Penalties",
+													"children": [
+														{
+															"id": "mOl6kpOU3PGzZ3ysT",
+															"name": "DX Penalty",
+															"reference": "B36",
+															"local_notes": "Gives -1 to DX per level",
+															"cost": 10,
+															"levels": 1,
+															"disabled": true
+														},
+														{
+															"id": "m7ODmfvZMd-LIt_nX",
+															"name": "Secondary DX Penalty",
+															"reference": "B36",
+															"local_notes": "Gives -1 to DX per level",
+															"cost": 2,
+															"levels": 1,
+															"disabled": true
+														},
+														{
+															"id": "mmGNScwkoY21B88Tu",
+															"name": "HT Penalty",
+															"reference": "B36",
+															"local_notes": "Gives -1 to HT per level",
+															"cost": 5,
+															"levels": 1,
+															"disabled": true
+														},
+														{
+															"id": "mkTpH6kbnJcF2EW5b",
+															"name": "Secondary HT Penalty",
+															"reference": "B36",
+															"local_notes": "Gives -1 to HT per level",
+															"cost": 1,
+															"levels": 1,
+															"disabled": true
+														},
+														{
+															"id": "mynShwGNUpOmv0mup",
+															"name": "IQ Penalty",
+															"reference": "B36",
+															"local_notes": "Gives -1 to IQ per level",
+															"cost": 10,
+															"levels": 1,
+															"disabled": true
+														},
+														{
+															"id": "m_xPIAGa4ZT4uG4ss",
+															"name": "Secondary IQ Penalty",
+															"reference": "B36",
+															"local_notes": "Gives -1 to IQ per level",
+															"cost": 2,
+															"levels": 1,
+															"disabled": true
+														},
+														{
+															"id": "mwp8C0rUODEP31F_o",
+															"name": "Secondary ST Penalty",
+															"reference": "B36",
+															"local_notes": "Gives -1 to ST per level",
+															"cost": 1,
+															"levels": 1,
+															"disabled": true
+														}
+													]
+												},
+												{
+													"id": "mXgfZtPtzPPM2DmGh",
+													"name": "Cancellation",
+													"reference": "PSI13",
+													"cost": 10,
+													"disabled": true
+												},
+												{
+													"id": "mE3BXpF2xbFFfjRdL",
+													"name": "Cumulative",
+													"reference": "B36",
+													"cost": 400,
+													"disabled": true
+												},
+												{
+													"id": "M3kivTkgvs_PxktZC",
+													"name": "Incapacitation",
+													"reference": "B36",
+													"children": [
+														{
+															"id": "mNq2pcPrP3hg_rHiq",
+															"name": "Agony",
+															"reference": "B428",
+															"local_notes": "Lose 1 FP per minute",
+															"cost": 100,
+															"disabled": true
+														},
+														{
+															"id": "mqTMaT7WsWHHJdhZH",
+															"name": "Secondary Agony",
+															"reference": "B428",
+															"local_notes": "Lose 1 FP per minute",
+															"cost": 20,
+															"disabled": true
+														},
+														{
+															"id": "mT597lFvXQKFvXgAX",
+															"name": "Choking",
+															"reference": "B428",
+															"cost": 100,
+															"disabled": true
+														},
+														{
+															"id": "mDrAx9G6s20Ehq3f1",
+															"name": "Secondary Choking",
+															"reference": "B428",
+															"cost": 20,
+															"disabled": true
+														},
+														{
+															"id": "muqqITyrtHiiwD3eQ",
+															"name": "Daze",
+															"reference": "B428",
+															"cost": 50,
+															"disabled": true
+														},
+														{
+															"id": "mVYRng-GyAppfkhrB",
+															"name": "Secondary Daze",
+															"reference": "B428",
+															"cost": 10,
+															"disabled": true
+														},
+														{
+															"id": "mZwZvit8_ZShcs4hZ",
+															"name": "Ecstasy",
+															"reference": "B428",
+															"cost": 100
+														},
+														{
+															"id": "mkt3uPBA2AtKgPG6O",
+															"name": "Secondary Ecstasy",
+															"reference": "B428",
+															"cost": 20,
+															"disabled": true
+														},
+														{
+															"id": "m6fwHw4Q03daXCy9T",
+															"name": "Hallucination",
+															"reference": "B429",
+															"cost": 50,
+															"disabled": true
+														},
+														{
+															"id": "mOQ9AgUwO3oSctD-b",
+															"name": "Secondary Hallucination",
+															"reference": "B429",
+															"cost": 10,
+															"disabled": true
+														},
+														{
+															"id": "muphUjc3Ps7Dscbj9",
+															"name": "Paralysis",
+															"reference": "B429",
+															"cost": 150,
+															"disabled": true
+														},
+														{
+															"id": "mudHJnYoJPx9ujlwo",
+															"name": "Secondary Paralysis",
+															"reference": "B429",
+															"cost": 30,
+															"disabled": true
+														},
+														{
+															"id": "mnx7lagRQTFHVaA1_",
+															"name": "Retching",
+															"reference": "B429",
+															"cost": 50,
+															"disabled": true
+														},
+														{
+															"id": "mWmHjNs7-6pdP8Vdu",
+															"name": "Secondary Retching",
+															"reference": "B429",
+															"cost": 10,
+															"disabled": true
+														},
+														{
+															"id": "ml548E1vJ_QuhTgPA",
+															"name": "Seizure",
+															"reference": "B429",
+															"local_notes": "Lose 1d FP at the end of the seizure",
+															"cost": 100,
+															"disabled": true
+														},
+														{
+															"id": "mSt45FUMtXCNGDo5m",
+															"name": "Secondary Seizure",
+															"reference": "B429",
+															"local_notes": "Lose 1d FP at the end of the seizure",
+															"cost": 20,
+															"disabled": true
+														},
+														{
+															"id": "mI_BdrtGpebeQHcgv",
+															"name": "Sleep",
+															"cost": 150,
+															"disabled": true
+														},
+														{
+															"id": "m6XeFrLWo49h5Aas6",
+															"name": "Secondary Sleep",
+															"cost": 30,
+															"disabled": true
+														},
+														{
+															"id": "msxABKK8dFt-YhmLi",
+															"name": "Unconsciousness",
+															"reference": "B429",
+															"cost": 200,
+															"disabled": true
+														},
+														{
+															"id": "mcNuS6etg8b5Hv_0e",
+															"name": "Secondary Unconsciousness",
+															"reference": "B429",
+															"cost": 40,
+															"disabled": true
+														}
+													]
+												},
+												{
+													"id": "MwvDPpA4g9f3PgmfM",
+													"name": "Irritations",
+													"reference": "B36",
+													"children": [
+														{
+															"id": "mHkQrOLRNqDn4nkAw",
+															"name": "Coughing",
+															"reference": "B428",
+															"local_notes": "Gives -3 to DX and -1 to IQ and cannot use Stealth",
+															"cost": 20,
+															"disabled": true
+														},
+														{
+															"id": "mASPEyoQA085uRlJk",
+															"name": "Secondary Coughing",
+															"reference": "B428",
+															"local_notes": "Gives -3 to DX and -1 to IQ and cannot use Stealth",
+															"cost": 4,
+															"disabled": true
+														},
+														{
+															"id": "mA3srz_Cld7Zmibvx",
+															"name": "Drunk",
+															"reference": "B428",
+															"local_notes": "Gives -2 to DX and IQ; -4 to self-control rolls except those to resist Cowardice",
+															"cost": 20,
+															"disabled": true
+														},
+														{
+															"id": "mzYF_OWYartiZhoRR",
+															"name": "Secondary Drunk",
+															"reference": "B428",
+															"local_notes": "Gives -2 to DX and IQ; -4 to self-control rolls except those to resist Cowardice",
+															"cost": 4,
+															"disabled": true
+														},
+														{
+															"id": "miiWN9KHrbhhe_Tdl",
+															"name": "Euphoria",
+															"reference": "B428",
+															"local_notes": "Gives -3 to all DX, IQ, skill and self-control rolls",
+															"cost": 30,
+															"disabled": true
+														},
+														{
+															"id": "m4VyvjZBOBaGfu_gY",
+															"name": "Secondary Euphoria",
+															"reference": "B428",
+															"local_notes": "Gives -3 to all DX, IQ, skill and self-control rolls",
+															"cost": 6,
+															"disabled": true
+														},
+														{
+															"id": "m4bvUMGKWDpP3QG2d",
+															"name": "Moderate Pain",
+															"reference": "B428",
+															"local_notes": "-2 to all DX, IQ, skill and self-control rolls",
+															"cost": 20,
+															"disabled": true
+														},
+														{
+															"id": "mu_vTXTEcasXF8sin",
+															"name": "Secondary Moderate Pain",
+															"reference": "B428",
+															"local_notes": "-2 to all DX, IQ, skill and self-control rolls",
+															"cost": 4,
+															"disabled": true
+														},
+														{
+															"id": "mJYaxCWLR2lWj0VZH",
+															"name": "Nauseated",
+															"reference": "B428",
+															"local_notes": "-2 to all attribute and skill rolls; -1 to active defenses",
+															"cost": 30,
+															"disabled": true
+														},
+														{
+															"id": "mYdnvJ0M_9tL8HUWI",
+															"name": "Secondary Nauseated",
+															"reference": "B428",
+															"local_notes": "-2 to all attribute and skill rolls; -1 to active defenses",
+															"cost": 6,
+															"disabled": true
+														},
+														{
+															"id": "m2I05yKlyklfjOX03",
+															"name": "Severe Pain",
+															"reference": "B428",
+															"local_notes": "-4 to all DX, IQ, skill and self-control rolls",
+															"cost": 40,
+															"disabled": true
+														},
+														{
+															"id": "mJic-JQeB3c4Iw_zT",
+															"name": "Secondary Severe Pain",
+															"reference": "B428",
+															"local_notes": "-4 to all DX, IQ, skill and self-control rolls",
+															"cost": 8,
+															"disabled": true
+														},
+														{
+															"id": "mGHb9k8IxurwhhIcF",
+															"name": "Terrible Pain",
+															"reference": "B428",
+															"local_notes": "-6 to all DX, IQ, skill and self-control rolls",
+															"cost": 60,
+															"disabled": true
+														},
+														{
+															"id": "m1d4BiiU2AtRTcLnS",
+															"name": "Secondary Terrible Pain",
+															"reference": "B428",
+															"local_notes": "-6 to all DX, IQ, skill and self-control rolls",
+															"cost": 12,
+															"disabled": true
+														},
+														{
+															"id": "mrFqFZb3HDDhCagSu",
+															"name": "Tipsy",
+															"reference": "B428",
+															"local_notes": "-1 to DX and IQ, -2 to self-control rolls except those to resist Cowardice",
+															"cost": 10,
+															"disabled": true
+														},
+														{
+															"id": "mszEIHn4t3r-altYG",
+															"name": "Secondary Tipsy",
+															"reference": "B428",
+															"local_notes": "-1 to DX and IQ, -2 to self-control rolls except those to resist Cowardice",
+															"cost": 2,
+															"disabled": true
+														}
+													]
+												},
+												{
+													"id": "MtTEliNsfLq9T0c3B",
+													"name": "Mortal Conditions",
+													"children": [
+														{
+															"id": "m3bFm9oKM39LWP9th",
+															"name": "Coma",
+															"reference": "B429",
+															"cost": 250,
+															"disabled": true
+														},
+														{
+															"id": "mgbLcB0vlRtp135F-",
+															"name": "Secondary Coma",
+															"reference": "B429",
+															"cost": 50,
+															"disabled": true
+														},
+														{
+															"id": "mvI7Iv3UCz1wZYTay",
+															"name": "Heart Attack",
+															"reference": "B429",
+															"cost": 300,
+															"disabled": true
+														},
+														{
+															"id": "maGQ3oroLLWmvO5iG",
+															"name": "Secondary Heart Attack",
+															"reference": "B429",
+															"cost": 60
+														}
+													]
+												},
+												{
+													"id": "msNJ3VhfOmDQT35QC",
+													"name": "Stunning",
+													"reference": "B36",
+													"cost": 10,
+													"disabled": true
+												},
+												{
+													"id": "mtuaISghCDGkdkpKQ",
+													"name": "Secondary Stunning",
+													"reference": "B36",
+													"cost": 2,
+													"disabled": true
+												},
+												{
+													"id": "MR6SMPZx00-nXwgdt",
+													"name": "Traits",
+													"children": [
+														{
+															"id": "m72WYU4-fX2YKdcAJ",
+															"name": "Gives @Advantage@",
+															"reference": "B36",
+															"local_notes": "1 point per level",
+															"cost": 10,
+															"levels": 1,
+															"disabled": true
+														},
+														{
+															"id": "mPE3u_U4gefTWZLb7",
+															"name": "Secondary Gives @Advantage@",
+															"reference": "B36",
+															"local_notes": "1 point per level",
+															"cost": 2,
+															"levels": 1,
+															"disabled": true
+														},
+														{
+															"id": "m_hXHhW3Oz7e8jFzT",
+															"name": "Gives @Disadvantage@",
+															"reference": "B36",
+															"local_notes": "1 point per level",
+															"cost": 1,
+															"levels": 1,
+															"disabled": true
+														},
+														{
+															"id": "mW-HxQh4SNCkoGUph",
+															"name": "Secondary Gives @Disadvantage@",
+															"reference": "B36",
+															"local_notes": "5 points per level",
+															"cost": 1,
+															"levels": 1,
+															"disabled": true
+														},
+														{
+															"id": "mhkj5lgRIUDcUzJhW",
+															"name": "Negates @Advantage@",
+															"reference": "B36",
+															"local_notes": "1 point per level",
+															"cost": 1,
+															"levels": 1,
+															"disabled": true
+														},
+														{
+															"id": "mUQJgILMA3A-gA-0q",
+															"name": "Secondary Negates @Advantage@",
+															"reference": "B36",
+															"local_notes": "5 points per level",
+															"cost": 1,
+															"levels": 1,
+															"disabled": true
+														}
+													]
+												},
+												{
+													"id": "mZUpbOJjlp5TmBn9x",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+														"id": "m9qu6zy-gjsxl3Jjw"
+													},
+													"name": "Blood Agent",
+													"reference": "B110,P100",
+													"cost": -40
+												},
+												{
+													"id": "mtes0L4u2NgqKIRgo",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+														"id": "m35mRHt7D1uGCmYeA"
+													},
+													"name": "Onset",
+													"reference": "B113,P104",
+													"local_notes": "1 minute",
+													"cost": -10
+												},
+												{
+													"id": "myKjVLp_U6plGXX0G",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+														"id": "m5NmnYfBmmJqwzSnv"
+													},
+													"name": "Emergencies Only",
+													"reference": "B112,P102",
+													"cost": -30
+												},
+												{
+													"id": "mXmz8qEwOQuXLjEOY",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+														"id": "mVtDQj3J1f5GAAQ-J"
+													},
+													"name": "Melee Attack",
+													"reference": "B112,P103",
+													"local_notes": "Reach C",
+													"cost": -30
+												}
+											],
+											"points_per_level": 10,
+											"can_level": true,
+											"levels": 1,
+											"calc": {
+												"points": 15
+											}
+										}
+									],
+									"calc": {
+										"points": 15
+									}
+								},
+								{
+									"id": "tud75EX1YK6SLoBN4",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tkr9rivWg8KtK_oDA"
+									},
+									"name": "Distinctive Features",
+									"reference": "PU6:14",
+									"local_notes": "@Subject@",
+									"tags": [
+										"Physical",
+										"Quirk",
+										"Social"
+									],
+									"replacements": {
+										"Subject": "Exaggerated Sexual Characteristics"
+									},
+									"base_points": -1,
+									"calc": {
+										"points": -1,
+										"resolved_notes": "Exaggerated Sexual Characteristics"
+									}
+								}
+							],
+							"calc": {
+								"points": 46
+							}
+						},
+						{
+							"id": "Tqgw9_bv9BnonTPI2",
+							"name": "Furry",
+							"local_notes": "+$3000. LC3.",
+							"children": [
+								{
+									"id": "TO9XMk7dJvn1iQDxK",
+									"name": "Choose One",
+									"template_picker": {
+										"type": "count",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": 1
+										}
+									},
+									"children": [
+										{
+											"id": "tob6UVC7083sGxQlK",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tdlCZw4YB4T7QkOnj"
+											},
+											"name": "Appearance",
+											"reference": "B21",
+											"tags": [
+												"Advantage",
+												"Physical"
+											],
+											"modifiers": [
+												{
+													"id": "me99Crb_-WBRMwV1l",
+													"name": "Attractive",
+													"reference": "B21",
+													"cost": 4,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 1
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mzWHRgaDH3lOsjkb2",
+													"name": "Average",
+													"reference": "B21",
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mygD3BJwJs7vbYujA",
+													"name": "Beautiful",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from those attracted to members of your sex, +2 from everyone else",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "m_1MbFbFZJ4sTG_zQ",
+													"name": "Beautiful (Androgynous)",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 3
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "m-3DSvoTHI897vKV9",
+													"name": "Beautiful (Impressive)",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 3
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mZ8_N60n9nevVptcj",
+													"name": "Handsome",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from those attracted to members of your sex, +2 from everyone else",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "m9FHDwCNzSYj5N9xI",
+													"name": "Handsome (Androgynous)",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 3
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "meBh2YIjLhymW_PdK",
+													"name": "Handsome (Impressive)",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 3
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "m29vaLa0J0asFPcda",
+													"name": "Hideous",
+													"reference": "B21,B202",
+													"cost": -16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "skill_bonus",
+															"selection_type": "skills_with_name",
+															"name": {
+																"compare": "is",
+																"qualifier": "Intimidation"
+															},
+															"amount": 2
+														},
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": -4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mkhCV1H9pULIXApk3",
+													"name": "Horrific",
+													"reference": "B21,B202",
+													"cost": -24,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "skill_bonus",
+															"selection_type": "skills_with_name",
+															"name": {
+																"compare": "is",
+																"qualifier": "Intimidation"
+															},
+															"amount": 4
+														},
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": -6
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mRY-1gar23WRGuxES",
+													"name": "Impressive",
+													"reference": "B21",
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mSHDAJWarsCVX-tXL",
+													"name": "Monstrous",
+													"reference": "B21,B202",
+													"cost": -20,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "skill_bonus",
+															"selection_type": "skills_with_name",
+															"name": {
+																"compare": "is",
+																"qualifier": "Intimidation"
+															},
+															"amount": 3
+														},
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": -5
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mjno3yWQmg4uWSVYz",
+													"name": "Off-the-Shelf Looks",
+													"reference": "B21",
+													"local_notes": "Halves the usual reaction bonus - adjust manually",
+													"cost": -50,
+													"disabled": true
+												},
+												{
+													"id": "mQV0AZoHnPXs1srqt",
+													"name": "Transcendent",
+													"reference": "B21",
+													"cost": 20,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+															"amount": 8
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mSGHrlmwrFMWpv0N0",
+													"name": "Transcendent (Androgynous)",
+													"reference": "B21",
+													"cost": 20,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 5
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mSs_kHBMCJAzirno6",
+													"name": "Transcendent (Impressive)",
+													"reference": "B21",
+													"cost": 20,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 5
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mD4rbbYTizPs_8z0C",
+													"name": "Ugly",
+													"reference": "B21",
+													"cost": -8,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": -2
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "m7qV7Ht7xpQS8SR7s",
+													"name": "Unattractive",
+													"reference": "B21",
+													"cost": -4,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": -1
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mKFcB9ZjX3X0w3QPc",
+													"name": "Universal",
+													"reference": "B21",
+													"cost": 25,
+													"disabled": true
+												},
+												{
+													"id": "mDcP45awRE7VuNR5P",
+													"name": "Very Beautiful",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+															"amount": 6
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mzlsmLyyKKjn6YsgW",
+													"name": "Very Beautiful (Androgynous)",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mfrwxtIW5X7bzouU8",
+													"name": "Very Beautiful (Impressive)",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "m2NMGgcq3ci0fWvup",
+													"name": "Very Handsome",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+															"amount": 6
+														}
+													]
+												},
+												{
+													"id": "mGaNkVFSuNRiFwngi",
+													"name": "Very Handsome (Androgynous)",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mRrTfQfNnDRV7o2e5",
+													"name": "Very Handsome (Impressive)",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												}
+											],
+											"calc": {
+												"points": 16
+											}
+										},
+										{
+											"id": "tx0pZJZMOj0e0mn1s",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tdlCZw4YB4T7QkOnj"
+											},
+											"name": "Appearance",
+											"reference": "B21",
+											"tags": [
+												"Advantage",
+												"Physical"
+											],
+											"modifiers": [
+												{
+													"id": "mDOZ_1N0TXpOHHpIV",
+													"name": "Attractive",
+													"reference": "B21",
+													"cost": 4,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 1
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mcMTgnsnK9VR3Wdby",
+													"name": "Average",
+													"reference": "B21",
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mEqkk8zJUk21zOd6V",
+													"name": "Beautiful",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from those attracted to members of your sex, +2 from everyone else",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mVvoQhv00YZGEQ7NZ",
+													"name": "Beautiful (Androgynous)",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 3
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "m-4vaVhpH9g97_1bN",
+													"name": "Beautiful (Impressive)",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 3
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mtsgjn8BE6XAf7tnR",
+													"name": "Handsome",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from those attracted to members of your sex, +2 from everyone else",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mZ3-TXGmr9aNDNi_3",
+													"name": "Handsome (Androgynous)",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 3
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mocEFGHiI_qhObDYN",
+													"name": "Handsome (Impressive)",
+													"reference": "B21",
+													"cost": 12,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 3
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "miUB3PibcMHVIWoTd",
+													"name": "Hideous",
+													"reference": "B21,B202",
+													"cost": -16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "skill_bonus",
+															"selection_type": "skills_with_name",
+															"name": {
+																"compare": "is",
+																"qualifier": "Intimidation"
+															},
+															"amount": 2
+														},
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": -4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "myvfX4kbb5gKgDqmE",
+													"name": "Horrific",
+													"reference": "B21,B202",
+													"cost": -24,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "skill_bonus",
+															"selection_type": "skills_with_name",
+															"name": {
+																"compare": "is",
+																"qualifier": "Intimidation"
+															},
+															"amount": 4
+														},
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": -6
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mokB490oITk6XIaN9",
+													"name": "Impressive",
+													"reference": "B21",
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mZlYFiIEGf-jhSh7n",
+													"name": "Monstrous",
+													"reference": "B21,B202",
+													"cost": -20,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "skill_bonus",
+															"selection_type": "skills_with_name",
+															"name": {
+																"compare": "is",
+																"qualifier": "Intimidation"
+															},
+															"amount": 3
+														},
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": -5
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "m7Fkzquj76zFwpW1R",
+													"name": "Off-the-Shelf Looks",
+													"reference": "B21",
+													"local_notes": "Halves the usual reaction bonus - adjust manually",
+													"cost": -50,
+													"disabled": true
+												},
+												{
+													"id": "mvpIuNOd3ZCjQvw0L",
+													"name": "Transcendent",
+													"reference": "B21",
+													"cost": 20,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+															"amount": 8
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "m_-gdPYYabkBvTxTB",
+													"name": "Transcendent (Androgynous)",
+													"reference": "B21",
+													"cost": 20,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 5
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mhZVieEaGCKyAETNr",
+													"name": "Transcendent (Impressive)",
+													"reference": "B21",
+													"cost": 20,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 5
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mWxGbZzsWYZqWoCpq",
+													"name": "Ugly",
+													"reference": "B21",
+													"cost": -8,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": -2
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "ma5j8BsXisDO3H_et",
+													"name": "Unattractive",
+													"reference": "B21",
+													"cost": -4,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": -1
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mVCjaYWmVnRt4RXae",
+													"name": "Universal",
+													"reference": "B21",
+													"cost": 25,
+													"disabled": true
+												},
+												{
+													"id": "mZxqViFnAmwP_4Gao",
+													"name": "Very Beautiful",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+															"amount": 6
+														}
+													]
+												},
+												{
+													"id": "m3me2bMRHOEgpijNP",
+													"name": "Very Beautiful (Androgynous)",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mEmEadmzP3xdfRXSZ",
+													"name": "Very Beautiful (Impressive)",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mEsGN-Yzz73iAUfXj",
+													"name": "Very Handsome",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+															"amount": 6
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "muhkhbx3m5vEcU-BR",
+													"name": "Very Handsome (Androgynous)",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												},
+												{
+													"id": "mW_rx4DYDqjcG8hPw",
+													"name": "Very Handsome (Impressive)",
+													"reference": "B21",
+													"cost": 16,
+													"cost_type": "points",
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "from others",
+															"amount": 4
+														}
+													],
+													"disabled": true
+												}
+											],
+											"calc": {
+												"points": 16
+											}
+										}
+									],
+									"calc": {
+										"points": 32
+									}
+								},
+								{
+									"id": "thSrFburaGZOACWAb",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tkr9rivWg8KtK_oDA"
+									},
+									"name": "Distinctive Features",
+									"reference": "PU6:14",
+									"local_notes": "@Subject@",
+									"tags": [
+										"Physical",
+										"Quirk",
+										"Social"
+									],
+									"replacements": {
+										"Subject": "Exaggerated Sexual Characteristics"
+									},
+									"base_points": -1,
+									"calc": {
+										"points": -1,
+										"resolved_notes": "Exaggerated Sexual Characteristics"
+									}
+								},
+								{
+									"id": "tnrP2o_11ZFktVaoe",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t6XtSYhM7yan5_B73"
+									},
+									"name": "Acute Hearing",
+									"reference": "B35",
+									"tags": [
+										"Advantage",
+										"Physical"
+									],
+									"points_per_level": 2,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "hearing",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": 2
+									}
+								},
+								{
+									"id": "tsm9i0Gt2wFxunV_f",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tsPqY8NyZ8sJbkdS-"
+									},
+									"name": "Fur",
+									"reference": "B101",
+									"tags": [
+										"Exotic",
+										"Perk",
+										"Physical"
+									],
+									"base_points": 1,
+									"calc": {
+										"points": 1
+									}
+								},
+								{
+									"id": "tvWOi1cuRGM8ARe_D",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tk0ZKpvgqpE35AZcM"
+									},
+									"name": "Night Vision",
+									"reference": "B71,P87",
+									"tags": [
+										"Advantage",
+										"Physical"
+									],
+									"points_per_level": 1,
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": 1
+									}
+								},
+								{
+									"id": "tmQbD8aTiDD_5HRPs",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t_ZUyO0Xhmi2p0Vku"
+									},
+									"name": "Unnatural Features (@Description@)",
+									"reference": "B22",
+									"tags": [
+										"Disadvantage",
+										"Physical"
+									],
+									"replacements": {
+										"Description": "Big eyes, soft fur, animal ears and a tail"
+									},
+									"points_per_level": -1,
+									"features": [
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "disguise"
+											},
+											"amount": -1,
+											"per_level": true
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "shadowing"
+											},
+											"amount": -1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": -1
+									}
+								}
+							],
+							"calc": {
+								"points": 34
+							}
+						},
+						{
+							"id": "TmhtiTz_G_eUImZw9",
+							"name": "Gothic",
+							"local_notes": "+$17000. LC3.",
+							"children": [
+								{
+									"id": "tolzM-Vpz530WP55c",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tkr9rivWg8KtK_oDA"
+									},
+									"name": "Distinctive Features",
+									"reference": "PU6:14",
+									"local_notes": "@Subject@",
+									"tags": [
+										"Physical",
+										"Quirk",
+										"Social"
+									],
+									"replacements": {
+										"Subject": "Pale skin and red eyes"
+									},
+									"base_points": -1,
+									"calc": {
+										"points": -1,
+										"resolved_notes": "Pale skin and red eyes"
+									}
+								},
+								{
+									"id": "tLMf0PU7vloxxiO32",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tdlCZw4YB4T7QkOnj"
+									},
+									"name": "Appearance",
+									"reference": "B21",
+									"tags": [
+										"Advantage",
+										"Physical"
+									],
+									"modifiers": [
+										{
+											"id": "mClC01MpWuj4qimoh",
+											"name": "Attractive",
+											"reference": "B21",
+											"cost": 4,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": 1
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mIqMCedXaXA-CkhSI",
+											"name": "Average",
+											"reference": "B21",
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "mxCyxBZrSGhpoTMmn",
+											"name": "Beautiful",
+											"reference": "B21",
+											"cost": 12,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from those attracted to members of your sex, +2 from everyone else",
+													"amount": 4
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mnGRDhqvBZF6sTwMa",
+											"name": "Beautiful (Androgynous)",
+											"reference": "B21",
+											"cost": 12,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": 3
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mT4eUyTvtL4eerBJi",
+											"name": "Beautiful (Impressive)",
+											"reference": "B21",
+											"cost": 12,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": 3
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mN6abLD3Kx8_B9fFV",
+											"name": "Handsome",
+											"reference": "B21",
+											"cost": 12,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from those attracted to members of your sex, +2 from everyone else",
+													"amount": 4
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mYn2eMfIMxSrrdY6G",
+											"name": "Handsome (Androgynous)",
+											"reference": "B21",
+											"cost": 12,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": 3
+												}
+											]
+										},
+										{
+											"id": "m-VIhjjKBAM6SYCn-",
+											"name": "Handsome (Impressive)",
+											"reference": "B21",
+											"cost": 12,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": 3
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "m3Xeub832eovXeLji",
+											"name": "Hideous",
+											"reference": "B21,B202",
+											"cost": -16,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Intimidation"
+													},
+													"amount": 2
+												},
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": -4
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mcVno7SDQXop03Yeq",
+											"name": "Horrific",
+											"reference": "B21,B202",
+											"cost": -24,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Intimidation"
+													},
+													"amount": 4
+												},
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": -6
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "m6-FKKXHUOhw-HHdX",
+											"name": "Impressive",
+											"reference": "B21",
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "m_15S27Gkg1lzMVzf",
+											"name": "Monstrous",
+											"reference": "B21,B202",
+											"cost": -20,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Intimidation"
+													},
+													"amount": 3
+												},
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": -5
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mSAnBzcq3cQr4Cs3U",
+											"name": "Off-the-Shelf Looks",
+											"reference": "B21",
+											"local_notes": "Halves the usual reaction bonus - adjust manually",
+											"cost": -50,
+											"disabled": true
+										},
+										{
+											"id": "m9V2Tltajs97xvUPZ",
+											"name": "Transcendent",
+											"reference": "B21",
+											"cost": 20,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+													"amount": 8
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mDVjse2boZFlGJea_",
+											"name": "Transcendent (Androgynous)",
+											"reference": "B21",
+											"cost": 20,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": 5
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mq9qlVew69Qbks7Sk",
+											"name": "Transcendent (Impressive)",
+											"reference": "B21",
+											"cost": 20,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": 5
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "m6KIW4bZm2fZfY1D0",
+											"name": "Ugly",
+											"reference": "B21",
+											"cost": -8,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": -2
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mRdNJuxt7Du06pjoN",
+											"name": "Unattractive",
+											"reference": "B21",
+											"cost": -4,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": -1
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "m7Fp3F5df5YC6Q9cs",
+											"name": "Universal",
+											"reference": "B21",
+											"cost": 25,
+											"disabled": true
+										},
+										{
+											"id": "mq6mRisGuEI3rwt-k",
+											"name": "Very Beautiful",
+											"reference": "B21",
+											"cost": 16,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+													"amount": 6
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mUNkwutCnCSWQHSRn",
+											"name": "Very Beautiful (Androgynous)",
+											"reference": "B21",
+											"cost": 16,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": 4
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mITNjLkegmPqLFotX",
+											"name": "Very Beautiful (Impressive)",
+											"reference": "B21",
+											"cost": 16,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": 4
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mIBt-OW188iJxlIw0",
+											"name": "Very Handsome",
+											"reference": "B21",
+											"cost": 16,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+													"amount": 6
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "mTh5JamSISpapmOn2",
+											"name": "Very Handsome (Androgynous)",
+											"reference": "B21",
+											"cost": 16,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": 4
+												}
+											],
+											"disabled": true
+										},
+										{
+											"id": "m_IGgVi2hSRn5RMte",
+											"name": "Very Handsome (Impressive)",
+											"reference": "B21",
+											"cost": 16,
+											"cost_type": "points",
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others",
+													"amount": 4
+												}
+											],
+											"disabled": true
+										}
+									],
+									"calc": {
+										"points": 12
+									}
+								},
+								{
+									"id": "tp0W-_4jbZyOnRqW1",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tMxgHfzVEy_QQtlfB"
+									},
+									"name": "Less Sleep",
+									"reference": "B65",
+									"local_notes": "Require 1 hour/level less sleep for a full night's rest (max 4)",
+									"tags": [
+										"Advantage",
+										"Physical"
+									],
+									"points_per_level": 2,
+									"can_level": true,
+									"levels": 4,
+									"calc": {
+										"points": 8
+									}
+								},
+								{
+									"id": "tZ_U-DoC7Y2TeaxY6",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t6p_KdmzfBCpkYoyn"
+									},
+									"name": "Metabolism Control",
+									"reference": "B68,P60",
+									"tags": [
+										"Advantage",
+										"Physical"
+									],
+									"modifiers": [
+										{
+											"id": "mVI0C5PDOCOMOIe7p",
+											"name": "Hibernation",
+											"reference": "B68",
+											"cost": -60,
+											"disabled": true
+										},
+										{
+											"id": "mu2iGGY40PZi31HST",
+											"name": "Maestry",
+											"reference": "P60",
+											"cost": 40,
+											"disabled": true
+										}
+									],
+									"points_per_level": 5,
+									"can_level": true,
+									"levels": 2,
+									"calc": {
+										"points": 10
+									}
+								},
+								{
+									"id": "tQzZGd-k-rjsZTuW7",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tk0ZKpvgqpE35AZcM"
+									},
+									"name": "Night Vision",
+									"reference": "B71,P87",
+									"tags": [
+										"Advantage",
+										"Physical"
+									],
+									"points_per_level": 1,
+									"can_level": true,
+									"levels": 2,
+									"calc": {
+										"points": 2
+									}
+								},
+								{
+									"id": "tXi3K2EHnJ6u9f4TG",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tK9Ov0WtlrhnJFy5n"
+									},
+									"name": "Sharp Teeth",
+									"reference": "B91",
+									"tags": [
+										"Exotic",
+										"Perk",
+										"Physical"
+									],
+									"modifiers": [
+										{
+											"id": "mzB-sWtuznDJQ9cU_",
+											"name": "Provided by Vampiric Bite",
+											"reference": "B96",
+											"cost": -1,
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "m364yg52xlyJh42tR",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Powers/Powers Modifiers.adm",
+												"id": "mPcdrHEQuuS1KP9kT"
+											},
+											"name": "Switchable",
+											"reference": "P109",
+											"cost": 10
+										}
+									],
+									"base_points": 1,
+									"weapons": [
+										{
+											"id": "wslPrZ-gpJvyRkFet",
+											"damage": {
+												"type": "cut",
+												"st": "thr",
+												"base": "-1"
+											},
+											"usage": "Bite",
+											"reach": "C",
+											"defaults": [
+												{
+													"type": "skill",
+													"name": "Brawling"
+												},
+												{
+													"type": "dx"
+												}
+											],
+											"calc": {
+												"damage": "thr-1 cut"
+											}
+										}
+									],
+									"calc": {
+										"points": 2
+									}
+								},
+								{
+									"id": "t90ywGbLeh8In3s7v",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "t9S6N9ULlxSiTaqEH"
+									},
+									"name": "Minor Addiction (@Subject@)",
+									"reference": "PU6:29",
+									"tags": [
+										"Mental",
+										"Quirk"
+									],
+									"replacements": {
+										"Subject": "Blood"
+									},
+									"base_points": -1,
+									"calc": {
+										"points": -1
+									}
+								}
+							],
+							"calc": {
+								"points": 32
+							}
+						}
+					],
+					"calc": {
+						"points": 143
+					}
+				}
+			],
+			"calc": {
+				"points": 173
+			}
+		}
+	]
+}

--- a/Library/Bio-Tech/Races/Februus.gct
+++ b/Library/Bio-Tech/Races/Februus.gct
@@ -1,0 +1,1297 @@
+{
+	"version": 5,
+	"id": "BxQ8Yz5j8FodVRDMy",
+	"traits": [
+		{
+			"id": "TBGauJO3l4OHzDjEE",
+			"name": "Februus",
+			"reference": "BT73",
+			"local_notes": "TL10. $94000. LC3.",
+			"tags": [
+				"Race"
+			],
+			"container_type": "ancestry",
+			"children": [
+				{
+					"id": "tGQUsM0q87NQLVbtw",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tVt3SvdGWNchJ8z4o"
+					},
+					"name": "Increased Health",
+					"reference": "B14",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"points_per_level": 10,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "ht",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 2,
+					"calc": {
+						"points": 20
+					}
+				},
+				{
+					"id": "t7CQer5rszPNm-mKX",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t6krAE1uo6M0oDJFL"
+					},
+					"name": "Lifting ST",
+					"reference": "B65,P58",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mAo69wr7t3iHWL2mp",
+							"name": "No Fine Manipulators",
+							"reference": "B15",
+							"cost": -40,
+							"disabled": true
+						},
+						{
+							"id": "meLfGe80Hj_-qFWHC",
+							"name": "Size",
+							"reference": "B15",
+							"cost": -10,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mtu57WXa2KOvBXf9j",
+							"name": "Super-Effort",
+							"reference": "P58",
+							"cost": 400,
+							"disabled": true
+						},
+						{
+							"id": "mu_JCo3Bny4QL-xI5",
+							"name": "Know Your Own Strength Variant Price",
+							"reference": "PY83:18",
+							"cost": 4,
+							"cost_type": "points",
+							"affects": "levels_only",
+							"disabled": true
+						},
+						{
+							"id": "mEtUPt0rrmia-Nt1J",
+							"name": "@Limb@ Grip ST",
+							"reference": "MATG28",
+							"cost": -70,
+							"disabled": true
+						},
+						{
+							"id": "muAUbAnPHn-cE-dnt",
+							"name": "Bite ST",
+							"reference": "MATG28",
+							"cost": -70,
+							"disabled": true
+						}
+					],
+					"points_per_level": 3,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"limitation": "lifting_only",
+							"attribute": "st",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 2,
+					"calc": {
+						"points": 6
+					}
+				},
+				{
+					"id": "t4Z1pIt3O9SRAjy_z",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tjKuFiuy3Fs6rm69e"
+					},
+					"name": "Discriminatory Smell",
+					"reference": "B49,P47",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mCz7JaiKtyZZl2ZLu",
+							"name": "Emotion Sense",
+							"reference": "B49",
+							"cost": 50,
+							"disabled": true
+						},
+						{
+							"id": "mhldQqcbilqXaBZKX",
+							"name": "Profiling",
+							"reference": "P47",
+							"cost": 50,
+							"disabled": true
+						}
+					],
+					"base_points": 15,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Tracking"
+							},
+							"amount": 4
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "on any task that utilizes sense of smell",
+							"amount": 4
+						}
+					],
+					"calc": {
+						"points": 15
+					}
+				},
+				{
+					"id": "tsDGEBdrNIqXZ0uoB",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tkVnKZcuYZ4Hth4v7"
+					},
+					"name": "Discriminatory Taste",
+					"reference": "B49,P47",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mWf6wieAEwF4PJf62",
+							"name": "Profiling",
+							"reference": "P47",
+							"cost": 50,
+							"disabled": true
+						}
+					],
+					"base_points": 10,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "on any task that utilizes the sense of taste",
+							"amount": 4
+						}
+					],
+					"calc": {
+						"points": 10
+					}
+				},
+				{
+					"id": "tDInbmq2MvMJuxdXW",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tBmSJ3pNE53c4IRUU"
+					},
+					"name": "Damage Resistance",
+					"reference": "B47,P45,MA43,PSI14",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mYJe5Xf8O6wmKJa9u",
+							"name": "Force Field",
+							"reference": "B47",
+							"cost": 20,
+							"disabled": true
+						},
+						{
+							"id": "mmRjgBQGU-IMbKKn8",
+							"name": "Hardened",
+							"reference": "B47",
+							"cost": 20,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mdXWmlpBj3lqQgMyO",
+							"name": "Absorption",
+							"reference": "B46",
+							"local_notes": "Enhances @Trait@",
+							"cost": 80,
+							"disabled": true
+						},
+						{
+							"id": "mmmTHucEafZ3uP79j",
+							"name": "Absorption",
+							"reference": "B46",
+							"local_notes": "Healing only",
+							"cost": 80,
+							"disabled": true
+						},
+						{
+							"id": "mKmIwVjVTF7TeHrzI",
+							"name": "Absorption",
+							"reference": "B46",
+							"local_notes": "Enhances any trait",
+							"cost": 100,
+							"disabled": true
+						},
+						{
+							"id": "mE51xfx8d0YUh5H21",
+							"name": "Reflection",
+							"reference": "B47",
+							"cost": 100,
+							"disabled": true
+						},
+						{
+							"id": "mcg2lqJlRc6KeT7En",
+							"name": "Bane",
+							"reference": "H14",
+							"local_notes": "@Rare@",
+							"cost": -1,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mGnjZxQCuPgoBDcAm",
+							"name": "Bane",
+							"reference": "H14",
+							"local_notes": "@Occasional@",
+							"cost": -5,
+							"disabled": true
+						},
+						{
+							"id": "mCcuciuM0oigpQMS9",
+							"name": "Bane",
+							"reference": "H14",
+							"local_notes": "@Common@",
+							"cost": -10,
+							"disabled": true
+						},
+						{
+							"id": "mmSQy0RieFwVOkkB7",
+							"name": "Bane",
+							"reference": "H14",
+							"local_notes": "@Very Common@",
+							"cost": -15,
+							"disabled": true
+						},
+						{
+							"id": "muQontGLIuQu_c9vu",
+							"name": "Directional",
+							"reference": "B47",
+							"local_notes": "Front",
+							"cost": -20,
+							"disabled": true
+						},
+						{
+							"id": "mbm05qbTxxH2K-Ve8",
+							"name": "Flexible",
+							"reference": "B47",
+							"cost": -20
+						},
+						{
+							"id": "m2IoVF3klaiZR8kpd",
+							"name": "Limited",
+							"reference": "B46",
+							"local_notes": "@Very Common Attack Form@",
+							"cost": -20,
+							"disabled": true
+						},
+						{
+							"id": "mfY771kKLx7rhUeTY",
+							"name": "Semi-Ablative",
+							"reference": "B47",
+							"cost": -20,
+							"disabled": true
+						},
+						{
+							"id": "mfr27uKEBWRQul9Ka",
+							"name": "Can't wear armor",
+							"reference": "B47",
+							"cost": -40,
+							"disabled": true
+						},
+						{
+							"id": "m2WFFAlJGPZFiiCb9",
+							"name": "Directional",
+							"reference": "B47",
+							"local_notes": "@Direction: Back, Right, Left, Top or Underside@",
+							"cost": -40,
+							"disabled": true
+						},
+						{
+							"id": "ml8sMuv31Vq2Nbtb-",
+							"name": "Limited",
+							"reference": "B46",
+							"local_notes": "@Common Attack Form@",
+							"cost": -40,
+							"disabled": true
+						},
+						{
+							"id": "mYXrqCASP6EBBr2GR",
+							"name": "Tough Skin",
+							"local_notes": "Effects that just require skin contact or a scratch ignore this DR",
+							"cost": -40,
+							"disabled": true
+						},
+						{
+							"id": "mW0sUawQbwC6mJ_w9",
+							"name": "Limited",
+							"reference": "B46",
+							"local_notes": "@Occasional Attack Form@",
+							"cost": -60,
+							"disabled": true
+						},
+						{
+							"id": "mdazCxU_U2rKGLgeo",
+							"name": "Ablative",
+							"reference": "B47",
+							"cost": -80,
+							"disabled": true
+						},
+						{
+							"id": "m69ukbiW_EdJrN7GT",
+							"name": "Limited",
+							"reference": "B46",
+							"local_notes": "@Rare Attack Form@",
+							"cost": -80,
+							"disabled": true
+						},
+						{
+							"id": "muGYdqyUUou7SfLAM",
+							"name": "Laminate",
+							"reference": "RSWL18",
+							"cost": 10,
+							"disabled": true
+						},
+						{
+							"id": "mTZgo9d1B0Xg9q81i",
+							"name": "Malediction-Proof",
+							"reference": "PSI14",
+							"cost": 50,
+							"disabled": true
+						},
+						{
+							"id": "mkkbTR2KKctoSh1DJ",
+							"name": "Maledictions Only",
+							"reference": "PSI14",
+							"disabled": true
+						},
+						{
+							"id": "m8dawqFO7YUDaqZPg",
+							"name": "Partial (@Location, 1 level per -1 Per Hit Modifier, Torso is -10% thus level 1@)",
+							"reference": "B47",
+							"cost": -10,
+							"disabled": true
+						}
+					],
+					"points_per_level": 5,
+					"features": [
+						{
+							"type": "dr_bonus",
+							"locations": [
+								"all"
+							],
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "dr_bonus",
+							"locations": [
+								"eye"
+							],
+							"amount": -1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 2,
+					"calc": {
+						"points": 8
+					}
+				},
+				{
+					"id": "t-jbQj1joZ6ryrdVY",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tFY7tz3BT0k253ky_"
+					},
+					"name": "Filter Lungs",
+					"reference": "B55",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"base_points": 5,
+					"calc": {
+						"points": 5
+					}
+				},
+				{
+					"id": "tof5HDQdeSy7M7oqr",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tWNGzCluuu3S1L8jv"
+					},
+					"name": "Nictitating Membrane",
+					"reference": "B71",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"points_per_level": 1,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "to all HT rolls concerned with eye damage",
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "dr_bonus",
+							"locations": [
+								"eye"
+							],
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 1
+					}
+				},
+				{
+					"id": "tqqeSmKju0DhVpESg",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tQrNIZ1kbn0I6UAZf"
+					},
+					"name": "Regeneration",
+					"reference": "B80,P70,MA47",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mYvjvUz6rAd55kTZH",
+							"name": "Slow",
+							"reference": "B80",
+							"local_notes": "You recover 1 HP per 12 hours",
+							"cost": 10,
+							"cost_type": "points"
+						},
+						{
+							"id": "mc4RhcmChFwx7Z36q",
+							"name": "Regular",
+							"reference": "B80",
+							"local_notes": "You recover 1 HP per hour",
+							"cost": 25,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mPHy_oRe9EXX0pzKY",
+							"name": "Fast",
+							"reference": "B80",
+							"local_notes": "You recover 1 HP per minute",
+							"cost": 50,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mzrOoEADbsWykur0N",
+							"name": "Very Fast",
+							"reference": "B80",
+							"local_notes": "You recover 1 HP per second",
+							"cost": 100,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "m6GU16-6ZP-05NEBj",
+							"name": "Extreme",
+							"reference": "B80",
+							"local_notes": "You recover 10 HP per second",
+							"cost": 150,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mt1QrOeaVFLqu4CqC",
+							"name": "Heals Radiation",
+							"reference": "B80",
+							"cost": 40,
+							"disabled": true
+						},
+						{
+							"id": "miABRFC5kXYvtkJ7o",
+							"name": "Radiation Only",
+							"reference": "B80",
+							"cost": -60,
+							"disabled": true
+						},
+						{
+							"id": "m9hZZz2bGjmXGzUBU",
+							"name": "Fatigue Recovery",
+							"reference": "P70",
+							"cost": 100,
+							"disabled": true
+						},
+						{
+							"id": "mPZNDniCrRQUNb71n",
+							"name": "Fatigue Only",
+							"reference": "P70",
+							"disabled": true
+						},
+						{
+							"id": "m8g3-or2sKP1idm4_",
+							"name": "Limited: @Advantage@ Only",
+							"reference": "P70",
+							"cost": -40,
+							"disabled": true
+						},
+						{
+							"id": "m3gzuSdQznQ8m_VoF",
+							"name": "Bane",
+							"reference": "H18",
+							"local_notes": "@Common or Very Common@",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "mjgm-q5T0O2io_uhW",
+							"name": "Bane",
+							"reference": "H18",
+							"local_notes": "@Occasional@",
+							"cost": -30,
+							"disabled": true
+						},
+						{
+							"id": "mJ9WlV34ePuW-3piO",
+							"name": "Bane",
+							"reference": "H18",
+							"local_notes": "@Rare@",
+							"cost": -10,
+							"disabled": true
+						}
+					],
+					"calc": {
+						"points": 10
+					}
+				},
+				{
+					"id": "tmGKb3-pZ8BMTPL9R",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tJTfFdHM7YI5IZR7I"
+					},
+					"name": "Resistant",
+					"reference": "B81,P71,MA47",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"replacements": {
+						"Occasional: Disease, Ingested Poison, etc.": "Ingested poison"
+					},
+					"modifiers": [
+						{
+							"id": "mHoSm8V6f8jFM-Ur5",
+							"name": "@Very Common: Metabolic Hazards, etc.@",
+							"reference": "B80",
+							"cost": 30,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "madZXqSMXMPAQX4DK",
+							"name": "@Common: Poison, Sickness, etc.@",
+							"reference": "B81",
+							"cost": 15,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mYNVXJq3J7Cie0ao6",
+							"name": "@Occasional: Disease, Ingested Poison, etc.@",
+							"reference": "B81",
+							"cost": 10,
+							"cost_type": "points"
+						},
+						{
+							"id": "mPykHSbIO2e3zTT23",
+							"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+							"reference": "B81",
+							"cost": 5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mGLzMNYWMFP3Tj2kS",
+							"name": "Immunity",
+							"reference": "B81",
+							"cost": 1,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "mRE0yfxkxz6Cl6qmo",
+							"name": "+8 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.5,
+							"cost_type": "multiplier"
+						},
+						{
+							"id": "mGC-CcVfDz-3wFpI3",
+							"name": "+3 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.33,
+							"cost_type": "multiplier",
+							"disabled": true
+						}
+					],
+					"round_down": true,
+					"calc": {
+						"points": 5
+					}
+				},
+				{
+					"id": "tZt-726I61GZWhcN2",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tdlCZw4YB4T7QkOnj"
+					},
+					"name": "Appearance",
+					"reference": "B21",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mgCVEY4NdfKljIUZw",
+							"name": "Attractive",
+							"reference": "B21",
+							"cost": 4,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mcvG_NlfZJ7MMx9OQ",
+							"name": "Average",
+							"reference": "B21",
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mJ2CTUsMhZUnxPPG2",
+							"name": "Beautiful",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mdUtqWlKw2JXuOkSU",
+							"name": "Beautiful (Androgynous)",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 3
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mfhNmMdN-HMEkaMZN",
+							"name": "Beautiful (Impressive)",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 3
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mv9xxPdqfpdktGdak",
+							"name": "Handsome",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mqaeQY5gppDPaMTY7",
+							"name": "Handsome (Androgynous)",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 3
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "m86RDNAc1Dhe-15xy",
+							"name": "Handsome (Impressive)",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 3
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mYHOD_s_mZkMwTc85",
+							"name": "Hideous",
+							"reference": "B21,B202",
+							"cost": -16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Intimidation"
+									},
+									"amount": 2
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mHh5iQryKaruJMcdD",
+							"name": "Horrific",
+							"reference": "B21,B202",
+							"cost": -24,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Intimidation"
+									},
+									"amount": 4
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -6
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mxE0if1T4icPVmkff",
+							"name": "Impressive",
+							"reference": "B21",
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mjdWshVXWKdpHKN3Z",
+							"name": "Monstrous",
+							"reference": "B21,B202",
+							"cost": -20,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Intimidation"
+									},
+									"amount": 3
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -5
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mQLtSRJ52DgQGhVos",
+							"name": "Off-the-Shelf Looks",
+							"reference": "B21",
+							"local_notes": "Halves the usual reaction bonus - adjust manually",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "mpIHnsqbC1Ou0In60",
+							"name": "Transcendent",
+							"reference": "B21",
+							"cost": 20,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+									"amount": 8
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mVInw9whQnT0lGnO_",
+							"name": "Transcendent (Androgynous)",
+							"reference": "B21",
+							"cost": 20,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 5
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mbDgPnhUBqPpPPOcT",
+							"name": "Transcendent (Impressive)",
+							"reference": "B21",
+							"cost": 20,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 5
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mqgyPvvncKHN7Kl1q",
+							"name": "Ugly",
+							"reference": "B21",
+							"cost": -8,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -2
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mpo8IXkF9SnO41J4e",
+							"name": "Unattractive",
+							"reference": "B21",
+							"cost": -4,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -1
+								}
+							]
+						},
+						{
+							"id": "mT5BdmcADmzeogZ1K",
+							"name": "Universal",
+							"reference": "B21",
+							"cost": 25,
+							"disabled": true
+						},
+						{
+							"id": "mbrRjVNGkuAi9iDrl",
+							"name": "Very Beautiful",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+									"amount": 6
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mHrocBYIrIoiG4i1d",
+							"name": "Very Beautiful (Androgynous)",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "moI2sRTuEd5-XgQ04",
+							"name": "Very Beautiful (Impressive)",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mI8STzUjaJ8yDFRzU",
+							"name": "Very Handsome",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+									"amount": 6
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "m8jA0o2eJ6_xlg3M_",
+							"name": "Very Handsome (Androgynous)",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mLJcr7aye21UICSUe",
+							"name": "Very Handsome (Impressive)",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						}
+					],
+					"calc": {
+						"points": -4
+					}
+				},
+				{
+					"id": "t9G-CuJhQ6iWOkQ8o",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tw81RysAzky-yjNYN"
+					},
+					"name": "Selfless",
+					"reference": "B153",
+					"local_notes": "You must make a self-control roll to put your needs – even survival – before those of someone else.",
+					"tags": [
+						"Disadvantage",
+						"Mental"
+					],
+					"cr": 12,
+					"base_points": -5,
+					"calc": {
+						"points": -5
+					}
+				},
+				{
+					"id": "tfi9-GGl6Pp11a68M",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t_ZUyO0Xhmi2p0Vku"
+					},
+					"name": "Unnatural Features (@Description@)",
+					"reference": "B22",
+					"tags": [
+						"Disadvantage",
+						"Physical"
+					],
+					"replacements": {
+						"Description": "Hairless, Bright orange/Lemon yellow leathery skin"
+					},
+					"points_per_level": -1,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "disguise"
+							},
+							"amount": -1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "shadowing"
+							},
+							"amount": -1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": -1
+					}
+				},
+				{
+					"id": "ToDqoMUJxGZ49_N7v",
+					"name": "Optionally, Choose",
+					"template_picker": {
+						"type": "count"
+					},
+					"children": [
+						{
+							"id": "TW7TLtNVWdnBdZES0",
+							"name": "Februus Bioroid",
+							"local_notes": "-$35000. LC2.",
+							"children": [
+								{
+									"id": "TMjIsRz7UFZOg766A",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Bio-Tech/Bio-Tech Traits.adq",
+										"id": "TluHkPSI8BnDWWEZo"
+									},
+									"name": "Bioroid",
+									"reference": "BT214",
+									"container_type": "meta_trait",
+									"children": [
+										{
+											"id": "tCh227pfQteZINqYB",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Bio-Tech/Bio-Tech Traits.adq",
+												"id": "tAgMr2EzmeXfC7Tkg"
+											},
+											"name": "Early Maturation",
+											"reference": "BT212",
+											"local_notes": "may be level 3-5",
+											"tags": [
+												"Feature"
+											],
+											"can_level": true,
+											"levels": 3,
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "tTxCglXFvTjLzrulr",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Template Toolkit/Template Toolkit 2 - Races/Template Toolkit 2 - Races Traits.adq",
+												"id": "tQY4rjF8t2sAPM9xv"
+											},
+											"name": "Sterile",
+											"reference": "TT2:12",
+											"tags": [
+												"Feature",
+												"Physical"
+											],
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "tRnMBN8SS0GrL9sCp",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tEYEuzMtxSsWCG7uW"
+											},
+											"name": "Unusual Biochemistry",
+											"reference": "B160",
+											"tags": [
+												"Disadvantage",
+												"Physical"
+											],
+											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										}
+									],
+									"calc": {
+										"points": -5
+									}
+								},
+								{
+									"id": "txlzwnWs4p5gqS05C",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t9Ayzq0-Ain8oiIM8"
+									},
+									"name": "Self-Destruct",
+									"reference": "B153",
+									"tags": [
+										"Disadvantage",
+										"Exotic",
+										"Physical"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "starts_with",
+													"qualifier": "terminally ill"
+												}
+											}
+										]
+									},
+									"base_points": -10,
+									"calc": {
+										"points": -10
+									}
+								},
+								{
+									"id": "t6a69qn_QSxslXpUS",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t9nyvI3uvjJi5aqF5"
+									},
+									"name": "Short Lifespan",
+									"reference": "B154",
+									"tags": [
+										"Disadvantage",
+										"Exotic",
+										"Physical"
+									],
+									"points_per_level": -10,
+									"can_level": true,
+									"levels": 2,
+									"calc": {
+										"points": -20
+									}
+								}
+							],
+							"calc": {
+								"points": -35
+							}
+						}
+					],
+					"calc": {
+						"points": -35
+					}
+				}
+			],
+			"calc": {
+				"points": 35
+			}
+		}
+	]
+}

--- a/Library/Bio-Tech/Races/Felicia.gct
+++ b/Library/Bio-Tech/Races/Felicia.gct
@@ -1,0 +1,1657 @@
+{
+	"version": 5,
+	"id": "BljctRUyTAwzqEqaK",
+	"traits": [
+		{
+			"id": "T5DEhMpoaw5yshgdL",
+			"name": "Felicia",
+			"reference": "BT73",
+			"local_notes": "TL10. $201000. LC3.",
+			"tags": [
+				"Race"
+			],
+			"container_type": "ancestry",
+			"children": [
+				{
+					"id": "tinSNtVPU_m-gI1p3",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "thI3hK3riuknUwkHF"
+					},
+					"name": "Decreased Strength",
+					"reference": "B14",
+					"tags": [
+						"Attribute",
+						"Disadvantage",
+						"Physical"
+					],
+					"points_per_level": -10,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "st",
+							"amount": -1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": -10
+					}
+				},
+				{
+					"id": "txaVXBOXjDsgEbLUc",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tGWOSEE6SmBHACE6Y"
+					},
+					"name": "Increased Dexterity",
+					"reference": "B15",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "my67VYar6QsmD1uEm",
+							"name": "No Fine Manipulators",
+							"cost": -40,
+							"disabled": true
+						}
+					],
+					"points_per_level": 20,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "dx",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 3,
+					"calc": {
+						"points": 60
+					}
+				},
+				{
+					"id": "tLqD58Et5bRtO68RV",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tVt3SvdGWNchJ8z4o"
+					},
+					"name": "Increased Health",
+					"reference": "B14",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"points_per_level": 10,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "ht",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 10
+					}
+				},
+				{
+					"id": "tJUAvmqlJXCqNARXv",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tWF1J_Z0Ziz-qJ6pn"
+					},
+					"name": "Increased Basic Speed",
+					"reference": "B17",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"replacements": {
+						"Disadvantage": "Gluttony and Lecherousness"
+					},
+					"modifiers": [
+						{
+							"id": "mZlqQ5R9lKfAw_lMW",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+								"id": "mb8dKIbPtFmqDLYaM"
+							},
+							"name": "Costs Fatigue",
+							"reference": "B111,P101",
+							"cost": -5,
+							"levels": 3
+						},
+						{
+							"id": "m_pzBoVK7HbdoVZME",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups 8 Limitations Limitation Modifiers.adm",
+								"id": "mx8rfXf1hiYDBCzWD"
+							},
+							"name": "Aftermath",
+							"reference": "PU8:11",
+							"local_notes": "@Disadvantage@",
+							"cost": -1,
+							"levels": 10,
+							"calc": {
+								"resolved_notes": "Gluttony and Lecherousness"
+							}
+						}
+					],
+					"points_per_level": 5,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "basic_speed",
+							"amount": 0.25,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 8,
+					"calc": {
+						"points": 30
+					}
+				},
+				{
+					"id": "t0an00-vSzAJzKeSY",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t6XtSYhM7yan5_B73"
+					},
+					"name": "Acute Hearing",
+					"reference": "B35",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"points_per_level": 2,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "hearing",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 2,
+					"calc": {
+						"points": 4
+					}
+				},
+				{
+					"id": "toGb9nr5R9x-e0cl-",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tAZ31tXG_HzDmVCRp"
+					},
+					"name": "Acute Taste \u0026 Smell",
+					"reference": "B35",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"points_per_level": 2,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "taste_smell",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 2,
+					"calc": {
+						"points": 4
+					}
+				},
+				{
+					"id": "t48_TkOeNpBJqsvVy",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tdlCZw4YB4T7QkOnj"
+					},
+					"name": "Appearance",
+					"reference": "B21",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mgfbozTLeMuj00PmJ",
+							"name": "Attractive",
+							"reference": "B21",
+							"cost": 4,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 1
+								}
+							]
+						},
+						{
+							"id": "mpTdGt5smKhByJGaa",
+							"name": "Average",
+							"reference": "B21",
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mOv6SebULQuMa8YJM",
+							"name": "Beautiful",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mIMDT8rXLFZfPZO_i",
+							"name": "Beautiful (Androgynous)",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 3
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "m8clRwix1XueYuwCu",
+							"name": "Beautiful (Impressive)",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 3
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "m9DneB9yrDF_e9yvS",
+							"name": "Handsome",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mc-hXmLMzS92yAouj",
+							"name": "Handsome (Androgynous)",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 3
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "m-RTjpCFZug7E0mhk",
+							"name": "Handsome (Impressive)",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 3
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mUBlWo3qvgnF2yCvV",
+							"name": "Hideous",
+							"reference": "B21,B202",
+							"cost": -16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Intimidation"
+									},
+									"amount": 2
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mdxZADPDfXvM8be_S",
+							"name": "Horrific",
+							"reference": "B21,B202",
+							"cost": -24,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Intimidation"
+									},
+									"amount": 4
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -6
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mGmy_tXLk91kMJyW_",
+							"name": "Impressive",
+							"reference": "B21",
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "msBKcQTwx8lbr2kQc",
+							"name": "Monstrous",
+							"reference": "B21,B202",
+							"cost": -20,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Intimidation"
+									},
+									"amount": 3
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -5
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mn26VpUU4wC3yKI43",
+							"name": "Off-the-Shelf Looks",
+							"reference": "B21",
+							"local_notes": "Halves the usual reaction bonus - adjust manually",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "m44myeOoGrjwJdlzz",
+							"name": "Transcendent",
+							"reference": "B21",
+							"cost": 20,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+									"amount": 8
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "m8qjDOHPJe769O0Bi",
+							"name": "Transcendent (Androgynous)",
+							"reference": "B21",
+							"cost": 20,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 5
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "meUiRDadN8bXuV8BH",
+							"name": "Transcendent (Impressive)",
+							"reference": "B21",
+							"cost": 20,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 5
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mEIPQwzB8gfATn_7m",
+							"name": "Ugly",
+							"reference": "B21",
+							"cost": -8,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -2
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mxKE29t0dLLBS8afL",
+							"name": "Unattractive",
+							"reference": "B21",
+							"cost": -4,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mUzCadP1Mu5x0wXx7",
+							"name": "Universal",
+							"reference": "B21",
+							"cost": 25,
+							"disabled": true
+						},
+						{
+							"id": "mGKUp-hbiZ7mLQkGi",
+							"name": "Very Beautiful",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+									"amount": 6
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mKlgeZkZPHC5Ocvyv",
+							"name": "Very Beautiful (Androgynous)",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mVN6RBxXtL0nS-3Wb",
+							"name": "Very Beautiful (Impressive)",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mNmnoWu9qFlxJoev1",
+							"name": "Very Handsome",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+									"amount": 6
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "m92BqFtAZLNEeuZEF",
+							"name": "Very Handsome (Androgynous)",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mCYD787jSp2z1DNao",
+							"name": "Very Handsome (Impressive)",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						}
+					],
+					"calc": {
+						"points": 4
+					}
+				},
+				{
+					"id": "tyk1HhG9dN5Zn186A",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tzQQVBRuixCbnRR0w"
+					},
+					"name": "Catfall",
+					"reference": "B41,P43",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mGt3bum4Bn4dWH12H",
+							"name": "Feather Fall",
+							"reference": "P43",
+							"cost": 20,
+							"disabled": true
+						},
+						{
+							"id": "mbEgvb0xJQhWYEkdq",
+							"name": "Parachute",
+							"reference": "P43",
+							"cost": -30,
+							"disabled": true
+						}
+					],
+					"base_points": 10,
+					"calc": {
+						"points": 10
+					}
+				},
+				{
+					"id": "tl3P9_f5W46CD1vCy",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tGjjVtxav9KsrG7Wx"
+					},
+					"name": "Combat Reflexes",
+					"reference": "B43",
+					"local_notes": "Never freeze",
+					"tags": [
+						"Advantage",
+						"Mental"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Enhanced Time Sense"
+								}
+							}
+						]
+					},
+					"base_points": 15,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "starts_with",
+								"qualifier": "fast-draw"
+							},
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "dodge",
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "parry",
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "block",
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "fright_check",
+							"amount": 2
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "on all IQ rolls to wake up or to recover from surprise or mental stun",
+							"amount": 6
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to initiative rolls for your side (+2 if you are the leader)",
+							"amount": 1
+						}
+					],
+					"calc": {
+						"points": 15
+					}
+				},
+				{
+					"id": "tff08SfAFi1CQh9Sn",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "ta7LDTJnsrxUu_hpV"
+					},
+					"name": "Flexibility",
+					"reference": "B56,MA44",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"base_points": 5,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "climbing"
+							},
+							"amount": 3
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "escape"
+							},
+							"amount": 3
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "erotic art"
+							},
+							"amount": 3
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "in penalties may be ignored when due to close quarters",
+							"amount": -3
+						}
+					],
+					"calc": {
+						"points": 5
+					}
+				},
+				{
+					"id": "tzomrjzYU_mj3j4a4",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tk0ZKpvgqpE35AZcM"
+					},
+					"name": "Night Vision",
+					"reference": "B71,P87",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"points_per_level": 1,
+					"can_level": true,
+					"levels": 3,
+					"calc": {
+						"points": 3
+					}
+				},
+				{
+					"id": "t-m9GvCrn1sZ-NEXk",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t2uxXuNNQjGUAFAd0"
+					},
+					"name": "Perfect Balance",
+					"reference": "B74",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"base_points": 15,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "on DX and DX-based skill rolls to keep your feet or avoid being knocked down in combat",
+							"amount": 4
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "on all rolls to keep your feet if the surface is wet, slippery or unstable",
+							"amount": 6
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "starts_with",
+								"qualifier": "piloting"
+							},
+							"amount": 1
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "acrobatics"
+							},
+							"amount": 1
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "aerobatics"
+							},
+							"amount": 1
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "aquabatics"
+							},
+							"amount": 1
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "climbing"
+							},
+							"amount": 1
+						}
+					],
+					"calc": {
+						"points": 15
+					}
+				},
+				{
+					"id": "tAZ8nre0Pn8mV48yC",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tJTfFdHM7YI5IZR7I"
+					},
+					"name": "Resistant",
+					"reference": "B81,P71,MA47",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"replacements": {
+						"Occasional: Disease, Ingested Poison, etc.": "Disease"
+					},
+					"modifiers": [
+						{
+							"id": "m_2-bkBgJdsD88epv",
+							"name": "@Very Common: Metabolic Hazards, etc.@",
+							"reference": "B80",
+							"cost": 30,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mVuIkHByFaXCEz-AT",
+							"name": "@Common: Poison, Sickness, etc.@",
+							"reference": "B81",
+							"cost": 15,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mLtePYntaDdbzuv6e",
+							"name": "@Occasional: Disease, Ingested Poison, etc.@",
+							"reference": "B81",
+							"cost": 10,
+							"cost_type": "points"
+						},
+						{
+							"id": "mEOg1zG_03VL53Lof",
+							"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+							"reference": "B81",
+							"cost": 5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "moqxq9xNHw_3-5gJI",
+							"name": "Immunity",
+							"reference": "B81",
+							"cost": 1,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "m4XUtSCz_5ZzHkHSw",
+							"name": "+8 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.5,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "mXIkkEQNNWoB8htc9",
+							"name": "+3 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.33,
+							"cost_type": "multiplier"
+						}
+					],
+					"round_down": true,
+					"calc": {
+						"points": 3
+					}
+				},
+				{
+					"id": "txvTGzn-X1lIsTfeL",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tj66NHKyO_GObgGsj"
+					},
+					"name": "Sharp Claws",
+					"reference": "B42",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"base_points": 5,
+					"weapons": [
+						{
+							"id": "wv6efT2jEZmKzyrj3",
+							"damage": {
+								"type": "cut",
+								"st": "thr",
+								"base": "-1"
+							},
+							"usage": "Slash",
+							"reach": "C",
+							"parry": "0",
+							"defaults": [
+								{
+									"type": "dx"
+								},
+								{
+									"type": "skill",
+									"name": "Brawling"
+								},
+								{
+									"type": "skill",
+									"name": "Boxing"
+								},
+								{
+									"type": "skill",
+									"name": "Karate"
+								}
+							],
+							"calc": {
+								"damage": "thr-1 cut"
+							}
+						},
+						{
+							"id": "wb8No0x2E0IJ2tXhA",
+							"damage": {
+								"type": "cut",
+								"st": "thr"
+							},
+							"usage": "Kick",
+							"reach": "C,1",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -2
+								},
+								{
+									"type": "skill",
+									"name": "Karate",
+									"modifier": -2
+								},
+								{
+									"type": "skill",
+									"name": "Brawling",
+									"modifier": -2
+								}
+							],
+							"calc": {
+								"damage": "thr cut"
+							}
+						}
+					],
+					"calc": {
+						"points": 5
+					}
+				},
+				{
+					"id": "t8YL58SmgtII6rKfd",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tK9Ov0WtlrhnJFy5n"
+					},
+					"name": "Sharp Teeth",
+					"reference": "B91",
+					"tags": [
+						"Exotic",
+						"Perk",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mJXvAviJx64yC_j3i",
+							"name": "Provided by Vampiric Bite",
+							"reference": "B96",
+							"cost": -1,
+							"cost_type": "points",
+							"disabled": true
+						}
+					],
+					"base_points": 1,
+					"weapons": [
+						{
+							"id": "wPh9MYXiZ2KAiZaBX",
+							"damage": {
+								"type": "cut",
+								"st": "thr",
+								"base": "-1"
+							},
+							"usage": "Bite",
+							"reach": "C",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Brawling"
+								},
+								{
+									"type": "dx"
+								}
+							],
+							"calc": {
+								"damage": "thr-1 cut"
+							}
+						}
+					],
+					"calc": {
+						"points": 1
+					}
+				},
+				{
+					"id": "tHwkgmRSL8zKLd5LI",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tsPqY8NyZ8sJbkdS-"
+					},
+					"name": "Fur",
+					"reference": "B101",
+					"tags": [
+						"Exotic",
+						"Perk",
+						"Physical"
+					],
+					"base_points": 1,
+					"calc": {
+						"points": 1
+					}
+				},
+				{
+					"id": "t_aEaBxkWJOqod3NM",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tijmxMEy4B1uAVMr9"
+					},
+					"name": "Extra Sleep",
+					"reference": "B136",
+					"local_notes": "Require 1 hour/level more sleep for a full night's rest (max 4)",
+					"tags": [
+						"Disadvantage",
+						"Physical"
+					],
+					"points_per_level": -2,
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": -2
+					}
+				},
+				{
+					"id": "tm04aNYOIkZYEcsEz",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tPbL1_rekOzkM86wz"
+					},
+					"name": "Overconfidence",
+					"reference": "B148",
+					"local_notes": "You must make a self-control roll any time the GM feels you show an unreasonable degree of caution. If you fail, you must go ahead as though you were able to handle the situation!",
+					"tags": [
+						"Disadvantage",
+						"Mental"
+					],
+					"cr": 12,
+					"base_points": -5,
+					"features": [
+						{
+							"type": "reaction_bonus",
+							"situation": "from young or naive individuals who believe you are as good as you say you are",
+							"amount": 2
+						},
+						{
+							"type": "reaction_bonus",
+							"situation": "from experienced NPCs",
+							"amount": -2
+						}
+					],
+					"calc": {
+						"points": -5
+					}
+				},
+				{
+					"id": "tZsjDOpczmXCH-NkZ",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t_ZUyO0Xhmi2p0Vku"
+					},
+					"name": "Unnatural Features (@Description@)",
+					"reference": "B22",
+					"tags": [
+						"Disadvantage",
+						"Physical"
+					],
+					"replacements": {
+						"Description": "Catgirl"
+					},
+					"points_per_level": -1,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "disguise"
+							},
+							"amount": -1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "shadowing"
+							},
+							"amount": -1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 2,
+					"calc": {
+						"points": -2
+					}
+				},
+				{
+					"id": "tkIqIOi1D4LRvjNT0",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "t1bffFTfNbTChFffc"
+					},
+					"name": "Ordinary Tail",
+					"reference": "BT51",
+					"local_notes": "TL9",
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "TFDEb1n_9Atlb_URb",
+					"name": "Choose One",
+					"template_picker": {
+						"type": "count"
+					},
+					"children": [
+						{
+							"id": "TSadX9go4guIbW0JS",
+							"name": "Base",
+							"children": [
+								{
+									"id": "TS0tDjQxjJbAEOR4F",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Bio-Tech/Bio-Tech Traits.adq",
+										"id": "T4I1lKbVAm_JUhoRo"
+									},
+									"name": "Estrus",
+									"reference": "BT59",
+									"local_notes": "TL9",
+									"children": [
+										{
+											"id": "TmPT54VJbNmF2NI2K",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Bio-Tech/Bio-Tech Traits.adq",
+												"id": "T5zT0SaOIgWuqlwxF"
+											},
+											"name": "Variant Humans also often have this:",
+											"template_picker": {
+												"type": "count"
+											},
+											"children": [
+												{
+													"id": "tnUyNXL0hH6G4TsJ9",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Basic Set/Basic Set Traits.adq",
+														"id": "tSiOKuvTJkqJhuRrI"
+													},
+													"name": "Lecherousness",
+													"reference": "B142",
+													"local_notes": "Make a self-control roll whenever you have more than the briefest contact with an appealing member of the sex you find attractive, at -5 if this person is Handsome/Beautiful, or at -10 if Very Handsome/Very Beautiful. If you fail, you must make a “pass” using whatever wiles and skills you can bring to bear.",
+													"tags": [
+														"Disadvantage",
+														"Mental"
+													],
+													"replacements": {
+														"Condition": "Only in mating season"
+													},
+													"modifiers": [
+														{
+															"id": "mfHBadKBreXqiQ5qP",
+															"source": {
+																"library": "richardwilkes/gcs_master_library",
+																"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+																"id": "m2IwCpU9KwYmjiSSA"
+															},
+															"name": "Accessibility (@Condition@)",
+															"reference": "B110,P99",
+															"local_notes": "1 point per level",
+															"cost": -1,
+															"levels": 80
+														}
+													],
+													"cr": 12,
+													"base_points": -15,
+													"calc": {
+														"points": -3
+													}
+												}
+											],
+											"calc": {
+												"points": -3
+											}
+										}
+									],
+									"calc": {
+										"points": -3
+									}
+								}
+							],
+							"calc": {
+								"points": -3
+							}
+						},
+						{
+							"id": "Te3SC8HIsteNG0ntw",
+							"name": "Felicia Bioroid",
+							"local_notes": "-$34000. LC2.",
+							"children": [
+								{
+									"id": "TQDzIOmMVdVkm7D7a",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Bio-Tech/Bio-Tech Traits.adq",
+										"id": "TluHkPSI8BnDWWEZo"
+									},
+									"name": "Bioroid",
+									"reference": "BT214",
+									"container_type": "meta_trait",
+									"children": [
+										{
+											"id": "tL88eFAa3ctr-5AAk",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Bio-Tech/Bio-Tech Traits.adq",
+												"id": "tAgMr2EzmeXfC7Tkg"
+											},
+											"name": "Early Maturation",
+											"reference": "BT212",
+											"local_notes": "may be level 3-5",
+											"tags": [
+												"Feature"
+											],
+											"can_level": true,
+											"levels": 3,
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "tO0AcN7mM4Sl4w438",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Template Toolkit/Template Toolkit 2 - Races/Template Toolkit 2 - Races Traits.adq",
+												"id": "tQY4rjF8t2sAPM9xv"
+											},
+											"name": "Sterile",
+											"reference": "TT2:12",
+											"tags": [
+												"Feature",
+												"Physical"
+											],
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "tLPM-LidiZVU6cwUo",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tEYEuzMtxSsWCG7uW"
+											},
+											"name": "Unusual Biochemistry",
+											"reference": "B160",
+											"tags": [
+												"Disadvantage",
+												"Physical"
+											],
+											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										}
+									],
+									"calc": {
+										"points": -5
+									}
+								},
+								{
+									"id": "tYUU7CvXipva-KfcH",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t9Ayzq0-Ain8oiIM8"
+									},
+									"name": "Self-Destruct",
+									"reference": "B153",
+									"tags": [
+										"Disadvantage",
+										"Exotic",
+										"Physical"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "starts_with",
+													"qualifier": "terminally ill"
+												}
+											}
+										]
+									},
+									"base_points": -10,
+									"calc": {
+										"points": -10
+									}
+								},
+								{
+									"id": "tSc18DNOZekZHGVgQ",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t9nyvI3uvjJi5aqF5"
+									},
+									"name": "Short Lifespan",
+									"reference": "B154",
+									"tags": [
+										"Disadvantage",
+										"Exotic",
+										"Physical"
+									],
+									"points_per_level": -10,
+									"can_level": true,
+									"levels": 2,
+									"calc": {
+										"points": -20
+									}
+								}
+							],
+							"calc": {
+								"points": -35
+							}
+						},
+						{
+							"id": "TrVCd8rtaowxkjQds",
+							"name": "Felicia Chimera",
+							"local_notes": "-$14000. LC2.",
+							"children": [
+								{
+									"id": "TZiNLE2JT-WPiZvO4",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Bio-Tech/Bio-Tech Traits.adq",
+										"id": "To3AVoJByLMnwXPPz"
+									},
+									"name": "Chimera",
+									"reference": "BT214",
+									"container_type": "meta_trait",
+									"children": [
+										{
+											"id": "t9KyVwIPHrrON9Fle",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t8duh7FJvBdSs4NOb"
+											},
+											"name": "Restricted Diet (@Food@)",
+											"reference": "B151",
+											"tags": [
+												"Disadvantage",
+												"Physical"
+											],
+											"replacements": {
+												"Food": "Fresh Meat"
+											},
+											"modifiers": [
+												{
+													"id": "mzTJDXY_bv1zUJ35Q",
+													"name": "Substitution",
+													"reference": "B151",
+													"cost": -50
+												},
+												{
+													"id": "mRmGPsTqXn1bZfFjg",
+													"name": "Very Common",
+													"reference": "B151",
+													"cost": -10,
+													"cost_type": "points"
+												},
+												{
+													"id": "m7BHAx28GRQdkEyHG",
+													"name": "Common",
+													"reference": "B151",
+													"cost": -20,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mNb8kFlAlhRXqpJcb",
+													"name": "Occasional",
+													"reference": "B151",
+													"cost": -30,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mFDwDg5CrxBc0_KGe",
+													"name": "Rare",
+													"reference": "B151",
+													"cost": -40,
+													"cost_type": "points",
+													"disabled": true
+												}
+											],
+											"calc": {
+												"points": -5
+											}
+										},
+										{
+											"id": "tqF_QEGYAVbtMczi7",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Template Toolkit/Template Toolkit 2 - Races/Template Toolkit 2 - Races Traits.adq",
+												"id": "tQY4rjF8t2sAPM9xv"
+											},
+											"name": "Sterile",
+											"reference": "TT2:12",
+											"tags": [
+												"Feature",
+												"Physical"
+											],
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "tQ9687hk-53rOBUVO",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tEYEuzMtxSsWCG7uW"
+											},
+											"name": "Unusual Biochemistry",
+											"reference": "B160",
+											"tags": [
+												"Disadvantage",
+												"Physical"
+											],
+											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										}
+									],
+									"calc": {
+										"points": -10
+									}
+								},
+								{
+									"id": "tb_B9lT2gtKRsdzNc",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t9nyvI3uvjJi5aqF5"
+									},
+									"name": "Short Lifespan",
+									"reference": "B154",
+									"tags": [
+										"Disadvantage",
+										"Exotic",
+										"Physical"
+									],
+									"points_per_level": -10,
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": -10
+									}
+								},
+								{
+									"id": "TGV5F-gJ7vfH8vR4b",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Bio-Tech/Bio-Tech Traits.adq",
+										"id": "T4I1lKbVAm_JUhoRo"
+									},
+									"name": "Estrus",
+									"reference": "BT59",
+									"local_notes": "TL9",
+									"children": [
+										{
+											"id": "TWHYFPOGe5tCZ4h21",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Bio-Tech/Bio-Tech Traits.adq",
+												"id": "T5zT0SaOIgWuqlwxF"
+											},
+											"name": "Variant Humans also often have this:",
+											"template_picker": {
+												"type": "count"
+											},
+											"children": [
+												{
+													"id": "tXuI2B4Rv_2Gr8_p4",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Basic Set/Basic Set Traits.adq",
+														"id": "tSiOKuvTJkqJhuRrI"
+													},
+													"name": "Lecherousness",
+													"reference": "B142",
+													"local_notes": "Make a self-control roll whenever you have more than the briefest contact with an appealing member of the sex you find attractive, at -5 if this person is Handsome/Beautiful, or at -10 if Very Handsome/Very Beautiful. If you fail, you must make a “pass” using whatever wiles and skills you can bring to bear.",
+													"tags": [
+														"Disadvantage",
+														"Mental"
+													],
+													"replacements": {
+														"Condition": "Only in mating season"
+													},
+													"modifiers": [
+														{
+															"id": "mktOTTt60WeCMrsw7",
+															"source": {
+																"library": "richardwilkes/gcs_master_library",
+																"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+																"id": "m2IwCpU9KwYmjiSSA"
+															},
+															"name": "Accessibility (@Condition@)",
+															"reference": "B110,P99",
+															"local_notes": "1 point per level",
+															"cost": -1,
+															"levels": 80
+														}
+													],
+													"cr": 12,
+													"base_points": -15,
+													"calc": {
+														"points": -3
+													}
+												}
+											],
+											"calc": {
+												"points": -3
+											}
+										}
+									],
+									"calc": {
+										"points": -3
+									}
+								}
+							],
+							"calc": {
+								"points": -23
+							}
+						}
+					],
+					"calc": {
+						"points": -61
+					}
+				}
+			],
+			"calc": {
+				"points": 90
+			}
+		}
+	]
+}

--- a/Library/Bio-Tech/Races/Gilgamesh.gct
+++ b/Library/Bio-Tech/Races/Gilgamesh.gct
@@ -1,0 +1,1016 @@
+{
+	"version": 5,
+	"id": "BHj9qF0ShYKgTLmV7",
+	"traits": [
+		{
+			"id": "TiUeqKYBbV43I-O8q",
+			"name": "Gilgamesh",
+			"reference": "BT69",
+			"local_notes": "TL10. $115000. LC3.",
+			"tags": [
+				"Race"
+			],
+			"container_type": "ancestry",
+			"children": [
+				{
+					"id": "t9neqNsrRSOhqwkdF",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tGWOSEE6SmBHACE6Y"
+					},
+					"name": "Increased Dexterity",
+					"reference": "B15",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "md4r2zuYwwitqXH49",
+							"name": "No Fine Manipulators",
+							"cost": -40,
+							"disabled": true
+						}
+					],
+					"points_per_level": 20,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "dx",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 20
+					}
+				},
+				{
+					"id": "tw2Zb3UNpQdptD46D",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t1w1RFcFceKR2T9_e"
+					},
+					"name": "Increased Intelligence",
+					"reference": "B15",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Mental"
+					],
+					"points_per_level": 20,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "iq",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 20
+					}
+				},
+				{
+					"id": "tHDiIUJNgHu2CIkGG",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tdlCZw4YB4T7QkOnj"
+					},
+					"name": "Appearance",
+					"reference": "B21",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "m87wkGY9FHJjhyKVF",
+							"name": "Attractive",
+							"reference": "B21",
+							"cost": 4,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 1
+								}
+							]
+						},
+						{
+							"id": "mAJL8md_XOJwyy8FG",
+							"name": "Average",
+							"reference": "B21",
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "m9lsXKH_t53N5jtrt",
+							"name": "Beautiful",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "musHrKfcKAYbdSvKZ",
+							"name": "Beautiful (Androgynous)",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 3
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mBdExFjGELnJS8vQx",
+							"name": "Beautiful (Impressive)",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 3
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mEF0vXSFeUPzWAl0x",
+							"name": "Handsome",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mUhglowU7BsS8Db6l",
+							"name": "Handsome (Androgynous)",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 3
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mVLPrv5qEdfcKnmVW",
+							"name": "Handsome (Impressive)",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 3
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mU_GX5bnaMaA2NYJh",
+							"name": "Hideous",
+							"reference": "B21,B202",
+							"cost": -16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Intimidation"
+									},
+									"amount": 2
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mdREGNfiaIBZ7T_Wx",
+							"name": "Horrific",
+							"reference": "B21,B202",
+							"cost": -24,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Intimidation"
+									},
+									"amount": 4
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -6
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mnUInqX1ppxzas0Bm",
+							"name": "Impressive",
+							"reference": "B21",
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mqVS43_arhSVowcXh",
+							"name": "Monstrous",
+							"reference": "B21,B202",
+							"cost": -20,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Intimidation"
+									},
+									"amount": 3
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -5
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mso-x6CxAtO-2xYWu",
+							"name": "Off-the-Shelf Looks",
+							"reference": "B21",
+							"local_notes": "Halves the usual reaction bonus - adjust manually",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "myUvS0zcT-d6P1ruI",
+							"name": "Transcendent",
+							"reference": "B21",
+							"cost": 20,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+									"amount": 8
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mZYT8cxezedJi6NaT",
+							"name": "Transcendent (Androgynous)",
+							"reference": "B21",
+							"cost": 20,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 5
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mx1UP6ZtLzEPLJ6zJ",
+							"name": "Transcendent (Impressive)",
+							"reference": "B21",
+							"cost": 20,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 5
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "m1HpJaoZzUFalxHuE",
+							"name": "Ugly",
+							"reference": "B21",
+							"cost": -8,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -2
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mKr12HsV06cYJRQtu",
+							"name": "Unattractive",
+							"reference": "B21",
+							"cost": -4,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "md-A-MSTRMrYCLEGg",
+							"name": "Universal",
+							"reference": "B21",
+							"cost": 25,
+							"disabled": true
+						},
+						{
+							"id": "m4iZtAvgLqaCFT74Q",
+							"name": "Very Beautiful",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+									"amount": 6
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mxtPCkhKZ5hN_LrTD",
+							"name": "Very Beautiful (Androgynous)",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "m7YN7UD90NnRk0v6l",
+							"name": "Very Beautiful (Impressive)",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mSHU7VKfGsDgWcBuq",
+							"name": "Very Handsome",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+									"amount": 6
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "myQ5w0PyUeIGt-FuL",
+							"name": "Very Handsome (Androgynous)",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mYH-mr5BqH3v4yZtR",
+							"name": "Very Handsome (Impressive)",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						}
+					],
+					"calc": {
+						"points": 4
+					}
+				},
+				{
+					"id": "tvt4wATy3r_SDNwd1",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tUJz4wvVveMiGDX0R"
+					},
+					"name": "Extended Lifespan",
+					"reference": "B53",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"points_per_level": 2,
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 2
+					}
+				},
+				{
+					"id": "t0qQILbrugzqkFsmx",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "thdJ55ghf__io9AQa"
+					},
+					"name": "Longevity",
+					"reference": "B66",
+					"local_notes": "You fail aging rolls only on a 17 or 18, or only on an 18 if your modified HT is 17 or better",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"base_points": 2,
+					"calc": {
+						"points": 2
+					}
+				},
+				{
+					"id": "ttbfATGxRiKgLIiE5",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tJTfFdHM7YI5IZR7I"
+					},
+					"name": "Resistant",
+					"reference": "B81,P71,MA47",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"replacements": {
+						"Occasional: Disease, Ingested Poison, etc.": "Disease"
+					},
+					"modifiers": [
+						{
+							"id": "mGRwkYQUsJnWyQk2C",
+							"name": "@Very Common: Metabolic Hazards, etc.@",
+							"reference": "B80",
+							"cost": 30,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mR6oXNYKh_HwFfrvT",
+							"name": "@Common: Poison, Sickness, etc.@",
+							"reference": "B81",
+							"cost": 15,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mVVGUkLx8TfHU1rZW",
+							"name": "@Occasional: Disease, Ingested Poison, etc.@",
+							"reference": "B81",
+							"cost": 10,
+							"cost_type": "points"
+						},
+						{
+							"id": "m0RMqqk6yWjaLnPjI",
+							"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+							"reference": "B81",
+							"cost": 5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mMgO1R9F5XXDEhhYP",
+							"name": "Immunity",
+							"reference": "B81",
+							"cost": 1,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "mmv_WItwAgIysqGaM",
+							"name": "+8 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.5,
+							"cost_type": "multiplier"
+						},
+						{
+							"id": "m4dObhAA1c_nCYgBU",
+							"name": "+3 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.33,
+							"cost_type": "multiplier",
+							"disabled": true
+						}
+					],
+					"round_down": true,
+					"calc": {
+						"points": 5
+					}
+				},
+				{
+					"id": "t2b53PBCZFWOX6uTn",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "tqoZjoMK01Dz00QE5"
+					},
+					"name": "Reproductive Control",
+					"reference": "BT59",
+					"local_notes": "TL9",
+					"base_points": 1,
+					"calc": {
+						"points": 1
+					}
+				},
+				{
+					"id": "t6KZKv5K8q0uJKQWY",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tf5DfdQFaNUVbkPV2"
+					},
+					"name": "Sanitized Metabolism",
+					"reference": "B101",
+					"tags": [
+						"Perk",
+						"Physical"
+					],
+					"base_points": 1,
+					"features": [
+						{
+							"type": "reaction_bonus",
+							"situation": "from others in close confines",
+							"amount": 1
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to attempts to track you by scent",
+							"amount": -1
+						}
+					],
+					"calc": {
+						"points": 1
+					}
+				},
+				{
+					"id": "tM2Mv1nv7LWSGLYYB",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "tKvd6bbXhGlQVR8lm"
+					},
+					"name": "Early Maturation",
+					"reference": "BT212",
+					"tags": [
+						"Feature"
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "t9BhHJH_xATrFiyg5",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "twlxLezOdicVKFwxJ"
+					},
+					"name": "No Appendix",
+					"reference": "BT46",
+					"local_notes": "TL9",
+					"tags": [
+						"Exotic",
+						"Physical"
+					],
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "ter_G7mykGMHyGNwa",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "tLe1-US7YK9twT2zS"
+					},
+					"name": "Taboo Trait (Genetic Defects)",
+					"reference": "BT65, B261",
+					"local_notes": "TL8; Also prohibits attributes more than 2 below the average for an adult with that template",
+					"tags": [
+						"Exotic",
+						"Mental",
+						"Physical",
+						"Taboo Trait"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Short Attention Span"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Non-Iconographic"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "No Sense of Smell/Taste"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Night Blindness"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Innumerate"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Hemophilia"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Gigantism"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dyslexia"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dwarfism"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Colorblindness"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "starts_with",
+									"qualifier": "Bad Sight"
+								}
+							}
+						]
+					},
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "T017S8y3LI32n41HA",
+					"name": "Choose One",
+					"template_picker": {
+						"type": "count",
+						"qualifier": {
+							"compare": "is",
+							"qualifier": 1
+						}
+					},
+					"children": [
+						{
+							"id": "TpxFktfmXJfx7YLye",
+							"name": "Base",
+							"children": [
+								{
+									"id": "tb8L-W8HxYHuWONsf",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tVt3SvdGWNchJ8z4o"
+									},
+									"name": "Increased Health",
+									"reference": "B14",
+									"tags": [
+										"Advantage",
+										"Attribute",
+										"Physical"
+									],
+									"points_per_level": 10,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "ht",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": 10
+									}
+								},
+								{
+									"id": "tqiJFxJQEvTbXWKGb",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Bio-Tech/Bio-Tech Traits.adq",
+										"id": "tDhx56D50aegwu4w6"
+									},
+									"name": "Taboo Trait (Mental Instability)",
+									"reference": "BT65, B261",
+									"local_notes": "TL9; Also prohibits any Compulsive Behaviour or Phobia worth -10 points or more",
+									"tags": [
+										"Exotic",
+										"Mental",
+										"Taboo Trait"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Pyromania"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Phantom Voices"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Paranoia"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "On the Edge"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Obsession"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Megalomania"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Manic-Depressive"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Lunacy"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Low Self-Image"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Kleptomania"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Guilt Complex"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Flashbacks"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Delusion"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "starts_with",
+													"qualifier": "Delusions"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Chronic Depression"
+												}
+											}
+										]
+									},
+									"calc": {
+										"points": 0
+									}
+								}
+							],
+							"calc": {
+								"points": 10
+							}
+						},
+						{
+							"id": "TjIHkVRGIA0C_srOM",
+							"name": "Ladon",
+							"local_notes": "TL11. +$10000. LC3.",
+							"children": [
+								{
+									"id": "tEJeT39SIcUbzwlk4",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tyrJL144Jz5QN6Z9r"
+									},
+									"name": "Doesn't Sleep",
+									"reference": "B50",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Physical"
+									],
+									"base_points": 20,
+									"calc": {
+										"points": 20
+									}
+								}
+							],
+							"calc": {
+								"points": 20
+							}
+						}
+					],
+					"calc": {
+						"points": 30
+					}
+				}
+			],
+			"calc": {
+				"points": 85
+			}
+		}
+	]
+}

--- a/Library/Bio-Tech/Races/Guardian.gct
+++ b/Library/Bio-Tech/Races/Guardian.gct
@@ -1,0 +1,2056 @@
+{
+	"version": 5,
+	"id": "BidiiaVMtGaLzVtwv",
+	"traits": [
+		{
+			"id": "TAVv95kkUHVePqevt",
+			"name": "Guardian",
+			"reference": "BT69",
+			"local_notes": "TL10. $185000. LC2.",
+			"tags": [
+				"Race"
+			],
+			"container_type": "ancestry",
+			"children": [
+				{
+					"id": "t8SyO0RLHXkyvCGwf",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tGWOSEE6SmBHACE6Y"
+					},
+					"name": "Increased Dexterity",
+					"reference": "B15",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "m3JJwWa7FY5jbX6yM",
+							"name": "No Fine Manipulators",
+							"cost": -40,
+							"disabled": true
+						}
+					],
+					"points_per_level": 20,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "dx",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 2,
+					"calc": {
+						"points": 40
+					}
+				},
+				{
+					"id": "tvfGizQYRux9ssnfL",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t1w1RFcFceKR2T9_e"
+					},
+					"name": "Increased Intelligence",
+					"reference": "B15",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Mental"
+					],
+					"points_per_level": 20,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "iq",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 2,
+					"calc": {
+						"points": 40
+					}
+				},
+				{
+					"id": "tjmhRjMjpouyVtplG",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tVt3SvdGWNchJ8z4o"
+					},
+					"name": "Increased Health",
+					"reference": "B14",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"points_per_level": 10,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "ht",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 2,
+					"calc": {
+						"points": 20
+					}
+				},
+				{
+					"id": "twQX-AJSW-g1TwTwY",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tdlCZw4YB4T7QkOnj"
+					},
+					"name": "Appearance",
+					"reference": "B21",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "m7zmHBPopruF4zrtS",
+							"name": "Attractive",
+							"reference": "B21",
+							"cost": 4,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 1
+								}
+							]
+						},
+						{
+							"id": "mzXBUUhl5Fv2BY8vb",
+							"name": "Average",
+							"reference": "B21",
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mfazkV2W6z-8g-8n_",
+							"name": "Beautiful",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mAhuzkZ2JFeH6Cu6Q",
+							"name": "Beautiful (Androgynous)",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 3
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mJwX0xsMm-UOpTMkZ",
+							"name": "Beautiful (Impressive)",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 3
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "m6meqn8MFdm3NTpGz",
+							"name": "Handsome",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mmhrBU6LHGVCXi1At",
+							"name": "Handsome (Androgynous)",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 3
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mEpxgkDKTDLE1BJRJ",
+							"name": "Handsome (Impressive)",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 3
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mtaAGc3yGlq47ecBk",
+							"name": "Hideous",
+							"reference": "B21,B202",
+							"cost": -16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Intimidation"
+									},
+									"amount": 2
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mHPUYSiGJsT5g_mzO",
+							"name": "Horrific",
+							"reference": "B21,B202",
+							"cost": -24,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Intimidation"
+									},
+									"amount": 4
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -6
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mwfsRwnILsYR3UrAH",
+							"name": "Impressive",
+							"reference": "B21",
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "m-dZfX5YorQzmhvqF",
+							"name": "Monstrous",
+							"reference": "B21,B202",
+							"cost": -20,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Intimidation"
+									},
+									"amount": 3
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -5
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mNwDSQFo99BroeWCF",
+							"name": "Off-the-Shelf Looks",
+							"reference": "B21",
+							"local_notes": "Halves the usual reaction bonus - adjust manually",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "mnH6_uF9JE4Q_Jb7r",
+							"name": "Transcendent",
+							"reference": "B21",
+							"cost": 20,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+									"amount": 8
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "m-3wW9Wwh5VT44T9i",
+							"name": "Transcendent (Androgynous)",
+							"reference": "B21",
+							"cost": 20,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 5
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "md0fkklfHaQps1aft",
+							"name": "Transcendent (Impressive)",
+							"reference": "B21",
+							"cost": 20,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 5
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mRWFzExj4cKEIR2Pm",
+							"name": "Ugly",
+							"reference": "B21",
+							"cost": -8,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -2
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mQLWPWHxFXnzCabui",
+							"name": "Unattractive",
+							"reference": "B21",
+							"cost": -4,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mk56gHPz52p0zTOei",
+							"name": "Universal",
+							"reference": "B21",
+							"cost": 25,
+							"disabled": true
+						},
+						{
+							"id": "m3o6750vhg6aPQyJr",
+							"name": "Very Beautiful",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+									"amount": 6
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "m4V0XHz_VAs4Y5FQU",
+							"name": "Very Beautiful (Androgynous)",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mKgU6IiDojBm1nVch",
+							"name": "Very Beautiful (Impressive)",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mvxtz7tr1VnTzXhlq",
+							"name": "Very Handsome",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+									"amount": 6
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mS7Br5VXkTtdzLxZp",
+							"name": "Very Handsome (Androgynous)",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mmBrn2n4eMLRoQrue",
+							"name": "Very Handsome (Impressive)",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						}
+					],
+					"calc": {
+						"points": 4
+					}
+				},
+				{
+					"id": "TyNKloSl90lpKP5IX",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "TGI6dd0FjmClSF30H"
+					},
+					"name": "Dominance Pheromones",
+					"reference": "BT48",
+					"local_notes": "TL11",
+					"container_type": "meta_trait",
+					"children": [
+						{
+							"id": "tQwKw9vIB0lVbLXJQ",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tMMQWflrKUPOkyIF9"
+							},
+							"name": "Charisma",
+							"reference": "B41",
+							"tags": [
+								"Advantage",
+								"Mental"
+							],
+							"replacements": {
+								"Condition": "no effect on nonhumans",
+								"senses": "Scent"
+							},
+							"modifiers": [
+								{
+									"id": "mPpksOJQ3yisB0-x9",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+										"id": "m2IwCpU9KwYmjiSSA"
+									},
+									"name": "Accessibility (@Condition@)",
+									"reference": "B110,P99",
+									"local_notes": "1 point per level",
+									"cost": -1,
+									"levels": 5
+								},
+								{
+									"id": "mnr0JoVKl4pMgVikj",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+										"id": "mwOn3HOcXabGaSQBP"
+									},
+									"name": "Sense-Based (@senses@)",
+									"reference": "B115",
+									"local_notes": "Manually add -5% for each sense beyond the first",
+									"cost": -20
+								}
+							],
+							"points_per_level": 5,
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "fortune-telling"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "leadership"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "panhandling"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "public speaking"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from sapient being with whom you actively interact (converse, lecture, etc.)",
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "to Influence rolls",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"levels": 4,
+							"calc": {
+								"points": 15
+							}
+						}
+					],
+					"calc": {
+						"points": 15
+					}
+				},
+				{
+					"id": "tvaaHaKZIKgsnMTmt",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tGjjVtxav9KsrG7Wx"
+					},
+					"name": "Combat Reflexes",
+					"reference": "B43",
+					"local_notes": "Never freeze",
+					"tags": [
+						"Advantage",
+						"Mental"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Enhanced Time Sense"
+								}
+							}
+						]
+					},
+					"base_points": 15,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "starts_with",
+								"qualifier": "fast-draw"
+							},
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "dodge",
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "parry",
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "block",
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "fright_check",
+							"amount": 2
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "on all IQ rolls to wake up or to recover from surprise or mental stun",
+							"amount": 6
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to initiative rolls for your side (+2 if you are the leader)",
+							"amount": 1
+						}
+					],
+					"calc": {
+						"points": 15
+					}
+				},
+				{
+					"id": "top8r-goz_ueoGEvG",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tJTfFdHM7YI5IZR7I"
+					},
+					"name": "Resistant",
+					"reference": "B81,P71,MA47",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"replacements": {
+						"Occasional: Disease, Ingested Poison, etc.": "Disease"
+					},
+					"modifiers": [
+						{
+							"id": "m9qnZO9j8aDJRBsGg",
+							"name": "@Very Common: Metabolic Hazards, etc.@",
+							"reference": "B80",
+							"cost": 30,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "m7V1lTF7Cv1iOzKBl",
+							"name": "@Common: Poison, Sickness, etc.@",
+							"reference": "B81",
+							"cost": 15,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mVVnLT7v41hD3xX6Z",
+							"name": "@Occasional: Disease, Ingested Poison, etc.@",
+							"reference": "B81",
+							"cost": 10,
+							"cost_type": "points"
+						},
+						{
+							"id": "mRXlnJddWaPlWHFcC",
+							"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+							"reference": "B81",
+							"cost": 5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "maIw69uDw2Qrnyu2r",
+							"name": "Immunity",
+							"reference": "B81",
+							"cost": 1,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "m1Kk3Q3Q2OIWFWPrZ",
+							"name": "+8 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.5,
+							"cost_type": "multiplier"
+						},
+						{
+							"id": "mXj4_pe4yXQnzawNn",
+							"name": "+3 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.33,
+							"cost_type": "multiplier",
+							"disabled": true
+						}
+					],
+					"round_down": true,
+					"calc": {
+						"points": 5
+					}
+				},
+				{
+					"id": "tv1j1s9zp0nh8VHEK",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tUJz4wvVveMiGDX0R"
+					},
+					"name": "Extended Lifespan",
+					"reference": "B53",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"points_per_level": 2,
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 2
+					}
+				},
+				{
+					"id": "txbfmWy5pVgB0kS-h",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "toTe273Ky82B6YdW5"
+					},
+					"name": "Fit",
+					"reference": "B55",
+					"local_notes": "Recover FP at twice the normal rate (but not FP spent for spells or psi powers)",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"base_points": 5,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "to all HT rolls to stay conscious, avoid death, resist disease, or resist poison",
+							"amount": 1
+						}
+					],
+					"calc": {
+						"points": 5
+					}
+				},
+				{
+					"id": "tyiAl-lMDNpJEh6UM",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "txSLRSX9nxLwQkE2n"
+					},
+					"name": "Hard to Kill",
+					"reference": "B58",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"points_per_level": 2,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "to HT rolls made for survival at -HP or below, and on any HT roll where failure means instant death. If this bonus makes the difference between success and failure, you collapse, apparently dead (or disabled), but come to in the usual amount of time. A successful Diagnosis roll reveals the truth.",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 2,
+					"calc": {
+						"points": 4
+					}
+				},
+				{
+					"id": "tBKkmlSwRrbRq-5LI",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "thdJ55ghf__io9AQa"
+					},
+					"name": "Longevity",
+					"reference": "B66",
+					"local_notes": "You fail aging rolls only on a 17 or 18, or only on an 18 if your modified HT is 17 or better",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"base_points": 2,
+					"calc": {
+						"points": 2
+					}
+				},
+				{
+					"id": "T9m_kVDZqJxbD47li",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "TcVRXc10rugmtWbC4"
+					},
+					"name": "Sex Pheromones",
+					"reference": "BT48",
+					"local_notes": "TL10",
+					"container_type": "meta_trait",
+					"children": [
+						{
+							"id": "tHlTOA1r8WzMJpZ96",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t9fwzDbdQy1S9CHUx"
+							},
+							"name": "Affliction",
+							"reference": "B35,P39,PSI13",
+							"tags": [
+								"Advantage",
+								"Exotic",
+								"Physical"
+							],
+							"replacements": {
+								"Condition": "Only on those attracted to your gender",
+								"Disadvantage": "Lecherousness (12)",
+								"senses": "Scent"
+							},
+							"modifiers": [
+								{
+									"id": "MNrebD26MSLp1C4F5",
+									"name": "Attribute Penalties",
+									"children": [
+										{
+											"id": "mXzxXi_scCRjgNNF-",
+											"name": "DX Penalty",
+											"reference": "B36",
+											"local_notes": "Gives -1 to DX per level",
+											"cost": 10,
+											"levels": 1,
+											"disabled": true
+										},
+										{
+											"id": "m8VStatUlJpJUcGLc",
+											"name": "HT Penalty",
+											"reference": "B36",
+											"local_notes": "Gives -1 to HT per level",
+											"cost": 5,
+											"levels": 1,
+											"disabled": true
+										},
+										{
+											"id": "mC0JQ7cVTVYvxYENV",
+											"name": "IQ Penalty",
+											"reference": "B36",
+											"local_notes": "Gives -1 to IQ per level",
+											"cost": 10,
+											"levels": 1,
+											"disabled": true
+										},
+										{
+											"id": "mUjYhKRVA9Q0NQpQc",
+											"name": "ST Penalty",
+											"reference": "B36",
+											"local_notes": "Gives -1 to ST per level",
+											"cost": 5,
+											"levels": 1,
+											"disabled": true
+										}
+									]
+								},
+								{
+									"id": "mkENaFY-MVTbmIVW1",
+									"name": "Cancellation",
+									"reference": "PSI13",
+									"cost": 10,
+									"disabled": true
+								},
+								{
+									"id": "mJViuRyfTnW0sHWdT",
+									"name": "Cumulative",
+									"reference": "B36",
+									"cost": 400,
+									"disabled": true
+								},
+								{
+									"id": "MkgWygYTU2on00wc3",
+									"name": "Incapacitation",
+									"reference": "B36",
+									"children": [
+										{
+											"id": "mghC432naSwQPtZI9",
+											"name": "Agony",
+											"reference": "B428",
+											"local_notes": "Lose 1 FP per minute",
+											"cost": 100,
+											"disabled": true
+										},
+										{
+											"id": "m6EwO7PqFUBrSLevB",
+											"name": "Choking",
+											"reference": "B428",
+											"cost": 100,
+											"disabled": true
+										},
+										{
+											"id": "mT1hNNPY0AMNXgKXQ",
+											"name": "Daze",
+											"reference": "B428",
+											"cost": 50,
+											"disabled": true
+										},
+										{
+											"id": "mOZPf7KbyH1TiraNg",
+											"name": "Ecstasy",
+											"reference": "B428",
+											"cost": 100,
+											"disabled": true
+										},
+										{
+											"id": "msyesmD-_q0cOkQxS",
+											"name": "Hallucination",
+											"reference": "B429",
+											"cost": 50,
+											"disabled": true
+										},
+										{
+											"id": "mQuHm4xvveBl2rgsY",
+											"name": "Paralysis",
+											"reference": "B429",
+											"cost": 150,
+											"disabled": true
+										},
+										{
+											"id": "mhXe1OEewhU5HGZ9T",
+											"name": "Retching",
+											"reference": "B429",
+											"cost": 50,
+											"disabled": true
+										},
+										{
+											"id": "mYrkuEGAASxgja21r",
+											"name": "Seizure",
+											"reference": "B429",
+											"local_notes": "Lose 1d FP at the end of the seizure",
+											"cost": 100,
+											"disabled": true
+										},
+										{
+											"id": "mEl5xWH18Eynmiqqh",
+											"name": "Sleep",
+											"cost": 150,
+											"disabled": true
+										},
+										{
+											"id": "mU_aRq8xJ-JDwzkpo",
+											"name": "Unconsciousness",
+											"reference": "B429",
+											"cost": 200,
+											"disabled": true
+										}
+									]
+								},
+								{
+									"id": "MX6gq-6TqtyXhoYn6",
+									"name": "Irritations",
+									"reference": "B36",
+									"children": [
+										{
+											"id": "m7zxlA1K1uiC2sf5O",
+											"name": "Coughing",
+											"reference": "B428",
+											"local_notes": "Gives -3 to DX and -1 to IQ and cannot use Stealth",
+											"cost": 20,
+											"disabled": true
+										},
+										{
+											"id": "m8mmjdNpBWTf_kO0-",
+											"name": "Drunk",
+											"reference": "B428",
+											"local_notes": "Gives -2 to DX and IQ; -4 to self-control rolls except those to resist Cowardice",
+											"cost": 20,
+											"disabled": true
+										},
+										{
+											"id": "mEAeQVHiQs5WIT-lU",
+											"name": "Euphoria",
+											"reference": "B428",
+											"local_notes": "Gives -3 to all DX, IQ, skill and self-control rolls",
+											"cost": 30,
+											"disabled": true
+										},
+										{
+											"id": "m1xg4psKDcBJmVTro",
+											"name": "Moderate Pain",
+											"reference": "B428",
+											"local_notes": "-2 to all DX, IQ, skill and self-control rolls",
+											"cost": 20,
+											"disabled": true
+										},
+										{
+											"id": "mRP88_YgTsXbzhVYE",
+											"name": "Nauseated",
+											"reference": "B428",
+											"local_notes": "-2 to all attribute and skill rolls; -1 to active defenses",
+											"cost": 30,
+											"disabled": true
+										},
+										{
+											"id": "m78fAkAyKWxhlDKf2",
+											"name": "Severe Pain",
+											"reference": "B428",
+											"local_notes": "-4 to all DX, IQ, skill and self-control rolls",
+											"cost": 40,
+											"disabled": true
+										},
+										{
+											"id": "mLxRC6cuPar5cAbyD",
+											"name": "Terrible Pain",
+											"reference": "B428",
+											"local_notes": "-6 to all DX, IQ, skill and self-control rolls",
+											"cost": 60,
+											"disabled": true
+										},
+										{
+											"id": "mwDUJ3PK8IkI783Mi",
+											"name": "Tipsy",
+											"reference": "B428",
+											"local_notes": "-1 to DX and IQ, -2 to self-control rolls except those to resist Cowardice",
+											"cost": 10,
+											"disabled": true
+										}
+									]
+								},
+								{
+									"id": "Mqscufod5e7BVyv9U",
+									"name": "Mortal Conditions",
+									"children": [
+										{
+											"id": "miwECpSmGKqu7WpmI",
+											"name": "Coma",
+											"reference": "B429",
+											"cost": 250,
+											"disabled": true
+										},
+										{
+											"id": "mBjPWhpCCbTS9HsXY",
+											"name": "Heart Attack",
+											"reference": "B429",
+											"cost": 300,
+											"disabled": true
+										}
+									]
+								},
+								{
+									"id": "moiti7XqS9wvchXJw",
+									"name": "Stunning",
+									"reference": "B36",
+									"cost": 10,
+									"disabled": true
+								},
+								{
+									"id": "MUCFi6-93qTJlGLtg",
+									"name": "Traits",
+									"children": [
+										{
+											"id": "mlFwDmVSwUA9KrMBP",
+											"name": "Gives @Advantage@",
+											"reference": "B36",
+											"local_notes": "1 point per level",
+											"cost": 10,
+											"levels": 1,
+											"disabled": true
+										},
+										{
+											"id": "mmTVCJjqL1mExUeeR",
+											"name": "Gives @Disadvantage@",
+											"reference": "B36",
+											"local_notes": "1 point per level",
+											"cost": 1,
+											"levels": 15
+										},
+										{
+											"id": "mWPl_wPxnRz8P8rUz",
+											"name": "Negates @Advantage@",
+											"reference": "B36",
+											"local_notes": "1 point per level",
+											"cost": 1,
+											"levels": 1,
+											"disabled": true
+										}
+									]
+								},
+								{
+									"id": "mE8sIdwrPxUkG6G6l",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+										"id": "m2IwCpU9KwYmjiSSA"
+									},
+									"name": "Accessibility (@Condition@)",
+									"reference": "B110,P99",
+									"local_notes": "1 point per level",
+									"cost": -1,
+									"levels": 20
+								},
+								{
+									"id": "mbOPLmIbvnZ4mxDU7",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+										"id": "mbO8GjGu_NuPTLz6e"
+									},
+									"name": "Area Effect",
+									"reference": "B102,P100",
+									"local_notes": "2^level radius",
+									"cost": 50,
+									"levels": 1
+								},
+								{
+									"id": "mt5SWaD0cSiiBb-TR",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+										"id": "mk76f3SlpNhhWuzRi"
+									},
+									"name": "Emanation",
+									"reference": "B112,P102",
+									"cost": -20
+								},
+								{
+									"id": "mvfflDO6kQWMVKCfp",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+										"id": "mR2B49Uxlo3jsnYYq"
+									},
+									"name": "Sense-Based (@senses@)",
+									"reference": "B109",
+									"local_notes": "Manually add +50% for each sense beyond the first",
+									"cost": 150
+								}
+							],
+							"points_per_level": 10,
+							"can_level": true,
+							"levels": 1,
+							"calc": {
+								"points": 28
+							}
+						}
+					],
+					"calc": {
+						"points": 28
+					}
+				},
+				{
+					"id": "t4VuAzEL69SR2_FL6",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t2vba3l0J2mCZM50M"
+					},
+					"name": "Voice",
+					"reference": "B97",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"base_points": 10,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "diplomacy"
+							},
+							"amount": 2
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "fast-talk"
+							},
+							"amount": 2
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "starts_with",
+								"qualifier": "mimicry"
+							},
+							"amount": 2
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "performance"
+							},
+							"amount": 2
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "politics"
+							},
+							"amount": 2
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "public speaking"
+							},
+							"amount": 2
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "sex appeal"
+							},
+							"amount": 2
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "singing"
+							},
+							"amount": 2
+						},
+						{
+							"type": "reaction_bonus",
+							"situation": "from others who can hear your voice",
+							"amount": 2
+						}
+					],
+					"calc": {
+						"points": 10
+					}
+				},
+				{
+					"id": "tEfoTWKJHhy917nqR",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tPbL1_rekOzkM86wz"
+					},
+					"name": "Overconfidence",
+					"reference": "B148",
+					"local_notes": "You must make a self-control roll any time the GM feels you show an unreasonable degree of caution. If you fail, you must go ahead as though you were able to handle the situation!",
+					"tags": [
+						"Disadvantage",
+						"Mental"
+					],
+					"cr": 12,
+					"base_points": -5,
+					"features": [
+						{
+							"type": "reaction_bonus",
+							"situation": "from young or naive individuals who believe you are as good as you say you are",
+							"amount": 2
+						},
+						{
+							"type": "reaction_bonus",
+							"situation": "from experienced NPCs",
+							"amount": -2
+						}
+					],
+					"calc": {
+						"points": -5
+					}
+				},
+				{
+					"id": "tPy-eQr3Xftl-yADv",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "tKvd6bbXhGlQVR8lm"
+					},
+					"name": "Early Maturation",
+					"reference": "BT212",
+					"tags": [
+						"Feature"
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "tNXwpBIr1SlmNnPt7",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "tLe1-US7YK9twT2zS"
+					},
+					"name": "Taboo Trait (Genetic Defects)",
+					"reference": "BT65, B261",
+					"local_notes": "TL8; Also prohibits attributes more than 2 below the average for an adult with that template",
+					"tags": [
+						"Exotic",
+						"Mental",
+						"Physical",
+						"Taboo Trait"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Short Attention Span"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Non-Iconographic"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "No Sense of Smell/Taste"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Night Blindness"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Innumerate"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Hemophilia"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Gigantism"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dyslexia"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dwarfism"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Colorblindness"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "starts_with",
+									"qualifier": "Bad Sight"
+								}
+							}
+						]
+					},
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "tS0reiR6SIY2rwpas",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "tTi0zSDyDA07Ttfvy"
+					},
+					"name": "Taboo Trait (Unattractiveness)",
+					"reference": "BT65, B261",
+					"local_notes": "TL9",
+					"tags": [
+						"Exotic",
+						"Physical",
+						"Taboo Trait"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Very Unfit"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Very Fat"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Overweight"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Fat"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Bowlegged"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Bad Smell"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Appearance"
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "Horrific"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Appearance"
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "Monstrous"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Appearance"
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "Hideous"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Appearance"
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "Ugly"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Appearance"
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "Unattractive"
+								}
+							}
+						]
+					},
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "tZiG1u1aOUxr2_su6",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "tDhx56D50aegwu4w6"
+					},
+					"name": "Taboo Trait (Mental Instability)",
+					"reference": "BT65, B261",
+					"local_notes": "TL9; Also prohibits any Compulsive Behaviour or Phobia worth -10 points or more",
+					"tags": [
+						"Exotic",
+						"Mental",
+						"Taboo Trait"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Pyromania"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Phantom Voices"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Paranoia"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "On the Edge"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Obsession"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Megalomania"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Manic-Depressive"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Lunacy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Low Self-Image"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Kleptomania"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Guilt Complex"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Flashbacks"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Delusion"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "starts_with",
+									"qualifier": "Delusions"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Chronic Depression"
+								}
+							}
+						]
+					},
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "TeM9h0s-yIz8Zazve",
+					"name": "Optionally, add",
+					"template_picker": {
+						"type": "count"
+					},
+					"children": [
+						{
+							"id": "Ta2JOrsVxj8w77bBh",
+							"name": "Guardian Warrior",
+							"local_notes": "+$42000. LC2.",
+							"children": [
+								{
+									"id": "TvXPu_xku90tP39V2",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Bio-Tech/Bio-Tech Traits.adq",
+										"id": "TQx1gGRXhk4dsFPAo"
+									},
+									"name": "Burst Reflexes",
+									"reference": "BT48",
+									"local_notes": "TL9",
+									"container_type": "meta_trait",
+									"children": [
+										{
+											"id": "tYJ2bVL0pDYRmH34F",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tWF1J_Z0Ziz-qJ6pn"
+											},
+											"name": "Increased Basic Speed",
+											"reference": "B17",
+											"tags": [
+												"Advantage",
+												"Attribute",
+												"Physical"
+											],
+											"modifiers": [
+												{
+													"id": "mL0k8fh17_zD6pIjY",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+														"id": "mb8dKIbPtFmqDLYaM"
+													},
+													"name": "Costs Fatigue",
+													"reference": "B111,P101",
+													"cost": -5,
+													"levels": 2
+												}
+											],
+											"points_per_level": 5,
+											"features": [
+												{
+													"type": "attribute_bonus",
+													"attribute": "basic_speed",
+													"amount": 0.25,
+													"per_level": true
+												}
+											],
+											"can_level": true,
+											"levels": 4,
+											"calc": {
+												"points": 18
+											}
+										}
+									],
+									"calc": {
+										"points": 18
+									}
+								},
+								{
+									"id": "TJTftv-onVfGbZVLp",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Bio-Tech/Bio-Tech Traits.adq",
+										"id": "T1hzWSwn-I1Ob0eW1"
+									},
+									"name": "Explosive Strength",
+									"reference": "BT48",
+									"local_notes": "TL9",
+									"container_type": "meta_trait",
+									"children": [
+										{
+											"id": "TzwhfoZfx9BFZNGoZ",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Bio-Tech/Bio-Tech Traits.adq",
+												"id": "ThyVm5klwxC70K_-M"
+											},
+											"name": "Enhanced Muscles",
+											"reference": "BT213",
+											"modifiers": [
+												{
+													"id": "m350DrujRrci-E1uo",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+														"id": "m3JXyTOmjIZwhY1_g"
+													},
+													"name": "Costs Fatigue",
+													"reference": "B111,P101",
+													"local_notes": "Has maintenance cost",
+													"cost": -10,
+													"levels": 1
+												},
+												{
+													"id": "mScsFvDOx41JtucSP",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+														"id": "m5NmnYfBmmJqwzSnv"
+													},
+													"name": "Emergencies Only",
+													"reference": "B112,P102",
+													"cost": -30
+												}
+											],
+											"container_type": "meta_trait",
+											"children": [
+												{
+													"id": "tWlYtUn7XkH8nSzzT",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Basic Set/Basic Set Traits.adq",
+														"id": "t6krAE1uo6M0oDJFL"
+													},
+													"name": "Lifting ST",
+													"reference": "B65,P58",
+													"tags": [
+														"Advantage",
+														"Exotic",
+														"Physical"
+													],
+													"modifiers": [
+														{
+															"id": "m0HmBq-MrkcT8nbOT",
+															"name": "No Fine Manipulators",
+															"reference": "B15",
+															"cost": -40,
+															"disabled": true
+														},
+														{
+															"id": "m33cev4jBICYcFYle",
+															"name": "Size",
+															"reference": "B15",
+															"cost": -10,
+															"levels": 1,
+															"disabled": true
+														},
+														{
+															"id": "mh3D38xzf4GRt9ZJK",
+															"name": "Super-Effort",
+															"reference": "P58",
+															"cost": 400,
+															"disabled": true
+														},
+														{
+															"id": "my1s_jgxxC827NR-F",
+															"name": "Know Your Own Strength Variant Price",
+															"reference": "PY83:18",
+															"cost": 4,
+															"cost_type": "points",
+															"affects": "levels_only",
+															"disabled": true
+														},
+														{
+															"id": "mAeXxFxRqbfbvxM0S",
+															"name": "@Limb@ Grip ST",
+															"reference": "MATG28",
+															"cost": -70,
+															"disabled": true
+														},
+														{
+															"id": "m89094wi94LLGkOxK",
+															"name": "Bite ST",
+															"reference": "MATG28",
+															"cost": -70,
+															"disabled": true
+														}
+													],
+													"points_per_level": 3,
+													"features": [
+														{
+															"type": "attribute_bonus",
+															"limitation": "lifting_only",
+															"attribute": "st",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"can_level": true,
+													"levels": 5,
+													"calc": {
+														"points": 9
+													}
+												},
+												{
+													"id": "taDeXPZM1BxgsRcIy",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Basic Set/Basic Set Traits.adq",
+														"id": "t8HajX_K4BDKPuUop"
+													},
+													"name": "Striking ST",
+													"reference": "B88,P78",
+													"tags": [
+														"Advantage",
+														"Exotic",
+														"Physical"
+													],
+													"modifiers": [
+														{
+															"id": "mXbvuSFcfq7s-5eTc",
+															"name": "No Fine Manipulators",
+															"cost": -40,
+															"disabled": true
+														},
+														{
+															"id": "mqJgW1ae_0Lllkcke",
+															"name": "Size",
+															"cost": -10,
+															"levels": 1,
+															"disabled": true
+														},
+														{
+															"id": "mrYF8u1v4ZYzuCpEy",
+															"name": "Super Effort",
+															"reference": "SU24",
+															"cost": 400,
+															"disabled": true
+														},
+														{
+															"id": "msPoqF_6eNpG0XgHC",
+															"name": "One Attack Only",
+															"reference": "P79",
+															"local_notes": "@Attack@",
+															"cost": -60,
+															"disabled": true
+														},
+														{
+															"id": "mUq-zAC5NpuRE9PfA",
+															"name": "Know Your Own Strength Pricing Variant",
+															"reference": "PY83:18",
+															"cost": -4,
+															"cost_type": "points",
+															"affects": "levels_only",
+															"disabled": true
+														}
+													],
+													"points_per_level": 5,
+													"features": [
+														{
+															"type": "attribute_bonus",
+															"limitation": "striking_only",
+															"attribute": "st",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"can_level": true,
+													"levels": 5,
+													"calc": {
+														"points": 15
+													}
+												}
+											],
+											"calc": {
+												"points": 24
+											}
+										}
+									],
+									"calc": {
+										"points": 24
+									}
+								}
+							],
+							"calc": {
+								"points": 42
+							}
+						}
+					],
+					"calc": {
+						"points": 42
+					}
+				}
+			],
+			"calc": {
+				"points": 227
+			}
+		}
+	]
+}

--- a/Library/Bio-Tech/Races/Heavy Worlder.gct
+++ b/Library/Bio-Tech/Races/Heavy Worlder.gct
@@ -1,0 +1,551 @@
+{
+	"version": 5,
+	"id": "BEyOcBNDSMfREfkzf",
+	"traits": [
+		{
+			"id": "TnTtm2l0E2PMtod-z",
+			"name": "Heavy Worlder",
+			"reference": "BT66",
+			"local_notes": "TL9. $71000. LC4.",
+			"tags": [
+				"Race"
+			],
+			"ancestry": "Human",
+			"container_type": "ancestry",
+			"children": [
+				{
+					"id": "tS92TQuYzUkyzD1Qi",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tqha9GlDBU9P-Wg-6"
+					},
+					"name": "Increased Strength",
+					"reference": "B14",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mXyU6nSkAwioYIfWY",
+							"name": "No Fine Manipulators",
+							"reference": "B15",
+							"cost": -40,
+							"disabled": true
+						},
+						{
+							"id": "m_2TIitedR7Vz1sW2",
+							"name": "Size",
+							"reference": "B15",
+							"cost": -10,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mBjEbqTrtKhc7UGug",
+							"name": "Super-Effort",
+							"reference": "SU24",
+							"cost": 300,
+							"disabled": true
+						}
+					],
+					"points_per_level": 10,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "st",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 3,
+					"calc": {
+						"points": 30
+					}
+				},
+				{
+					"id": "tphfvxT6o3E-m7Q23",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tVt3SvdGWNchJ8z4o"
+					},
+					"name": "Increased Health",
+					"reference": "B14",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"points_per_level": 10,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "ht",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 10
+					}
+				},
+				{
+					"id": "tqUFLP59zQBBDbNV-",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "txREhxV6L1SKixwe_"
+					},
+					"name": "Improved G-tolerance",
+					"reference": "B60",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mP-fSjnhaBUaVVwrI",
+							"name": "0.3G",
+							"reference": "B60",
+							"cost": 5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mTroF9Bozh9_9u_z3",
+							"name": "0.5G",
+							"reference": "B60",
+							"cost": 10,
+							"cost_type": "points"
+						},
+						{
+							"id": "mRKx9HTvodS095F6o",
+							"name": "1G",
+							"reference": "B60",
+							"cost": 15,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mb6z8UrRqBgaicNhv",
+							"name": "5G",
+							"reference": "B60",
+							"cost": 20,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mSfKK6n1MVyFV1FvC",
+							"name": "10G",
+							"reference": "B60",
+							"cost": 25,
+							"cost_type": "points",
+							"disabled": true
+						}
+					],
+					"calc": {
+						"points": 10
+					}
+				},
+				{
+					"id": "tEIjGk5iaTyxeRyb4",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tdlCZw4YB4T7QkOnj"
+					},
+					"name": "Appearance",
+					"reference": "B21",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mavKrHoyTwtEOBbbq",
+							"name": "Attractive",
+							"reference": "B21",
+							"cost": 4,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mJJl_WrxYLNPj2WuV",
+							"name": "Average",
+							"reference": "B21",
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mjWF-R59J4xbyeLj_",
+							"name": "Beautiful",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "m-z_0FzuDGGdBU2Nv",
+							"name": "Beautiful (Androgynous)",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 3
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mU241U7E780Tn07qm",
+							"name": "Beautiful (Impressive)",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 3
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "m55Osy9RQSkLPxapx",
+							"name": "Handsome",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mAxOMfbKGrMB8-Jsf",
+							"name": "Handsome (Androgynous)",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 3
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mcRq6qRwu3EzonUBB",
+							"name": "Handsome (Impressive)",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 3
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mMT4PWzciND6oyxjs",
+							"name": "Hideous",
+							"reference": "B21,B202",
+							"cost": -16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Intimidation"
+									},
+									"amount": 2
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "myKNcA-6drqecfF9j",
+							"name": "Horrific",
+							"reference": "B21,B202",
+							"cost": -24,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Intimidation"
+									},
+									"amount": 4
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -6
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mCBF5RqxBdNlDYWtG",
+							"name": "Impressive",
+							"reference": "B21",
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mV-ZlQoa4bxIYYwFV",
+							"name": "Monstrous",
+							"reference": "B21,B202",
+							"cost": -20,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Intimidation"
+									},
+									"amount": 3
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -5
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mGf1H2I6Ys98AF5Gc",
+							"name": "Off-the-Shelf Looks",
+							"reference": "B21",
+							"local_notes": "Halves the usual reaction bonus - adjust manually",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "mD-bLf04zqFIzx4Ye",
+							"name": "Transcendent",
+							"reference": "B21",
+							"cost": 20,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+									"amount": 8
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mXuMXPq6Dv2VLzaAH",
+							"name": "Transcendent (Androgynous)",
+							"reference": "B21",
+							"cost": 20,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 5
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mv5t3S_B9Z02BDNXH",
+							"name": "Transcendent (Impressive)",
+							"reference": "B21",
+							"cost": 20,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 5
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mydB2ZfYOVh5NmrDN",
+							"name": "Ugly",
+							"reference": "B21",
+							"cost": -8,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -2
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mrKTVYlE4exv1mrOJ",
+							"name": "Unattractive",
+							"reference": "B21",
+							"cost": -4,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -1
+								}
+							]
+						},
+						{
+							"id": "mcsxS2MGSz8l50p6k",
+							"name": "Universal",
+							"reference": "B21",
+							"cost": 25,
+							"disabled": true
+						},
+						{
+							"id": "md0eE29FzI3rwjeXF",
+							"name": "Very Beautiful",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+									"amount": 6
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "msfM9XHMAkWC6oDmQ",
+							"name": "Very Beautiful (Androgynous)",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mb_DdSctrOr7OHm2o",
+							"name": "Very Beautiful (Impressive)",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "m-LemCjdiioL4euD9",
+							"name": "Very Handsome",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+									"amount": 6
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mWjHuiGQFkCDO3cL6",
+							"name": "Very Handsome (Androgynous)",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mOKe_tyM2WtT_rW6a",
+							"name": "Very Handsome (Impressive)",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						}
+					],
+					"calc": {
+						"points": -4
+					}
+				}
+			],
+			"calc": {
+				"points": 46
+			}
+		}
+	]
+}

--- a/Library/Bio-Tech/Races/Helot.gct
+++ b/Library/Bio-Tech/Races/Helot.gct
@@ -1,0 +1,822 @@
+{
+	"version": 5,
+	"id": "BG14oNM5bF-GYAp71",
+	"traits": [
+		{
+			"id": "TFoRr-SRKXMvson_s",
+			"name": "Helot",
+			"reference": "BT67",
+			"local_notes": "TL10. $37000. LC2.",
+			"tags": [
+				"Race"
+			],
+			"container_type": "ancestry",
+			"children": [
+				{
+					"id": "tto1aV_P2iS4f0FPg",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tVt3SvdGWNchJ8z4o"
+					},
+					"name": "Increased Health",
+					"reference": "B14",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"points_per_level": 10,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "ht",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 10
+					}
+				},
+				{
+					"id": "tL0ONy0COXuxwU0Ix",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tJTfFdHM7YI5IZR7I"
+					},
+					"name": "Resistant",
+					"reference": "B81,P71,MA47",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"replacements": {
+						"Occasional: Disease, Ingested Poison, etc.": "Disease"
+					},
+					"modifiers": [
+						{
+							"id": "mxSwpgJVXkICwQMrA",
+							"name": "@Very Common: Metabolic Hazards, etc.@",
+							"reference": "B80",
+							"cost": 30,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mdaSJoHbZvRNoweAn",
+							"name": "@Common: Poison, Sickness, etc.@",
+							"reference": "B81",
+							"cost": 15,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mk9SvNyK4CC6OKbmw",
+							"name": "@Occasional: Disease, Ingested Poison, etc.@",
+							"reference": "B81",
+							"cost": 10,
+							"cost_type": "points"
+						},
+						{
+							"id": "mBKsQc7cwMG_5-OWc",
+							"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+							"reference": "B81",
+							"cost": 5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mMvfhRq4Seo6xanCT",
+							"name": "Immunity",
+							"reference": "B81",
+							"cost": 1,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "moF1cZ2-6E-oCletB",
+							"name": "+8 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.5,
+							"cost_type": "multiplier"
+						},
+						{
+							"id": "mzDoAzfiyIJUf0XVM",
+							"name": "+3 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.33,
+							"cost_type": "multiplier",
+							"disabled": true
+						}
+					],
+					"round_down": true,
+					"calc": {
+						"points": 5
+					}
+				},
+				{
+					"id": "towcdKcVL3j5LoGuV",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "ttkZb4D-srbLBDQT3"
+					},
+					"name": "Broad-Minded",
+					"reference": "B163",
+					"tags": [
+						"Mental",
+						"Quirk"
+					],
+					"base_points": -1,
+					"calc": {
+						"points": -1
+					}
+				},
+				{
+					"id": "tWrNTuEiB8gD7-Nwx",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tmvQodT3s0JuvbtIx"
+					},
+					"name": "Humble",
+					"reference": "B164",
+					"tags": [
+						"Mental",
+						"Quirk"
+					],
+					"base_points": -1,
+					"calc": {
+						"points": -1
+					}
+				},
+				{
+					"id": "teywOY2w43qw9XwmA",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "txSQyk2LjrgBcnj16"
+					},
+					"name": "Staid",
+					"reference": "B164",
+					"tags": [
+						"Mental",
+						"Quirk"
+					],
+					"base_points": -1,
+					"calc": {
+						"points": -1
+					}
+				},
+				{
+					"id": "tyLIkCFfUq9UOve-l",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "tLe1-US7YK9twT2zS"
+					},
+					"name": "Taboo Trait (Genetic Defects)",
+					"reference": "BT65, B261",
+					"local_notes": "TL8; Also prohibits attributes more than 2 below the average for an adult with that template",
+					"tags": [
+						"Exotic",
+						"Mental",
+						"Physical",
+						"Taboo Trait"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Short Attention Span"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Non-Iconographic"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "No Sense of Smell/Taste"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Night Blindness"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Innumerate"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Hemophilia"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Gigantism"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dyslexia"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dwarfism"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Colorblindness"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "starts_with",
+									"qualifier": "Bad Sight"
+								}
+							}
+						]
+					},
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "tI--VsYGlLELCCF3x",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "tTi0zSDyDA07Ttfvy"
+					},
+					"name": "Taboo Trait (Unattractiveness)",
+					"reference": "BT65, B261",
+					"local_notes": "TL9",
+					"tags": [
+						"Exotic",
+						"Physical",
+						"Taboo Trait"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Very Unfit"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Very Fat"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Overweight"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Fat"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Bowlegged"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Bad Smell"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Appearance"
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "Horrific"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Appearance"
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "Monstrous"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Appearance"
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "Hideous"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Appearance"
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "Ugly"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Appearance"
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "Unattractive"
+								}
+							}
+						]
+					},
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "tVxHCor84TMvUwbPn",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "t020EdMCSbDSrITDv"
+					},
+					"name": "Taboo Trait (Aggressiveness)",
+					"reference": "BT65, B261",
+					"local_notes": "TL9",
+					"tags": [
+						"Exotic",
+						"Mental",
+						"Taboo Trait"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Bad Temper"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Berserk"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Bully"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Stubbornness"
+								}
+							}
+						]
+					},
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "tpy1BL8l2EZ40ikF0",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "tDhx56D50aegwu4w6"
+					},
+					"name": "Taboo Trait (Mental Instability)",
+					"reference": "BT65, B261",
+					"local_notes": "TL9; Also prohibits any Compulsive Behaviour or Phobia worth -10 points or more",
+					"tags": [
+						"Exotic",
+						"Mental",
+						"Taboo Trait"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Pyromania"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Phantom Voices"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Paranoia"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "On the Edge"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Obsession"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Megalomania"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Manic-Depressive"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Lunacy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Low Self-Image"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Kleptomania"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Guilt Complex"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Flashbacks"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Delusion"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "starts_with",
+									"qualifier": "Delusions"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Chronic Depression"
+								}
+							}
+						]
+					},
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "T6GiVn3ppXkmHnZot",
+					"name": "Optionally, also choose one or both",
+					"template_picker": {
+						"type": "count"
+					},
+					"children": [
+						{
+							"id": "TfMozmOLebfJgDKwH",
+							"name": "Helot II",
+							"reference": "BT67",
+							"local_notes": "$58000. LC2.",
+							"children": [
+								{
+									"id": "td-RnE1fDCZAObPCG",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tLYJ7NUl3CYeLk0Yc"
+									},
+									"name": "Susceptible (@Substance@)",
+									"reference": "B158",
+									"tags": [
+										"Disadvantage",
+										"Physical"
+									],
+									"replacements": {
+										"Substance": "Pheromones"
+									},
+									"modifiers": [
+										{
+											"id": "moO5LFxSltCxOkGtn",
+											"name": "Occasional",
+											"reference": "B158",
+											"cost": 1,
+											"cost_type": "multiplier",
+											"disabled": true
+										},
+										{
+											"id": "mzVXwv_8fXRAmX__l",
+											"name": "Common",
+											"reference": "B158",
+											"cost": 2,
+											"cost_type": "multiplier",
+											"disabled": true
+										},
+										{
+											"id": "m6CC1YbybKToNupvE",
+											"name": "Very Common",
+											"reference": "B158",
+											"cost": 4,
+											"cost_type": "multiplier",
+											"disabled": true
+										}
+									],
+									"points_per_level": -1,
+									"can_level": true,
+									"levels": 4,
+									"calc": {
+										"points": -4
+									}
+								}
+							],
+							"calc": {
+								"points": -4
+							}
+						},
+						{
+							"id": "TuE3tgAE_j1Ri70dn",
+							"name": "Helot Bioroid",
+							"reference": "BT67",
+							"local_notes": "$50000. LC2.",
+							"children": [
+								{
+									"id": "T5uGgVAvSpKBwFeXz",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Bio-Tech/Bio-Tech Traits.adq",
+										"id": "TluHkPSI8BnDWWEZo"
+									},
+									"name": "Bioroid",
+									"reference": "BT214",
+									"container_type": "meta_trait",
+									"children": [
+										{
+											"id": "teXIRkQT2EEygEsTk",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Bio-Tech/Bio-Tech Traits.adq",
+												"id": "tAgMr2EzmeXfC7Tkg"
+											},
+											"name": "Early Maturation",
+											"reference": "BT212",
+											"local_notes": "may be level 3-5",
+											"tags": [
+												"Feature"
+											],
+											"can_level": true,
+											"levels": 3,
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "t9xqAIgEn-mrlKSc-",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Template Toolkit/Template Toolkit 2 - Races/Template Toolkit 2 - Races Traits.adq",
+												"id": "tQY4rjF8t2sAPM9xv"
+											},
+											"name": "Sterile",
+											"reference": "TT2:12",
+											"tags": [
+												"Feature",
+												"Physical"
+											],
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "tfXk0QUpqoZAuid_X",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tEYEuzMtxSsWCG7uW"
+											},
+											"name": "Unusual Biochemistry",
+											"reference": "B160",
+											"tags": [
+												"Disadvantage",
+												"Physical"
+											],
+											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										}
+									],
+									"calc": {
+										"points": -5
+									}
+								},
+								{
+									"id": "tdqXG45cTuXHxQZQo",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t9Ayzq0-Ain8oiIM8"
+									},
+									"name": "Self-Destruct",
+									"reference": "B153",
+									"tags": [
+										"Disadvantage",
+										"Exotic",
+										"Physical"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "starts_with",
+													"qualifier": "terminally ill"
+												}
+											}
+										]
+									},
+									"base_points": -10,
+									"calc": {
+										"points": -10
+									}
+								}
+							],
+							"calc": {
+								"points": -15
+							}
+						}
+					],
+					"calc": {
+						"points": -19
+					}
+				}
+			],
+			"calc": {
+				"points": -7
+			}
+		}
+	],
+	"notes": [
+		{
+			"id": "nmpdDQp6foAllbKTM",
+			"markdown": "Helot II price overrides Helot. Helot Bioroid price overrides both."
+		}
+	]
+}

--- a/Library/Bio-Tech/Races/Herakles.gct
+++ b/Library/Bio-Tech/Races/Herakles.gct
@@ -1,0 +1,1402 @@
+{
+	"version": 5,
+	"id": "BwOlCAI3DAAlPWhCO",
+	"traits": [
+		{
+			"id": "Tbof-KzOJ6MYdwm0m",
+			"name": "Herakles",
+			"reference": "BT70",
+			"local_notes": "TL11. $242000. LC3.",
+			"tags": [
+				"Race"
+			],
+			"container_type": "ancestry",
+			"children": [
+				{
+					"id": "tVr88cyt2jXjACLpb",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tGWOSEE6SmBHACE6Y"
+					},
+					"name": "Increased Dexterity",
+					"reference": "B15",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "myRnn9LyIXp2eI03l",
+							"name": "No Fine Manipulators",
+							"cost": -40,
+							"disabled": true
+						}
+					],
+					"points_per_level": 20,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "dx",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 4,
+					"calc": {
+						"points": 80
+					}
+				},
+				{
+					"id": "t-aj-VU8cLK8EJ3rv",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t1w1RFcFceKR2T9_e"
+					},
+					"name": "Increased Intelligence",
+					"reference": "B15",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Mental"
+					],
+					"points_per_level": 20,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "iq",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 2,
+					"calc": {
+						"points": 40
+					}
+				},
+				{
+					"id": "tTvWxEExDE0mWQhL7",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tVt3SvdGWNchJ8z4o"
+					},
+					"name": "Increased Health",
+					"reference": "B14",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"points_per_level": 10,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "ht",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 4,
+					"calc": {
+						"points": 40
+					}
+				},
+				{
+					"id": "teqIvOiT13eGKumcH",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tdlCZw4YB4T7QkOnj"
+					},
+					"name": "Appearance",
+					"reference": "B21",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "m-yzOCi_5fXz73t8Y",
+							"name": "Attractive",
+							"reference": "B21",
+							"cost": 4,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 1
+								}
+							]
+						},
+						{
+							"id": "m_fHN7t828F2q2tFL",
+							"name": "Average",
+							"reference": "B21",
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mlqzAIZIFlSlE8O9U",
+							"name": "Beautiful",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mVJbkOAnKChLE9ito",
+							"name": "Beautiful (Androgynous)",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 3
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mqfTc_S0zo7_5PYrA",
+							"name": "Beautiful (Impressive)",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 3
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mfBfK2WzQzvtpEpel",
+							"name": "Handsome",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mYiCSehhKd7rj5_GK",
+							"name": "Handsome (Androgynous)",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 3
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mP2l9yRSD_Efg69d_",
+							"name": "Handsome (Impressive)",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 3
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "msMzEGCXx9b1DHD9G",
+							"name": "Hideous",
+							"reference": "B21,B202",
+							"cost": -16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Intimidation"
+									},
+									"amount": 2
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "m05hV0GWUsglafslN",
+							"name": "Horrific",
+							"reference": "B21,B202",
+							"cost": -24,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Intimidation"
+									},
+									"amount": 4
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -6
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mtg-bab54CYdO8JPX",
+							"name": "Impressive",
+							"reference": "B21",
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mA_A4JNXsyHQryFZ-",
+							"name": "Monstrous",
+							"reference": "B21,B202",
+							"cost": -20,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Intimidation"
+									},
+									"amount": 3
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -5
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mq5xF0DJF5NyCRGOp",
+							"name": "Off-the-Shelf Looks",
+							"reference": "B21",
+							"local_notes": "Halves the usual reaction bonus - adjust manually",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "maA4lsnd2k5z67Pwh",
+							"name": "Transcendent",
+							"reference": "B21",
+							"cost": 20,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+									"amount": 8
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mq3JAuvUAN7LEeMVS",
+							"name": "Transcendent (Androgynous)",
+							"reference": "B21",
+							"cost": 20,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 5
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mqUNkWDH7XyEzmwR4",
+							"name": "Transcendent (Impressive)",
+							"reference": "B21",
+							"cost": 20,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 5
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mgfYKYYimN27V_Ob5",
+							"name": "Ugly",
+							"reference": "B21",
+							"cost": -8,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -2
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mVItG_9pfHpemA4-L",
+							"name": "Unattractive",
+							"reference": "B21",
+							"cost": -4,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mn1cWkxtpRBq8FQxE",
+							"name": "Universal",
+							"reference": "B21",
+							"cost": 25,
+							"disabled": true
+						},
+						{
+							"id": "mgMxy8z6DBbuPx1z8",
+							"name": "Very Beautiful",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+									"amount": 6
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mTB00BFzM9yo61Lxh",
+							"name": "Very Beautiful (Androgynous)",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mLJtpHc4C47zzrJIm",
+							"name": "Very Beautiful (Impressive)",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mx4Cm-fKPhEWxecL2",
+							"name": "Very Handsome",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+									"amount": 6
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mWbXqdHmboJsWYPh4",
+							"name": "Very Handsome (Androgynous)",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "m_CEIuP2rYZDPAMTQ",
+							"name": "Very Handsome (Impressive)",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						}
+					],
+					"calc": {
+						"points": 4
+					}
+				},
+				{
+					"id": "t0eslkE3F5ZtzsEZ2",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tUJz4wvVveMiGDX0R"
+					},
+					"name": "Extended Lifespan",
+					"reference": "B53",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"points_per_level": 2,
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 2
+					}
+				},
+				{
+					"id": "t6-sFOK8i8KI7FlTz",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "thdJ55ghf__io9AQa"
+					},
+					"name": "Longevity",
+					"reference": "B66",
+					"local_notes": "You fail aging rolls only on a 17 or 18, or only on an 18 if your modified HT is 17 or better",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"base_points": 2,
+					"calc": {
+						"points": 2
+					}
+				},
+				{
+					"id": "tWaYu9AqWmQWSTeeM",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "trMfToThYl9fEmPdt"
+					},
+					"name": "Rapid Healing",
+					"reference": "B79",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "attribute_prereq",
+								"has": true,
+								"qualifier": {
+									"compare": "at_least",
+									"qualifier": 10
+								},
+								"which": "ht"
+							}
+						]
+					},
+					"base_points": 5,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "to your effective HT whenever you roll to recover lost HP or to see if you can get over a crippling injury",
+							"amount": 5
+						}
+					],
+					"calc": {
+						"points": 5
+					}
+				},
+				{
+					"id": "tWkpKBaTrVuC1woL1",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tMxgHfzVEy_QQtlfB"
+					},
+					"name": "Less Sleep",
+					"reference": "B65",
+					"local_notes": "Require 1 hour/level less sleep for a full night's rest (max 4)",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"points_per_level": 2,
+					"can_level": true,
+					"levels": 4,
+					"calc": {
+						"points": 8
+					}
+				},
+				{
+					"id": "tRySHWq9Zez3onNvc",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tJTfFdHM7YI5IZR7I"
+					},
+					"name": "Resistant",
+					"reference": "B81,P71,MA47",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"replacements": {
+						"Occasional: Disease, Ingested Poison, etc.": "Disease"
+					},
+					"modifiers": [
+						{
+							"id": "mx73PfrkXlxczWRgZ",
+							"name": "@Very Common: Metabolic Hazards, etc.@",
+							"reference": "B80",
+							"cost": 30,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mIWm5UNlAPSn5SsUE",
+							"name": "@Common: Poison, Sickness, etc.@",
+							"reference": "B81",
+							"cost": 15,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mc3CLGDZf2CxT3ls0",
+							"name": "@Occasional: Disease, Ingested Poison, etc.@",
+							"reference": "B81",
+							"cost": 10,
+							"cost_type": "points"
+						},
+						{
+							"id": "mBpV6bMwyfP5MOvVg",
+							"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+							"reference": "B81",
+							"cost": 5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mQNwc524vd_CThCQq",
+							"name": "Immunity",
+							"reference": "B81",
+							"cost": 1,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "mAirCkpYz068MCPAl",
+							"name": "+8 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.5,
+							"cost_type": "multiplier"
+						},
+						{
+							"id": "mIyUMRwkPgCCVoVwg",
+							"name": "+3 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.33,
+							"cost_type": "multiplier",
+							"disabled": true
+						}
+					],
+					"round_down": true,
+					"calc": {
+						"points": 5
+					}
+				},
+				{
+					"id": "tgD1RtQrU1IcdWDaR",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tJTfFdHM7YI5IZR7I"
+					},
+					"name": "Resistant",
+					"reference": "B81,P71,MA47",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"replacements": {
+						"Common: Poison, Sickness, etc.": "Poison"
+					},
+					"modifiers": [
+						{
+							"id": "m4xaXXWU8Ly9C31F5",
+							"name": "@Very Common: Metabolic Hazards, etc.@",
+							"reference": "B80",
+							"cost": 30,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "meWxjlfJuJu0ka6Pq",
+							"name": "@Common: Poison, Sickness, etc.@",
+							"reference": "B81",
+							"cost": 15,
+							"cost_type": "points"
+						},
+						{
+							"id": "mvul_C205_wIqAC6d",
+							"name": "@Occasional: Disease, Ingested Poison, etc.@",
+							"reference": "B81",
+							"cost": 10,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mbEWSLflVmoJubjHy",
+							"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+							"reference": "B81",
+							"cost": 5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mptuX-BxSCY-IlFx1",
+							"name": "Immunity",
+							"reference": "B81",
+							"cost": 1,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "mReA7qvMolfapnNp7",
+							"name": "+8 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.5,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "mEf_ANijSXoNNufIv",
+							"name": "+3 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.33,
+							"cost_type": "multiplier"
+						}
+					],
+					"round_down": true,
+					"calc": {
+						"points": 4
+					}
+				},
+				{
+					"id": "toS_jhAMPYGQbih_y",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tf5DfdQFaNUVbkPV2"
+					},
+					"name": "Sanitized Metabolism",
+					"reference": "B101",
+					"tags": [
+						"Perk",
+						"Physical"
+					],
+					"base_points": 1,
+					"features": [
+						{
+							"type": "reaction_bonus",
+							"situation": "from others in close confines",
+							"amount": 1
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to attempts to track you by scent",
+							"amount": -1
+						}
+					],
+					"calc": {
+						"points": 1
+					}
+				},
+				{
+					"id": "tCYyHPxBeI9kchjA-",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "tqoZjoMK01Dz00QE5"
+					},
+					"name": "Reproductive Control",
+					"reference": "BT59",
+					"local_notes": "TL9",
+					"base_points": 1,
+					"calc": {
+						"points": 1
+					}
+				},
+				{
+					"id": "tt8EmD_urapek07uL",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tnrtPQ0mWF4k75plo"
+					},
+					"name": "Bad Temper",
+					"reference": "B124",
+					"tags": [
+						"Disadvantage",
+						"Mental"
+					],
+					"cr": 12,
+					"base_points": -10,
+					"calc": {
+						"points": -10
+					}
+				},
+				{
+					"id": "tcVKdJB_xZKnY_Vsu",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "te2vFre2KU0dZrDgd"
+					},
+					"name": "Increased Consumption",
+					"reference": "B139",
+					"tags": [
+						"Disadvantage",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mmFz4YVm3dAEPRv8-",
+							"name": "Consumption x2",
+							"reference": "B139",
+							"cost": -10,
+							"cost_type": "points"
+						},
+						{
+							"id": "m84jSk0zwOIYaPZ9t",
+							"name": "Consumption x4",
+							"reference": "B139",
+							"cost": -20,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mjZBAY1G87DfdlGgm",
+							"name": "Consumption x8",
+							"reference": "B139",
+							"cost": -30,
+							"cost_type": "points",
+							"disabled": true
+						}
+					],
+					"calc": {
+						"points": -10
+					}
+				},
+				{
+					"id": "teXz1-2gDSJgQB3Mw",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tPbL1_rekOzkM86wz"
+					},
+					"name": "Overconfidence",
+					"reference": "B148",
+					"local_notes": "You must make a self-control roll any time the GM feels you show an unreasonable degree of caution. If you fail, you must go ahead as though you were able to handle the situation!",
+					"tags": [
+						"Disadvantage",
+						"Mental"
+					],
+					"cr": 12,
+					"base_points": -5,
+					"features": [
+						{
+							"type": "reaction_bonus",
+							"situation": "from young or naive individuals who believe you are as good as you say you are",
+							"amount": 2
+						},
+						{
+							"type": "reaction_bonus",
+							"situation": "from experienced NPCs",
+							"amount": -2
+						}
+					],
+					"calc": {
+						"points": -5
+					}
+				},
+				{
+					"id": "tXLDnB03X5WMg7daJ",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tEYEuzMtxSsWCG7uW"
+					},
+					"name": "Unusual Biochemistry",
+					"reference": "B160",
+					"tags": [
+						"Disadvantage",
+						"Physical"
+					],
+					"base_points": -5,
+					"calc": {
+						"points": -5
+					}
+				},
+				{
+					"id": "tks973qzDoB-sBUwM",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tkvBzkhf0YNP2cF5j"
+					},
+					"name": "Proud",
+					"reference": "B164",
+					"tags": [
+						"Mental",
+						"Quirk"
+					],
+					"base_points": -1,
+					"features": [
+						{
+							"type": "reaction_bonus",
+							"situation": "to orders, insults, or social slights",
+							"amount": -1
+						}
+					],
+					"calc": {
+						"points": -1
+					}
+				},
+				{
+					"id": "tq1E9QKifFhO7SjFV",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "tKvd6bbXhGlQVR8lm"
+					},
+					"name": "Early Maturation",
+					"reference": "BT212",
+					"tags": [
+						"Feature"
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "t2PpPCbih_67TBRLH",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "twlxLezOdicVKFwxJ"
+					},
+					"name": "No Appendix",
+					"reference": "BT46",
+					"local_notes": "TL9",
+					"tags": [
+						"Exotic",
+						"Physical"
+					],
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "tCzAcbJKCmJXh82v4",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "tLe1-US7YK9twT2zS"
+					},
+					"name": "Taboo Trait (Genetic Defects)",
+					"reference": "BT65, B261",
+					"local_notes": "TL8; Also prohibits attributes more than 2 below the average for an adult with that template",
+					"tags": [
+						"Exotic",
+						"Mental",
+						"Physical",
+						"Taboo Trait"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Short Attention Span"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Non-Iconographic"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "No Sense of Smell/Taste"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Night Blindness"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Innumerate"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Hemophilia"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Gigantism"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dyslexia"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dwarfism"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Colorblindness"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "starts_with",
+									"qualifier": "Bad Sight"
+								}
+							}
+						]
+					},
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "tnYdhfHkqCOC25QHj",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "tDhx56D50aegwu4w6"
+					},
+					"name": "Taboo Trait (Mental Instability)",
+					"reference": "BT65, B261",
+					"local_notes": "TL9; Also prohibits any Compulsive Behaviour or Phobia worth -10 points or more",
+					"tags": [
+						"Exotic",
+						"Mental",
+						"Taboo Trait"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Pyromania"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Phantom Voices"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Paranoia"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "On the Edge"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Obsession"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Megalomania"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Manic-Depressive"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Lunacy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Low Self-Image"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Kleptomania"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Guilt Complex"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Flashbacks"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Delusion"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "starts_with",
+									"qualifier": "Delusions"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Chronic Depression"
+								}
+							}
+						]
+					},
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "T2QhY_wKNcFggUCfv",
+					"name": "Choose One",
+					"template_picker": {
+						"type": "count",
+						"qualifier": {
+							"compare": "is",
+							"qualifier": 1
+						}
+					},
+					"children": [
+						{
+							"id": "TQoeS-zkEFcIaQ6hM",
+							"name": "Base",
+							"calc": {
+								"points": 0
+							}
+						},
+						{
+							"id": "tQXHSDpakQkNH_O7v",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tqha9GlDBU9P-Wg-6"
+							},
+							"name": "Increased Strength",
+							"reference": "B14",
+							"tags": [
+								"Advantage",
+								"Attribute",
+								"Physical"
+							],
+							"modifiers": [
+								{
+									"id": "mgFxIf_HQ1ktuAhtp",
+									"name": "No Fine Manipulators",
+									"reference": "B15",
+									"cost": -40,
+									"disabled": true
+								},
+								{
+									"id": "mn5KQNMW633yXrxQF",
+									"name": "Size",
+									"reference": "B15",
+									"cost": -10,
+									"levels": 1,
+									"disabled": true
+								},
+								{
+									"id": "mcVrnC0LWQ38fL4Or",
+									"name": "Super-Effort",
+									"reference": "SU24",
+									"cost": 300,
+									"disabled": true
+								}
+							],
+							"points_per_level": 10,
+							"features": [
+								{
+									"type": "attribute_bonus",
+									"attribute": "st",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"levels": 3,
+							"calc": {
+								"points": 30
+							}
+						},
+						{
+							"id": "T9cf5lIfaZcH_PexM",
+							"name": "Atlas",
+							"local_notes": "+$42000. LC3.",
+							"children": [
+								{
+									"id": "tJ6aSwA-aMs5wA73k",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tGpcVbjudWqlXl_xf"
+									},
+									"name": "Increased Size Modifier",
+									"reference": "B19",
+									"tags": [
+										"Advantage",
+										"Attribute",
+										"Physical"
+									],
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "sm",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": 0
+									}
+								},
+								{
+									"id": "t7TjilvYV-YRzTL44",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tqha9GlDBU9P-Wg-6"
+									},
+									"name": "Increased Strength",
+									"reference": "B14",
+									"tags": [
+										"Advantage",
+										"Attribute",
+										"Physical"
+									],
+									"modifiers": [
+										{
+											"id": "m0B1xJCnMin63U1En",
+											"name": "No Fine Manipulators",
+											"reference": "B15",
+											"cost": -40,
+											"disabled": true
+										},
+										{
+											"id": "m9gc8GuxYN9AKP6Cz",
+											"name": "Size",
+											"reference": "B15",
+											"cost": -10,
+											"levels": 1
+										},
+										{
+											"id": "mouSTFyHEfFlVFzPt",
+											"name": "Super-Effort",
+											"reference": "SU24",
+											"cost": 300,
+											"disabled": true
+										}
+									],
+									"points_per_level": 10,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "st",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 8,
+									"calc": {
+										"points": 72
+									}
+								}
+							],
+							"calc": {
+								"points": 72
+							}
+						}
+					],
+					"calc": {
+						"points": 102
+					}
+				}
+			],
+			"calc": {
+				"points": 263
+			}
+		}
+	]
+}

--- a/Library/Bio-Tech/Races/Ishtar.gct
+++ b/Library/Bio-Tech/Races/Ishtar.gct
@@ -1,0 +1,1457 @@
+{
+	"version": 5,
+	"id": "B7cGS2gmCtlH4CKnB",
+	"traits": [
+		{
+			"id": "T5HQb9SiKjTAQLAcg",
+			"name": "Ishtar",
+			"reference": "BT66",
+			"local_notes": "TL9. $45000. LC4.",
+			"tags": [
+				"Race"
+			],
+			"ancestry": "Human",
+			"container_type": "ancestry",
+			"children": [
+				{
+					"id": "t7Bk4z0omtz8oQwnX",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tGWOSEE6SmBHACE6Y"
+					},
+					"name": "Increased Dexterity",
+					"reference": "B15",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mPZiN5gyU_8khbUuQ",
+							"name": "No Fine Manipulators",
+							"cost": -40,
+							"disabled": true
+						}
+					],
+					"points_per_level": 20,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "dx",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 20
+					}
+				},
+				{
+					"id": "to7EWoR_gIZiY1kVn",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tVt3SvdGWNchJ8z4o"
+					},
+					"name": "Increased Health",
+					"reference": "B14",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"points_per_level": 10,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "ht",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 10
+					}
+				},
+				{
+					"id": "tAsERcsbyDKzsNl7f",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "thI3hK3riuknUwkHF"
+					},
+					"name": "Decreased Strength",
+					"reference": "B14",
+					"tags": [
+						"Attribute",
+						"Disadvantage",
+						"Physical"
+					],
+					"points_per_level": -10,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "st",
+							"amount": -1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": -10
+					}
+				},
+				{
+					"id": "T9rfbh5ep24G_9ywu",
+					"name": "Choose One",
+					"template_picker": {
+						"type": "count",
+						"qualifier": {
+							"compare": "is",
+							"qualifier": 1
+						}
+					},
+					"children": [
+						{
+							"id": "toY7qDMGsK3m8dZz-",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tdlCZw4YB4T7QkOnj"
+							},
+							"name": "Appearance",
+							"reference": "B21",
+							"tags": [
+								"Advantage",
+								"Physical"
+							],
+							"modifiers": [
+								{
+									"id": "mYFyFaJWiDDAioy2V",
+									"name": "Attractive",
+									"reference": "B21",
+									"cost": 4,
+									"cost_type": "points",
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from others",
+											"amount": 1
+										}
+									],
+									"disabled": true
+								},
+								{
+									"id": "mrrgIMS3DOyb6hb7Y",
+									"name": "Average",
+									"reference": "B21",
+									"cost_type": "points",
+									"disabled": true
+								},
+								{
+									"id": "m2dhTuigUmlx2wdru",
+									"name": "Beautiful",
+									"reference": "B21",
+									"cost": 12,
+									"cost_type": "points",
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from those attracted to members of your sex, +2 from everyone else",
+											"amount": 4
+										}
+									]
+								},
+								{
+									"id": "mKwvlPfCGOCAWtfJh",
+									"name": "Beautiful (Androgynous)",
+									"reference": "B21",
+									"cost": 12,
+									"cost_type": "points",
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from others",
+											"amount": 3
+										}
+									],
+									"disabled": true
+								},
+								{
+									"id": "mped2o5DbZ8_nGI9V",
+									"name": "Beautiful (Impressive)",
+									"reference": "B21",
+									"cost": 12,
+									"cost_type": "points",
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from others",
+											"amount": 3
+										}
+									],
+									"disabled": true
+								},
+								{
+									"id": "miQhnieaIR--jjxda",
+									"name": "Handsome",
+									"reference": "B21",
+									"cost": 12,
+									"cost_type": "points",
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from those attracted to members of your sex, +2 from everyone else",
+											"amount": 4
+										}
+									],
+									"disabled": true
+								},
+								{
+									"id": "mmi5CfLIkM5ZWLjuP",
+									"name": "Handsome (Androgynous)",
+									"reference": "B21",
+									"cost": 12,
+									"cost_type": "points",
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from others",
+											"amount": 3
+										}
+									],
+									"disabled": true
+								},
+								{
+									"id": "mAlrpFccGLzp9IELA",
+									"name": "Handsome (Impressive)",
+									"reference": "B21",
+									"cost": 12,
+									"cost_type": "points",
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from others",
+											"amount": 3
+										}
+									],
+									"disabled": true
+								},
+								{
+									"id": "m5Pre44u7M6YYa1T-",
+									"name": "Hideous",
+									"reference": "B21,B202",
+									"cost": -16,
+									"cost_type": "points",
+									"features": [
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "Intimidation"
+											},
+											"amount": 2
+										},
+										{
+											"type": "reaction_bonus",
+											"situation": "from others",
+											"amount": -4
+										}
+									],
+									"disabled": true
+								},
+								{
+									"id": "mAnwb08xHuNcd8yIj",
+									"name": "Horrific",
+									"reference": "B21,B202",
+									"cost": -24,
+									"cost_type": "points",
+									"features": [
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "Intimidation"
+											},
+											"amount": 4
+										},
+										{
+											"type": "reaction_bonus",
+											"situation": "from others",
+											"amount": -6
+										}
+									],
+									"disabled": true
+								},
+								{
+									"id": "mYM5uvm-7SfLgYGjr",
+									"name": "Impressive",
+									"reference": "B21",
+									"cost_type": "points",
+									"disabled": true
+								},
+								{
+									"id": "mpvVPG01h2aedT-Ug",
+									"name": "Monstrous",
+									"reference": "B21,B202",
+									"cost": -20,
+									"cost_type": "points",
+									"features": [
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "Intimidation"
+											},
+											"amount": 3
+										},
+										{
+											"type": "reaction_bonus",
+											"situation": "from others",
+											"amount": -5
+										}
+									],
+									"disabled": true
+								},
+								{
+									"id": "m71E0xw2z1KHtp-4L",
+									"name": "Off-the-Shelf Looks",
+									"reference": "B21",
+									"local_notes": "Halves the usual reaction bonus - adjust manually",
+									"cost": -50,
+									"disabled": true
+								},
+								{
+									"id": "m3pcPTMHkrqGDK7KQ",
+									"name": "Transcendent",
+									"reference": "B21",
+									"cost": 20,
+									"cost_type": "points",
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+											"amount": 8
+										}
+									],
+									"disabled": true
+								},
+								{
+									"id": "mqKPBxSvvmrqkIEFQ",
+									"name": "Transcendent (Androgynous)",
+									"reference": "B21",
+									"cost": 20,
+									"cost_type": "points",
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from others",
+											"amount": 5
+										}
+									],
+									"disabled": true
+								},
+								{
+									"id": "mpzSRIWrWTvTFAU-t",
+									"name": "Transcendent (Impressive)",
+									"reference": "B21",
+									"cost": 20,
+									"cost_type": "points",
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from others",
+											"amount": 5
+										}
+									],
+									"disabled": true
+								},
+								{
+									"id": "m2T0OUjX7ddJ0LHeZ",
+									"name": "Ugly",
+									"reference": "B21",
+									"cost": -8,
+									"cost_type": "points",
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from others",
+											"amount": -2
+										}
+									],
+									"disabled": true
+								},
+								{
+									"id": "m4mvH-0QKhUJYqilr",
+									"name": "Unattractive",
+									"reference": "B21",
+									"cost": -4,
+									"cost_type": "points",
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from others",
+											"amount": -1
+										}
+									],
+									"disabled": true
+								},
+								{
+									"id": "mMFkA-mU11SdlZj3y",
+									"name": "Universal",
+									"reference": "B21",
+									"cost": 25,
+									"disabled": true
+								},
+								{
+									"id": "m0i17nB5zrqKYMRlj",
+									"name": "Very Beautiful",
+									"reference": "B21",
+									"cost": 16,
+									"cost_type": "points",
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+											"amount": 6
+										}
+									],
+									"disabled": true
+								},
+								{
+									"id": "m2XW-7fNk12WpeqRh",
+									"name": "Very Beautiful (Androgynous)",
+									"reference": "B21",
+									"cost": 16,
+									"cost_type": "points",
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from others",
+											"amount": 4
+										}
+									],
+									"disabled": true
+								},
+								{
+									"id": "m5o9xPTjO5LgsER2Q",
+									"name": "Very Beautiful (Impressive)",
+									"reference": "B21",
+									"cost": 16,
+									"cost_type": "points",
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from others",
+											"amount": 4
+										}
+									],
+									"disabled": true
+								},
+								{
+									"id": "mHUbAqM6LfXW2QOp3",
+									"name": "Very Handsome",
+									"reference": "B21",
+									"cost": 16,
+									"cost_type": "points",
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+											"amount": 6
+										}
+									],
+									"disabled": true
+								},
+								{
+									"id": "mLfKqxc3ffxREDcuK",
+									"name": "Very Handsome (Androgynous)",
+									"reference": "B21",
+									"cost": 16,
+									"cost_type": "points",
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from others",
+											"amount": 4
+										}
+									],
+									"disabled": true
+								},
+								{
+									"id": "mOKtOMa51fhIZplXS",
+									"name": "Very Handsome (Impressive)",
+									"reference": "B21",
+									"cost": 16,
+									"cost_type": "points",
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from others",
+											"amount": 4
+										}
+									],
+									"disabled": true
+								}
+							],
+							"calc": {
+								"points": 12
+							}
+						},
+						{
+							"id": "t0xNeOfuHXlu4Vq5x",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tdlCZw4YB4T7QkOnj"
+							},
+							"name": "Appearance",
+							"reference": "B21",
+							"tags": [
+								"Advantage",
+								"Physical"
+							],
+							"modifiers": [
+								{
+									"id": "m8AFI9ekmrFG7LNSm",
+									"name": "Attractive",
+									"reference": "B21",
+									"cost": 4,
+									"cost_type": "points",
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from others",
+											"amount": 1
+										}
+									],
+									"disabled": true
+								},
+								{
+									"id": "mT2za9vIN8zoSSsG4",
+									"name": "Average",
+									"reference": "B21",
+									"cost_type": "points",
+									"disabled": true
+								},
+								{
+									"id": "m-jqiZ3LcRzAUaWYI",
+									"name": "Beautiful",
+									"reference": "B21",
+									"cost": 12,
+									"cost_type": "points",
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from those attracted to members of your sex, +2 from everyone else",
+											"amount": 4
+										}
+									],
+									"disabled": true
+								},
+								{
+									"id": "mpabBRHwHLr9IYPUF",
+									"name": "Beautiful (Androgynous)",
+									"reference": "B21",
+									"cost": 12,
+									"cost_type": "points",
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from others",
+											"amount": 3
+										}
+									],
+									"disabled": true
+								},
+								{
+									"id": "m54Cn5aKCrYCHjYq4",
+									"name": "Beautiful (Impressive)",
+									"reference": "B21",
+									"cost": 12,
+									"cost_type": "points",
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from others",
+											"amount": 3
+										}
+									],
+									"disabled": true
+								},
+								{
+									"id": "m1KRY62cRaT6XeADY",
+									"name": "Handsome",
+									"reference": "B21",
+									"cost": 12,
+									"cost_type": "points",
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from those attracted to members of your sex, +2 from everyone else",
+											"amount": 4
+										}
+									]
+								},
+								{
+									"id": "mFDf0OJB0e7OGiaWF",
+									"name": "Handsome (Androgynous)",
+									"reference": "B21",
+									"cost": 12,
+									"cost_type": "points",
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from others",
+											"amount": 3
+										}
+									],
+									"disabled": true
+								},
+								{
+									"id": "mnkdWRIOL-5oTw642",
+									"name": "Handsome (Impressive)",
+									"reference": "B21",
+									"cost": 12,
+									"cost_type": "points",
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from others",
+											"amount": 3
+										}
+									],
+									"disabled": true
+								},
+								{
+									"id": "mg7WeyygnVzOOFDvk",
+									"name": "Hideous",
+									"reference": "B21,B202",
+									"cost": -16,
+									"cost_type": "points",
+									"features": [
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "Intimidation"
+											},
+											"amount": 2
+										},
+										{
+											"type": "reaction_bonus",
+											"situation": "from others",
+											"amount": -4
+										}
+									],
+									"disabled": true
+								},
+								{
+									"id": "mdb9vl2tDWTVYfj6R",
+									"name": "Horrific",
+									"reference": "B21,B202",
+									"cost": -24,
+									"cost_type": "points",
+									"features": [
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "Intimidation"
+											},
+											"amount": 4
+										},
+										{
+											"type": "reaction_bonus",
+											"situation": "from others",
+											"amount": -6
+										}
+									],
+									"disabled": true
+								},
+								{
+									"id": "mKVioLCwnTgOGlABr",
+									"name": "Impressive",
+									"reference": "B21",
+									"cost_type": "points",
+									"disabled": true
+								},
+								{
+									"id": "mmHC3dXAUDUpgWbea",
+									"name": "Monstrous",
+									"reference": "B21,B202",
+									"cost": -20,
+									"cost_type": "points",
+									"features": [
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "Intimidation"
+											},
+											"amount": 3
+										},
+										{
+											"type": "reaction_bonus",
+											"situation": "from others",
+											"amount": -5
+										}
+									],
+									"disabled": true
+								},
+								{
+									"id": "ml8elL6liTv-Pzb8e",
+									"name": "Off-the-Shelf Looks",
+									"reference": "B21",
+									"local_notes": "Halves the usual reaction bonus - adjust manually",
+									"cost": -50,
+									"disabled": true
+								},
+								{
+									"id": "m4XTQWv4w076klXXU",
+									"name": "Transcendent",
+									"reference": "B21",
+									"cost": 20,
+									"cost_type": "points",
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+											"amount": 8
+										}
+									],
+									"disabled": true
+								},
+								{
+									"id": "mdU2H-a43Z-7lwY0U",
+									"name": "Transcendent (Androgynous)",
+									"reference": "B21",
+									"cost": 20,
+									"cost_type": "points",
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from others",
+											"amount": 5
+										}
+									],
+									"disabled": true
+								},
+								{
+									"id": "mfeDzY2EzuFP0DrwJ",
+									"name": "Transcendent (Impressive)",
+									"reference": "B21",
+									"cost": 20,
+									"cost_type": "points",
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from others",
+											"amount": 5
+										}
+									],
+									"disabled": true
+								},
+								{
+									"id": "mxfi35SMJ6hoCdKvi",
+									"name": "Ugly",
+									"reference": "B21",
+									"cost": -8,
+									"cost_type": "points",
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from others",
+											"amount": -2
+										}
+									],
+									"disabled": true
+								},
+								{
+									"id": "mtz86SBFDxZdlxA7E",
+									"name": "Unattractive",
+									"reference": "B21",
+									"cost": -4,
+									"cost_type": "points",
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from others",
+											"amount": -1
+										}
+									],
+									"disabled": true
+								},
+								{
+									"id": "mfkqqNJ6oyosgPZiV",
+									"name": "Universal",
+									"reference": "B21",
+									"cost": 25,
+									"disabled": true
+								},
+								{
+									"id": "mJwD9fcifYoe251b8",
+									"name": "Very Beautiful",
+									"reference": "B21",
+									"cost": 16,
+									"cost_type": "points",
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+											"amount": 6
+										}
+									],
+									"disabled": true
+								},
+								{
+									"id": "mt14FiTjL9eD_vlPR",
+									"name": "Very Beautiful (Androgynous)",
+									"reference": "B21",
+									"cost": 16,
+									"cost_type": "points",
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from others",
+											"amount": 4
+										}
+									],
+									"disabled": true
+								},
+								{
+									"id": "mTO6pjm7HjPuqO87V",
+									"name": "Very Beautiful (Impressive)",
+									"reference": "B21",
+									"cost": 16,
+									"cost_type": "points",
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from others",
+											"amount": 4
+										}
+									],
+									"disabled": true
+								},
+								{
+									"id": "mWjTRmSenp9u3BZ0R",
+									"name": "Very Handsome",
+									"reference": "B21",
+									"cost": 16,
+									"cost_type": "points",
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+											"amount": 6
+										}
+									],
+									"disabled": true
+								},
+								{
+									"id": "m79sV0Y1vWvOpY1Ew",
+									"name": "Very Handsome (Androgynous)",
+									"reference": "B21",
+									"cost": 16,
+									"cost_type": "points",
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from others",
+											"amount": 4
+										}
+									],
+									"disabled": true
+								},
+								{
+									"id": "mHUn_QjIcnAJUmn0G",
+									"name": "Very Handsome (Impressive)",
+									"reference": "B21",
+									"cost": 16,
+									"cost_type": "points",
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from others",
+											"amount": 4
+										}
+									],
+									"disabled": true
+								}
+							],
+							"calc": {
+								"points": 12
+							}
+						}
+					],
+					"calc": {
+						"points": 24
+					}
+				},
+				{
+					"id": "t0f-gpuLi7U1mlRzl",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tJTfFdHM7YI5IZR7I"
+					},
+					"name": "Resistant",
+					"reference": "B81,P71,MA47",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"replacements": {
+						"Occasional: Disease, Ingested Poison, etc.": "Disease"
+					},
+					"modifiers": [
+						{
+							"id": "mxatYdOk-2wPfxRNX",
+							"name": "@Very Common: Metabolic Hazards, etc.@",
+							"reference": "B80",
+							"cost": 30,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mI7xItXAXBy6DIHZx",
+							"name": "@Common: Poison, Sickness, etc.@",
+							"reference": "B81",
+							"cost": 15,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mWwIzNzqWDRhK7Mgn",
+							"name": "@Occasional: Disease, Ingested Poison, etc.@",
+							"reference": "B81",
+							"cost": 10,
+							"cost_type": "points"
+						},
+						{
+							"id": "mAApXVYwaLY4s7kSV",
+							"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+							"reference": "B81",
+							"cost": 5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "ms-UOsNvA_75p9uTF",
+							"name": "Immunity",
+							"reference": "B81",
+							"cost": 1,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "mZDT4bySNYxKh-Lp5",
+							"name": "+8 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.5,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "m95Mqg3QI_gnCU6ZD",
+							"name": "+3 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.33,
+							"cost_type": "multiplier"
+						}
+					],
+					"round_down": true,
+					"calc": {
+						"points": 3
+					}
+				},
+				{
+					"id": "ts5PP-Mv7ErPxVSyv",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t59wSfU9kpC1rus5P"
+					},
+					"name": "Alcohol Tolerance",
+					"reference": "B100",
+					"tags": [
+						"Perk",
+						"Physical"
+					],
+					"base_points": 1,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "on all HT rolls related to drinking",
+							"amount": 2
+						}
+					],
+					"calc": {
+						"points": 1
+					}
+				},
+				{
+					"id": "tmclFIOGTVixjI1fs",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tPbL1_rekOzkM86wz"
+					},
+					"name": "Overconfidence",
+					"reference": "B148",
+					"local_notes": "You must make a self-control roll any time the GM feels you show an unreasonable degree of caution. If you fail, you must go ahead as though you were able to handle the situation!",
+					"tags": [
+						"Disadvantage",
+						"Mental"
+					],
+					"cr": 12,
+					"base_points": -5,
+					"features": [
+						{
+							"type": "reaction_bonus",
+							"situation": "from young or naive individuals who believe you are as good as you say you are",
+							"amount": 2
+						},
+						{
+							"type": "reaction_bonus",
+							"situation": "from experienced NPCs",
+							"amount": -2
+						}
+					],
+					"calc": {
+						"points": -5
+					}
+				},
+				{
+					"id": "tVTiTfan1ni9eWTqy",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t4slIFEFLKoDYazcy"
+					},
+					"name": "Imaginative",
+					"reference": "B164",
+					"tags": [
+						"Mental",
+						"Quirk"
+					],
+					"base_points": -1,
+					"calc": {
+						"points": -1
+					}
+				},
+				{
+					"id": "tPBR5RG_202no0r0R",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "tLe1-US7YK9twT2zS"
+					},
+					"name": "Taboo Trait (Genetic Defects)",
+					"reference": "BT65, B261",
+					"local_notes": "TL8; Also prohibits attributes more than 2 below the average for an adult with that template",
+					"tags": [
+						"Exotic",
+						"Mental",
+						"Physical",
+						"Taboo Trait"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Short Attention Span"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Non-Iconographic"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "No Sense of Smell/Taste"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Night Blindness"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Innumerate"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Hemophilia"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Gigantism"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dyslexia"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dwarfism"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Colorblindness"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "starts_with",
+									"qualifier": "Bad Sight"
+								}
+							}
+						]
+					},
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "tSi1oWq1o8iEq1SXc",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "tTi0zSDyDA07Ttfvy"
+					},
+					"name": "Taboo Trait (Unattractiveness)",
+					"reference": "BT65, B261",
+					"local_notes": "TL9",
+					"tags": [
+						"Exotic",
+						"Physical",
+						"Taboo Trait"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Very Unfit"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Very Fat"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Overweight"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Fat"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Bowlegged"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Bad Smell"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Appearance"
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "Horrific"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Appearance"
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "Monstrous"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Appearance"
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "Hideous"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Appearance"
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "Ugly"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Appearance"
+								},
+								"notes": {
+									"compare": "contains",
+									"qualifier": "Unattractive"
+								}
+							}
+						]
+					},
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "TFsWoIM1jtfIodjeg",
+					"name": "Choose One",
+					"template_picker": {
+						"type": "count",
+						"qualifier": {
+							"compare": "is",
+							"qualifier": 1
+						}
+					},
+					"children": [
+						{
+							"id": "TSpfHhhUzYLx1v4sA",
+							"name": "Base",
+							"children": [
+								{
+									"id": "TryqYadIff1k3kPfj",
+									"name": "Choose One",
+									"template_picker": {
+										"type": "count",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": 1
+										}
+									},
+									"children": [
+										{
+											"id": "trJ9Cra-yA8-DNttE",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tNNZgqAtiUMQ_dZs6"
+											},
+											"name": "Jealousy",
+											"reference": "B140",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"base_points": -10,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "toward those you are jealous of (may be as much as -4, at GM's discretion)",
+													"amount": -2
+												}
+											],
+											"calc": {
+												"points": -10
+											}
+										},
+										{
+											"id": "t2WDQDK4EKCtn9FKM",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tYdqy1uPSGI8VqvLV"
+											},
+											"name": "Selfish",
+											"reference": "B153",
+											"local_notes": "Make a self-control roll whenever you experience a clear social slight or “snub.” On a failure, you lash out at the offending party just as if you had Bad Temper.",
+											"tags": [
+												"Disadvantage",
+												"Mental"
+											],
+											"cr": 12,
+											"base_points": -5,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "from others when your Selfishness surfaces",
+													"amount": -3
+												}
+											],
+											"calc": {
+												"points": -5
+											}
+										}
+									],
+									"calc": {
+										"points": -15
+									}
+								}
+							],
+							"calc": {
+								"points": -15
+							}
+						},
+						{
+							"id": "TWPyGg3QQ2nWnIHBS",
+							"name": "Siduri",
+							"local_notes": "+$3000. LC3.",
+							"children": [
+								{
+									"id": "tRW76RQYrJukuyzay",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "thdJ55ghf__io9AQa"
+									},
+									"name": "Longevity",
+									"reference": "B66",
+									"local_notes": "You fail aging rolls only on a 17 or 18, or only on an 18 if your modified HT is 17 or better",
+									"tags": [
+										"Advantage",
+										"Physical"
+									],
+									"base_points": 2,
+									"calc": {
+										"points": 2
+									}
+								},
+								{
+									"id": "t1Rt5qENJZhwaOTsG",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tkvBzkhf0YNP2cF5j"
+									},
+									"name": "Proud",
+									"reference": "B164",
+									"tags": [
+										"Mental",
+										"Quirk"
+									],
+									"base_points": -1,
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "to orders, insults, or social slights",
+											"amount": -1
+										}
+									],
+									"calc": {
+										"points": -1
+									}
+								}
+							],
+							"calc": {
+								"points": 1
+							}
+						}
+					],
+					"calc": {
+						"points": -14
+					}
+				}
+			],
+			"calc": {
+				"points": 28
+			}
+		}
+	]
+}

--- a/Library/Bio-Tech/Races/Lepus.gct
+++ b/Library/Bio-Tech/Races/Lepus.gct
@@ -1,0 +1,705 @@
+{
+	"version": 5,
+	"id": "B7TTVX1zR4wUNbDAK",
+	"traits": [
+		{
+			"id": "THdCvTD4TZ-veetEd",
+			"name": "Lepus",
+			"reference": "BT74",
+			"local_notes": "TL10. $59000. LC3.",
+			"tags": [
+				"Race"
+			],
+			"container_type": "ancestry",
+			"children": [
+				{
+					"id": "tCYyiLLiWZqhobS0r",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "thI3hK3riuknUwkHF"
+					},
+					"name": "Decreased Strength",
+					"reference": "B14",
+					"tags": [
+						"Attribute",
+						"Disadvantage",
+						"Physical"
+					],
+					"points_per_level": -10,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "st",
+							"amount": -1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": -10
+					}
+				},
+				{
+					"id": "tFdTyL1JbhaEpbzP7",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tVt3SvdGWNchJ8z4o"
+					},
+					"name": "Increased Health",
+					"reference": "B14",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"points_per_level": 10,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "ht",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 10
+					}
+				},
+				{
+					"id": "t1i0KerpDzoFpSQFz",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t6XtSYhM7yan5_B73"
+					},
+					"name": "Acute Hearing",
+					"reference": "B35",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"points_per_level": 2,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "hearing",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 3,
+					"calc": {
+						"points": 6
+					}
+				},
+				{
+					"id": "tsZQXiKS1P5b2wH5l",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tAZ31tXG_HzDmVCRp"
+					},
+					"name": "Acute Taste \u0026 Smell",
+					"reference": "B35",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"points_per_level": 2,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "taste_smell",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 2,
+					"calc": {
+						"points": 4
+					}
+				},
+				{
+					"id": "tHNcNb65Lx5iFOmuV",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tJTfFdHM7YI5IZR7I"
+					},
+					"name": "Resistant",
+					"reference": "B81,P71,MA47",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"replacements": {
+						"Occasional: Disease, Ingested Poison, etc.": "Disease"
+					},
+					"modifiers": [
+						{
+							"id": "mswCRWtw6j5Nzx2nD",
+							"name": "@Very Common: Metabolic Hazards, etc.@",
+							"reference": "B80",
+							"cost": 30,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "m0MONZs3jaPNCIUuP",
+							"name": "@Common: Poison, Sickness, etc.@",
+							"reference": "B81",
+							"cost": 15,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mVPVDE8pu5Vf_CJUo",
+							"name": "@Occasional: Disease, Ingested Poison, etc.@",
+							"reference": "B81",
+							"cost": 10,
+							"cost_type": "points"
+						},
+						{
+							"id": "mcFRHHlPmAmG0HSyI",
+							"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+							"reference": "B81",
+							"cost": 5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "moivB_4W-LvJCuVie",
+							"name": "Immunity",
+							"reference": "B81",
+							"cost": 1,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "mZgLss1y4Vc31VXTZ",
+							"name": "+8 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.5,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "miCn7x-bJFwxCdrvH",
+							"name": "+3 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.33,
+							"cost_type": "multiplier"
+						}
+					],
+					"round_down": true,
+					"calc": {
+						"points": 3
+					}
+				},
+				{
+					"id": "tSYY2KHJxaCJbXAJB",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tc74I5tb8McOGp5nr"
+					},
+					"name": "Peripheral Vision",
+					"reference": "B74,P87",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mBV-DY_dKZfmNPDxq",
+							"name": "Easy to Hit",
+							"reference": "B75",
+							"local_notes": "Others can target your eyes at only -6 to hit",
+							"cost": -20,
+							"disabled": true
+						}
+					],
+					"base_points": 15,
+					"calc": {
+						"points": 15
+					}
+				},
+				{
+					"id": "tx-cH-HU4_lYP1wOK",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tsPqY8NyZ8sJbkdS-"
+					},
+					"name": "Fur",
+					"reference": "B101",
+					"tags": [
+						"Exotic",
+						"Perk",
+						"Physical"
+					],
+					"base_points": 1,
+					"calc": {
+						"points": 1
+					}
+				},
+				{
+					"id": "tYbQcimzacuPBzUUh",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tyVBpBR5-Ca0VD1Kd"
+					},
+					"name": "Colorblindness",
+					"reference": "B127",
+					"tags": [
+						"Disadvantage",
+						"Physical"
+					],
+					"base_points": -10,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "contains",
+								"qualifier": "artist"
+							},
+							"amount": -1
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "contains",
+								"qualifier": "chemistry"
+							},
+							"amount": -1
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "contains",
+								"qualifier": "driving"
+							},
+							"amount": -1
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "merchant"
+							},
+							"amount": -1
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "contains",
+								"qualifier": "piloting"
+							},
+							"amount": -1
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "contains",
+								"qualifier": "tracking"
+							},
+							"amount": -1
+						}
+					],
+					"calc": {
+						"points": -10
+					}
+				},
+				{
+					"id": "tK88UCSC9SyR4QrNO",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tSiOKuvTJkqJhuRrI"
+					},
+					"name": "Lecherousness",
+					"reference": "B142",
+					"local_notes": "Make a self-control roll whenever you have more than the briefest contact with an appealing member of the sex you find attractive, at -5 if this person is Handsome/Beautiful, or at -10 if Very Handsome/Very Beautiful. If you fail, you must make a “pass” using whatever wiles and skills you can bring to bear.",
+					"tags": [
+						"Disadvantage",
+						"Mental"
+					],
+					"replacements": {
+						"Condition": "Only in mating season"
+					},
+					"modifiers": [
+						{
+							"id": "mHIGzhlTKiRJN8yQo",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+								"id": "m2IwCpU9KwYmjiSSA"
+							},
+							"name": "Accessibility (@Condition@)",
+							"reference": "B110,P99",
+							"local_notes": "1 point per level",
+							"cost": -1,
+							"levels": 80
+						}
+					],
+					"cr": 9,
+					"base_points": -15,
+					"calc": {
+						"points": -4
+					}
+				},
+				{
+					"id": "tj9GQoy8qhq8lUeIJ",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t_ZUyO0Xhmi2p0Vku"
+					},
+					"name": "Unnatural Features (@Description@)",
+					"reference": "B22",
+					"tags": [
+						"Disadvantage",
+						"Physical"
+					],
+					"replacements": {
+						"Description": "Rabbitoid"
+					},
+					"points_per_level": -1,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "disguise"
+							},
+							"amount": -1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "shadowing"
+							},
+							"amount": -1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": -1
+					}
+				},
+				{
+					"id": "tnitnN3Ew8SJ-M-QZ",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tEYEuzMtxSsWCG7uW"
+					},
+					"name": "Unusual Biochemistry",
+					"reference": "B160",
+					"tags": [
+						"Disadvantage",
+						"Physical"
+					],
+					"base_points": -5,
+					"calc": {
+						"points": -5
+					}
+				},
+				{
+					"id": "t0bDAWpH5lzdVr1XC",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "tKvd6bbXhGlQVR8lm"
+					},
+					"name": "Early Maturation",
+					"reference": "BT212",
+					"tags": [
+						"Feature"
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "Tl1iX0sKcCx8PrGax",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "T4I1lKbVAm_JUhoRo"
+					},
+					"name": "Estrus",
+					"reference": "BT59",
+					"local_notes": "TL9",
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "TqH0N7VUYqtpZKHcj",
+					"name": "Choose One",
+					"template_picker": {
+						"type": "count",
+						"qualifier": {
+							"compare": "is",
+							"qualifier": 1
+						}
+					},
+					"children": [
+						{
+							"id": "T8cUKpXuWuHJVm7tJ",
+							"name": "Base",
+							"children": [
+								{
+									"id": "tCKV443GBG75QCG8t",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Bio-Tech/Bio-Tech Traits.adq",
+										"id": "ttmb3CyN09tIra5GP"
+									},
+									"name": "Increased Fecundity (@Litter Size@)",
+									"reference": "BT59",
+									"local_notes": "TL9",
+									"replacements": {
+										"Litter Size": "6-8"
+									},
+									"calc": {
+										"points": 0
+									}
+								}
+							],
+							"calc": {
+								"points": 0
+							}
+						},
+						{
+							"id": "TXtkVj3KUX982ss82",
+							"name": "Lepus Bioroid",
+							"local_notes": "-$9000. LC3.",
+							"children": [
+								{
+									"id": "Te05-aEYaM8U0nJAZ",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Bio-Tech/Bio-Tech Traits.adq",
+										"id": "TluHkPSI8BnDWWEZo"
+									},
+									"name": "Bioroid",
+									"reference": "BT214",
+									"container_type": "meta_trait",
+									"children": [
+										{
+											"id": "toyEvDJjxxSgvO1iP",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Bio-Tech/Bio-Tech Traits.adq",
+												"id": "tAgMr2EzmeXfC7Tkg"
+											},
+											"name": "Early Maturation",
+											"reference": "BT212",
+											"local_notes": "may be level 3-5",
+											"tags": [
+												"Feature"
+											],
+											"can_level": true,
+											"levels": 3,
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "tKAjSL24DjaVStbHZ",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Template Toolkit/Template Toolkit 2 - Races/Template Toolkit 2 - Races Traits.adq",
+												"id": "tQY4rjF8t2sAPM9xv"
+											},
+											"name": "Sterile",
+											"reference": "TT2:12",
+											"tags": [
+												"Feature",
+												"Physical"
+											],
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "tU1H8l7dxW2F5lF3s",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tEYEuzMtxSsWCG7uW"
+											},
+											"name": "Unusual Biochemistry",
+											"reference": "B160",
+											"tags": [
+												"Disadvantage",
+												"Physical"
+											],
+											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										}
+									],
+									"calc": {
+										"points": -5
+									}
+								}
+							],
+							"calc": {
+								"points": -5
+							}
+						},
+						{
+							"id": "Tmreg0Aql50eq1UWs",
+							"name": "Lepus Chimera",
+							"local_notes": "-$9000. LC3.",
+							"children": [
+								{
+									"id": "TZRzP5-VziIAJrIJ9",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Bio-Tech/Bio-Tech Traits.adq",
+										"id": "To3AVoJByLMnwXPPz"
+									},
+									"name": "Chimera",
+									"reference": "BT214",
+									"container_type": "meta_trait",
+									"children": [
+										{
+											"id": "tzjSwpn3M_jHspItk",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t8duh7FJvBdSs4NOb"
+											},
+											"name": "Restricted Diet (@Food@)",
+											"reference": "B151",
+											"tags": [
+												"Disadvantage",
+												"Physical"
+											],
+											"modifiers": [
+												{
+													"id": "mOqlDFQDk7YH2A0wn",
+													"name": "Substitution",
+													"reference": "B151",
+													"cost": -50
+												},
+												{
+													"id": "mKGjeArCZq5qNGvRU",
+													"name": "Very Common",
+													"reference": "B151",
+													"cost": -10,
+													"cost_type": "points"
+												},
+												{
+													"id": "m4qsYXRWyNO56te49",
+													"name": "Common",
+													"reference": "B151",
+													"cost": -20,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mNwpTtG_reMrKPeL6",
+													"name": "Occasional",
+													"reference": "B151",
+													"cost": -30,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mbnoUF5VEawsyejI5",
+													"name": "Rare",
+													"reference": "B151",
+													"cost": -40,
+													"cost_type": "points",
+													"disabled": true
+												}
+											],
+											"calc": {
+												"points": -5
+											}
+										},
+										{
+											"id": "t4Y0OfxTPDavgro9L",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Template Toolkit/Template Toolkit 2 - Races/Template Toolkit 2 - Races Traits.adq",
+												"id": "tQY4rjF8t2sAPM9xv"
+											},
+											"name": "Sterile",
+											"reference": "TT2:12",
+											"tags": [
+												"Feature",
+												"Physical"
+											],
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "tJUpgcNeXBRyET1ZL",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tEYEuzMtxSsWCG7uW"
+											},
+											"name": "Unusual Biochemistry",
+											"reference": "B160",
+											"tags": [
+												"Disadvantage",
+												"Physical"
+											],
+											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										}
+									],
+									"calc": {
+										"points": -10
+									}
+								}
+							],
+							"calc": {
+								"points": -10
+							}
+						}
+					],
+					"calc": {
+						"points": -15
+					}
+				}
+			],
+			"calc": {
+				"points": -6
+			}
+		}
+	]
+}

--- a/Library/Bio-Tech/Races/Light Worlder.gct
+++ b/Library/Bio-Tech/Races/Light Worlder.gct
@@ -1,0 +1,208 @@
+{
+	"version": 5,
+	"id": "BsXZDVRmcJjV2R-AB",
+	"traits": [
+		{
+			"id": "TrH1o7rJFX-iTuXqj",
+			"name": "Light Worlder",
+			"reference": "BT67",
+			"local_notes": "TL9. $35000. LC4.",
+			"tags": [
+				"Race"
+			],
+			"container_type": "ancestry",
+			"children": [
+				{
+					"id": "tk6w6VgSX3Dma2SHA",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "thI3hK3riuknUwkHF"
+					},
+					"name": "Decreased Strength",
+					"reference": "B14",
+					"tags": [
+						"Attribute",
+						"Disadvantage",
+						"Physical"
+					],
+					"points_per_level": -10,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "st",
+							"amount": -1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 2,
+					"calc": {
+						"points": -20
+					}
+				},
+				{
+					"id": "tREdR0aY9gKWZ3rg2",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tOWDg9Tm1ImEUemm8"
+					},
+					"name": "Modified Arm",
+					"reference": "B53",
+					"reference_highlight": "Modifying Beings With One or Two Arms",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mCgzIpSLBsHhHxuhK",
+							"name": "Extra-Flexible",
+							"reference": "B53",
+							"cost": 5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mWB9GoVGGvHumNwZd",
+							"name": "Long",
+							"reference": "B53",
+							"cost": 10,
+							"cost_type": "points",
+							"levels": 1
+						},
+						{
+							"id": "msKSYLq5H8fqm1myi",
+							"name": "Foot Manipulators",
+							"reference": "B53",
+							"cost": -3,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "m_ZNOvA-Hu-LaJhOp",
+							"name": "No Physical Attack",
+							"reference": "B53",
+							"cost": -5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "m9ONYMJZr3G-e0hiM",
+							"name": "Short",
+							"reference": "B53",
+							"cost": -5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mx6w4kdge2_6Hk7gp",
+							"name": "Weak",
+							"reference": "B53",
+							"local_notes": "Half body ST",
+							"cost": -2.5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mmpqFS66vogOCXiqp",
+							"name": "Weak",
+							"reference": "B53",
+							"local_notes": "Quarter body ST",
+							"cost": -5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mZvQ84cx06cQtfZmi",
+							"name": "Weapon Mount",
+							"reference": "B53",
+							"cost": -8,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "m8ChMn-lG95vFiFD6",
+							"name": "No Grasping Hand",
+							"reference": "MATG28",
+							"cost": -4,
+							"cost_type": "points",
+							"disabled": true
+						}
+					],
+					"points_per_level": 10,
+					"can_level": true,
+					"levels": 2,
+					"calc": {
+						"points": 30
+					}
+				},
+				{
+					"id": "tl4jJjtQHXdngckC3",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tKQss2MjGVWvj-RaR"
+					},
+					"name": "Modified Legs",
+					"reference": "B54",
+					"reference_highlight": "Modifying Beings With Two Legs",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mOvGJTNoyLv8YyohP",
+							"name": "Long",
+							"reference": "B55",
+							"cost": 10,
+							"cost_type": "points",
+							"levels": 1
+						},
+						{
+							"id": "mwqxefwYg03tyBMkU",
+							"name": "Cannot Kick",
+							"reference": "B55",
+							"cost": -5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mVxcmB-KmgvTJGmku",
+							"name": "Extra Flexible",
+							"reference": "MATG27",
+							"cost": 5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "m9oZRmuxzwAIWhsGl",
+							"name": "Prehensile Feet",
+							"reference": "MATG28",
+							"cost": 2,
+							"cost_type": "points",
+							"disabled": true
+						}
+					],
+					"calc": {
+						"points": 10
+					}
+				}
+			],
+			"calc": {
+				"points": 20
+			}
+		}
+	],
+	"notes": [
+		{
+			"id": "n8Nu5ObC8lY6d7k8w",
+			"markdown": "Home Gravity is .2 to .7 G. Increase height by 2' up to over the norm for the lowered ST.\nWeight is 15% to 25% lower than normal.",
+			"reference": "BT67"
+		}
+	]
+}

--- a/Library/Bio-Tech/Races/Orion.gct
+++ b/Library/Bio-Tech/Races/Orion.gct
@@ -1,0 +1,1018 @@
+{
+	"version": 5,
+	"id": "BIrSIXE5OeBWQoZJr",
+	"traits": [
+		{
+			"id": "T6KELSLVA2pCLGVyt",
+			"name": "Orion",
+			"reference": "BT67",
+			"local_notes": "TL9. $95000. LC4.",
+			"tags": [
+				"Race"
+			],
+			"container_type": "ancestry",
+			"children": [
+				{
+					"id": "td6i0LMFoduNirYCG",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tqha9GlDBU9P-Wg-6"
+					},
+					"name": "Increased Strength",
+					"reference": "B14",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mNFpveY-tVTJ751Vm",
+							"name": "No Fine Manipulators",
+							"reference": "B15",
+							"cost": -40,
+							"disabled": true
+						},
+						{
+							"id": "mRnNgAuyRaJU3-EIx",
+							"name": "Size",
+							"reference": "B15",
+							"cost": -10,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mUK6lr2cuaAb4LaKS",
+							"name": "Super-Effort",
+							"reference": "SU24",
+							"cost": 300,
+							"disabled": true
+						}
+					],
+					"points_per_level": 10,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "st",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 10
+					}
+				},
+				{
+					"id": "t3hfPd_mIkJMlxHsr",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tGWOSEE6SmBHACE6Y"
+					},
+					"name": "Increased Dexterity",
+					"reference": "B15",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mD2KX2oP8YgIttES6",
+							"name": "No Fine Manipulators",
+							"cost": -40,
+							"disabled": true
+						}
+					],
+					"points_per_level": 20,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "dx",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 20
+					}
+				},
+				{
+					"id": "tvkTQP-JSi5ow189R",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tVt3SvdGWNchJ8z4o"
+					},
+					"name": "Increased Health",
+					"reference": "B14",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"points_per_level": 10,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "ht",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 10
+					}
+				},
+				{
+					"id": "tnZQ7-uiHt0X2XGPP",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tdlCZw4YB4T7QkOnj"
+					},
+					"name": "Appearance",
+					"reference": "B21",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "m-wPhZVXsrxABLG5U",
+							"name": "Attractive",
+							"reference": "B21",
+							"cost": 4,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 1
+								}
+							]
+						},
+						{
+							"id": "mK8K_fS2Ge60A9__5",
+							"name": "Average",
+							"reference": "B21",
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mPdRmMkHdWvs_Aj6p",
+							"name": "Beautiful",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mDjwqmSOh8OdpT8mm",
+							"name": "Beautiful (Androgynous)",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 3
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mpXzithhtkckkeXz_",
+							"name": "Beautiful (Impressive)",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 3
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mHaPTNhuIiiAqZ8Vy",
+							"name": "Handsome",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mNkGrWCExBXTeSUh5",
+							"name": "Handsome (Androgynous)",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 3
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mDZxRkBNnRjMRpoZV",
+							"name": "Handsome (Impressive)",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 3
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "muFWSNYH-ugxJfbgC",
+							"name": "Hideous",
+							"reference": "B21,B202",
+							"cost": -16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Intimidation"
+									},
+									"amount": 2
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mTrbniQh213A1Ia9J",
+							"name": "Horrific",
+							"reference": "B21,B202",
+							"cost": -24,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Intimidation"
+									},
+									"amount": 4
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -6
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mSUa-Pj4Jksr0FG1a",
+							"name": "Impressive",
+							"reference": "B21",
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mnwK3-pd3cfRTz0jb",
+							"name": "Monstrous",
+							"reference": "B21,B202",
+							"cost": -20,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Intimidation"
+									},
+									"amount": 3
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -5
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mawOYH4pED6n1nOC4",
+							"name": "Off-the-Shelf Looks",
+							"reference": "B21",
+							"local_notes": "Halves the usual reaction bonus - adjust manually",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "mXTexE8Wg2y6bGSmW",
+							"name": "Transcendent",
+							"reference": "B21",
+							"cost": 20,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+									"amount": 8
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mPcDRU6-5zXuhDRFn",
+							"name": "Transcendent (Androgynous)",
+							"reference": "B21",
+							"cost": 20,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 5
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "moL235gEYrTB2mD-a",
+							"name": "Transcendent (Impressive)",
+							"reference": "B21",
+							"cost": 20,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 5
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "m2GPQMo38cvvDAalS",
+							"name": "Ugly",
+							"reference": "B21",
+							"cost": -8,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -2
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "msPZSOhF7ZvRULcd7",
+							"name": "Unattractive",
+							"reference": "B21",
+							"cost": -4,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mxUhKfpMA80eCMUNO",
+							"name": "Universal",
+							"reference": "B21",
+							"cost": 25,
+							"disabled": true
+						},
+						{
+							"id": "mtj_K9REI90EyZOcz",
+							"name": "Very Beautiful",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+									"amount": 6
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mAM-wRZeO2T31ANv6",
+							"name": "Very Beautiful (Androgynous)",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mviOHak2C99tD0Wp-",
+							"name": "Very Beautiful (Impressive)",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "meBvHlhQA_QRvlG7_",
+							"name": "Very Handsome",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+									"amount": 6
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mBUabRDAWmUQoYudv",
+							"name": "Very Handsome (Androgynous)",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "m4mFgu9MkTgjK8UgW",
+							"name": "Very Handsome (Impressive)",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						}
+					],
+					"calc": {
+						"points": 4
+					}
+				},
+				{
+					"id": "tdVBwhrhuWjeOQNt_",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tGjjVtxav9KsrG7Wx"
+					},
+					"name": "Combat Reflexes",
+					"reference": "B43",
+					"local_notes": "Never freeze",
+					"tags": [
+						"Advantage",
+						"Mental"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Enhanced Time Sense"
+								}
+							}
+						]
+					},
+					"base_points": 15,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "starts_with",
+								"qualifier": "fast-draw"
+							},
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "dodge",
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "parry",
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "block",
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "fright_check",
+							"amount": 2
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "on all IQ rolls to wake up or to recover from surprise or mental stun",
+							"amount": 6
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to initiative rolls for your side (+2 if you are the leader)",
+							"amount": 1
+						}
+					],
+					"calc": {
+						"points": 15
+					}
+				},
+				{
+					"id": "tQmTSaQLVf3DVftqR",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tQa3EUrs4Hjt9gxK6"
+					},
+					"name": "Fearlessness",
+					"reference": "B55,MA44",
+					"tags": [
+						"Advantage",
+						"Mental"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Fearfulness"
+								}
+							}
+						]
+					},
+					"points_per_level": 2,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "fright_check",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 2
+					}
+				},
+				{
+					"id": "tcBgtRF5Dj-WE8zUo",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "toTe273Ky82B6YdW5"
+					},
+					"name": "Fit",
+					"reference": "B55",
+					"local_notes": "Recover FP at twice the normal rate (but not FP spent for spells or psi powers)",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"base_points": 5,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "to all HT rolls to stay conscious, avoid death, resist disease, or resist poison",
+							"amount": 1
+						}
+					],
+					"calc": {
+						"points": 5
+					}
+				},
+				{
+					"id": "tXCtwG78AluxLaGfc",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "teRggYn926_I1YeWO"
+					},
+					"name": "High Pain Threshold",
+					"reference": "B59",
+					"local_notes": "Never suffer shock penalties when injured",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"base_points": 10,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "on all HT rolls to avoid knockdown and stunning",
+							"amount": 3
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to resist torture",
+							"amount": 3
+						}
+					],
+					"calc": {
+						"points": 10
+					}
+				},
+				{
+					"id": "tPbnRwgkmj0IkHwtW",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tPbL1_rekOzkM86wz"
+					},
+					"name": "Overconfidence",
+					"reference": "B148",
+					"local_notes": "You must make a self-control roll any time the GM feels you show an unreasonable degree of caution. If you fail, you must go ahead as though you were able to handle the situation!",
+					"tags": [
+						"Disadvantage",
+						"Mental"
+					],
+					"cr": 12,
+					"base_points": -5,
+					"features": [
+						{
+							"type": "reaction_bonus",
+							"situation": "from young or naive individuals who believe you are as good as you say you are",
+							"amount": 2
+						},
+						{
+							"type": "reaction_bonus",
+							"situation": "from experienced NPCs",
+							"amount": -2
+						}
+					],
+					"calc": {
+						"points": -5
+					}
+				},
+				{
+					"id": "taXCuXCmFJUm6wtRs",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t5Qs23yaRu3D4T_hM"
+					},
+					"name": "Attentive",
+					"reference": "B163",
+					"tags": [
+						"Mental",
+						"Quirk"
+					],
+					"base_points": -1,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "to skill rolls when working on lengthy tasks, but -3 to notice any important interruption",
+							"amount": 1
+						}
+					],
+					"calc": {
+						"points": -1
+					}
+				},
+				{
+					"id": "tO0LP3fB1bdtEx8Re",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "tLe1-US7YK9twT2zS"
+					},
+					"name": "Taboo Trait (Genetic Defects)",
+					"reference": "BT65, B261",
+					"local_notes": "TL8; Also prohibits attributes more than 2 below the average for an adult with that template",
+					"tags": [
+						"Exotic",
+						"Mental",
+						"Physical",
+						"Taboo Trait"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Short Attention Span"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Non-Iconographic"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "No Sense of Smell/Taste"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Night Blindness"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Innumerate"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Hemophilia"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Gigantism"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dyslexia"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dwarfism"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Colorblindness"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "starts_with",
+									"qualifier": "Bad Sight"
+								}
+							}
+						]
+					},
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "tMV0xPqf4zHRfb17Y",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "tDhx56D50aegwu4w6"
+					},
+					"name": "Taboo Trait (Mental Instability)",
+					"reference": "BT65, B261",
+					"local_notes": "TL9; Also prohibits any Compulsive Behaviour or Phobia worth -10 points or more",
+					"tags": [
+						"Exotic",
+						"Mental",
+						"Taboo Trait"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Pyromania"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Phantom Voices"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Paranoia"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "On the Edge"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Obsession"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Megalomania"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Manic-Depressive"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Lunacy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Low Self-Image"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Kleptomania"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Guilt Complex"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Flashbacks"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Delusion"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "starts_with",
+									"qualifier": "Delusions"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Chronic Depression"
+								}
+							}
+						]
+					},
+					"calc": {
+						"points": 0
+					}
+				}
+			],
+			"calc": {
+				"points": 70
+			}
+		}
+	]
+}

--- a/Library/Bio-Tech/Races/Pandora.gct
+++ b/Library/Bio-Tech/Races/Pandora.gct
@@ -1,0 +1,398 @@
+{
+	"version": 5,
+	"id": "BYQUTbO5vhvnGEVwF",
+	"traits": [
+		{
+			"id": "T5qSEkpSR1gMGd0e4",
+			"name": "Pandora ",
+			"reference": "BT69",
+			"local_notes": "TL10. $166000. LC3.",
+			"tags": [
+				"Race"
+			],
+			"container_type": "ancestry",
+			"children": [
+				{
+					"id": "tVc5-4vag_7lHH_lT",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t1w1RFcFceKR2T9_e"
+					},
+					"name": "Increased Intelligence",
+					"reference": "B15",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Mental"
+					],
+					"points_per_level": 20,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "iq",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 2,
+					"calc": {
+						"points": 40
+					}
+				},
+				{
+					"id": "tzjF8AueFQ4c3KgIy",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tAdgvQpc5XxYoM2Zu"
+					},
+					"name": "Enhanced Time Sense",
+					"reference": "B52,MA44",
+					"local_notes": "You immediately act in combat before those without Enhanced Time Sense; Never freeze",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Mental"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Combat Reflexes"
+								}
+							}
+						]
+					},
+					"base_points": 45,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "contains",
+								"qualifier": "fast-draw"
+							},
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "dodge",
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "parry",
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "block",
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "fright_check",
+							"amount": 2
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "on all IQ rolls to wake up or to recover from surprise or mental stun",
+							"amount": 6
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to your side on initiative rolls (+2 if you're the leader)",
+							"amount": 1
+						}
+					],
+					"calc": {
+						"points": 45
+					}
+				},
+				{
+					"id": "tE14NPA2g2GoZsNOE",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "tLe1-US7YK9twT2zS"
+					},
+					"name": "Taboo Trait (Genetic Defects)",
+					"reference": "BT65, B261",
+					"local_notes": "TL8; Also prohibits attributes more than 2 below the average for an adult with that template",
+					"tags": [
+						"Exotic",
+						"Mental",
+						"Physical",
+						"Taboo Trait"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Short Attention Span"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Non-Iconographic"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "No Sense of Smell/Taste"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Night Blindness"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Innumerate"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Hemophilia"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Gigantism"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dyslexia"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dwarfism"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Colorblindness"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "starts_with",
+									"qualifier": "Bad Sight"
+								}
+							}
+						]
+					},
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "Tw8TWM9011njeEZbp",
+					"name": "Choose One",
+					"template_picker": {
+						"type": "count",
+						"qualifier": {
+							"compare": "is",
+							"qualifier": 1
+						}
+					},
+					"children": [
+						{
+							"id": "TSINMQ9-uBtVLlgId",
+							"name": "Base",
+							"children": [
+								{
+									"id": "tDyo-PIoGdLHdtsEZ",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "trvn9KmEPe9qGbSdZ"
+									},
+									"name": "Decreased Health",
+									"reference": "B14",
+									"tags": [
+										"Attribute",
+										"Disadvantage",
+										"Physical"
+									],
+									"points_per_level": -10,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "ht",
+											"amount": -1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": -10
+									}
+								},
+								{
+									"id": "tlI-4Cf79fgbztZm1",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t-2sTLqD5b68AuEhY"
+									},
+									"name": "Stuttering",
+									"reference": "B157",
+									"tags": [
+										"Disadvantage",
+										"Physical"
+									],
+									"replacements": {
+										"Condition": "No penalty if talking to someone else with Enhanced Time Sense"
+									},
+									"modifiers": [
+										{
+											"id": "mTj90F1-s0pKcIHcr",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+												"id": "m2IwCpU9KwYmjiSSA"
+											},
+											"name": "Accessibility (@Condition@)",
+											"reference": "B110,P99",
+											"local_notes": "1 point per level",
+											"cost": -1,
+											"levels": 10
+										}
+									],
+									"base_points": -10,
+									"features": [
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "diplomacy"
+											},
+											"amount": -2
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "fast-talk"
+											},
+											"amount": -2
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "performance"
+											},
+											"amount": -2
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "public speaking"
+											},
+											"amount": -2
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "sex appeal"
+											},
+											"amount": -2
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "singing"
+											},
+											"amount": -2
+										},
+										{
+											"type": "reaction_bonus",
+											"situation": "from others where conversation is required",
+											"amount": -2
+										}
+									],
+									"calc": {
+										"points": -9
+									}
+								}
+							],
+							"calc": {
+								"points": -19
+							}
+						},
+						{
+							"id": "TDqyr1kX29oBUtVmc",
+							"name": "Prometheus",
+							"local_notes": "+$19000. LC3.",
+							"calc": {
+								"points": 0
+							}
+						}
+					],
+					"calc": {
+						"points": -19
+					}
+				}
+			],
+			"calc": {
+				"points": 66
+			}
+		}
+	]
+}

--- a/Library/Bio-Tech/Races/Ranger.gct
+++ b/Library/Bio-Tech/Races/Ranger.gct
@@ -1,0 +1,1374 @@
+{
+	"version": 5,
+	"id": "BPgN1sCGCNxwps-UO",
+	"traits": [
+		{
+			"id": "T6bLKhw32A_IOiCVQ",
+			"name": "Ranger",
+			"reference": "BT74",
+			"local_notes": "TL10. $119000. LC3.",
+			"tags": [
+				"Race"
+			],
+			"container_type": "ancestry",
+			"children": [
+				{
+					"id": "t9OjyNSe8zNS-85eP",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tqha9GlDBU9P-Wg-6"
+					},
+					"name": "Increased Strength",
+					"reference": "B14",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "m-Y5yLqkF1nS8UcrP",
+							"name": "No Fine Manipulators",
+							"reference": "B15",
+							"cost": -40,
+							"disabled": true
+						},
+						{
+							"id": "mE36r6OC_UdpV8u_g",
+							"name": "Size",
+							"reference": "B15",
+							"cost": -10,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "m2RWL7h0bcQCQZRPx",
+							"name": "Super-Effort",
+							"reference": "SU24",
+							"cost": 300,
+							"disabled": true
+						}
+					],
+					"points_per_level": 10,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "st",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 10
+					}
+				},
+				{
+					"id": "tUMV6NXZnV10uFN5T",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tGWOSEE6SmBHACE6Y"
+					},
+					"name": "Increased Dexterity",
+					"reference": "B15",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mG854qZ-E6AHoJujU",
+							"name": "No Fine Manipulators",
+							"cost": -40,
+							"disabled": true
+						}
+					],
+					"points_per_level": 20,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "dx",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 20
+					}
+				},
+				{
+					"id": "tE04QrAXcO9nyANN7",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tVt3SvdGWNchJ8z4o"
+					},
+					"name": "Increased Health",
+					"reference": "B14",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"points_per_level": 10,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "ht",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 10
+					}
+				},
+				{
+					"id": "twi6wZkdvlPF4pK8v",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tM6z7Mx6e2V4VvUR4"
+					},
+					"name": "Absolute Direction",
+					"reference": "B34",
+					"tags": [
+						"Advantage",
+						"Mental",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mw5y76fvcThVIOeKw",
+							"name": "Requires signal",
+							"reference": "B34",
+							"cost": -20,
+							"disabled": true
+						},
+						{
+							"id": "mUKRKOENJvOvXlK_c",
+							"name": "3D Spatial Sense",
+							"reference": "B34",
+							"cost": 5,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "starts_with",
+										"qualifier": "piloting"
+									},
+									"amount": 1
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "aerobatics"
+									},
+									"amount": 2
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "free fall"
+									},
+									"amount": 2
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "navigation"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "hyperspace"
+									},
+									"amount": 2
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "navigation"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "space"
+									},
+									"amount": 2
+								}
+							],
+							"disabled": true
+						}
+					],
+					"base_points": 5,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "body sense"
+							},
+							"amount": 3
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "navigation"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "air"
+							},
+							"amount": 3
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "navigation"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "land"
+							},
+							"amount": 3
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "navigation"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "sea"
+							},
+							"amount": 3
+						}
+					],
+					"calc": {
+						"points": 5
+					}
+				},
+				{
+					"id": "te_Q2v0_iFkd2lkM4",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t6XtSYhM7yan5_B73"
+					},
+					"name": "Acute Hearing",
+					"reference": "B35",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"points_per_level": 2,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "hearing",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 2,
+					"calc": {
+						"points": 4
+					}
+				},
+				{
+					"id": "tuFZ-stO4cmLF6ZVw",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tAZ31tXG_HzDmVCRp"
+					},
+					"name": "Acute Taste \u0026 Smell",
+					"reference": "B35",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"points_per_level": 2,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "taste_smell",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 3,
+					"calc": {
+						"points": 6
+					}
+				},
+				{
+					"id": "trL-qicC_QORvEMbN",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tjKuFiuy3Fs6rm69e"
+					},
+					"name": "Discriminatory Smell",
+					"reference": "B49,P47",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "micgK9XS3iOfflLTf",
+							"name": "Emotion Sense",
+							"reference": "B49",
+							"cost": 50,
+							"disabled": true
+						},
+						{
+							"id": "mf5xKE8ZMFhQjry2A",
+							"name": "Profiling",
+							"reference": "P47",
+							"cost": 50,
+							"disabled": true
+						}
+					],
+					"base_points": 15,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Tracking"
+							},
+							"amount": 4
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "on any task that utilizes sense of smell",
+							"amount": 4
+						}
+					],
+					"calc": {
+						"points": 15
+					}
+				},
+				{
+					"id": "tC-qYa0NsE26KkpEr",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tynHtgvWZmmNOL97D"
+					},
+					"name": "Reduced Consumption",
+					"reference": "B80",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mdV1k6coZ4TPbsKmZ",
+							"name": "Cast-Iron Stomach",
+							"reference": "B80",
+							"cost": -50
+						},
+						{
+							"id": "mt2RgYuD2yRO1mzp4",
+							"name": "Food Only",
+							"reference": "B80",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "mBAaf0vmEjx5crcwS",
+							"name": "Water Only",
+							"reference": "B80",
+							"cost": -50,
+							"disabled": true
+						}
+					],
+					"points_per_level": 2,
+					"can_level": true,
+					"levels": 4,
+					"calc": {
+						"points": 4
+					}
+				},
+				{
+					"id": "tIHEYTdj80PZWr7Kc",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tJTfFdHM7YI5IZR7I"
+					},
+					"name": "Resistant",
+					"reference": "B81,P71,MA47",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"replacements": {
+						"Occasional: Disease, Ingested Poison, etc.": "Disease"
+					},
+					"modifiers": [
+						{
+							"id": "mYM-BdoCzwrKKKjYu",
+							"name": "@Very Common: Metabolic Hazards, etc.@",
+							"reference": "B80",
+							"cost": 30,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "m5-L5jtCPgfhNNvRb",
+							"name": "@Common: Poison, Sickness, etc.@",
+							"reference": "B81",
+							"cost": 15,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mEd_0U3FAHA7tAd6G",
+							"name": "@Occasional: Disease, Ingested Poison, etc.@",
+							"reference": "B81",
+							"cost": 10,
+							"cost_type": "points"
+						},
+						{
+							"id": "miWp7sWS6u9OAwLu1",
+							"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+							"reference": "B81",
+							"cost": 5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mQGc3e6r6YoftyJMe",
+							"name": "Immunity",
+							"reference": "B81",
+							"cost": 1,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "m7Voya9acfxHHq5If",
+							"name": "+8 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.5,
+							"cost_type": "multiplier"
+						},
+						{
+							"id": "mpoZ9yTjmtmaOVVKg",
+							"name": "+3 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.33,
+							"cost_type": "multiplier",
+							"disabled": true
+						}
+					],
+					"round_down": true,
+					"calc": {
+						"points": 5
+					}
+				},
+				{
+					"id": "teT_Uegkg7BIW4VQe",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tJTfFdHM7YI5IZR7I"
+					},
+					"name": "Resistant",
+					"reference": "B81,P71,MA47",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"replacements": {
+						"Common: Poison, Sickness, etc.": "Poison"
+					},
+					"modifiers": [
+						{
+							"id": "mlc8OD56Jj933voGZ",
+							"name": "@Very Common: Metabolic Hazards, etc.@",
+							"reference": "B80",
+							"cost": 30,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mH1D4cnXRdWo1ZFC6",
+							"name": "@Common: Poison, Sickness, etc.@",
+							"reference": "B81",
+							"cost": 15,
+							"cost_type": "points"
+						},
+						{
+							"id": "mqzm3-fH3ISfbYhiu",
+							"name": "@Occasional: Disease, Ingested Poison, etc.@",
+							"reference": "B81",
+							"cost": 10,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "m4rOVGTs3bRu3V80m",
+							"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+							"reference": "B81",
+							"cost": 5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "ma8VeHSf8SPJ0-GPc",
+							"name": "Immunity",
+							"reference": "B81",
+							"cost": 1,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "mkziuMwYWeIYjno8G",
+							"name": "+8 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.5,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "mA0gk7A2-lXgOm23L",
+							"name": "+3 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.33,
+							"cost_type": "multiplier"
+						}
+					],
+					"round_down": true,
+					"calc": {
+						"points": 4
+					}
+				},
+				{
+					"id": "tvsVb5qcaERyrpm03",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tnrtPQ0mWF4k75plo"
+					},
+					"name": "Bad Temper",
+					"reference": "B124",
+					"tags": [
+						"Disadvantage",
+						"Mental"
+					],
+					"cr": 15,
+					"base_points": -10,
+					"calc": {
+						"points": -5
+					}
+				},
+				{
+					"id": "teZhQjlCjTW9IlFBg",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tOW5XqmChX0NBm1AP"
+					},
+					"name": "Light Sleeper",
+					"reference": "B142",
+					"local_notes": "Whenever you must sleep in an uncomfortable place, or whenever there is more than the slightest noise, you must make a HT roll in order to fall asleep. On a failure, you can try again after one hour, but you will suffer all the usual effects of one hour of missed sleep.",
+					"tags": [
+						"Disadvantage",
+						"Physical"
+					],
+					"base_points": -5,
+					"calc": {
+						"points": -5
+					}
+				},
+				{
+					"id": "tPr695kR2CCVvDXPn",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tPbL1_rekOzkM86wz"
+					},
+					"name": "Overconfidence",
+					"reference": "B148",
+					"local_notes": "You must make a self-control roll any time the GM feels you show an unreasonable degree of caution. If you fail, you must go ahead as though you were able to handle the situation!",
+					"tags": [
+						"Disadvantage",
+						"Mental"
+					],
+					"cr": 12,
+					"base_points": -5,
+					"features": [
+						{
+							"type": "reaction_bonus",
+							"situation": "from young or naive individuals who believe you are as good as you say you are",
+							"amount": 2
+						},
+						{
+							"type": "reaction_bonus",
+							"situation": "from experienced NPCs",
+							"amount": -2
+						}
+					],
+					"calc": {
+						"points": -5
+					}
+				},
+				{
+					"id": "tcRMQCWNtTWBcybCE",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "twlxLezOdicVKFwxJ"
+					},
+					"name": "No Appendix",
+					"reference": "BT46",
+					"local_notes": "TL9",
+					"tags": [
+						"Exotic",
+						"Physical"
+					],
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "tW59zClDfyn9SYxjk",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "tLe1-US7YK9twT2zS"
+					},
+					"name": "Taboo Trait (Genetic Defects)",
+					"reference": "BT65, B261",
+					"local_notes": "TL8; Also prohibits attributes more than 2 below the average for an adult with that template",
+					"tags": [
+						"Exotic",
+						"Mental",
+						"Physical",
+						"Taboo Trait"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Short Attention Span"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Non-Iconographic"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "No Sense of Smell/Taste"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Night Blindness"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Innumerate"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Hemophilia"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Gigantism"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dyslexia"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dwarfism"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Colorblindness"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "starts_with",
+									"qualifier": "Bad Sight"
+								}
+							}
+						]
+					},
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "teNyJxpyqL2fHEh3b",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "tDhx56D50aegwu4w6"
+					},
+					"name": "Taboo Trait (Mental Instability)",
+					"reference": "BT65, B261",
+					"local_notes": "TL9; Also prohibits any Compulsive Behaviour or Phobia worth -10 points or more",
+					"tags": [
+						"Exotic",
+						"Mental",
+						"Taboo Trait"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Pyromania"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Phantom Voices"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Paranoia"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "On the Edge"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Obsession"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Megalomania"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Manic-Depressive"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Lunacy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Low Self-Image"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Kleptomania"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Guilt Complex"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Flashbacks"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Delusion"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "starts_with",
+									"qualifier": "Delusions"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Chronic Depression"
+								}
+							}
+						]
+					},
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "T5f4i4UCdKAOZ8WfZ",
+					"name": "Choose Any, don't combine Bioroid and Chimera",
+					"template_picker": {
+						"type": "count",
+						"qualifier": {
+							"compare": "at_most",
+							"qualifier": 2
+						}
+					},
+					"children": [
+						{
+							"id": "TQF-xcngYTcwWAU69",
+							"name": "Ranger Bioroid",
+							"local_notes": "-$25000. LC2.",
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Ranger Chimera"
+										}
+									}
+								]
+							},
+							"children": [
+								{
+									"id": "T-wthISamqjU1VLBe",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Bio-Tech/Bio-Tech Traits.adq",
+										"id": "TluHkPSI8BnDWWEZo"
+									},
+									"name": "Bioroid",
+									"reference": "BT214",
+									"container_type": "meta_trait",
+									"children": [
+										{
+											"id": "taqvbQ6YCxPsxY3GT",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Bio-Tech/Bio-Tech Traits.adq",
+												"id": "tAgMr2EzmeXfC7Tkg"
+											},
+											"name": "Early Maturation",
+											"reference": "BT212",
+											"local_notes": "may be level 3-5",
+											"tags": [
+												"Feature"
+											],
+											"can_level": true,
+											"levels": 3,
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "tc2seyrIIylKtcuNa",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Template Toolkit/Template Toolkit 2 - Races/Template Toolkit 2 - Races Traits.adq",
+												"id": "tQY4rjF8t2sAPM9xv"
+											},
+											"name": "Sterile",
+											"reference": "TT2:12",
+											"tags": [
+												"Feature",
+												"Physical"
+											],
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "tIYYR-sh7EdlHddmD",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tEYEuzMtxSsWCG7uW"
+											},
+											"name": "Unusual Biochemistry",
+											"reference": "B160",
+											"tags": [
+												"Disadvantage",
+												"Physical"
+											],
+											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										}
+									],
+									"calc": {
+										"points": -5
+									}
+								},
+								{
+									"id": "tNUodRR7bLSt_Kt_L",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t9Ayzq0-Ain8oiIM8"
+									},
+									"name": "Self-Destruct",
+									"reference": "B153",
+									"tags": [
+										"Disadvantage",
+										"Exotic",
+										"Physical"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "starts_with",
+													"qualifier": "terminally ill"
+												}
+											}
+										]
+									},
+									"base_points": -10,
+									"calc": {
+										"points": -10
+									}
+								},
+								{
+									"id": "tAAGQ1HC9d-V1TNoZ",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t9nyvI3uvjJi5aqF5"
+									},
+									"name": "Short Lifespan",
+									"reference": "B154",
+									"tags": [
+										"Disadvantage",
+										"Exotic",
+										"Physical"
+									],
+									"points_per_level": -10,
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": -10
+									}
+								}
+							],
+							"calc": {
+								"points": -25
+							}
+						},
+						{
+							"id": "TC3ErZQbGkYl4bfx9",
+							"name": "Ranger Chimera",
+							"local_notes": "-$15000. LC2.",
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Ranger Bioroid"
+										}
+									}
+								]
+							},
+							"children": [
+								{
+									"id": "TV3fE6pb6dpk3f7KI",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Bio-Tech/Bio-Tech Traits.adq",
+										"id": "To3AVoJByLMnwXPPz"
+									},
+									"name": "Chimera",
+									"reference": "BT214",
+									"container_type": "meta_trait",
+									"children": [
+										{
+											"id": "tgRmlZ38VbyKrjwiW",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t8duh7FJvBdSs4NOb"
+											},
+											"name": "Restricted Diet (@Food@)",
+											"reference": "B151",
+											"tags": [
+												"Disadvantage",
+												"Physical"
+											],
+											"modifiers": [
+												{
+													"id": "m0TJqloN-GbqR74wT",
+													"name": "Substitution",
+													"reference": "B151",
+													"cost": -50
+												},
+												{
+													"id": "mnc-7QFzX6ZDkRS-V",
+													"name": "Very Common",
+													"reference": "B151",
+													"cost": -10,
+													"cost_type": "points"
+												},
+												{
+													"id": "mZeMg7frXqN-mpBQj",
+													"name": "Common",
+													"reference": "B151",
+													"cost": -20,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mQG9g9Nzun69i4fdg",
+													"name": "Occasional",
+													"reference": "B151",
+													"cost": -30,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mFROJoh6hvbbr0NP5",
+													"name": "Rare",
+													"reference": "B151",
+													"cost": -40,
+													"cost_type": "points",
+													"disabled": true
+												}
+											],
+											"calc": {
+												"points": -5
+											}
+										},
+										{
+											"id": "tgxyVRgOg65JFLr_Z",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Template Toolkit/Template Toolkit 2 - Races/Template Toolkit 2 - Races Traits.adq",
+												"id": "tQY4rjF8t2sAPM9xv"
+											},
+											"name": "Sterile",
+											"reference": "TT2:12",
+											"tags": [
+												"Feature",
+												"Physical"
+											],
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "tW00_TVrfTZTcZTrw",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tEYEuzMtxSsWCG7uW"
+											},
+											"name": "Unusual Biochemistry",
+											"reference": "B160",
+											"tags": [
+												"Disadvantage",
+												"Physical"
+											],
+											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										}
+									],
+									"calc": {
+										"points": -10
+									}
+								},
+								{
+									"id": "t0COh9KjAzafy6tdv",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t9nyvI3uvjJi5aqF5"
+									},
+									"name": "Short Lifespan",
+									"reference": "B154",
+									"tags": [
+										"Disadvantage",
+										"Exotic",
+										"Physical"
+									],
+									"points_per_level": -10,
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": -10
+									}
+								}
+							],
+							"calc": {
+								"points": -20
+							}
+						},
+						{
+							"id": "TaTTGubn6TU5l2J5u",
+							"name": "Fenris",
+							"local_notes": "+$0",
+							"children": [
+								{
+									"id": "t_IN50yG6KUr_yQdW",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tsPqY8NyZ8sJbkdS-"
+									},
+									"name": "Fur",
+									"reference": "B101",
+									"tags": [
+										"Exotic",
+										"Perk",
+										"Physical"
+									],
+									"base_points": 1,
+									"calc": {
+										"points": 1
+									}
+								},
+								{
+									"id": "t2T70dzUGJY3qR10O",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tK9Ov0WtlrhnJFy5n"
+									},
+									"name": "Sharp Teeth",
+									"reference": "B91",
+									"tags": [
+										"Exotic",
+										"Perk",
+										"Physical"
+									],
+									"modifiers": [
+										{
+											"id": "mWphh5-SOdgeBMfS1",
+											"name": "Provided by Vampiric Bite",
+											"reference": "B96",
+											"cost": -1,
+											"cost_type": "points",
+											"disabled": true
+										}
+									],
+									"base_points": 1,
+									"weapons": [
+										{
+											"id": "wq5ZTqXxqiIlWTrwv",
+											"damage": {
+												"type": "cut",
+												"st": "thr",
+												"base": "-1"
+											},
+											"usage": "Bite",
+											"reach": "C",
+											"defaults": [
+												{
+													"type": "skill",
+													"name": "Brawling"
+												},
+												{
+													"type": "dx"
+												}
+											],
+											"calc": {
+												"damage": "thr-1 cut"
+											}
+										}
+									],
+									"calc": {
+										"points": 1
+									}
+								},
+								{
+									"id": "ttKUTQhZHBsaOszQR",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t_ZUyO0Xhmi2p0Vku"
+									},
+									"name": "Unnatural Features (@Description@)",
+									"reference": "B22",
+									"tags": [
+										"Disadvantage",
+										"Physical"
+									],
+									"replacements": {
+										"Description": "Lupine face, ears and bushy tail"
+									},
+									"points_per_level": -1,
+									"features": [
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "disguise"
+											},
+											"amount": -1,
+											"per_level": true
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "shadowing"
+											},
+											"amount": -1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 2,
+									"calc": {
+										"points": -2
+									}
+								}
+							],
+							"calc": {
+								"points": 0
+							}
+						}
+					],
+					"calc": {
+						"points": -45
+					}
+				}
+			],
+			"calc": {
+				"points": 23
+			}
+		}
+	]
+}

--- a/Library/Bio-Tech/Races/Selkie.gct
+++ b/Library/Bio-Tech/Races/Selkie.gct
@@ -1,0 +1,801 @@
+{
+	"version": 5,
+	"id": "BlfSDa-8abVMUHBms",
+	"traits": [
+		{
+			"id": "TsQRGmXpXb7-2mVfu",
+			"name": "Selkie",
+			"reference": "BT71",
+			"local_notes": "TL9. $107000. LC3.",
+			"tags": [
+				"Race"
+			],
+			"container_type": "ancestry",
+			"children": [
+				{
+					"id": "t8S2I9sbf8bc0pmBR",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tsIfS0jZqdshsDFOM"
+					},
+					"name": "Extra Fatigue Points",
+					"reference": "B16",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"points_per_level": 3,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "fp",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 3,
+					"calc": {
+						"points": 9
+					}
+				},
+				{
+					"id": "t9rj3trlhaOPLTbjt",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tS-7-nKXlxWatBXhg"
+					},
+					"name": "Amphibious",
+					"reference": "B40,P42",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"base_points": 10,
+					"calc": {
+						"points": 10
+					}
+				},
+				{
+					"id": "tQKLvfp1_SqLsVVX2",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tGjjVtxav9KsrG7Wx"
+					},
+					"name": "Combat Reflexes",
+					"reference": "B43",
+					"local_notes": "Never freeze",
+					"tags": [
+						"Advantage",
+						"Mental"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Enhanced Time Sense"
+								}
+							}
+						]
+					},
+					"base_points": 15,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "starts_with",
+								"qualifier": "fast-draw"
+							},
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "dodge",
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "parry",
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "block",
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "fright_check",
+							"amount": 2
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "on all IQ rolls to wake up or to recover from surprise or mental stun",
+							"amount": 6
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to initiative rolls for your side (+2 if you are the leader)",
+							"amount": 1
+						}
+					],
+					"calc": {
+						"points": 15
+					}
+				},
+				{
+					"id": "t1W_nLBOCu7lIYb3-",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tUX_zxoB4sWyeNpHi"
+					},
+					"name": "Doesn't Breathe",
+					"reference": "B49",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mV4BzH8Hy0PzQ1UCf",
+							"name": "Gills",
+							"reference": "B49",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "mUyHV8-soy5eAJQlk",
+							"name": "Gills",
+							"reference": "B49",
+							"local_notes": "Suffocates in air",
+							"cost": -20,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mH0p-YWfUa-t2DQBV",
+							"name": "Oxygen Absorption",
+							"reference": "B49",
+							"cost": -25,
+							"disabled": true
+						},
+						{
+							"id": "mNRT-bav_9sh_UxiE",
+							"name": "Oxygen Storage",
+							"reference": "B49",
+							"local_notes": "Can hold breath 25 times as long as normal",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "m8levACMZCP7FbBWw",
+							"name": "Oxygen Storage",
+							"reference": "B49",
+							"local_notes": "Can hold breath 50 times as long as normal",
+							"cost": -40,
+							"disabled": true
+						},
+						{
+							"id": "mup6nurbSHaNJo8To",
+							"name": "Oxygen Storage",
+							"reference": "B49",
+							"local_notes": "Can hold breath 100 times as long as normal",
+							"cost": -30
+						},
+						{
+							"id": "mZ-gH2FkCnWxnd_6j",
+							"name": "Oxygen Storage",
+							"reference": "B49",
+							"local_notes": "Can hold breath 200 times as long as normal",
+							"cost": -20,
+							"disabled": true
+						},
+						{
+							"id": "m3g22YV44AIt7rA58",
+							"name": "Oxygen Storage",
+							"reference": "B49",
+							"local_notes": "Can hold breath 300 times as long as normal",
+							"cost": -10,
+							"disabled": true
+						},
+						{
+							"id": "mcyY5FPf19d1ehs15",
+							"name": "Oxygen Combustion",
+							"reference": "B49",
+							"cost": -50,
+							"disabled": true
+						}
+					],
+					"base_points": 20,
+					"calc": {
+						"points": 14
+					}
+				},
+				{
+					"id": "tJNLP3-fmZr11LReP",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tWNGzCluuu3S1L8jv"
+					},
+					"name": "Nictitating Membrane",
+					"reference": "B71",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"points_per_level": 1,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "to all HT rolls concerned with eye damage",
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "dr_bonus",
+							"locations": [
+								"eye"
+							],
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 1
+					}
+				},
+				{
+					"id": "ttwF2jL-th2B2qpQo",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tAZ2CavSLHdVMI5HJ"
+					},
+					"name": "Pressure Support",
+					"reference": "B77",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"points_per_level": 5,
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 5
+					}
+				},
+				{
+					"id": "t_sSR8jKl4BNT_KQm",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tJTfFdHM7YI5IZR7I"
+					},
+					"name": "Resistant",
+					"reference": "B81,P71,MA47",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"replacements": {
+						"Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.": "Disease"
+					},
+					"modifiers": [
+						{
+							"id": "mbB21C94i2K-1iR6Z",
+							"name": "@Very Common: Metabolic Hazards, etc.@",
+							"reference": "B80",
+							"cost": 30,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mXsVQelsh9eyxlbP6",
+							"name": "@Common: Poison, Sickness, etc.@",
+							"reference": "B81",
+							"cost": 15,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mpJ5JfXl6rY00R8Eb",
+							"name": "@Occasional: Disease, Ingested Poison, etc.@",
+							"reference": "B81",
+							"cost": 10,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mz5rpv_bu30LRJvmW",
+							"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+							"reference": "B81",
+							"cost": 5,
+							"cost_type": "points"
+						},
+						{
+							"id": "m3w3G6EUbCw-O_crM",
+							"name": "Immunity",
+							"reference": "B81",
+							"cost": 1,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "mqvYUw1WCX8wS2nI8",
+							"name": "+8 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.5,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "mKWPEBH4j8FZFWr_F",
+							"name": "+3 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.33,
+							"cost_type": "multiplier"
+						}
+					],
+					"round_down": true,
+					"calc": {
+						"points": 1
+					}
+				},
+				{
+					"id": "tlJODz5COnR0C9nTb",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "touwUIFalnae02BUl"
+					},
+					"name": "Temperature Tolerance",
+					"reference": "B93",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"points_per_level": 1,
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 1
+					}
+				},
+				{
+					"id": "tcpI8Z2arxOMWPLVF",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t_ZUyO0Xhmi2p0Vku"
+					},
+					"name": "Unnatural Features (@Description@)",
+					"reference": "B22",
+					"tags": [
+						"Disadvantage",
+						"Physical"
+					],
+					"replacements": {
+						"Description": "Webbed fingers and toes"
+					},
+					"points_per_level": -1,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "disguise"
+							},
+							"amount": -1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "shadowing"
+							},
+							"amount": -1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": -1
+					}
+				},
+				{
+					"id": "TDtbjD1z3mdLUyGlc",
+					"name": "Optionally, add one",
+					"template_picker": {
+						"type": "count",
+						"qualifier": {
+							"compare": "at_most",
+							"qualifier": 1
+						}
+					},
+					"children": [
+						{
+							"id": "TzErJEAm7fdQEUK_z",
+							"name": "Selkie Bioroid",
+							"local_notes": "-$35000. LC3.",
+							"children": [
+								{
+									"id": "TKNyZqeJE4FyfuGOm",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Bio-Tech/Bio-Tech Traits.adq",
+										"id": "TluHkPSI8BnDWWEZo"
+									},
+									"name": "Bioroid",
+									"reference": "BT214",
+									"container_type": "meta_trait",
+									"children": [
+										{
+											"id": "tTWRHZGwo8acU2x6w",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Bio-Tech/Bio-Tech Traits.adq",
+												"id": "tAgMr2EzmeXfC7Tkg"
+											},
+											"name": "Early Maturation",
+											"reference": "BT212",
+											"local_notes": "may be level 3-5",
+											"tags": [
+												"Feature"
+											],
+											"can_level": true,
+											"levels": 3,
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "ta5hiZJsijKqBKiv2",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Template Toolkit/Template Toolkit 2 - Races/Template Toolkit 2 - Races Traits.adq",
+												"id": "tQY4rjF8t2sAPM9xv"
+											},
+											"name": "Sterile",
+											"reference": "TT2:12",
+											"tags": [
+												"Feature",
+												"Physical"
+											],
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "ttFELPn4rHK-SAp9S",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tEYEuzMtxSsWCG7uW"
+											},
+											"name": "Unusual Biochemistry",
+											"reference": "B160",
+											"tags": [
+												"Disadvantage",
+												"Physical"
+											],
+											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										}
+									],
+									"calc": {
+										"points": -5
+									}
+								},
+								{
+									"id": "tFtWxxfIdNB4G1kPo",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t9Ayzq0-Ain8oiIM8"
+									},
+									"name": "Self-Destruct",
+									"reference": "B153",
+									"tags": [
+										"Disadvantage",
+										"Exotic",
+										"Physical"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "starts_with",
+													"qualifier": "terminally ill"
+												}
+											}
+										]
+									},
+									"base_points": -10,
+									"calc": {
+										"points": -10
+									}
+								},
+								{
+									"id": "tOvbTGyTzC8X0oQhF",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t9nyvI3uvjJi5aqF5"
+									},
+									"name": "Short Lifespan",
+									"reference": "B154",
+									"tags": [
+										"Disadvantage",
+										"Exotic",
+										"Physical"
+									],
+									"points_per_level": -10,
+									"can_level": true,
+									"levels": 2,
+									"calc": {
+										"points": -20
+									}
+								}
+							],
+							"calc": {
+								"points": -35
+							}
+						},
+						{
+							"id": "THYmsYoeDCdtUl-D2",
+							"name": "Selkie Chimera",
+							"local_notes": "$-25000. LC3.",
+							"children": [
+								{
+									"id": "t-_cT-5QzrcNZQl1K",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tK9Ov0WtlrhnJFy5n"
+									},
+									"name": "Sharp Teeth",
+									"reference": "B91",
+									"tags": [
+										"Exotic",
+										"Perk",
+										"Physical"
+									],
+									"modifiers": [
+										{
+											"id": "mIGGSdRs34hLTJtYL",
+											"name": "Provided by Vampiric Bite",
+											"reference": "B96",
+											"cost": -1,
+											"cost_type": "points",
+											"disabled": true
+										}
+									],
+									"base_points": 1,
+									"weapons": [
+										{
+											"id": "wsvDGnM-5plw6H42D",
+											"damage": {
+												"type": "cut",
+												"st": "thr",
+												"base": "-1"
+											},
+											"usage": "Bite",
+											"reach": "C",
+											"defaults": [
+												{
+													"type": "skill",
+													"name": "Brawling"
+												},
+												{
+													"type": "dx"
+												}
+											],
+											"calc": {
+												"damage": "thr-1 cut"
+											}
+										}
+									],
+									"calc": {
+										"points": 1
+									}
+								},
+								{
+									"id": "TSzRf2kGeraFi3F-7",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Bio-Tech/Bio-Tech Traits.adq",
+										"id": "To3AVoJByLMnwXPPz"
+									},
+									"name": "Chimera",
+									"reference": "BT214",
+									"container_type": "meta_trait",
+									"children": [
+										{
+											"id": "tHCo5pnSzPQgmY6x3",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t8duh7FJvBdSs4NOb"
+											},
+											"name": "Restricted Diet (@Food@)",
+											"reference": "B151",
+											"tags": [
+												"Disadvantage",
+												"Physical"
+											],
+											"replacements": {
+												"Food": "Fresh Meat"
+											},
+											"modifiers": [
+												{
+													"id": "m5MHHmqE4GdsHn_kc",
+													"name": "Substitution",
+													"reference": "B151",
+													"cost": -50
+												},
+												{
+													"id": "m1yUdBsZA99SG4u_u",
+													"name": "Very Common",
+													"reference": "B151",
+													"cost": -10,
+													"cost_type": "points"
+												},
+												{
+													"id": "m7T2cku27lvBt-D0g",
+													"name": "Common",
+													"reference": "B151",
+													"cost": -20,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mmg_1d0NudKdQrBvF",
+													"name": "Occasional",
+													"reference": "B151",
+													"cost": -30,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "m9jgTImlqqbRSYMJP",
+													"name": "Rare",
+													"reference": "B151",
+													"cost": -40,
+													"cost_type": "points",
+													"disabled": true
+												}
+											],
+											"calc": {
+												"points": -5
+											}
+										},
+										{
+											"id": "t78mNJnXryYLhS8aR",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Template Toolkit/Template Toolkit 2 - Races/Template Toolkit 2 - Races Traits.adq",
+												"id": "tQY4rjF8t2sAPM9xv"
+											},
+											"name": "Sterile",
+											"reference": "TT2:12",
+											"tags": [
+												"Feature",
+												"Physical"
+											],
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "tiXR8d44Fy9PFfxud",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tEYEuzMtxSsWCG7uW"
+											},
+											"name": "Unusual Biochemistry",
+											"reference": "B160",
+											"tags": [
+												"Disadvantage",
+												"Physical"
+											],
+											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										}
+									],
+									"calc": {
+										"points": -10
+									}
+								},
+								{
+									"id": "tt0jmJFhlhlM-6JEt",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t_ZUyO0Xhmi2p0Vku"
+									},
+									"name": "Unnatural Features (@Description@)",
+									"reference": "B22",
+									"tags": [
+										"Disadvantage",
+										"Physical"
+									],
+									"replacements": {
+										"Description": "Seal-like face"
+									},
+									"points_per_level": -1,
+									"features": [
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "disguise"
+											},
+											"amount": -1,
+											"per_level": true
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "shadowing"
+											},
+											"amount": -1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": -1
+									}
+								}
+							],
+							"calc": {
+								"points": -10
+							}
+						}
+					],
+					"calc": {
+						"points": -45
+					}
+				}
+			],
+			"calc": {
+				"points": 10
+			}
+		}
+	]
+}

--- a/Library/Bio-Tech/Races/Spacer.gct
+++ b/Library/Bio-Tech/Races/Spacer.gct
@@ -1,0 +1,469 @@
+{
+	"version": 5,
+	"id": "BJxnJ9fsGokJN-Wl9",
+	"traits": [
+		{
+			"id": "T9qCKEbRt6Y99mGxy",
+			"name": "Spacer",
+			"reference": "BT71",
+			"local_notes": "TL9. $55000. LC3.",
+			"tags": [
+				"Race"
+			],
+			"container_type": "ancestry",
+			"children": [
+				{
+					"id": "tnBEqM5xbLH1K0_e2",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "thI3hK3riuknUwkHF"
+					},
+					"name": "Decreased Strength",
+					"reference": "B14",
+					"tags": [
+						"Attribute",
+						"Disadvantage",
+						"Physical"
+					],
+					"points_per_level": -10,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "st",
+							"amount": -1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 2,
+					"calc": {
+						"points": -20
+					}
+				},
+				{
+					"id": "tW8Fvy0Vsu5Z1tuaS",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tGWOSEE6SmBHACE6Y"
+					},
+					"name": "Increased Dexterity",
+					"reference": "B15",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mn6NC73wixsxPFKdb",
+							"name": "No Fine Manipulators",
+							"cost": -40,
+							"disabled": true
+						}
+					],
+					"points_per_level": 20,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "dx",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 20
+					}
+				},
+				{
+					"id": "TlheNo7VCDx4H9kaN",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "TyRzqRLDFKZJZiCB_"
+					},
+					"name": "Prehensile Toes",
+					"reference": "BT51",
+					"local_notes": "TL9",
+					"container_type": "meta_trait",
+					"children": [
+						{
+							"id": "tXofxGl6zfYuUa-qw",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tkCi-pV0exqSyPhyv"
+							},
+							"name": "Extra Arm",
+							"reference": "B53",
+							"tags": [
+								"Advantage",
+								"Exotic",
+								"Physical"
+							],
+							"modifiers": [
+								{
+									"id": "mf-HR8oyEF41y_GUr",
+									"name": "Extra-Flexible",
+									"reference": "B53",
+									"cost": 50,
+									"disabled": true
+								},
+								{
+									"id": "mp7dLa1gPLnCEMiyB",
+									"name": "Long",
+									"reference": "B53",
+									"cost": 100,
+									"levels": 1,
+									"disabled": true
+								},
+								{
+									"id": "moNn7Bx21EdqZfXgO",
+									"name": "Foot Manipulators",
+									"reference": "B53",
+									"cost": -30
+								},
+								{
+									"id": "mZjlkZrRsbT0NaH_c",
+									"name": "No Physical Attack",
+									"reference": "B53",
+									"cost": -50,
+									"disabled": true
+								},
+								{
+									"id": "mXg0KGnaVuY60bzMH",
+									"name": "Short",
+									"reference": "B53",
+									"cost": -50
+								},
+								{
+									"id": "mMSUwgNNWWgUsGk_L",
+									"name": "Weak",
+									"reference": "B53",
+									"local_notes": "Half body ST",
+									"cost": -25,
+									"disabled": true
+								},
+								{
+									"id": "mmIFRZokYXrIU3pLP",
+									"name": "Weak",
+									"reference": "B53",
+									"local_notes": "Quarter body ST",
+									"cost": -50,
+									"disabled": true
+								},
+								{
+									"id": "mKIuwLxVPKu1vPyeX",
+									"name": "Weapon Mount",
+									"reference": "B53",
+									"cost": -80,
+									"disabled": true
+								},
+								{
+									"id": "mZdDpyuZ8J-XCx-Qv",
+									"name": "No Grasping Hand",
+									"reference": "MATG28",
+									"cost": -40,
+									"disabled": true
+								}
+							],
+							"points_per_level": 10,
+							"can_level": true,
+							"levels": 2,
+							"calc": {
+								"points": 4
+							}
+						}
+					],
+					"calc": {
+						"points": 4
+					}
+				},
+				{
+					"id": "tq8SGMC5iQagc7FtE",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tEyfe8xc70W3xpJ0z"
+					},
+					"name": "Radiation Tolerance",
+					"reference": "B79,P70",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mScvZtEuGrjzzhrDZ",
+							"name": "Extended",
+							"reference": "P70",
+							"local_notes": "@Type@",
+							"cost": 30,
+							"disabled": true
+						},
+						{
+							"id": "mS4rus732qPDTyMzv",
+							"name": "PF: 2",
+							"reference": "B79",
+							"cost": 5,
+							"cost_type": "points"
+						},
+						{
+							"id": "mYMfBOJY0sWHP7N42",
+							"name": "PF: 5",
+							"reference": "B79",
+							"cost": 10,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mWrNCcFrYvarLW1Fs",
+							"name": "PF: 10",
+							"reference": "B79",
+							"cost": 15,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "m3elQrb7-FnCfTi7v",
+							"name": "PF: 20",
+							"reference": "B79",
+							"cost": 20,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "me2Rlfhe1B9SvGbys",
+							"name": "PF: 50",
+							"reference": "B79",
+							"cost": 25,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mlwRPqHBQPJoTPIEj",
+							"name": "PF: 100",
+							"reference": "B79",
+							"cost": 30,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mrOxjL0VLxgFo1Gn1",
+							"name": "PF: 200",
+							"reference": "B79",
+							"cost": 35,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mJ0AEdkkRI0Xl8Zbm",
+							"name": "PF: 500",
+							"reference": "B79",
+							"cost": 40,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "m9Of_DQUr4RqH4Ffd",
+							"name": "PF: 1000",
+							"reference": "B79",
+							"cost": 45,
+							"cost_type": "points",
+							"disabled": true
+						}
+					],
+					"calc": {
+						"points": 5
+					}
+				},
+				{
+					"id": "tXKD88e6s-6Z20022",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "tcpWN_ZW2kBHtFd_-"
+					},
+					"name": "No Degeneration in Zero-G",
+					"reference": "BT211",
+					"tags": [
+						"Perk"
+					],
+					"base_points": 1,
+					"calc": {
+						"points": 1
+					}
+				},
+				{
+					"id": "tk0NHOCybMMfuS449",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "taEdO2Q-RgdH-CiHq"
+					},
+					"name": "Skinny",
+					"reference": "B18",
+					"tags": [
+						"Disadvantage",
+						"Physical"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "attribute_prereq",
+								"has": true,
+								"qualifier": {
+									"compare": "at_most",
+									"qualifier": 14
+								},
+								"which": "ht"
+							}
+						]
+					},
+					"base_points": -5,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "disguise"
+							},
+							"amount": -2
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "shadowing"
+							},
+							"amount": -2
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to ST vs. knockback",
+							"amount": -2
+						}
+					],
+					"calc": {
+						"points": -5
+					}
+				},
+				{
+					"id": "T1zN7Lny5aisKQJsh",
+					"name": "Optionally, add",
+					"template_picker": {
+						"type": "count"
+					},
+					"children": [
+						{
+							"id": "T0ktBBj6hCrnABMIC",
+							"name": "Bioroid Spacer",
+							"reference": "BT71",
+							"local_notes": "$50000. LC3.",
+							"tags": [
+								"Race"
+							],
+							"container_type": "ancestry",
+							"children": [
+								{
+									"id": "TzPYRFaZDzRvxQuPm",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Bio-Tech/Bio-Tech Traits.adq",
+										"id": "TluHkPSI8BnDWWEZo"
+									},
+									"name": "Bioroid",
+									"reference": "BT214",
+									"container_type": "meta_trait",
+									"children": [
+										{
+											"id": "trEcc8yOXkXmtekz6",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Bio-Tech/Bio-Tech Traits.adq",
+												"id": "tAgMr2EzmeXfC7Tkg"
+											},
+											"name": "Early Maturation",
+											"reference": "BT212",
+											"local_notes": "may be level 3-5",
+											"tags": [
+												"Feature"
+											],
+											"can_level": true,
+											"levels": 3,
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "tWOVXpyyeIcChaUhE",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Template Toolkit/Template Toolkit 2 - Races/Template Toolkit 2 - Races Traits.adq",
+												"id": "tQY4rjF8t2sAPM9xv"
+											},
+											"name": "Sterile",
+											"reference": "TT2:12",
+											"tags": [
+												"Feature",
+												"Physical"
+											],
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "tiVaziH6xUFg1-YMn",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tEYEuzMtxSsWCG7uW"
+											},
+											"name": "Unusual Biochemistry",
+											"reference": "B160",
+											"tags": [
+												"Disadvantage",
+												"Physical"
+											],
+											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										}
+									],
+									"calc": {
+										"points": -5
+									}
+								}
+							],
+							"calc": {
+								"points": -5
+							}
+						}
+					],
+					"calc": {
+						"points": -5
+					}
+				}
+			],
+			"calc": {
+				"points": 0
+			}
+		}
+	],
+	"notes": [
+		{
+			"id": "nZ9dkvbRw1IIEwdzX",
+			"markdown": "Home gravity 0G. Increased height by 3 feet over the norm of the lowered strength. Weight is 50% of normal.",
+			"reference": "BT71"
+		}
+	]
+}

--- a/Library/Bio-Tech/Races/Spartan.gct
+++ b/Library/Bio-Tech/Races/Spartan.gct
@@ -1,0 +1,407 @@
+{
+	"version": 5,
+	"id": "BRcN85jopSV0Ztq1J",
+	"traits": [
+		{
+			"id": "TAJM6wGw2ov6p927z",
+			"name": "Spartan",
+			"reference": "BT74",
+			"local_notes": "TL10. $96000. LC3.",
+			"tags": [
+				"Race"
+			],
+			"container_type": "ancestry",
+			"children": [
+				{
+					"id": "tBdXpEoVjnNUlJdr3",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tqha9GlDBU9P-Wg-6"
+					},
+					"name": "Increased Strength",
+					"reference": "B14",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "m0GHTQQQ9PD5nbzgy",
+							"name": "No Fine Manipulators",
+							"reference": "B15",
+							"cost": -40,
+							"disabled": true
+						},
+						{
+							"id": "mfFdNM93PyqBRWEVW",
+							"name": "Size",
+							"reference": "B15",
+							"cost": -10,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mYIYzuR7FoCt6x83t",
+							"name": "Super-Effort",
+							"reference": "SU24",
+							"cost": 300,
+							"disabled": true
+						}
+					],
+					"points_per_level": 10,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "st",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 3,
+					"calc": {
+						"points": 30
+					}
+				},
+				{
+					"id": "tADkL2nAq-GTLFZoo",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t6krAE1uo6M0oDJFL"
+					},
+					"name": "Lifting ST",
+					"reference": "B65,P58",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mDSWC5mzdIcbmy3MP",
+							"name": "No Fine Manipulators",
+							"reference": "B15",
+							"cost": -40,
+							"disabled": true
+						},
+						{
+							"id": "muO6KK3UYbd_SVYWr",
+							"name": "Size",
+							"reference": "B15",
+							"cost": -10,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "m9fR_AKpv-3rj-kWy",
+							"name": "Super-Effort",
+							"reference": "P58",
+							"cost": 400,
+							"disabled": true
+						},
+						{
+							"id": "m715G0yDizUmD3E2_",
+							"name": "Know Your Own Strength Variant Price",
+							"reference": "PY83:18",
+							"cost": 4,
+							"cost_type": "points",
+							"affects": "levels_only",
+							"disabled": true
+						},
+						{
+							"id": "mLYCpGra1ch4ue4gQ",
+							"name": "@Limb@ Grip ST",
+							"reference": "MATG28",
+							"cost": -70,
+							"disabled": true
+						},
+						{
+							"id": "m0QsQbsaIVNhOl9iw",
+							"name": "Bite ST",
+							"reference": "MATG28",
+							"cost": -70,
+							"disabled": true
+						}
+					],
+					"points_per_level": 3,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"limitation": "lifting_only",
+							"attribute": "st",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 2,
+					"calc": {
+						"points": 6
+					}
+				},
+				{
+					"id": "t2XCnHG0zB57ly3as",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tGjjVtxav9KsrG7Wx"
+					},
+					"name": "Combat Reflexes",
+					"reference": "B43",
+					"local_notes": "Never freeze",
+					"tags": [
+						"Advantage",
+						"Mental"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Enhanced Time Sense"
+								}
+							}
+						]
+					},
+					"base_points": 15,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "starts_with",
+								"qualifier": "fast-draw"
+							},
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "dodge",
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "parry",
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "block",
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "fright_check",
+							"amount": 2
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "on all IQ rolls to wake up or to recover from surprise or mental stun",
+							"amount": 6
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to initiative rolls for your side (+2 if you are the leader)",
+							"amount": 1
+						}
+					],
+					"calc": {
+						"points": 15
+					}
+				},
+				{
+					"id": "t-OyHJlXduesPYWhD",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "teRggYn926_I1YeWO"
+					},
+					"name": "High Pain Threshold",
+					"reference": "B59",
+					"local_notes": "Never suffer shock penalties when injured",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"base_points": 10,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "on all HT rolls to avoid knockdown and stunning",
+							"amount": 3
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to resist torture",
+							"amount": 3
+						}
+					],
+					"calc": {
+						"points": 10
+					}
+				},
+				{
+					"id": "TtAUJnlCcQGyB1Cz-",
+					"name": "Optionally, choose",
+					"template_picker": {
+						"type": "count"
+					},
+					"children": [
+						{
+							"id": "Tgcc0GcSDAPqVyAuA",
+							"name": "Spartan Bioroid",
+							"reference": "BT74",
+							"local_notes": "-$45000. LC2.",
+							"tags": [
+								"Race"
+							],
+							"container_type": "ancestry",
+							"children": [
+								{
+									"id": "TCipMb7OerT4NgCwI",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Bio-Tech/Bio-Tech Traits.adq",
+										"id": "TluHkPSI8BnDWWEZo"
+									},
+									"name": "Bioroid",
+									"reference": "BT214",
+									"container_type": "meta_trait",
+									"children": [
+										{
+											"id": "t4eNL2KMXDeGkn5mH",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Bio-Tech/Bio-Tech Traits.adq",
+												"id": "tAgMr2EzmeXfC7Tkg"
+											},
+											"name": "Early Maturation",
+											"reference": "BT212",
+											"local_notes": "may be level 3-5",
+											"tags": [
+												"Feature"
+											],
+											"can_level": true,
+											"levels": 3,
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "tmKFsSsOOfUEdyeOA",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Template Toolkit/Template Toolkit 2 - Races/Template Toolkit 2 - Races Traits.adq",
+												"id": "tQY4rjF8t2sAPM9xv"
+											},
+											"name": "Sterile",
+											"reference": "TT2:12",
+											"tags": [
+												"Feature",
+												"Physical"
+											],
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "tQBSimXkTkH6TiT2W",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tEYEuzMtxSsWCG7uW"
+											},
+											"name": "Unusual Biochemistry",
+											"reference": "B160",
+											"tags": [
+												"Disadvantage",
+												"Physical"
+											],
+											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										}
+									],
+									"calc": {
+										"points": -5
+									}
+								},
+								{
+									"id": "tVurI9loDKAMRiRFF",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t9Ayzq0-Ain8oiIM8"
+									},
+									"name": "Self-Destruct",
+									"reference": "B153",
+									"tags": [
+										"Disadvantage",
+										"Exotic",
+										"Physical"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "starts_with",
+													"qualifier": "terminally ill"
+												}
+											}
+										]
+									},
+									"base_points": -10,
+									"calc": {
+										"points": -10
+									}
+								},
+								{
+									"id": "tSZDKJGmm7oNWENLU",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t9nyvI3uvjJi5aqF5"
+									},
+									"name": "Short Lifespan",
+									"reference": "B154",
+									"tags": [
+										"Disadvantage",
+										"Exotic",
+										"Physical"
+									],
+									"points_per_level": -10,
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": -10
+									}
+								}
+							],
+							"calc": {
+								"points": -25
+							}
+						}
+					],
+					"calc": {
+						"points": -25
+					}
+				}
+			],
+			"calc": {
+				"points": 36
+			}
+		}
+	]
+}

--- a/Library/Bio-Tech/Races/Tek-rat.gct
+++ b/Library/Bio-Tech/Races/Tek-rat.gct
@@ -1,0 +1,919 @@
+{
+	"version": 5,
+	"id": "BgiOoav9TL2YZIWmy",
+	"traits": [
+		{
+			"id": "TfV6NYCpa2bZzuskW",
+			"name": "Tek-rat",
+			"reference": "BT74",
+			"local_notes": "TL10. $50000. LC3.",
+			"tags": [
+				"Race"
+			],
+			"container_type": "ancestry",
+			"children": [
+				{
+					"id": "t3MFCpag27vBW8ZL0",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t9JmDbmYS-RXMN3vt"
+					},
+					"name": "Decreased Size Modifier",
+					"reference": "B19",
+					"tags": [
+						"Attribute",
+						"Disadvantage",
+						"Physical"
+					],
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "sm",
+							"amount": -1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 2,
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "tSyB8Ii7kM62I4fv8",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "thI3hK3riuknUwkHF"
+					},
+					"name": "Decreased Strength",
+					"reference": "B14",
+					"tags": [
+						"Attribute",
+						"Disadvantage",
+						"Physical"
+					],
+					"points_per_level": -10,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "st",
+							"amount": -1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 6,
+					"calc": {
+						"points": -60
+					}
+				},
+				{
+					"id": "tgmweBVlZ5AnuW6fC",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tGWOSEE6SmBHACE6Y"
+					},
+					"name": "Increased Dexterity",
+					"reference": "B15",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mP1SkUSUoTnQhX11G",
+							"name": "No Fine Manipulators",
+							"cost": -40,
+							"disabled": true
+						}
+					],
+					"points_per_level": 20,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "dx",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 20
+					}
+				},
+				{
+					"id": "tSXrp3badJBp4IwWY",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t50ZzyORV0rTiYwnb"
+					},
+					"name": "Decreased Intelligence",
+					"reference": "B15",
+					"tags": [
+						"Attribute",
+						"Disadvantage",
+						"Mental"
+					],
+					"points_per_level": -20,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "iq",
+							"amount": -1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": -20
+					}
+				},
+				{
+					"id": "tnMuKuZKOdS6AQ4UP",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tWoMSz-IMAxDJo8rh"
+					},
+					"name": "Extra Hit Points",
+					"reference": "B16",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mM-AmtGE3gwRW7HEs",
+							"name": "Size",
+							"cost": -10,
+							"levels": 1,
+							"disabled": true
+						}
+					],
+					"points_per_level": 2,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "hp",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 2
+					}
+				},
+				{
+					"id": "tsZWKlMYr95I1dYN5",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tM6z7Mx6e2V4VvUR4"
+					},
+					"name": "Absolute Direction",
+					"reference": "B34",
+					"tags": [
+						"Advantage",
+						"Mental",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mIWoBvcF1U32tBfhy",
+							"name": "Requires signal",
+							"reference": "B34",
+							"cost": -20,
+							"disabled": true
+						},
+						{
+							"id": "mq6s2qXcvBWpfy0Cr",
+							"name": "3D Spatial Sense",
+							"reference": "B34",
+							"cost": 5,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "starts_with",
+										"qualifier": "piloting"
+									},
+									"amount": 1
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "aerobatics"
+									},
+									"amount": 2
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "free fall"
+									},
+									"amount": 2
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "navigation"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "hyperspace"
+									},
+									"amount": 2
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "navigation"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "space"
+									},
+									"amount": 2
+								}
+							]
+						}
+					],
+					"base_points": 5,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "body sense"
+							},
+							"amount": 3
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "navigation"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "air"
+							},
+							"amount": 3
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "navigation"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "land"
+							},
+							"amount": 3
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "navigation"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "sea"
+							},
+							"amount": 3
+						}
+					],
+					"calc": {
+						"points": 10
+					}
+				},
+				{
+					"id": "tq2BcDOB21GBLO1ia",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t6XtSYhM7yan5_B73"
+					},
+					"name": "Acute Hearing",
+					"reference": "B35",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"points_per_level": 2,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "hearing",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 2
+					}
+				},
+				{
+					"id": "tAo4hkplratl0lVvN",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tAZ31tXG_HzDmVCRp"
+					},
+					"name": "Acute Taste \u0026 Smell",
+					"reference": "B35",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"points_per_level": 2,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "taste_smell",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 2
+					}
+				},
+				{
+					"id": "tJx5cSk-BMtmhZo5y",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tkCi-pV0exqSyPhyv"
+					},
+					"name": "Extra Arm",
+					"reference": "B53",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mHhBeRin7KmZsX2bx",
+							"name": "Extra-Flexible",
+							"reference": "B53",
+							"cost": 50
+						},
+						{
+							"id": "ma2FYD2eA0KBcgB0c",
+							"name": "Long",
+							"reference": "B53",
+							"cost": 100,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "m1dWsnWl_6FlhmkY1",
+							"name": "Foot Manipulators",
+							"reference": "B53",
+							"cost": -30,
+							"disabled": true
+						},
+						{
+							"id": "m5GPjGd9EWPZSpY9L",
+							"name": "No Physical Attack",
+							"reference": "B53",
+							"cost": -50
+						},
+						{
+							"id": "mTNoervuDmLNMJ4lR",
+							"name": "Short",
+							"reference": "B53",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "mXF6B-oBTMk6uis4l",
+							"name": "Weak",
+							"reference": "B53",
+							"local_notes": "Half body ST",
+							"cost": -25,
+							"disabled": true
+						},
+						{
+							"id": "m0s1JODyC_RLOsNsU",
+							"name": "Weak",
+							"reference": "B53",
+							"local_notes": "Quarter body ST",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "mLpko0I7y3rcnoZvV",
+							"name": "Weapon Mount",
+							"reference": "B53",
+							"cost": -80,
+							"disabled": true
+						},
+						{
+							"id": "mCySvq024hVmerUPI",
+							"name": "No Grasping Hand",
+							"reference": "MATG28",
+							"cost": -40,
+							"disabled": true
+						}
+					],
+					"points_per_level": 10,
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 10
+					}
+				},
+				{
+					"id": "tUvnVdT9WIOfzzMcD",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tsPqY8NyZ8sJbkdS-"
+					},
+					"name": "Fur",
+					"reference": "B101",
+					"tags": [
+						"Exotic",
+						"Perk",
+						"Physical"
+					],
+					"base_points": 1,
+					"calc": {
+						"points": 1
+					}
+				},
+				{
+					"id": "tfFpHfrCxGDXoZA6r",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t7a13kFVl53ZfbkrK"
+					},
+					"name": "Payload (@Load@)",
+					"reference": "B74",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"replacements": {
+						"Load": "0.64 lbs"
+					},
+					"modifiers": [
+						{
+							"id": "mzCPxG0-Sx0eTw9DS",
+							"name": "Exposed",
+							"reference": "B74",
+							"cost": -50,
+							"disabled": true
+						}
+					],
+					"points_per_level": 1,
+					"can_level": true,
+					"levels": 2,
+					"calc": {
+						"points": 2
+					}
+				},
+				{
+					"id": "tUQ-Ko2z4UVVuD96A",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tK9Ov0WtlrhnJFy5n"
+					},
+					"name": "Sharp Teeth",
+					"reference": "B91",
+					"tags": [
+						"Exotic",
+						"Perk",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mE7pxYUCAChIfO5_-",
+							"name": "Provided by Vampiric Bite",
+							"reference": "B96",
+							"cost": -1,
+							"cost_type": "points",
+							"disabled": true
+						}
+					],
+					"base_points": 1,
+					"weapons": [
+						{
+							"id": "w837PBMHFYwNA2x5P",
+							"damage": {
+								"type": "cut",
+								"st": "thr",
+								"base": "-1"
+							},
+							"usage": "Bite",
+							"reach": "C",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": "Brawling"
+								},
+								{
+									"type": "dx"
+								}
+							],
+							"calc": {
+								"damage": "thr-1 cut"
+							}
+						}
+					],
+					"calc": {
+						"points": 1
+					}
+				},
+				{
+					"id": "tc-WIHClTxTTEfrB7",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t_ZUyO0Xhmi2p0Vku"
+					},
+					"name": "Unnatural Features (@Description@)",
+					"reference": "B22",
+					"tags": [
+						"Disadvantage",
+						"Physical"
+					],
+					"replacements": {
+						"Description": "Small rodent-man"
+					},
+					"points_per_level": -1,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "disguise"
+							},
+							"amount": -1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "shadowing"
+							},
+							"amount": -1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 2,
+					"calc": {
+						"points": -2
+					}
+				},
+				{
+					"id": "tEGPvEwt-aYCr0ulw",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "te2vFre2KU0dZrDgd"
+					},
+					"name": "Increased Consumption",
+					"reference": "B139",
+					"tags": [
+						"Disadvantage",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mqVLq1uF-YalIuBuP",
+							"name": "Consumption x2",
+							"reference": "B139",
+							"cost": -10,
+							"cost_type": "points"
+						},
+						{
+							"id": "mmrvd596_H3wr-gNf",
+							"name": "Consumption x4",
+							"reference": "B139",
+							"cost": -20,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mYU1AIe2Ed0gxxOQ0",
+							"name": "Consumption x8",
+							"reference": "B139",
+							"cost": -30,
+							"cost_type": "points",
+							"disabled": true
+						}
+					],
+					"calc": {
+						"points": -10
+					}
+				},
+				{
+					"id": "TrZ4m3bQjVc-2SIOY",
+					"name": "Optionally, choose one",
+					"template_picker": {
+						"type": "count",
+						"qualifier": {
+							"compare": "at_most",
+							"qualifier": 1
+						}
+					},
+					"children": [
+						{
+							"id": "TWheOCLG1x52mGhDE",
+							"name": "Tek-rat Bioroid",
+							"reference": "BT74",
+							"local_notes": "-$14000. LC3.",
+							"tags": [
+								"Race"
+							],
+							"container_type": "ancestry",
+							"children": [
+								{
+									"id": "T9ErroJDNkXww2Doi",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Bio-Tech/Bio-Tech Traits.adq",
+										"id": "TluHkPSI8BnDWWEZo"
+									},
+									"name": "Bioroid",
+									"reference": "BT214",
+									"container_type": "meta_trait",
+									"children": [
+										{
+											"id": "tGZH_JUfEVOKO07Eo",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Bio-Tech/Bio-Tech Traits.adq",
+												"id": "tAgMr2EzmeXfC7Tkg"
+											},
+											"name": "Early Maturation",
+											"reference": "BT212",
+											"local_notes": "may be level 3-5",
+											"tags": [
+												"Feature"
+											],
+											"can_level": true,
+											"levels": 3,
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "ty6mMO54Vn0j_BWY5",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Template Toolkit/Template Toolkit 2 - Races/Template Toolkit 2 - Races Traits.adq",
+												"id": "tQY4rjF8t2sAPM9xv"
+											},
+											"name": "Sterile",
+											"reference": "TT2:12",
+											"tags": [
+												"Feature",
+												"Physical"
+											],
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "tqs01aD39zQzLuv6p",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tEYEuzMtxSsWCG7uW"
+											},
+											"name": "Unusual Biochemistry",
+											"reference": "B160",
+											"tags": [
+												"Disadvantage",
+												"Physical"
+											],
+											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										}
+									],
+									"calc": {
+										"points": -5
+									}
+								},
+								{
+									"id": "tKzkBHHrNufm2Rr7u",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t9Ayzq0-Ain8oiIM8"
+									},
+									"name": "Self-Destruct",
+									"reference": "B153",
+									"tags": [
+										"Disadvantage",
+										"Exotic",
+										"Physical"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "starts_with",
+													"qualifier": "terminally ill"
+												}
+											}
+										]
+									},
+									"base_points": -10,
+									"calc": {
+										"points": -10
+									}
+								}
+							],
+							"calc": {
+								"points": -15
+							}
+						},
+						{
+							"id": "TlQQ3YFqTxWQ5eGoo",
+							"name": "Tek-rat Chimera",
+							"reference": "BT74",
+							"local_notes": "-$14000. LC3.",
+							"tags": [
+								"Race"
+							],
+							"container_type": "ancestry",
+							"children": [
+								{
+									"id": "TJSVuzYCSxWOcSkyj",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Bio-Tech/Bio-Tech Traits.adq",
+										"id": "To3AVoJByLMnwXPPz"
+									},
+									"name": "Chimera",
+									"reference": "BT214",
+									"container_type": "meta_trait",
+									"children": [
+										{
+											"id": "tAxeWtVnpDcWUEJu2",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "t8duh7FJvBdSs4NOb"
+											},
+											"name": "Restricted Diet (@Food@)",
+											"reference": "B151",
+											"tags": [
+												"Disadvantage",
+												"Physical"
+											],
+											"modifiers": [
+												{
+													"id": "m09JxhGv9vbC7mdHq",
+													"name": "Substitution",
+													"reference": "B151",
+													"cost": -50
+												},
+												{
+													"id": "mZlndi1OZ4rteU9KI",
+													"name": "Very Common",
+													"reference": "B151",
+													"cost": -10,
+													"cost_type": "points"
+												},
+												{
+													"id": "mQY4BXC7lZcwVtuFq",
+													"name": "Common",
+													"reference": "B151",
+													"cost": -20,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mp-rHy29qagPhSClo",
+													"name": "Occasional",
+													"reference": "B151",
+													"cost": -30,
+													"cost_type": "points",
+													"disabled": true
+												},
+												{
+													"id": "mp5j1CVa5Yv_P8kGq",
+													"name": "Rare",
+													"reference": "B151",
+													"cost": -40,
+													"cost_type": "points",
+													"disabled": true
+												}
+											],
+											"calc": {
+												"points": -5
+											}
+										},
+										{
+											"id": "txg0KcQztdHeAnDyE",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Template Toolkit/Template Toolkit 2 - Races/Template Toolkit 2 - Races Traits.adq",
+												"id": "tQY4rjF8t2sAPM9xv"
+											},
+											"name": "Sterile",
+											"reference": "TT2:12",
+											"tags": [
+												"Feature",
+												"Physical"
+											],
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "tylixU3FplA6EumNB",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tEYEuzMtxSsWCG7uW"
+											},
+											"name": "Unusual Biochemistry",
+											"reference": "B160",
+											"tags": [
+												"Disadvantage",
+												"Physical"
+											],
+											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										}
+									],
+									"calc": {
+										"points": -10
+									}
+								}
+							],
+							"calc": {
+								"points": -10
+							}
+						}
+					],
+					"calc": {
+						"points": -25
+					}
+				}
+			],
+			"calc": {
+				"points": -67
+			}
+		}
+	],
+	"notes": [
+		{
+			"id": "nRAwejGFcu1430RwF",
+			"markdown": "Size Modifer -2."
+		}
+	]
+}

--- a/Library/Bio-Tech/Races/Tiresia.gct
+++ b/Library/Bio-Tech/Races/Tiresia.gct
@@ -1,0 +1,811 @@
+{
+	"version": 5,
+	"id": "BQnSICRs4LB1kLUoH",
+	"traits": [
+		{
+			"id": "ToCl8EPoJtzrtub6K",
+			"name": "Tiresia",
+			"reference": "BT70",
+			"local_notes": "TL10. $97000. LC3.",
+			"tags": [
+				"Race"
+			],
+			"container_type": "ancestry",
+			"children": [
+				{
+					"id": "tUvaHY_lHFhN0LwzZ",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t1w1RFcFceKR2T9_e"
+					},
+					"name": "Increased Intelligence",
+					"reference": "B15",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Mental"
+					],
+					"points_per_level": 20,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "iq",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 20
+					}
+				},
+				{
+					"id": "ttpUZhhgQv_6dh5Gf",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tVt3SvdGWNchJ8z4o"
+					},
+					"name": "Increased Health",
+					"reference": "B14",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"points_per_level": 10,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "ht",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 10
+					}
+				},
+				{
+					"id": "tggt3a248-oqsT8IE",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tdlCZw4YB4T7QkOnj"
+					},
+					"name": "Appearance",
+					"reference": "B21",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "myfD-DgG6dQnpL6vi",
+							"name": "Attractive",
+							"reference": "B21",
+							"cost": 4,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mxG8O3AAt32YmB1RU",
+							"name": "Average",
+							"reference": "B21",
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "monP_d0Fpqom_1dQj",
+							"name": "Beautiful",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mnsff3UM50X0kho8a",
+							"name": "Beautiful (Androgynous)",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 3
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mCyDpvQjFSoLeuDky",
+							"name": "Beautiful (Impressive)",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 3
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mJ5dzZTOvo_ukxy09",
+							"name": "Handsome",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mVqyYkdm8QeXEupGO",
+							"name": "Handsome (Androgynous)",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 3
+								}
+							]
+						},
+						{
+							"id": "mMNpNv2jB9f09LsPf",
+							"name": "Handsome (Impressive)",
+							"reference": "B21",
+							"cost": 12,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 3
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "m32BdA5sMlDpNervD",
+							"name": "Hideous",
+							"reference": "B21,B202",
+							"cost": -16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Intimidation"
+									},
+									"amount": 2
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "m0YKBPu0WEuRZVRL3",
+							"name": "Horrific",
+							"reference": "B21,B202",
+							"cost": -24,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Intimidation"
+									},
+									"amount": 4
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -6
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mEr4mooHzYDedcGzc",
+							"name": "Impressive",
+							"reference": "B21",
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "myiP3mZkSWE09VXSv",
+							"name": "Monstrous",
+							"reference": "B21,B202",
+							"cost": -20,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Intimidation"
+									},
+									"amount": 3
+								},
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -5
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "muMfKJ8GVb9fv7wbJ",
+							"name": "Off-the-Shelf Looks",
+							"reference": "B21",
+							"local_notes": "Halves the usual reaction bonus - adjust manually",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "mCYC97Bfy_I3l_88t",
+							"name": "Transcendent",
+							"reference": "B21",
+							"cost": 20,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+									"amount": 8
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mX0eDS_UqpM2VYvkc",
+							"name": "Transcendent (Androgynous)",
+							"reference": "B21",
+							"cost": 20,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 5
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "m4DT5-uz1h98Tsm6i",
+							"name": "Transcendent (Impressive)",
+							"reference": "B21",
+							"cost": 20,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 5
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mkEZmWrpniGeGs-cv",
+							"name": "Ugly",
+							"reference": "B21",
+							"cost": -8,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -2
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mYTbRldRteqHMd616",
+							"name": "Unattractive",
+							"reference": "B21",
+							"cost": -4,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": -1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mpLRhS0BEXQqM64ZD",
+							"name": "Universal",
+							"reference": "B21",
+							"cost": 25,
+							"disabled": true
+						},
+						{
+							"id": "mzOm_N_1oE6KSZ6xY",
+							"name": "Very Beautiful",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+									"amount": 6
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mYhAOe7ADrdfXrLCw",
+							"name": "Very Beautiful (Androgynous)",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "moWemjn5uiqPk_2OJ",
+							"name": "Very Beautiful (Impressive)",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mYMcmCqq_iJGh6tN2",
+							"name": "Very Handsome",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from those attracted to members of your sex, +2 from everyone else. Exception: Members of the same sex with reason to dislike you (more than -4 in reaction penalties regardless of bonuses) resent your good looks and react at -2 instead.",
+									"amount": 6
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "m8m-mpO7pF1o78Iyl",
+							"name": "Very Handsome (Androgynous)",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "m_gJKZGeGRLA1hBjK",
+							"name": "Very Handsome (Impressive)",
+							"reference": "B21",
+							"cost": 16,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from others",
+									"amount": 4
+								}
+							],
+							"disabled": true
+						}
+					],
+					"calc": {
+						"points": 12
+					}
+				},
+				{
+					"id": "tBfB8-u2gY_QUXE54",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tud6WHncq1hwuXoxS"
+					},
+					"name": "Hermaphromorph",
+					"reference": "B59",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"replacements": {
+						"Condition": "Not while pregnant"
+					},
+					"modifiers": [
+						{
+							"id": "masbBDjpFKIhAZCSX",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+								"id": "m2IwCpU9KwYmjiSSA"
+							},
+							"name": "Accessibility (@Condition@)",
+							"reference": "B110,P99",
+							"local_notes": "1 point per level",
+							"cost": -1,
+							"levels": 20
+						}
+					],
+					"base_points": 5,
+					"calc": {
+						"points": 4
+					}
+				},
+				{
+					"id": "tCkks2fcJyCR-j1RH",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "tqoZjoMK01Dz00QE5"
+					},
+					"name": "Reproductive Control",
+					"reference": "BT59",
+					"local_notes": "TL9",
+					"base_points": 1,
+					"calc": {
+						"points": 1
+					}
+				},
+				{
+					"id": "teGA5NwtwK0LlfEFY",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "tAxoUhk-hCacq90oj"
+					},
+					"name": "Light Menses",
+					"reference": "BT58",
+					"local_notes": "TL9",
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "tSV7UGfAvTaJ70XkG",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "twlxLezOdicVKFwxJ"
+					},
+					"name": "No Appendix",
+					"reference": "BT46",
+					"local_notes": "TL9",
+					"tags": [
+						"Exotic",
+						"Physical"
+					],
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "tY8et3xaZN4-2cotN",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "tLe1-US7YK9twT2zS"
+					},
+					"name": "Taboo Trait (Genetic Defects)",
+					"reference": "BT65, B261",
+					"local_notes": "TL8; Also prohibits attributes more than 2 below the average for an adult with that template",
+					"tags": [
+						"Exotic",
+						"Mental",
+						"Physical",
+						"Taboo Trait"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Short Attention Span"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Non-Iconographic"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "No Sense of Smell/Taste"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Night Blindness"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Innumerate"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Hemophilia"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Gigantism"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dyslexia"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dwarfism"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Colorblindness"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "starts_with",
+									"qualifier": "Bad Sight"
+								}
+							}
+						]
+					},
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "tAeJzDyAAK5okpd1s",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "tDhx56D50aegwu4w6"
+					},
+					"name": "Taboo Trait (Mental Instability)",
+					"reference": "BT65, B261",
+					"local_notes": "TL9; Also prohibits any Compulsive Behaviour or Phobia worth -10 points or more",
+					"tags": [
+						"Exotic",
+						"Mental",
+						"Taboo Trait"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Pyromania"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Phantom Voices"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Paranoia"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "On the Edge"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Obsession"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Megalomania"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Manic-Depressive"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Lunacy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Low Self-Image"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Kleptomania"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Guilt Complex"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Flashbacks"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Delusion"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "starts_with",
+									"qualifier": "Delusions"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Chronic Depression"
+								}
+							}
+						]
+					},
+					"calc": {
+						"points": 0
+					}
+				}
+			],
+			"calc": {
+				"points": 47
+			}
+		}
+	]
+}

--- a/Library/Bio-Tech/Races/Triton.gct
+++ b/Library/Bio-Tech/Races/Triton.gct
@@ -1,0 +1,711 @@
+{
+	"version": 5,
+	"id": "BdWtKgfUaXrtZ67YF",
+	"traits": [
+		{
+			"id": "TkalvPvFfiFZwJpZs",
+			"name": "Triton",
+			"reference": "BT71",
+			"local_notes": "TL11. $136000. LC3.",
+			"tags": [
+				"Race"
+			],
+			"container_type": "ancestry",
+			"children": [
+				{
+					"id": "tfSd9zhhbylSvzNO7",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tS-7-nKXlxWatBXhg"
+					},
+					"name": "Amphibious",
+					"reference": "B40,P42",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"base_points": 10,
+					"calc": {
+						"points": 10
+					}
+				},
+				{
+					"id": "t_LcaGy2lr_cS6h1z",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tUX_zxoB4sWyeNpHi"
+					},
+					"name": "Doesn't Breathe",
+					"reference": "B49",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mfE2wNhaftL9CR24p",
+							"name": "Gills",
+							"reference": "B49",
+							"cost": -50
+						},
+						{
+							"id": "m7iW_kADQKk6ldUv3",
+							"name": "Gills",
+							"reference": "B49",
+							"local_notes": "Suffocates in air",
+							"cost": -20,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "m9oG7Kr5bE_6RwsEi",
+							"name": "Oxygen Absorption",
+							"reference": "B49",
+							"cost": -25,
+							"disabled": true
+						},
+						{
+							"id": "mNZfp1Z1Cm-TK-9dy",
+							"name": "Oxygen Storage",
+							"reference": "B49",
+							"local_notes": "Can hold breath 25 times as long as normal",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "maAgis_kgs5zggiYM",
+							"name": "Oxygen Storage",
+							"reference": "B49",
+							"local_notes": "Can hold breath 50 times as long as normal",
+							"cost": -40,
+							"disabled": true
+						},
+						{
+							"id": "mTYKBEIouTOJohVkI",
+							"name": "Oxygen Storage",
+							"reference": "B49",
+							"local_notes": "Can hold breath 100 times as long as normal",
+							"cost": -30,
+							"disabled": true
+						},
+						{
+							"id": "mO-EXUx1CGwCYDWTH",
+							"name": "Oxygen Storage",
+							"reference": "B49",
+							"local_notes": "Can hold breath 200 times as long as normal",
+							"cost": -20,
+							"disabled": true
+						},
+						{
+							"id": "mz9sfWAITZ2B4ACX1",
+							"name": "Oxygen Storage",
+							"reference": "B49",
+							"local_notes": "Can hold breath 300 times as long as normal",
+							"cost": -10,
+							"disabled": true
+						},
+						{
+							"id": "ml_M-Nwr1MrhJL9Iw",
+							"name": "Oxygen Combustion",
+							"reference": "B49",
+							"cost": -50,
+							"disabled": true
+						}
+					],
+					"base_points": 20,
+					"calc": {
+						"points": 10
+					}
+				},
+				{
+					"id": "tkV92eXbXRILlpYD8",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tG2tK0QWXPQqFk-rd"
+					},
+					"name": "Enhanced Move (@type@)",
+					"reference": "B52,P49",
+					"local_notes": "Double your normal @type@ Move for each level",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"replacements": {
+						"type": "Water"
+					},
+					"modifiers": [
+						{
+							"id": "mlyxqfeLv0yWZvHE2",
+							"name": "Handling Bonus",
+							"reference": "B52",
+							"cost": 5,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "m5DoDlaAeoQ0LZGR7",
+							"name": "Handling Penalty",
+							"reference": "B52",
+							"cost": -5,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mbON8DWirpMWykZvP",
+							"name": "Newtonian",
+							"reference": "B52",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "mA_0WtJ2bZ18TGxJi",
+							"name": "Road-Bound",
+							"reference": "B52",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "m7n-eb6zFXFeOEZhB",
+							"name": "All-Out",
+							"reference": "P49",
+							"cost": -20,
+							"disabled": true
+						},
+						{
+							"id": "m68fnKRpnAi0HCzOc",
+							"name": "Cosmic",
+							"reference": "SU26",
+							"local_notes": "Instantaneous Acceleration",
+							"cost": 50,
+							"disabled": true
+						},
+						{
+							"id": "mw1YYaTsOhCD7LgCq",
+							"name": "Cosmic",
+							"reference": "SU27",
+							"local_notes": "Complete Maneuverability",
+							"cost": 50,
+							"disabled": true
+						}
+					],
+					"points_per_level": 20,
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 20,
+						"resolved_notes": "Double your normal Water Move for each level"
+					}
+				},
+				{
+					"id": "tM5HputNx68-HEuEj",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tWNGzCluuu3S1L8jv"
+					},
+					"name": "Nictitating Membrane",
+					"reference": "B71",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"points_per_level": 1,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "to all HT rolls concerned with eye damage",
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "dr_bonus",
+							"locations": [
+								"eye"
+							],
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 1
+					}
+				},
+				{
+					"id": "tZv2QhU2S1Se7z81p",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tAZ2CavSLHdVMI5HJ"
+					},
+					"name": "Pressure Support",
+					"reference": "B77",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"points_per_level": 5,
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 5
+					}
+				},
+				{
+					"id": "tAMRfTj0Yvz3CML9Y",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tJTfFdHM7YI5IZR7I"
+					},
+					"name": "Resistant",
+					"reference": "B81,P71,MA47",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"replacements": {
+						"Occasional: Disease, Ingested Poison, etc.": "Disease"
+					},
+					"modifiers": [
+						{
+							"id": "mhbyrf-zjt4REfeuU",
+							"name": "@Very Common: Metabolic Hazards, etc.@",
+							"reference": "B80",
+							"cost": 30,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mIJkzOKZh1jd1iVRx",
+							"name": "@Common: Poison, Sickness, etc.@",
+							"reference": "B81",
+							"cost": 15,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mksHj9hgWRpFdgmd1",
+							"name": "@Occasional: Disease, Ingested Poison, etc.@",
+							"reference": "B81",
+							"cost": 10,
+							"cost_type": "points"
+						},
+						{
+							"id": "mA20VqQA0ki3aUdWw",
+							"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+							"reference": "B81",
+							"cost": 5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mGLpA9m5L_SUS9Zte",
+							"name": "Immunity",
+							"reference": "B81",
+							"cost": 1,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "m7E5GHQXgDCbQ5wLn",
+							"name": "+8 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.5,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "mNe1gCwik35Nk6drG",
+							"name": "+3 to all HT rolls to resist",
+							"reference": "B81",
+							"cost": 0.33,
+							"cost_type": "multiplier"
+						}
+					],
+					"round_down": true,
+					"calc": {
+						"points": 3
+					}
+				},
+				{
+					"id": "tmtbeT8-2InT4-rLD",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "touwUIFalnae02BUl"
+					},
+					"name": "Temperature Tolerance",
+					"reference": "B93",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"points_per_level": 1,
+					"can_level": true,
+					"levels": 2,
+					"calc": {
+						"points": 2
+					}
+				},
+				{
+					"id": "t6BS5WfouSiQ9dFHp",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tXnB__Om4YM2hwTL7"
+					},
+					"name": "Cold-Blooded",
+					"reference": "B127",
+					"local_notes": "Under 50-degrees",
+					"tags": [
+						"Disadvantage",
+						"Exotic",
+						"Physical"
+					],
+					"base_points": -5,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "to HT to resist the effects of temperature",
+							"amount": 2
+						}
+					],
+					"calc": {
+						"points": -5
+					}
+				},
+				{
+					"id": "tnkLBhcxzDPZWkN2Y",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tkruLIseh5plYfwvK"
+					},
+					"name": "Weakness",
+					"reference": "B161",
+					"tags": [
+						"Disadvantage",
+						"Exotic",
+						"Physical"
+					],
+					"replacements": {
+						"Occasional Substance": "Immersion in water of the \"wrong\" salinity"
+					},
+					"modifiers": [
+						{
+							"id": "mtWl2zc_IF-fLjw9H",
+							"name": "1d damage per minute",
+							"reference": "B161",
+							"cost": -20,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mIY-Be6Kko9xEk6cd",
+							"name": "1d damage per 5 minutes",
+							"reference": "B161",
+							"cost": -10,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "m9qqCCgzUsm109dZZ",
+							"name": "1d damage per 30 minutes",
+							"reference": "B161",
+							"cost": -5,
+							"cost_type": "points"
+						},
+						{
+							"id": "mp7GyUKnONSbOkPd6",
+							"name": "@Rare Substance@",
+							"reference": "B161",
+							"cost": 0.5,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "mlSbD4dP90azENfl3",
+							"name": "@Occasional Substance@",
+							"reference": "B161",
+							"cost": 1,
+							"cost_type": "multiplier"
+						},
+						{
+							"id": "mPEtaVKaBdrcMt3fj",
+							"name": "@Common Substance@",
+							"reference": "B161",
+							"cost": 2,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "mQEopsy_M9a3Cw8b7",
+							"name": "@Very Common Substance@",
+							"reference": "B161",
+							"cost": 3,
+							"cost_type": "multiplier",
+							"disabled": true
+						},
+						{
+							"id": "mTvLXHlz0AZkAylSE",
+							"name": "Fatigue Only",
+							"reference": "B161",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "m1evxgaGE3TR9Ln7L",
+							"name": "Variable",
+							"reference": "B161",
+							"cost": -40,
+							"disabled": true
+						}
+					],
+					"calc": {
+						"points": -5
+					}
+				},
+				{
+					"id": "t_b0TcxECL4KHkBUi",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t_ZUyO0Xhmi2p0Vku"
+					},
+					"name": "Unnatural Features (@Description@)",
+					"reference": "B22",
+					"tags": [
+						"Disadvantage",
+						"Physical"
+					],
+					"replacements": {
+						"Description": "Smooth grey mottled skin, large gill structures on their chests"
+					},
+					"points_per_level": -1,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "disguise"
+							},
+							"amount": -1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "shadowing"
+							},
+							"amount": -1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 2,
+					"calc": {
+						"points": -2
+					}
+				},
+				{
+					"id": "TAc6_6LLBDdO55uj7",
+					"name": "Choose one",
+					"template_picker": {
+						"type": "count",
+						"qualifier": {
+							"compare": "is",
+							"qualifier": 1
+						}
+					},
+					"children": [
+						{
+							"id": "Tu05jQbpcfSTC8RMd",
+							"name": "Base",
+							"children": [
+								{
+									"id": "tdNVysi9jGPUdZsGz",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tEYEuzMtxSsWCG7uW"
+									},
+									"name": "Unusual Biochemistry",
+									"reference": "B160",
+									"tags": [
+										"Disadvantage",
+										"Physical"
+									],
+									"base_points": -5,
+									"calc": {
+										"points": -5
+									}
+								}
+							],
+							"calc": {
+								"points": -5
+							}
+						},
+						{
+							"id": "TLA59COiryRPyEgzL",
+							"name": "Triton Bioroid",
+							"reference": "BT72",
+							"local_notes": "-$20000. LC3.",
+							"tags": [
+								"Race"
+							],
+							"container_type": "ancestry",
+							"children": [
+								{
+									"id": "T2jNDJLAeQHI1acuC",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Bio-Tech/Bio-Tech Traits.adq",
+										"id": "TluHkPSI8BnDWWEZo"
+									},
+									"name": "Bioroid",
+									"reference": "BT214",
+									"container_type": "meta_trait",
+									"children": [
+										{
+											"id": "tN7LL-XcDkJ0cvhhV",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Bio-Tech/Bio-Tech Traits.adq",
+												"id": "tAgMr2EzmeXfC7Tkg"
+											},
+											"name": "Early Maturation",
+											"reference": "BT212",
+											"local_notes": "may be level 3-5",
+											"tags": [
+												"Feature"
+											],
+											"can_level": true,
+											"levels": 3,
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "tq_c3cpOFQnVnQoap",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Template Toolkit/Template Toolkit 2 - Races/Template Toolkit 2 - Races Traits.adq",
+												"id": "tQY4rjF8t2sAPM9xv"
+											},
+											"name": "Sterile",
+											"reference": "TT2:12",
+											"tags": [
+												"Feature",
+												"Physical"
+											],
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "txV0xTNa5QLThJRa9",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tEYEuzMtxSsWCG7uW"
+											},
+											"name": "Unusual Biochemistry",
+											"reference": "B160",
+											"tags": [
+												"Disadvantage",
+												"Physical"
+											],
+											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										}
+									],
+									"calc": {
+										"points": -5
+									}
+								},
+								{
+									"id": "tdxamc4SM2vypMR7c",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t9Ayzq0-Ain8oiIM8"
+									},
+									"name": "Self-Destruct",
+									"reference": "B153",
+									"tags": [
+										"Disadvantage",
+										"Exotic",
+										"Physical"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "starts_with",
+													"qualifier": "terminally ill"
+												}
+											}
+										]
+									},
+									"base_points": -10,
+									"calc": {
+										"points": -10
+									}
+								},
+								{
+									"id": "ti2Ra67Y1h0CvayRI",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t9nyvI3uvjJi5aqF5"
+									},
+									"name": "Short Lifespan",
+									"reference": "B154",
+									"tags": [
+										"Disadvantage",
+										"Exotic",
+										"Physical"
+									],
+									"points_per_level": -10,
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": -10
+									}
+								}
+							],
+							"calc": {
+								"points": -25
+							}
+						}
+					],
+					"calc": {
+						"points": -30
+					}
+				}
+			],
+			"calc": {
+				"points": 9
+			}
+		}
+	]
+}

--- a/Library/Bio-Tech/Races/Void Dancer.gct
+++ b/Library/Bio-Tech/Races/Void Dancer.gct
@@ -1,0 +1,1443 @@
+{
+	"version": 5,
+	"id": "B7dirlQlDjAxttDTp",
+	"traits": [
+		{
+			"id": "T_E9M04RO3SQBJaM_",
+			"name": "Void Dancer",
+			"reference": "BT72",
+			"local_notes": "$131000. LC3.",
+			"tags": [
+				"Race"
+			],
+			"container_type": "ancestry",
+			"children": [
+				{
+					"id": "t8QmcxTJJeXczlxom",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tM6z7Mx6e2V4VvUR4"
+					},
+					"name": "Absolute Direction",
+					"reference": "B34",
+					"tags": [
+						"Advantage",
+						"Mental",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mbwcsum7OuCwkXSGa",
+							"name": "Requires signal",
+							"reference": "B34",
+							"cost": -20,
+							"disabled": true
+						},
+						{
+							"id": "m9PBQBJ_7sMXoFg8x",
+							"name": "3D Spatial Sense",
+							"reference": "B34",
+							"cost": 5,
+							"cost_type": "points",
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "starts_with",
+										"qualifier": "piloting"
+									},
+									"amount": 1
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "aerobatics"
+									},
+									"amount": 2
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "free fall"
+									},
+									"amount": 2
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "navigation"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "hyperspace"
+									},
+									"amount": 2
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "navigation"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "space"
+									},
+									"amount": 2
+								}
+							]
+						}
+					],
+					"base_points": 5,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "body sense"
+							},
+							"amount": 3
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "navigation"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "air"
+							},
+							"amount": 3
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "navigation"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "land"
+							},
+							"amount": 3
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "navigation"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "sea"
+							},
+							"amount": 3
+						}
+					],
+					"calc": {
+						"points": 10
+					}
+				},
+				{
+					"id": "t0sP6vouGXXZZgYPA",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tBmSJ3pNE53c4IRUU"
+					},
+					"name": "Damage Resistance",
+					"reference": "B47,P45,MA43,PSI14",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mFdI-k7BPcUDgbqHx",
+							"name": "Force Field",
+							"reference": "B47",
+							"cost": 20,
+							"disabled": true
+						},
+						{
+							"id": "mDIJeKzqDzknORYvo",
+							"name": "Hardened",
+							"reference": "B47",
+							"cost": 20,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mNiC9-CeVt0psM4-3",
+							"name": "Absorption",
+							"reference": "B46",
+							"local_notes": "Enhances @Trait@",
+							"cost": 80,
+							"disabled": true
+						},
+						{
+							"id": "m-fgxTU3tfJZv3yeq",
+							"name": "Absorption",
+							"reference": "B46",
+							"local_notes": "Healing only",
+							"cost": 80,
+							"disabled": true
+						},
+						{
+							"id": "mvOi_V5Sg88PC0Si5",
+							"name": "Absorption",
+							"reference": "B46",
+							"local_notes": "Enhances any trait",
+							"cost": 100,
+							"disabled": true
+						},
+						{
+							"id": "m9K9AzDTytNHsMhil",
+							"name": "Reflection",
+							"reference": "B47",
+							"cost": 100,
+							"disabled": true
+						},
+						{
+							"id": "mOEv1OLjHbsv4JXIA",
+							"name": "Bane",
+							"reference": "H14",
+							"local_notes": "@Rare@",
+							"cost": -1,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mQNYvfHv1mxF4mnWV",
+							"name": "Bane",
+							"reference": "H14",
+							"local_notes": "@Occasional@",
+							"cost": -5,
+							"disabled": true
+						},
+						{
+							"id": "mC0z1pKEoBzNJ0LP9",
+							"name": "Bane",
+							"reference": "H14",
+							"local_notes": "@Common@",
+							"cost": -10,
+							"disabled": true
+						},
+						{
+							"id": "mqA2B9g_i6ftBjfCM",
+							"name": "Bane",
+							"reference": "H14",
+							"local_notes": "@Very Common@",
+							"cost": -15,
+							"disabled": true
+						},
+						{
+							"id": "mXWwQuZrlcCET7-sl",
+							"name": "Directional",
+							"reference": "B47",
+							"local_notes": "Front",
+							"cost": -20,
+							"disabled": true
+						},
+						{
+							"id": "mAuqusCx9IYz7R1Zv",
+							"name": "Flexible",
+							"reference": "B47",
+							"cost": -20,
+							"disabled": true
+						},
+						{
+							"id": "mLZqu5aQ_d85y58TR",
+							"name": "Limited",
+							"reference": "B46",
+							"local_notes": "@Very Common Attack Form@",
+							"cost": -20,
+							"disabled": true
+						},
+						{
+							"id": "mBzfPdkeM_idjBztQ",
+							"name": "Semi-Ablative",
+							"reference": "B47",
+							"cost": -20,
+							"disabled": true
+						},
+						{
+							"id": "m2DIbhSApfcJvnjyy",
+							"name": "Can't wear armor",
+							"reference": "B47",
+							"cost": -40,
+							"disabled": true
+						},
+						{
+							"id": "muUbdYYZUaaCN-AN8",
+							"name": "Directional",
+							"reference": "B47",
+							"local_notes": "@Direction: Back, Right, Left, Top or Underside@",
+							"cost": -40,
+							"disabled": true
+						},
+						{
+							"id": "mBzeBh3VNdyvFJ4-3",
+							"name": "Limited",
+							"reference": "B46",
+							"local_notes": "@Common Attack Form@",
+							"cost": -40,
+							"disabled": true
+						},
+						{
+							"id": "m49BXmUswVfdmZhUF",
+							"name": "Tough Skin",
+							"local_notes": "Effects that just require skin contact or a scratch ignore this DR",
+							"cost": -40,
+							"disabled": true
+						},
+						{
+							"id": "mm7uDfOTVgyE6GkCs",
+							"name": "Limited",
+							"reference": "B46",
+							"local_notes": "@Occasional Attack Form@",
+							"cost": -60,
+							"disabled": true
+						},
+						{
+							"id": "mtIGPnmG_52kqWWB6",
+							"name": "Ablative",
+							"reference": "B47",
+							"cost": -80,
+							"disabled": true
+						},
+						{
+							"id": "mLvq5spg9a9nxy15o",
+							"name": "Limited",
+							"reference": "B46",
+							"local_notes": "@Rare Attack Form@",
+							"cost": -80,
+							"disabled": true
+						},
+						{
+							"id": "mpb4N5iP_iEBeiAV4",
+							"name": "Laminate",
+							"reference": "RSWL18",
+							"cost": 10,
+							"disabled": true
+						},
+						{
+							"id": "m9J6F_z7PcaoyYqX_",
+							"name": "Malediction-Proof",
+							"reference": "PSI14",
+							"cost": 50,
+							"disabled": true
+						},
+						{
+							"id": "mOyM_YLdsI_5jyj37",
+							"name": "Maledictions Only",
+							"reference": "PSI14",
+							"disabled": true
+						},
+						{
+							"id": "moPI9VLChN_ZI9Qnm",
+							"name": "Partial (@Location, 1 level per -1 Per Hit Modifier, Torso is -10% thus level 1@)",
+							"reference": "B47",
+							"cost": -10,
+							"disabled": true
+						}
+					],
+					"points_per_level": 5,
+					"features": [
+						{
+							"type": "dr_bonus",
+							"locations": [
+								"all"
+							],
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "dr_bonus",
+							"locations": [
+								"eye"
+							],
+							"amount": -1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 5
+					}
+				},
+				{
+					"id": "t2tfTUSF7BoehBXYo",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tUX_zxoB4sWyeNpHi"
+					},
+					"name": "Doesn't Breathe",
+					"reference": "B49",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mSz2OJ82f_2e0yqHh",
+							"name": "Gills",
+							"reference": "B49",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "ms4ao6CLMMLT3Zlxa",
+							"name": "Gills",
+							"reference": "B49",
+							"local_notes": "Suffocates in air",
+							"cost": -20,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mr8Rxr0BFOf7gR35s",
+							"name": "Oxygen Absorption",
+							"reference": "B49",
+							"cost": -25,
+							"disabled": true
+						},
+						{
+							"id": "mc-3MyXWfwfqVJBPb",
+							"name": "Oxygen Storage",
+							"reference": "B49",
+							"local_notes": "Can hold breath 25 times as long as normal",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "mPzHqp3bi-GV_eqis",
+							"name": "Oxygen Storage",
+							"reference": "B49",
+							"local_notes": "Can hold breath 50 times as long as normal",
+							"cost": -40,
+							"disabled": true
+						},
+						{
+							"id": "mzwhduCFMtNoxA_u2",
+							"name": "Oxygen Storage",
+							"reference": "B49",
+							"local_notes": "Can hold breath 100 times as long as normal",
+							"cost": -30
+						},
+						{
+							"id": "mkz6dGpsx3PjqLdCQ",
+							"name": "Oxygen Storage",
+							"reference": "B49",
+							"local_notes": "Can hold breath 200 times as long as normal",
+							"cost": -20,
+							"disabled": true
+						},
+						{
+							"id": "mUG1aQ4wJ1XanTCF-",
+							"name": "Oxygen Storage",
+							"reference": "B49",
+							"local_notes": "Can hold breath 300 times as long as normal",
+							"cost": -10,
+							"disabled": true
+						},
+						{
+							"id": "m8p_jEUG5WNX0wwfA",
+							"name": "Oxygen Combustion",
+							"reference": "B49",
+							"cost": -50,
+							"disabled": true
+						}
+					],
+					"base_points": 20,
+					"calc": {
+						"points": 14
+					}
+				},
+				{
+					"id": "thvcWfxNyxKNmEbFR",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tkCi-pV0exqSyPhyv"
+					},
+					"name": "Extra Arm",
+					"reference": "B53",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "m0fYJ8gACZ16W9HVB",
+							"name": "Extra-Flexible",
+							"reference": "B53",
+							"cost": 50,
+							"disabled": true
+						},
+						{
+							"id": "meYRyNYST_BRydLVA",
+							"name": "Long",
+							"reference": "B53",
+							"cost": 100,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "m-L0i9gnhzFV5LIcJ",
+							"name": "Foot Manipulators",
+							"reference": "B53",
+							"cost": -30
+						},
+						{
+							"id": "miZmpuVOZWWdZry4C",
+							"name": "No Physical Attack",
+							"reference": "B53",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "m8I6-12svTKdRiyB9",
+							"name": "Short",
+							"reference": "B53",
+							"cost": -50
+						},
+						{
+							"id": "mEpvMNsgZyj5zvxCN",
+							"name": "Weak",
+							"reference": "B53",
+							"local_notes": "Half body ST",
+							"cost": -25,
+							"disabled": true
+						},
+						{
+							"id": "mXwRMnfWl6189Tukf",
+							"name": "Weak",
+							"reference": "B53",
+							"local_notes": "Quarter body ST",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "me3lVJPYuSKmUP_ny",
+							"name": "Weapon Mount",
+							"reference": "B53",
+							"cost": -80,
+							"disabled": true
+						},
+						{
+							"id": "mWNFKhHN-XZnK8HnI",
+							"name": "No Grasping Hand",
+							"reference": "MATG28",
+							"cost": -40,
+							"disabled": true
+						}
+					],
+					"points_per_level": 10,
+					"can_level": true,
+					"levels": 2,
+					"calc": {
+						"points": 4
+					}
+				},
+				{
+					"id": "t33XaI0A7_SXeoWlx",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "thdJ55ghf__io9AQa"
+					},
+					"name": "Longevity",
+					"reference": "B66",
+					"local_notes": "You fail aging rolls only on a 17 or 18, or only on an 18 if your modified HT is 17 or better",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"base_points": 2,
+					"calc": {
+						"points": 2
+					}
+				},
+				{
+					"id": "tUAJlOV1Gzw3rlcUg",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tXhp5q6e5CEtI0AOJ"
+					},
+					"name": "Sealed",
+					"reference": "B82",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"base_points": 15,
+					"calc": {
+						"points": 15
+					}
+				},
+				{
+					"id": "tUkzmGF33ezU59qID",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tEyfe8xc70W3xpJ0z"
+					},
+					"name": "Radiation Tolerance",
+					"reference": "B79,P70",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mWfCxTmGAa8z8L7Cc",
+							"name": "Extended",
+							"reference": "P70",
+							"local_notes": "@Type@",
+							"cost": 30,
+							"disabled": true
+						},
+						{
+							"id": "m68lduJrrNkw-6FWg",
+							"name": "PF: 2",
+							"reference": "B79",
+							"cost": 5,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mIKVQ7XiHmNSBRaxu",
+							"name": "PF: 5",
+							"reference": "B79",
+							"cost": 10,
+							"cost_type": "points"
+						},
+						{
+							"id": "mBI1ZVsPjebH3A4_E",
+							"name": "PF: 10",
+							"reference": "B79",
+							"cost": 15,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mz0acFI9au1jPrBSm",
+							"name": "PF: 20",
+							"reference": "B79",
+							"cost": 20,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mqXxzNQxoX0ft-VU2",
+							"name": "PF: 50",
+							"reference": "B79",
+							"cost": 25,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mMjyF2Y_l9jek6-jQ",
+							"name": "PF: 100",
+							"reference": "B79",
+							"cost": 30,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mnbnjVHURKs0PzvQN",
+							"name": "PF: 200",
+							"reference": "B79",
+							"cost": 35,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mUgibiuXLW2w813HS",
+							"name": "PF: 500",
+							"reference": "B79",
+							"cost": 40,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mMe58XzLx30R_q9L0",
+							"name": "PF: 1000",
+							"reference": "B79",
+							"cost": 45,
+							"cost_type": "points",
+							"disabled": true
+						}
+					],
+					"calc": {
+						"points": 10
+					}
+				},
+				{
+					"id": "t-KL2vwk-A42tHtgQ",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tQrNIZ1kbn0I6UAZf"
+					},
+					"name": "Regeneration",
+					"reference": "B80,P70,MA47",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mBwah9OkUjf4jeeRy",
+							"name": "Slow",
+							"reference": "B80",
+							"local_notes": "You recover 1 HP per 12 hours",
+							"cost": 10,
+							"cost_type": "points"
+						},
+						{
+							"id": "mU1Y5R11HNu-UumOv",
+							"name": "Regular",
+							"reference": "B80",
+							"local_notes": "You recover 1 HP per hour",
+							"cost": 25,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mRPG-bbSm-Rowp1pm",
+							"name": "Fast",
+							"reference": "B80",
+							"local_notes": "You recover 1 HP per minute",
+							"cost": 50,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "m5wxc0jgVFz7Uj6hq",
+							"name": "Very Fast",
+							"reference": "B80",
+							"local_notes": "You recover 1 HP per second",
+							"cost": 100,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "m7x9bjlqRji30O9Gm",
+							"name": "Extreme",
+							"reference": "B80",
+							"local_notes": "You recover 10 HP per second",
+							"cost": 150,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "m8xUItewT2LRxH6f1",
+							"name": "Heals Radiation",
+							"reference": "B80",
+							"cost": 40,
+							"disabled": true
+						},
+						{
+							"id": "m3Tw8LTMsy3r9gzhL",
+							"name": "Radiation Only",
+							"reference": "B80",
+							"cost": -60
+						},
+						{
+							"id": "mEz7Io7AamRFl6BQx",
+							"name": "Fatigue Recovery",
+							"reference": "P70",
+							"cost": 100,
+							"disabled": true
+						},
+						{
+							"id": "mY9Y1CbIjRz8E3Cbd",
+							"name": "Fatigue Only",
+							"reference": "P70",
+							"disabled": true
+						},
+						{
+							"id": "m4ROOfMlj50OhWchE",
+							"name": "Limited: @Advantage@ Only",
+							"reference": "P70",
+							"cost": -40,
+							"disabled": true
+						},
+						{
+							"id": "mPCURNOJZVVMZChqS",
+							"name": "Bane",
+							"reference": "H18",
+							"local_notes": "@Common or Very Common@",
+							"cost": -50,
+							"disabled": true
+						},
+						{
+							"id": "m_TirONIW_xjJ2ShJ",
+							"name": "Bane",
+							"reference": "H18",
+							"local_notes": "@Occasional@",
+							"cost": -30,
+							"disabled": true
+						},
+						{
+							"id": "m029pJ76uxja2PsNu",
+							"name": "Bane",
+							"reference": "H18",
+							"local_notes": "@Rare@",
+							"cost": -10,
+							"disabled": true
+						}
+					],
+					"calc": {
+						"points": 4
+					}
+				},
+				{
+					"id": "taba9uS-uMLxrro8K",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "touwUIFalnae02BUl"
+					},
+					"name": "Temperature Tolerance",
+					"reference": "B93",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"points_per_level": 1,
+					"can_level": true,
+					"levels": 10,
+					"calc": {
+						"points": 10
+					}
+				},
+				{
+					"id": "t2A3CiFU7cuQwNLHd",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "txHSphIWk4vt8Fe1M"
+					},
+					"name": "Vacuum Support",
+					"reference": "B96",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"base_points": 5,
+					"calc": {
+						"points": 5
+					}
+				},
+				{
+					"id": "tCluZ3AT5fjjjBSfR",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Bio-Tech/Bio-Tech Traits.adq",
+						"id": "tcpWN_ZW2kBHtFd_-"
+					},
+					"name": "No Degeneration in Zero-G",
+					"reference": "BT211",
+					"tags": [
+						"Perk"
+					],
+					"base_points": 1,
+					"calc": {
+						"points": 1
+					}
+				},
+				{
+					"id": "t14C6fWd6HRI9gNFC",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tf5DfdQFaNUVbkPV2"
+					},
+					"name": "Sanitized Metabolism",
+					"reference": "B101",
+					"tags": [
+						"Perk",
+						"Physical"
+					],
+					"base_points": 1,
+					"features": [
+						{
+							"type": "reaction_bonus",
+							"situation": "from others in close confines",
+							"amount": 1
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to attempts to track you by scent",
+							"amount": -1
+						}
+					],
+					"calc": {
+						"points": 1
+					}
+				},
+				{
+					"id": "tmdGSDGZlU4vf8xus",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "taEdO2Q-RgdH-CiHq"
+					},
+					"name": "Skinny",
+					"reference": "B18",
+					"tags": [
+						"Disadvantage",
+						"Physical"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "attribute_prereq",
+								"has": true,
+								"qualifier": {
+									"compare": "at_most",
+									"qualifier": 14
+								},
+								"which": "ht"
+							}
+						]
+					},
+					"base_points": -5,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "disguise"
+							},
+							"amount": -2
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "shadowing"
+							},
+							"amount": -2
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to ST vs. knockback",
+							"amount": -2
+						}
+					],
+					"calc": {
+						"points": -5
+					}
+				},
+				{
+					"id": "tJr9pusgImBuz7a0k",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t_ZUyO0Xhmi2p0Vku"
+					},
+					"name": "Unnatural Features (@Description@)",
+					"reference": "B22",
+					"tags": [
+						"Disadvantage",
+						"Physical"
+					],
+					"replacements": {
+						"Description": "Unnaturally slender"
+					},
+					"points_per_level": -1,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "disguise"
+							},
+							"amount": -1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "shadowing"
+							},
+							"amount": -1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": -1
+					}
+				},
+				{
+					"id": "T1W6U-w9oogtsX46X",
+					"name": "Choose one",
+					"template_picker": {
+						"type": "count",
+						"qualifier": {
+							"compare": "is",
+							"qualifier": 1
+						}
+					},
+					"children": [
+						{
+							"id": "TKRB31eY0SC0uqlBO",
+							"name": "Base",
+							"children": [
+								{
+									"id": "t6eYnHr0eWPpo8ik0",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "thI3hK3riuknUwkHF"
+									},
+									"name": "Decreased Strength",
+									"reference": "B14",
+									"tags": [
+										"Attribute",
+										"Disadvantage",
+										"Physical"
+									],
+									"points_per_level": -10,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "st",
+											"amount": -1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 3,
+									"calc": {
+										"points": -30
+									}
+								},
+								{
+									"id": "tu1a6Huy8HTcEt_2o",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tIir5i3ZjJJyWwpxI"
+									},
+									"name": "G-Intolerance (0.1G increment)",
+									"reference": "B137",
+									"tags": [
+										"Disadvantage",
+										"Physical"
+									],
+									"base_points": -10,
+									"calc": {
+										"points": -10
+									}
+								},
+								{
+									"id": "tSzDba2T4yXX4Y2up",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tLYJ7NUl3CYeLk0Yc"
+									},
+									"name": "Susceptible (@Substance@)",
+									"reference": "B158",
+									"tags": [
+										"Disadvantage",
+										"Physical"
+									],
+									"replacements": {
+										"Substance": "Disease"
+									},
+									"modifiers": [
+										{
+											"id": "mrMDi801eAP6C-TcQ",
+											"name": "Occasional",
+											"reference": "B158",
+											"cost": 1,
+											"cost_type": "multiplier",
+											"disabled": true
+										},
+										{
+											"id": "mOJGU-obNNzJ68DUj",
+											"name": "Common",
+											"reference": "B158",
+											"cost": 2,
+											"cost_type": "multiplier",
+											"disabled": true
+										},
+										{
+											"id": "mLbdBjNl1iO9Zkevt",
+											"name": "Very Common",
+											"reference": "B158",
+											"cost": 4,
+											"cost_type": "multiplier"
+										}
+									],
+									"points_per_level": -1,
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": -4
+									}
+								}
+							],
+							"calc": {
+								"points": -44
+							}
+						},
+						{
+							"id": "T2K-Y3PYfYNPoeinZ",
+							"name": "Dark Angel Bioroid",
+							"reference": "BT72",
+							"local_notes": "+$65000. LC3.",
+							"tags": [
+								"Race"
+							],
+							"container_type": "ancestry",
+							"children": [
+								{
+									"id": "tjmxOvjqkMWTLhe71",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "thI3hK3riuknUwkHF"
+									},
+									"name": "Decreased Strength",
+									"reference": "B14",
+									"tags": [
+										"Attribute",
+										"Disadvantage",
+										"Physical"
+									],
+									"points_per_level": -10,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "st",
+											"amount": -1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": -10
+									}
+								},
+								{
+									"id": "t0zdDEmvYL90OlPno",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tGWOSEE6SmBHACE6Y"
+									},
+									"name": "Increased Dexterity",
+									"reference": "B15",
+									"tags": [
+										"Advantage",
+										"Attribute",
+										"Physical"
+									],
+									"modifiers": [
+										{
+											"id": "mSDpFXiA2UGlBlY3w",
+											"name": "No Fine Manipulators",
+											"cost": -40,
+											"disabled": true
+										}
+									],
+									"points_per_level": 20,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "dx",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": 20
+									}
+								},
+								{
+									"id": "t655UlGX5u4DJW02T",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tGjjVtxav9KsrG7Wx"
+									},
+									"name": "Combat Reflexes",
+									"reference": "B43",
+									"local_notes": "Never freeze",
+									"tags": [
+										"Advantage",
+										"Mental"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Enhanced Time Sense"
+												}
+											}
+										]
+									},
+									"base_points": 15,
+									"features": [
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "starts_with",
+												"qualifier": "fast-draw"
+											},
+											"amount": 1
+										},
+										{
+											"type": "attribute_bonus",
+											"attribute": "dodge",
+											"amount": 1
+										},
+										{
+											"type": "attribute_bonus",
+											"attribute": "parry",
+											"amount": 1
+										},
+										{
+											"type": "attribute_bonus",
+											"attribute": "block",
+											"amount": 1
+										},
+										{
+											"type": "attribute_bonus",
+											"attribute": "fright_check",
+											"amount": 2
+										},
+										{
+											"type": "conditional_modifier",
+											"situation": "on all IQ rolls to wake up or to recover from surprise or mental stun",
+											"amount": 6
+										},
+										{
+											"type": "conditional_modifier",
+											"situation": "to initiative rolls for your side (+2 if you are the leader)",
+											"amount": 1
+										}
+									],
+									"calc": {
+										"points": 15
+									}
+								},
+								{
+									"id": "tPxgHoMtGhaPghgAC",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tJTfFdHM7YI5IZR7I"
+									},
+									"name": "Resistant",
+									"reference": "B81,P71,MA47",
+									"tags": [
+										"Advantage",
+										"Physical"
+									],
+									"replacements": {
+										"Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.": "Acceleration"
+									},
+									"modifiers": [
+										{
+											"id": "mpeE-3-1dJtzWG351",
+											"name": "@Very Common: Metabolic Hazards, etc.@",
+											"reference": "B80",
+											"cost": 30,
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "m-D2ZclkuG06vOrr9",
+											"name": "@Common: Poison, Sickness, etc.@",
+											"reference": "B81",
+											"cost": 15,
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "myBY6eBJiNo8OiYj1",
+											"name": "@Occasional: Disease, Ingested Poison, etc.@",
+											"reference": "B81",
+											"cost": 10,
+											"cost_type": "points",
+											"disabled": true
+										},
+										{
+											"id": "m75kajpQo90vcOfiy",
+											"name": "@Rare: Acceleration, Altitude Sickness, Bends, Seasickness, Space Sickness, Nanomachines, etc.@",
+											"reference": "B81",
+											"cost": 5,
+											"cost_type": "points"
+										},
+										{
+											"id": "mjYRiPqEy9ze45Ifj",
+											"name": "Immunity",
+											"reference": "B81",
+											"cost": 1,
+											"cost_type": "multiplier",
+											"disabled": true
+										},
+										{
+											"id": "mpkrPzhXkTcAF4hMy",
+											"name": "+8 to all HT rolls to resist",
+											"reference": "B81",
+											"cost": 0.5,
+											"cost_type": "multiplier",
+											"disabled": true
+										},
+										{
+											"id": "mBlTaPNmLP2BN_K5C",
+											"name": "+3 to all HT rolls to resist",
+											"reference": "B81",
+											"cost": 0.33,
+											"cost_type": "multiplier"
+										}
+									],
+									"round_down": true,
+									"calc": {
+										"points": 1
+									}
+								},
+								{
+									"id": "TxaBE0nxcum5g-fkp",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Bio-Tech/Bio-Tech Traits.adq",
+										"id": "TluHkPSI8BnDWWEZo"
+									},
+									"name": "Bioroid",
+									"reference": "BT214",
+									"container_type": "meta_trait",
+									"children": [
+										{
+											"id": "t13uUnccSilD0Wygq",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Bio-Tech/Bio-Tech Traits.adq",
+												"id": "tAgMr2EzmeXfC7Tkg"
+											},
+											"name": "Early Maturation",
+											"reference": "BT212",
+											"local_notes": "may be level 3-5",
+											"tags": [
+												"Feature"
+											],
+											"can_level": true,
+											"levels": 3,
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "tekKm0N1bfMYNfnxY",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Template Toolkit/Template Toolkit 2 - Races/Template Toolkit 2 - Races Traits.adq",
+												"id": "tQY4rjF8t2sAPM9xv"
+											},
+											"name": "Sterile",
+											"reference": "TT2:12",
+											"tags": [
+												"Feature",
+												"Physical"
+											],
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "t1cidyXPJZYx7Xng8",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tEYEuzMtxSsWCG7uW"
+											},
+											"name": "Unusual Biochemistry",
+											"reference": "B160",
+											"tags": [
+												"Disadvantage",
+												"Physical"
+											],
+											"base_points": -5,
+											"calc": {
+												"points": -5
+											}
+										}
+									],
+									"calc": {
+										"points": -5
+									}
+								}
+							],
+							"calc": {
+								"points": 21
+							}
+						}
+					],
+					"calc": {
+						"points": -23
+					}
+				}
+			],
+			"calc": {
+				"points": 52
+			}
+		}
+	],
+	"notes": [
+		{
+			"id": "nGrueL7JI03y3rSjJ",
+			"markdown": "Home Gravity is 0G"
+		}
+	]
+}


### PR DESCRIPTION
This adds all the Gengineered Human Racial Templates from Bio-Tech.

They are implemented as Templates that use Template Choices to choose either the base template or one of the Sub-Races (where they exist).

This is based on the work by anders3865 on the gcs discord, change to support the aforementioned Template Choices, plus the traits are linked to ones in source libraries, and the template's TL, cost and LC are listed.

This uses traits from #373 so if this pull request is merged before that one then gcs will report that the traits differ from their source libraries (or that the source library is missing).