### PR TITLE
Fright Check mods for Cowardice and Xenophilia

### DIFF
--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -4434,6 +4434,7 @@
 				"Disadvantage",
 				"Mental"
 			],
+			"cr_adj": "fright_check_penalty",
 			"cr": 12,
 			"base_points": -10,
 			"calc": {
@@ -30000,6 +30001,7 @@
 				"Disadvantage",
 				"Mental"
 			],
+			"cr_adj": "fright_check_bonus",
 			"cr": 12,
 			"base_points": -10,
 			"calc": {


### PR DESCRIPTION
These modifiers were coded into GCS, apparently specifically for these disadvantages (see B129 and B162), but the respective traits didn't feature them.