### PR TITLE
Fix issue with Silence trait feature bonuses

### DIFF
--- a/Library/Banestorm/Races/Halfling.gct
+++ b/Library/Banestorm/Races/Halfling.gct
@@ -140,7 +140,8 @@
 								"compare": "is",
 								"qualifier": "stealth"
 							},
-							"amount": 2
+							"amount": 2,
+							"per_level": true
 						}
 					],
 					"can_level": true,

--- a/Library/Banestorm/Races/Insect Man.gct
+++ b/Library/Banestorm/Races/Insect Man.gct
@@ -617,7 +617,8 @@
 								"compare": "is",
 								"qualifier": "stealth"
 							},
-							"amount": 2
+							"amount": 2,
+							"per_level": true
 						}
 					],
 					"can_level": true,

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 12/Ninja.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 12/Ninja.gct
@@ -1190,7 +1190,8 @@
 																"compare": "is",
 																"qualifier": "stealth"
 															},
-															"amount": 2
+															"amount": 2,
+															"per_level": true
 														}
 													],
 													"can_level": true,
@@ -1245,7 +1246,8 @@
 																"compare": "is",
 																"qualifier": "stealth"
 															},
-															"amount": 2
+															"amount": 2,
+															"per_level": true
 														}
 													],
 													"can_level": true,

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 2/Toxifier.gcs
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 2/Toxifier.gcs
@@ -1049,7 +1049,8 @@
 						"compare": "is",
 						"qualifier": "stealth"
 					},
-					"amount": 2
+					"amount": 2,
+					"per_level": true
 				}
 			],
 			"can_level": true,

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Cleric Variants/Messenger Rogue Cleric.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Cleric Variants/Messenger Rogue Cleric.gct
@@ -2205,7 +2205,8 @@
 														"compare": "is",
 														"qualifier": "stealth"
 													},
-													"amount": 2
+													"amount": 2,
+													"per_level": true
 												}
 											],
 											"can_level": true,

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Cleric Variants/Night Cleric.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Cleric Variants/Night Cleric.gct
@@ -2037,7 +2037,8 @@
 														"compare": "is",
 														"qualifier": "stealth"
 													},
-													"amount": 2
+													"amount": 2,
+													"per_level": true
 												}
 											],
 											"can_level": true,

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Messenger Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Messenger Holy Warrior.gct
@@ -1358,7 +1358,8 @@
 														"compare": "is",
 														"qualifier": "stealth"
 													},
-													"amount": 2
+													"amount": 2,
+													"per_level": true
 												}
 											],
 											"can_level": true,

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Night Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Night Holy Warrior.gct
@@ -1348,7 +1348,8 @@
 														"compare": "is",
 														"qualifier": "stealth"
 													},
-													"amount": 2
+													"amount": 2,
+													"per_level": true
 												}
 											],
 											"can_level": true,

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Rogue Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Rogue Holy Warrior.gct
@@ -2009,7 +2009,8 @@
 														"compare": "is",
 														"qualifier": "stealth"
 													},
-													"amount": 2
+													"amount": 2,
+													"per_level": true
 												}
 											],
 											"can_level": true,

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 9/Classes/Necromancer.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 9/Classes/Necromancer.gct
@@ -2715,7 +2715,8 @@
 												"compare": "is",
 												"qualifier": "stealth"
 											},
-											"amount": 2
+											"amount": 2,
+											"per_level": true
 										}
 									],
 									"can_level": true,

--- a/Library/Dungeon Fantasy/Races/Corpse Eater.gct
+++ b/Library/Dungeon Fantasy/Races/Corpse Eater.gct
@@ -399,7 +399,8 @@
 								"compare": "is",
 								"qualifier": "stealth"
 							},
-							"amount": 2
+							"amount": 2,
+							"per_level": true
 						}
 					],
 					"can_level": true,

