### PR TITLE
Fix the incorrect point value in the "modified arm" trait

### DIFF
--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -7719,6 +7719,7 @@
 					"reference": "B53",
 					"cost": 5,
 					"cost_type": "points",
+					"use_level_from_trait": true,
 					"disabled": true
 				},
 				{
@@ -7727,6 +7728,7 @@
 					"reference": "B53",
 					"cost": 10,
 					"cost_type": "points",
+					"use_level_from_trait": true,
 					"levels": 1,
 					"disabled": true
 				},
@@ -7736,6 +7738,7 @@
 					"reference": "B53",
 					"cost": -3,
 					"cost_type": "points",
+					"use_level_from_trait": true,
 					"disabled": true
 				},
 				{
@@ -7744,6 +7747,7 @@
 					"reference": "B53",
 					"cost": -5,
 					"cost_type": "points",
+					"use_level_from_trait": true,
 					"disabled": true
 				},
 				{
@@ -7752,6 +7756,7 @@
 					"reference": "B53",
 					"cost": -5,
 					"cost_type": "points",
+					"use_level_from_trait": true,
 					"disabled": true
 				},
 				{
@@ -7761,6 +7766,7 @@
 					"local_notes": "Half body ST",
 					"cost": -2.5,
 					"cost_type": "points",
+					"use_level_from_trait": true,
 					"disabled": true
 				},
 				{
@@ -7770,6 +7776,7 @@
 					"local_notes": "Quarter body ST",
 					"cost": -5,
 					"cost_type": "points",
+					"use_level_from_trait": true,
 					"disabled": true
 				},
 				{
@@ -7778,6 +7785,7 @@
 					"reference": "B53",
 					"cost": -8,
 					"cost_type": "points",
+					"use_level_from_trait": true,
 					"disabled": true
 				},
 				{
@@ -7786,14 +7794,14 @@
 					"reference": "MATG28",
 					"cost": -4,
 					"cost_type": "points",
+					"use_level_from_trait": true,
 					"disabled": true
 				}
 			],
-			"points_per_level": 10,
 			"can_level": true,
 			"levels": 1,
 			"calc": {
-				"points": 10
+				"points": 0
 			}
 		},
 		{

--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -8017,6 +8017,7 @@
 			"reference_highlight": "Modifying Beings With Two Legs",
 			"tags": [
 				"Advantage",
+				"Disadvantage",
 				"Exotic",
 				"Physical"
 			],

--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -7709,6 +7709,7 @@
 			"reference_highlight": "Modifying Beings With One or Two Arms",
 			"tags": [
 				"Advantage",
+				"Disadvantage",
 				"Exotic",
 				"Physical"
 			],

--- a/Library/Bio-Tech/Races/Light Worlder.gct
+++ b/Library/Bio-Tech/Races/Light Worlder.gct
@@ -58,85 +58,93 @@
 					],
 					"modifiers": [
 						{
-							"id": "mCgzIpSLBsHhHxuhK",
+							"id": "mMsbTy035y8CGwdl8",
 							"name": "Extra-Flexible",
 							"reference": "B53",
 							"cost": 5,
 							"cost_type": "points",
+							"use_level_from_trait": true,
 							"disabled": true
 						},
 						{
-							"id": "mWB9GoVGGvHumNwZd",
+							"id": "m1FuH1HxpRsvsGUQT",
 							"name": "Long",
 							"reference": "B53",
 							"cost": 10,
 							"cost_type": "points",
+							"use_level_from_trait": true,
 							"levels": 1
 						},
 						{
-							"id": "msKSYLq5H8fqm1myi",
+							"id": "mEEVGGjo4ZD6xJume",
 							"name": "Foot Manipulators",
 							"reference": "B53",
 							"cost": -3,
 							"cost_type": "points",
+							"use_level_from_trait": true,
 							"disabled": true
 						},
 						{
-							"id": "m_ZNOvA-Hu-LaJhOp",
+							"id": "m089D2y0nqceZcYL6",
 							"name": "No Physical Attack",
 							"reference": "B53",
 							"cost": -5,
 							"cost_type": "points",
+							"use_level_from_trait": true,
 							"disabled": true
 						},
 						{
-							"id": "m9ONYMJZr3G-e0hiM",
+							"id": "mGKoBGBmgjwzXbal-",
 							"name": "Short",
 							"reference": "B53",
 							"cost": -5,
 							"cost_type": "points",
+							"use_level_from_trait": true,
 							"disabled": true
 						},
 						{
-							"id": "mx6w4kdge2_6Hk7gp",
+							"id": "mHC3NZEHqXPIP4G76",
 							"name": "Weak",
 							"reference": "B53",
 							"local_notes": "Half body ST",
 							"cost": -2.5,
 							"cost_type": "points",
+							"use_level_from_trait": true,
 							"disabled": true
 						},
 						{
-							"id": "mmpqFS66vogOCXiqp",
+							"id": "mmh3FQ2nN4sAI5lZR",
 							"name": "Weak",
 							"reference": "B53",
 							"local_notes": "Quarter body ST",
 							"cost": -5,
 							"cost_type": "points",
+							"use_level_from_trait": true,
 							"disabled": true
 						},
 						{
-							"id": "mZvQ84cx06cQtfZmi",
+							"id": "m-ABcHT1H4bJMNQhQ",
 							"name": "Weapon Mount",
 							"reference": "B53",
 							"cost": -8,
 							"cost_type": "points",
+							"use_level_from_trait": true,
 							"disabled": true
 						},
 						{
-							"id": "m8ChMn-lG95vFiFD6",
+							"id": "m_tjzDQVnEqXPfyWK",
 							"name": "No Grasping Hand",
 							"reference": "MATG28",
 							"cost": -4,
 							"cost_type": "points",
+							"use_level_from_trait": true,
 							"disabled": true
 						}
 					],
