### PR TITLE
Fix errors found in talents

### DIFF
--- a/Library/Power Ups/Power Ups Traits.adq
+++ b/Library/Power Ups/Power Ups Traits.adq
@@ -8914,20 +8914,6 @@
 					"selection_type": "skills_with_name",
 					"name": {
 						"compare": "is",
-						"qualifier": "Computer Programming"
-					},
-					"specialization": {
-						"compare": "is",
-						"qualifier": "AI"
-					},
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "skill_bonus",
-					"selection_type": "skills_with_name",
-					"name": {
-						"compare": "is",
 						"qualifier": "Electronics Repair"
 					},
 					"specialization": {


### PR DESCRIPTION
This fixes the errors with talents that are described in #448.

In brief, this includes:
* Adding Conditional Modifiers for conditional bonuses
* Fixing missing specializations for skill bonuses
* Removing blank skill bonuses that shouldn't be there
* Fixing the capitalization of some skill bonuses' names (though I think the lack of capitalization is harmless)
* Add the hyphen to "Born War-Leader".