--- a/Library/Dungeon Fantasy/Races/Elves/Shadow Elf.gct
+++ b/Library/Dungeon Fantasy/Races/Elves/Shadow Elf.gct
@@ -258,7 +258,8 @@
 								"compare": "is",
 								"qualifier": "stealth"
 							},
-							"amount": 2
+							"amount": 2,
+							"per_level": true
 						}
 					],
 					"can_level": true,

--- a/Library/Dungeon Fantasy/Races/Halfling.gct
+++ b/Library/Dungeon Fantasy/Races/Halfling.gct
@@ -250,7 +250,8 @@
 								"compare": "is",
 								"qualifier": "stealth"
 							},
-							"amount": 2
+							"amount": 2,
+							"per_level": true
 						}
 					],
 					"can_level": true,

--- a/Library/Fantasy/Races/Ghoul.gct
+++ b/Library/Fantasy/Races/Ghoul.gct
@@ -172,7 +172,8 @@
 										"compare": "is",
 										"qualifier": "stealth"
 									},
-									"amount": 2
+									"amount": 2,
+									"per_level": true
 								}
 							],
 							"can_level": true,

--- a/Library/Fantasy/Races/Halfling.gct
+++ b/Library/Fantasy/Races/Halfling.gct
@@ -162,7 +162,8 @@
 								"compare": "is",
 								"qualifier": "stealth"
 							},
-							"amount": 2
+							"amount": 2,
+							"per_level": true
 						}
 					],
 					"can_level": true,

--- a/Library/Monster Hunters/Classes/Champions/Inhuman Weretiger.gct
+++ b/Library/Monster Hunters/Classes/Champions/Inhuman Weretiger.gct
@@ -422,7 +422,8 @@
 										"compare": "is",
 										"qualifier": "stealth"
 									},
-									"amount": 2
+									"amount": 2,
+									"per_level": true
 								}
 							],
 							"can_level": true,

--- a/Library/Pyramid Magazine/Pyramid 115/Homo Sapiens Felis.gct
+++ b/Library/Pyramid Magazine/Pyramid 115/Homo Sapiens Felis.gct
@@ -562,7 +562,8 @@
 								"compare": "is",
 								"qualifier": "stealth"
 							},
-							"amount": 2
+							"amount": 2,
+							"per_level": true
 						}
 					],
 					"can_level": true,

--- a/Library/Pyramid Magazine/Pyramid 115/Toxic Zombie.gct
+++ b/Library/Pyramid Magazine/Pyramid 115/Toxic Zombie.gct
@@ -296,7 +296,8 @@
 										"compare": "is",
 										"qualifier": "stealth"
 									},
-									"amount": 2
+									"amount": 2,
+									"per_level": true
 								}
 							],
 							"can_level": true,

--- a/Library/Pyramid Magazine/Pyramid 50/Elf.gct
+++ b/Library/Pyramid Magazine/Pyramid 50/Elf.gct
@@ -965,7 +965,8 @@
 												"compare": "is",
 												"qualifier": "stealth"
 											},
-											"amount": 2
+											"amount": 2,
+											"per_level": true
 										}
 									],
 									"can_level": true,

--- a/Library/Pyramid Magazine/Pyramid 50/Gray Necromancer.gct
+++ b/Library/Pyramid Magazine/Pyramid 50/Gray Necromancer.gct
@@ -1759,7 +1759,8 @@
 												"compare": "is",
 												"qualifier": "stealth"
 											},
-											"amount": 2
+											"amount": 2,
+											"per_level": true
 										}
 									],
 									"can_level": true,

--- a/Library/Technomancer/Atomic Lich.gct
+++ b/Library/Technomancer/Atomic Lich.gct
@@ -706,7 +706,8 @@
 						"compare": "is",
 						"qualifier": "stealth"
 					},
-					"amount": 2
+					"amount": 2,
+					"per_level": true
 				}
 			],
 			"can_level": true,

