### PR TITLE
Low-Tech Equipment: Add broadsword-based defaults to the Khopesh

### DIFF
--- a/Library/Low Tech/Low Tech Equipment.eqp
+++ b/Library/Low Tech/Low Tech Equipment.eqp
@@ -17234,7 +17234,7 @@
 			"base_weight": "3 lb",
 			"weapons": [
 				{
-					"id": "w27_zku_Va8IBL4Ig",
+					"id": "wKPtQScfJKNLG7P4d",
 					"sv": 1,
 					"damage": {
 						"type": "cut",
@@ -17249,6 +17249,35 @@
 						{
 							"type": "dx",
 							"modifier": -5
+						},
+						{
+							"type": "skill",
+							"name": "Broadsword"
+						},
+						{
+							"type": "skill",
+							"name": "Force Sword",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Rapier",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Saber",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Shortsword",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Two-Handed Sword",
+							"modifier": -4
 						},
 						{
 							"type": "skill",
@@ -17270,7 +17299,7 @@
 					}
 				},
 				{
-					"id": "w1q31QgQEO1rbV0yF",
+					"id": "wDarLLleugEGfrLUQ",
 					"sv": 1,
 					"damage": {
 						"type": "cut",
@@ -17285,6 +17314,35 @@
 						{
 							"type": "dx",
 							"modifier": -5
+						},
+						{
+							"type": "skill",
+							"name": "Broadsword"
+						},
+						{
+							"type": "skill",
+							"name": "Force Sword",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Rapier",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Saber",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Shortsword",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Two-Handed Sword",
+							"modifier": -4
 						},
 						{
 							"type": "skill",


### PR DESCRIPTION
As raised in Discord by Gavvin Quinn, Low Tech's Khopesh can be wielded with Axe/Mace skill or Broadsword skill.

This Pull Request has one commit to apply the file format changes to the Low Tech Equipment library, and one to add Broadsword (and its related defaults) to the Khopesh's melee attacks.