### PR TITLE
Add Arden Vul and Traveller calendars.

### DIFF
--- a/Library/Settings/Calendars/Arden Vul.calendar
+++ b/Library/Settings/Calendars/Arden Vul.calendar
@@ -1,0 +1,102 @@
+{
+  "weekdays": [
+    "Basilsday",
+    "Lunday",
+    "Tothsday",
+    "Mitrasday",
+    "Tahsday",
+    "Horasday",
+    "Demmasday"
+  ],
+  "day_zero_weekday": 1,
+  "months": [
+    {
+      "name": "Mercedonian Days",
+      "days": 6
+    },
+    {
+      "name": "Molivios",
+      "days": 30
+    },
+    {
+      "name": "Deuterios",
+      "days": 30
+    },
+    {
+      "name": "Toternios",
+      "days": 30
+    },
+    {
+      "name": "Lucrios",
+      "days": 30
+    },
+    {
+      "name": "Ligarios",
+      "days": 30
+    },
+    {
+      "name": "Jelenios",
+      "days": 30
+    },
+    {
+      "name": "Masporios",
+      "days": 30
+    },
+    {
+      "name": "Gerakios",
+      "days": 30
+    },
+    {
+      "name": "Voluptarian Days",
+      "days": 6
+    },
+    {
+      "name": "Besemios",
+      "days": 30
+    },
+    {
+      "name": "Basilembrios",
+      "days": 30
+    },
+    {
+      "name": "Dikaios",
+      "days": 30
+    },
+    {
+      "name": "Fidios",
+      "days": 30
+    }
+  ],
+  "seasons": [
+    {
+      "name": "Winter",
+      "start_month": 11,
+      "start_day": 1,
+      "end_month": 2,
+      "end_day": 28
+    },
+    {
+      "name": "Spring",
+      "start_month": 3,
+      "start_day": 1,
+      "end_month": 5,
+      "end_day": 31
+    },
+    {
+      "name": "Summer",
+      "start_month": 6,
+      "start_day": 1,
+      "end_month": 8,
+      "end_day": 31
+    },
+    {
+      "name": "Fall",
+      "start_month": 9,
+      "start_day": 1,
+      "end_month": 10,
+      "end_day": 31
+    }
+  ],
+  "era": "AEP",
+  "previous_era": "SP"
+}

--- a/Library/Settings/Calendars/Traveller.calendar
+++ b/Library/Settings/Calendars/Traveller.calendar
@@ -1,0 +1,19 @@
+{
+  "weekdays": [
+    "Wunday",
+    "Tuday",
+    "Thirday",
+    "Forday",
+    "Fiday",
+    "Sixday",
+    "Senday"
+  ],
+  "day_zero_weekday": 1,
+  "months": [
+    {
+      "name": "Day",
+      "days": 365
+    }
+  ],
+  "era": "IC"
+}


### PR DESCRIPTION
Arden Vul isn't an official GURPS setting so it should be Home Brew, but we don't have that concept for Settings/Calendar.  I submitted it anyway because more examples of calendars are good.

For Traveller I treated the year as one 365-day month called "Day" so that birthdays would be like "Day 123".  I did not tag Holiday as outside of any week as I don't think there is support for that, but it doesn't really matter for current uses of this data.