--- a/Library/Technomancer/Homo Sapiens Felis.gct
+++ b/Library/Technomancer/Homo Sapiens Felis.gct
@@ -575,7 +575,8 @@
 						"compare": "is",
 						"qualifier": "stealth"
 					},
-					"amount": 2
+					"amount": 2,
+					"per_level": true
 				}
 			],
 			"can_level": true,

--- a/Library/Technomancer/Toxic Zombie.gct
+++ b/Library/Technomancer/Toxic Zombie.gct
@@ -675,7 +675,8 @@
 						"compare": "is",
 						"qualifier": "stealth"
 					},
-					"amount": 2
+					"amount": 2,
+					"per_level": true
 				}
 			],
 			"can_level": true,

--- a/Library/Transhuman Space/Cybershells/Amphibious RATS.gct
+++ b/Library/Transhuman Space/Cybershells/Amphibious RATS.gct
@@ -1592,7 +1592,8 @@
 								"compare": "is",
 								"qualifier": "stealth"
 							},
-							"amount": 2
+							"amount": 2,
+							"per_level": true
 						}
 					],
 					"can_level": true,

--- a/Library/Transhuman Space/Cybershells/Jump RATS.gct
+++ b/Library/Transhuman Space/Cybershells/Jump RATS.gct
@@ -1874,7 +1874,8 @@
 								"compare": "is",
 								"qualifier": "stealth"
 							},
-							"amount": 2
+							"amount": 2,
+							"per_level": true
 						}
 					],
 					"can_level": true,

--- a/Library/Transhuman Space/Cybershells/Mini Scout-RATS.gct
+++ b/Library/Transhuman Space/Cybershells/Mini Scout-RATS.gct
@@ -1415,7 +1415,8 @@
 								"compare": "is",
 								"qualifier": "stealth"
 							},
-							"amount": 2
+							"amount": 2,
+							"per_level": true
 						}
 					],
 					"can_level": true,

--- a/Library/Transhuman Space/Cybershells/RATS.gct
+++ b/Library/Transhuman Space/Cybershells/RATS.gct
@@ -1352,7 +1352,8 @@
 								"compare": "is",
 								"qualifier": "stealth"
 							},
-							"amount": 2
+							"amount": 2,
+							"per_level": true
 						}
 					],
 					"can_level": true,

--- a/Library/Ultra Tech/Races/Combat Android.gct
+++ b/Library/Ultra Tech/Races/Combat Android.gct
@@ -668,7 +668,8 @@
 										"compare": "is",
 										"qualifier": "stealth"
 									},
-									"amount": 2
+									"amount": 2,
+									"per_level": true
 								}
 							],
 							"can_level": true,

--- a/Library/Ultra Tech/Races/Housebot.gct
+++ b/Library/Ultra Tech/Races/Housebot.gct
@@ -635,7 +635,8 @@
 										"compare": "is",
 										"qualifier": "stealth"
 									},
-									"amount": 2
+									"amount": 2,
+									"per_level": true
 								}
 							],
 							"can_level": true,

--- a/Library/Ultra Tech/Races/Scout Robot.gct
+++ b/Library/Ultra Tech/Races/Scout Robot.gct
@@ -1608,7 +1608,8 @@
 												"compare": "is",
 												"qualifier": "stealth"
 											},
-											"amount": 2
+											"amount": 2,
+											"per_level": true
 										}
 									],
 									"can_level": true,


### PR DESCRIPTION
The Silence trait features provide bonuses to the Stealth skill that scale with level. This fixes most instances where Silence was applying a Stealth bonus as a fixed amount.

NOTE: The Silence trait still needs another pass across all locations to bring it into sync with how the Basic Set represents the trait now. The direct Stealth bonus is not 100% correct and is invisible if the Stealth skill is not on the character sheet. It also does not convey the difference in bonus amount between moving vs not moving. The latest Basic Set version of the trait has a note explaining that it's only applicable for hearing based Stealth checks and it communicates the bonuses by using conditional modifiers that show even without the Stealth skill being on the character sheet.