### PR TITLE
Fix Enhanced Parry (@One weapon skill@) to add a weapon parry modifier

### DIFF
--- a/Library/Action/Action Traits.adq
+++ b/Library/Action/Action Traits.adq
@@ -1265,9 +1265,14 @@
 							"points_per_level": 5,
 							"features": [
 								{
-									"type": "attribute_bonus",
-									"attribute": "parry",
-									"amount": 1
+									"type": "weapon_parry_bonus",
+									"selection_type": "weapons_with_required_skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "@Melee weapon skill@"
+									},
+									"amount": 1,
+									"leveled": true
 								}
 							],
 							"can_level": true,
@@ -3583,8 +3588,13 @@
 						},
 						{
 							"id": "t8skuS5PHIhpCxDjG",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tDw6GZRxayNGMc8wW"
+							},
 							"name": "Enhanced Parry (@Melee weapon skill@)",
-							"reference": "B51",
+							"reference": "B51,MA43",
 							"tags": [
 								"Advantage",
 								"Mental"
@@ -3592,9 +3602,17 @@
 							"points_per_level": 5,
 							"features": [
 								{
-									"type": "attribute_bonus",
-									"attribute": "parry",
-									"amount": 1
+									"type": "weapon_parry_bonus",
+									"selection_type": "weapons_with_required_skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "@Melee weapon skill@"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1,
+									"leveled": true
 								}
 							],
 							"can_level": true,

--- a/Library/Action/Action Traits.adq
+++ b/Library/Action/Action Traits.adq
@@ -839,6 +839,7 @@
 					"weapons": [
 						{
 							"id": "wkgRi94gFhs__aoLu",
+							"sv": 1,
 							"damage": {
 								"type": "cr",
 								"st": "thr",
@@ -1514,6 +1515,7 @@
 					"weapons": [
 						{
 							"id": "wA1cPgUtVOskQkxLM",
+							"sv": 1,
 							"damage": {
 								"type": "cr",
 								"st": "thr",
@@ -1878,6 +1880,7 @@
 					"weapons": [
 						{
 							"id": "w01D0g-Tim5KZI5Ht",
+							"sv": 1,
 							"damage": {
 								"type": "pi",
 								"st": "thr",

--- a/Library/Action/Classes/Furious Fists/Ninja.gct
+++ b/Library/Action/Classes/Furious Fists/Ninja.gct
@@ -361,19 +361,52 @@
 									}
 								},
 								{
-									"id": "tkV170eRgW9tES2A_",
+									"id": "tTPG9nfY3B57ggfXB",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Action/Action Traits.adq",
+										"id": "ttT45g2kaW4REzovx"
+									},
 									"name": "Enhanced Parry (@Melee weapon skill@)",
-									"reference": "B51",
+									"reference": "B51,ACT3:13",
+									"local_notes": "Max level 3.",
 									"tags": [
 										"Advantage",
 										"Mental"
 									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": false,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Trained by a Master"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Weapon Master"
+												}
+											}
+										]
+									},
 									"points_per_level": 5,
 									"features": [
 										{
-											"type": "attribute_bonus",
-											"attribute": "parry",
-											"amount": 1
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"amount": 1,
+											"leveled": true
 										}
 									],
 									"can_level": true,

--- a/Library/Action/Classes/Furious Fists/Weapon Master.gct
+++ b/Library/Action/Classes/Furious Fists/Weapon Master.gct
@@ -294,19 +294,52 @@
 									}
 								},
 								{
-									"id": "t2xs9S4-wv5EFv6CY",
-									"name": "Enhanced Parry (@Weapon of Choice@)",
-									"reference": "B51",
+									"id": "tDeBqpLvntHu3ECqu",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Action/Action Traits.adq",
+										"id": "ttT45g2kaW4REzovx"
+									},
+									"name": "Enhanced Parry (@Melee weapon skill@)",
+									"reference": "B51,ACT3:13",
+									"local_notes": "Max level 3.",
 									"tags": [
 										"Advantage",
 										"Mental"
 									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": false,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Trained by a Master"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Weapon Master"
+												}
+											}
+										]
+									},
 									"points_per_level": 5,
 									"features": [
 										{
-											"type": "attribute_bonus",
-											"attribute": "parry",
-											"amount": 1
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"amount": 1,
+											"leveled": true
 										}
 									],
 									"can_level": true,
@@ -1484,19 +1517,52 @@
 							}
 						},
 						{
-							"id": "tyS6jNNRGQRxz4fal",
-							"name": "Enhanced Parry (@Weapon of choice@)",
-							"reference": "B51",
+							"id": "tDK_T5DlKt9aHS0kd",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Action/Action Traits.adq",
+								"id": "ttT45g2kaW4REzovx"
+							},
+							"name": "Enhanced Parry (@Melee weapon skill@)",
+							"reference": "B51,ACT3:13",
+							"local_notes": "Max level 3.",
 							"tags": [
 								"Advantage",
 								"Mental"
 							],
+							"prereqs": {
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Trained by a Master"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Weapon Master"
+										}
+									}
+								]
+							},
 							"points_per_level": 5,
 							"features": [
 								{
-									"type": "attribute_bonus",
-									"attribute": "parry",
-									"amount": 1
+									"type": "weapon_parry_bonus",
+									"selection_type": "weapons_with_required_skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "@Melee weapon skill@"
+									},
+									"amount": 1,
+									"leveled": true
 								}
 							],
 							"can_level": true,

--- a/Library/Action/Classes/Specialists/Skill Sets/Obsolete Weapons.gct
+++ b/Library/Action/Classes/Specialists/Skill Sets/Obsolete Weapons.gct
@@ -8,9 +8,14 @@
 			"reference": "ACT4:19",
 			"children": [
 				{
-					"id": "t4H1uIdNtzYGQAiN7",
+					"id": "tIwaDYgH4yOm3ibzl",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tDw6GZRxayNGMc8wW"
+					},
 					"name": "Enhanced Parry (@Melee weapon skill@)",
-					"reference": "B51",
+					"reference": "B51,MA43",
 					"tags": [
 						"Advantage",
 						"Mental"
@@ -18,9 +23,17 @@
 					"points_per_level": 5,
 					"features": [
 						{
-							"type": "attribute_bonus",
-							"attribute": "parry",
-							"amount": 1
+							"type": "weapon_parry_bonus",
+							"selection_type": "weapons_with_required_skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "@Melee weapon skill@"
+							},
+							"level": {
+								"compare": "at_least"
+							},
+							"amount": 1,
+							"leveled": true
 						}
 					],
 					"can_level": true,

--- a/Library/After the End/Lenses/Fast.gct
+++ b/Library/After the End/Lenses/Fast.gct
@@ -187,9 +187,14 @@
 							}
 						},
 						{
-							"id": "tTepJC4BPN99KQhzZ",
+							"id": "tTfHKRgJ1NTvzNI49",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tDw6GZRxayNGMc8wW"
+							},
 							"name": "Enhanced Parry (@Melee weapon skill@)",
-							"reference": "B51",
+							"reference": "B51,MA43",
 							"tags": [
 								"Advantage",
 								"Mental"
@@ -197,9 +202,14 @@
 							"points_per_level": 5,
 							"features": [
 								{
-									"type": "attribute_bonus",
-									"attribute": "parry",
-									"amount": 1
+									"type": "weapon_parry_bonus",
+									"selection_type": "weapons_with_required_skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "@Melee weapon skill@"
+									},
+									"amount": 1,
+									"leveled": true
 								}
 							],
 							"can_level": true,

--- a/Library/After the End/Templates/Hulk.gct
+++ b/Library/After the End/Templates/Hulk.gct
@@ -1915,9 +1915,14 @@
 									}
 								},
 								{
-									"id": "tCPZ1pHJrnPQYVQ7B",
+									"id": "t5n5b9arZyDgxU6W5",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tDw6GZRxayNGMc8wW"
+									},
 									"name": "Enhanced Parry (@Melee weapon skill@)",
-									"reference": "B51",
+									"reference": "B51,MA43",
 									"tags": [
 										"Advantage",
 										"Mental"
@@ -1925,9 +1930,14 @@
 									"points_per_level": 5,
 									"features": [
 										{
-											"type": "attribute_bonus",
-											"attribute": "parry",
-											"amount": 1
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"amount": 1,
+											"leveled": true
 										}
 									],
 									"can_level": true,

--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -7695,9 +7695,14 @@
 			"points_per_level": 5,
 			"features": [
 				{
-					"type": "conditional_modifier",
-					"situation": "to Parry with @Melee weapon skill@",
-					"amount": 1
+					"type": "weapon_parry_bonus",
+					"selection_type": "weapons_with_required_skill",
+					"name": {
+						"compare": "is",
+						"qualifier": "@Melee weapon skill@"
+					},
+					"amount": 1,
+					"leveled": true
 				}
 			],
 			"can_level": true,

--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -2673,6 +2673,7 @@
 			"weapons": [
 				{
 					"id": "w7Sh2fbCzUixWx1kr",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "thr",
@@ -2705,6 +2706,7 @@
 				},
 				{
 					"id": "wkBhgJNSch_qxNPSv",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "thr",
@@ -4860,6 +4862,7 @@
 			"weapons": [
 				{
 					"id": "wfJ14KcD6GnELsKUZ",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "thr",
@@ -5051,6 +5054,7 @@
 			"weapons": [
 				{
 					"id": "w77UBVpEqh8O-wIlJ",
+					"sv": 1,
 					"damage": {
 						"type": "cut",
 						"st": "thr",
@@ -8509,6 +8513,7 @@
 			"weapons": [
 				{
 					"id": "w99a1utO5OPMt-fAJ",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr",
@@ -10486,6 +10491,7 @@
 			"weapons": [
 				{
 					"id": "w7Mhg1erXF4ukiVxL",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "thr",
@@ -10888,6 +10894,7 @@
 			"weapons": [
 				{
 					"id": "waJ3519aydB9aNelt",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr",
@@ -11865,9 +11872,10 @@
 			"weapons": [
 				{
 					"id": "WOqqNtlHQ3HDlLdUs",
+					"sv": 1,
 					"damage": {
 						"type": "burn",
-						"base": "1d"
+						"base_leveled": "1d"
 					},
 					"accuracy": "3",
 					"range": "10/100",
@@ -11890,7 +11898,7 @@
 						}
 					],
 					"calc": {
-						"damage": "1d burn"
+						"damage": "1d per level  burn"
 					}
 				}
 			],
@@ -12145,9 +12153,10 @@
 			"weapons": [
 				{
 					"id": "W_2es21CldrtOcK1d",
+					"sv": 1,
 					"damage": {
 						"type": "cor",
-						"base": "1d"
+						"base_leveled": "1d"
 					},
 					"accuracy": "3",
 					"range": "10/100",
@@ -12170,7 +12179,7 @@
 						}
 					],
 					"calc": {
-						"damage": "1d cor"
+						"damage": "1d per level  cor"
 					}
 				}
 			],
@@ -12332,9 +12341,10 @@
 			"weapons": [
 				{
 					"id": "WNH41X_GiXmpOs0Sn",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
-						"base": "1d"
+						"base_leveled": "1d"
 					},
 					"accuracy": "3",
 					"range": "10/100",
@@ -12357,7 +12367,7 @@
 						}
 					],
 					"calc": {
-						"damage": "1d cr"
+						"damage": "1d per level  cr"
 					}
 				}
 			],
@@ -12520,9 +12530,10 @@
 			"weapons": [
 				{
 					"id": "WzMZIve5naC08zogi",
+					"sv": 1,
 					"damage": {
 						"type": "cut",
-						"base": "1d"
+						"base_leveled": "1d"
 					},
 					"accuracy": "3",
 					"range": "10/100",
@@ -12545,7 +12556,7 @@
 						}
 					],
 					"calc": {
-						"damage": "1d cut"
+						"damage": "1d per level  cut"
 					}
 				}
 			],
@@ -12832,9 +12843,10 @@
 			"weapons": [
 				{
 					"id": "WF0ekK8hvBOJFnvUb",
+					"sv": 1,
 					"damage": {
 						"type": "fat",
-						"base": "1d"
+						"base_leveled": "1d"
 					},
 					"accuracy": "3",
 					"range": "10/100",
@@ -12857,7 +12869,7 @@
 						}
 					],
 					"calc": {
-						"damage": "1d fat"
+						"damage": "1d per level  fat"
 					}
 				}
 			],
@@ -13019,9 +13031,10 @@
 			"weapons": [
 				{
 					"id": "WxqIj0_oaf96bbIjR",
+					"sv": 1,
 					"damage": {
 						"type": "pi++",
-						"base": "1d"
+						"base_leveled": "1d"
 					},
 					"accuracy": "3",
 					"range": "10/100",
@@ -13044,7 +13057,7 @@
 						}
 					],
 					"calc": {
-						"damage": "1d pi++"
+						"damage": "1d per level  pi++"
 					}
 				}
 			],
@@ -13206,9 +13219,10 @@
 			"weapons": [
 				{
 					"id": "W0diudF9UEWv3pkbX",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
-						"base": "1d"
+						"base_leveled": "1d"
 					},
 					"accuracy": "3",
 					"range": "10/100",
@@ -13231,7 +13245,7 @@
 						}
 					],
 					"calc": {
-						"damage": "1d imp"
+						"damage": "1d per level  imp"
 					}
 				}
 			],
@@ -13408,9 +13422,10 @@
 			"weapons": [
 				{
 					"id": "WAwftiP3wHW3h9kq3",
+					"sv": 1,
 					"damage": {
 						"type": "pi+",
-						"base": "1d"
+						"base_leveled": "1d"
 					},
 					"accuracy": "3",
 					"range": "10/100",
@@ -13433,7 +13448,7 @@
 						}
 					],
 					"calc": {
-						"damage": "1d pi+"
+						"damage": "1d per level  pi+"
 					}
 				}
 			],