-					"points_per_level": 10,
 					"can_level": true,
 					"levels": 2,
 					"calc": {
-						"points": 30
+						"points": 20
 					}
 				},
 				{
@@ -194,7 +202,7 @@
 				}
 			],
 			"calc": {
-				"points": 20
+				"points": 10
 			}
 		}
 	],

--- a/Library/Template Toolkit/Template Toolkit 2 - Races/Meta-Traits/Morphology Meta-Traits/Organisms/Asteroid.gct
+++ b/Library/Template Toolkit/Template Toolkit 2 - Races/Meta-Traits/Morphology Meta-Traits/Organisms/Asteroid.gct
@@ -245,8 +245,14 @@
 				},
 				{
 					"id": "tL7cWUtNAaPVZtUZ2",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tOWDg9Tm1ImEUemm8"
+					},
 					"name": "Modified Arm",
 					"reference": "B53",
+					"reference_highlight": "Modifying Beings With One or Two Arms",
 					"tags": [
 						"Advantage",
 						"Disadvantage",
@@ -255,20 +261,86 @@
 					],
 					"modifiers": [
 						{
-							"id": "my54J1vebpm1h4AFp",
+							"id": "mJ1l-ftQMur-MXyWl",
+							"name": "Extra-Flexible",
+							"reference": "B53",
+							"cost": 5,
+							"cost_type": "points",
+							"use_level_from_trait": true,
+							"disabled": true
+						},
+						{
+							"id": "mQlxoOAYoFXz_ZKiz",
+							"name": "Long",
+							"reference": "B53",
+							"cost": 10,
+							"cost_type": "points",
+							"use_level_from_trait": true,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mc-vbFtnD_dI7nZdZ",
+							"name": "Foot Manipulators",
+							"reference": "B53",
+							"cost": -3,
+							"cost_type": "points",
+							"use_level_from_trait": true
+						},
+						{
+							"id": "m6oNUY5K6pPUClIv5",
+							"name": "No Physical Attack",
+							"reference": "B53",
+							"cost": -5,
+							"cost_type": "points",
+							"use_level_from_trait": true,
+							"disabled": true
+						},
+						{
+							"id": "moelvSp0_MxYRAi8c",
 							"name": "Short",
 							"reference": "B53",
 							"cost": -5,
 							"cost_type": "points",
-							"affects": "levels_only"
+							"use_level_from_trait": true
 						},
 						{
-							"id": "mII7jAlBWs_6PCVSL",
-							"name": "Foot Manipulator",
+							"id": "m9rtIxJeknVimK6eh",
+							"name": "Weak",
 							"reference": "B53",
-							"cost": -3,
+							"local_notes": "Half body ST",
+							"cost": -2.5,
 							"cost_type": "points",
-							"affects": "levels_only"
+							"use_level_from_trait": true,
+							"disabled": true
+						},
+						{
+							"id": "mVCvG3SXw8--BGDqC",
+							"name": "Weak",
+							"reference": "B53",
+							"local_notes": "Quarter body ST",
+							"cost": -5,
+							"cost_type": "points",
+							"use_level_from_trait": true,
+							"disabled": true
+						},
+						{
+							"id": "myQ_BrzKPWR62zSWq",
+							"name": "Weapon Mount",
+							"reference": "B53",
+							"cost": -8,
+							"cost_type": "points",
+							"use_level_from_trait": true,
+							"disabled": true
+						},
+						{
+							"id": "mCFEuX5k3UEEUHq06",
+							"name": "No Grasping Hand",
+							"reference": "MATG28",
+							"cost": -4,
+							"cost_type": "points",
+							"use_level_from_trait": true,
+							"disabled": true
 						}
 					],
 					"can_level": true,

