### PR TITLE
Basic Set Traits: fix the script in Payload

### DIFF
--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -19919,7 +19919,7 @@
 			"id": "t7a13kFVl53ZfbkrK",
 			"name": "Payload",
 			"reference": "B74",
-			"local_notes": "\u003cscript\u003e\niff(entity.exists,\n  measure.formatWeight(\n    self.level * entity.encumbrance().basicLift / 10,\n    entity.displayWeightUnits,\n  ),\n  \"Payload will be calculated when added to a character sheet\")\n\u003c/script\u003e",
+			"local_notes": "\u003cscript\u003e\nif(entity.exists) {\n  measure.formatWeight(\n    self.level * entity.encumbrance.basicLift / 10,\n    entity.displayWeightUnits,\n  )\n} else {\n  \"Payload will be calculated when added to a character sheet\"\n}\n\u003c/script\u003e",
 			"tags": [
 				"Advantage",
 				"Exotic",
@@ -19927,7 +19927,7 @@
 			],
 			"modifiers": [
 				{
-					"id": "mkzsxytAnZGGbpfjS",
+					"id": "mjLLPKjkvP1SLBWS_",
 					"name": "Exposed",
 					"reference": "B74",
 					"cost_adj": "-50%",
@@ -19939,7 +19939,7 @@
 			"levels": 1,
 			"calc": {
 				"points": 1,
-				"resolved_notes": "TypeError: Value is not an object: undefined at \u003ceval\u003e:4:36(10)",
+				"resolved_notes": "Payload will be calculated when added to a character sheet",
 				"current_level": 1
 			}
 		},


### PR DESCRIPTION
Scripting changes meant that `entity.encumbrance()` changed to `entity.encumbrance`. In addition, calling `entity.encumbrance.basicLift` raised an error that overrode the `iff` block when entity.encumbrance is undefined, so this has been changed to an ordinary if-else block.