@@ -13610,9 +13625,10 @@
 			"weapons": [
 				{
 					"id": "Wrkfa2KffJqL3RWx7",
+					"sv": 1,
 					"damage": {
 						"type": "pi",
-						"base": "1d"
+						"base_leveled": "1d"
 					},
 					"accuracy": "3",
 					"range": "10/100",
@@ -13635,7 +13651,7 @@
 						}
 					],
 					"calc": {
-						"damage": "1d pi"
+						"damage": "1d per level  pi"
 					}
 				}
 			],
@@ -13798,9 +13814,10 @@
 			"weapons": [
 				{
 					"id": "WyKO8VQKM-6ayWMXz",
+					"sv": 1,
 					"damage": {
 						"type": "pi-",
-						"base": "1d"
+						"base_leveled": "1d"
 					},
 					"accuracy": "3",
 					"range": "10/100",
@@ -13823,7 +13840,7 @@
 						}
 					],
 					"calc": {
-						"damage": "1d pi-"
+						"damage": "1d per level  pi-"
 					}
 				}
 			],
@@ -14085,9 +14102,10 @@
 			"weapons": [
 				{
 					"id": "WGg47FdXg4ENOxO8Q",
+					"sv": 1,
 					"damage": {
 						"type": "tox",
-						"base": "1d"
+						"base_leveled": "1d"
 					},
 					"accuracy": "3",
 					"range": "10/100",
@@ -14110,7 +14128,7 @@
 						}
 					],
 					"calc": {
-						"damage": "1d tox"
+						"damage": "1d per level  tox"
 					}
 				}
 			],
