### PR TITLE
Power-Ups Enhancements: Add Cosmic modifiers

### DIFF
--- a/Library/Power Ups/Power Ups 4 Enhancements Enhancement Modifiers.adm
+++ b/Library/Power Ups/Power Ups 4 Enhancements Enhancement Modifiers.adm
@@ -64,7 +64,77 @@
 			"name": "Can Carry Objects",
 			"reference": "PU4:13",
 			"local_notes": "Extra-Heavy Encumberance",
-			"cost": 150
+			"cost_adj": "150%"
+		},
+		{
+			"id": "m76xVWn9HOCphce2M",
+			"name": "Cosmic",
+			"reference": "B103, PU4:7",
+			"local_notes": "@Avoided drawback@",
+			"cost_adj": "+50%"
+		},
+		{
+			"id": "mY0HDn_xQG_FgLNCu",
+			"name": "Cosmic",
+			"reference": "B103, PU4:7",
+			"local_notes": "Defensive",
+			"cost_adj": "+50%"
+		},
+		{
+			"id": "m7WTBbaGx9WCn5yyY",
+			"name": "Cosmic",
+			"reference": "PU4:7",
+			"local_notes": "No Rule of 16",
+			"cost_adj": "+50%"
+		},
+		{
+			"id": "mBdt4Cq7zcxUYJeEH",
+			"name": "Cosmic",
+			"reference": "PU4:7",
+			"local_notes": "Privileged attack",
+			"cost_adj": "+50%"
+		},
+		{
+			"id": "meyDqlT0bLdPZEmq9",
+			"name": "Cosmic",
+			"reference": "B103, PU4:8",
+			"local_notes": "Lingering effect",
+			"cost_adj": "+100%"
+		},
+		{
+			"id": "mAhlwPrxGuFJnBG-6",
+			"name": "Cosmic",
+			"reference": "PU4:8",
+			"local_notes": "No die roll required",
+			"cost_adj": "+100%"
+		},
+		{
+			"id": "mGLYvnCbz2s5GqCCO",
+			"name": "Cosmic",
+			"reference": "PU4:8",
+			"local_notes": "Unhealing damage",
+			"cost_adj": "+100%"
+		},
+		{
+			"id": "miPSP0ujt9mHSlGTr",
+			"name": "Cosmic",
+			"reference": "B103, PU4:8",
+			"local_notes": "Irresistible attack",
+			"cost_adj": "+300%"
+		},
+		{
+			"id": "mBxC2zWgIXVo0nsv1",
+			"name": "Cosmic",
+			"reference": "PU4:8",
+			"local_notes": "No active defense allowed",
+			"cost_adj": "+300%"
+		},
+		{
+			"id": "mEx-sFa9rY48Q8fJb",
+			"name": "Cosmic",
+			"reference": "PU4:8",
+			"local_notes": "Unrestricted powers",
+			"cost_adj": "+300%"
 		},
 		{
 			"id": "mkHVSVqPjEGUwox-t",


### PR DESCRIPTION
 I couldn't find the "No die roll required" modifier in any libraries, so I went through Power-Ups 4: Enhancements and added all the modifiers listed.