### PR TITLE
Fix Quarterstaff in Basic Set Equipment

### DIFF
--- a/Library/Basic Set/Basic Set Equipment.eqp
+++ b/Library/Basic Set/Basic Set Equipment.eqp
@@ -201,6 +201,7 @@
 			"weapons": [
 				{
 					"id": "WiWK9mfmPOkaLtSCN",
+					"sv": 1,
 					"damage": {
 						"type": "pi",
 						"base": "4d+2"
@@ -302,6 +303,7 @@
 			"weapons": [
 				{
 					"id": "WPrjsj7ARr-Eu0QKg",
+					"sv": 1,
 					"damage": {
 						"type": "pi",
 						"base": "5d"
@@ -403,6 +405,7 @@
 			"weapons": [
 				{
 					"id": "WOWWT1_PoQP6EcCi-",
+					"sv": 1,
 					"damage": {
 						"type": "pi",
 						"base": "5d+1"
@@ -504,6 +507,7 @@
 			"weapons": [
 				{
 					"id": "WdZBCxTek6-60y3U9",
+					"sv": 1,
 					"damage": {
 						"type": "cr ex",
 						"base": "6dx10",
@@ -554,6 +558,7 @@
 			"weapons": [
 				{
 					"id": "WgSmMSAoS_r-2DV9Y",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "sw",
@@ -607,6 +612,7 @@
 			"weapons": [
 				{
 					"id": "Wt4qkbJ6Sf6MPU5OK",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "sw",
@@ -660,6 +666,7 @@
 			"weapons": [
 				{
 					"id": "WSArc0lCxT_6K2eoC",
+					"sv": 1,
 					"damage": {
 						"type": "pi",
 						"base": "2d+2"
@@ -761,6 +768,7 @@
 			"weapons": [
 				{
 					"id": "WVkgUGWw-MjRCY8QZ",
+					"sv": 1,
 					"damage": {
 						"type": "pi",
 						"base": "2d+2"
@@ -862,6 +870,7 @@
 			"weapons": [
 				{
 					"id": "W9niIoXE5JzbTG4Wc",
+					"sv": 1,
 					"damage": {
 						"type": "pi",
 						"base": "2d+2"
@@ -963,6 +972,7 @@
 			"weapons": [
 				{
 					"id": "WjSicDhPR-xKz0jTI",
+					"sv": 1,
 					"damage": {
 						"type": "pi+",
 						"base": "2d"
@@ -1064,6 +1074,7 @@
 			"weapons": [
 				{
 					"id": "WYsr2P9sMqQbBGoap",
+					"sv": 1,
 					"damage": {
 						"type": "pi+",
 						"base": "3d"
@@ -1165,6 +1176,7 @@
 			"weapons": [
 				{
 					"id": "W0ivVVQGdVvrSC_oZ",
+					"sv": 1,
 					"damage": {
 						"type": "pi+",
 						"base": "2d"
@@ -1266,6 +1278,7 @@
 			"weapons": [
 				{
 					"id": "WF1TpDiarZKyR9snW",
+					"sv": 1,
 					"damage": {
 						"type": "pi",
 						"base": "7d"
@@ -1367,6 +1380,7 @@
 			"weapons": [
 				{
 					"id": "WTVDCvxq5CrFXDqzc",
+					"sv": 1,
 					"damage": {
 						"type": "pi",
 						"base": "1d+1"
@@ -1467,6 +1481,7 @@
 			"weapons": [
 				{
 					"id": "w7qRgmurhN1MWXcbt",
+					"sv": 1,
 					"damage": {
 						"type": "cut",
 						"st": "sw",
@@ -2169,6 +2184,7 @@
 			"weapons": [
 				{
 					"id": "wx6xyqYCUmPuZS1mR",
+					"sv": 1,
 					"damage": {
 						"type": "cut",
 						"st": "sw",
@@ -2224,6 +2240,7 @@
 				},
 				{
 					"id": "wlhyu8lGmmbFH94IG",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "thr",
@@ -2279,6 +2296,7 @@
 				},
 				{
 					"id": "wwn4_2eHHO2KSCEWQ",
+					"sv": 1,
 					"damage": {
 						"type": "cut",
 						"st": "sw",
@@ -2319,6 +2337,7 @@
 				},
 				{
 					"id": "wX3etqc7prNbcAU3N",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "thr",
@@ -2379,6 +2398,7 @@
 			"weapons": [
 				{
 					"id": "wELUqoYixPVgbZOvQ",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "sw"
@@ -2442,6 +2462,7 @@
 				},
 				{
 					"id": "wLkXCclzuMkpBeb01",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "thr"
@@ -2543,6 +2564,7 @@
 			"weapons": [
 				{
 					"id": "Wz9RZkanRyrbkCYsg",
+					"sv": 1,
 					"damage": {
 						"type": "pi",
 						"base": "7d"
@@ -2974,6 +2996,7 @@
 			"weapons": [
 				{
 					"id": "Wk0NCIuRsgck3dut4",
+					"sv": 1,
 					"damage": {
 						"type": "cr ex",
 						"base": "6dx2",
@@ -3113,6 +3136,7 @@
 			"weapons": [
 				{
 					"id": "wjQdtdw2fAfkhT0Ov",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "thr"
@@ -3175,6 +3199,7 @@
 			"weapons": [
 				{
 					"id": "WxUGtdkiU5z0GhCbw",
+					"sv": 1,
 					"damage": {
 						"type": "burn",
 						"base": "3d",
@@ -3247,6 +3272,7 @@
 			"weapons": [
 				{
 					"id": "WZOdlEFe0VhOyc-yY",
+					"sv": 1,
 					"damage": {
 						"type": "burn",
 						"base": "6d",
@@ -3319,6 +3345,7 @@
 			"weapons": [
 				{
 					"id": "WiokJRftpR5uSRT9p",
+					"sv": 1,
 					"damage": {
 						"type": "pi-",
 						"base": "1d-3"
@@ -3385,6 +3412,7 @@
 			"weapons": [
 				{
 					"id": "WSGdAoAlFRWkY63YA",
+					"sv": 1,
 					"damage": {
 						"type": "pi-",
 						"base": "1d"
@@ -3485,6 +3513,7 @@
 			"weapons": [
 				{
 					"id": "WDixW34RztdQF2ZvS",
+					"sv": 1,
 					"damage": {
 						"type": "cr (see B411)",
 						"st": "thr",
@@ -3528,6 +3557,7 @@
 			"weapons": [
 				{
 					"id": "Wn38x1ZJH2mBfqvp5",
+					"sv": 1,
 					"damage": {
 						"type": "pi",
 						"base": "7d"
@@ -3697,6 +3727,7 @@
 			"weapons": [
 				{
 					"id": "w_1OzveStRqaECMYV",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "thr"
@@ -3747,6 +3778,7 @@
 			"weapons": [
 				{
 					"id": "w3Mv6vbbDTfG9tS3J",
+					"sv": 1,
 					"damage": {
 						"type": "cut",
 						"st": "sw",
@@ -3801,6 +3833,7 @@
 				},
 				{
 					"id": "wiDc84PMNESu6VGl8",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "thr",
@@ -4281,6 +4314,7 @@
 			"weapons": [
 				{
 					"id": "WrgU0a4kPAfpu3cLs",
+					"sv": 1,
 					"damage": {
 						"type": "pi+",
 						"base": "5d"
@@ -4381,6 +4415,7 @@
 			"weapons": [
 				{
 					"id": "weczi6g4Huai7Dcfa",
+					"sv": 1,
 					"damage": {
 						"type": "burn",
 						"base": "1d-3"
@@ -4464,6 +4499,7 @@
 			"weapons": [
 				{
 					"id": "wKUOQU1WNCtafA8pv",
+					"sv": 1,
 					"damage": {
 						"type": "cut",
 						"st": "sw",
@@ -4518,6 +4554,7 @@
 				},
 				{
 					"id": "wuURYfRDacbXhNgEE",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr",
@@ -4611,6 +4648,7 @@
 			"weapons": [
 				{
 					"id": "wjqtkJmf7IznZKOSY",
+					"sv": 1,
 					"damage": {
 						"type": "cut",
 						"st": "sw",
@@ -5141,6 +5179,7 @@
 			"weapons": [
 				{
 					"id": "Wwu-TgQXJJzgUhZvL",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr",
@@ -5163,7 +5202,8 @@
 						}
 					],
 					"calc": {
-						"damage": "thr+3 imp"
+						"damage": "thr+3 imp",
+						"range": "200/250"
 					}
 				}
 			],
@@ -5344,6 +5384,7 @@
 			"weapons": [
 				{
 					"id": "WAZxpIq-BGqx6QQla",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr",
@@ -5366,7 +5407,8 @@
 						}
 					],
 					"calc": {
-						"damage": "thr+4 imp"
+						"damage": "thr+4 imp",
+						"range": "140/175"
 					}
 				}
 			],
@@ -5414,6 +5456,7 @@
 			"weapons": [
 				{
 					"id": "wvHYVxsSefAXKbJSu",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "sw",
@@ -5450,6 +5493,7 @@
 				},
 				{
 					"id": "WaG_Dmp4MyPcJd15c",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "sw",
@@ -5500,6 +5544,7 @@
 			"weapons": [
 				{
 					"id": "wFoah_2FrHfKKs78t",
+					"sv": 1,
 					"damage": {
 						"type": "cut",
 						"st": "sw"
@@ -5563,6 +5608,7 @@
 				},
 				{
 					"id": "wz562EAb4iGtvbVnm",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr"
@@ -5685,6 +5731,7 @@
 			"weapons": [
 				{
 					"id": "wJTIk6ZiDY5BdBw0h",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr",
@@ -5729,6 +5776,7 @@
 				},
 				{
 					"id": "WrffJrHZRwjIpDGKt",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr",
@@ -5777,6 +5825,7 @@
 			"weapons": [
 				{
 					"id": "WS53mW4B0ZZeGF4EV",
+					"sv": 1,
 					"damage": {
 						"type": "pi-",
 						"base": "1d",
@@ -5879,6 +5928,7 @@
 			"weapons": [
 				{
 					"id": "WWMmhzpd8H2FcCL4O",
+					"sv": 1,
 					"damage": {
 						"type": "pi+",
 						"base": "1d"
@@ -6051,6 +6101,7 @@
 			"weapons": [
 				{
 					"id": "WtxJos5uW5dLqYB50",
+					"sv": 1,
 					"damage": {
 						"type": "pi",
 						"base": "1d+2"
@@ -6190,6 +6241,7 @@
 			"weapons": [
 				{
 					"id": "WjaoIPT07LHaRVd8V",
+					"sv": 1,
 					"damage": {
 						"type": "burn",
 						"base": "1d-3"
@@ -6260,6 +6312,7 @@
 			"weapons": [
 				{
 					"id": "WEOR_D5Lcnx-KsI8M",
+					"sv": 1,
 					"damage": {
 						"type": "burn",
 						"base": "1d-3"
@@ -6427,6 +6480,7 @@
 			"weapons": [
 				{
 					"id": "wrKNb-iKXFwGicFUF",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "sw",
@@ -6518,6 +6572,7 @@
 			"weapons": [
 				{
 					"id": "W4N4aj-UvJT1TnlNh",
+					"sv": 1,
 					"damage": {
 						"type": "burn",
 						"base": "3d"
@@ -6621,6 +6676,7 @@
 			"weapons": [
 				{
 					"id": "WEir9SDxBJr9NLbis",
+					"sv": 1,
 					"damage": {
 						"type": "pi++",
 						"base": "4d"
@@ -6722,6 +6778,7 @@
 			"weapons": [
 				{
 					"id": "WKVMy6LsWPZyzJ7wi",
+					"sv": 1,
 					"damage": {
 						"type": "pi+",
 						"base": "2d-1"
@@ -6823,6 +6880,7 @@
 			"weapons": [
 				{
 					"id": "wZJR2RDgkrEaI4PU-",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "thr"
@@ -6887,6 +6945,7 @@
 			"weapons": [
 				{
 					"id": "wZ32nHwqZEYMXEna8",
+					"sv": 1,
 					"damage": {
 						"type": "burn",
 						"base": "8d",
@@ -7245,6 +7304,7 @@
 			"weapons": [
 				{
 					"id": "w_dG2Gq7I9iNGyPEr",
+					"sv": 1,
 					"damage": {
 						"type": "see B405"
 					},
@@ -7359,6 +7419,7 @@
 			"weapons": [
 				{
 					"id": "W4tqW6kMLCx8lhiz5",
+					"sv": 1,
 					"damage": {
 						"type": "pi-",
 						"base": "4d",
@@ -7461,6 +7522,7 @@
 			"weapons": [
 				{
 					"id": "WfHPuGmgBtieDKeLt",
+					"sv": 1,
 					"damage": {
 						"type": "pi-",
 						"base": "6d+2",
@@ -7562,6 +7624,7 @@
 			"weapons": [
 				{
 					"id": "wHOvVMG_DBIobHvFG",
+					"sv": 1,
 					"damage": {
 						"type": "cut",
 						"st": "sw",
@@ -7602,6 +7665,7 @@
 				},
 				{
 					"id": "wvzxYgAsQ-9sBQwio",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr",
@@ -7718,6 +7782,7 @@
 			"weapons": [
 				{
 					"id": "wvANhpVcl6w81tXuo",
+					"sv": 1,
 					"damage": {
 						"type": "cut",
 						"st": "sw",
@@ -7809,6 +7874,7 @@
 			"weapons": [
 				{
 					"id": "wGWOjIo3HCw0W74Co",
+					"sv": 1,
 					"damage": {
 						"type": "cut",
 						"st": "sw",
@@ -7848,6 +7914,7 @@
 				},
 				{
 					"id": "wQMa1d5jNRuQVCg79",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "thr",
@@ -7927,6 +7994,7 @@
 			"weapons": [
 				{
 					"id": "W8Sp99LALXKAdk-1L",
+					"sv": 1,
 					"damage": {
 						"type": "pi++",
 						"base": "6d"
@@ -8027,6 +8095,7 @@
 			"weapons": [
 				{
 					"id": "w2Mq4JWfAA2MEOCUg",
+					"sv": 1,
 					"damage": {
 						"type": "cut",
 						"st": "sw",
@@ -8067,6 +8136,7 @@
 				},
 				{
 					"id": "wrQz-PxlW7WqwSbEO",
+					"sv": 1,
 					"damage": {
 						"type": "imp (may stick)",
 						"st": "sw",
@@ -8107,6 +8177,7 @@
 				},
 				{
 					"id": "wLdkAYajyLYBCdt1x",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr",
@@ -8169,6 +8240,7 @@
 			"weapons": [
 				{
 					"id": "WrP_QFJvd6iW-MIt6",
+					"sv": 1,
 					"damage": {
 						"type": "cr ex",
 						"base": "3d",
@@ -8221,6 +8293,7 @@
 			"weapons": [
 				{
 					"id": "Wuch_jonKiHLoFZoD",
+					"sv": 1,
 					"damage": {
 						"type": "spec. (2 y)"
 					},
@@ -8270,6 +8343,7 @@
 			"weapons": [
 				{
 					"id": "WMdD6YVU5vfjwZ8sF",
+					"sv": 1,
 					"damage": {
 						"type": "cr ex",
 						"base": "6d"
@@ -8320,6 +8394,7 @@
 			"weapons": [
 				{
 					"id": "WXKVjBKmNLCHe6gr3",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"base": "5dx2"
@@ -8370,6 +8445,7 @@
 			"weapons": [
 				{
 					"id": "WvUeWdJkCR1HK0_vN",
+					"sv": 1,
 					"damage": {
 						"type": "cr ex",
 						"base": "4d",
@@ -8422,6 +8498,7 @@
 			"weapons": [
 				{
 					"id": "WU1SyjwlMoKykqz2s",
+					"sv": 1,
 					"damage": {
 						"type": "cr ex",
 						"base": "8d",
@@ -8474,6 +8551,7 @@
 			"weapons": [
 				{
 					"id": "W5Y2u3XW5_dpmT2dy",
+					"sv": 1,
 					"damage": {
 						"type": "burn ex",
 						"base": "6dx4"
@@ -8524,6 +8602,7 @@
 			"weapons": [
 				{
 					"id": "WdVgHE6qhUTW1T1xb",
+					"sv": 1,
 					"damage": {
 						"type": ""
 					},
@@ -8600,6 +8679,7 @@
 			"weapons": [
 				{
 					"id": "WpC7IdmqZLXgsHrXy",
+					"sv": 1,
 					"damage": {
 						"type": "pi++",
 						"base": "2d"
@@ -8699,6 +8779,7 @@
 			"weapons": [
 				{
 					"id": "WI1SIdNJB1lYCrmh_",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr",
@@ -8755,6 +8836,7 @@
 			"weapons": [
 				{
 					"id": "wMYnSjzFrsddOzZmi",
+					"sv": 1,
 					"damage": {
 						"type": "cut",
 						"st": "sw"
@@ -8789,6 +8871,7 @@
 				},
 				{
 					"id": "WruZ9WbntpBE_6xps",
+					"sv": 1,
 					"damage": {
 						"type": "cut",
 						"st": "sw"
@@ -8838,6 +8921,7 @@
 			"weapons": [
 				{
 					"id": "WoGLyV-ijAoXoZ4a4",
+					"sv": 1,
 					"damage": {
 						"type": "burn",
 						"base": "8d",
@@ -8910,6 +8994,7 @@
 			"weapons": [
 				{
 					"id": "w8uxip2kmbflJu1Eu",
+					"sv": 1,
 					"damage": {
 						"type": "See B404"
 					},
@@ -8943,6 +9028,7 @@
 				},
 				{
 					"id": "WP5EpU7ziY2PNTuMU",
+					"sv": 1,
 					"damage": {
 						"type": "See B411"
 					},
@@ -9194,6 +9280,7 @@
 			"weapons": [
 				{
 					"id": "Wj0znzPNJp0Hkzgdf",
+					"sv": 1,
 					"damage": {
 						"type": "pi+",
 						"base": "13d+1"
@@ -9267,6 +9354,7 @@
 			"weapons": [
 				{
 					"id": "WEP1jDMAjhA9kbQNW",
+					"sv": 1,
 					"damage": {
 						"type": "pi",
 						"base": "2d"
@@ -9442,6 +9530,7 @@
 			"weapons": [
 				{
 					"id": "WIErNhzkpP4vfYKLB",
+					"sv": 1,
 					"damage": {
 						"type": "cr ex",
 						"base": "7d",
@@ -9524,6 +9613,7 @@
 				},
 				{
 					"id": "WVdQ1yBTGYHJTQyQA",
+					"sv": 1,
 					"damage": {
 						"type": "cr ex",
 						"base": "4d"
@@ -9604,6 +9694,7 @@
 				},
 				{
 					"id": "WrxaeMzusgGnpRKQZ",
+					"sv": 1,
 					"damage": {
 						"type": "HT-5 aff (10 yd)"
 					},
@@ -9704,6 +9795,7 @@
 			"weapons": [
 				{
 					"id": "W1f-Cmz_LeX5UoXfK",
+					"sv": 1,
 					"damage": {
 						"type": "pi",
 						"base": "6d"
@@ -9802,6 +9894,7 @@
 			"weapons": [
 				{
 					"id": "W-A33tVnRhevB8YsC",
+					"sv": 1,
 					"damage": {
 						"type": "cr ex",
 						"base": "7d",
@@ -9923,6 +10016,7 @@
 			"weapons": [
 				{
 					"id": "wK5xqhK-77lTpLiaW",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr",
@@ -9958,6 +10052,7 @@
 				},
 				{
 					"id": "Wl_vzvxuppwHzOo9W",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr",
@@ -10018,6 +10113,7 @@
 			"weapons": [
 				{
 					"id": "wsn4XQsCc3RCsSr5X",
+					"sv": 1,
 					"damage": {
 						"type": "cut",
 						"st": "sw",
@@ -10073,6 +10169,7 @@
 				},
 				{
 					"id": "wK6tmlAYGqF3Fv0Hm",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr",
@@ -10128,6 +10225,7 @@
 				},
 				{
 					"id": "wZCgWNoJ_L8q6kJ5i",
+					"sv": 1,
 					"damage": {
 						"type": "cut",
 						"st": "sw",
@@ -10168,6 +10266,7 @@
 				},
 				{
 					"id": "w6MJqW0A7e5k-rfvR",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr",
@@ -10263,6 +10362,7 @@
 			"weapons": [
 				{
 					"id": "wK-ZVP5r545I-BK6x",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "sw",
@@ -10324,6 +10424,7 @@
 			"weapons": [
 				{
 					"id": "wBthQqNzqG90phN46",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr",
@@ -10429,6 +10530,7 @@
 			"weapons": [
 				{
 					"id": "wL3_P_HVWUOiABVir",
+					"sv": 1,
 					"damage": {
 						"type": "cut",
 						"st": "sw",
@@ -10473,6 +10575,7 @@
 				},
 				{
 					"id": "wwQDrDMsPQYoPKRRt",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr"
@@ -10516,6 +10619,7 @@
 				},
 				{
 					"id": "WCE9cEVOQJfXrps-D",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr"
@@ -10563,6 +10667,7 @@
 			"weapons": [
 				{
 					"id": "W4eKGBbu33_CfmTvQ",
+					"sv": 1,
 					"damage": {
 						"type": "see B411"
 					},
@@ -10609,6 +10714,7 @@
 			"weapons": [
 				{
 					"id": "w9e01JVLqsvdEcKWs",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "thr"
@@ -10677,6 +10783,7 @@
 			"weapons": [
 				{
 					"id": "WMlBMyNmk4cPh_hLG",
+					"sv": 1,
 					"damage": {
 						"type": "see B411"
 					},
@@ -10738,6 +10845,7 @@
 			"weapons": [
 				{
 					"id": "WoOJD2ubiYycPk8PH",
+					"sv": 1,
 					"damage": {
 						"type": "burn",
 						"base": "3d",
@@ -10810,6 +10918,7 @@
 			"weapons": [
 				{
 					"id": "W6lItGIUNKGR9eCXT",
+					"sv": 1,
 					"damage": {
 						"type": "burn",
 						"base": "5d",
@@ -10900,6 +11009,7 @@
 			"weapons": [
 				{
 					"id": "WsnHfJK3FORFqnXAq",
+					"sv": 1,
 					"damage": {
 						"type": "burn",
 						"base": "5d",
@@ -10972,6 +11082,7 @@
 			"weapons": [
 				{
 					"id": "WP9GDTt-um24pU1rk",
+					"sv": 1,
 					"damage": {
 						"type": "cr ex",
 						"base": "6dx6",
@@ -11342,6 +11453,7 @@
 			"weapons": [
 				{
 					"id": "WHlWYhRFtygEJ3YRe",
+					"sv": 1,
 					"damage": {
 						"type": "pi",
 						"base": "5d"
@@ -11461,6 +11573,7 @@
 			"weapons": [
 				{
 					"id": "wTbUUlNIQLtG8w_t_",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "thr"
@@ -11523,6 +11636,7 @@
 			"weapons": [
 				{
 					"id": "wvR6BjdHFaPVQWHFW",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "thr",
@@ -11587,6 +11701,7 @@
 			"weapons": [
 				{
 					"id": "wbp83KyRmyZooNrWw",
+					"sv": 1,
 					"damage": {
 						"type": "See B404"
 					},
@@ -11620,6 +11735,7 @@
 				},
 				{
 					"id": "WaKzfLpq8QewqA4Sf",
+					"sv": 1,
 					"damage": {
 						"type": "See B411"
 					},
@@ -11683,6 +11799,7 @@
 			"weapons": [
 				{
 					"id": "wl0VFPw-S3tRdzyFC",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "sw",
@@ -11737,6 +11854,7 @@
 				},
 				{
 					"id": "wCzjnvOkE-90q23yf",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "thr",
@@ -11840,6 +11958,7 @@
 			"weapons": [
 				{
 					"id": "wrPH-HCsN-9KNpsYR",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "thr"
@@ -11904,6 +12023,7 @@
 			"weapons": [
 				{
 					"id": "WRl2kTX793p2gyeTc",
+					"sv": 1,
 					"damage": {
 						"type": "pi",
 						"base": "7d"
@@ -12024,6 +12144,7 @@
 			"weapons": [
 				{
 					"id": "wHCE5Ql4trBUIyl8O",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr",
@@ -12059,6 +12180,7 @@
 				},
 				{
 					"id": "wiCjlutpkeaBm12G_",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr",
@@ -12115,6 +12237,7 @@
 			"weapons": [
 				{
 					"id": "WdJrfwk7x9Bvy0x34",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr",
@@ -12137,7 +12260,8 @@
 						}
 					],
 					"calc": {
-						"damage": "thr+2 imp"
+						"damage": "thr+2 imp",
+						"range": "165/220"
 					}
 				}
 			],
@@ -12193,6 +12317,7 @@
 			"weapons": [
 				{
 					"id": "wPq1BbHgzWbYRo0wQ",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "sw",
@@ -12228,6 +12353,7 @@
 				},
 				{
 					"id": "WNtez22_QbQv8MtfU",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "sw",
@@ -12277,6 +12403,7 @@
 			"weapons": [
 				{
 					"id": "WBlq2U2nJaFvkMfc5",
+					"sv": 1,
 					"damage": {
 						"type": "pi",
 						"base": "2d+2"
@@ -12606,6 +12733,7 @@
 			"weapons": [
 				{
 					"id": "WQvV2sykfZQg2-2gq",
+					"sv": 1,
 					"damage": {
 						"type": "pi++",
 						"base": "4d"
@@ -12706,6 +12834,7 @@
 			"weapons": [
 				{
 					"id": "w5Fxh0we7wrAIOwHZ",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "sw",
@@ -12766,6 +12895,7 @@
 			"weapons": [
 				{
 					"id": "wXeHtPNTVBzx1m_do",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "thr"
@@ -12828,6 +12958,7 @@
 			"weapons": [
 				{
 					"id": "wn9_I9FnS1IB3yEuW",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "thr",
@@ -12892,6 +13023,7 @@
 			"weapons": [
 				{
 					"id": "wL8RSbDLhAWX_b_Xr",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "thr"
@@ -12953,6 +13085,7 @@
 			"weapons": [
 				{
 					"id": "WNFjKqZsftG0MiEjF",
+					"sv": 1,
 					"damage": {
 						"type": "see B411"
 					},
@@ -13090,6 +13223,7 @@
 			"weapons": [
 				{
 					"id": "Wz-6hK0ObDUyX29aj",
+					"sv": 1,
 					"damage": {
 						"type": "spec. (1 y)"
 					},
@@ -13137,6 +13271,7 @@
 			"weapons": [
 				{
 					"id": "w-OqYlCQZiT7MjHw9",
+					"sv": 1,
 					"damage": {
 						"type": "cut",
 						"st": "sw",
@@ -13192,6 +13327,7 @@
 			"weapons": [
 				{
 					"id": "wQ_J3APpAmGkWjyQV",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "sw",
@@ -13248,6 +13384,7 @@
 			"weapons": [
 				{
 					"id": "wYUzuJbNVdNcxfCwc",
+					"sv": 1,
 					"damage": {
 						"type": "cut",
 						"st": "sw",
@@ -13289,6 +13426,7 @@
 				},
 				{
 					"id": "wYfFRCJflOPE4p9Cw",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr",
@@ -13330,6 +13468,7 @@
 				},
 				{
 					"id": "wWtf1jXtEheO2zN1z",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "sw",
@@ -13366,6 +13505,7 @@
 				},
 				{
 					"id": "whxgyZgbIq4Gu-7e6",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "thr",
@@ -13402,6 +13542,7 @@
 				},
 				{
 					"id": "wSXW1pZZQrkTZTxJV",
+					"sv": 1,
 					"damage": {
 						"type": "cut",
 						"st": "sw",
@@ -13442,6 +13583,7 @@
 				},
 				{
 					"id": "wwTJmsd0JkLzeRvgF",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr",
@@ -13642,6 +13784,7 @@
 			"weapons": [
 				{
 					"id": "wmXM0VpHIIIqcNV2f",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "sw",
@@ -13849,6 +13992,7 @@
 			"weapons": [
 				{
 					"id": "W2g74AJ8iZicOwRuY",
+					"sv": 1,
 					"damage": {
 						"type": "pi-",
 						"base": "4d+1"
@@ -13969,6 +14113,7 @@
 			"weapons": [
 				{
 					"id": "wNPpmKg66MhAfFeqI",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "sw",
@@ -14044,6 +14189,7 @@
 			"weapons": [
 				{
 					"id": "WhNl1lTa-iuDUrf7S",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr",
@@ -14066,7 +14212,8 @@
 						}
 					],
 					"calc": {
-						"damage": "thr+2 imp"
+						"damage": "thr+2 imp",
+						"range": "105/140"
 					}
 				}
 			],
@@ -14222,6 +14369,7 @@
 			"weapons": [
 				{
 					"id": "wX1CJ9wrOGuCzzPih",
+					"sv": 1,
 					"damage": {
 						"type": "cut",
 						"st": "sw",
@@ -14262,6 +14410,7 @@
 				},
 				{
 					"id": "wqahgKLAzb-0mhIJC",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "sw",
@@ -14508,6 +14657,7 @@
 			"weapons": [
 				{
 					"id": "WCebzCxKN_hS_u8MW",
+					"sv": 1,
 					"damage": {
 						"type": "pi",
 						"base": "1d+1"
@@ -14555,6 +14705,7 @@
 			"weapons": [
 				{
 					"id": "WbM0xUjB2q-8hSWtn",
+					"sv": 1,
 					"damage": {
 						"type": "pi",
 						"base": "1d+1"
@@ -14602,6 +14753,7 @@
 			"weapons": [
 				{
 					"id": "W3wbnOel8-z9HZU6I",
+					"sv": 1,
 					"damage": {
 						"type": "pi",
 						"base": "1d+2"
@@ -14649,6 +14801,7 @@
 			"weapons": [
 				{
 					"id": "W7EF6CBxaLZQniqAw",
+					"sv": 1,
 					"damage": {
 						"type": "pi",
 						"base": "1d+2"
@@ -14696,6 +14849,7 @@
 			"weapons": [
 				{
 					"id": "W4oBEyg6H4rdNjFKI",
+					"sv": 1,
 					"damage": {
 						"type": "pi",
 						"base": "1d+3"
@@ -14743,6 +14897,7 @@
 			"weapons": [
 				{
 					"id": "W6cE3WBUrzdm0rU0e",
+					"sv": 1,
 					"damage": {
 						"type": "pi",
 						"base": "1d+3"
@@ -14790,6 +14945,7 @@
 			"weapons": [
 				{
 					"id": "WDvzQAZ0AvGBKrS7k",
+					"sv": 1,
 					"damage": {
 						"type": "pi",
 						"base": "2d"
@@ -14837,6 +14993,7 @@
 			"weapons": [
 				{
 					"id": "Wnkdt-E7WxnFj_W29",
+					"sv": 1,
 					"damage": {
 						"type": "pi",
 						"base": "2d"
@@ -14884,6 +15041,7 @@
 			"weapons": [
 				{
 					"id": "W7Nh-KR2S5_4RTQga",
+					"sv": 1,
 					"damage": {
 						"type": "pi",
 						"base": "2d+1"
@@ -14931,6 +15089,7 @@
 			"weapons": [
 				{
 					"id": "Wt82x058BnvOIdDHA",
+					"sv": 1,
 					"damage": {
 						"type": "pi",
 						"base": "2d+1"
@@ -14978,6 +15137,7 @@
 			"weapons": [
 				{
 					"id": "Wq1YUwwwQH4-OUNxo",
+					"sv": 1,
 					"damage": {
 						"type": "pi",
 						"base": "2d+2"
@@ -15025,6 +15185,7 @@
 			"weapons": [
 				{
 					"id": "W1SJK9D4B5QUiqalc",
+					"sv": 1,
 					"damage": {
 						"type": "pi",
 						"base": "2d+2"
@@ -15072,6 +15233,7 @@
 			"weapons": [
 				{
 					"id": "WF7sT2Qrt3wRkgE0H",
+					"sv": 1,
 					"damage": {
 						"type": "pi",
 						"base": "2d+3"
@@ -15119,6 +15281,7 @@
 			"weapons": [
 				{
 					"id": "WWKehZdfJMtZbMT3Q",
+					"sv": 1,
 					"damage": {
 						"type": "pi",
 						"base": "2d+3"
@@ -15165,6 +15328,7 @@
 			"weapons": [
 				{
 					"id": "WtG-ZBIFfo-AQIxx1",
+					"sv": 1,
 					"damage": {
 						"type": "pi",
 						"base": "1d+1"
@@ -15296,7 +15460,8 @@
 			"base_weight": "4 lb",
 			"weapons": [
 				{
-					"id": "wjatXMxdtCzVwzBLR",
+					"id": "wDcDSHy73Q7fxhRTn",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "sw",
@@ -15332,7 +15497,8 @@
 					}
 				},
 				{
-					"id": "wStmMT7Mhz7uOXrqA",
+					"id": "w4FrobpQ1F-2EN-H8",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "thr",
@@ -15365,86 +15531,6 @@
 					],
 					"calc": {
 						"damage": "thr+2 cr"
-					}
-				},
-				{
-					"id": "wVN6OWI7fNGfLif7v",
-					"damage": {
-						"type": "cr",
-						"st": "sw",
-						"base": "2"
-					},
-					"strength": "9†",
-					"usage": "Swung",
-					"usage_notes": "Two-Handed Sword",
-					"reach": "1-2",
-					"parry": "0",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -5
-						},
-						{
-							"type": "skill",
-							"name": "Two-Handed Sword"
-						},
-						{
-							"type": "skill",
-							"name": "Broadsword",
-							"modifier": -4
-						},
-						{
-							"type": "skill",
-							"name": "Force Sword",
-							"modifier": -4
-						},
-						{
-							"type": "skill",
-							"name": "Sword!"
-						}
-					],
-					"calc": {
-						"damage": "sw+2 cr"
-					}
-				},
-				{
-					"id": "w7zWDaBdGo9qlEQaR",
-					"damage": {
-						"type": "cr",
-						"st": "thr",
-						"base": "1"
-					},
-					"strength": "9†",
-					"usage": "Thrust",
-					"usage_notes": "Two-Handed Sword",
-					"reach": "2",
-					"parry": "0",
-					"defaults": [
-						{
-							"type": "dx",
-							"modifier": -5
-						},
-						{
-							"type": "skill",
-							"name": "Two-Handed Sword"
-						},
-						{
-							"type": "skill",
-							"name": "Broadsword",
-							"modifier": -4
-						},
-						{
-							"type": "skill",
-							"name": "Force Sword",
-							"modifier": -4
-						},
-						{
-							"type": "skill",
-							"name": "Sword!"
-						}
-					],
-					"calc": {
-						"damage": "thr+1 cr"
 					}
 				}
 			],
@@ -15545,6 +15631,7 @@
 			"weapons": [
 				{
 					"id": "wrlEIwcDfnCj86cSU",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr",
@@ -15615,6 +15702,7 @@
 			"weapons": [
 				{
 					"id": "WfqW1JGF2lk0Rghs5",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr",
@@ -15637,7 +15725,8 @@
 						}
 					],
 					"calc": {
-						"damage": "thr+1 imp"
+						"damage": "thr+1 imp",
+						"range": "150/200"
 					}
 				}
 			],
@@ -15664,6 +15753,7 @@
 			"weapons": [
 				{
 					"id": "WvqE82UbO62tNWa2u",
+					"sv": 1,
 					"damage": {
 						"type": "pi",
 						"base": "7d+2",
@@ -15802,6 +15892,7 @@
 			"weapons": [
 				{
 					"id": "WVwI1aNlnkGD2kAAd",
+					"sv": 1,
 					"damage": {
 						"type": "pi",
 						"base": "2d-1"
@@ -15903,6 +15994,7 @@
 			"weapons": [
 				{
 					"id": "WymP8K6NCPmi-CNNW",
+					"sv": 1,
 					"damage": {
 						"type": "pi",
 						"base": "2d-1"
@@ -16004,6 +16096,7 @@
 			"weapons": [
 				{
 					"id": "W62Evgr3VBA5wmCGO",
+					"sv": 1,
 					"damage": {
 						"type": "pi+",
 						"base": "3d"
@@ -16105,6 +16198,7 @@
 			"weapons": [
 				{
 					"id": "Wp_AU1pxN0rOehbfY",
+					"sv": 1,
 					"damage": {
 						"type": "pi",
 						"base": "3d-1"
@@ -16206,6 +16300,7 @@
 			"weapons": [
 				{
 					"id": "WcSx1CCBOUh9lGuMX",
+					"sv": 1,
 					"damage": {
 						"type": "pi+",
 						"base": "4d"
@@ -16383,6 +16478,7 @@
 			"weapons": [
 				{
 					"id": "WAOC7Jd8EPCU7nZYa",
+					"sv": 1,
 					"damage": {
 						"type": "cr ex",
 						"base": "6dx3",
@@ -16484,6 +16580,7 @@
 			"weapons": [
 				{
 					"id": "wl7QeidUnJKkGqJDN",
+					"sv": 1,
 					"damage": {
 						"type": "cut",
 						"st": "sw",
@@ -16538,6 +16635,7 @@
 				},
 				{
 					"id": "wM6s8TSxVVF2Otgtd",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr",
@@ -16664,6 +16762,7 @@
 			"weapons": [
 				{
 					"id": "Wj1_k64Pf56aHbrn9",
+					"sv": 1,
 					"damage": {
 						"type": "cr ex",
 						"base": "6dx3",
@@ -16743,6 +16842,7 @@
 			"weapons": [
 				{
 					"id": "wSMfp4v0NO1Svg8fl",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "thr"
@@ -16825,6 +16925,7 @@
 			"weapons": [
 				{
 					"id": "WnqcIwFKpuICI7qPk",
+					"sv": 1,
 					"damage": {
 						"type": "pi",
 						"base": "5d+1"
@@ -17049,6 +17150,7 @@
 			"weapons": [
 				{
 					"id": "WilBv4Bw4DrCvW0wd",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"base": "5d"
@@ -17140,6 +17242,7 @@
 			"weapons": [
 				{
 					"id": "w6bnG49gGJENbXeBu",
+					"sv": 1,
 					"damage": {
 						"type": "cut",
 						"st": "sw",
@@ -17180,6 +17283,7 @@
 				},
 				{
 					"id": "wwc0J0mKmRrqXirCZ",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "sw"
@@ -17240,6 +17344,7 @@
 			"weapons": [
 				{
 					"id": "WvXSJrjT57O54RhDE",
+					"sv": 1,
 					"damage": {
 						"type": "pi",
 						"base": "7d"
@@ -17369,6 +17474,7 @@
 			"weapons": [
 				{
 					"id": "WPUqTlwRXlhaweo6x",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr"
@@ -17390,7 +17496,8 @@
 						}
 					],
 					"calc": {
-						"damage": "thr imp"
+						"damage": "thr imp",
+						"range": "70/105"
 					}
 				}
 			],
@@ -17416,6 +17523,7 @@
 			"weapons": [
 				{
 					"id": "wvOCBtcs6nJP60mgX",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "sw"
@@ -17464,6 +17572,7 @@
 				},
 				{
 					"id": "wUOBoKdsXio7ge32w",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "thr"
@@ -17532,6 +17641,7 @@
 			"weapons": [
 				{
 					"id": "wL1VXNsAGbV6xx8nR",
+					"sv": 1,
 					"damage": {
 						"type": "cut",
 						"st": "sw"
@@ -17595,6 +17705,7 @@
 				},
 				{
 					"id": "wt6XIbyK9UDzPhW26",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr"
@@ -17737,6 +17848,7 @@
 			"weapons": [
 				{
 					"id": "WqrLp1JPFaltiZj-e",
+					"sv": 1,
 					"damage": {
 						"type": "cut",
 						"st": "thr",
@@ -17882,6 +17994,7 @@
 			"weapons": [
 				{
 					"id": "WFThSKfXD3KuIz6jd",
+					"sv": 1,
 					"damage": {
 						"type": "pi",
 						"st": "sw"
@@ -17946,6 +18059,7 @@
 			"weapons": [
 				{
 					"id": "w4JDMIrBS4TAhfzMy",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "thr"
@@ -18008,6 +18122,7 @@
 			"weapons": [
 				{
 					"id": "wznG8rPGdQUDOZBGG",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "thr",
@@ -18072,6 +18187,7 @@
 			"weapons": [
 				{
 					"id": "wjuuIz5RySA93mzSW",
+					"sv": 1,
 					"damage": {
 						"type": "cut",
 						"st": "sw",
@@ -18116,6 +18232,7 @@
 				},
 				{
 					"id": "wa4joc7UHvhmwlfPR",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr",
@@ -18160,6 +18277,7 @@
 				},
 				{
 					"id": "WGAKDJWNDj3i8XYHi",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr",
@@ -18209,6 +18327,7 @@
 			"weapons": [
 				{
 					"id": "wbYN16_hvNyCIxMfj",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "sw",
@@ -18244,6 +18363,7 @@
 				},
 				{
 					"id": "W7yP6PY5EzhazARja",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "sw",
@@ -18294,6 +18414,7 @@
 			"weapons": [
 				{
 					"id": "wmDswK6LD9JprILJG",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "thr"
@@ -18357,6 +18478,7 @@
 			"weapons": [
 				{
 					"id": "w2T2xdIQcKuK3GBSK",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr",
@@ -18427,6 +18549,7 @@
 			"weapons": [
 				{
 					"id": "W0jUp9ZouZfwxrXJY",
+					"sv": 1,
 					"damage": {
 						"type": "pi",
 						"base": "3d-1"
@@ -18528,6 +18651,7 @@
 			"weapons": [
 				{
 					"id": "W5MopXEk2ul4u8YZf",
+					"sv": 1,
 					"damage": {
 						"type": "pi",
 						"base": "3d-1"
@@ -18629,6 +18753,7 @@
 			"weapons": [
 				{
 					"id": "WXQWgjiT0fSrSgs8R",
+					"sv": 1,
 					"damage": {
 						"type": "pi+",
 						"base": "2d+1"
@@ -18730,6 +18855,7 @@
 			"weapons": [
 				{
 					"id": "WTcgKjAVCrn1X7gcI",
+					"sv": 1,
 					"damage": {
 						"type": "pi",
 						"base": "9d+1"
@@ -18831,6 +18957,7 @@
 			"weapons": [
 				{
 					"id": "WLsf1qHkM95UF0E8z",
+					"sv": 1,
 					"damage": {
 						"type": "pi",
 						"base": "1d+2"
@@ -19390,6 +19517,7 @@
 			"weapons": [
 				{
 					"id": "wUWHzxrhr72NrJXxq",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr",
@@ -19425,6 +19553,7 @@
 				},
 				{
 					"id": "wlbBRnkeGMtBhOogu",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr",
@@ -19460,6 +19589,7 @@
 				},
 				{
 					"id": "WP-aSj6fG5bMV1sT0",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr",
@@ -19576,6 +19706,7 @@
 			"weapons": [
 				{
 					"id": "WrXABQ5pGO7ADbxXX",
+					"sv": 1,
 					"damage": {
 						"type": "pi",
 						"st": "sw",
@@ -19985,6 +20116,7 @@
 			"weapons": [
 				{
 					"id": "wQkmwAvjQz24u7cSC",
+					"sv": 1,
 					"damage": {
 						"type": "HT-3(0.5) aff"
 					},
@@ -20524,6 +20656,7 @@
 			"weapons": [
 				{
 					"id": "wDaGknuStC1nllZcz",
+					"sv": 1,
 					"damage": {
 						"type": "cut",
 						"st": "sw",
@@ -20559,6 +20692,7 @@
 				},
 				{
 					"id": "W3D-gnma38CZgiyyy",
+					"sv": 1,
 					"damage": {
 						"type": "cut",
 						"st": "sw",
@@ -20608,6 +20742,7 @@
 			"weapons": [
 				{
 					"id": "wTD3z3ccQLb1wqBMe",
+					"sv": 1,
 					"damage": {
 						"type": "cut",
 						"st": "sw",
@@ -20662,6 +20797,7 @@
 				},
 				{
 					"id": "w8AeNPhx3cYzY20nH",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr",
@@ -20716,6 +20852,7 @@
 				},
 				{
 					"id": "wJnArgeLyMkcuxD_y",
+					"sv": 1,
 					"damage": {
 						"type": "cut",
 						"st": "sw",
@@ -20756,6 +20893,7 @@
 				},
 				{
 					"id": "wQQlSsRMP_PTV_Nwr",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr",
@@ -20816,6 +20954,7 @@
 			"weapons": [
 				{
 					"id": "wrpM6HEl791b0gXl4",
+					"sv": 1,
 					"damage": {
 						"type": "cut",
 						"st": "sw",
@@ -20870,6 +21009,7 @@
 				},
 				{
 					"id": "wEufjEhCYoc8Kr6MF",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr",
@@ -20944,6 +21084,7 @@
 			"weapons": [
 				{
 					"id": "wu7AQIu1obIDOu-VB",
+					"sv": 1,
 					"damage": {
 						"type": "cut",
 						"st": "sw",
@@ -20983,6 +21124,7 @@
 				},
 				{
 					"id": "wJfInmqQ0HJhvIZVR",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr",
@@ -21137,6 +21279,7 @@
 			"weapons": [
 				{
 					"id": "WY9DnMn3p-BCbMHbA",
+					"sv": 1,
 					"damage": {
 						"type": "cr ex",
 						"base": "4d",
@@ -21511,6 +21654,7 @@
 			"weapons": [
 				{
 					"id": "wvoRS5wtBvc9uhJ6n",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "sw",
@@ -21629,6 +21773,7 @@
 			"weapons": [
 				{
 					"id": "Wc6LY9jy1xinYdpVS",
+					"sv": 1,
 					"damage": {
 						"type": "pi+",
 						"base": "1d+1"
@@ -21781,6 +21926,7 @@
 			"weapons": [
 				{
 					"id": "wzuUncOOr8NAvEqVt",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "sw",
@@ -21836,6 +21982,7 @@
 			"weapons": [
 				{
 					"id": "wtmap3S69OBvRqHkc",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "sw",
@@ -21891,6 +22038,7 @@
 			"weapons": [
 				{
 					"id": "whucnLGuqkhrHkiDv",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "sw",
@@ -21946,6 +22094,7 @@
 			"weapons": [
 				{
 					"id": "wVpIF5FN4f3KQ1Wpe",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "sw",
@@ -22001,6 +22150,7 @@
 			"weapons": [
 				{
 					"id": "wLEl6vQiy4WD9t1PF",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "sw",
@@ -22056,6 +22206,7 @@
 			"weapons": [
 				{
 					"id": "wm6HUdJTFqiFf5dhQ",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "sw",
@@ -22111,6 +22262,7 @@
 			"weapons": [
 				{
 					"id": "w5LI2L_P_mPTCo3JQ",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "sw",
@@ -22313,6 +22465,7 @@
 			"weapons": [
 				{
 					"id": "wDO6ZjCdQcHn5smyl",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr",
@@ -22357,6 +22510,7 @@
 				},
 				{
 					"id": "Wuz4Gwn0WFJTOalXX",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr",


### PR DESCRIPTION
The Quarterstaff's Melee Usage stats included stats for swords which is not aligned to the stats published in B273. I removed the two additional usage stats.