### PR TITLE
Make Psionic Talents add skill bonuses by tag by adding specific tags to psionic skills

### DIFF
--- a/Library/Psionics/Psionic Packages/Anti-Psi/Basic Anti-Psi.gct
+++ b/Library/Psionics/Psionic Packages/Anti-Psi/Basic Anti-Psi.gct
@@ -224,6 +224,7 @@
 					"reference": "PSI23",
 					"tags": [
 						"Anti-Psi",
+						"PsionicSkill:Anti-Psi",
 						"Psionics"
 					],
 					"difficulty": "will/h",
@@ -288,6 +289,7 @@
 					"reference": "PSI24",
 					"tags": [
 						"Anti-Psi",
+						"PsionicSkill:Anti-Psi",
 						"Psionics"
 					],
 					"difficulty": "will/h",

--- a/Library/Psionics/Psionic Packages/Anti-Psi/Disruptor.gct
+++ b/Library/Psionics/Psionic Packages/Anti-Psi/Disruptor.gct
@@ -26,79 +26,9 @@
 						{
 							"type": "skill_bonus",
 							"selection_type": "skills_with_name",
-							"name": {
+							"tags": {
 								"compare": "is",
-								"qualifier": "Cancellation"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Para-Invisibility"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Psionic Shield"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Screaming"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "True Sight"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Psychic Armor"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Psionic Resistance (All)"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Psionic Resistance"
+								"qualifier": "PsionicSkill:Anti-Psi"
 							},
 							"amount": 1,
 							"per_level": true
@@ -323,6 +253,7 @@
 					"reference": "PSI23",
 					"tags": [
 						"Anti-Psi",
+						"PsionicSkill:Anti-Psi",
 						"Psionics"
 					],
 					"difficulty": "will/h",
@@ -387,6 +318,7 @@
 					"reference": "PSI24",
 					"tags": [
 						"Anti-Psi",
+						"PsionicSkill:Anti-Psi",
 						"Psionics"
 					],
 					"difficulty": "will/h",

--- a/Library/Psionics/Psionic Packages/Anti-Psi/Highly Resistant.gct
+++ b/Library/Psionics/Psionic Packages/Anti-Psi/Highly Resistant.gct
@@ -153,6 +153,7 @@
 					"reference": "PSI23",
 					"tags": [
 						"Anti-Psi",
+						"PsionicSkill:Anti-Psi",
 						"Psionics"
 					],
 					"difficulty": "will/h",
@@ -201,6 +202,7 @@
 					"reference": "PSI25",
 					"tags": [
 						"Anti-Psi",
+						"PsionicSkill:Anti-Psi",
 						"Psionics"
 					],
 					"difficulty": "will/h",

--- a/Library/Psionics/Psionic Packages/Anti-Psi/Perception Master.gct
+++ b/Library/Psionics/Psionic Packages/Anti-Psi/Perception Master.gct
@@ -103,6 +103,7 @@
 					"reference": "PSI23",
 					"tags": [
 						"Anti-Psi",
+						"PsionicSkill:Anti-Psi",
 						"Psionics"
 					],
 					"difficulty": "iq/h",
@@ -143,6 +144,7 @@
 					"reference": "PSI25",
 					"tags": [
 						"Anti-Psi",
+						"PsionicSkill:Anti-Psi",
 						"Psionics"
 					],
 					"difficulty": "will/h",

--- a/Library/Psionics/Psionic Packages/Anti-Psi/Psychic Null.gct
+++ b/Library/Psionics/Psionic Packages/Anti-Psi/Psychic Null.gct
@@ -128,6 +128,7 @@
 					"reference": "PSI25",
 					"tags": [
 						"Anti-Psi",
+						"PsionicSkill:Anti-Psi",
 						"Psionics"
 					],
 					"difficulty": "will/h",

--- a/Library/Psionics/Psionic Packages/Anti-Psi/Simple Screamer.gct
+++ b/Library/Psionics/Psionic Packages/Anti-Psi/Simple Screamer.gct
@@ -53,6 +53,7 @@
 					"reference": "PSI25",
 					"tags": [
 						"Anti-Psi",
+						"PsionicSkill:Anti-Psi",
 						"Psionics"
 					],
 					"difficulty": "will/h",

--- a/Library/Psionics/Psionic Packages/Anti-Psi/Strong Screamer.gct
+++ b/Library/Psionics/Psionic Packages/Anti-Psi/Strong Screamer.gct
@@ -73,6 +73,7 @@
 					"reference": "PSI25",
 					"tags": [
 						"Anti-Psi",
+						"PsionicSkill:Anti-Psi",
 						"Psionics"
 					],
 					"difficulty": "will/h",

--- a/Library/Psionics/Psionic Packages/Astral Projection/Astral Perception.gct
+++ b/Library/Psionics/Psionic Packages/Astral Projection/Astral Perception.gct
@@ -100,6 +100,7 @@
 					"reference": "PSI28",
 					"tags": [
 						"Astral Projection",
+						"PsionicSkill:Astral Projection",
 						"Psionics"
 					],
 					"difficulty": "dx/h",

--- a/Library/Psionics/Psionic Packages/Astral Projection/Basic Projector.gct
+++ b/Library/Psionics/Psionic Packages/Astral Projection/Basic Projector.gct
@@ -99,6 +99,7 @@
 					"local_notes": "Astral Move \u003cscript\u003e\nif(entity.exists) {\n  self.level()/2\n} else {\n  \"will be shown when added to a character sheet.\"\n}\u003c/script\u003e",
 					"tags": [
 						"Astral Projection",
+						"PsionicSkill:Astral Projection",
 						"Psionics"
 					],
 					"difficulty": "iq/h",

--- a/Library/Psionics/Psionic Packages/Astral Projection/Dual-Plane Projector.gct
+++ b/Library/Psionics/Psionic Packages/Astral Projection/Dual-Plane Projector.gct
@@ -137,6 +137,7 @@
 					"local_notes": "Astral Move \u003cscript\u003e\nif(entity.exists) {\n  self.level()/2\n} else {\n  \"will be shown when added to a character sheet.\"\n}\u003c/script\u003e",
 					"tags": [
 						"Astral Projection",
+						"PsionicSkill:Astral Projection",
 						"Psionics"
 					],
 					"difficulty": "iq/h",

--- a/Library/Psionics/Psionic Packages/Astral Projection/Extra Speed.gct
+++ b/Library/Psionics/Psionic Packages/Astral Projection/Extra Speed.gct
@@ -67,6 +67,7 @@
 					"reference": "PSI26",
 					"tags": [
 						"Astral Projection",
+						"PsionicSkill:Astral Projection",
 						"Psionics"
 					],
 					"difficulty": "will/h",

--- a/Library/Psionics/Psionic Packages/Astral Projection/Fast Projector.gct
+++ b/Library/Psionics/Psionic Packages/Astral Projection/Fast Projector.gct
@@ -121,6 +121,7 @@
 					"reference": "PSI26",
 					"tags": [
 						"Astral Projection",
+						"PsionicSkill:Astral Projection",
 						"Psionics"
 					],
 					"difficulty": "will/h",
@@ -162,6 +163,7 @@
 					"local_notes": "Astral Move \u003cscript\u003e\nif(entity.exists) {\n  self.level()/2\n} else {\n  \"will be shown when added to a character sheet.\"\n}\u003c/script\u003e",
 					"tags": [
 						"Astral Projection",
+						"PsionicSkill:Astral Projection",
 						"Psionics"
 					],
 					"difficulty": "iq/h",

--- a/Library/Psionics/Psionic Packages/Astral Projection/Long-Term Projector.gct
+++ b/Library/Psionics/Psionic Packages/Astral Projection/Long-Term Projector.gct
@@ -130,6 +130,7 @@
 					"local_notes": "Astral Move \u003cscript\u003e\nif(entity.exists) {\n  self.level()/2\n} else {\n  \"will be shown when added to a character sheet.\"\n}\u003c/script\u003e",
 					"tags": [
 						"Astral Projection",
+						"PsionicSkill:Astral Projection",
 						"Psionics"
 					],
 					"difficulty": "iq/h",

--- a/Library/Psionics/Psionic Packages/Astral Projection/Phantasm.gct
+++ b/Library/Psionics/Psionic Packages/Astral Projection/Phantasm.gct
@@ -118,6 +118,7 @@
 					"local_notes": "Astral Move \u003cscript\u003e\nif(entity.exists) {\n  self.level()/2\n} else {\n  \"will be shown when added to a character sheet.\"\n}\u003c/script\u003e",
 					"tags": [
 						"Astral Projection",
+						"PsionicSkill:Astral Projection",
 						"Psionics"
 					],
 					"difficulty": "iq/h",

--- a/Library/Psionics/Psionic Packages/Astral Projection/Spirit Warrior.gct
+++ b/Library/Psionics/Psionic Packages/Astral Projection/Spirit Warrior.gct
@@ -85,6 +85,7 @@
 					"weapons": [
 						{
 							"id": "wlAD6_TKTKXZ_q3eE",
+							"sv": 1,
 							"damage": {
 								"type": "cut",
 								"base": "1d-3"
@@ -172,6 +173,7 @@
 					"reference": "PSI26",
 					"tags": [
 						"Astral Projection",
+						"PsionicSkill:Astral Projection",
 						"Psionics"
 					],
 					"difficulty": "will/h",
@@ -212,6 +214,7 @@
 					"reference": "PSI28",
 					"tags": [
 						"Astral Projection",
+						"PsionicSkill:Astral Projection",
 						"Psionics"
 					],
 					"difficulty": "dx/h",

--- a/Library/Psionics/Psionic Packages/Astral Projection/Visual Hunter.gct
+++ b/Library/Psionics/Psionic Packages/Astral Projection/Visual Hunter.gct
@@ -101,6 +101,7 @@
 					"weapons": [
 						{
 							"id": "ws14TSpr4w_9dtWl7",
+							"sv": 1,
 							"damage": {
 								"type": "cut",
 								"base": "1d-3"
@@ -169,6 +170,7 @@
 					"reference": "PSI27",
 					"tags": [
 						"Astral Projection",
+						"PsionicSkill:Astral Projection",
 						"Psionics"
 					],
 					"difficulty": "per/h",
@@ -209,6 +211,7 @@
 					"reference": "PSI28",
 					"tags": [
 						"Astral Projection",
+						"PsionicSkill:Astral Projection",
 						"Psionics"
 					],
 					"difficulty": "dx/h",

--- a/Library/Psionics/Psionic Packages/ESP/Fortune Teller.gct
+++ b/Library/Psionics/Psionic Packages/ESP/Fortune Teller.gct
@@ -55,6 +55,8 @@
 					"tags": [
 						"Divination",
 						"ESP",
+						"PsionicSkill:Divination",
+						"PsionicSkill:ESP",
 						"Psionics"
 					],
 					"difficulty": "iq/h",

--- a/Library/Psionics/Psionic Packages/ESP/Ghost Sight.gct
+++ b/Library/Psionics/Psionic Packages/ESP/Ghost Sight.gct
@@ -82,6 +82,8 @@
 					"reference": "PSI43",
 					"tags": [
 						"ESP",
+						"PsionicSkill:ESP",
+						"PsionicSkill:Remote Senses",
 						"Psionics",
 						"Remote Senses"
 					],

--- a/Library/Psionics/Psionic Packages/ESP/Hard to Hit.gct
+++ b/Library/Psionics/Psionic Packages/ESP/Hard to Hit.gct
@@ -74,6 +74,8 @@
 					"tags": [
 						"Divination",
 						"ESP",
+						"PsionicSkill:Divination",
+						"PsionicSkill:ESP",
 						"Psionics"
 					],
 					"specialization": "Divination",

--- a/Library/Psionics/Psionic Packages/ESP/Hyper-Observant.gct
+++ b/Library/Psionics/Psionic Packages/ESP/Hyper-Observant.gct
@@ -85,173 +85,9 @@
 						{
 							"type": "skill_bonus",
 							"selection_type": "skills_with_name",
-							"name": {
+							"tags": {
 								"compare": "is",
-								"qualifier": "Common Sense"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Danger Sense"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Illuminated"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Oracle"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Psidar"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Psychic Hunches"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Racial Memory"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Seekersense"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Spirit Communication"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "True Sight (ESP)"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Combat Sense"
-							},
-							"specialization": {
-								"compare": "is",
-								"qualifier": "Divination"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Prognostication"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Psi Sense"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Retrocognition"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Visions"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Awareness"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Clairvoyance"
+								"qualifier": "PsionicSkill:ESP"
 							},
 							"amount": 1,
 							"per_level": true
@@ -503,6 +339,8 @@
 					"tags": [
 						"Divination",
 						"ESP",
+						"PsionicSkill:Divination",
+						"PsionicSkill:ESP",
 						"Psionics"
 					],
 					"difficulty": "per/h",
@@ -544,6 +382,8 @@
 					"tags": [
 						"Divination",
 						"ESP",
+						"PsionicSkill:Divination",
+						"PsionicSkill:ESP",
 						"Psionics"
 					],
 					"difficulty": "iq/h",
@@ -584,6 +424,8 @@
 					"reference": "PSI43",
 					"tags": [
 						"ESP",
+						"PsionicSkill:ESP",
+						"PsionicSkill:Remote Senses",
 						"Psionics",
 						"Remote Senses"
 					],

--- a/Library/Psionics/Psionic Packages/ESP/Intuitive Divination.gct
+++ b/Library/Psionics/Psionic Packages/ESP/Intuitive Divination.gct
@@ -98,6 +98,8 @@
 					"tags": [
 						"Divination",
 						"ESP",
+						"PsionicSkill:Divination",
+						"PsionicSkill:ESP",
 						"Psionics"
 					],
 					"difficulty": "iq/h",
@@ -139,6 +141,8 @@
 					"tags": [
 						"Divination",
 						"ESP",
+						"PsionicSkill:Divination",
+						"PsionicSkill:ESP",
 						"Psionics"
 					],
 					"difficulty": "iq/h",

--- a/Library/Psionics/Psionic Packages/ESP/Past-Scanner.gct
+++ b/Library/Psionics/Psionic Packages/ESP/Past-Scanner.gct
@@ -153,6 +153,8 @@
 					"tags": [
 						"Divination",
 						"ESP",
+						"PsionicSkill:Divination",
+						"PsionicSkill:ESP",
 						"Psionics"
 					],
 					"difficulty": "iq/h",

--- a/Library/Psionics/Psionic Packages/ESP/Precognitive Master.gct
+++ b/Library/Psionics/Psionic Packages/ESP/Precognitive Master.gct
@@ -96,6 +96,8 @@
 					"tags": [
 						"Divination",
 						"ESP",
+						"PsionicSkill:Divination",
+						"PsionicSkill:ESP",
 						"Psionics"
 					],
 					"difficulty": "iq/h",
@@ -137,6 +139,8 @@
 					"tags": [
 						"Divination",
 						"ESP",
+						"PsionicSkill:Divination",
+						"PsionicSkill:ESP",
 						"Psionics"
 					],
 					"difficulty": "iq/h",

--- a/Library/Psionics/Psionic Packages/ESP/Psi Detector.gct
+++ b/Library/Psionics/Psionic Packages/ESP/Psi Detector.gct
@@ -152,6 +152,8 @@
 					"tags": [
 						"Divination",
 						"ESP",
+						"PsionicSkill:Divination",
+						"PsionicSkill:ESP",
 						"Psionics"
 					],
 					"difficulty": "per/h",

--- a/Library/Psionics/Psionic Packages/ESP/Psychic Tracker.gct
+++ b/Library/Psionics/Psionic Packages/ESP/Psychic Tracker.gct
@@ -118,6 +118,8 @@
 					"reference": "PSI42",
 					"tags": [
 						"ESP",
+						"PsionicSkill:ESP",
+						"PsionicSkill:Remote Senses",
 						"Psionics",
 						"Remote Senses"
 					],
@@ -160,6 +162,8 @@
 					"tags": [
 						"Divination",
 						"ESP",
+						"PsionicSkill:Divination",
+						"PsionicSkill:ESP",
 						"Psionics"
 					],
 					"difficulty": "iq/h",

--- a/Library/Psionics/Psionic Packages/ESP/Sensory Projection.gct
+++ b/Library/Psionics/Psionic Packages/ESP/Sensory Projection.gct
@@ -95,6 +95,8 @@
 					"reference": "PSI40",
 					"tags": [
 						"ESP",
+						"PsionicSkill:ESP",
+						"PsionicSkill:Remote Senses",
 						"Psionics",
 						"Remote Senses"
 					],

--- a/Library/Psionics/Psionic Packages/ESP/Spotter.gct
+++ b/Library/Psionics/Psionic Packages/ESP/Spotter.gct
@@ -135,6 +135,8 @@
 					"tags": [
 						"Divination",
 						"ESP",
+						"PsionicSkill:Divination",
+						"PsionicSkill:ESP",
 						"Psionics"
 					],
 					"difficulty": "per/h",
@@ -187,6 +189,8 @@
 					"reference": "PSI41",
 					"tags": [
 						"ESP",
+						"PsionicSkill:ESP",
+						"PsionicSkill:Remote Senses",
 						"Psionics",
 						"Remote Senses"
 					],

--- a/Library/Psionics/Psionic Packages/ESP/Visions of Future and Past.gct
+++ b/Library/Psionics/Psionic Packages/ESP/Visions of Future and Past.gct
@@ -105,6 +105,8 @@
 					"tags": [
 						"Divination",
 						"ESP",
+						"PsionicSkill:Divination",
+						"PsionicSkill:ESP",
 						"Psionics"
 					],
 					"difficulty": "iq/h",
@@ -158,6 +160,8 @@
 					"tags": [
 						"Divination",
 						"ESP",
+						"PsionicSkill:Divination",
+						"PsionicSkill:ESP",
 						"Psionics"
 					],
 					"difficulty": "iq/h",

--- a/Library/Psionics/Psionic Packages/ESP/X-Ray Specs.gct
+++ b/Library/Psionics/Psionic Packages/ESP/X-Ray Specs.gct
@@ -54,6 +54,8 @@
 					"reference": "PSI40",
 					"tags": [
 						"ESP",
+						"PsionicSkill:ESP",
+						"PsionicSkill:Remote Senses",
 						"Psionics",
 						"Remote Senses"
 					],

--- a/Library/Psionics/Psionic Packages/Ergokinesis/Amperage Regulator.gct
+++ b/Library/Psionics/Psionic Packages/Ergokinesis/Amperage Regulator.gct
@@ -78,6 +78,8 @@
 					"tags": [
 						"Electrokinesis",
 						"Ergokinesis",
+						"PsionicSkill:Electrokinesis",
+						"PsionicSkill:Ergokinesis",
 						"Psionics"
 					],
 					"difficulty": "iq/h",
@@ -119,6 +121,8 @@
 					"tags": [
 						"Electrokinesis",
 						"Ergokinesis",
+						"PsionicSkill:Electrokinesis",
+						"PsionicSkill:Ergokinesis",
 						"Psionics"
 					],
 					"difficulty": "will/h",

--- a/Library/Psionics/Psionic Packages/Ergokinesis/Computer Domination.gct
+++ b/Library/Psionics/Psionic Packages/Ergokinesis/Computer Domination.gct
@@ -72,139 +72,9 @@
 						{
 							"type": "skill_bonus",
 							"selection_type": "skills_with_name",
-							"name": {
+							"tags": {
 								"compare": "is",
-								"qualifier": "Data Retrieval"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "I/O Tap"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Netrunning"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Remote Control"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Confuse"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Dampen"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "EK Shield"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Electric Vision"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Lightning"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Radar Sense"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Surge"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Flash"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Hologram"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Photorefraction"
+								"qualifier": "PsionicSkill:Ergokinesis"
 							},
 							"amount": 1,
 							"per_level": true
@@ -591,6 +461,8 @@
 					"tags": [
 						"Cyberpsi",
 						"Ergokinesis",
+						"PsionicSkill:Cyberpsi",
+						"PsionicSkill:Ergokinesis",
 						"Psionics"
 					],
 					"difficulty": "iq/h",
@@ -632,6 +504,8 @@
 					"tags": [
 						"Cyberpsi",
 						"Ergokinesis",
+						"PsionicSkill:Cyberpsi",
+						"PsionicSkill:Ergokinesis",
 						"Psionics"
 					],
 					"difficulty": "iq/h",
@@ -673,6 +547,8 @@
 					"tags": [
 						"Cyberpsi",
 						"Ergokinesis",
+						"PsionicSkill:Cyberpsi",
+						"PsionicSkill:Ergokinesis",
 						"Psionics"
 					],
 					"difficulty": "iq/h",

--- a/Library/Psionics/Psionic Packages/Ergokinesis/EM Sense.gct
+++ b/Library/Psionics/Psionic Packages/Ergokinesis/EM Sense.gct
@@ -80,6 +80,8 @@
 					"tags": [
 						"Electrokinesis",
 						"Ergokinesis",
+						"PsionicSkill:Electrokinesis",
+						"PsionicSkill:Ergokinesis",
 						"Psionics"
 					],
 					"difficulty": "per/h",
@@ -121,6 +123,8 @@
 					"tags": [
 						"Electrokinesis",
 						"Ergokinesis",
+						"PsionicSkill:Electrokinesis",
+						"PsionicSkill:Ergokinesis",
 						"Psionics"
 					],
 					"difficulty": "per/h",

--- a/Library/Psionics/Psionic Packages/Ergokinesis/Energy Absorber.gct
+++ b/Library/Psionics/Psionic Packages/Ergokinesis/Energy Absorber.gct
@@ -96,6 +96,8 @@
 					"tags": [
 						"Electrokinesis",
 						"Ergokinesis",
+						"PsionicSkill:Electrokinesis",
+						"PsionicSkill:Ergokinesis",
 						"Psionics"
 					],
 					"difficulty": "iq/h",
@@ -133,10 +135,12 @@
 						"id": "sXPF7Cai8fxgyYWz_"
 					},
 					"name": "Photorefraction",
-					"reference": "PSI35",
+					"reference": "PSI36",
 					"tags": [
 						"Ergokinesis",
 						"Photokinesis",
+						"PsionicSkill:Ergokinesis",
+						"PsionicSkill:Photokinesis",
 						"Psionics"
 					],
 					"difficulty": "iq/h",

--- a/Library/Psionics/Psionic Packages/Ergokinesis/Ghost in the Machine.gct
+++ b/Library/Psionics/Psionic Packages/Ergokinesis/Ghost in the Machine.gct
@@ -108,6 +108,8 @@
 					"tags": [
 						"Cyberpsi",
 						"Ergokinesis",
+						"PsionicSkill:Cyberpsi",
+						"PsionicSkill:Ergokinesis",
 						"Psionics"
 					],
 					"difficulty": "iq/h",

--- a/Library/Psionics/Psionic Packages/Ergokinesis/Hacker's Touch.gct
+++ b/Library/Psionics/Psionic Packages/Ergokinesis/Hacker's Touch.gct
@@ -203,6 +203,8 @@
 					"tags": [
 						"Cyberpsi",
 						"Ergokinesis",
+						"PsionicSkill:Cyberpsi",
+						"PsionicSkill:Ergokinesis",
 						"Psionics"
 					],
 					"difficulty": "iq/h",
@@ -244,6 +246,8 @@
 					"tags": [
 						"Cyberpsi",
 						"Ergokinesis",
+						"PsionicSkill:Cyberpsi",
+						"PsionicSkill:Ergokinesis",
 						"Psionics"
 					],
 					"difficulty": "iq/h",

--- a/Library/Psionics/Psionic Packages/Ergokinesis/Illusionist.gct
+++ b/Library/Psionics/Psionic Packages/Ergokinesis/Illusionist.gct
@@ -154,6 +154,8 @@
 					"tags": [
 						"Ergokinesis",
 						"Photokinesis",
+						"PsionicSkill:Ergokinesis",
+						"PsionicSkill:Photokinesis",
 						"Psionics"
 					],
 					"difficulty": "iq/h",
@@ -191,10 +193,12 @@
 						"id": "sXPF7Cai8fxgyYWz_"
 					},
 					"name": "Photorefraction",
-					"reference": "PSI35",
+					"reference": "PSI36",
 					"tags": [
 						"Ergokinesis",
 						"Photokinesis",
+						"PsionicSkill:Ergokinesis",
+						"PsionicSkill:Photokinesis",
 						"Psionics"
 					],
 					"difficulty": "iq/h",

--- a/Library/Psionics/Psionic Packages/Ergokinesis/Photon Projection.gct
+++ b/Library/Psionics/Psionic Packages/Ergokinesis/Photon Projection.gct
@@ -72,139 +72,9 @@
 						{
 							"type": "skill_bonus",
 							"selection_type": "skills_with_name",
-							"name": {
+							"tags": {
 								"compare": "is",
-								"qualifier": "Data Retrieval"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "I/O Tap"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Netrunning"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Remote Control"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Confuse"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Dampen"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "EK Shield"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Electric Vision"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Lightning"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Radar Sense"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Surge"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Flash"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Hologram"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Photorefraction"
+								"qualifier": "PsionicSkill:Ergokinesis"
 							},
 							"amount": 1,
 							"per_level": true
@@ -539,6 +409,8 @@
 					"tags": [
 						"Ergokinesis",
 						"Photokinesis",
+						"PsionicSkill:Ergokinesis",
+						"PsionicSkill:Photokinesis",
 						"Psionics"
 					],
 					"difficulty": "will/h",
@@ -580,6 +452,8 @@
 					"tags": [
 						"Ergokinesis",
 						"Photokinesis",
+						"PsionicSkill:Ergokinesis",
+						"PsionicSkill:Photokinesis",
 						"Psionics"
 					],
 					"difficulty": "iq/h",

--- a/Library/Psionics/Psionic Packages/Ergokinesis/Spark Slinger.gct
+++ b/Library/Psionics/Psionic Packages/Ergokinesis/Spark Slinger.gct
@@ -101,9 +101,10 @@
 							"weapons": [
 								{
 									"id": "WRbv8x-M4_XB8zPAZ",
+									"sv": 1,
 									"damage": {
 										"type": "",
-										"base": "1d"
+										"base_leveled": "1d"
 									},
 									"usage": "Lightning",
 									"accuracy": "3",
@@ -120,7 +121,7 @@
 										}
 									],
 									"calc": {
-										"damage": "1d"
+										"damage": "1d per level"
 									}
 								}
 							],
@@ -159,6 +160,8 @@
 					"tags": [
 						"Electrokinesis",
 						"Ergokinesis",
+						"PsionicSkill:Electrokinesis",
+						"PsionicSkill:Ergokinesis",
 						"Psionics"
 					],
 					"difficulty": "will/h",
@@ -200,6 +203,8 @@
 					"tags": [
 						"Electrokinesis",
 						"Ergokinesis",
+						"PsionicSkill:Electrokinesis",
+						"PsionicSkill:Ergokinesis",
 						"Psionics"
 					],
 					"difficulty": "iq/h",

--- a/Library/Psionics/Psionic Packages/Ergokinesis/System Control.gct
+++ b/Library/Psionics/Psionic Packages/Ergokinesis/System Control.gct
@@ -106,6 +106,8 @@
 					"tags": [
 						"Cyberpsi",
 						"Ergokinesis",
+						"PsionicSkill:Cyberpsi",
+						"PsionicSkill:Ergokinesis",
 						"Psionics"
 					],
 					"difficulty": "iq/h",

--- a/Library/Psionics/Psionic Packages/Probability Alteration/Beginner's Luck.gct
+++ b/Library/Psionics/Psionic Packages/Probability Alteration/Beginner's Luck.gct
@@ -26,9 +26,9 @@
 						{
 							"type": "skill_bonus",
 							"selection_type": "skills_with_name",
-							"name": {
+							"tags": {
 								"compare": "is",
-								"qualifier": "Adjustment"
+								"qualifier": "PsionicSkill:Probability Alteration"
 							},
 							"amount": 1,
 							"per_level": true
@@ -80,41 +80,11 @@
 							"selection_type": "skills_with_name",
 							"name": {
 								"compare": "is",
-								"qualifier": "Coincidence"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
 								"qualifier": "Crushing Strike"
 							},
 							"specialization": {
 								"compare": "contains",
 								"qualifier": "Probability Alteration"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Curse"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Combat Sense"
 							},
 							"amount": 1,
 							"per_level": true
@@ -185,26 +155,6 @@
 							"specialization": {
 								"compare": "contains",
 								"qualifier": "Probability Alteration"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Second Chance"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Weather Control"
 							},
 							"amount": 1,
 							"per_level": true

--- a/Library/Psionics/Psionic Packages/Probability Alteration/Chess Master.gct
+++ b/Library/Psionics/Psionic Packages/Probability Alteration/Chess Master.gct
@@ -73,6 +73,7 @@
 					"reference": "PSI44",
 					"tags": [
 						"Probability Alteration",
+						"PsionicSkill:Probability Alteration",
 						"Psionics"
 					],
 					"difficulty": "iq/h",

--- a/Library/Psionics/Psionic Packages/Probability Alteration/Combat Fixer.gct
+++ b/Library/Psionics/Psionic Packages/Probability Alteration/Combat Fixer.gct
@@ -91,9 +91,9 @@
 						{
 							"type": "skill_bonus",
 							"selection_type": "skills_with_name",
-							"name": {
+							"tags": {
 								"compare": "is",
-								"qualifier": "Adjustment"
+								"qualifier": "PsionicSkill:Probability Alteration"
 							},
 							"amount": 1,
 							"per_level": true
@@ -145,41 +145,11 @@
 							"selection_type": "skills_with_name",
 							"name": {
 								"compare": "is",
-								"qualifier": "Coincidence"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
 								"qualifier": "Crushing Strike"
 							},
 							"specialization": {
 								"compare": "contains",
 								"qualifier": "Probability Alteration"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Curse"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Combat Sense"
 							},
 							"amount": 1,
 							"per_level": true
@@ -259,26 +229,6 @@
 							"selection_type": "skills_with_name",
 							"name": {
 								"compare": "is",
-								"qualifier": "Second Chance"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Weather Control"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
 								"qualifier": "Widen Shield"
 							},
 							"specialization": {
@@ -340,6 +290,7 @@
 					"reference": "PSI44",
 					"tags": [
 						"Probability Alteration",
+						"PsionicSkill:Probability Alteration",
 						"Psionics"
 					],
 					"difficulty": "iq/h",
@@ -380,6 +331,7 @@
 					"reference": "PSI45",
 					"tags": [
 						"Probability Alteration",
+						"PsionicSkill:Probability Alteration",
 						"Psionics"
 					],
 					"specialization": "Probability Alteration",
@@ -421,6 +373,7 @@
 					"reference": "PSI45",
 					"tags": [
 						"Probability Alteration",
+						"PsionicSkill:Probability Alteration",
 						"Psionics"
 					],
 					"difficulty": "iq/h",

--- a/Library/Psionics/Psionic Packages/Probability Alteration/Doom-Bringer.gct
+++ b/Library/Psionics/Psionic Packages/Probability Alteration/Doom-Bringer.gct
@@ -75,6 +75,7 @@
 					"reference": "PSI45",
 					"tags": [
 						"Probability Alteration",
+						"PsionicSkill:Probability Alteration",
 						"Psionics"
 					],
 					"difficulty": "will/h",
@@ -115,6 +116,7 @@
 					"reference": "PSI45",
 					"tags": [
 						"Probability Alteration",
+						"PsionicSkill:Probability Alteration",
 						"Psionics"
 					],
 					"difficulty": "iq/h",

--- a/Library/Psionics/Psionic Packages/Probability Alteration/Hard to Hit.gct
+++ b/Library/Psionics/Psionic Packages/Probability Alteration/Hard to Hit.gct
@@ -72,6 +72,7 @@
 					"reference": "PSI45",
 					"tags": [
 						"Probability Alteration",
+						"PsionicSkill:Probability Alteration",
 						"Psionics"
 					],
 					"specialization": "Probability Alteration",

--- a/Library/Psionics/Psionic Packages/Probability Alteration/Lucky Devil.gct
+++ b/Library/Psionics/Psionic Packages/Probability Alteration/Lucky Devil.gct
@@ -94,6 +94,7 @@
 					"reference": "PSI44",
 					"tags": [
 						"Probability Alteration",
+						"PsionicSkill:Probability Alteration",
 						"Psionics"
 					],
 					"difficulty": "iq/h",
@@ -134,6 +135,7 @@
 					"reference": "PSI45",
 					"tags": [
 						"Probability Alteration",
+						"PsionicSkill:Probability Alteration",
 						"Psionics"
 					],
 					"difficulty": "iq/h",

--- a/Library/Psionics/Psionic Packages/Probability Alteration/Rain Dancer.gct
+++ b/Library/Psionics/Psionic Packages/Probability Alteration/Rain Dancer.gct
@@ -52,6 +52,7 @@
 					"reference": "PSI45",
 					"tags": [
 						"Probability Alteration",
+						"PsionicSkill:Probability Alteration",
 						"Psionics"
 					],
 					"difficulty": "iq/h",

--- a/Library/Psionics/Psionic Packages/Probability Alteration/Situational Manipulator.gct
+++ b/Library/Psionics/Psionic Packages/Probability Alteration/Situational Manipulator.gct
@@ -75,6 +75,7 @@
 					"reference": "PSI44",
 					"tags": [
 						"Probability Alteration",
+						"PsionicSkill:Probability Alteration",
 						"Psionics"
 					],
 					"difficulty": "iq/h",
@@ -115,6 +116,7 @@
 					"reference": "PSI45",
 					"tags": [
 						"Probability Alteration",
+						"PsionicSkill:Probability Alteration",
 						"Psionics"
 					],
 					"difficulty": "iq/h",

--- a/Library/Psionics/Psionic Packages/Probability Alteration/Weather Wizard.gct
+++ b/Library/Psionics/Psionic Packages/Probability Alteration/Weather Wizard.gct
@@ -52,6 +52,7 @@
 					"reference": "PSI45",
 					"tags": [
 						"Probability Alteration",
+						"PsionicSkill:Probability Alteration",
 						"Psionics"
 					],
 					"difficulty": "iq/h",

--- a/Library/Psionics/Psionic Packages/Psychic Healing/Accelerated Recovery.gct
+++ b/Library/Psionics/Psionic Packages/Psychic Healing/Accelerated Recovery.gct
@@ -157,6 +157,7 @@
 					"name": "Life Extension",
 					"reference": "PSI46",
 					"tags": [
+						"PsionicSkill:Psychic Healing",
 						"Psionics",
 						"Psychic Healing"
 					],

--- a/Library/Psionics/Psionic Packages/Psychic Healing/Anesthesiologist.gct
+++ b/Library/Psionics/Psionic Packages/Psychic Healing/Anesthesiologist.gct
@@ -91,8 +91,9 @@
 							"cost": -10
 						}
 					],
+					"round_down": true,
 					"calc": {
-						"points": 7
+						"points": 6
 					}
 				},
 				{
@@ -190,7 +191,7 @@
 				}
 			],
 			"calc": {
-				"points": 34
+				"points": 33
 			}
 		}
 	],
@@ -210,6 +211,7 @@
 					"name": "Sleep (Psychic Healing)",
 					"reference": "PSI49",
 					"tags": [
+						"PsionicSkill:Psychic Healing",
 						"Psionics",
 						"Psychic Healing"
 					],

--- a/Library/Psionics/Psionic Packages/Psychic Healing/Antibodies.gct
+++ b/Library/Psionics/Psionic Packages/Psychic Healing/Antibodies.gct
@@ -52,6 +52,7 @@
 					"name": "Disease Shield",
 					"reference": "PSI48",
 					"tags": [
+						"PsionicSkill:Psychic Healing",
 						"Psionics",
 						"Psychic Healing"
 					],

--- a/Library/Psionics/Psionic Packages/Psychic Healing/Cellular Control.gct
+++ b/Library/Psionics/Psionic Packages/Psychic Healing/Cellular Control.gct
@@ -102,6 +102,7 @@
 					"name": "Metabolism Control",
 					"reference": "PSI49",
 					"tags": [
+						"PsionicSkill:Psychic Healing",
 						"Psionics",
 						"Psychic Healing"
 					],

--- a/Library/Psionics/Psionic Packages/Psychic Healing/Empathic Bond.gct
+++ b/Library/Psionics/Psionic Packages/Psychic Healing/Empathic Bond.gct
@@ -135,6 +135,7 @@
 					"name": "Aura Reading",
 					"reference": "PSI46",
 					"tags": [
+						"PsionicSkill:Psychic Healing",
 						"Psionics",
 						"Psychic Healing"
 					],
@@ -175,6 +176,7 @@
 					"name": "Empathy",
 					"reference": "PSI49",
 					"tags": [
+						"PsionicSkill:Psychic Healing",
 						"Psionics",
 						"Psychic Healing"
 					],

--- a/Library/Psionics/Psionic Packages/Psychic Healing/Lay on Hands.gct
+++ b/Library/Psionics/Psionic Packages/Psychic Healing/Lay on Hands.gct
@@ -52,6 +52,7 @@
 					"name": "Cure",
 					"reference": "PSI46",
 					"tags": [
+						"PsionicSkill:Psychic Healing",
 						"Psionics",
 						"Psychic Healing"
 					],

--- a/Library/Psionics/Psionic Packages/Psychic Healing/Regulate Body.gct
+++ b/Library/Psionics/Psionic Packages/Psychic Healing/Regulate Body.gct
@@ -100,6 +100,7 @@
 					"name": "Life Extension",
 					"reference": "PSI46",
 					"tags": [
+						"PsionicSkill:Psychic Healing",
 						"Psionics",
 						"Psychic Healing"
 					],
@@ -140,6 +141,7 @@
 					"name": "Metabolism Control",
 					"reference": "PSI49",
 					"tags": [
+						"PsionicSkill:Psychic Healing",
 						"Psionics",
 						"Psychic Healing"
 					],

--- a/Library/Psionics/Psionic Packages/Psychic Healing/Restore Damage.gct
+++ b/Library/Psionics/Psionic Packages/Psychic Healing/Restore Damage.gct
@@ -97,6 +97,7 @@
 					"name": "Cure",
 					"reference": "PSI46",
 					"tags": [
+						"PsionicSkill:Psychic Healing",
 						"Psionics",
 						"Psychic Healing"
 					],

--- a/Library/Psionics/Psionic Packages/Psychic Healing/Saintly Healer.gct
+++ b/Library/Psionics/Psionic Packages/Psychic Healing/Saintly Healer.gct
@@ -109,69 +109,9 @@
 						{
 							"type": "skill_bonus",
 							"selection_type": "skills_with_name",
-							"name": {
+							"tags": {
 								"compare": "is",
-								"qualifier": "Aura Reading"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Cure"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Disease Shield"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Life Extension"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Sleep (Psychic Healing)"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Empathy"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Metabolism Control"
+								"qualifier": "PsionicSkill:Psychic Healing"
 							},
 							"amount": 1,
 							"per_level": true
@@ -379,6 +319,7 @@
 					"name": "Aura Reading",
 					"reference": "PSI46",
 					"tags": [
+						"PsionicSkill:Psychic Healing",
 						"Psionics",
 						"Psychic Healing"
 					],
@@ -419,6 +360,7 @@
 					"name": "Cure",
 					"reference": "PSI46",
 					"tags": [
+						"PsionicSkill:Psychic Healing",
 						"Psionics",
 						"Psychic Healing"
 					],

--- a/Library/Psionics/Psionic Packages/Psychic Healing/Treat Disease.gct
+++ b/Library/Psionics/Psionic Packages/Psychic Healing/Treat Disease.gct
@@ -108,69 +108,9 @@
 						{
 							"type": "skill_bonus",
 							"selection_type": "skills_with_name",
-							"name": {
+							"tags": {
 								"compare": "is",
-								"qualifier": "Aura Reading"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Cure"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Disease Shield"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Life Extension"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Sleep (Psychic Healing)"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Empathy"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Metabolism Control"
+								"qualifier": "PsionicSkill:Psychic Healing"
 							},
 							"amount": 1,
 							"per_level": true
@@ -378,6 +318,7 @@
 					"name": "Aura Reading",
 					"reference": "PSI46",
 					"tags": [
+						"PsionicSkill:Psychic Healing",
 						"Psionics",
 						"Psychic Healing"
 					],
@@ -418,6 +359,7 @@
 					"name": "Cure",
 					"reference": "PSI46",
 					"tags": [
+						"PsionicSkill:Psychic Healing",
 						"Psionics",
 						"Psychic Healing"
 					],

--- a/Library/Psionics/Psionic Packages/Psychic Vampirism/Basic Weakening (DX).gct
+++ b/Library/Psionics/Psionic Packages/Psychic Vampirism/Basic Weakening (DX).gct
@@ -52,6 +52,7 @@
 					"name": "Drain DX",
 					"reference": "PSI50",
 					"tags": [
+						"PsionicSkill:Psychic Vampirism",
 						"Psionics",
 						"Psychic Vampirism"
 					],

--- a/Library/Psionics/Psionic Packages/Psychic Vampirism/Basic Weakening (HT).gct
+++ b/Library/Psionics/Psionic Packages/Psychic Vampirism/Basic Weakening (HT).gct
@@ -52,6 +52,7 @@
 					"name": "Drain HT",
 					"reference": "PSI50",
 					"tags": [
+						"PsionicSkill:Psychic Vampirism",
 						"Psionics",
 						"Psychic Vampirism"
 					],

--- a/Library/Psionics/Psionic Packages/Psychic Vampirism/Basic Weakening (IQ).gct
+++ b/Library/Psionics/Psionic Packages/Psychic Vampirism/Basic Weakening (IQ).gct
@@ -52,6 +52,7 @@
 					"name": "Drain IQ",
 					"reference": "PSI50",
 					"tags": [
+						"PsionicSkill:Psychic Vampirism",
 						"Psionics",
 						"Psychic Vampirism"
 					],

--- a/Library/Psionics/Psionic Packages/Psychic Vampirism/Basic Weakening (ST).gct
+++ b/Library/Psionics/Psionic Packages/Psychic Vampirism/Basic Weakening (ST).gct
@@ -52,6 +52,7 @@
 					"name": "Drain ST",
 					"reference": "PSI50",
 					"tags": [
+						"PsionicSkill:Psychic Vampirism",
 						"Psionics",
 						"Psychic Vampirism"
 					],

--- a/Library/Psionics/Psionic Packages/Psychic Vampirism/Debilitation.gct
+++ b/Library/Psionics/Psionic Packages/Psychic Vampirism/Debilitation.gct
@@ -243,99 +243,9 @@
 						{
 							"type": "skill_bonus",
 							"selection_type": "skills_with_name",
-							"name": {
+							"tags": {
 								"compare": "is",
-								"qualifier": "Detect Life"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Drain DX"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Drain Emotion"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Drain HT"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Drain IQ"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Drain ST"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Steal Dreams"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Steal Energy"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Steal Life"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Steal Power"
+								"qualifier": "PsionicSkill:Psychic Vampirism"
 							},
 							"amount": 1,
 							"per_level": true
@@ -523,6 +433,7 @@
 					"name": "Drain DX",
 					"reference": "PSI50",
 					"tags": [
+						"PsionicSkill:Psychic Vampirism",
 						"Psionics",
 						"Psychic Vampirism"
 					],
@@ -563,6 +474,7 @@
 					"name": "Drain HT",
 					"reference": "PSI50",
 					"tags": [
+						"PsionicSkill:Psychic Vampirism",
 						"Psionics",
 						"Psychic Vampirism"
 					],
@@ -603,6 +515,7 @@
 					"name": "Drain IQ",
 					"reference": "PSI50",
 					"tags": [
+						"PsionicSkill:Psychic Vampirism",
 						"Psionics",
 						"Psychic Vampirism"
 					],
@@ -643,6 +556,7 @@
 					"name": "Drain ST",
 					"reference": "PSI50",
 					"tags": [
+						"PsionicSkill:Psychic Vampirism",
 						"Psionics",
 						"Psychic Vampirism"
 					],
@@ -683,6 +597,7 @@
 					"name": "Steal Energy",
 					"reference": "PSI51",
 					"tags": [
+						"PsionicSkill:Psychic Vampirism",
 						"Psionics",
 						"Psychic Vampirism"
 					],

--- a/Library/Psionics/Psionic Packages/Psychic Vampirism/Emotional Vampire.gct
+++ b/Library/Psionics/Psionic Packages/Psychic Vampirism/Emotional Vampire.gct
@@ -106,6 +106,7 @@
 					"name": "Drain Emotion",
 					"reference": "PSI50",
 					"tags": [
+						"PsionicSkill:Psychic Vampirism",
 						"Psionics",
 						"Psychic Vampirism"
 					],

--- a/Library/Psionics/Psionic Packages/Psychic Vampirism/Energy Theft.gct
+++ b/Library/Psionics/Psionic Packages/Psychic Vampirism/Energy Theft.gct
@@ -116,6 +116,7 @@
 					"name": "Steal Energy",
 					"reference": "PSI51",
 					"tags": [
+						"PsionicSkill:Psychic Vampirism",
 						"Psionics",
 						"Psychic Vampirism"
 					],

--- a/Library/Psionics/Psionic Packages/Psychic Vampirism/Foolishness.gct
+++ b/Library/Psionics/Psionic Packages/Psychic Vampirism/Foolishness.gct
@@ -77,6 +77,7 @@
 					"name": "Drain IQ",
 					"reference": "PSI50",
 					"tags": [
+						"PsionicSkill:Psychic Vampirism",
 						"Psionics",
 						"Psychic Vampirism"
 					],

--- a/Library/Psionics/Psionic Packages/Psychic Vampirism/Life-Force Devourer.gct
+++ b/Library/Psionics/Psionic Packages/Psychic Vampirism/Life-Force Devourer.gct
@@ -108,6 +108,7 @@
 					"name": "Detect Life",
 					"reference": "PSI52",
 					"tags": [
+						"PsionicSkill:Psychic Vampirism",
 						"Psionics",
 						"Psychic Vampirism"
 					],
@@ -144,6 +145,7 @@
 					"name": "Steal Life",
 					"reference": "PSI52",
 					"tags": [
+						"PsionicSkill:Psychic Vampirism",
 						"Psionics",
 						"Psychic Vampirism"
 					],

--- a/Library/Psionics/Psionic Packages/Psychic Vampirism/Psi Thief.gct
+++ b/Library/Psionics/Psionic Packages/Psychic Vampirism/Psi Thief.gct
@@ -72,6 +72,7 @@
 					"name": "Steal Power",
 					"reference": "PSI52",
 					"tags": [
+						"PsionicSkill:Psychic Vampirism",
 						"Psionics",
 						"Psychic Vampirism"
 					],

--- a/Library/Psionics/Psionic Packages/Psychic Vampirism/Steal Dreams.gct
+++ b/Library/Psionics/Psionic Packages/Psychic Vampirism/Steal Dreams.gct
@@ -117,6 +117,7 @@
 					"name": "Steal Dreams",
 					"reference": "PSI50",
 					"tags": [
+						"PsionicSkill:Psychic Vampirism",
 						"Psionics",
 						"Psychic Vampirism"
 					],

--- a/Library/Psionics/Psionic Packages/Psychic Vampirism/System Shock.gct
+++ b/Library/Psionics/Psionic Packages/Psychic Vampirism/System Shock.gct
@@ -82,99 +82,9 @@
 						{
 							"type": "skill_bonus",
 							"selection_type": "skills_with_name",
-							"name": {
+							"tags": {
 								"compare": "is",
-								"qualifier": "Detect Life"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Drain DX"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Drain Emotion"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Drain HT"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Drain IQ"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Drain ST"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Steal Dreams"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Steal Energy"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Steal Life"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Steal Power"
+								"qualifier": "PsionicSkill:Psychic Vampirism"
 							},
 							"amount": 1,
 							"per_level": true
@@ -382,6 +292,7 @@
 					"name": "Drain HT",
 					"reference": "PSI50",
 					"tags": [
+						"PsionicSkill:Psychic Vampirism",
 						"Psionics",
 						"Psychic Vampirism"
 					],
@@ -422,6 +333,7 @@
 					"name": "Drain ST",
 					"reference": "PSI50",
 					"tags": [
+						"PsionicSkill:Psychic Vampirism",
 						"Psionics",
 						"Psychic Vampirism"
 					],

--- a/Library/Psionics/Psionic Packages/Psychic Vampirism/Waking Nightmare.gct
+++ b/Library/Psionics/Psionic Packages/Psychic Vampirism/Waking Nightmare.gct
@@ -90,6 +90,7 @@
 					"name": "Steal Dreams",
 					"reference": "PSI50",
 					"tags": [
+						"PsionicSkill:Psychic Vampirism",
 						"Psionics",
 						"Psychic Vampirism"
 					],

--- a/Library/Psionics/Psionic Packages/Psychic Vampirism/Zone of Logic.gct
+++ b/Library/Psionics/Psionic Packages/Psychic Vampirism/Zone of Logic.gct
@@ -49,99 +49,9 @@
 						{
 							"type": "skill_bonus",
 							"selection_type": "skills_with_name",
-							"name": {
+							"tags": {
 								"compare": "is",
-								"qualifier": "Detect Life"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Drain DX"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Drain Emotion"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Drain HT"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Drain IQ"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Drain ST"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Steal Dreams"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Steal Energy"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Steal Life"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Steal Power"
+								"qualifier": "PsionicSkill:Psychic Vampirism"
 							},
 							"amount": 1,
 							"per_level": true
@@ -329,6 +239,7 @@
 					"name": "Drain Emotion",
 					"reference": "PSI50",
 					"tags": [
+						"PsionicSkill:Psychic Vampirism",
 						"Psionics",
 						"Psychic Vampirism"
 					],

--- a/Library/Psionics/Psionic Packages/Psychokinesis/Advanced Telekinesis.gct
+++ b/Library/Psionics/Psionic Packages/Psychokinesis/Advanced Telekinesis.gct
@@ -52,6 +52,8 @@
 					"name": "Telekinetic Control",
 					"reference": "PSI54",
 					"tags": [
+						"PsionicSkill:Psychokinesis",
+						"PsionicSkill:Telekinesis",
 						"Psionics",
 						"Psychokinesis",
 						"Telekinesis"

--- a/Library/Psionics/Psionic Packages/Psychokinesis/Basic Telekinesis.gct
+++ b/Library/Psionics/Psionic Packages/Psychokinesis/Basic Telekinesis.gct
@@ -52,6 +52,8 @@
 					"name": "Telekinetic Control",
 					"reference": "PSI54",
 					"tags": [
+						"PsionicSkill:Psychokinesis",
+						"PsionicSkill:Telekinesis",
 						"Psionics",
 						"Psychokinesis",
 						"Telekinesis"

--- a/Library/Psionics/Psionic Packages/Psychokinesis/Deflector Shield.gct
+++ b/Library/Psionics/Psionic Packages/Psychokinesis/Deflector Shield.gct
@@ -108,9 +108,9 @@
 					"name": "PK Shield",
 					"reference": "PSI56",
 					"tags": [
+						"PsionicSkill:Psychokinesis",
 						"Psionics",
-						"Psychokinesis",
-						"Telekinesis"
+						"Psychokinesis"
 					],
 					"difficulty": "iq/h",
 					"defaults": [

--- a/Library/Psionics/Psionic Packages/Psychokinesis/Fast Flight.gct
+++ b/Library/Psionics/Psionic Packages/Psychokinesis/Fast Flight.gct
@@ -73,6 +73,8 @@
 					"name": "Levitation",
 					"reference": "PSI55",
 					"tags": [
+						"PsionicSkill:Psychokinesis",
+						"PsionicSkill:Telekinesis",
 						"Psionics",
 						"Psychokinesis",
 						"Telekinesis"

--- a/Library/Psionics/Psionic Packages/Psychokinesis/Firestarter.gct
+++ b/Library/Psionics/Psionic Packages/Psychokinesis/Firestarter.gct
@@ -51,9 +51,9 @@
 					"name": "Pyrokinesis",
 					"reference": "PSI56",
 					"tags": [
+						"PsionicSkill:Psychokinesis",
 						"Psionics",
-						"Psychokinesis",
-						"Telekinesis"
+						"Psychokinesis"
 					],
 					"difficulty": "will/h",
 					"defaults": [

--- a/Library/Psionics/Psionic Packages/Psychokinesis/Flying Burglar.gct
+++ b/Library/Psionics/Psionic Packages/Psychokinesis/Flying Burglar.gct
@@ -83,6 +83,8 @@
 					"name": "Levitation",
 					"reference": "PSI55",
 					"tags": [
+						"PsionicSkill:Psychokinesis",
+						"PsionicSkill:Telekinesis",
 						"Psionics",
 						"Psychokinesis",
 						"Telekinesis"
@@ -124,6 +126,8 @@
 					"name": "TK Grab",
 					"reference": "PSI54",
 					"tags": [
+						"PsionicSkill:Psychokinesis",
+						"PsionicSkill:Telekinesis",
 						"Psionics",
 						"Psychokinesis",
 						"Telekinesis"

--- a/Library/Psionics/Psionic Packages/Psychokinesis/Hover-Step.gct
+++ b/Library/Psionics/Psionic Packages/Psychokinesis/Hover-Step.gct
@@ -106,9 +106,9 @@
 					"name": "PK Shield",
 					"reference": "PSI56",
 					"tags": [
+						"PsionicSkill:Psychokinesis",
 						"Psionics",
-						"Psychokinesis",
-						"Telekinesis"
+						"Psychokinesis"
 					],
 					"difficulty": "iq/h",
 					"defaults": [

--- a/Library/Psionics/Psionic Packages/Psychokinesis/Ice Maker.gct
+++ b/Library/Psionics/Psionic Packages/Psychokinesis/Ice Maker.gct
@@ -113,9 +113,9 @@
 					"name": "Cryokinesis",
 					"reference": "PSI55",
 					"tags": [
+						"PsionicSkill:Psychokinesis",
 						"Psionics",
-						"Psychokinesis",
-						"Telekinesis"
+						"Psychokinesis"
 					],
 					"difficulty": "will/h",
 					"defaults": [
@@ -154,9 +154,9 @@
 					"name": "PK Shield",
 					"reference": "PSI56",
 					"tags": [
+						"PsionicSkill:Psychokinesis",
 						"Psionics",
-						"Psychokinesis",
-						"Telekinesis"
+						"Psychokinesis"
 					],
 					"difficulty": "iq/h",
 					"defaults": [

--- a/Library/Psionics/Psionic Packages/Psychokinesis/Organ Grinder.gct
+++ b/Library/Psionics/Psionic Packages/Psychokinesis/Organ Grinder.gct
@@ -44,79 +44,9 @@
 						{
 							"type": "skill_bonus",
 							"selection_type": "skills_with_name",
-							"name": {
+							"tags": {
 								"compare": "is",
-								"qualifier": "TK Grab"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "TK Crush"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "TK Bullet"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Levitation"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Telekinetic Control"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Pyrokinesis"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "PK Shield"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Cryokinesis"
+								"qualifier": "PsionicSkill:Psychokinesis"
 							},
 							"amount": 1,
 							"per_level": true
@@ -475,9 +405,10 @@
 							"weapons": [
 								{
 									"id": "W4WOo_rSp8ReiWzeC",
+									"sv": 1,
 									"damage": {
 										"type": "pi/level",
-										"base": "1"
+										"base_leveled": "1"
 									},
 									"usage": "Gaze",
 									"rate_of_fire": "1",
@@ -499,7 +430,7 @@
 										}
 									],
 									"calc": {
-										"damage": "1 pi/level"
+										"damage": "1 per level  pi/level"
 									}
 								}
 							],
@@ -567,6 +498,8 @@
 					"name": "TK Crush",
 					"reference": "PSI54",
 					"tags": [
+						"PsionicSkill:Psychokinesis",
+						"PsionicSkill:Telekinesis",
 						"Psionics",
 						"Psychokinesis",
 						"Telekinesis"
@@ -608,6 +541,8 @@
 					"name": "TK Grab",
 					"reference": "PSI54",
 					"tags": [
+						"PsionicSkill:Psychokinesis",
+						"PsionicSkill:Telekinesis",
 						"Psionics",
 						"Psychokinesis",
 						"Telekinesis"

--- a/Library/Psionics/Psionic Packages/Psychokinesis/Psychokinetic Warrior.gct
+++ b/Library/Psionics/Psionic Packages/Psychokinesis/Psychokinetic Warrior.gct
@@ -66,79 +66,9 @@
 						{
 							"type": "skill_bonus",
 							"selection_type": "skills_with_name",
-							"name": {
+							"tags": {
 								"compare": "is",
-								"qualifier": "TK Grab"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "TK Crush"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "TK Bullet"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Levitation"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Telekinetic Control"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Pyrokinesis"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "PK Shield"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Cryokinesis"
+								"qualifier": "PsionicSkill:Psychokinesis"
 							},
 							"amount": 1,
 							"per_level": true
@@ -497,9 +427,10 @@
 							"weapons": [
 								{
 									"id": "WdbEPOMPzStRDzMwS",
+									"sv": 1,
 									"damage": {
 										"type": "pi",
-										"base": "1d-1"
+										"base_leveled": "1d-1"
 									},
 									"usage": "Bullet",
 									"accuracy": "3",
@@ -513,14 +444,15 @@
 										}
 									],
 									"calc": {
-										"damage": "1d-1 pi"
+										"damage": "1d-1 per level  pi"
 									}
 								},
 								{
 									"id": "Wcl2rqU4IGf3UqF6d",
+									"sv": 1,
 									"damage": {
 										"type": "pi+",
-										"base": "1d-1"
+										"base_leveled": "1d-1"
 									},
 									"usage": "Flat Edge",
 									"accuracy": "3",
@@ -540,14 +472,15 @@
 										}
 									],
 									"calc": {
-										"damage": "1d-1 pi+"
+										"damage": "1d-1 per level  pi+"
 									}
 								},
 								{
 									"id": "WKH03WfZEtYYzyjkl",
+									"sv": 1,
 									"damage": {
 										"type": "pi",
-										"base": "1d-1",
+										"base_leveled": "1d-1",
 										"armor_divisor": 2
 									},
 									"usage": "Sharp Edge",
@@ -568,14 +501,15 @@
 										}
 									],
 									"calc": {
-										"damage": "1d-1(2) pi"
+										"damage": "1d-1 per level (2) pi"
 									}
 								},
 								{
 									"id": "WfQAQ0DiOaWn8kCIg",
+									"sv": 1,
 									"damage": {
 										"type": "pi",
-										"base": "1d-1"
+										"base_leveled": "1d-1"
 									},
 									"usage": "Rapid Fire",
 									"accuracy": "3",
@@ -595,14 +529,15 @@
 										}
 									],
 									"calc": {
-										"damage": "1d-1 pi"
+										"damage": "1d-1 per level  pi"
 									}
 								},
 								{
 									"id": "W4FvtDqJvGROKVA2X",
+									"sv": 1,
 									"damage": {
 										"type": "pi",
-										"base": "1d-2"
+										"base_leveled": "1d-2"
 									},
 									"usage": "Silencer",
 									"accuracy": "3",
@@ -622,7 +557,7 @@
 										}
 									],
 									"calc": {
-										"damage": "1d-2 pi"
+										"damage": "1d-2 per level  pi"
 									}
 								}
 							],
@@ -652,9 +587,10 @@
 							"weapons": [
 								{
 									"id": "Wb4BzNP4EVjfOBYAS",
+									"sv": 1,
 									"damage": {
 										"type": "pi/level",
-										"base": "1"
+										"base_leveled": "1"
 									},
 									"usage": "Gaze",
 									"rate_of_fire": "1",
@@ -676,7 +612,7 @@
 										}
 									],
 									"calc": {
-										"damage": "1 pi/level"
+										"damage": "1 per level  pi/level"
 									}
 								}
 							],
@@ -713,9 +649,9 @@
 					"name": "PK Shield",
 					"reference": "PSI56",
 					"tags": [
+						"PsionicSkill:Psychokinesis",
 						"Psionics",
-						"Psychokinesis",
-						"Telekinesis"
+						"Psychokinesis"
 					],
 					"difficulty": "iq/h",
 					"defaults": [
@@ -754,6 +690,8 @@
 					"name": "TK Bullet",
 					"reference": "PSI53",
 					"tags": [
+						"PsionicSkill:Psychokinesis",
+						"PsionicSkill:Telekinesis",
 						"Psionics",
 						"Psychokinesis",
 						"Telekinesis"
@@ -795,6 +733,8 @@
 					"name": "TK Crush",
 					"reference": "PSI54",
 					"tags": [
+						"PsionicSkill:Psychokinesis",
+						"PsionicSkill:Telekinesis",
 						"Psionics",
 						"Psychokinesis",
 						"Telekinesis"

--- a/Library/Psionics/Psionic Packages/Psychokinesis/Space Heater.gct
+++ b/Library/Psionics/Psionic Packages/Psychokinesis/Space Heater.gct
@@ -107,9 +107,9 @@
 					"name": "Pyrokinesis",
 					"reference": "PSI56",
 					"tags": [
+						"PsionicSkill:Psychokinesis",
 						"Psionics",
-						"Psychokinesis",
-						"Telekinesis"
+						"Psychokinesis"
 					],
 					"difficulty": "will/h",
 					"defaults": [

--- a/Library/Psionics/Psionic Packages/Psychokinesis/Ultra-Telekinesis.gct
+++ b/Library/Psionics/Psionic Packages/Psychokinesis/Ultra-Telekinesis.gct
@@ -52,6 +52,8 @@
 					"name": "Telekinetic Control",
 					"reference": "PSI54",
 					"tags": [
+						"PsionicSkill:Psychokinesis",
+						"PsionicSkill:Telekinesis",
 						"Psionics",
 						"Psychokinesis",
 						"Telekinesis"

--- a/Library/Psionics/Psionic Packages/Psychokinesis/Utility Lifting.gct
+++ b/Library/Psionics/Psionic Packages/Psychokinesis/Utility Lifting.gct
@@ -59,6 +59,8 @@
 					"name": "TK Grab",
 					"reference": "PSI54",
 					"tags": [
+						"PsionicSkill:Psychokinesis",
+						"PsionicSkill:Telekinesis",
 						"Psionics",
 						"Psychokinesis",
 						"Telekinesis"

--- a/Library/Psionics/Psionic Packages/Telepathy/Communications Hub.gct
+++ b/Library/Psionics/Psionic Packages/Telepathy/Communications Hub.gct
@@ -101,6 +101,8 @@
 					"reference": "PSI60",
 					"tags": [
 						"Communication",
+						"PsionicSkill:Communication",
+						"PsionicSkill:Telepathy",
 						"Psionics",
 						"Telepathy"
 					],

--- a/Library/Psionics/Psionic Packages/Telepathy/Eavesdropper.gct
+++ b/Library/Psionics/Psionic Packages/Telepathy/Eavesdropper.gct
@@ -101,6 +101,8 @@
 					"reference": "PSI58",
 					"tags": [
 						"Communication",
+						"PsionicSkill:Communication",
+						"PsionicSkill:Telepathy",
 						"Psionics",
 						"Telepathy"
 					],

--- a/Library/Psionics/Psionic Packages/Telepathy/Empath.gct
+++ b/Library/Psionics/Psionic Packages/Telepathy/Empath.gct
@@ -156,6 +156,8 @@
 					"reference": "PSI58",
 					"tags": [
 						"Communication",
+						"PsionicSkill:Communication",
+						"PsionicSkill:Telepathy",
 						"Psionics",
 						"Telepathy"
 					],
@@ -197,6 +199,8 @@
 					"reference": "PSI61",
 					"tags": [
 						"Control",
+						"PsionicSkill:Control",
+						"PsionicSkill:Telepathy",
 						"Psionics",
 						"Telepathy"
 					],

--- a/Library/Psionics/Psionic Packages/Telepathy/Hidden Communication.gct
+++ b/Library/Psionics/Psionic Packages/Telepathy/Hidden Communication.gct
@@ -193,6 +193,8 @@
 					"reference": "PSI58",
 					"tags": [
 						"Communication",
+						"PsionicSkill:Communication",
+						"PsionicSkill:Telepathy",
 						"Psionics",
 						"Telepathy"
 					],
@@ -246,6 +248,8 @@
 					"reference": "PSI60",
 					"tags": [
 						"Communication",
+						"PsionicSkill:Communication",
+						"PsionicSkill:Telepathy",
 						"Psionics",
 						"Telepathy"
 					],

--- a/Library/Psionics/Psionic Packages/Telepathy/Likable.gct
+++ b/Library/Psionics/Psionic Packages/Telepathy/Likable.gct
@@ -168,6 +168,8 @@
 					"reference": "PSI61",
 					"tags": [
 						"Control",
+						"PsionicSkill:Control",
+						"PsionicSkill:Telepathy",
 						"Psionics",
 						"Telepathy"
 					],
@@ -209,6 +211,8 @@
 					"reference": "PSI61",
 					"tags": [
 						"Control",
+						"PsionicSkill:Control",
+						"PsionicSkill:Telepathy",
 						"Psionics",
 						"Telepathy"
 					],

--- a/Library/Psionics/Psionic Packages/Telepathy/Mental Guard.gct
+++ b/Library/Psionics/Psionic Packages/Telepathy/Mental Guard.gct
@@ -128,6 +128,8 @@
 					"name": "Mind Shield",
 					"reference": "PSI66",
 					"tags": [
+						"PsionicSkill:Sense and Defense",
+						"PsionicSkill:Telepathy",
 						"Psionics",
 						"Sense and Defense",
 						"Telepathy"
@@ -169,6 +171,8 @@
 					"name": "Telepathy Sense",
 					"reference": "PSI67",
 					"tags": [
+						"PsionicSkill:Sense and Defense",
+						"PsionicSkill:Telepathy",
 						"Psionics",
 						"Sense and Defense",
 						"Telepathy"

--- a/Library/Psionics/Psionic Packages/Telepathy/Mental Mastery.gct
+++ b/Library/Psionics/Psionic Packages/Telepathy/Mental Mastery.gct
@@ -210,189 +210,9 @@
 						{
 							"type": "skill_bonus",
 							"selection_type": "skills_with_name",
-							"name": {
+							"tags": {
 								"compare": "is",
-								"qualifier": "Borrow Skill"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Emotion Sense"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Telereceive"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Telesend"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Aspect"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Mental Surgery"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Mind Swap"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Mindwipe"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Sensory Control"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Suggestion"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Telecontrol"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Instill Fear"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Mental Blow"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Mental Stab"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Sleep (Telepathy)"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Mind Clouding"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Mind Shield"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Telepathy Sense"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Telescan"
+								"qualifier": "PsionicSkill:Telepathy"
 							},
 							"amount": 1,
 							"per_level": true
@@ -732,6 +552,8 @@
 					"name": "Mind Shield",
 					"reference": "PSI66",
 					"tags": [
+						"PsionicSkill:Sense and Defense",
+						"PsionicSkill:Telepathy",
 						"Psionics",
 						"Sense and Defense",
 						"Telepathy"
@@ -774,6 +596,8 @@
 					"reference": "PSI61",
 					"tags": [
 						"Control",
+						"PsionicSkill:Control",
+						"PsionicSkill:Telepathy",
 						"Psionics",
 						"Telepathy"
 					],
@@ -827,6 +651,8 @@
 					"reference": "PSI58",
 					"tags": [
 						"Communication",
+						"PsionicSkill:Communication",
+						"PsionicSkill:Telepathy",
 						"Psionics",
 						"Telepathy"
 					],
@@ -880,6 +706,8 @@
 					"reference": "PSI60",
 					"tags": [
 						"Communication",
+						"PsionicSkill:Communication",
+						"PsionicSkill:Telepathy",
 						"Psionics",
 						"Telepathy"
 					],

--- a/Library/Psionics/Psionic Packages/Telepathy/Mental Override.gct
+++ b/Library/Psionics/Psionic Packages/Telepathy/Mental Override.gct
@@ -174,6 +174,8 @@
 					"reference": "PSI62",
 					"tags": [
 						"Control",
+						"PsionicSkill:Control",
+						"PsionicSkill:Telepathy",
 						"Psionics",
 						"Telepathy"
 					],
@@ -227,6 +229,8 @@
 					"reference": "PSI61",
 					"tags": [
 						"Control",
+						"PsionicSkill:Control",
+						"PsionicSkill:Telepathy",
 						"Psionics",
 						"Telepathy"
 					],

--- a/Library/Psionics/Psionic Packages/Telepathy/Psychic Ninja.gct
+++ b/Library/Psionics/Psionic Packages/Telepathy/Psychic Ninja.gct
@@ -312,189 +312,9 @@
 						{
 							"type": "skill_bonus",
 							"selection_type": "skills_with_name",
-							"name": {
+							"tags": {
 								"compare": "is",
-								"qualifier": "Borrow Skill"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Emotion Sense"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Telereceive"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Telesend"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Aspect"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Mental Surgery"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Mind Swap"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Mindwipe"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Sensory Control"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Suggestion"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Telecontrol"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Instill Fear"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Mental Blow"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Mental Stab"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Sleep (Telepathy)"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Mind Clouding"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Mind Shield"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Telepathy Sense"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Telescan"
+								"qualifier": "PsionicSkill:Telepathy"
 							},
 							"amount": 1,
 							"per_level": true
@@ -683,6 +503,8 @@
 					"reference": "PSI65",
 					"tags": [
 						"Offense",
+						"PsionicSkill:Offense",
+						"PsionicSkill:Telepathy",
 						"Psionics",
 						"Telepathy"
 					],
@@ -724,6 +546,8 @@
 					"reference": "PSI65",
 					"tags": [
 						"Offense",
+						"PsionicSkill:Offense",
+						"PsionicSkill:Telepathy",
 						"Psionics",
 						"Telepathy"
 					],
@@ -764,6 +588,8 @@
 					"name": "Mind Clouding",
 					"reference": "PSI66",
 					"tags": [
+						"PsionicSkill:Sense and Defense",
+						"PsionicSkill:Telepathy",
 						"Psionics",
 						"Sense and Defense",
 						"Telepathy"
@@ -805,6 +631,8 @@
 					"name": "Mind Shield",
 					"reference": "PSI66",
 					"tags": [
+						"PsionicSkill:Sense and Defense",
+						"PsionicSkill:Telepathy",
 						"Psionics",
 						"Sense and Defense",
 						"Telepathy"

--- a/Library/Psionics/Psionic Packages/Telepathy/Puppeteer.gct
+++ b/Library/Psionics/Psionic Packages/Telepathy/Puppeteer.gct
@@ -75,6 +75,8 @@
 					"reference": "PSI64",
 					"tags": [
 						"Control",
+						"PsionicSkill:Control",
+						"PsionicSkill:Telepathy",
 						"Psionics",
 						"Telepathy"
 					],

--- a/Library/Psionics/Psionic Packages/Telepathy/Reprogrammer.gct
+++ b/Library/Psionics/Psionic Packages/Telepathy/Reprogrammer.gct
@@ -163,6 +163,8 @@
 					"reference": "PSI61",
 					"tags": [
 						"Control",
+						"PsionicSkill:Control",
+						"PsionicSkill:Telepathy",
 						"Psionics",
 						"Telepathy"
 					],
@@ -204,6 +206,8 @@
 					"reference": "PSI62",
 					"tags": [
 						"Control",
+						"PsionicSkill:Control",
+						"PsionicSkill:Telepathy",
 						"Psionics",
 						"Telepathy"
 					],

--- a/Library/Psionics/Psionic Packages/Telepathy/Shadow.gct
+++ b/Library/Psionics/Psionic Packages/Telepathy/Shadow.gct
@@ -24,6 +24,13 @@
 						"Telepathy"
 					],
 					"points_per_level": 6,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "to Stealth against subject who fails to resist Mind Clouding, double if standing still",
+							"amount": 2
+						}
+					],
 					"can_level": true,
 					"levels": 3,
 					"calc": {
@@ -52,6 +59,8 @@
 					"name": "Mind Clouding",
 					"reference": "PSI66",
 					"tags": [
+						"PsionicSkill:Sense and Defense",
+						"PsionicSkill:Telepathy",
 						"Psionics",
 						"Sense and Defense",
 						"Telepathy"

--- a/Library/Psionics/Psionic Packages/Telepathy/Shout.gct
+++ b/Library/Psionics/Psionic Packages/Telepathy/Shout.gct
@@ -203,6 +203,8 @@
 					"reference": "PSI65",
 					"tags": [
 						"Offense",
+						"PsionicSkill:Offense",
+						"PsionicSkill:Telepathy",
 						"Psionics",
 						"Telepathy"
 					],
@@ -244,6 +246,8 @@
 					"reference": "PSI60",
 					"tags": [
 						"Communication",
+						"PsionicSkill:Communication",
+						"PsionicSkill:Telepathy",
 						"Psionics",
 						"Telepathy"
 					],

--- a/Library/Psionics/Psionic Packages/Telepathy/Thought Thief.gct
+++ b/Library/Psionics/Psionic Packages/Telepathy/Thought Thief.gct
@@ -122,6 +122,8 @@
 					"reference": "PSI58",
 					"tags": [
 						"Communication",
+						"PsionicSkill:Communication",
+						"PsionicSkill:Telepathy",
 						"Psionics",
 						"Telepathy"
 					],

--- a/Library/Psionics/Psionic Packages/Telepathy/Trade Bodies.gct
+++ b/Library/Psionics/Psionic Packages/Telepathy/Trade Bodies.gct
@@ -107,6 +107,8 @@
 					"reference": "PSI62",
 					"tags": [
 						"Control",
+						"PsionicSkill:Control",
+						"PsionicSkill:Telepathy",
 						"Psionics",
 						"Telepathy"
 					],

--- a/Library/Psionics/Psionic Packages/Teleportation/Evisceration.gct
+++ b/Library/Psionics/Psionic Packages/Teleportation/Evisceration.gct
@@ -26,9 +26,10 @@
 					"weapons": [
 						{
 							"id": "WF0mV24KsXRERtdkv",
+							"sv": 1,
 							"damage": {
 								"type": "imp",
-								"base": "1d-2"
+								"base_leveled": "1d-2"
 							},
 							"usage": "Innerportation",
 							"rate_of_fire": "1",
@@ -43,7 +44,7 @@
 								}
 							],
 							"calc": {
-								"damage": "1d-2 imp"
+								"damage": "1d-2 per level  imp"
 							}
 						}
 					],
@@ -95,6 +96,7 @@
 					"name": "Innerportation",
 					"reference": "PSI70",
 					"tags": [
+						"PsionicSkill:Teleportation",
 						"Psionics",
 						"Teleportation"
 					],

--- a/Library/Psionics/Psionic Packages/Teleportation/Fetching.gct
+++ b/Library/Psionics/Psionic Packages/Teleportation/Fetching.gct
@@ -62,6 +62,7 @@
 					"name": "Exoteleport",
 					"reference": "PSI69",
 					"tags": [
+						"PsionicSkill:Teleportation",
 						"Psionics",
 						"Teleportation"
 					],

--- a/Library/Psionics/Psionic Packages/Teleportation/Grounded.gct
+++ b/Library/Psionics/Psionic Packages/Teleportation/Grounded.gct
@@ -101,6 +101,7 @@
 					"name": "Portersense",
 					"reference": "PSI71",
 					"tags": [
+						"PsionicSkill:Teleportation",
 						"Psionics",
 						"Teleportation"
 					],

--- a/Library/Psionics/Psionic Packages/Teleportation/Hop Other.gct
+++ b/Library/Psionics/Psionic Packages/Teleportation/Hop Other.gct
@@ -175,6 +175,7 @@
 					"name": "Exoteleport",
 					"reference": "PSI69",
 					"tags": [
+						"PsionicSkill:Teleportation",
 						"Psionics",
 						"Teleportation"
 					],

--- a/Library/Psionics/Psionic Packages/Teleportation/Hop.gct
+++ b/Library/Psionics/Psionic Packages/Teleportation/Hop.gct
@@ -167,6 +167,7 @@
 			"name": "Autoteleport",
 			"reference": "PSI68",
 			"tags": [
+				"PsionicSkill:Teleportation",
 				"Psionics",
 				"Teleportation"
 			],

--- a/Library/Psionics/Psionic Packages/Teleportation/Object-Sending.gct
+++ b/Library/Psionics/Psionic Packages/Teleportation/Object-Sending.gct
@@ -81,6 +81,7 @@
 					"name": "Exoteleport",
 					"reference": "PSI69",
 					"tags": [
+						"PsionicSkill:Teleportation",
 						"Psionics",
 						"Teleportation"
 					],

--- a/Library/Psionics/Psionic Packages/Teleportation/Personal Teleportation.gct
+++ b/Library/Psionics/Psionic Packages/Teleportation/Personal Teleportation.gct
@@ -205,6 +205,7 @@
 					"name": "Autoteleport",
 					"reference": "PSI68",
 					"tags": [
+						"PsionicSkill:Teleportation",
 						"Psionics",
 						"Teleportation"
 					],

--- a/Library/Psionics/Psionic Packages/Teleportation/Tele-Dodge.gct
+++ b/Library/Psionics/Psionic Packages/Teleportation/Tele-Dodge.gct
@@ -59,6 +59,7 @@
 					"name": "Autoteleport",
 					"reference": "PSI68",
 					"tags": [
+						"PsionicSkill:Teleportation",
 						"Psionics",
 						"Teleportation"
 					],

--- a/Library/Psionics/Psionic Packages/Teleportation/Versatile Teleportation.gct
+++ b/Library/Psionics/Psionic Packages/Teleportation/Versatile Teleportation.gct
@@ -175,6 +175,7 @@
 					"name": "Exoteleport",
 					"reference": "PSI69",
 					"tags": [
+						"PsionicSkill:Teleportation",
 						"Psionics",
 						"Teleportation"
 					],

--- a/Library/Psionics/Psionics Skills.skl
+++ b/Library/Psionics/Psionics Skills.skl
@@ -5195,10 +5195,8 @@
 					"reference": "PSI55",
 					"tags": [
 						"PsionicSkill:Psychokinesis",
-						"PsionicSkill:Telekinesis",
 						"Psionics",
-						"Psychokinesis",
-						"Telekinesis"
+						"Psychokinesis"
 					],
 					"difficulty": "will/h",
 					"defaults": [
@@ -5305,10 +5303,8 @@
 					"reference": "PSI56",
 					"tags": [
 						"PsionicSkill:Psychokinesis",
-						"PsionicSkill:Telekinesis",
 						"Psionics",
-						"Psychokinesis",
-						"Telekinesis"
+						"Psychokinesis"
 					],
 					"difficulty": "iq/h",
 					"defaults": [
@@ -5343,10 +5339,8 @@
 					"reference": "PSI56",
 					"tags": [
 						"PsionicSkill:Psychokinesis",
-						"PsionicSkill:Telekinesis",
 						"Psionics",
-						"Psychokinesis",
-						"Telekinesis"
+						"Psychokinesis"
 					],
 					"difficulty": "will/h",
 					"defaults": [

--- a/Library/Psionics/Psionics Skills.skl
+++ b/Library/Psionics/Psionics Skills.skl
@@ -3465,6 +3465,8 @@
 					"name": "Spirit Communication",
 					"reference": "PSI43",
 					"tags": [
+						"PsionicSkill:Necrokinesis",
+						"PsionicSkill:Animakinesis",
 						"PsionicSkill:Remote Senses",
 						"PsionicSkill:ESP",
 						"ESP",
@@ -3993,6 +3995,8 @@
 					"name": "Aura Reading",
 					"reference": "PSI46",
 					"tags": [
+						"PsionicSkill:Necrokinesis",
+						"PsionicSkill:Animakinesis",
 						"PsionicSkill:Psychic Healing",
 						"Psionics",
 						"Psychic Healing"

--- a/Library/Psionics/Psionics Skills.skl
+++ b/Library/Psionics/Psionics Skills.skl
@@ -15,6 +15,7 @@
 					"name": "Animal Speech",
 					"reference": "PSI71",
 					"tags": [
+						"PsionicSkill:Animal Telepathy",
 						"Animal Telepathy",
 						"Psionics"
 					],
@@ -44,6 +45,7 @@
 					"name": "Beast Control",
 					"reference": "PSI72",
 					"tags": [
+						"PsionicSkill:Animal Telepathy",
 						"Animal Telepathy",
 						"Psionics"
 					],
@@ -156,6 +158,7 @@
 					"name": "Cancellation",
 					"reference": "PSI23",
 					"tags": [
+						"PsionicSkill:Anti-Psi",
 						"Anti-Psi",
 						"Psionics"
 					],
@@ -341,6 +344,7 @@
 					"name": "Para-Invisibility",
 					"reference": "PSI23",
 					"tags": [
+						"PsionicSkill:Anti-Psi",
 						"Anti-Psi",
 						"Psionics"
 					],
@@ -412,6 +416,7 @@
 					"name": "Psionic Resistance",
 					"reference": "PSI23",
 					"tags": [
+						"PsionicSkill:Anti-Psi",
 						"Anti-Psi",
 						"Psionics"
 					],
@@ -452,6 +457,7 @@
 					"name": "Psionic Resistance (All)",
 					"reference": "PSI23",
 					"tags": [
+						"PsionicSkill:Anti-Psi",
 						"Anti-Psi",
 						"Psionics"
 					],
@@ -495,6 +501,7 @@
 					"name": "Psionic Shield",
 					"reference": "PSI24",
 					"tags": [
+						"PsionicSkill:Anti-Psi",
 						"Anti-Psi",
 						"Psionics"
 					],
@@ -530,6 +537,7 @@
 					"name": "Psychic Armor",
 					"reference": "PSI25",
 					"tags": [
+						"PsionicSkill:Anti-Psi",
 						"Anti-Psi",
 						"Psionics"
 					],
@@ -583,6 +591,7 @@
 					"name": "Screaming",
 					"reference": "PSI25",
 					"tags": [
+						"PsionicSkill:Anti-Psi",
 						"Anti-Psi",
 						"Psionics"
 					],
@@ -654,6 +663,7 @@
 					"name": "True Sight (Anti-Psi)",
 					"reference": "PSI25",
 					"tags": [
+						"PsionicSkill:Anti-Psi",
 						"Anti-Psi",
 						"Psionics"
 					],
@@ -700,6 +710,7 @@
 					"name": "Astral Armor",
 					"reference": "PSI26",
 					"tags": [
+						"PsionicSkill:Astral Projection",
 						"Astral Projection",
 						"Psionics"
 					],
@@ -753,6 +764,7 @@
 					"name": "Astral Movement",
 					"reference": "PSI26",
 					"tags": [
+						"PsionicSkill:Astral Projection",
 						"Astral Projection",
 						"Psionics"
 					],
@@ -788,6 +800,7 @@
 					"name": "Astral Sight",
 					"reference": "PSI27",
 					"tags": [
+						"PsionicSkill:Astral Projection",
 						"Astral Projection",
 						"Psionics"
 					],
@@ -823,6 +836,7 @@
 					"name": "Astral Sword",
 					"reference": "PSI28",
 					"tags": [
+						"PsionicSkill:Astral Projection",
 						"Astral Projection",
 						"Psionics"
 					],
@@ -864,6 +878,7 @@
 					"reference": "PSI28",
 					"local_notes": "Astral Move \u003cscript\u003e\nif(entity.exists) {\n  self.level()/2\n} else {\n  \"will be shown when added to a character sheet.\"\n}\u003c/script\u003e",
 					"tags": [
+						"PsionicSkill:Astral Projection",
 						"Astral Projection",
 						"Psionics"
 					],
@@ -1093,6 +1108,7 @@
 					"name": "Mold Flesh",
 					"reference": "PSI72",
 					"tags": [
+						"PsionicSkill:Biokinesis",
 						"Biokinesis",
 						"Psionics"
 					],
@@ -1158,6 +1174,7 @@
 					"name": "Strike Sense",
 					"reference": "PSI73",
 					"tags": [
+						"PsionicSkill:Biokinesis",
 						"Biokinesis",
 						"Psionics"
 					],
@@ -1193,6 +1210,7 @@
 					"name": "Dream Projection",
 					"reference": "PSI73",
 					"tags": [
+						"PsionicSkill:Dream Control",
 						"Dream Control",
 						"Psionics"
 					],
@@ -1258,6 +1276,7 @@
 					"name": "Reshape Dream",
 					"reference": "PSI74",
 					"tags": [
+						"PsionicSkill:Dream Control",
 						"Dream Control",
 						"Psionics"
 					],
@@ -1367,6 +1386,8 @@
 							"name": "Data Retrieval",
 							"reference": "PSI30",
 							"tags": [
+								"PsionicSkill:Cyberpsi",
+								"PsionicSkill:Ergokinesis",
 								"Cyberpsi",
 								"Ergokinesis",
 								"Psionics"
@@ -1403,6 +1424,8 @@
 							"name": "I/O Tap",
 							"reference": "PSI30",
 							"tags": [
+								"PsionicSkill:Cyberpsi",
+								"PsionicSkill:Ergokinesis",
 								"Cyberpsi",
 								"Ergokinesis",
 								"Psionics"
@@ -1458,6 +1481,8 @@
 							"name": "Netrunning",
 							"reference": "PSI31",
 							"tags": [
+								"PsionicSkill:Cyberpsi",
+								"PsionicSkill:Ergokinesis",
 								"Cyberpsi",
 								"Ergokinesis",
 								"Psionics"
@@ -1494,6 +1519,8 @@
 							"name": "Remote Control",
 							"reference": "PSI31",
 							"tags": [
+								"PsionicSkill:Cyberpsi",
+								"PsionicSkill:Ergokinesis",
 								"Cyberpsi",
 								"Ergokinesis",
 								"Psionics"
@@ -1618,6 +1645,8 @@
 							"name": "Confuse",
 							"reference": "PSI32",
 							"tags": [
+								"PsionicSkill:Electrokinesis",
+								"PsionicSkill:Ergokinesis",
 								"Electrokinesis",
 								"Ergokinesis",
 								"Psionics"
@@ -1654,6 +1683,8 @@
 							"name": "Dampen",
 							"reference": "PSI33",
 							"tags": [
+								"PsionicSkill:Electrokinesis",
+								"PsionicSkill:Ergokinesis",
 								"Electrokinesis",
 								"Ergokinesis",
 								"Psionics"
@@ -1728,6 +1759,8 @@
 							"name": "EK Shield",
 							"reference": "PSI33",
 							"tags": [
+								"PsionicSkill:Electrokinesis",
+								"PsionicSkill:Ergokinesis",
 								"Electrokinesis",
 								"Ergokinesis",
 								"Psionics"
@@ -1764,6 +1797,8 @@
 							"name": "Electric Vision",
 							"reference": "PSI33",
 							"tags": [
+								"PsionicSkill:Electrokinesis",
+								"PsionicSkill:Ergokinesis",
 								"Electrokinesis",
 								"Ergokinesis",
 								"Psionics"
@@ -1838,6 +1873,8 @@
 							"name": "Lightning",
 							"reference": "PSI33",
 							"tags": [
+								"PsionicSkill:Electrokinesis",
+								"PsionicSkill:Ergokinesis",
 								"Electrokinesis",
 								"Ergokinesis",
 								"Psionics"
@@ -1950,6 +1987,8 @@
 							"name": "Radar Sense",
 							"reference": "PSI34",
 							"tags": [
+								"PsionicSkill:Electrokinesis",
+								"PsionicSkill:Ergokinesis",
 								"Electrokinesis",
 								"Ergokinesis",
 								"Psionics"
@@ -2005,6 +2044,8 @@
 							"name": "Surge",
 							"reference": "PSI34",
 							"tags": [
+								"PsionicSkill:Electrokinesis",
+								"PsionicSkill:Ergokinesis",
 								"Electrokinesis",
 								"Ergokinesis",
 								"Psionics"
@@ -2128,6 +2169,8 @@
 							"name": "Flash",
 							"reference": "PSI35",
 							"tags": [
+								"PsionicSkill:Photokinesis",
+								"PsionicSkill:Ergokinesis",
 								"Ergokinesis",
 								"Photokinesis",
 								"Psionics"
@@ -2164,6 +2207,8 @@
 							"name": "Hologram",
 							"reference": "PSI35",
 							"tags": [
+								"PsionicSkill:Photokinesis",
+								"PsionicSkill:Ergokinesis",
 								"Ergokinesis",
 								"Photokinesis",
 								"Psionics"
@@ -2257,6 +2302,8 @@
 							"name": "Photorefraction",
 							"reference": "PSI35",
 							"tags": [
+								"PsionicSkill:Photokinesis",
+								"PsionicSkill:Ergokinesis",
 								"Ergokinesis",
 								"Photokinesis",
 								"Psionics"
@@ -2343,6 +2390,8 @@
 					"name": "Common Sense",
 					"reference": "PSI43",
 					"tags": [
+						"PsionicSkill:Divination",
+						"PsionicSkill:ESP",
 						"Divination",
 						"ESP",
 						"Psionics"
@@ -2397,6 +2446,8 @@
 					"name": "Danger Sense",
 					"reference": "PSI43",
 					"tags": [
+						"PsionicSkill:Divination",
+						"PsionicSkill:ESP",
 						"Divination",
 						"ESP",
 						"Psionics"
@@ -2443,6 +2494,8 @@
 							"name": "Combat Sense",
 							"reference": "PSI37",
 							"tags": [
+								"PsionicSkill:Divination",
+								"PsionicSkill:ESP",
 								"Divination",
 								"ESP",
 								"Psionics"
@@ -2575,6 +2628,8 @@
 							"name": "Prognostication",
 							"reference": "PSI37",
 							"tags": [
+								"PsionicSkill:Divination",
+								"PsionicSkill:ESP",
 								"Divination",
 								"ESP",
 								"Psionics"
@@ -2611,6 +2666,8 @@
 							"name": "Psi Sense",
 							"reference": "PSI41",
 							"tags": [
+								"PsionicSkill:Divination",
+								"PsionicSkill:ESP",
 								"Divination",
 								"ESP",
 								"Psionics"
@@ -2659,6 +2716,8 @@
 							"name": "Retrocognition",
 							"reference": "PSI38",
 							"tags": [
+								"PsionicSkill:Divination",
+								"PsionicSkill:ESP",
 								"Divination",
 								"ESP",
 								"Psionics"
@@ -2707,6 +2766,8 @@
 							"name": "Visions",
 							"reference": "PSI37",
 							"tags": [
+								"PsionicSkill:Divination",
+								"PsionicSkill:ESP",
 								"Divination",
 								"ESP",
 								"Psionics"
@@ -2818,6 +2879,8 @@
 					"name": "Illuminated",
 					"reference": "PSI43",
 					"tags": [
+						"PsionicSkill:Divination",
+						"PsionicSkill:ESP",
 						"Divination",
 						"ESP",
 						"Psionics"
@@ -2890,6 +2953,8 @@
 					"name": "Oracle",
 					"reference": "PSI43",
 					"tags": [
+						"PsionicSkill:Divination",
+						"PsionicSkill:ESP",
 						"Divination",
 						"ESP",
 						"Psionics"
@@ -2944,6 +3009,8 @@
 					"name": "Psidar",
 					"reference": "PSI41",
 					"tags": [
+						"PsionicSkill:Remote Senses",
+						"PsionicSkill:ESP",
 						"ESP",
 						"Psionics",
 						"Remote Senses"
@@ -2980,6 +3047,8 @@
 					"name": "Psychic Hunches",
 					"reference": "PSI42",
 					"tags": [
+						"PsionicSkill:Divination",
+						"PsionicSkill:ESP",
 						"Divination",
 						"ESP",
 						"Psionics"
@@ -3016,6 +3085,8 @@
 					"name": "Racial Memory",
 					"reference": "PSI43",
 					"tags": [
+						"PsionicSkill:Divination",
+						"PsionicSkill:ESP",
 						"Divination",
 						"ESP",
 						"Psionics"
@@ -3085,6 +3156,8 @@
 							"name": "Awareness",
 							"reference": "PSI39",
 							"tags": [
+								"PsionicSkill:Remote Senses",
+								"PsionicSkill:ESP",
 								"ESP",
 								"Psionics",
 								"Remote Senses"
@@ -3140,6 +3213,8 @@
 							"name": "Clairvoyance",
 							"reference": "PSI40",
 							"tags": [
+								"PsionicSkill:Remote Senses",
+								"PsionicSkill:ESP",
 								"ESP",
 								"Psionics",
 								"Remote Senses"
@@ -3316,6 +3391,8 @@
 					"name": "Seekersense",
 					"reference": "PSI42",
 					"tags": [
+						"PsionicSkill:Remote Senses",
+						"PsionicSkill:ESP",
 						"ESP",
 						"Psionics",
 						"Remote Senses"
@@ -3388,6 +3465,8 @@
 					"name": "Spirit Communication",
 					"reference": "PSI43",
 					"tags": [
+						"PsionicSkill:Remote Senses",
+						"PsionicSkill:ESP",
 						"ESP",
 						"Psionics",
 						"Remote Senses"
@@ -3424,6 +3503,8 @@
 					"name": "True Sight (ESP)",
 					"reference": "PSI43",
 					"tags": [
+						"PsionicSkill:Remote Senses",
+						"PsionicSkill:ESP",
 						"ESP",
 						"Psionics",
 						"Remote Senses"
@@ -3559,6 +3640,7 @@
 					"name": "Adjustment",
 					"reference": "PSI44",
 					"tags": [
+						"PsionicSkill:Probability Alteration",
 						"Probability Alteration",
 						"Psionics"
 					],
@@ -3611,6 +3693,7 @@
 					"name": "Coincidence",
 					"reference": "PSI44",
 					"tags": [
+						"PsionicSkill:Probability Alteration",
 						"Probability Alteration",
 						"Psionics"
 					],
@@ -3646,6 +3729,7 @@
 					"name": "Combat Sense",
 					"reference": "PSI45",
 					"tags": [
+						"PsionicSkill:Probability Alteration",
 						"Probability Alteration",
 						"Psionics"
 					],
@@ -3682,6 +3766,7 @@
 					"name": "Curse",
 					"reference": "PSI45",
 					"tags": [
+						"PsionicSkill:Probability Alteration",
 						"Probability Alteration",
 						"Psionics"
 					],
@@ -3771,6 +3856,7 @@
 					"name": "Second Chance",
 					"reference": "PSI45",
 					"tags": [
+						"PsionicSkill:Probability Alteration",
 						"Probability Alteration",
 						"Psionics"
 					],
@@ -3842,6 +3928,7 @@
 					"name": "Weather Control",
 					"reference": "PSI45",
 					"tags": [
+						"PsionicSkill:Probability Alteration",
 						"Probability Alteration",
 						"Psionics"
 					],
@@ -3906,6 +3993,7 @@
 					"name": "Aura Reading",
 					"reference": "PSI46",
 					"tags": [
+						"PsionicSkill:Psychic Healing",
 						"Psionics",
 						"Psychic Healing"
 					],
@@ -3941,6 +4029,7 @@
 					"name": "Cure",
 					"reference": "PSI46",
 					"tags": [
+						"PsionicSkill:Psychic Healing",
 						"Psionics",
 						"Psychic Healing"
 					],
@@ -4054,6 +4143,7 @@
 					"name": "Disease Shield",
 					"reference": "PSI48",
 					"tags": [
+						"PsionicSkill:Psychic Healing",
 						"Psionics",
 						"Psychic Healing"
 					],
@@ -4089,6 +4179,7 @@
 					"name": "Empathy",
 					"reference": "PSI49",
 					"tags": [
+						"PsionicSkill:Psychic Healing",
 						"Psionics",
 						"Psychic Healing"
 					],
@@ -4142,6 +4233,7 @@
 					"name": "Life Extension",
 					"reference": "PSI46",
 					"tags": [
+						"PsionicSkill:Psychic Healing",
 						"Psionics",
 						"Psychic Healing"
 					],
@@ -4195,6 +4287,7 @@
 					"name": "Metabolism Control",
 					"reference": "PSI49",
 					"tags": [
+						"PsionicSkill:Psychic Healing",
 						"Psionics",
 						"Psychic Healing"
 					],
@@ -4266,6 +4359,7 @@
 					"name": "Sleep (Psychic Healing)",
 					"reference": "PSI49",
 					"tags": [
+						"PsionicSkill:Psychic Healing",
 						"Psionics",
 						"Psychic Healing"
 					],
@@ -4481,6 +4575,7 @@
 					"name": "Detect Life",
 					"reference": "PSI52",
 					"tags": [
+						"PsionicSkill:Psychic Vampirism",
 						"Psionics",
 						"Psychic Vampirism"
 					],
@@ -4512,6 +4607,7 @@
 					"name": "Drain DX",
 					"reference": "PSI50",
 					"tags": [
+						"PsionicSkill:Psychic Vampirism",
 						"Psionics",
 						"Psychic Vampirism"
 					],
@@ -4547,6 +4643,7 @@
 					"name": "Drain Emotion",
 					"reference": "PSI50",
 					"tags": [
+						"PsionicSkill:Psychic Vampirism",
 						"Psionics",
 						"Psychic Vampirism"
 					],
@@ -4582,6 +4679,7 @@
 					"name": "Drain HT",
 					"reference": "PSI50",
 					"tags": [
+						"PsionicSkill:Psychic Vampirism",
 						"Psionics",
 						"Psychic Vampirism"
 					],
@@ -4617,6 +4715,7 @@
 					"name": "Drain IQ",
 					"reference": "PSI50",
 					"tags": [
+						"PsionicSkill:Psychic Vampirism",
 						"Psionics",
 						"Psychic Vampirism"
 					],
@@ -4652,6 +4751,7 @@
 					"name": "Drain ST",
 					"reference": "PSI50",
 					"tags": [
+						"PsionicSkill:Psychic Vampirism",
 						"Psionics",
 						"Psychic Vampirism"
 					],
@@ -4939,6 +5039,7 @@
 					"name": "Steal Dreams",
 					"reference": "PSI50",
 					"tags": [
+						"PsionicSkill:Psychic Vampirism",
 						"Psionics",
 						"Psychic Vampirism"
 					],
@@ -4974,6 +5075,7 @@
 					"name": "Steal Energy",
 					"reference": "PSI51",
 					"tags": [
+						"PsionicSkill:Psychic Vampirism",
 						"Psionics",
 						"Psychic Vampirism"
 					],
@@ -5009,6 +5111,7 @@
 					"name": "Steal Life",
 					"reference": "PSI52",
 					"tags": [
+						"PsionicSkill:Psychic Vampirism",
 						"Psionics",
 						"Psychic Vampirism"
 					],
@@ -5044,6 +5147,7 @@
 					"name": "Steal Power",
 					"reference": "PSI52",
 					"tags": [
+						"PsionicSkill:Psychic Vampirism",
 						"Psionics",
 						"Psychic Vampirism"
 					],
@@ -5090,6 +5194,8 @@
 					"name": "Cryokinesis",
 					"reference": "PSI55",
 					"tags": [
+						"PsionicSkill:Psychokinesis",
+						"PsionicSkill:Telekinesis",
 						"Psionics",
 						"Psychokinesis",
 						"Telekinesis"
@@ -5198,6 +5304,8 @@
 					"name": "PK Shield",
 					"reference": "PSI56",
 					"tags": [
+						"PsionicSkill:Psychokinesis",
+						"PsionicSkill:Telekinesis",
 						"Psionics",
 						"Psychokinesis",
 						"Telekinesis"
@@ -5234,6 +5342,8 @@
 					"name": "Pyrokinesis",
 					"reference": "PSI56",
 					"tags": [
+						"PsionicSkill:Psychokinesis",
+						"PsionicSkill:Telekinesis",
 						"Psionics",
 						"Psychokinesis",
 						"Telekinesis"
@@ -5336,6 +5446,8 @@
 							"name": "Levitation",
 							"reference": "PSI55",
 							"tags": [
+								"PsionicSkill:Psychokinesis",
+								"PsionicSkill:Telekinesis",
 								"Psionics",
 								"Psychokinesis",
 								"Telekinesis"
@@ -5467,6 +5579,8 @@
 							"name": "Telekinetic Control",
 							"reference": "PSI54",
 							"tags": [
+								"PsionicSkill:Psychokinesis",
+								"PsionicSkill:Telekinesis",
 								"Psionics",
 								"Psychokinesis",
 								"Telekinesis"
@@ -5522,6 +5636,8 @@
 							"name": "TK Bullet",
 							"reference": "PSI53",
 							"tags": [
+								"PsionicSkill:Psychokinesis",
+								"PsionicSkill:Telekinesis",
 								"Psionics",
 								"Psychokinesis",
 								"Telekinesis"
@@ -5558,6 +5674,8 @@
 							"name": "TK Crush",
 							"reference": "PSI54",
 							"tags": [
+								"PsionicSkill:Psychokinesis",
+								"PsionicSkill:Telekinesis",
 								"Psionics",
 								"Psychokinesis",
 								"Telekinesis"
@@ -5594,6 +5712,8 @@
 							"name": "TK Grab",
 							"reference": "PSI54",
 							"tags": [
+								"PsionicSkill:Psychokinesis",
+								"PsionicSkill:Telekinesis",
 								"Psionics",
 								"Psychokinesis",
 								"Telekinesis"
@@ -5643,6 +5763,7 @@
 					"name": "Damage Control",
 					"reference": "PSI75",
 					"tags": [
+						"PsionicSkill:Psychometabolism",
 						"Psionics",
 						"Psychometabolism"
 					],
@@ -5690,6 +5811,7 @@
 					"name": "Projected Senses",
 					"reference": "PSI75",
 					"tags": [
+						"PsionicSkill:Psychometabolism",
 						"Psionics",
 						"Psychometabolism"
 					],
@@ -5777,6 +5899,8 @@
 							"name": "Borrow Skill",
 							"reference": "PSI57",
 							"tags": [
+								"PsionicSkill:Telepathy",
+								"PsionicSkill:Communication",
 								"Communication",
 								"Psionics",
 								"Telepathy"
@@ -5851,6 +5975,8 @@
 							"name": "Emotion Sense",
 							"reference": "PSI58",
 							"tags": [
+								"PsionicSkill:Telepathy",
+								"PsionicSkill:Communication",
 								"Communication",
 								"Psionics",
 								"Telepathy"
@@ -6040,6 +6166,8 @@
 							"name": "Telereceive",
 							"reference": "PSI58",
 							"tags": [
+								"PsionicSkill:Telepathy",
+								"PsionicSkill:Communication",
 								"Communication",
 								"Psionics",
 								"Telepathy"
@@ -6088,6 +6216,8 @@
 							"name": "Telesend",
 							"reference": "PSI60",
 							"tags": [
+								"PsionicSkill:Telepathy",
+								"PsionicSkill:Communication",
 								"Communication",
 								"Psionics",
 								"Telepathy"
@@ -6224,6 +6354,8 @@
 							"name": "Aspect",
 							"reference": "PSI61",
 							"tags": [
+								"PsionicSkill:Telepathy",
+								"PsionicSkill:Control",
 								"Control",
 								"Psionics",
 								"Telepathy"
@@ -6355,6 +6487,8 @@
 							"name": "Mental Surgery",
 							"reference": "PSI61",
 							"tags": [
+								"PsionicSkill:Telepathy",
+								"PsionicSkill:Control",
 								"Control",
 								"Psionics",
 								"Telepathy"
@@ -6391,6 +6525,8 @@
 							"name": "Mind Swap",
 							"reference": "PSI62",
 							"tags": [
+								"PsionicSkill:Telepathy",
+								"PsionicSkill:Control",
 								"Control",
 								"Psionics",
 								"Telepathy"
@@ -6427,6 +6563,8 @@
 							"name": "Mindwipe",
 							"reference": "PSI62",
 							"tags": [
+								"PsionicSkill:Telepathy",
+								"PsionicSkill:Control",
 								"Control",
 								"Psionics",
 								"Telepathy"
@@ -6577,6 +6715,8 @@
 							"name": "Sensory Control",
 							"reference": "PSI62",
 							"tags": [
+								"PsionicSkill:Telepathy",
+								"PsionicSkill:Control",
 								"Control",
 								"Psionics",
 								"Telepathy"
@@ -6644,6 +6784,8 @@
 							"name": "Suggestion",
 							"reference": "PSI61",
 							"tags": [
+								"PsionicSkill:Telepathy",
+								"PsionicSkill:Control",
 								"Control",
 								"Psionics",
 								"Telepathy"
@@ -6692,6 +6834,8 @@
 							"name": "Telecontrol",
 							"reference": "PSI64",
 							"tags": [
+								"PsionicSkill:Telepathy",
+								"PsionicSkill:Control",
 								"Control",
 								"Psionics",
 								"Telepathy"
@@ -6797,6 +6941,8 @@
 							"name": "Instill Fear",
 							"reference": "PSI64",
 							"tags": [
+								"PsionicSkill:Telepathy",
+								"PsionicSkill:Offense",
 								"Offense",
 								"Psionics",
 								"Telepathy"
@@ -6852,6 +6998,8 @@
 							"name": "Mental Blow",
 							"reference": "PSI65",
 							"tags": [
+								"PsionicSkill:Telepathy",
+								"PsionicSkill:Offense",
 								"Offense",
 								"Psionics",
 								"Telepathy"
@@ -6888,6 +7036,8 @@
 							"name": "Mental Stab",
 							"reference": "PSI65",
 							"tags": [
+								"PsionicSkill:Telepathy",
+								"PsionicSkill:Offense",
 								"Offense",
 								"Psionics",
 								"Telepathy"
@@ -6962,6 +7112,8 @@
 							"name": "Sleep (Telepathy)",
 							"reference": "PSI65",
 							"tags": [
+								"PsionicSkill:Telepathy",
+								"PsionicSkill:Offense",
 								"Offense",
 								"Psionics",
 								"Telepathy"
@@ -7067,6 +7219,8 @@
 							"name": "Mind Clouding",
 							"reference": "PSI66",
 							"tags": [
+								"PsionicSkill:Telepathy",
+								"PsionicSkill:Sense and Defense",
 								"Psionics",
 								"Sense and Defense",
 								"Telepathy"
@@ -7103,6 +7257,8 @@
 							"name": "Mind Shield",
 							"reference": "PSI66",
 							"tags": [
+								"PsionicSkill:Telepathy",
+								"PsionicSkill:Sense and Defense",
 								"Psionics",
 								"Sense and Defense",
 								"Telepathy"
@@ -7177,6 +7333,8 @@
 							"name": "Telepathy Sense",
 							"reference": "PSI67",
 							"tags": [
+								"PsionicSkill:Telepathy",
+								"PsionicSkill:Sense and Defense",
 								"Psionics",
 								"Sense and Defense",
 								"Telepathy"
@@ -7213,6 +7371,8 @@
 							"name": "Telescan",
 							"reference": "PSI67",
 							"tags": [
+								"PsionicSkill:Telepathy",
+								"PsionicSkill:Sense and Defense",
 								"Psionics",
 								"Sense and Defense",
 								"Telepathy"
@@ -7262,6 +7422,7 @@
 					"name": "Autoteleport",
 					"reference": "PSI68",
 					"tags": [
+						"PsionicSkill:Teleportation",
 						"Psionics",
 						"Teleportation"
 					],
@@ -7349,6 +7510,7 @@
 					"name": "Exoteleport",
 					"reference": "PSI69",
 					"tags": [
+						"PsionicSkill:Teleportation",
 						"Psionics",
 						"Teleportation"
 					],
@@ -7441,6 +7603,7 @@
 					"name": "Innerportation",
 					"reference": "PSI70",
 					"tags": [
+						"PsionicSkill:Teleportation",
 						"Psionics",
 						"Teleportation"
 					],
@@ -7512,6 +7675,7 @@
 					"name": "Portersense",
 					"reference": "PSI71",
 					"tags": [
+						"PsionicSkill:Teleportation",
 						"Psionics",
 						"Teleportation"
 					],
@@ -7548,8 +7712,8 @@
 					"reference": "PSI41",
 					"tags": [
 						"Psionics",
-						"Teleportation",
-						"Technique"
+						"Technique",
+						"Teleportation"
 					],
 					"difficulty": "h",
 					"default": {
@@ -7566,8 +7730,8 @@
 					"reference": "PSI41",
 					"tags": [
 						"Psionics",
-						"Teleportation",
-						"Technique"
+						"Technique",
+						"Teleportation"
 					],
 					"difficulty": "h",
 					"default": {

--- a/Library/Psionics/Psionics Skills.skl
+++ b/Library/Psionics/Psionics Skills.skl
@@ -2300,7 +2300,7 @@
 						{
 							"id": "sXPF7Cai8fxgyYWz_",
 							"name": "Photorefraction",
-							"reference": "PSI35",
+							"reference": "PSI36",
 							"tags": [
 								"PsionicSkill:Photokinesis",
 								"PsionicSkill:Ergokinesis",

--- a/Library/Psionics/Psionics Traits.adq
+++ b/Library/Psionics/Psionics Traits.adq
@@ -2452,9 +2452,10 @@
 						{
 							"id": "tGg2X3mbY68hUg9Q-",
 							"name": "Dream Control Talent",
-							"reference": "Dream Control, Power",
 							"tags": [
-								"Mental"
+								"Mental",
+								"Dream Control",
+								"Power"
 							],
 							"points_per_level": 5,
 							"features": [

--- a/Library/Psionics/Psionics Traits.adq
+++ b/Library/Psionics/Psionics Traits.adq
@@ -370,19 +370,9 @@
 								{
 									"type": "skill_bonus",
 									"selection_type": "skills_with_name",
-									"name": {
+									"tags": {
 										"compare": "is",
-										"qualifier": "Animal Speech"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Beast Control"
+										"qualifier": "PsionicSkill:Animal Telepathy"
 									},
 									"amount": 1,
 									"per_level": true
@@ -472,79 +462,9 @@
 								{
 									"type": "skill_bonus",
 									"selection_type": "skills_with_name",
-									"name": {
+									"tags": {
 										"compare": "is",
-										"qualifier": "Cancellation"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Para-Invisibility"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Psionic Shield"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Screaming"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "True Sight"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Psychic Armor"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Psionic Resistance (All)"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Psionic Resistance"
+										"qualifier": "PsionicSkill:Anti-Psi"
 									},
 									"amount": 1,
 									"per_level": true
@@ -1336,49 +1256,9 @@
 								{
 									"type": "skill_bonus",
 									"selection_type": "skills_with_name",
-									"name": {
+									"tags": {
 										"compare": "is",
-										"qualifier": "Astral Armor"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Astral Movement"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Astral Sight"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Astral Travel"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Astral Sword"
+										"qualifier": "PsionicSkill:Astral Projection"
 									},
 									"amount": 1,
 									"per_level": true
@@ -1587,6 +1467,7 @@
 							"weapons": [
 								{
 									"id": "wmT_KsnggaPBwrUIF",
+									"sv": 1,
 									"damage": {
 										"type": "cut",
 										"base": "1d-3"
@@ -1853,19 +1734,9 @@
 								{
 									"type": "skill_bonus",
 									"selection_type": "skills_with_name",
-									"name": {
+									"tags": {
 										"compare": "is",
-										"qualifier": "Mold Flesh"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Strike Sense"
+										"qualifier": "PsionicSkill:Biokinesis"
 									},
 									"amount": 1,
 									"per_level": true
@@ -1982,39 +1853,9 @@
 								{
 									"type": "skill_bonus",
 									"selection_type": "skills_with_name",
-									"name": {
+									"tags": {
 										"compare": "is",
-										"qualifier": "Borrow Skill"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Emotion Sense"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Telereceive"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Telesend"
+										"qualifier": "PsionicSkill:Communication"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2059,69 +1900,9 @@
 								{
 									"type": "skill_bonus",
 									"selection_type": "skills_with_name",
-									"name": {
+									"tags": {
 										"compare": "is",
-										"qualifier": "Aspect"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Mental Surgery"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Mind Swap"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Mindwipe"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Sensory Control"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Suggestion"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Telecontrol"
+										"qualifier": "PsionicSkill:Control"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2162,39 +1943,9 @@
 								{
 									"type": "skill_bonus",
 									"selection_type": "skills_with_name",
-									"name": {
+									"tags": {
 										"compare": "is",
-										"qualifier": "Data Retrieval"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Netrunning"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Remote Control"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "I/O Tap"
+										"qualifier": "PsionicSkill:Cyberpsi"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2241,113 +1992,9 @@
 								{
 									"type": "skill_bonus",
 									"selection_type": "skills_with_name",
-									"name": {
+									"tags": {
 										"compare": "is",
-										"qualifier": "Common Sense"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Danger Sense"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Illuminated"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Oracle"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Psychic Hunches"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Racial Memory"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Combat Sense"
-									},
-									"specialization": {
-										"compare": "is",
-										"qualifier": "Divination"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Prognostication"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Psi Sense"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Retrocognition"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Visions"
+										"qualifier": "PsionicSkill:Divination"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2388,69 +2035,9 @@
 								{
 									"type": "skill_bonus",
 									"selection_type": "skills_with_name",
-									"name": {
+									"tags": {
 										"compare": "is",
-										"qualifier": "Confuse"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Dampen"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "EK Shield"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Electric Vision"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Lightning"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Radar Sense"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Surge"
+										"qualifier": "PsionicSkill:Electrokinesis"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2593,39 +2180,9 @@
 								{
 									"type": "skill_bonus",
 									"selection_type": "skills_with_name",
-									"name": {
+									"tags": {
 										"compare": "is",
-										"qualifier": "Instill Fear"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Mental Blow"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Mental Stab"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Sleep (Telepathy)"
+										"qualifier": "PsionicSkill:Offense"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2666,29 +2223,9 @@
 								{
 									"type": "skill_bonus",
 									"selection_type": "skills_with_name",
-									"name": {
+									"tags": {
 										"compare": "is",
-										"qualifier": "Flash"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Hologram"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Photorefraction"
+										"qualifier": "PsionicSkill:Photokinesis"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2791,59 +2328,9 @@
 								{
 									"type": "skill_bonus",
 									"selection_type": "skills_with_name",
-									"name": {
+									"tags": {
 										"compare": "is",
-										"qualifier": "Psidar"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Seekersense"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Spirit Communication"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "True Sight (ESP)"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Awareness"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Clairvoyance"
+										"qualifier": "PsionicSkill:Remote Senses"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2888,39 +2375,9 @@
 								{
 									"type": "skill_bonus",
 									"selection_type": "skills_with_name",
-									"name": {
+									"tags": {
 										"compare": "is",
-										"qualifier": "Mind Clouding"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Mind Shield"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Telepathy Sense"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Telescan"
+										"qualifier": "PsionicSkill:Sense and Defense"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2964,49 +2421,9 @@
 								{
 									"type": "skill_bonus",
 									"selection_type": "skills_with_name",
-									"name": {
+									"tags": {
 										"compare": "is",
-										"qualifier": "TK Grab"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "TK Crush"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "TK Bullet"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Levitation"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Telekinetic Control"
+										"qualifier": "PsionicSkill:Telekinesis"
 									},
 									"amount": 1,
 									"per_level": true
@@ -3044,21 +2461,12 @@
 								{
 									"type": "skill_bonus",
 									"selection_type": "skills_with_name",
-									"name": {
+									"tags": {
 										"compare": "is",
-										"qualifier": "Dream Projection"
+										"qualifier": "PsionicSkill:Dream Control"
 									},
 									"amount": 1,
 									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Reshape Dream"
-									},
-									"amount": 1
 								}
 							],
 							"can_level": true,
@@ -3677,9 +3085,10 @@
 									"weapons": [
 										{
 											"id": "Wu9q1bhLJpk4K9FTT",
+											"sv": 1,
 											"damage": {
 												"type": "",
-												"base": "1d"
+												"base_leveled": "1d"
 											},
 											"usage": "Lightning",
 											"accuracy": "3",
@@ -3696,7 +3105,7 @@
 												}
 											],
 											"calc": {
-												"damage": "1d"
+												"damage": "1d per level"
 											}
 										}
 									],
@@ -3823,139 +3232,9 @@
 								{
 									"type": "skill_bonus",
 									"selection_type": "skills_with_name",
-									"name": {
+									"tags": {
 										"compare": "is",
-										"qualifier": "Data Retrieval"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "I/O Tap"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Netrunning"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Remote Control"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Confuse"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Dampen"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "EK Shield"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Electric Vision"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Lightning"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Radar Sense"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Surge"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Flash"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Hologram"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Photorefraction"
+										"qualifier": "PsionicSkill:Ergokinesis"
 									},
 									"amount": 1,
 									"per_level": true
@@ -5000,173 +4279,9 @@
 								{
 									"type": "skill_bonus",
 									"selection_type": "skills_with_name",
-									"name": {
+									"tags": {
 										"compare": "is",
-										"qualifier": "Common Sense"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Danger Sense"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Illuminated"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Oracle"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Psidar"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Psychic Hunches"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Racial Memory"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Seekersense"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Spirit Communication"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "True Sight (ESP)"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Combat Sense"
-									},
-									"specialization": {
-										"compare": "is",
-										"qualifier": "Divination"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Prognostication"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Psi Sense"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Retrocognition"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Visions"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Awareness"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Clairvoyance"
+										"qualifier": "PsionicSkill:ESP"
 									},
 									"amount": 1,
 									"per_level": true
@@ -6073,9 +5188,9 @@
 								{
 									"type": "skill_bonus",
 									"selection_type": "skills_with_name",
-									"name": {
+									"tags": {
 										"compare": "is",
-										"qualifier": "Adjustment"
+										"qualifier": "PsionicSkill:Probability Alteration"
 									},
 									"amount": 1,
 									"per_level": true
@@ -6127,41 +5242,11 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "Coincidence"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
 										"qualifier": "Crushing Strike"
 									},
 									"specialization": {
 										"compare": "contains",
 										"qualifier": "Probability Alteration"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Curse"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Combat Sense"
 									},
 									"amount": 1,
 									"per_level": true
@@ -6232,26 +5317,6 @@
 									"specialization": {
 										"compare": "contains",
 										"qualifier": "Probability Alteration"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Second Chance"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Weather Control"
 									},
 									"amount": 1,
 									"per_level": true
@@ -6979,69 +6044,9 @@
 								{
 									"type": "skill_bonus",
 									"selection_type": "skills_with_name",
-									"name": {
+									"tags": {
 										"compare": "is",
-										"qualifier": "Aura Reading"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Cure"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Disease Shield"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Life Extension"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Sleep (Psychic Healing)"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Empathy"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Metabolism Control"
+										"qualifier": "PsionicSkill:Psychic Healing"
 									},
 									"amount": 1,
 									"per_level": true
@@ -7597,99 +6602,9 @@
 								{
 									"type": "skill_bonus",
 									"selection_type": "skills_with_name",
-									"name": {
+									"tags": {
 										"compare": "is",
-										"qualifier": "Detect Life"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Drain DX"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Drain Emotion"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Drain HT"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Drain IQ"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Drain ST"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Steal Dreams"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Steal Energy"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Steal Life"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Steal Power"
+										"qualifier": "PsionicSkill:Psychic Vampirism"
 									},
 									"amount": 1,
 									"per_level": true
@@ -8311,79 +7226,9 @@
 								{
 									"type": "skill_bonus",
 									"selection_type": "skills_with_name",
-									"name": {
+									"tags": {
 										"compare": "is",
-										"qualifier": "TK Grab"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "TK Crush"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "TK Bullet"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Levitation"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Telekinetic Control"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Pyrokinesis"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "PK Shield"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Cryokinesis"
+										"qualifier": "PsionicSkill:Psychokinesis"
 									},
 									"amount": 1,
 									"per_level": true
@@ -8860,9 +7705,10 @@
 									"weapons": [
 										{
 											"id": "WDdi4oa7Au1iw0bbK",
+											"sv": 1,
 											"damage": {
 												"type": "pi",
-												"base": "1d-1"
+												"base_leveled": "1d-1"
 											},
 											"usage": "Bullet",
 											"accuracy": "3",
@@ -8876,14 +7722,15 @@
 												}
 											],
 											"calc": {
-												"damage": "1d-1 pi"
+												"damage": "1d-1 per level  pi"
 											}
 										},
 										{
 											"id": "W5OiWn_NM0WvDYZn8",
+											"sv": 1,
 											"damage": {
 												"type": "pi+",
-												"base": "1d-1"
+												"base_leveled": "1d-1"
 											},
 											"usage": "Flat Edge",
 											"accuracy": "3",
@@ -8903,14 +7750,15 @@
 												}
 											],
 											"calc": {
-												"damage": "1d-1 pi+"
+												"damage": "1d-1 per level  pi+"
 											}
 										},
 										{
 											"id": "WqoXDIWc9bYFTbtMB",
+											"sv": 1,
 											"damage": {
 												"type": "pi",
-												"base": "1d-1",
+												"base_leveled": "1d-1",
 												"armor_divisor": 2
 											},
 											"usage": "Sharp Edge",
@@ -8931,14 +7779,15 @@
 												}
 											],
 											"calc": {
-												"damage": "1d-1(2) pi"
+												"damage": "1d-1 per level (2) pi"
 											}
 										},
 										{
 											"id": "WE0sAZ08sWWPI_F1n",
+											"sv": 1,
 											"damage": {
 												"type": "pi",
-												"base": "1d-1"
+												"base_leveled": "1d-1"
 											},
 											"usage": "Rapid Fire",
 											"accuracy": "3",
@@ -8958,14 +7807,15 @@
 												}
 											],
 											"calc": {
-												"damage": "1d-1 pi"
+												"damage": "1d-1 per level  pi"
 											}
 										},
 										{
 											"id": "WPyouCP6cdw-TVOd4",
+											"sv": 1,
 											"damage": {
 												"type": "pi",
-												"base": "1d-2"
+												"base_leveled": "1d-2"
 											},
 											"usage": "Silencer",
 											"accuracy": "3",
@@ -8985,7 +7835,7 @@
 												}
 											],
 											"calc": {
-												"damage": "1d-2 pi"
+												"damage": "1d-2 per level  pi"
 											}
 										}
 									],
@@ -9010,9 +7860,10 @@
 									"weapons": [
 										{
 											"id": "W2biOmXLwGbRM3S7z",
+											"sv": 1,
 											"damage": {
 												"type": "pi/level",
-												"base": "1"
+												"base_leveled": "1"
 											},
 											"usage": "Gaze",
 											"rate_of_fire": "1",
@@ -9034,7 +7885,7 @@
 												}
 											],
 											"calc": {
-												"damage": "1 pi/level"
+												"damage": "1 per level  pi/level"
 											}
 										}
 									],
@@ -9304,19 +8155,9 @@
 								{
 									"type": "skill_bonus",
 									"selection_type": "skills_with_name",
-									"name": {
+									"tags": {
 										"compare": "is",
-										"qualifier": "Damage Control"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Projected Senses"
+										"qualifier": "PsionicSkill:Psychometabolism"
 									},
 									"amount": 1,
 									"per_level": true
@@ -11042,189 +9883,9 @@
 								{
 									"type": "skill_bonus",
 									"selection_type": "skills_with_name",
-									"name": {
+									"tags": {
 										"compare": "is",
-										"qualifier": "Borrow Skill"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Emotion Sense"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Telereceive"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Telesend"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Aspect"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Mental Surgery"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Mind Swap"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Mindwipe"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Sensory Control"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Suggestion"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Telecontrol"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Instill Fear"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Mental Blow"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Mental Stab"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Sleep (Telepathy)"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Mind Clouding"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Mind Shield"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Telepathy Sense"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Telescan"
+										"qualifier": "PsionicSkill:Telepathy"
 									},
 									"amount": 1,
 									"per_level": true
@@ -11708,9 +10369,10 @@
 							"weapons": [
 								{
 									"id": "WCkLSAHFPhWd4V9jk",
+									"sv": 1,
 									"damage": {
 										"type": "imp",
-										"base": "1d-2"
+										"base_leveled": "1d-2"
 									},
 									"usage": "Innerportation",
 									"rate_of_fire": "1",
@@ -11725,7 +10387,7 @@
 										}
 									],
 									"calc": {
-										"damage": "1d-2 imp"
+										"damage": "1d-2 per level  imp"
 									}
 								}
 							],
@@ -11940,39 +10602,9 @@
 								{
 									"type": "skill_bonus",
 									"selection_type": "skills_with_name",
-									"name": {
+									"tags": {
 										"compare": "is",
-										"qualifier": "Autoteleport"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Exoteleport"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Innerportation"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Portersense"
+										"qualifier": "PsionicSkill:Teleportation"
 									},
 									"amount": 1,
 									"per_level": true

--- a/Library/Pyramid Magazine/Pyramid 99/Pyramid 99 Skills.skl
+++ b/Library/Pyramid Magazine/Pyramid 99/Pyramid 99 Skills.skl
@@ -13,7 +13,7 @@
 					"children": [
 						{
 							"id": "scfEBKM-lWHAuZULv",
-							"name": "Animakinesis",
+							"name": "Soul Sight",
 							"reference": "PY99:4",
 							"tags": [
 								"Animakinesis",

--- a/Library/Pyramid Magazine/Pyramid 99/Pyramid 99 Skills.skl
+++ b/Library/Pyramid Magazine/Pyramid 99/Pyramid 99 Skills.skl
@@ -16,6 +16,8 @@
 							"name": "Soul Sight",
 							"reference": "PY99:4",
 							"tags": [
+								"PsionicSkill:Necrokinesis",
+								"PsionicSkill:Animakinesis",
 								"Animakinesis",
 								"Necrokinesis",
 								"Psionics"
@@ -104,6 +106,8 @@
 							"name": "Spectral Surge",
 							"reference": "PY99:5",
 							"tags": [
+								"PsionicSkill:Necrokinesis",
+								"PsionicSkill:Animakinesis",
 								"Animakinesis",
 								"Necrokinesis",
 								"Psionics"
@@ -180,6 +184,8 @@
 							"name": "Corpse Sense",
 							"reference": "PY99:5",
 							"tags": [
+								"PsionicSkill:Necrokinesis",
+								"PsionicSkill:Thanatokinesis",
 								"Necrokinesis",
 								"Psionics",
 								"Thanatokinesis"
@@ -325,6 +331,8 @@
 							"name": "Necrocontrol",
 							"reference": "PY99:6",
 							"tags": [
+								"PsionicSkill:Necrokinesis",
+								"PsionicSkill:Thanatokinesis",
 								"Necrokinesis",
 								"Psionics",
 								"Thanatokinesis"
@@ -337,6 +345,8 @@
 							"name": "Necrotic Blast",
 							"reference": "PY99:7",
 							"tags": [
+								"PsionicSkill:Necrokinesis",
+								"PsionicSkill:Thanatokinesis",
 								"Necrokinesis",
 								"Psionics",
 								"Thanatokinesis"
@@ -527,6 +537,8 @@
 							"name": "Shadow Control",
 							"reference": "PY99:8",
 							"tags": [
+								"PsionicSkill:Necrokinesis",
+								"PsionicSkill:Umbrakinesis",
 								"Necrokinesis",
 								"Psionics",
 								"Umbrakinesis"
@@ -577,6 +589,8 @@
 							"name": "Silhouette",
 							"reference": "PY99:9",
 							"tags": [
+								"PsionicSkill:Necrokinesis",
+								"PsionicSkill:Umbrakinesis",
 								"Necrokinesis",
 								"Psionics",
 								"Umbrakinesis"

--- a/Library/Pyramid Magazine/Pyramid 99/Pyramid 99 Traits.adq
+++ b/Library/Pyramid Magazine/Pyramid 99/Pyramid 99 Traits.adq
@@ -43,39 +43,9 @@
 								{
 									"type": "skill_bonus",
 									"selection_type": "skills_with_name",
-									"name": {
+									"tags": {
 										"compare": "is",
-										"qualifier": "Soul Sight"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Spectral Surge"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Spirit Communication"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Aura Reading"
+										"qualifier": "PsionicSkill:Animakinesis"
 									},
 									"amount": 1,
 									"per_level": true
@@ -148,9 +118,10 @@
 							"weapons": [
 								{
 									"id": "W6HshnMBcrfiaBh7w",
+									"sv": 1,
 									"damage": {
 										"type": "cor",
-										"base": "2"
+										"base_leveled": "2"
 									},
 									"rate_of_fire": "1",
 									"recoil": "1",
@@ -161,7 +132,7 @@
 										}
 									],
 									"calc": {
-										"damage": "2 cor"
+										"damage": "2 per level  cor"
 									}
 								}
 							],
@@ -297,89 +268,9 @@
 						{
 							"type": "skill_bonus",
 							"selection_type": "skills_with_name",
-							"name": {
+							"tags": {
 								"compare": "is",
-								"qualifier": "Soul Sight"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Spectral Surge"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Corpse Sense"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Necrocontrol"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Necrotic Blast"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Shadow Control"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Silhouette"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Spirit Communication"
-							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "Aura Reading"
+								"qualifier": "PsionicSkill:Necrokinesis"
 							},
 							"amount": 1,
 							"per_level": true
@@ -506,9 +397,10 @@
 							"weapons": [
 								{
 									"id": "WRG3BV3tSPgN_xZT8",
+									"sv": 1,
 									"damage": {
 										"type": "tox",
-										"base": "1d"
+										"base_leveled": "1d"
 									},
 									"accuracy": "3",
 									"range": "100",
@@ -520,7 +412,7 @@
 										}
 									],
 									"calc": {
-										"damage": "1d tox"
+										"damage": "1d per level  tox"
 									}
 								}
 							],
@@ -562,29 +454,9 @@
 								{
 									"type": "skill_bonus",
 									"selection_type": "skills_with_name",
-									"name": {
+									"tags": {
 										"compare": "is",
-										"qualifier": "Corpse Sense"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Necrocontrol"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Necrotic Blast"
+										"qualifier": "PsionicSkill:Thanatokinesis"
 									},
 									"amount": 1,
 									"per_level": true
@@ -724,19 +596,9 @@
 								{
 									"type": "skill_bonus",
 									"selection_type": "skills_with_name",
-									"name": {
+									"tags": {
 										"compare": "is",
-										"qualifier": "Shadow Control"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "Silhouette"
+										"qualifier": "PsionicSkill:Umbrakinesis"
 									},
 									"amount": 1,
 									"per_level": true


### PR DESCRIPTION
i.e. every psionic skill now has a tag named `PsionicSkill:@powername@` (i.e. TK Grab has a tag added called `PsionicSkill:Psychokinesis`).

I also changed the Necrokinesis abilities from Pyramid 99 to use tags.

There are also a couple of minor changes, like:
* Photorefraction's page reference is fixed.
* The Telekinesis tag is removed from Pyrokinesis, Cryokinesis and PK Shield.
* Dream Control's tags were moved out of the Page Reference field.
* Soul Sight's skill has been fixed (was previously misnamed Animakinesis).

These changes should overlap somewhat with the changes in #408 (psi-amps should add to skills using these tags), and #413 (Pyramid 69: Mind and Body adds some new psionic abilities, which should be tagged as `PsionicSkill:Psychokinesis`).
Ideally, this would be merged before #408 and #413, and then I update those to use the tags properly, but I can update those after this is merged if they go first.