@@ -15362,6 +15380,7 @@
 			"weapons": [
 				{
 					"id": "wSrO-lhUs7rHOs6Cx",
+					"sv": 1,
 					"damage": {
 						"type": "pi+",
 						"st": "thr",
@@ -15659,6 +15678,7 @@
 			"weapons": [
 				{
 					"id": "wjrw9c6s78gJWRorj",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"base": "1d"
@@ -15692,6 +15712,7 @@
 			"weapons": [
 				{
 					"id": "wkKelQoPnKVKktQNq",
+					"sv": 1,
 					"damage": {
 						"type": "cut",
 						"st": "thr",
@@ -15724,6 +15745,7 @@
 				},
 				{
 					"id": "w9-16kiwbm5P1KH_U",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr",
@@ -20509,6 +20531,7 @@
 			"weapons": [
 				{
 					"id": "w2EXA9V3hLjhagdZO",
+					"sv": 1,
 					"damage": {
 						"type": "pi",
 						"st": "thr",
@@ -20893,7 +20916,7 @@
 			"features": [
 				{
 					"type": "spell_bonus",
-					"match": "tag",
+					"match": "all_colleges",
 					"name": {
 						"compare": "is",
 						"qualifier": "Clerical"
@@ -23116,6 +23139,7 @@
 			"weapons": [
 				{
 					"id": "wYQ7fwrHqDBFfB9lR",
+					"sv": 1,
 					"damage": {
 						"type": "pi+",
 						"st": "thr",
@@ -23153,6 +23177,7 @@
 			"weapons": [
 				{
 					"id": "wkE0JQ6fQDfZXlVxi",
+					"sv": 1,
 					"damage": {
 						"type": "cut",
 						"st": "thr",
@@ -23184,6 +23209,7 @@
 				},
 				{
 					"id": "w5iQbMNDH8evj8Rx-",
+					"sv": 1,
 					"damage": {
 						"type": "cut",
 						"st": "thr"
@@ -23238,6 +23264,7 @@
 			"weapons": [
 				{
 					"id": "wHEoEf3UP7N5ZYeFA",
+					"sv": 1,
 					"damage": {
 						"type": "cut",
 						"st": "thr",
@@ -23307,6 +23334,7 @@
 			"weapons": [
 				{
 					"id": "wHLWdseHxX2nNfgyd",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"base": "1d-2"
@@ -27408,6 +27436,7 @@
 			"weapons": [
 				{
 					"id": "wEZ4DwBgQGYeIQD7h",
+					"sv": 1,
 					"damage": {
 						"type": "cut",
 						"st": "thr",
@@ -27439,6 +27468,7 @@
 				},
 				{
 					"id": "wfLJRfw92ZnxCkmxC",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr",
@@ -29751,6 +29781,7 @@
 			"weapons": [
 				{
 					"id": "wexqxi-urId9eU2ZO",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "thr",

--- a/Library/Delvers to Grow/DTG Fast Delver Build Template.gct
+++ b/Library/Delvers to Grow/DTG Fast Delver Build Template.gct
@@ -12498,8 +12498,13 @@
 									}
 								},
 								{
-									"id": "tO_Gu2SjOzMtGIbDa",
-									"name": "Enhanced Parry (@weapon of choice@)",
+									"id": "t2Q41qPiano4G9lQB",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
+										"id": "tfE1xvUa4a3Ppo5aq"
+									},
+									"name": "Enhanced Parry (@Melee weapon skill Or Unarmed@)",
 									"reference": "DFA49",
 									"tags": [
 										"Advantage",
@@ -12508,9 +12513,14 @@
 									"points_per_level": 5,
 									"features": [
 										{
-											"type": "attribute_bonus",
-											"attribute": "parry",
-											"amount": 1
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill Or Unarmed@"
+											},
+											"amount": 1,
+											"leveled": true
 										}
 									],
 									"can_level": true,

--- a/Library/Delvers to Grow/DTG Strong Delver Build Template.gct
+++ b/Library/Delvers to Grow/DTG Strong Delver Build Template.gct
@@ -3211,8 +3211,13 @@
 									}
 								},
 								{
-									"id": "tkXz3PJxOzCmTO1y_",
-									"name": "Enhanced Parry (@Weapon Skill@)",
+									"id": "tvD4GbgJWw0Xh-pYD",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
+										"id": "tfE1xvUa4a3Ppo5aq"
+									},
+									"name": "Enhanced Parry (@Melee weapon skill Or Unarmed@)",
 									"reference": "DFA49",
 									"tags": [
 										"Advantage",
@@ -3221,10 +3226,14 @@
 									"points_per_level": 5,
 									"features": [
 										{
-											"type": "attribute_bonus",
-											"attribute": "parry",
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill Or Unarmed@"
+											},
 											"amount": 1,
-											"per_level": true
+											"leveled": true
 										}
 									],
 									"can_level": true,

--- a/Library/Discworld Roleplaying Game/Discworld Roleplaying Game Traits.adq
+++ b/Library/Discworld Roleplaying Game/Discworld Roleplaying Game Traits.adq
@@ -3204,9 +3204,14 @@
 									"points_per_level": 5,
 									"features": [
 										{
-											"type": "conditional_modifier",
-											"situation": "to Parry with @Melee weapon skill@",
-											"amount": 1
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"amount": 1,
+											"leveled": true
 										}
 									],
 									"can_level": true,

--- a/Library/Discworld Roleplaying Game/Discworld Roleplaying Game Traits.adq
+++ b/Library/Discworld Roleplaying Game/Discworld Roleplaying Game Traits.adq
@@ -6257,6 +6257,7 @@
 							"weapons": [
 								{
 									"id": "wlbdxOTz9Y2PonzYn",
+									"sv": 1,
 									"damage": {
 										"type": "pi+",
 										"st": "thr",
@@ -10921,14 +10922,15 @@
 									"weapons": [
 										{
 											"id": "wGYWzvZR90ga4Y5gM",
+											"sv": 1,
 											"damage": {
 												"type": "burn",
-												"base": "1d"
+												"base_leveled": "1d"
 											},
 											"usage": "Short-Range Flame",
 											"reach": "1",
 											"calc": {
-												"damage": "1d burn"
+												"damage": "1d per level  burn"
 											}
 										}
 									],
@@ -10946,16 +10948,17 @@
 									"weapons": [
 										{
 											"id": "WWOJKwKL-hxteEZ3S",
+											"sv": 1,
 											"damage": {
 												"type": "burn",
-												"base": "1d"
+												"base_leveled": "1d"
 											},
 											"usage": "Lightning Bolt",
 											"accuracy": "4",
 											"range": "100",
 											"rate_of_fire": "1",
 											"calc": {
-												"damage": "1d burn"
+												"damage": "1d per level  burn"
 											}
 										}
 									],
@@ -10973,15 +10976,16 @@
 									"weapons": [
 										{
 											"id": "Wfr6JcwrnNK8BuuMv",
+											"sv": 1,
 											"damage": {
 												"type": "burn",
-												"base": "1d"
+												"base_leveled": "1d"
 											},
 											"usage": "Flame Jet",
 											"range": "5/10",
 											"rate_of_fire": "1",
 											"calc": {
-												"damage": "1d burn"
+												"damage": "1d per level  burn"
 											}
 										}
 									],
@@ -11036,6 +11040,7 @@
 									"weapons": [
 										{
 											"id": "wMhOmz_YLCaHdwJGo",
+											"sv": 1,
 											"damage": {
 												"type": "cut",
 												"st": "thr",
@@ -11055,6 +11060,7 @@
 										},
 										{
 											"id": "wwzxlz6QboHCxbCMZ",
+											"sv": 1,
 											"damage": {
 												"type": "imp",
 												"st": "thr",
@@ -11085,6 +11091,7 @@
 									"weapons": [
 										{
 											"id": "wpKWppBDQ-LMUowsH",
+											"sv": 1,
 											"damage": {
 												"type": "cut",
 												"st": "thr",
@@ -11104,6 +11111,7 @@
 										},
 										{
 											"id": "w1xjWUbnzBS6dDrxk",
+											"sv": 1,
 											"damage": {
 												"type": "cut",
 												"st": "thr"
@@ -11133,6 +11141,7 @@
 									"weapons": [
 										{
 											"id": "wDKs5dMGlPEn6Ct4Y",
+											"sv": 1,
 											"damage": {
 												"type": "cut",
 												"st": "thr",
@@ -11153,6 +11162,7 @@
 										},
 										{
 											"id": "w07swQI3uBirF7Eh4",
+											"sv": 1,
 											"damage": {
 												"type": "imp",
 												"st": "thr",
@@ -11184,6 +11194,7 @@
 									"weapons": [
 										{
 											"id": "w6AXchC-6iKIaRcP0",
+											"sv": 1,
 											"damage": {
 												"type": "cr",
 												"st": "thr",
@@ -11223,6 +11234,7 @@
 									"weapons": [
 										{
 											"id": "wQ9zIiioBAH_DKb37",
+											"sv": 1,
 											"damage": {
 												"type": "cr",
 												"st": "thr",
@@ -11243,6 +11255,7 @@
 										},
 										{
 											"id": "wCyWIQcMPjA-9iSUl",
+											"sv": 1,
 											"damage": {
 												"type": "cr",
 												"st": "thr",
@@ -11902,6 +11915,7 @@
 									"weapons": [
 										{
 											"id": "w749gW1KrHg3jLISF",
+											"sv": 1,
 											"damage": {
 												"type": "cut",
 												"st": "thr",
@@ -11931,6 +11945,7 @@
 									"weapons": [
 										{
 											"id": "wzQx0rD-g4sk5AB8z",
+											"sv": 1,
 											"damage": {
 												"type": "pi+",
 												"st": "thr",
@@ -11960,6 +11975,7 @@
 									"weapons": [
 										{
 											"id": "wKPQiWNvotdEi_67J",
+											"sv": 1,
 											"damage": {
 												"type": "imp",
 												"st": "thr",
@@ -13133,6 +13149,7 @@
 							"weapons": [
 								{
 									"id": "wK6R7ox80lT9If58V",
+									"sv": 1,
 									"damage": {
 										"type": "cr",
 										"st": "thr",

--- a/Library/Discworld Roleplaying Game/Occupational Templates/Medium-Powered Characters/Barbarian Hero Wannabe.gct
+++ b/Library/Discworld Roleplaying Game/Occupational Templates/Medium-Powered Characters/Barbarian Hero Wannabe.gct
@@ -782,15 +782,26 @@
 							}
 						},
 						{
-							"id": "tUuBQ869vmC82J5EN",
-							"name": "Enhanced Parry (@Melee weapon skill@)",
+							"id": "tJWbQiHsUbuZUOzko",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Discworld Roleplaying Game/Discworld Roleplaying Game Traits.adq",
+								"id": "t-KIzkBgbGZavn9L1"
+							},
+							"name": "Enhanced Parry",
 							"reference": "DW42",
+							"local_notes": "@Melee weapon skill@",
 							"points_per_level": 5,
 							"features": [
 								{
-									"type": "conditional_modifier",
-									"situation": "to Parry with @Melee weapon skill@",
-									"amount": 1
+									"type": "weapon_parry_bonus",
+									"selection_type": "weapons_with_required_skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "@Melee weapon skill@"
+									},
+									"amount": 1,
+									"leveled": true
 								}
 							],
 							"can_level": true,

--- a/Library/Discworld Roleplaying Game/Occupational Templates/Medium-Powered Characters/Dark Clerk.gct
+++ b/Library/Discworld Roleplaying Game/Occupational Templates/Medium-Powered Characters/Dark Clerk.gct
@@ -579,14 +579,48 @@
 							}
 						},
 						{
-							"id": "tG3CyXOn244w9h595",
-							"name": "Enhanced Parry (@barehanded or a single weapon@)",
+							"id": "tchmb1zI5q2wIUAEz",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Discworld Roleplaying Game/Discworld Roleplaying Game Traits.adq",
+								"id": "t-KIzkBgbGZavn9L1"
+							},
+							"name": "Enhanced Parry",
+							"reference": "DW42",
+							"local_notes": "@Melee weapon skill@",
+							"points_per_level": 5,
+							"features": [
+								{
+									"type": "weapon_parry_bonus",
+									"selection_type": "weapons_with_required_skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "@Melee weapon skill@"
+									},
+									"amount": 1,
+									"leveled": true
+								}
+							],
+							"can_level": true,
+							"levels": 1,
+							"calc": {
+								"points": 5
+							}
+						},
+						{
+							"id": "tOCX1JBUXM7fZ7SIO",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Discworld Roleplaying Game/Discworld Roleplaying Game Traits.adq",
+								"id": "tR9OdcLgzAxEjfrFR"
+							},
+							"name": "Enhanced Parry (Bare hands)",
 							"reference": "DW42",
 							"points_per_level": 5,
 							"features": [
 								{
 									"type": "conditional_modifier",
-									"situation": "to Parry with @Melee weapon skill@",
+									"situation": "to Parry with bare hands",
 									"amount": 1
 								}
 							],
@@ -724,7 +758,7 @@
 						}
 					],
 					"calc": {
-						"points": 35
+						"points": 40
 					}
 				},
 				{
@@ -1086,7 +1120,7 @@
 				}
 			],
 			"calc": {
-				"points": 174
+				"points": 179
 			}
 		},
 		{

--- a/Library/Dungeon Fantasy RPG/Classes/Holy Warrior.gct
+++ b/Library/Dungeon Fantasy RPG/Classes/Holy Warrior.gct
@@ -681,7 +681,12 @@
 									}
 								},
 								{
-									"id": "t51rsU9bvPeKjfUtj",
+									"id": "tZGBfQTAExrpcwRyn",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
+										"id": "tfE1xvUa4a3Ppo5aq"
+									},
 									"name": "Enhanced Parry (@Melee weapon skill Or Unarmed@)",
 									"reference": "DFA49",
 									"tags": [
@@ -691,9 +696,14 @@
 									"points_per_level": 5,
 									"features": [
 										{
-											"type": "attribute_bonus",
-											"attribute": "parry",
-											"amount": 1
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill Or Unarmed@"
+											},
+											"amount": 1,
+											"leveled": true
 										}
 									],
 									"can_level": true,

--- a/Library/Dungeon Fantasy RPG/Classes/Knight.gct
+++ b/Library/Dungeon Fantasy RPG/Classes/Knight.gct
@@ -661,8 +661,13 @@
 									}
 								},
 								{
-									"id": "tmPp1K-nWA5QTRG_t",
-									"name": "Enhanced Parry (@Melee weapon skill@)",
+									"id": "t8T-s8a-V2QGnTkwu",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
+										"id": "tfE1xvUa4a3Ppo5aq"
+									},
+									"name": "Enhanced Parry (@Melee weapon skill Or Unarmed@)",
 									"reference": "DFA49",
 									"tags": [
 										"Advantage",
@@ -671,9 +676,14 @@
 									"points_per_level": 5,
 									"features": [
 										{
-											"type": "attribute_bonus",
-											"attribute": "parry",
-											"amount": 1
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill Or Unarmed@"
+											},
+											"amount": 1,
+											"leveled": true
 										}
 									],
 									"can_level": true,

--- a/Library/Dungeon Fantasy RPG/Classes/Swashbuckler.gct
+++ b/Library/Dungeon Fantasy RPG/Classes/Swashbuckler.gct
@@ -162,19 +162,32 @@
 							}
 						},
 						{
-							"id": "tKqUF_yLpqmLV5Osq",
-							"name": "Enhanced Parry (@weapon of choice@)",
+							"id": "tRwnR97XMW3Ih00ij",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
+								"id": "tfE1xvUa4a3Ppo5aq"
+							},
+							"name": "Enhanced Parry (@Melee weapon skill Or Unarmed@)",
 							"reference": "DFA49",
 							"tags": [
 								"Advantage",
 								"Mental"
 							],
+							"replacements": {
+								"Melee weapon skill Or Unarmed": "@weapon of choice@"
+							},
 							"points_per_level": 5,
 							"features": [
 								{
-									"type": "attribute_bonus",
-									"attribute": "parry",
-									"amount": 1
+									"type": "weapon_parry_bonus",
+									"selection_type": "weapons_with_required_skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "@Melee weapon skill Or Unarmed@"
+									},
+									"amount": 1,
+									"leveled": true
 								}
 							],
 							"can_level": true,
@@ -2023,19 +2036,32 @@
 									}
 								},
 								{
-									"id": "tndbi7ushP42oW6xv",
-									"name": "Enhanced Parry (@Same as original@)",
+									"id": "txiCEbLl2nh0lgzvO",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
+										"id": "tfE1xvUa4a3Ppo5aq"
+									},
+									"name": "Enhanced Parry (@Melee weapon skill Or Unarmed@)",
 									"reference": "DFA49",
 									"tags": [
 										"Advantage",
 										"Mental"
 									],
+									"replacements": {
+										"Melee weapon skill Or Unarmed": "@Same as original@"
+									},
 									"points_per_level": 5,
 									"features": [
 										{
-											"type": "attribute_bonus",
-											"attribute": "parry",
-											"amount": 1
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill Or Unarmed@"
+											},
+											"amount": 1,
+											"leveled": true
 										}
 									],
 									"can_level": true,

--- a/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq
+++ b/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq
@@ -3669,9 +3669,14 @@
 			"points_per_level": 5,
 			"features": [
 				{
-					"type": "attribute_bonus",
-					"attribute": "parry",
-					"amount": 1
+					"type": "weapon_parry_bonus",
+					"selection_type": "weapons_with_required_skill",
+					"name": {
+						"compare": "is",
+						"qualifier": "@Melee weapon skill Or Unarmed@"
+					},
+					"amount": 1,
+					"leveled": true
 				}
 			],
 			"can_level": true,

--- a/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq
+++ b/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq
@@ -7997,6 +7997,7 @@
 			"weapons": [
 				{
 					"id": "wkUqzU_lrkopOoK3u",
+					"sv": 1,
 					"damage": {
 						"type": "cut",
 						"st": "thr",
@@ -8028,6 +8029,7 @@
 				},
 				{
 					"id": "wRDiJiFKtVsROWSRK",
+					"sv": 1,
 					"damage": {
 						"type": "cut",
 						"st": "thr"
@@ -8749,6 +8751,7 @@
 			"weapons": [
 				{
 					"id": "w_K7saFqgMJYszIL7",
+					"sv": 1,
 					"damage": {
 						"type": "cut",
 						"st": "thr",

--- a/Library/Dungeon Fantasy RPG/Monsters/Sword Spirit.gcs
+++ b/Library/Dungeon Fantasy RPG/Monsters/Sword Spirit.gcs
@@ -772,19 +772,32 @@
 			}
 		},
 		{
-			"id": "t8uwBzq95CVv2pozf",
-			"name": "Enhanced Parry (Broadsword)",
+			"id": "trWZ2cPL6dgV5PEmo",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
+				"id": "tfE1xvUa4a3Ppo5aq"
+			},
+			"name": "Enhanced Parry (@Melee weapon skill Or Unarmed@)",
 			"reference": "DFA49",
 			"tags": [
 				"Advantage",
 				"Mental"
 			],
+			"replacements": {
+				"Melee weapon skill Or Unarmed": "Broadsword"
+			},
 			"points_per_level": 5,
 			"features": [
 				{
-					"type": "attribute_bonus",
-					"attribute": "parry",
-					"amount": 1
+					"type": "weapon_parry_bonus",
+					"selection_type": "weapons_with_required_skill",
+					"name": {
+						"compare": "is",
+						"qualifier": "@Melee weapon skill Or Unarmed@"
+					},
+					"amount": 1,
+					"leveled": true
 				}
 			],
 			"can_level": true,
@@ -1134,6 +1147,7 @@
 			"weapons": [
 				{
 					"id": "wUtbP-TxKQr8FXK1t",
+					"sv": 1,
 					"damage": {
 						"type": "cut",
 						"st": "sw",
@@ -1186,6 +1200,7 @@
 				},
 				{
 					"id": "w-kPH_AsCLvqZi-v3",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr",
@@ -1272,14 +1287,14 @@
 		}
 	],
 	"created_date": "2021-11-17T00:22:00-08:00",
-	"modified_date": "2021-11-17T00:28:00-08:00",
+	"modified_date": "2025-08-30T19:44:52+01:00",
 	"calc": {
 		"swing": "2d+1",
 		"thrust": "1d+1",
 		"basic_lift": "34 lb",
 		"striking_st_bonus": 2,
 		"dodge_bonus": 1,
-		"parry_bonus": 2,
+		"parry_bonus": 1,
 		"block_bonus": 1,
 		"move": [
 			8,

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 1/Classes/Duelist.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 1/Classes/Duelist.gct
@@ -237,9 +237,9 @@
 									}
 								},
 								{
-									"id": "t8crEhPh-M-B0E1mM",
-									"name": "Enhanced Parry ()",
-									"reference": "B51",
+									"id": "tZ44y-yO63ICud8wJ",
+									"name": "Enhanced Parry (@Melee weapon skill@)",
+									"reference": "B51,MA43",
 									"local_notes": "+2 or +3",
 									"tags": [
 										"Advantage",
@@ -248,10 +248,17 @@
 									"points_per_level": 5,
 									"features": [
 										{
-											"type": "attribute_bonus",
-											"attribute": "parry",
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"level": {
+												"compare": "at_least"
+											},
 											"amount": 1,
-											"per_level": true
+											"leveled": true
 										}
 									],
 									"can_level": true,
@@ -752,9 +759,14 @@
 							}
 						},
 						{
-							"id": "tlHWc4UE1FyemKMx2",
-							"name": "Enhanced Parry (@weapon of choice@)",
-							"reference": "B51",
+							"id": "toYJ5XkIEMKKxI5XS",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tDw6GZRxayNGMc8wW"
+							},
+							"name": "Enhanced Parry (@Melee weapon skill@)",
+							"reference": "B51,MA43",
 							"tags": [
 								"Advantage",
 								"Mental"
@@ -762,9 +774,14 @@
 							"points_per_level": 5,
 							"features": [
 								{
-									"type": "attribute_bonus",
-									"attribute": "parry",
-									"amount": 1
+									"type": "weapon_parry_bonus",
+									"selection_type": "weapons_with_required_skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "@Melee weapon skill@"
+									},
+									"amount": 1,
+									"leveled": true
 								}
 							],
 							"can_level": true,
@@ -2526,6 +2543,7 @@
 					"weapons": [
 						{
 							"id": "wk5eFDQtbKgRafS3l",
+							"sv": 1,
 							"damage": {
 								"type": "cut",
 								"st": "sw",
@@ -2586,6 +2604,7 @@
 						},
 						{
 							"id": "wW0lk656AMNNSIEb6",
+							"sv": 1,
 							"damage": {
 								"type": "imp",
 								"st": "thr"
@@ -2645,6 +2664,7 @@
 						},
 						{
 							"id": "W0B4dI6bx2LIjIeSl",
+							"sv": 1,
 							"damage": {
 								"type": "imp",
 								"st": "thr"
@@ -2692,6 +2712,7 @@
 					"weapons": [
 						{
 							"id": "wrOx8_dc-Ua_EX5CP",
+							"sv": 1,
 							"damage": {
 								"type": "cut",
 								"st": "sw",
@@ -2742,6 +2763,7 @@
 						},
 						{
 							"id": "wOYTkTlDFmu06NIQH",
+							"sv": 1,
 							"damage": {
 								"type": "imp",
 								"st": "thr",

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 1/Classes/Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 1/Classes/Holy Warrior.gct
@@ -2024,14 +2024,33 @@
 									}
 								},
 								{
-									"id": "ts29uafni6nHZVCwQ",
-									"name": "Enhanced Parry (@One Melee Weapon Skill@)",
-									"reference": "B51",
+									"id": "tmLJY90vuA39B1zBs",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tDw6GZRxayNGMc8wW"
+									},
+									"name": "Enhanced Parry (@Melee weapon skill@)",
+									"reference": "B51,MA43",
 									"tags": [
 										"Advantage",
 										"Mental"
 									],
-									"base_points": 5,
+									"points_per_level": 5,
+									"features": [
+										{
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"amount": 1,
+											"leveled": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
 									"calc": {
 										"points": 5
 									}
@@ -4063,6 +4082,7 @@
 					"weapons": [
 						{
 							"id": "wDCuESRdMSp2AyF69",
+							"sv": 1,
 							"damage": {
 								"type": "cut",
 								"st": "sw",
@@ -4103,6 +4123,7 @@
 						},
 						{
 							"id": "wAp37_kONbUghjP2N",
+							"sv": 1,
 							"damage": {
 								"type": "imp",
 								"st": "thr",
@@ -4143,6 +4164,7 @@
 						},
 						{
 							"id": "wc16a7t4jcpKAU5tH",
+							"sv": 1,
 							"damage": {
 								"type": "imp",
 								"st": "sw",
@@ -4310,6 +4332,7 @@
 					"weapons": [
 						{
 							"id": "weuUsYRsLelfLbQ1H",
+							"sv": 1,
 							"damage": {
 								"type": "cut",
 								"st": "sw",
@@ -4370,6 +4393,7 @@
 						},
 						{
 							"id": "wv9edHBtqRlXMF-Ba",
+							"sv": 1,
 							"damage": {
 								"type": "imp",
 								"st": "thr"
@@ -4429,6 +4453,7 @@
 						},
 						{
 							"id": "WwvHU-s51wWJRRmie",
+							"sv": 1,
 							"damage": {
 								"type": "imp",
 								"st": "thr"
@@ -4536,6 +4561,7 @@
 					"weapons": [
 						{
 							"id": "w1X7tVjnx3YgBy9TI",
+							"sv": 1,
 							"damage": {
 								"type": "cr",
 								"st": "thr"
@@ -4638,6 +4664,7 @@
 					"weapons": [
 						{
 							"id": "W56sbSvhM41D0GLW_",
+							"sv": 1,
 							"damage": {
 								"type": "imp",
 								"st": "thr",
@@ -4844,6 +4871,7 @@
 					"weapons": [
 						{
 							"id": "woyHaTyZFsNIjjfBK",
+							"sv": 1,
 							"damage": {
 								"type": "cr",
 								"st": "thr"
@@ -5012,6 +5040,7 @@
 					"weapons": [
 						{
 							"id": "wbbv7wcvLrK-1DHQF",
+							"sv": 1,
 							"damage": {
 								"type": "cut",
 								"st": "sw",
@@ -5062,6 +5091,7 @@
 						},
 						{
 							"id": "wN8W3tzYvBpI3Zc_x",
+							"sv": 1,
 							"damage": {
 								"type": "imp",
 								"st": "thr",

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 1/Classes/Knight.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 1/Classes/Knight.gct
@@ -162,24 +162,35 @@
 									}
 								},
 								{
-									"id": "t0jB8ihRroJrSebIX",
-									"name": "Enhanced Parry",
-									"reference": "B51",
-									"local_notes": "Choose a weapon",
+									"id": "t5FZuyE6aSIfSpT2T",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tDw6GZRxayNGMc8wW"
+									},
+									"name": "Enhanced Parry (@Melee weapon skill@)",
+									"reference": "B51,MA43",
 									"tags": [
 										"Advantage",
 										"Mental"
 									],
-									"base_points": 10,
+									"points_per_level": 5,
 									"features": [
 										{
-											"type": "attribute_bonus",
-											"attribute": "parry",
-											"amount": 1
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"amount": 1,
+											"leveled": true
 										}
 									],
+									"can_level": true,
+									"levels": 1,
 									"calc": {
-										"points": 10
+										"points": 5
 									}
 								},
 								{
@@ -658,7 +669,7 @@
 								}
 							],
 							"calc": {
-								"points": 123
+								"points": 118
 							}
 						},
 						{
@@ -789,7 +800,7 @@
 						}
 					],
 					"calc": {
-						"points": 158
+						"points": 153
 					}
 				},
 				{
@@ -1094,7 +1105,7 @@
 				}
 			],
 			"calc": {
-				"points": 128
+				"points": 123
 			}
 		}
 	],
@@ -3296,6 +3307,7 @@
 					"weapons": [
 						{
 							"id": "wS0Hkfx_sbQfzmyqt",
+							"sv": 1,
 							"damage": {
 								"type": "cut",
 								"st": "sw",
@@ -3331,6 +3343,7 @@
 						},
 						{
 							"id": "wtNfK12_N0XViBzsn",
+							"sv": 1,
 							"damage": {
 								"type": "cut",
 								"st": "sw",
@@ -3391,6 +3404,7 @@
 					"weapons": [
 						{
 							"id": "w0L755MumDTuXw7Dq",
+							"sv": 1,
 							"damage": {
 								"type": "cut",
 								"st": "sw"
@@ -3425,6 +3439,7 @@
 						},
 						{
 							"id": "WPQF9IXIJ0qFcUp1_",
+							"sv": 1,
 							"damage": {
 								"type": "cut",
 								"st": "sw"
@@ -3473,6 +3488,7 @@
 					"weapons": [
 						{
 							"id": "wjcLAJh8JvSX4RGW5",
+							"sv": 1,
 							"damage": {
 								"type": "cr",
 								"st": "thr"
@@ -3558,6 +3574,7 @@
 					"weapons": [
 						{
 							"id": "WghM4CVSrMX0gHE22",
+							"sv": 1,
 							"damage": {
 								"type": "imp",
 								"st": "thr",
@@ -3607,6 +3624,7 @@
 					"weapons": [
 						{
 							"id": "wINOGBKSWKGFCTufo",
+							"sv": 1,
 							"damage": {
 								"type": "cut",
 								"st": "sw",
@@ -3647,6 +3665,7 @@
 						},
 						{
 							"id": "wPrYvWl7taUbNHkv8",
+							"sv": 1,
 							"damage": {
 								"type": "imp",
 								"st": "thr",
@@ -3687,6 +3706,7 @@
 						},
 						{
 							"id": "whobmdHhpCgeFPl1u",
+							"sv": 1,
 							"damage": {
 								"type": "imp",
 								"st": "sw",
@@ -3787,6 +3807,7 @@
 					"weapons": [
 						{
 							"id": "wh-mlBHHKkkMsmeVU",
+							"sv": 1,
 							"damage": {
 								"type": "cut",
 								"st": "sw",
@@ -3847,6 +3868,7 @@
 						},
 						{
 							"id": "wJQbMQpkeROjnOoMs",
+							"sv": 1,
 							"damage": {
 								"type": "imp",
 								"st": "thr"
@@ -3906,6 +3928,7 @@
 						},
 						{
 							"id": "WoAfTGu7PY8d_0IK7",
+							"sv": 1,
 							"damage": {
 								"type": "imp",
 								"st": "thr"
@@ -4006,6 +4029,7 @@
 					"weapons": [
 						{
 							"id": "wdRWZfsvmEYHrUbAj",
+							"sv": 1,
 							"damage": {
 								"type": "cut",
 								"st": "sw",
@@ -4066,6 +4090,7 @@
 						},
 						{
 							"id": "wfmc-3n932WVb4vqH",
+							"sv": 1,
 							"damage": {
 								"type": "imp",
 								"st": "thr"
@@ -4125,6 +4150,7 @@
 						},
 						{
 							"id": "W8YHm4IkDl2KN6QRP",
+							"sv": 1,
 							"damage": {
 								"type": "imp",
 								"st": "thr"
@@ -4172,6 +4198,7 @@
 					"weapons": [
 						{
 							"id": "wDXOnzYEjbePWfLwI",
+							"sv": 1,
 							"damage": {
 								"type": "cr",
 								"st": "thr"
@@ -4243,6 +4270,7 @@
 					"weapons": [
 						{
 							"id": "W-rQ-7CC5Z2FkGxCf",
+							"sv": 1,
 							"damage": {
 								"type": "imp",
 								"st": "thr",
@@ -4291,6 +4319,7 @@
 					"weapons": [
 						{
 							"id": "wuatvc06Y9lt2Tw51",
+							"sv": 1,
 							"damage": {
 								"type": "cut",
 								"st": "sw",
@@ -4341,6 +4370,7 @@
 						},
 						{
 							"id": "wX7DXwQvhVE2icmvj",
+							"sv": 1,
 							"damage": {
 								"type": "imp",
 								"st": "thr",
@@ -4425,6 +4455,7 @@
 					"weapons": [
 						{
 							"id": "wRullM8uWyPCwEM0p",
+							"sv": 1,
 							"damage": {
 								"type": "cut",
 								"st": "sw",
@@ -4485,6 +4516,7 @@
 					"weapons": [
 						{
 							"id": "wjIm4W7zx9jcJUSw_",
+							"sv": 1,
 							"damage": {
 								"type": "cut",
 								"st": "sw",
@@ -4520,6 +4552,7 @@
 						},
 						{
 							"id": "w6tSFfF6eAaoTjuD4",
+							"sv": 1,
 							"damage": {
 								"type": "cut",
 								"st": "sw",
@@ -4560,6 +4593,7 @@
 						},
 						{
 							"id": "WhqaNzFF5dhg3f71u",
+							"sv": 1,
 							"damage": {
 								"type": "cut",
 								"st": "sw",
@@ -4624,6 +4658,7 @@
 					"weapons": [
 						{
 							"id": "WLTNB90lmjdWmojcO",
+							"sv": 1,
 							"damage": {
 								"type": "imp",
 								"st": "thr",
@@ -4672,6 +4707,7 @@
 					"weapons": [
 						{
 							"id": "weuOPTZ5Z5skfE8M8",
+							"sv": 1,
 							"damage": {
 								"type": "cut",
 								"st": "sw",
@@ -4707,6 +4743,7 @@
 						},
 						{
 							"id": "wzehndHp7R61E-1Lr",
+							"sv": 1,
 							"damage": {
 								"type": "cr",
 								"st": "thr",
@@ -4802,6 +4839,7 @@
 					"weapons": [
 						{
 							"id": "wjSRL6-5-7-yDnvem",
+							"sv": 1,
 							"damage": {
 								"type": "cut",
 								"st": "sw",
@@ -4862,6 +4900,7 @@
 						},
 						{
 							"id": "w1jMAm4CSQVxRiDPv",
+							"sv": 1,
 							"damage": {
 								"type": "imp",
 								"st": "thr"
@@ -4921,6 +4960,7 @@
 						},
 						{
 							"id": "WZvF4TVEcbUBUZmI2",
+							"sv": 1,
 							"damage": {
 								"type": "imp",
 								"st": "thr"

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 1/Classes/Swashbuckler.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 1/Classes/Swashbuckler.gct
@@ -368,9 +368,9 @@
 									}
 								},
 								{
-									"id": "ty18on5X7GsCyH8Yu",
-									"name": "Enhanced Parry (@weapon of choice@)",
-									"reference": "B51",
+									"id": "taQqhnxTRG4h4h-xK",
+									"name": "Enhanced Parry (@Melee weapon skill@)",
+									"reference": "B51,MA43",
 									"local_notes": "+2 or +3",
 									"tags": [
 										"Advantage",
@@ -379,9 +379,14 @@
 									"points_per_level": 5,
 									"features": [
 										{
-											"type": "attribute_bonus",
-											"attribute": "parry",
-											"amount": 1
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"amount": 1,
+											"leveled": true
 										}
 									],
 									"can_level": true,
@@ -792,9 +797,14 @@
 							}
 						},
 						{
-							"id": "t9G2TNKbc3-GNASru",
-							"name": "Enhanced Parry (@weapon of choice@)",
-							"reference": "B51",
+							"id": "t50F1e_-PEAi-JhiP",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tDw6GZRxayNGMc8wW"
+							},
+							"name": "Enhanced Parry (@Melee weapon skill@)",
+							"reference": "B51,MA43",
 							"tags": [
 								"Advantage",
 								"Mental"
@@ -802,9 +812,14 @@
 							"points_per_level": 5,
 							"features": [
 								{
-									"type": "attribute_bonus",
-									"attribute": "parry",
-									"amount": 1
+									"type": "weapon_parry_bonus",
+									"selection_type": "weapons_with_required_skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "@Melee weapon skill@"
+									},
+									"amount": 1,
+									"leveled": true
 								}
 							],
 							"can_level": true,
@@ -3295,6 +3310,7 @@
 					"weapons": [
 						{
 							"id": "wA9lQt8Cajby1h1Ow",
+							"sv": 1,
 							"damage": {
 								"type": "cr",
 								"st": "thr"
@@ -3367,6 +3383,7 @@
 					"weapons": [
 						{
 							"id": "wqy8yktMGc0gV8PFL",
+							"sv": 1,
 							"damage": {
 								"type": "imp",
 								"st": "thr",
@@ -3446,6 +3463,7 @@
 					"weapons": [
 						{
 							"id": "wCYZm2Ae0-N_h6EGT",
+							"sv": 1,
 							"damage": {
 								"type": "cut",
 								"st": "sw",
@@ -3505,6 +3523,7 @@
 						},
 						{
 							"id": "w4N_O8y5A7OOLLXzH",
+							"sv": 1,
 							"damage": {
 								"type": "imp",
 								"st": "thr"
@@ -3592,6 +3611,7 @@
 					"weapons": [
 						{
 							"id": "wjr_JOtvUN6En9t7s",
+							"sv": 1,
 							"damage": {
 								"type": "cut",
 								"st": "sw"
@@ -3651,6 +3671,7 @@
 						},
 						{
 							"id": "wfxyA2Aw0xIenvbYR",
+							"sv": 1,
 							"damage": {
 								"type": "imp",
 								"st": "thr",
@@ -3745,6 +3766,7 @@
 					"weapons": [
 						{
 							"id": "w2vonQ7PDc2EA3CLW",
+							"sv": 1,
 							"damage": {
 								"type": "-"
 							},
@@ -3761,6 +3783,7 @@
 						},
 						{
 							"id": "Wx7V-uiDLmnibUQvI",
+							"sv": 1,
 							"damage": {
 								"type": "Special"
 							},
@@ -3834,6 +3857,7 @@
 					"weapons": [
 						{
 							"id": "wWVOf24z79ojhZuiL",
+							"sv": 1,
 							"damage": {
 								"type": "imp",
 								"st": "thr",
@@ -3913,6 +3937,7 @@
 					"weapons": [
 						{
 							"id": "wMdtZrpkCRj7ll4s6",
+							"sv": 1,
 							"damage": {
 								"type": "cut",
 								"st": "sw",
@@ -3973,6 +3998,7 @@
 						},
 						{
 							"id": "wDuCFOjYpNIv22tqw",
+							"sv": 1,
 							"damage": {
 								"type": "imp",
 								"st": "thr"
@@ -4032,6 +4058,7 @@
 						},
 						{
 							"id": "WySFZKn8PQlEVZ14d",
+							"sv": 1,
 							"damage": {
 								"type": "imp",
 								"st": "thr"
@@ -4079,6 +4106,7 @@
 					"weapons": [
 						{
 							"id": "wVN9XiovwMbZ6_Osi",
+							"sv": 1,
 							"damage": {
 								"type": "cut",
 								"st": "sw",
@@ -4129,6 +4157,7 @@
 						},
 						{
 							"id": "wxff_NqCgCA9tDVQs",
+							"sv": 1,
 							"damage": {
 								"type": "imp",
 								"st": "thr",

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 15/Brute.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 15/Brute.gct
@@ -671,9 +671,14 @@
 									}
 								},
 								{
-									"id": "tq_6SuGLFNzw_LnSM",
+									"id": "tbvD-YnHFYvS6Ewmm",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tDw6GZRxayNGMc8wW"
+									},
 									"name": "Enhanced Parry (@Melee weapon skill@)",
-									"reference": "B51",
+									"reference": "B51,MA43",
 									"tags": [
 										"Advantage",
 										"Mental"
@@ -681,9 +686,14 @@
 									"points_per_level": 5,
 									"features": [
 										{
-											"type": "attribute_bonus",
-											"attribute": "parry",
-											"amount": 1
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"amount": 1,
+											"leveled": true
 										}
 									],
 									"can_level": true,

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 15/Skirmisher.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 15/Skirmisher.gct
@@ -208,9 +208,14 @@
 									}
 								},
 								{
-									"id": "t--BGG408eX44AuYD",
+									"id": "t6f6WAenb-z3bI5Mg",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tDw6GZRxayNGMc8wW"
+									},
 									"name": "Enhanced Parry (@Melee weapon skill@)",
-									"reference": "B51",
+									"reference": "B51,MA43",
 									"tags": [
 										"Advantage",
 										"Mental"
@@ -218,9 +223,14 @@
 									"points_per_level": 5,
 									"features": [
 										{
-											"type": "attribute_bonus",
-											"attribute": "parry",
-											"amount": 1
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"amount": 1,
+											"leveled": true
 										}
 									],
 									"can_level": true,

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 15/Squire.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 15/Squire.gct
@@ -1286,9 +1286,14 @@
 									}
 								},
 								{
-									"id": "tMrqF_pPa7iImSoki",
+									"id": "twh8PkD_vHwt2b13A",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tDw6GZRxayNGMc8wW"
+									},
 									"name": "Enhanced Parry (@Melee weapon skill@)",
-									"reference": "B51",
+									"reference": "B51,MA43",
 									"tags": [
 										"Advantage",
 										"Mental"
@@ -1296,9 +1301,14 @@
 									"points_per_level": 5,
 									"features": [
 										{
-											"type": "attribute_bonus",
-											"attribute": "parry",
-											"amount": 1
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"amount": 1,
+											"leveled": true
 										}
 									],
 									"can_level": true,

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 3/Unholy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 3/Unholy Warrior.gct
@@ -1024,9 +1024,10 @@
 											"weapons": [
 												{
 													"id": "W90r7xaKXxkYCOnNC",
+													"sv": 1,
 													"damage": {
 														"type": "tox",
-														"base": "1d"
+														"base_leveled": "1d"
 													},
 													"accuracy": "3",
 													"range": "10",
@@ -1048,7 +1049,7 @@
 														}
 													],
 													"calc": {
-														"damage": "1d tox"
+														"damage": "1d per level  tox"
 													}
 												}
 											],
@@ -1761,14 +1762,33 @@
 									}
 								},
 								{
-									"id": "tvmpr18Md6-U_6APF",
-									"name": "Enhanced Parry (@One Melee Weapon Skill@)",
-									"reference": "B51",
+									"id": "tAbZ-enxsVKek3MFa",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tDw6GZRxayNGMc8wW"
+									},
+									"name": "Enhanced Parry (@Melee weapon skill@)",
+									"reference": "B51,MA43",
 									"tags": [
 										"Advantage",
 										"Mental"
 									],
-									"base_points": 5,
+									"points_per_level": 5,
+									"features": [
+										{
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"amount": 1,
+											"leveled": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
 									"calc": {
 										"points": 5
 									}

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Agriculture Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Agriculture Holy Warrior.gct
@@ -1745,14 +1745,33 @@
 									}
 								},
 								{
-									"id": "tscFet608K0DURWpz",
-									"name": "Enhanced Parry (@One Melee Weapon Skill@)",
-									"reference": "B51",
+									"id": "tWMjVMdMVyo8TOYUV",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tDw6GZRxayNGMc8wW"
+									},
+									"name": "Enhanced Parry (@Melee weapon skill@)",
+									"reference": "B51,MA43",
 									"tags": [
 										"Advantage",
 										"Mental"
 									],
-									"base_points": 5,
+									"points_per_level": 5,
+									"features": [
+										{
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"amount": 1,
+											"leveled": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
 									"calc": {
 										"points": 5
 									}

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Artificer Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Artificer Holy Warrior.gct
@@ -1704,14 +1704,33 @@
 									}
 								},
 								{
-									"id": "t5J5nJcGoBuffGIo2",
-									"name": "Enhanced Parry (@One Melee Weapon Skill@)",
-									"reference": "B51",
+									"id": "tFHvI39baYIzWQ0E7",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tDw6GZRxayNGMc8wW"
+									},
+									"name": "Enhanced Parry (@Melee weapon skill@)",
+									"reference": "B51,MA43",
 									"tags": [
 										"Advantage",
 										"Mental"
 									],
-									"base_points": 5,
+									"points_per_level": 5,
+									"features": [
+										{
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"amount": 1,
+											"leveled": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
 									"calc": {
 										"points": 5
 									}

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Death Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Death Holy Warrior.gct
@@ -1582,14 +1582,33 @@
 									}
 								},
 								{
-									"id": "tdFloepfEWFfPF_O3",
-									"name": "Enhanced Parry (@One Melee Weapon Skill@)",
-									"reference": "B51",
+									"id": "tCo_lwoB4niYnuVn2",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tDw6GZRxayNGMc8wW"
+									},
+									"name": "Enhanced Parry (@Melee weapon skill@)",
+									"reference": "B51,MA43",
 									"tags": [
 										"Advantage",
 										"Mental"
 									],
-									"base_points": 5,
+									"points_per_level": 5,
+									"features": [
+										{
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"amount": 1,
+											"leveled": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
 									"calc": {
 										"points": 5
 									}

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Earth Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Earth Holy Warrior.gct
@@ -2130,14 +2130,33 @@
 									}
 								},
 								{
-									"id": "tCQbPw9HyuqsVKx7z",
-									"name": "Enhanced Parry (@One Melee Weapon Skill@)",
-									"reference": "B51",
+									"id": "t35-EsQFFdQJDN9aZ",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tDw6GZRxayNGMc8wW"
+									},
+									"name": "Enhanced Parry (@Melee weapon skill@)",
+									"reference": "B51,MA43",
 									"tags": [
 										"Advantage",
 										"Mental"
 									],
-									"base_points": 5,
+									"points_per_level": 5,
+									"features": [
+										{
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"amount": 1,
+											"leveled": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
 									"calc": {
 										"points": 5
 									}

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Fire Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Fire Holy Warrior.gct
@@ -1471,9 +1471,10 @@
 											"weapons": [
 												{
 													"id": "wBy1kQBTRehO5xLlY",
+													"sv": 1,
 													"damage": {
 														"type": "brn",
-														"base": "1d"
+														"base_leveled": "1d"
 													},
 													"usage": "Hellfire Touch",
 													"reach": "C",
@@ -1491,7 +1492,7 @@
 														}
 													],
 													"calc": {
-														"damage": "1d brn"
+														"damage": "1d per level  brn"
 													}
 												}
 											],
@@ -2248,14 +2249,33 @@
 									}
 								},
 								{
-									"id": "tZKxYTQ-wNuIJMHJT",
-									"name": "Enhanced Parry (@One Melee Weapon Skill@)",
-									"reference": "B51",
+									"id": "tRHBDIuPh_55ltaxj",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tDw6GZRxayNGMc8wW"
+									},
+									"name": "Enhanced Parry (@Melee weapon skill@)",
+									"reference": "B51,MA43",
 									"tags": [
 										"Advantage",
 										"Mental"
 									],
-									"base_points": 5,
+									"points_per_level": 5,
+									"features": [
+										{
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"amount": 1,
+											"leveled": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
 									"calc": {
 										"points": 5
 									}

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Healing Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Healing Holy Warrior.gct
@@ -1629,14 +1629,33 @@
 									}
 								},
 								{
-									"id": "tK5JI5OEfn15ojQy7",
-									"name": "Enhanced Parry (@One Melee Weapon Skill@)",
-									"reference": "B51",
+									"id": "tvC1_fcnn5f7jLWvV",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tDw6GZRxayNGMc8wW"
+									},
+									"name": "Enhanced Parry (@Melee weapon skill@)",
+									"reference": "B51,MA43",
 									"tags": [
 										"Advantage",
 										"Mental"
 									],
-									"base_points": 5,
+									"points_per_level": 5,
+									"features": [
+										{
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"amount": 1,
+											"leveled": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
 									"calc": {
 										"points": 5
 									}

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Hunter Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Hunter Holy Warrior.gct
@@ -1899,14 +1899,33 @@
 									}
 								},
 								{
-									"id": "tT_-_DidxjCIYsumZ",
-									"name": "Enhanced Parry (@One Melee Weapon Skill@)",
-									"reference": "B51",
+									"id": "t8RJY2d52KAJFOnvI",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tDw6GZRxayNGMc8wW"
+									},
+									"name": "Enhanced Parry (@Melee weapon skill@)",
+									"reference": "B51,MA43",
 									"tags": [
 										"Advantage",
 										"Mental"
 									],
-									"base_points": 5,
+									"points_per_level": 5,
+									"features": [
+										{
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"amount": 1,
+											"leveled": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
 									"calc": {
 										"points": 5
 									}

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Love and Fertility Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Love and Fertility Holy Warrior.gct
@@ -1705,14 +1705,33 @@
 									}
 								},
 								{
-									"id": "t8stdf1G0Gq2uXI1i",
-									"name": "Enhanced Parry (@One Melee Weapon Skill@)",
-									"reference": "B51",
+									"id": "tpvs2eUWRwEgPB17F",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tDw6GZRxayNGMc8wW"
+									},
+									"name": "Enhanced Parry (@Melee weapon skill@)",
+									"reference": "B51,MA43",
 									"tags": [
 										"Advantage",
 										"Mental"
 									],
-									"base_points": 5,
+									"points_per_level": 5,
+									"features": [
+										{
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"amount": 1,
+											"leveled": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
 									"calc": {
 										"points": 5
 									}

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Night Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Night Holy Warrior.gct
@@ -1555,14 +1555,33 @@
 									}
 								},
 								{
-									"id": "tQQeXNfKZigwcApom",
-									"name": "Enhanced Parry (@One Melee Weapon Skill@)",
-									"reference": "B51",
+									"id": "tFtwhhVWUMwLmoKTM",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tDw6GZRxayNGMc8wW"
+									},
+									"name": "Enhanced Parry (@Melee weapon skill@)",
+									"reference": "B51,MA43",
 									"tags": [
 										"Advantage",
 										"Mental"
 									],
-									"base_points": 5,
+									"points_per_level": 5,
+									"features": [
+										{
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"amount": 1,
+											"leveled": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
 									"calc": {
 										"points": 5
 									}

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Rogue Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Rogue Holy Warrior.gct
@@ -368,9 +368,9 @@
 									}
 								},
 								{
-									"id": "tTnrK2Ylzi4tJfxjn",
-									"name": "Enhanced Parry (@weapon of choice@)",
-									"reference": "B51",
+									"id": "tkwROpWyfT1aHi44x",
+									"name": "Enhanced Parry (@Melee weapon skill@)",
+									"reference": "B51,MA43",
 									"local_notes": "+2 or +3",
 									"tags": [
 										"Advantage",
@@ -379,9 +379,14 @@
 									"points_per_level": 5,
 									"features": [
 										{
-											"type": "attribute_bonus",
-											"attribute": "parry",
-											"amount": 1
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"amount": 1,
+											"leveled": true
 										}
 									],
 									"can_level": true,
@@ -2135,9 +2140,14 @@
 							}
 						},
 						{
-							"id": "tpicaJbbEHRO91LmQ",
-							"name": "Enhanced Parry (@weapon of choice@)",
-							"reference": "B51",
+							"id": "t0_MApMw1D4IujECQ",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tDw6GZRxayNGMc8wW"
+							},
+							"name": "Enhanced Parry (@Melee weapon skill@)",
+							"reference": "B51,MA43",
 							"tags": [
 								"Advantage",
 								"Mental"
@@ -2145,9 +2155,14 @@
 							"points_per_level": 5,
 							"features": [
 								{
-									"type": "attribute_bonus",
-									"attribute": "parry",
-									"amount": 1
+									"type": "weapon_parry_bonus",
+									"selection_type": "weapons_with_required_skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "@Melee weapon skill@"
+									},
+									"amount": 1,
+									"leveled": true
 								}
 							],
 							"can_level": true,

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Sea Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Sea Holy Warrior.gct
@@ -2016,14 +2016,33 @@
 									}
 								},
 								{
-									"id": "tJB6_hICmgPpkHzAr",
-									"name": "Enhanced Parry (@One Melee Weapon Skill@)",
-									"reference": "B51",
+									"id": "tDhvRYoL0OnQ7sofl",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tDw6GZRxayNGMc8wW"
+									},
+									"name": "Enhanced Parry (@Melee weapon skill@)",
+									"reference": "B51,MA43",
 									"tags": [
 										"Advantage",
 										"Mental"
 									],
-									"base_points": 5,
+									"points_per_level": 5,
+									"features": [
+										{
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"amount": 1,
+											"leveled": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
 									"calc": {
 										"points": 5
 									}

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Storm Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Storm Holy Warrior.gct
@@ -1961,14 +1961,33 @@
 									}
 								},
 								{
-									"id": "t6kdarJi9T6sAS8tc",
-									"name": "Enhanced Parry (@One Melee Weapon Skill@)",
-									"reference": "B51",
+									"id": "tIgOxT1UgiGDagA22",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tDw6GZRxayNGMc8wW"
+									},
+									"name": "Enhanced Parry (@Melee weapon skill@)",
+									"reference": "B51,MA43",
 									"tags": [
 										"Advantage",
 										"Mental"
 									],
-									"base_points": 5,
+									"points_per_level": 5,
+									"features": [
+										{
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"amount": 1,
+											"leveled": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
 									"calc": {
 										"points": 5
 									}

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Sun Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Sun Holy Warrior.gct
@@ -1926,14 +1926,33 @@
 									}
 								},
 								{
-									"id": "tFHXgIzcT_4bS36E7",
-									"name": "Enhanced Parry (@One Melee Weapon Skill@)",
-									"reference": "B51",
+									"id": "txIJg3RZeflyJejip",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tDw6GZRxayNGMc8wW"
+									},
+									"name": "Enhanced Parry (@Melee weapon skill@)",
+									"reference": "B51,MA43",
 									"tags": [
 										"Advantage",
 										"Mental"
 									],
-									"base_points": 5,
+									"points_per_level": 5,
+									"features": [
+										{
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"amount": 1,
+											"leveled": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
 									"calc": {
 										"points": 5
 									}

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Urban Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Urban Holy Warrior.gct
@@ -1629,14 +1629,33 @@
 									}
 								},
 								{
-									"id": "t9nKItT6PW-4ziX5l",
-									"name": "Enhanced Parry (@One Melee Weapon Skill@)",
-									"reference": "B51",
+									"id": "tz1eQDQJ-2CUv526l",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tDw6GZRxayNGMc8wW"
+									},
+									"name": "Enhanced Parry (@Melee weapon skill@)",
+									"reference": "B51,MA43",
 									"tags": [
 										"Advantage",
 										"Mental"
 									],
-									"base_points": 5,
+									"points_per_level": 5,
+									"features": [
+										{
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"amount": 1,
+											"leveled": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
 									"calc": {
 										"points": 5
 									}

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/War Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/War Holy Warrior.gct
@@ -1488,14 +1488,33 @@
 									}
 								},
 								{
-									"id": "tApAAGs01c_TV6PCQ",
-									"name": "Enhanced Parry (@One Melee Weapon Skill@)",
-									"reference": "B51",
+									"id": "tDOyIF_1-fGt6JRIG",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tDw6GZRxayNGMc8wW"
+									},
+									"name": "Enhanced Parry (@Melee weapon skill@)",
+									"reference": "B51,MA43",
 									"tags": [
 										"Advantage",
 										"Mental"
 									],
-									"base_points": 5,
+									"points_per_level": 5,
+									"features": [
+										{
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"amount": 1,
+											"leveled": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
 									"calc": {
 										"points": 5
 									}

--- a/Library/Dungeon Fantasy/Dungeon Fantasy Adventure 1/Rivals/Aristocrat - High Elven Swashbuckler.gcs
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy Adventure 1/Rivals/Aristocrat - High Elven Swashbuckler.gcs
@@ -817,19 +817,32 @@
 					}
 				},
 				{
-					"id": "ttWEErRFRynBWHitz",
-					"name": "Enhanced Parry (Rapier)",
-					"reference": "B51",
+					"id": "tGo32E0g5bYsAw1dR",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tDw6GZRxayNGMc8wW"
+					},
+					"name": "Enhanced Parry (@Melee weapon skill@)",
+					"reference": "B51,MA43",
 					"tags": [
 						"Advantage",
 						"Mental"
 					],
+					"replacements": {
+						"Melee weapon skill": "Rapier"
+					},
 					"points_per_level": 5,
 					"features": [
 						{
-							"type": "attribute_bonus",
-							"attribute": "parry",
-							"amount": 1
+							"type": "weapon_parry_bonus",
+							"selection_type": "weapons_with_required_skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "@Melee weapon skill@"
+							},
+							"amount": 1,
+							"leveled": true
 						}
 					],
 					"can_level": true,
@@ -876,6 +889,7 @@
 					"weapons": [
 						{
 							"id": "wPDATzuCOT0qf5FHN",
+							"sv": 1,
 							"damage": {
 								"type": "cr",
 								"st": "thr",
@@ -899,6 +913,7 @@
 						},
 						{
 							"id": "wr1H5yXHbwFntVMFR",
+							"sv": 1,
 							"damage": {
 								"type": "cr",
 								"st": "thr",
@@ -927,11 +942,12 @@
 							"calc": {
 								"level": 17,
 								"damage": "1d-2 cr",
-								"parry": "14"
+								"parry": "13"
 							}
 						},
 						{
 							"id": "wChVuD1W-oQLIgioH",
+							"sv": 1,
 							"damage": {
 								"type": "cr",
 								"st": "thr"
@@ -2431,6 +2447,7 @@
 			"weapons": [
 				{
 					"id": "wL-hbUvOcPUTZybho",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr",
@@ -2503,6 +2520,7 @@
 			"weapons": [
 				{
 					"id": "wan8K0o-fbG_FYaMy",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "thr"
@@ -3075,13 +3093,13 @@
 		}
 	],
 	"created_date": "2022-11-07T19:47:54-05:00",
-	"modified_date": "2022-11-20T04:03:59-05:00",
+	"modified_date": "2025-08-30T20:54:59+01:00",
 	"calc": {
 		"swing": "1d+1",
 		"thrust": "1d-1",
 		"basic_lift": "24 lb",
 		"dodge_bonus": 2,
-		"parry_bonus": 3,
+		"parry_bonus": 2,
 		"block_bonus": 2,
 		"move": [
 			7,

--- a/Library/Dungeon Fantasy/Dungeon Fantasy Adventure 1/Rivals/Holy Warrior.gcs
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy Adventure 1/Rivals/Holy Warrior.gcs
@@ -913,14 +913,36 @@
 					}
 				},
 				{
-					"id": "tK0ITWL3MTKqhMAtV",
-					"name": "Enhanced Parry (Polearm)",
-					"reference": "B51",
+					"id": "tbpRAwekL_SZQMrL7",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tDw6GZRxayNGMc8wW"
+					},
+					"name": "Enhanced Parry (@Melee weapon skill@)",
+					"reference": "B51,MA43",
 					"tags": [
 						"Advantage",
 						"Mental"
 					],
-					"base_points": 5,
+					"replacements": {
+						"Melee weapon skill": "Polearm"
+					},
+					"points_per_level": 5,
+					"features": [
+						{
+							"type": "weapon_parry_bonus",
+							"selection_type": "weapons_with_required_skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "@Melee weapon skill@"
+							},
+							"amount": 1,
+							"leveled": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
 					"calc": {
 						"points": 5
 					}
@@ -1190,6 +1212,7 @@
 			"weapons": [
 				{
 					"id": "wzpHlIfEP7Un8kCbI",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "thr",
@@ -1213,6 +1236,7 @@
 				},
 				{
 					"id": "wZ85dIXnqkrvND4lv",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "thr",
@@ -1246,6 +1270,7 @@
 				},
 				{
 					"id": "wIWF1FNt7rssV6PHp",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "thr"
@@ -2071,6 +2096,7 @@
 			"weapons": [
 				{
 					"id": "w4ZbKa65PfwMwxkcJ",
+					"sv": 1,
 					"damage": {
 						"type": "cut",
 						"st": "sw",
@@ -2109,11 +2135,12 @@
 					"calc": {
 						"level": 18,
 						"damage": "2d+2 cut",
-						"parry": "12U"
+						"parry": "13U"
 					}
 				},
 				{
 					"id": "wxuwVpJmYelSf9tl3",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr",
@@ -2152,11 +2179,12 @@
 					"calc": {
 						"level": 18,
 						"damage": "1d+3 imp",
-						"parry": "12"
+						"parry": "13"
 					}
 				},
 				{
 					"id": "wnNQ5ndBOITUxzvP9",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "sw",
@@ -2190,11 +2218,12 @@
 					"calc": {
 						"level": 14,
 						"damage": "2d+2 cr",
-						"parry": "10U"
+						"parry": "11U"
 					}
 				},
 				{
 					"id": "w9bfPdZgMFMUXsbmG",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "thr",
@@ -2228,11 +2257,12 @@
 					"calc": {
 						"level": 14,
 						"damage": "1d+2 cr",
-						"parry": "10"
+						"parry": "11"
 					}
 				},
 				{
 					"id": "wOaUFajjuzG3FM8nl",
+					"sv": 1,
 					"damage": {
 						"type": "cut",
 						"st": "sw",
@@ -2275,6 +2305,7 @@
 				},
 				{
 					"id": "w_6UAO-ASx54iessC",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr",
@@ -2339,6 +2370,7 @@
 			"weapons": [
 				{
 					"id": "WNAIuQSkduD460wRP",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"base": "2d"
@@ -2936,7 +2968,7 @@
 		}
 	],
 	"created_date": "2022-11-17T22:04:18-05:00",
-	"modified_date": "2022-11-17T23:32:27-05:00",
+	"modified_date": "2025-08-30T20:56:27+01:00",
 	"calc": {
 		"swing": "2d",
 		"thrust": "1d",

--- a/Library/Dungeon Fantasy/Dungeon Fantasy Denizens/Swashbucklers/Aristocrat Henchman.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy Denizens/Swashbucklers/Aristocrat Henchman.gct
@@ -922,9 +922,14 @@
 									}
 								},
 								{
-									"id": "tBXARS5-kvf9B6Ah2",
+									"id": "trZuPhcJfl5fu0LKp",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tDw6GZRxayNGMc8wW"
+									},
 									"name": "Enhanced Parry (@Melee weapon skill@)",
-									"reference": "B51",
+									"reference": "B51,MA43",
 									"tags": [
 										"Advantage",
 										"Mental"
@@ -932,9 +937,14 @@
 									"points_per_level": 5,
 									"features": [
 										{
-											"type": "attribute_bonus",
-											"attribute": "parry",
-											"amount": 1
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"amount": 1,
+											"leveled": true
 										}
 									],
 									"can_level": true,

--- a/Library/Dungeon Fantasy/Dungeon Fantasy Denizens/Swashbucklers/Aristocrat.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy Denizens/Swashbucklers/Aristocrat.gct
@@ -995,9 +995,14 @@
 									}
 								},
 								{
-									"id": "tyoDptM401v1kRgkP",
+									"id": "tuqe0qzmUo2SZz620",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tDw6GZRxayNGMc8wW"
+									},
 									"name": "Enhanced Parry (@Melee weapon skill@)",
-									"reference": "B51",
+									"reference": "B51,MA43",
 									"tags": [
 										"Advantage",
 										"Mental"
@@ -1005,9 +1010,14 @@
 									"points_per_level": 5,
 									"features": [
 										{
-											"type": "attribute_bonus",
-											"attribute": "parry",
-											"amount": 1
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"amount": 1,
+											"leveled": true
 										}
 									],
 									"can_level": true,

--- a/Library/Dungeon Fantasy/Dungeon Fantasy Denizens/Swashbucklers/Buccaneer Henchman.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy Denizens/Swashbucklers/Buccaneer Henchman.gct
@@ -626,9 +626,14 @@
 									}
 								},
 								{
-									"id": "t-Cn_GYU8fUSgoHsR",
+									"id": "teEnKE1Si2Qn56qSr",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tDw6GZRxayNGMc8wW"
+									},
 									"name": "Enhanced Parry (@Melee weapon skill@)",
-									"reference": "B51",
+									"reference": "B51,MA43",
 									"tags": [
 										"Advantage",
 										"Mental"
@@ -636,9 +641,14 @@
 									"points_per_level": 5,
 									"features": [
 										{
-											"type": "attribute_bonus",
-											"attribute": "parry",
-											"amount": 1
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"amount": 1,
+											"leveled": true
 										}
 									],
 									"can_level": true,

--- a/Library/Dungeon Fantasy/Dungeon Fantasy Denizens/Swashbucklers/Buccaneer.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy Denizens/Swashbucklers/Buccaneer.gct
@@ -1851,9 +1851,14 @@
 									}
 								},
 								{
-									"id": "tXKn-nkW12W6Jrt15",
+									"id": "tx4TCa0zQLvU-x_Up",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tDw6GZRxayNGMc8wW"
+									},
 									"name": "Enhanced Parry (@Melee weapon skill@)",
-									"reference": "B51",
+									"reference": "B51,MA43",
 									"tags": [
 										"Advantage",
 										"Mental"
@@ -1861,9 +1866,14 @@
 									"points_per_level": 5,
 									"features": [
 										{
-											"type": "attribute_bonus",
-											"attribute": "parry",
-											"amount": 1
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"amount": 1,
+											"leveled": true
 										}
 									],
 									"can_level": true,

--- a/Library/Dungeon Fantasy/Dungeon Fantasy Denizens/Swashbucklers/Duelist Henchman.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy Denizens/Swashbucklers/Duelist Henchman.gct
@@ -212,9 +212,14 @@
 									}
 								},
 								{
-									"id": "tu6GB7CXx8UmOZlcD",
+									"id": "tV8XhaLaYE_V--eRw",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tDw6GZRxayNGMc8wW"
+									},
 									"name": "Enhanced Parry (@Melee weapon skill@)",
-									"reference": "B51",
+									"reference": "B51,MA43",
 									"tags": [
 										"Advantage",
 										"Mental"
@@ -222,9 +227,14 @@
 									"points_per_level": 5,
 									"features": [
 										{
-											"type": "attribute_bonus",
-											"attribute": "parry",
-											"amount": 1
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"amount": 1,
+											"leveled": true
 										}
 									],
 									"can_level": true,

--- a/Library/Dungeon Fantasy/Dungeon Fantasy Denizens/Swashbucklers/Duelist.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy Denizens/Swashbucklers/Duelist.gct
@@ -617,9 +617,14 @@
 							}
 						},
 						{
-							"id": "t2bUIqFUaVIjBDHth",
+							"id": "t0EvJeNcbOpgz9bMM",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tDw6GZRxayNGMc8wW"
+							},
 							"name": "Enhanced Parry (@Melee weapon skill@)",
-							"reference": "B51",
+							"reference": "B51,MA43",
 							"tags": [
 								"Advantage",
 								"Mental"
@@ -627,9 +632,14 @@
 							"points_per_level": 5,
 							"features": [
 								{
-									"type": "attribute_bonus",
-									"attribute": "parry",
-									"amount": 1
+									"type": "weapon_parry_bonus",
+									"selection_type": "weapons_with_required_skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "@Melee weapon skill@"
+									},
+									"amount": 1,
+									"leveled": true
 								}
 							],
 							"can_level": true,
@@ -818,9 +828,14 @@
 									}
 								},
 								{
-									"id": "tw9RUL7jF_iLm_JQH",
+									"id": "t9PitpRhMA0wN6MKU",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tDw6GZRxayNGMc8wW"
+									},
 									"name": "Enhanced Parry (@Melee weapon skill@)",
-									"reference": "B51",
+									"reference": "B51,MA43",
 									"tags": [
 										"Advantage",
 										"Mental"
@@ -828,9 +843,14 @@
 									"points_per_level": 5,
 									"features": [
 										{
-											"type": "attribute_bonus",
-											"attribute": "parry",
-											"amount": 1
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"amount": 1,
+											"leveled": true
 										}
 									],
 									"can_level": true,

--- a/Library/Dungeon Fantasy/Dungeon Fantasy Denizens/Swashbucklers/Rogue Henchman.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy Denizens/Swashbucklers/Rogue Henchman.gct
@@ -695,9 +695,14 @@
 									}
 								},
 								{
-									"id": "tRRxMTSSu7h9l0Osb",
+									"id": "tiBo_wf-N0fto41MK",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tDw6GZRxayNGMc8wW"
+									},
 									"name": "Enhanced Parry (@Melee weapon skill@)",
-									"reference": "B51",
+									"reference": "B51,MA43",
 									"tags": [
 										"Advantage",
 										"Mental"
@@ -705,9 +710,14 @@
 									"points_per_level": 5,
 									"features": [
 										{
-											"type": "attribute_bonus",
-											"attribute": "parry",
-											"amount": 1
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"amount": 1,
+											"leveled": true
 										}
 									],
 									"can_level": true,

--- a/Library/Dungeon Fantasy/Dungeon Fantasy Denizens/Swashbucklers/Rogue.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy Denizens/Swashbucklers/Rogue.gct
@@ -383,9 +383,14 @@
 									}
 								},
 								{
-									"id": "txLgbJVBlWpYue4E2",
+									"id": "tVaXnypfLrd1-xNWn",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tDw6GZRxayNGMc8wW"
+									},
 									"name": "Enhanced Parry (@Melee weapon skill@)",
-									"reference": "B51",
+									"reference": "B51,MA43",
 									"tags": [
 										"Advantage",
 										"Mental"
@@ -393,9 +398,14 @@
 									"points_per_level": 5,
 									"features": [
 										{
-											"type": "attribute_bonus",
-											"attribute": "parry",
-											"amount": 1
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"amount": 1,
+											"leveled": true
 										}
 									],
 									"can_level": true,

--- a/Library/Dungeon Fantasy/Dungeon Fantasy Denizens/Swashbucklers/Swashbuckler Henchman.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy Denizens/Swashbucklers/Swashbuckler Henchman.gct
@@ -389,9 +389,15 @@
 									}
 								},
 								{
-									"id": "trt9VTfSTqZHJGc21",
-									"name": "Enhanced Parry (@weapon of choice@)",
-									"reference": "B51",
+									"id": "tEIuj-Z20q_4GxR89",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tDw6GZRxayNGMc8wW"
+									},
+									"name": "Enhanced Parry (@Melee weapon skill@)",
+									"reference": "B51,MA43",
+									"local_notes": "maximum +3",
 									"tags": [
 										"Advantage",
 										"Mental"
@@ -399,32 +405,14 @@
 									"points_per_level": 5,
 									"features": [
 										{
-											"type": "attribute_bonus",
-											"attribute": "parry",
-											"amount": 1
-										}
-									],
-									"can_level": true,
-									"levels": 1,
-									"calc": {
-										"points": 5
-									}
-								},
-								{
-									"id": "tF5CF8uxz3KiK10bC",
-									"name": "Enhanced Parry (@weapon of choice@)",
-									"reference": "B51",
-									"local_notes": "+2 or +3",
-									"tags": [
-										"Advantage",
-										"Mental"
-									],
-									"points_per_level": 5,
-									"features": [
-										{
-											"type": "attribute_bonus",
-											"attribute": "parry",
-											"amount": 1
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"amount": 1,
+											"leveled": true
 										}
 									],
 									"can_level": true,
@@ -960,12 +948,12 @@
 								}
 							],
 							"calc": {
-								"points": 209
+								"points": 204
 							}
 						}
 					],
 					"calc": {
-						"points": 209
+						"points": 204
 					}
 				},
 				{
@@ -1471,7 +1459,7 @@
 				}
 			],
 			"calc": {
-				"points": 119
+				"points": 114
 			}
 		}
 	],

--- a/Library/Dungeon Fantasy/Dungeon Fantasy Denizens/Swashbucklers/Swashbuckler.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy Denizens/Swashbucklers/Swashbuckler.gct
@@ -368,9 +368,9 @@
 									}
 								},
 								{
-									"id": "t-dV7xnPYeK96xq73",
-									"name": "Enhanced Parry (@weapon of choice@)",
-									"reference": "B51",
+									"id": "tRoGGqqjp1I8n2E44",
+									"name": "Enhanced Parry (@Melee weapon skill@)",
+									"reference": "B51,MA43",
 									"local_notes": "+2 or +3",
 									"tags": [
 										"Advantage",
@@ -379,9 +379,14 @@
 									"points_per_level": 5,
 									"features": [
 										{
-											"type": "attribute_bonus",
-											"attribute": "parry",
-											"amount": 1
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"amount": 1,
+											"leveled": true
 										}
 									],
 									"can_level": true,
@@ -847,9 +852,14 @@
 							}
 						},
 						{
-							"id": "tnFKrb12I3fKWJ7H3",
-							"name": "Enhanced Parry (@weapon of choice@)",
-							"reference": "B51",
+							"id": "t7zvE2tHspaEENR5S",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tDw6GZRxayNGMc8wW"
+							},
+							"name": "Enhanced Parry (@Melee weapon skill@)",
+							"reference": "B51,MA43",
 							"tags": [
 								"Advantage",
 								"Mental"
@@ -857,9 +867,14 @@
 							"points_per_level": 5,
 							"features": [
 								{
-									"type": "attribute_bonus",
-									"attribute": "parry",
-									"amount": 1
+									"type": "weapon_parry_bonus",
+									"selection_type": "weapons_with_required_skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "@Melee weapon skill@"
+									},
+									"amount": 1,
+									"leveled": true
 								}
 							],
 							"can_level": true,

--- a/Library/Dungeon Fantasy/Dungeon Fantasy Monsters 1/Sword Spirit.gcs
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy Monsters 1/Sword Spirit.gcs
@@ -601,6 +601,7 @@
 			"weapons": [
 				{
 					"id": "wL8Ai5HdlOQj2xvsB",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "thr",
@@ -624,6 +625,7 @@
 				},
 				{
 					"id": "w4hWOyl_I3OW74MEe",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "thr",
@@ -652,11 +654,12 @@
 					"calc": {
 						"level": 18,
 						"damage": "1d+1 cr",
-						"parry": "14"
+						"parry": "13"
 					}
 				},
 				{
 					"id": "wW7LYHVMQ-I2yjQm7",
+					"sv": 1,
 					"damage": {
 						"type": "cr",
 						"st": "thr"
@@ -882,19 +885,32 @@
 			}
 		},
 		{
-			"id": "tojjRqwWBOWNwkmiU",
-			"name": "Enhanced Parry (Broadsword)",
-			"reference": "B51",
+			"id": "tw40zC92gQLFRWiXH",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Basic Set/Basic Set Traits.adq",
+				"id": "tDw6GZRxayNGMc8wW"
+			},
+			"name": "Enhanced Parry (@Melee weapon skill@)",
+			"reference": "B51,MA43",
 			"tags": [
 				"Advantage",
 				"Mental"
 			],
+			"replacements": {
+				"Melee weapon skill": "Broadsword"
+			},
 			"points_per_level": 5,
 			"features": [
 				{
-					"type": "attribute_bonus",
-					"attribute": "parry",
-					"amount": 1
+					"type": "weapon_parry_bonus",
+					"selection_type": "weapons_with_required_skill",
+					"name": {
+						"compare": "is",
+						"qualifier": "@Melee weapon skill@"
+					},
+					"amount": 1,
+					"leveled": true
 				}
 			],
 			"can_level": true,
@@ -1475,6 +1491,7 @@
 			"weapons": [
 				{
 					"id": "w1VFBzh5ZZHK5R0NS",
+					"sv": 1,
 					"damage": {
 						"type": "cut",
 						"st": "sw",
@@ -1526,11 +1543,12 @@
 					"calc": {
 						"level": 23,
 						"damage": "2d+7 cut",
-						"parry": "16"
+						"parry": "17"
 					}
 				},
 				{
 					"id": "wnQihddsUCncwF_Mu",
+					"sv": 1,
 					"damage": {
 						"type": "imp",
 						"st": "thr",
@@ -1582,7 +1600,7 @@
 					"calc": {
 						"level": 23,
 						"damage": "1d+6 imp",
-						"parry": "16"
+						"parry": "17"
 					}
 				}
 			],
@@ -1619,14 +1637,14 @@
 		}
 	],
 	"created_date": "2021-10-17T20:14:00-07:00",
-	"modified_date": "2021-10-17T21:36:00-07:00",
+	"modified_date": "2025-08-30T21:04:24+01:00",
 	"calc": {
 		"swing": "2d+1",
 		"thrust": "1d+1",
 		"basic_lift": "34 lb",
 		"striking_st_bonus": 2,
 		"dodge_bonus": 1,
-		"parry_bonus": 2,
+		"parry_bonus": 1,
 		"block_bonus": 1,
 		"move": [
 			8,

--- a/Library/Fantasy Folk/Goblins and Hobgoblins/Martial Arts/Double-Knife.gct
+++ b/Library/Fantasy Folk/Goblins and Hobgoblins/Martial Arts/Double-Knife.gct
@@ -218,20 +218,33 @@
 							}
 						},
 						{
-							"id": "t2F-V5vk_HAvP4Sut",
-							"name": "Enhanced Parry (Knife)",
+							"id": "tbmmqv55kr8PY9fGQ",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tDw6GZRxayNGMc8wW"
+							},
+							"name": "Enhanced Parry (@Melee weapon skill@)",
 							"reference": "B51,MA43",
 							"tags": [
 								"Advantage",
 								"Mental"
 							],
+							"replacements": {
+								"Melee weapon skill": "Knife"
+							},
 							"disabled": true,
 							"points_per_level": 5,
 							"features": [
 								{
-									"type": "conditional_modifier",
-									"situation": "to Parry with Knnife",
-									"amount": 1
+									"type": "weapon_parry_bonus",
+									"selection_type": "weapons_with_required_skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "@Melee weapon skill@"
+									},
+									"amount": 1,
+									"leveled": true
 								}
 							],
 							"can_level": true,
@@ -241,20 +254,33 @@
 							}
 						},
 						{
-							"id": "tNZO9Wjb91V6S8PxL",
-							"name": "Enhanced Parry (Main-Gauche)",
+							"id": "tX3YWeUOBzT8-SYE-",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tDw6GZRxayNGMc8wW"
+							},
+							"name": "Enhanced Parry (@Melee weapon skill@)",
 							"reference": "B51,MA43",
 							"tags": [
 								"Advantage",
 								"Mental"
 							],
+							"replacements": {
+								"Melee weapon skill": "Main Gauche"
+							},
 							"disabled": true,
 							"points_per_level": 5,
 							"features": [
 								{
-									"type": "conditional_modifier",
-									"situation": "to Parry with Main-Gauche",
-									"amount": 1
+									"type": "weapon_parry_bonus",
+									"selection_type": "weapons_with_required_skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "@Melee weapon skill@"
+									},
+									"amount": 1,
+									"leveled": true
 								}
 							],
 							"can_level": true,
@@ -1349,6 +1375,7 @@
 							"weapons": [
 								{
 									"id": "wkLeoFdoT9054-sc-",
+									"sv": 1,
 									"damage": {
 										"type": "",
 										"st": "thr",

--- a/Library/Fantasy Folk/Goblins and Hobgoblins/Martial Arts/The Way of Confusion.gct
+++ b/Library/Fantasy Folk/Goblins and Hobgoblins/Martial Arts/The Way of Confusion.gct
@@ -123,20 +123,33 @@
 							}
 						},
 						{
-							"id": "tVI5bPYC7EoSGOtpn",
-							"name": "Enhanced Parry (Knife)",
+							"id": "tl_3TrsjGdFGgEBCr",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tDw6GZRxayNGMc8wW"
+							},
+							"name": "Enhanced Parry (@Melee weapon skill@)",
 							"reference": "B51,MA43",
 							"tags": [
 								"Advantage",
 								"Mental"
 							],
+							"replacements": {
+								"Melee weapon skill": "Knife"
+							},
 							"disabled": true,
 							"points_per_level": 5,
 							"features": [
 								{
-									"type": "conditional_modifier",
-									"situation": "to Parry with Knife",
-									"amount": 1
+									"type": "weapon_parry_bonus",
+									"selection_type": "weapons_with_required_skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "@Melee weapon skill@"
+									},
+									"amount": 1,
+									"leveled": true
 								}
 							],
 							"can_level": true,
@@ -146,20 +159,33 @@
 							}
 						},
 						{
-							"id": "tEwtzbMTzvAmq2NQZ",
-							"name": "Enhanced Parry (Staff)",
+							"id": "tyklUjgGwkscqU4j1",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tDw6GZRxayNGMc8wW"
+							},
+							"name": "Enhanced Parry (@Melee weapon skill@)",
 							"reference": "B51,MA43",
 							"tags": [
 								"Advantage",
 								"Mental"
 							],
+							"replacements": {
+								"Melee weapon skill": "Staff"
+							},
 							"disabled": true,
 							"points_per_level": 5,
 							"features": [
 								{
-									"type": "conditional_modifier",
-									"situation": "to Parry with Staff",
-									"amount": 1
+									"type": "weapon_parry_bonus",
+									"selection_type": "weapons_with_required_skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "@Melee weapon skill@"
+									},
+									"amount": 1,
+									"leveled": true
 								}
 							],
 							"can_level": true,

--- a/Library/Home Brew/Enraged Eggplant/Occupational Templates/Fighter.gct
+++ b/Library/Home Brew/Enraged Eggplant/Occupational Templates/Fighter.gct
@@ -284,7 +284,12 @@
 							}
 						},
 						{
-							"id": "tYkEeEX49LyPeLrBq",
+							"id": "tMuW0LKLGHsMOVgis",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tDw6GZRxayNGMc8wW"
+							},
 							"name": "Enhanced Parry (@Melee weapon skill@)",
 							"reference": "B51,MA43",
 							"tags": [
@@ -294,9 +299,14 @@
 							"points_per_level": 5,
 							"features": [
 								{
-									"type": "conditional_modifier",
-									"situation": "to Parry with @Melee weapon skill@",
-									"amount": 1
+									"type": "weapon_parry_bonus",
+									"selection_type": "weapons_with_required_skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "@Melee weapon skill@"
+									},
+									"amount": 1,
+									"leveled": true
 								}
 							],
 							"can_level": true,

--- a/Library/Home Brew/Enraged Eggplant/Occupational Templates/Paladin.gct
+++ b/Library/Home Brew/Enraged Eggplant/Occupational Templates/Paladin.gct
@@ -379,7 +379,12 @@
 							}
 						},
 						{
-							"id": "t89a9X1YdcmqNcmnh",
+							"id": "t2mkJn34-qYclFvZn",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tDw6GZRxayNGMc8wW"
+							},
 							"name": "Enhanced Parry (@Melee weapon skill@)",
 							"reference": "B51,MA43",
 							"tags": [
@@ -389,9 +394,14 @@
 							"points_per_level": 5,
 							"features": [
 								{
-									"type": "conditional_modifier",
-									"situation": "to Parry with @Melee weapon skill@",
-									"amount": 1
+									"type": "weapon_parry_bonus",
+									"selection_type": "weapons_with_required_skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "@Melee weapon skill@"
+									},
+									"amount": 1,
+									"leveled": true
 								}
 							],
 							"can_level": true,

--- a/Library/Lite/Lite Traits.adq
+++ b/Library/Lite/Lite Traits.adq
@@ -544,9 +544,14 @@
 			"points_per_level": 5,
 			"features": [
 				{
-					"type": "attribute_bonus",
-					"attribute": "parry",
-					"amount": 1
+					"type": "weapon_parry_bonus",
+					"selection_type": "weapons_with_required_skill",
+					"name": {
+						"compare": "is",
+						"qualifier": "@Melee weapon skill@"
+					},
+					"amount": 1,
+					"leveled": true
 				}
 			],
 			"can_level": true,

--- a/Library/Monster Hunters/Classes/Champions/Warrior.gct
+++ b/Library/Monster Hunters/Classes/Champions/Warrior.gct
@@ -1441,20 +1441,32 @@
 									}
 								},
 								{
-									"id": "tTv8qIbAXKCPbvpbW",
-									"name": "Enhanced Parry (Blade!)",
+									"id": "tqdXTBU4ycn9mIdlP",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tDw6GZRxayNGMc8wW"
+									},
+									"name": "Enhanced Parry (@Melee weapon skill@)",
 									"reference": "B51,MA43",
-									"local_notes": "1-3 levels",
 									"tags": [
 										"Advantage",
 										"Mental"
 									],
+									"replacements": {
+										"Melee weapon skill": "Blade!"
+									},
 									"points_per_level": 5,
 									"features": [
 										{
-											"type": "conditional_modifier",
-											"situation": "to Parry with Blade!",
-											"amount": 1
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"amount": 1,
+											"leveled": true
 										}
 									],
 									"can_level": true,

--- a/Library/Monster Hunters/Classes/Sidekicks/Muscle.gct
+++ b/Library/Monster Hunters/Classes/Sidekicks/Muscle.gct
@@ -768,10 +768,14 @@
 									}
 								},
 								{
-									"id": "t2kFS_ix72hkIzbVz",
+									"id": "t5A5SQCijSh7LOn5k",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tDw6GZRxayNGMc8wW"
+									},
 									"name": "Enhanced Parry (@Melee weapon skill@)",
-									"reference": "B51",
-									"local_notes": "Up to 1",
+									"reference": "B51,MA43",
 									"tags": [
 										"Advantage",
 										"Mental"
@@ -779,9 +783,14 @@
 									"points_per_level": 5,
 									"features": [
 										{
-											"type": "attribute_bonus",
-											"attribute": "parry",
-											"amount": 1
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"amount": 1,
+											"leveled": true
 										}
 									],
 									"can_level": true,

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Brute Warrior 2.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Brute Warrior 2.gct
@@ -284,9 +284,14 @@
 							"points_per_level": 5,
 							"features": [
 								{
-									"type": "attribute_bonus",
-									"attribute": "parry",
-									"amount": 1
+									"type": "weapon_parry_bonus",
+									"selection_type": "weapons_with_required_skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "@Melee weapon skill Or Unarmed@"
+									},
+									"amount": 1,
+									"leveled": true
 								}
 							],
 							"can_level": true,

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Finesse Warrior 2.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Finesse Warrior 2.gct
@@ -150,8 +150,13 @@
 							}
 						},
 						{
-							"id": "tKqUF_yLpqmLV5Osq",
-							"name": "Enhanced Parry (@weapon of choice@)",
+							"id": "tAvDHMlU9N-H60SQb",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
+								"id": "tfE1xvUa4a3Ppo5aq"
+							},
+							"name": "Enhanced Parry (@Melee weapon skill Or Unarmed@)",
 							"reference": "DFA49",
 							"tags": [
 								"Advantage",
@@ -160,9 +165,14 @@
 							"points_per_level": 5,
 							"features": [
 								{
-									"type": "attribute_bonus",
-									"attribute": "parry",
-									"amount": 1
+									"type": "weapon_parry_bonus",
+									"selection_type": "weapons_with_required_skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "@Melee weapon skill Or Unarmed@"
+									},
+									"amount": 1,
+									"leveled": true
 								}
 							],
 							"can_level": true,

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Finesse Warrior.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Finesse Warrior.gct
@@ -112,8 +112,13 @@
 							}
 						},
 						{
-							"id": "tKqUF_yLpqmLV5Osq",
-							"name": "Enhanced Parry (@weapon of choice@)",
+							"id": "thKhtcx3kX7ouMRZ1",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
+								"id": "tfE1xvUa4a3Ppo5aq"
+							},
+							"name": "Enhanced Parry (@Melee weapon skill Or Unarmed@)",
 							"reference": "DFA49",
 							"tags": [
 								"Advantage",
@@ -122,9 +127,14 @@
 							"points_per_level": 5,
 							"features": [
 								{
-									"type": "attribute_bonus",
-									"attribute": "parry",
-									"amount": 1
+									"type": "weapon_parry_bonus",
+									"selection_type": "weapons_with_required_skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "@Melee weapon skill Or Unarmed@"
+									},
+									"amount": 1,
+									"leveled": true
 								}
 							],
 							"can_level": true,

--- a/Library/Pyramid Magazine/Pyramid 13/Mystic Knight.gct
+++ b/Library/Pyramid Magazine/Pyramid 13/Mystic Knight.gct
@@ -650,15 +650,31 @@
 									}
 								},
 								{
-									"id": "tg7hQ5hCb-TYWKCEg",
+									"id": "tpkEIbCwMcKuc62-U",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tDw6GZRxayNGMc8wW"
+									},
 									"name": "Enhanced Parry (@Melee weapon skill@)",
-									"reference": "B51",
-									"local_notes": "Gives +1 bonus to Parry with @Melee weapon skill@ (add manually)",
+									"reference": "B51,MA43",
 									"tags": [
 										"Advantage",
 										"Mental"
 									],
 									"points_per_level": 5,
+									"features": [
+										{
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"amount": 1,
+											"leveled": true
+										}
+									],
 									"can_level": true,
 									"levels": 1,
 									"calc": {

--- a/Library/Pyramid Magazine/Pyramid 36/Mystic Swordsman.gct
+++ b/Library/Pyramid Magazine/Pyramid 36/Mystic Swordsman.gct
@@ -414,9 +414,14 @@
 							}
 						},
 						{
-							"id": "t8Sco0bkoBc1ifchv",
-							"name": "Enhanced Parry (@weapon of choice@)",
-							"reference": "B51",
+							"id": "tSefzFCbHmDoaGMYf",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tDw6GZRxayNGMc8wW"
+							},
+							"name": "Enhanced Parry (@Melee weapon skill@)",
+							"reference": "B51,MA43",
 							"tags": [
 								"Advantage",
 								"Mental"
@@ -424,9 +429,14 @@
 							"points_per_level": 5,
 							"features": [
 								{
-									"type": "attribute_bonus",
-									"attribute": "parry",
-									"amount": 1
+									"type": "weapon_parry_bonus",
+									"selection_type": "weapons_with_required_skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "@Melee weapon skill@"
+									},
+									"amount": 1,
+									"leveled": true
 								}
 							],
 							"can_level": true,
@@ -828,9 +838,9 @@
 									}
 								},
 								{
-									"id": "tXleSSjEPNOSBhm60",
-									"name": "Enhanced Parry (@weapon of choice@)",
-									"reference": "B51",
+									"id": "twvQVdqzEu_5Tykto",
+									"name": "Enhanced Parry (@Melee weapon skill@)",
+									"reference": "B51,MA43",
 									"local_notes": "+2 or +3",
 									"tags": [
 										"Advantage",
@@ -839,9 +849,14 @@
 									"points_per_level": 5,
 									"features": [
 										{
-											"type": "attribute_bonus",
-											"attribute": "parry",
-											"amount": 1
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"amount": 1,
+											"leveled": true
 										}
 									],
 									"can_level": true,

--- a/Library/Pyramid Magazine/Pyramid 36/Warrior-Saint.gct
+++ b/Library/Pyramid Magazine/Pyramid 36/Warrior-Saint.gct
@@ -1734,14 +1734,33 @@
 									}
 								},
 								{
-									"id": "t34ULnClPlgm59qMU",
-									"name": "Enhanced Parry (@One Melee Weapon Skill@)",
-									"reference": "B51",
+									"id": "tKqvYiNCqn2T4Fvac",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tDw6GZRxayNGMc8wW"
+									},
+									"name": "Enhanced Parry (@Melee weapon skill@)",
+									"reference": "B51,MA43",
 									"tags": [
 										"Advantage",
 										"Mental"
 									],
-									"base_points": 5,
+									"points_per_level": 5,
+									"features": [
+										{
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"amount": 1,
+											"leveled": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
 									"calc": {
 										"points": 5
 									}

--- a/Library/Pyramid Magazine/Pyramid 50/Dwarf.gct
+++ b/Library/Pyramid Magazine/Pyramid 50/Dwarf.gct
@@ -1959,19 +1959,32 @@
 									}
 								},
 								{
-									"id": "tg0ztXt_qYjkNEJRt",
-									"name": "Enhanced Parry (@Axe/Mace or Two-Handed Axe/Mace@)",
-									"reference": "B51",
+									"id": "t5WLdBDNV-hK2YEP-",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tDw6GZRxayNGMc8wW"
+									},
+									"name": "Enhanced Parry (@Melee weapon skill@)",
+									"reference": "B51,MA43",
 									"tags": [
 										"Advantage",
 										"Mental"
 									],
+									"replacements": {
+										"Melee weapon skill": "@Axe/Mace or Two-Handed Axe/Mace@"
+									},
 									"points_per_level": 5,
 									"features": [
 										{
-											"type": "attribute_bonus",
-											"attribute": "parry",
-											"amount": 1
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"amount": 1,
+											"leveled": true
 										}
 									],
 									"can_level": true,

--- a/Library/Pyramid Magazine/Pyramid 78/Chaos Holy Warrior.gct
+++ b/Library/Pyramid Magazine/Pyramid 78/Chaos Holy Warrior.gct
@@ -2025,14 +2025,33 @@
 									}
 								},
 								{
-									"id": "t972acihqCoHclZX9",
-									"name": "Enhanced Parry (@One Melee Weapon Skill@)",
-									"reference": "B51",
+									"id": "t_4CsBqXeonoebZUw",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tDw6GZRxayNGMc8wW"
+									},
+									"name": "Enhanced Parry (@Melee weapon skill@)",
+									"reference": "B51,MA43",
 									"tags": [
 										"Advantage",
 										"Mental"
 									],
-									"base_points": 5,
+									"points_per_level": 5,
+									"features": [
+										{
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"amount": 1,
+											"leveled": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
 									"calc": {
 										"points": 5
 									}

--- a/Library/Pyramid Magazine/Pyramid 78/Order Holy Warrior.gct
+++ b/Library/Pyramid Magazine/Pyramid 78/Order Holy Warrior.gct
@@ -2298,14 +2298,33 @@
 									}
 								},
 								{
-									"id": "tPZ7f0rHgrco_gfpl",
-									"name": "Enhanced Parry (@One Melee Weapon Skill@)",
-									"reference": "B51",
+									"id": "tw_SWQwI9sW6yNz7f",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tDw6GZRxayNGMc8wW"
+									},
+									"name": "Enhanced Parry (@Melee weapon skill@)",
+									"reference": "B51,MA43",
 									"tags": [
 										"Advantage",
 										"Mental"
 									],
-									"base_points": 5,
+									"points_per_level": 5,
+									"features": [
+										{
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"amount": 1,
+											"leveled": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
 									"calc": {
 										"points": 5
 									}

--- a/Library/Supers/Templates/Sifu.gct
+++ b/Library/Supers/Templates/Sifu.gct
@@ -475,8 +475,13 @@
 									}
 								},
 								{
-									"id": "tO9_ODgN4Bn7jf-bE",
-									"name": "Enhanced Parry (Melee Weapon Skill)",
+									"id": "tpuwdGWKhqDDrtP74",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tDw6GZRxayNGMc8wW"
+									},
+									"name": "Enhanced Parry (@Melee weapon skill@)",
 									"reference": "B51,MA43",
 									"tags": [
 										"Advantage",
@@ -485,9 +490,14 @@
 									"points_per_level": 5,
 									"features": [
 										{
-											"type": "conditional_modifier",
-											"situation": "to Parry with ",
-											"amount": 1
+											"type": "weapon_parry_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "@Melee weapon skill@"
+											},
+											"amount": 1,
+											"leveled": true
 										}
 									],
 									"can_level": true,


### PR DESCRIPTION
This affects the Enhanced Parry traits in:
* Basic Set Traits
* Action Traits
* DFRPG Traits
* Discworld Roleplaying Game Traits
* Lite Traits

and updates all the templates and characters that use Enhanced Parry to use the fixed version.