### PR TITLE
Fix perks in Psionics Traits

### DIFF
--- a/Library/Psionics/Classes/Celebrity.gct
+++ b/Library/Psionics/Classes/Celebrity.gct
@@ -909,14 +909,21 @@
 									}
 								},
 								{
-									"id": "tTTkXd2Vkc8Bvrn7T",
-									"name": "Estatic Psi (@Drug@)",
+									"id": "teTRwSjZz_uEMj4ci",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Psionics/Psionics Traits.adq",
+										"id": "tDODfGVTNSJ6RsbOr"
+									},
+									"name": "Ecstatic Psi (@Drug@)",
 									"reference": "PSI19",
 									"tags": [
+										"Perk",
 										"Physical"
 									],
+									"base_points": 1,
 									"calc": {
-										"points": 0
+										"points": 1
 									}
 								},
 								{
@@ -2676,7 +2683,7 @@
 								}
 							],
 							"calc": {
-								"points": 174
+								"points": 175
 							}
 						},
 						{
@@ -3995,7 +4002,7 @@
 						}
 					],
 					"calc": {
-						"points": 239
+						"points": 240
 					}
 				},
 				{
@@ -6499,7 +6506,7 @@
 				}
 			],
 			"calc": {
-				"points": -336
+				"points": -335
 			}
 		},
 		{

--- a/Library/Psionics/Classes/Criminal.gct
+++ b/Library/Psionics/Classes/Criminal.gct
@@ -1061,14 +1061,21 @@
 									}
 								},
 								{
-									"id": "thyvmaGXcJeJ3PRas",
-									"name": "Estatic Psi (@Drug@)",
+									"id": "tS6vd9Jvy0ZSGBBQs",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Psionics/Psionics Traits.adq",
+										"id": "tDODfGVTNSJ6RsbOr"
+									},
+									"name": "Ecstatic Psi (@Drug@)",
 									"reference": "PSI19",
 									"tags": [
+										"Perk",
 										"Physical"
 									],
+									"base_points": 1,
 									"calc": {
-										"points": 0
+										"points": 1
 									}
 								},
 								{
@@ -3528,12 +3535,12 @@
 								}
 							],
 							"calc": {
-								"points": 289
+								"points": 290
 							}
 						}
 					],
 					"calc": {
-						"points": 289
+						"points": 290
 					}
 				},
 				{
@@ -6039,7 +6046,7 @@
 				}
 			],
 			"calc": {
-				"points": -282
+				"points": -281
 			}
 		},
 		{

--- a/Library/Psionics/Classes/Experiment.gct
+++ b/Library/Psionics/Classes/Experiment.gct
@@ -594,14 +594,21 @@
 									}
 								},
 								{
-									"id": "tRQlnav0jQ_oQKpzg",
-									"name": "Estatic Psi (@Drug@)",
+									"id": "tctXxiTgbYCkGOgHQ",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Psionics/Psionics Traits.adq",
+										"id": "tDODfGVTNSJ6RsbOr"
+									},
+									"name": "Ecstatic Psi (@Drug@)",
 									"reference": "PSI19",
 									"tags": [
+										"Perk",
 										"Physical"
 									],
+									"base_points": 1,
 									"calc": {
-										"points": 0
+										"points": 1
 									}
 								},
 								{
@@ -2283,12 +2290,12 @@
 								}
 							],
 							"calc": {
-								"points": 237
+								"points": 238
 							}
 						}
 					],
 					"calc": {
-						"points": 237
+						"points": 238
 					}
 				},
 				{
@@ -6065,7 +6072,7 @@
 				}
 			],
 			"calc": {
-				"points": -520
+				"points": -519
 			}
 		}
 	],

--- a/Library/Psionics/Psionics Traits.adq
+++ b/Library/Psionics/Psionics Traits.adq
@@ -53,8 +53,9 @@
 				"Perk",
 				"Physical"
 			],