--- a/Library/Template Toolkit/Template Toolkit 2 - Races/Meta-Traits/Morphology Meta-Traits/Organisms/Octopod.gct
+++ b/Library/Template Toolkit/Template Toolkit 2 - Races/Meta-Traits/Morphology Meta-Traits/Organisms/Octopod.gct
@@ -150,28 +150,102 @@
 				},
 				{
 					"id": "tZYEZalMPHo9EQG5Q",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tOWDg9Tm1ImEUemm8"
+					},
 					"name": "Modified Arm",
 					"reference": "B53",
+					"reference_highlight": "Modifying Beings With One or Two Arms",
 					"tags": [
+						"Advantage",
+						"Disadvantage",
 						"Exotic",
 						"Physical"
 					],
 					"modifiers": [
 						{
-							"id": "mkzpEzpOdAtxB5S_u",
+							"id": "mpu9npSYPVHtdHeZm",
 							"name": "Extra-Flexible",
 							"reference": "B53",
 							"cost": 5,
 							"cost_type": "points",
-							"affects": "levels_only"
+							"use_level_from_trait": true
 						},
 						{
-							"id": "mWhuhTkApwTABkFFl",
-							"name": "Foot Manipulator",
+							"id": "maCafI52F1fnSUGBh",
+							"name": "Long",
+							"reference": "B53",
+							"cost": 10,
+							"cost_type": "points",
+							"use_level_from_trait": true,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "mfaG25uVGG4LI7jg-",
+							"name": "Foot Manipulators",
 							"reference": "B53",
 							"cost": -3,
 							"cost_type": "points",
-							"affects": "levels_only"
+							"use_level_from_trait": true
+						},
+						{
+							"id": "mUgwZB9cn1yqEAsxb",
+							"name": "No Physical Attack",
+							"reference": "B53",
+							"cost": -5,
+							"cost_type": "points",
+							"use_level_from_trait": true,
+							"disabled": true
+						},
+						{
+							"id": "mdXEVR4NoXD0xiBoN",
+							"name": "Short",
+							"reference": "B53",
+							"cost": -5,
+							"cost_type": "points",
+							"use_level_from_trait": true,
+							"disabled": true
+						},
+						{
+							"id": "m7wA9M1EyEj4aIHEM",
+							"name": "Weak",
+							"reference": "B53",
+							"local_notes": "Half body ST",
+							"cost": -2.5,
+							"cost_type": "points",
+							"use_level_from_trait": true,
+							"disabled": true
+						},
+						{
+							"id": "mZJvlxeWA5W6KrcKB",
+							"name": "Weak",
+							"reference": "B53",
+							"local_notes": "Quarter body ST",
+							"cost": -5,
+							"cost_type": "points",
+							"use_level_from_trait": true,
+							"disabled": true
+						},
+						{
+							"id": "mmlBUFgcXJIfGVfDN",
+							"name": "Weapon Mount",
+							"reference": "B53",
+							"cost": -8,
+							"cost_type": "points",
+							"use_level_from_trait": true,
+							"disabled": true
+						},
+						{
+							"id": "mr0g95ZUCeEhb3FEL",
+							"name": "No Grasping Hand",
+							"reference": "MATG28",
+							"cost": -4,
+							"cost_type": "points",
+							"use_level_from_trait": true,
+							"disabled": true
 						}
 					],
 					"can_level": true,

