### PR TITLE
Sorted the DR trait's modifiers to match book order + added a reference note to Hardened

### DIFF
--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -5048,7 +5048,7 @@
 		{
 			"id": "tBmSJ3pNE53c4IRUU",
 			"name": "Damage Resistance",
-			"reference": "B47,P45,MA43,PSI14",
+			"reference": "B46,B47,P45,MA43,PSI14",
 			"tags": [
 				"Advantage",
 				"Exotic",
@@ -5056,193 +5056,207 @@
 			],
 			"modifiers": [
 				{
-					"id": "mkcqwfozXpQmC4BIx",
-					"name": "Force Field",
-					"reference": "B47",
-					"cost": 20,
-					"disabled": true
+					"id": "MNGwNvpoQ0he3h7A7",
+					"name": "Special Enhancements",
+					"children": [
+						{
+							"id": "mJxX9ApiNM2Hh9akl",
+							"name": "Absorption",
+							"reference": "B46",
+							"local_notes": "Enhances @Trait@",
+							"cost": 80,
+							"disabled": true
+						},
+						{
+							"id": "mHwfpp1_SY3jN-JjF",
+							"name": "Absorption",
+							"reference": "B46",
+							"local_notes": "Healing only",
+							"cost": 80,
+							"disabled": true
+						},
+						{
+							"id": "mvDYFqhwd-tS12G97",
+							"name": "Absorption",
+							"reference": "B46",
+							"local_notes": "Enhances any trait",
+							"cost": 100,
+							"disabled": true
+						},
+						{
+							"id": "mKZQfoJhVcaw04aPy",
+							"name": "Force Field",
+							"reference": "B47",
+							"cost": 20,
+							"disabled": true
+						},
+						{
+							"id": "mTxwPrj2QOL79_Emh",
+							"name": "Hardened",
+							"reference": "B47",
+							"local_notes": "Reduces armor divisor by @Hardened level@ step(s): \"ignores DR\"→100→10→5→3→2→\"no divisor\"",
+							"cost": 20,
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "moRQ906qHeIUxEtDH",
+							"name": "Laminate",
+							"reference": "RSWL18",
+							"cost": 10,
+							"disabled": true
+						},
+						{
+							"id": "mdZamgGXO5wzrri6F",
+							"name": "Malediction-Proof",
+							"reference": "PSI14",
+							"cost": 50,
+							"disabled": true
+						},
+						{
+							"id": "mn4Yj3uRBdathIgxl",
+							"name": "Maledictions Only",
+							"reference": "PSI14",
+							"disabled": true
+						},
+						{
+							"id": "mtRJjmPRbkagvp56y",
+							"name": "Reflection",
+							"reference": "B47",
+							"cost": 100,
+							"disabled": true
+						}
+					]
 				},
 				{
-					"id": "mX7S4__1LX2NS1Gxk",
-					"name": "Hardened",
-					"reference": "B47",
-					"cost": 20,
-					"levels": 1,
-					"disabled": true
-				},
-				{
-					"id": "mLKkGDB453aomguWB",
-					"name": "Absorption",
-					"reference": "B46",
-					"local_notes": "Enhances @Trait@",
-					"cost": 80,
-					"disabled": true
-				},
-				{
-					"id": "mTSRK0F1l5H1E9zlQ",
-					"name": "Absorption",
-					"reference": "B46",
-					"local_notes": "Healing only",
-					"cost": 80,
-					"disabled": true
-				},
-				{
-					"id": "mwdyXsf0PjxQpkwys",
-					"name": "Absorption",
-					"reference": "B46",
-					"local_notes": "Enhances any trait",
-					"cost": 100,
-					"disabled": true
-				},
-				{
-					"id": "m5rFLFYiCh0DyQK0M",
-					"name": "Reflection",
-					"reference": "B47",
-					"cost": 100,
-					"disabled": true
-				},
-				{
-					"id": "mrol-ruC63GptlO5Y",
-					"name": "Bane",
-					"reference": "H14",
-					"local_notes": "@Rare@",
-					"cost": -1,
-					"cost_type": "points",
-					"disabled": true
-				},
-				{
-					"id": "mNTH01qidziSAnsfl",
-					"name": "Bane",
-					"reference": "H14",
-					"local_notes": "@Occasional@",
-					"cost": -5,
-					"disabled": true
-				},
-				{
-					"id": "m0cOdK_aRPj1X5kOe",
-					"name": "Bane",
-					"reference": "H14",
-					"local_notes": "@Common@",
-					"cost": -10,
-					"disabled": true
-				},
-				{
-					"id": "mkw9KpTKQdDwOY5o0",
-					"name": "Bane",
-					"reference": "H14",
-					"local_notes": "@Very Common@",
-					"cost": -15,
-					"disabled": true
-				},
-				{
-					"id": "m1PhXehIpnHG5Rn4z",
-					"name": "Directional",
-					"reference": "B47",
-					"local_notes": "Front",
-					"cost": -20,
-					"disabled": true
-				},
-				{
-					"id": "my2e1ZpCoAq09C6DT",
-					"name": "Flexible",
-					"reference": "B47",
-					"cost": -20,
-					"disabled": true
-				},
-				{
-					"id": "m7Ku5U9mz2Gn2m-Gi",
-					"name": "Limited",
-					"reference": "B46",
-					"local_notes": "@Very Common Attack Form@",
-					"cost": -20,
-					"disabled": true
-				},
-				{
-					"id": "moSP_fU7yJ4rKxaxw",
-					"name": "Semi-Ablative",
-					"reference": "B47",
-					"cost": -20,
-					"disabled": true
-				},
-				{
-					"id": "mBLGEMpIdshUgFB5H",
-					"name": "Can't wear armor",
-					"reference": "B47",
-					"cost": -40,
-					"disabled": true
-				},
-				{
-					"id": "m4GNdd1d4hOZF5O3H",
-					"name": "Directional",
-					"reference": "B47",
-					"local_notes": "@Direction: Back, Right, Left, Top or Underside@",
-					"cost": -40,
-					"disabled": true
-				},
-				{
-					"id": "m6EBMMFhLLAMnLeA0",
-					"name": "Limited",
-					"reference": "B46",
-					"local_notes": "@Common Attack Form@",
-					"cost": -40,
-					"disabled": true
-				},
-				{
-					"id": "mSGMspBOdLFnNjEEL",
-					"name": "Tough Skin",
-					"local_notes": "Effects that just require skin contact or a scratch ignore this DR",
-					"cost": -40,
-					"disabled": true
-				},
-				{
-					"id": "mOa2VvJZCqxzsyRB4",
-					"name": "Limited",
-					"reference": "B46",
-					"local_notes": "@Occasional Attack Form@",
-					"cost": -60,
-					"disabled": true
-				},
-				{
-					"id": "mqnZvSQPakijXtFdM",
-					"name": "Ablative",
-					"reference": "B47",
-					"cost": -80,
-					"disabled": true
-				},
-				{
-					"id": "mS7ViUfxP-rUTM_bo",
-					"name": "Limited",
-					"reference": "B46",
-					"local_notes": "@Rare Attack Form@",
-					"cost": -80,
-					"disabled": true
-				},
-				{
-					"id": "mK3l_i2EKmFiDuujB",
-					"name": "Laminate",
-					"reference": "RSWL18",
-					"cost": 10,
-					"disabled": true
-				},
-				{
-					"id": "mFmJgLWKHvd4DOQrS",
-					"name": "Malediction-Proof",
-					"reference": "PSI14",
-					"cost": 50,
-					"disabled": true
-				},
-				{
-					"id": "muAXYnEYDyUVr2S84",
-					"name": "Maledictions Only",
-					"reference": "PSI14",
-					"disabled": true
-				},
-				{
-					"id": "mor7wprMZpTySiYyo",
-					"name": "Partial (@Location, 1 level per -1 Per Hit Modifier, Torso is -10% thus level 1@)",
-					"reference": "B47",
-					"cost": -10,
-					"disabled": true
+					"id": "MLdtoe0kIczt1CwQK",
+					"name": "Special Limitations",
+					"children": [
+						{
+							"id": "m5yX0DkbngKxcMk3U",
+							"name": "Ablative",
+							"reference": "B47",
+							"cost": -80,
+							"disabled": true
+						},
+						{
+							"id": "mriC_suSIQRyOEPIf",
+							"name": "Bane",
+							"reference": "H14",
+							"local_notes": "@Very Common@",
+							"cost": -15,
+							"disabled": true
+						},
+						{
+							"id": "mGhdjo4vkF4K3wlU4",
+							"name": "Bane",
+							"reference": "H14",
+							"local_notes": "@Common@",
+							"cost": -10,
+							"disabled": true
+						},
+						{
+							"id": "mKFXBIZdlnqy30umW",
+							"name": "Bane",
+							"reference": "H14",
+							"local_notes": "@Occasional@",
+							"cost": -5,
+							"disabled": true
+						},
+						{
+							"id": "m82EYyrIt9oPcHoUi",
+							"name": "Bane",
+							"reference": "H14",
+							"local_notes": "@Rare@",
+							"cost": -1,
+							"cost_type": "points",
+							"disabled": true
+						},
+						{
+							"id": "mh0D3QvmBdTb2Fj35",
+							"name": "Can't wear armor",
+							"reference": "B47",
+							"cost": -40,
+							"disabled": true
+						},
+						{
+							"id": "mJOqQDNVieB3BqNZq",
+							"name": "Directional",
+							"reference": "B47",
+							"local_notes": "Front",
+							"cost": -20,
+							"disabled": true
+						},
+						{
+							"id": "mJI6krqiiAhykZkqD",
+							"name": "Directional",
+							"reference": "B47",
+							"local_notes": "@Direction: Back, Right, Left, Top or Underside@",
+							"cost": -40,
+							"disabled": true
+						},
+						{
+							"id": "mdXLyaSji8XL7ogcm",
+							"name": "Flexible",
+							"reference": "B47",
+							"cost": -20,
+							"disabled": true
+						},
+						{
+							"id": "mHX9jNBEFXDMx9Udj",
+							"name": "Limited",
+							"reference": "B46",
+							"local_notes": "@Very Common Attack Form@",
+							"cost": -20,
+							"disabled": true
+						},
+						{
+							"id": "mydbXeU0Gp6_5IXwP",
+							"name": "Limited",
+							"reference": "B46",
+							"local_notes": "@Common Attack Form@",
+							"cost": -40,
+							"disabled": true
+						},
+						{
+							"id": "mEhEeAZtQ31RY7uEQ",
+							"name": "Limited",
+							"reference": "B46",
+							"local_notes": "@Occasional Attack Form@",
+							"cost": -60,
+							"disabled": true
+						},
+						{
+							"id": "mjfZ7ao6KmZfLqHZL",
+							"name": "Limited",
+							"reference": "B46",
+							"local_notes": "@Rare Attack Form@",
+							"cost": -80,
+							"disabled": true
+						},
+						{
+							"id": "mWmUeD6W1op93mlr8",
+							"name": "Partial (@Location, 1 level per -1 Per Hit Modifier, Torso is -10% thus level 1@)",
+							"reference": "B47",
+							"cost": -10,
+							"disabled": true
+						},
+						{
+							"id": "mv-FSylFn8Naju4GK",
+							"name": "Semi-Ablative",
+							"reference": "B47",
+							"cost": -20,
+							"disabled": true
+						},
+						{
+							"id": "mP4bVdigxz3GIkAfk",
+							"name": "Tough Skin",
+							"reference": "B47",
+							"local_notes": "Effects that just require skin contact or a scratch ignore this DR",
+							"cost": -40,
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 5,

--- a/Library/Settings/Calendars/Gregorian.calendar
+++ b/Library/Settings/Calendars/Gregorian.calendar
@@ -15,7 +15,7 @@
       "days": 31
     },
     {
-      "name": "Feburary",
+      "name": "February",
       "days": 28
     },
     {


### PR DESCRIPTION
Sorted the modifiers to match the order in the books:
1. Enhancements first, then Limitations;
2. Inside each category, alphabetical order;
3. For different sub-types of the same modifier, I matched the book order.

For simplicity, rather than adding separate categories for each of the other books (Horror, Psi, etc.), I placed them inside those same two major categories (Enhancements and Limitations), in alphabetical order.

For Hardened, I also added a note with a reference to the armor divisor steps, which is VERY handy if you're playing a super with Hardened DR.