+			"base_points": 1,
 			"calc": {
-				"points": 0
+				"points": 1
 			}
 		},
 		{

--- a/Library/Psionics/Psionics Traits.adq
+++ b/Library/Psionics/Psionics Traits.adq
@@ -34,7 +34,7 @@
 		},
 		{
 			"id": "tDODfGVTNSJ6RsbOr",
-			"name": "Estatic Psi",
+			"name": "Ecstatic Psi",
 			"reference": "PSI19",
 			"tags": [
 				"Perk",

--- a/Library/Psionics/Psionics Traits.adq
+++ b/Library/Psionics/Psionics Traits.adq
@@ -1587,6 +1587,7 @@
 							"weapons": [
 								{
 									"id": "wmT_KsnggaPBwrUIF",
+									"sv": 1,
 									"damage": {
 										"type": "cut",
 										"base": "1d-3"
@@ -3677,9 +3678,10 @@
 									"weapons": [
 										{
 											"id": "Wu9q1bhLJpk4K9FTT",
+											"sv": 1,
 											"damage": {
 												"type": "",
-												"base": "1d"
+												"base_leveled": "1d"
 											},
 											"usage": "Lightning",
 											"accuracy": "3",
@@ -3696,7 +3698,7 @@
 												}
 											],
 											"calc": {
-												"damage": "1d"
+												"damage": "1d per level"
 											}
 										}
 									],
@@ -8860,9 +8862,10 @@
 									"weapons": [
 										{
 											"id": "WDdi4oa7Au1iw0bbK",
+											"sv": 1,
 											"damage": {
 												"type": "pi",
-												"base": "1d-1"
+												"base_leveled": "1d-1"
 											},
 											"usage": "Bullet",
 											"accuracy": "3",
@@ -8876,14 +8879,15 @@
 												}
 											],
 											"calc": {
-												"damage": "1d-1 pi"
+												"damage": "1d-1 per level  pi"
 											}
 										},
 										{
 											"id": "W5OiWn_NM0WvDYZn8",
+											"sv": 1,
 											"damage": {
 												"type": "pi+",
-												"base": "1d-1"
+												"base_leveled": "1d-1"
 											},
 											"usage": "Flat Edge",
 											"accuracy": "3",
@@ -8903,14 +8907,15 @@
 												}
 											],
 											"calc": {
-												"damage": "1d-1 pi+"
+												"damage": "1d-1 per level  pi+"
 											}
 										},
 										{
 											"id": "WqoXDIWc9bYFTbtMB",
+											"sv": 1,
 											"damage": {
 												"type": "pi",
-												"base": "1d-1",
+												"base_leveled": "1d-1",
 												"armor_divisor": 2
 											},
 											"usage": "Sharp Edge",
@@ -8931,14 +8936,15 @@
 												}
 											],
 											"calc": {
-												"damage": "1d-1(2) pi"
+												"damage": "1d-1 per level (2) pi"
 											}
 										},
 										{
 											"id": "WE0sAZ08sWWPI_F1n",
+											"sv": 1,
 											"damage": {
 												"type": "pi",
-												"base": "1d-1"
+												"base_leveled": "1d-1"
 											},
 											"usage": "Rapid Fire",
 											"accuracy": "3",
@@ -8958,14 +8964,15 @@
 												}
 											],
 											"calc": {
-												"damage": "1d-1 pi"
+												"damage": "1d-1 per level  pi"
 											}
 										},
 										{
 											"id": "WPyouCP6cdw-TVOd4",
+											"sv": 1,
 											"damage": {
 												"type": "pi",
-												"base": "1d-2"
+												"base_leveled": "1d-2"
 											},
 											"usage": "Silencer",
 											"accuracy": "3",
@@ -8985,7 +8992,7 @@
 												}
 											],
 											"calc": {
-												"damage": "1d-2 pi"
+												"damage": "1d-2 per level  pi"
 											}
 										}
 									],
@@ -9010,9 +9017,10 @@
 									"weapons": [
 										{
 											"id": "W2biOmXLwGbRM3S7z",
+											"sv": 1,
 											"damage": {
 												"type": "pi/level",
-												"base": "1"
+												"base_leveled": "1"
 											},
 											"usage": "Gaze",
 											"rate_of_fire": "1",
@@ -9034,7 +9042,7 @@
 												}
 											],
 											"calc": {
-												"damage": "1 pi/level"
+												"damage": "1 per level  pi/level"
 											}
 										}
 									],
@@ -11708,9 +11716,10 @@
 							"weapons": [
 								{
 									"id": "WCkLSAHFPhWd4V9jk",
+									"sv": 1,
 									"damage": {
 										"type": "imp",
-										"base": "1d-2"
+										"base_leveled": "1d-2"
 									},
 									"usage": "Innerportation",
 									"rate_of_fire": "1",
@@ -11725,7 +11734,7 @@
 										}
 									],
 									"calc": {
-										"damage": "1d-2 imp"
+										"damage": "1d-2 per level  imp"
 									}
 								}
 							],

--- a/Library/Psionics/Psionics Traits.adq
+++ b/Library/Psionics/Psionics Traits.adq
@@ -47,7 +47,7 @@
 		},
 		{
 			"id": "tsNfPWwwVvCQQrMKn",
-			"name": "Gesalt Familiarity",
+			"name": "Gestalt Familiarity",
 			"reference": "PSI19",
 			"tags": [
 				"Perk",

--- a/Library/Psionics/Psionics Traits.adq
+++ b/Library/Psionics/Psionics Traits.adq
@@ -34,7 +34,7 @@
 		},
 		{
 			"id": "tDODfGVTNSJ6RsbOr",
-			"name": "Ecstatic Psi",
+			"name": "Ecstatic Psi (@Drug@)",
 			"reference": "PSI19",
 			"tags": [
 				"Perk",


### PR DESCRIPTION
Fixes the "Ecstatic Psi" and "Gestalt Familiarity" perks in Psionics Traits.

For Ecstatic Psi:
* Fixed  the misspelled name 'Estatic Psi'
* Made it specialise by drug
* Made the Psis classes "Experiment", "Celebrity" and "Criminal" use the fixed Ecstatic Psi.

For Gestalt Familiarity:
* Fixed the misspelled name 'Gesalt Familiarity'
* Fixed the point cost

This also includes some automated changes to the Psionics Traits file caused by a change in the data format.