### PR TITLE
Add extra defaults for Armoury specialties

### DIFF
--- a/Library/Basic Set/Basic Set Skills.skl
+++ b/Library/Basic Set/Basic Set Skills.skl
@@ -814,7 +814,7 @@
 				{
 					"type": "skill",
 					"name": "Engineer",
-					"specialization": "Battlesuits",
+					"specialization": "@Armor type@",
 					"modifier": -4
 				}
 			],
@@ -868,6 +868,35 @@
 					"name": "Engineer",
 					"specialization": "Body Armor",
 					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Smith",
+					"specialization": "Bronze",
+					"modifier": -3,
+					"when_tl": {
+						"compare": "is",
+						"qualifier": 1
+					}
+				},
+				{
+					"type": "skill",
+					"name": "Smith",
+					"specialization": "Iron",
+					"modifier": -3,
+					"when_tl": {
+						"compare": "at_most",
+						"qualifier": 4
+					}
+				},
+				{
+					"type": "skill",
+					"name": "Machinist",
+					"modifier": -3,
+					"when_tl": {
+						"compare": "at_least",
+						"qualifier": 5
+					}
 				}
 			],
 			"tech_level": "",
@@ -946,6 +975,35 @@
 					"name": "Engineer",
 					"specialization": "Melee Weapons",
 					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Smith",
+					"specialization": "Bronze",
+					"modifier": -3,
+					"when_tl": {
+						"compare": "is",
+						"qualifier": 1
+					}
+				},
+				{
+					"type": "skill",
+					"name": "Smith",
+					"specialization": "Iron",
+					"modifier": -3,
+					"when_tl": {
+						"compare": "at_most",
+						"qualifier": 4
+					}
+				},
+				{
+					"type": "skill",
+					"name": "Machinist",
+					"modifier": -3,
+					"when_tl": {
+						"compare": "at_least",
+						"qualifier": 5
+					}
 				}
 			],
 			"tech_level": "",
@@ -998,6 +1056,15 @@
 					"name": "Engineer",
 					"specialization": "Small Arms",
 					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Machinist",
+					"modifier": -5,
+					"when_tl": {
+						"compare": "at_least",
+						"qualifier": 5
+					}
 				}
 			],
 			"tech_level": "",


### PR DESCRIPTION
Added TL-dependent defaults to Smith (Bronze), Smith (Iron), and/or Machinist for Armoury (Body Armour), (Melee (Weapons), (Small Arms), per B178

Also fixed the default for the generic (@ Armour type@) version to actually use the chosen specialty when defaulting to Engineer.