--- a/Library/Template Toolkit/Template Toolkit 2 - Races/Meta-Traits/Morphology Meta-Traits/Organisms/Vespertilian.gct
+++ b/Library/Template Toolkit/Template Toolkit 2 - Races/Meta-Traits/Morphology Meta-Traits/Organisms/Vespertilian.gct
@@ -148,8 +148,14 @@
 				},
 				{
 					"id": "tn1w8mPsL4d94f_9E",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tOWDg9Tm1ImEUemm8"
+					},
 					"name": "Modified Arm",
 					"reference": "B53",
+					"reference_highlight": "Modifying Beings With One or Two Arms",
 					"tags": [
 						"Advantage",
 						"Disadvantage",
@@ -158,20 +164,86 @@
 					],
 					"modifiers": [
 						{
-							"id": "mHlqAq1dnvv3pnSgd",
-							"name": "Short",
+							"id": "mXXeqAPREqeHSOp7P",
+							"name": "Extra-Flexible",
 							"reference": "B53",
-							"cost": -5,
+							"cost": 5,
 							"cost_type": "points",
-							"affects": "levels_only"
+							"use_level_from_trait": true,
+							"disabled": true
 						},
 						{
-							"id": "mca023lE_dkuoXzku",
+							"id": "m2RlRI042qRmpjrMI",
+							"name": "Long",
+							"reference": "B53",
+							"cost": 10,
+							"cost_type": "points",
+							"use_level_from_trait": true,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "m0Ieb4JNDtxbqI_Au",
+							"name": "Foot Manipulators",
+							"reference": "B53",
+							"cost": -3,
+							"cost_type": "points",
+							"use_level_from_trait": true,
+							"disabled": true
+						},
+						{
+							"id": "mjNRemwc-0tuCaRMY",
 							"name": "No Physical Attack",
 							"reference": "B53",
 							"cost": -5,
 							"cost_type": "points",
-							"affects": "levels_only"
+							"use_level_from_trait": true
+						},
+						{
+							"id": "mCQzpiuhhX6KGVsEv",
+							"name": "Short",
+							"reference": "B53",
+							"cost": -5,
+							"cost_type": "points",
+							"use_level_from_trait": true
+						},
+						{
+							"id": "m89YWM0r02znDLsn-",
+							"name": "Weak",
+							"reference": "B53",
+							"local_notes": "Half body ST",
+							"cost": -2.5,
+							"cost_type": "points",
+							"use_level_from_trait": true,
+							"disabled": true
+						},
+						{
+							"id": "m86fkM1GkFfrxXd8A",
+							"name": "Weak",
+							"reference": "B53",
+							"local_notes": "Quarter body ST",
+							"cost": -5,
+							"cost_type": "points",
+							"use_level_from_trait": true,
+							"disabled": true
+						},
+						{
+							"id": "m4LEYvD2Gu2NUoV5u",
+							"name": "Weapon Mount",
+							"reference": "B53",
+							"cost": -8,
+							"cost_type": "points",
+							"use_level_from_trait": true,
+							"disabled": true
+						},
+						{
+							"id": "mXuVvuLGlDZwCvy3Y",
+							"name": "No Grasping Hand",
+							"reference": "MATG28",
+							"cost": -4,
+							"cost_type": "points",
+							"use_level_from_trait": true,
+							"disabled": true
 						}
 					],
 					"can_level": true,


### PR DESCRIPTION
I noticed, when I used it for different templates, that the "Modified Arm" trait I added wasn't calculating the price properly.

This should have the correct price whether you're modifying one arm or two.

I also updated all templates that use "Modified Arm" in the master library to use the fixed version of this.