### PR TITLE
Stress & Derangement From GURPS Horror

### DIFF
--- a/Library/Settings/Attributes/Stress and Derangement.attr
+++ b/Library/Settings/Attributes/Stress and Derangement.attr
@@ -234,7 +234,7 @@
 			"base": "$will",
 			"thresholds": [
 				{
-					"state": "Over Stressed",
+					"state": "Overstressed",
 					"value": "0",
 					"explanation": "Further Stress Points go directly to Derangement. See Horror pg. 142"
 				},

--- a/Library/Settings/Attributes/Stress and Derangement.attr
+++ b/Library/Settings/Attributes/Stress and Derangement.attr
@@ -1,0 +1,268 @@
+{
+	"version": 5,
+	"rows": [
+		{
+			"id": "st",
+			"type": "integer",
+			"name": "ST",
+			"full_name": "Strength",
+			"base": "10",
+			"cost_per_point": 10,
+			"cost_adj_percent_per_sm": 10
+		},
+		{
+			"id": "dx",
+			"type": "integer",
+			"name": "DX",
+			"full_name": "Dexterity",
+			"base": "10",
+			"cost_per_point": 20
+		},
+		{
+			"id": "iq",
+			"type": "integer",
+			"name": "IQ",
+			"full_name": "Intelligence",
+			"base": "10",
+			"cost_per_point": 20
+		},
+		{
+			"id": "ht",
+			"type": "integer",
+			"name": "HT",
+			"full_name": "Health",
+			"base": "10",
+			"cost_per_point": 10
+		},
+		{
+			"id": "will",
+			"type": "integer",
+			"name": "Will",
+			"base": "$iq",
+			"cost_per_point": 5
+		},
+		{
+			"id": "fright_check",
+			"type": "integer",
+			"name": "Fright Check",
+			"base": "$will",
+			"cost_per_point": 2
+		},
+		{
+			"id": "per",
+			"type": "integer",
+			"name": "Per",
+			"full_name": "Perception",
+			"base": "$iq",
+			"cost_per_point": 5
+		},
+		{
+			"id": "vision",
+			"type": "integer",
+			"name": "Vision",
+			"base": "$per",
+			"cost_per_point": 2
+		},
+		{
+			"id": "hearing",
+			"type": "integer",
+			"name": "Hearing",
+			"base": "$per",
+			"cost_per_point": 2
+		},
+		{
+			"id": "taste_smell",
+			"type": "integer",
+			"name": "Taste & Smell",
+			"base": "$per",
+			"cost_per_point": 2
+		},
+		{
+			"id": "touch",
+			"type": "integer",
+			"name": "Touch",
+			"base": "$per",
+			"cost_per_point": 2
+		},
+		{
+			"id": "basic_speed",
+			"type": "decimal",
+			"name": "Basic Speed",
+			"base": "($dx + $ht) / 4",
+			"cost_per_point": 20
+		},
+		{
+			"id": "basic_move",
+			"type": "integer",
+			"name": "Basic Move",
+			"base": "Math.floor($basic_speed)",
+			"cost_per_point": 5
+		},
+		{
+			"id": "fp",
+			"type": "pool",
+			"name": "FP",
+			"full_name": "Fatigue Points",
+			"base": "$ht",
+			"cost_per_point": 3,
+			"thresholds": [
+				{
+					"state": "Unconscious",
+					"value": "-$fp",
+					"ops": [
+						"halve_move",
+						"halve_dodge",
+						"halve_st"
+					]
+				},
+				{
+					"state": "Collapse",
+					"value": "0",
+					"explanation": "<html><body>\n<b>Roll vs. Will</b> to do anything besides talk or rest; failure causes unconsciousness<br>\nEach FP you lose below 0 also causes 1 HP of injury<br>\nMove, Dodge and ST are halved (B426)\n</body></html>",
+					"ops": [
+						"halve_move",
+						"halve_dodge",
+						"halve_st"
+					]
+				},
+				{
+					"state": "Tired",
+					"value": "Math.ceil($fp / 3) - 1",
+					"explanation": "Move, Dodge and ST are halved (B426)",
+					"ops": [
+						"halve_move",
+						"halve_dodge",
+						"halve_st"
+					]
+				},
+				{
+					"state": "Tiring",
+					"value": "$fp - 1"
+				},
+				{
+					"state": "Rested",
+					"value": "$fp"
+				}
+			]
+		},
+		{
+			"id": "hp",
+			"type": "pool",
+			"name": "HP",
+			"full_name": "Hit Points",
+			"base": "$st",
+			"cost_per_point": 2,
+			"cost_adj_percent_per_sm": 10,
+			"thresholds": [
+				{
+					"state": "Dead",
+					"value": "Math.round(-$hp * 5)",
+					"ops": [
+						"halve_move",
+						"halve_dodge"
+					]
+				},
+				{
+					"state": "Dying #4",
+					"value": "Math.round(-$hp * 4)",
+					"explanation": "<html><body>\n<b>Roll vs. HT</b> to avoid death<br>\n<b>Roll vs. HT-4</b> every second to avoid falling unconscious<br>\nMove and Dodge are halved (B419)\n</body></html>",
+					"ops": [
+						"halve_move",
+						"halve_dodge"
+					]
+				},
+				{
+					"state": "Dying #3",
+					"value": "Math.round(-$hp * 3)",
+					"explanation": "<html><body>\n<b>Roll vs. HT</b> to avoid death<br>\n<b>Roll vs. HT-3</b> every second to avoid falling unconscious<br>\nMove and Dodge are halved (B419)\n</body></html>",
+					"ops": [
+						"halve_move",
+						"halve_dodge"
+					]
+				},
+				{
+					"state": "Dying #2",
+					"value": "Math.round(-$hp * 2)",
+					"explanation": "<html><body>\n<b>Roll vs. HT</b> to avoid death<br>\n<b>Roll vs. HT-2</b> every second to avoid falling unconscious<br>\nMove and Dodge are halved (B419)\n</body></html>",
+					"ops": [
+						"halve_move",
+						"halve_dodge"
+					]
+				},
+				{
+					"state": "Dying #1",
+					"value": "-$hp",
+					"explanation": "<html><body>\n<b>Roll vs. HT</b> to avoid death<br>\n<b>Roll vs. HT-1</b> every second to avoid falling unconscious<br>\nMove and Dodge are halved (B419)\n</body></html>",
+					"ops": [
+						"halve_move",
+						"halve_dodge"
+					]
+				},
+				{
+					"state": "Collapse",
+					"value": "0",
+					"explanation": "<html><body>\n<b>Roll vs. HT</b> every second to avoid falling unconscious<br>\nMove and Dodge are halved (B419)\n</body></html>",
+					"ops": [
+						"halve_move",
+						"halve_dodge"
+					]
+				},
+				{
+					"state": "Reeling",
+					"value": "Math.ceil($hp / 3) - 1",
+					"explanation": "Move and Dodge are halved (B419)",
+					"ops": [
+						"halve_move",
+						"halve_dodge"
+					]
+				},
+				{
+					"state": "Wounded",
+					"value": "$hp - 1"
+				},
+				{
+					"state": "Healthy",
+					"value": "$hp"
+				}
+			]
+		},
+		{
+			"id": "stress",
+			"type": "pool_ref",
+			"name": "Stress",
+			"full_name": "Stress Points",
+			"base": "$will",
+			"thresholds": [
+				{
+					"state": "Over Stressed",
+					"value": "0",
+					"explanation": "Further Stress Points go directly to Derangement. See Horror pg. 142"
+				},
+				{
+					"state": "Calm",
+					"value": "$will",
+					"explanation": "See Horror pg. 142"
+				}
+			]
+		},
+		{
+			"id": "der",
+			"type": "pool_ref",
+			"name": "Derangement",
+			"full_name": "Derangement Points",
+			"base": "$will",
+			"thresholds": [
+				{
+					"state": "Disturbed",
+					"value": "0",
+					"explanation": "Further Derangement Points add up and become Disadvantages. See Horror pg. 142"
+				},
+				{
+					"state": "Sane",
+					"value": "$will",
+					"explanation": "See Horror pg. 142"
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
1. Created a new attr file.
2. Tested locally on GCS.

### Overview
This Attribute file contains two reference-only pools: Stress and Derangement. They each include one threshold as per the rules in Horror on pg. 142. Instead of tracking these points as the book suggests, it is easier to track them as positive points to 0 (vs. 0 points into negatives).

Tooltips were included.

Stress includes "Calm" down to 0, then "Overstressed".

Derangement includes "Sane" down to 0, then "Disturbed".

It is possible to enter negative numbers. Which is not terrible since they are there for tracking only.