### PR TITLE
fix: HTML - NPC card add border bottom padding to show dr

### DIFF
--- a/Library/Output Templates/HTML - NPC Card.html
+++ b/Library/Output Templates/HTML - NPC Card.html
@@ -22,6 +22,7 @@
 			height: 3in;
 			border: 2px solid black;
 			margin: 0.05in;
+			padding-bottom: 0.3in;
 			text-overflow: ellipsis;
 			overflow: hidden;
 			grid-template-columns: 2in 3in;


### PR DESCRIPTION
Adds a 0.3 inch padding to show the DR/armor table previously cut off by the bottom border in the html npc card export.
Tested in Firefox.


<img width="755" height="134" alt="New bottom border of the NPC card" src="https://github.com/user-attachments/assets/0f698643-0c9f-462b-bb5c-cfe2cc1f91b3" />

New bottom border of the NPC card,

<img width="755" height="134" alt="Old bottom border of the NPC card" src="https://github.com/user-attachments/assets/82ce56c3-117d-445c-a8e1-e3e3478cd141" />

Old bottom border of the NPC card.
