### PR TITLE
Fixing book references for "LOT" templates

### DIFF
--- a/Library/Lands Out of Time/Classes/Tarn Warrior.gct
+++ b/Library/Lands Out of Time/Classes/Tarn Warrior.gct
@@ -5,7 +5,7 @@
 		{
 			"id": "T40ILCPNMqPhUtaqD",
 			"name": "Tarn Warrior",
-			"reference": "LooT19",
+			"reference": "LOT19",
 			"children": [
 				{
 					"id": "TjP-YZ5P4vYibz0M3",
@@ -721,7 +721,7 @@
 		{
 			"id": "SjKThVCMXPzjGjUZz",
 			"name": "Tarn Warrior",
-			"reference": "LooT19",
+			"reference": "LOT19",
 			"children": [
 				{
 					"id": "SUZJ2JwUY-_xUBjKB",

--- a/Library/Lands Out of Time/Classes/Timelost Explorer.gct
+++ b/Library/Lands Out of Time/Classes/Timelost Explorer.gct
@@ -5,7 +5,7 @@
 		{
 			"id": "TntrmMALDA6MV2KL7",
 			"name": "Timelost Explorer",
-			"reference": "LooT17",
+			"reference": "LOT17",
 			"children": [
 				{
 					"id": "TeKfr2nMNXLnciVk1",
@@ -1450,7 +1450,7 @@
 				{
 					"id": "TomHvTc82X7x8zbgn",
 					"name": "Timelost Hunter",
-					"reference": "LooT18",
+					"reference": "LOT18",
 					"children": [
 						{
 							"id": "TIFFZz1j21JKGmxrJ",
@@ -1532,7 +1532,7 @@
 		{
 			"id": "SnOkbHZBEJXxz28f8",
 			"name": "Timelost Explorer",
-			"reference": "LooT17",
+			"reference": "LOT17",
 			"children": [
 				{
 					"id": "SSrtN8yQdtASHgZyz",

--- a/Library/Lands Out of Time/Classes/Timelost Kid.gct
+++ b/Library/Lands Out of Time/Classes/Timelost Kid.gct
@@ -5,7 +5,7 @@
 		{
 			"id": "T8jjSeW2mfzPErEoq",
 			"name": "Timelost Kid",
-			"reference": "LooT18",
+			"reference": "LOT18",
 			"children": [
 				{
 					"id": "TztaR6bBTmuZ-MgOA",
@@ -1619,7 +1619,7 @@
 				{
 					"id": "TiHlXVdcym3Onjyds",
 					"name": "Timelost Teen",
-					"reference": "LooT18",
+					"reference": "LOT18",
 					"children": [
 						{
 							"id": "TMljhq9yv7gYczWXs",
@@ -1821,7 +1821,7 @@
 		{
 			"id": "Si0IDM7FH_8N6StgC",
 			"name": "Timelost Kid",
-			"reference": "LooT18",
+			"reference": "LOT18",
 			"children": [
 				{
 					"id": "ScLRnc2OrU9w7tXdU",

--- a/Library/Lands Out of Time/Classes/Timelost Scientist.gct
+++ b/Library/Lands Out of Time/Classes/Timelost Scientist.gct
@@ -5,7 +5,7 @@
 		{
 			"id": "TtYa4Rj7VyzROd0o_",
 			"name": "Timelost Scientist",
-			"reference": "LooT18",
+			"reference": "LOT18",
 			"children": [
 				{
 					"id": "T6PIJtiW-5XU_X9X2",
@@ -1077,7 +1077,7 @@
 		{
 			"id": "SwTvBkCCUtenkJ5f3",
 			"name": "Timelost Scientist",
-			"reference": "LooT18",
+			"reference": "LOT18",
 			"children": [
 				{
 					"id": "SMki4IAsKRzVJ9o3n",

--- a/Library/Lands Out of Time/Classes/Timelost Soldier.gct
+++ b/Library/Lands Out of Time/Classes/Timelost Soldier.gct
@@ -5,7 +5,7 @@
 		{
 			"id": "Tl6gQngN1Ji8foRTL",
 			"name": "Timelost Soldier",
-			"reference": "LooT19",
+			"reference": "LOT19",
 			"children": [
 				{
 					"id": "T8T8Sxx5Wv6y_-zWU",
@@ -1059,7 +1059,7 @@
 		{
 			"id": "SyWHfXvlkLdInI75h",
 			"name": "Timelost Soldier",
-			"reference": "LooT19",
+			"reference": "LOT19",
 			"children": [
 				{
 					"id": "SAQ-cNfe27mLatBLp",

--- a/Library/Lands Out of Time/Classes/Tribal Chief.gct
+++ b/Library/Lands Out of Time/Classes/Tribal Chief.gct
@@ -5,7 +5,7 @@
 		{
 			"id": "TqjCJCD1xOIXsHz4l",
 			"name": "Tribal Chief",
-			"reference": "LooT15",
+			"reference": "LOT15",
 			"children": [
 				{
 					"id": "TGA2GblcXe73dMioe",
@@ -1532,7 +1532,7 @@
 		{
 			"id": "S6uD3qpAjAr5xk4kV",
 			"name": "Tribe Chief",
-			"reference": "LooT15",
+			"reference": "LOT15",
 			"children": [
 				{
 					"id": "S920OMZTncc9s6T49",
@@ -2266,7 +2266,7 @@
 				{
 					"id": "SXehXMCv2QVXZ4FYu",
 					"name": "Jungle Princess",
-					"reference": "LooT16",
+					"reference": "LOT16",
 					"children": [
 						{
 							"id": "sqxxX-Tg5cmr-xZFS",

--- a/Library/Lands Out of Time/Classes/Tribal Shaman.gct
+++ b/Library/Lands Out of Time/Classes/Tribal Shaman.gct
@@ -5,7 +5,7 @@
 		{
 			"id": "TwXKhzzk0RPUQT1RL",
 			"name": "Tribal Shaman",
-			"reference": "LooT16",
+			"reference": "LOT16",
 			"children": [
 				{
 					"id": "TJmoNGlq09DusMTw-",
@@ -1680,7 +1680,7 @@
 		{
 			"id": "SC6svhy9Ub8iYSUyq",
 			"name": "Tribal Shaman",
-			"reference": "LooT16",
+			"reference": "LOT16",
 			"children": [
 				{
 					"id": "S_kn9S_CDJCvq_QvD",

--- a/Library/Lands Out of Time/Classes/Tribal Wanderer.gct
+++ b/Library/Lands Out of Time/Classes/Tribal Wanderer.gct
@@ -5,7 +5,7 @@
 		{
 			"id": "TmY_IfjAJQTH0poK7",
 			"name": "Tribal Wanderer",
-			"reference": "LooT17",
+			"reference": "LOT17",
 			"children": [
 				{
 					"id": "TXijJjft5Hk1jy4d7",
@@ -1027,7 +1027,7 @@
 				{
 					"id": "Tp3zhMTaaND9JMZxT",
 					"name": "Tribal Outcast",
-					"reference": "LooT17",
+					"reference": "LOT17",
 					"children": [
 						{
 							"id": "TxUbko28BYoc2Q6Gg",
@@ -1044,7 +1044,7 @@
 				{
 					"id": "TyTvAIBNNQ9cEWzKm",
 					"name": "Visionary",
-					"reference": "LooT17",
+					"reference": "LOT17",
 					"children": [
 						{
 							"id": "TqFhEQba_LNKsThoM",
@@ -1149,7 +1149,7 @@
 		{
 			"id": "SVrvSqcQeIDkkexMf",
 			"name": "Tribal Wanderer",
-			"reference": "LooT17",
+			"reference": "LOT17",
 			"children": [
 				{
 					"id": "SM667xqxrUZsCEDZa",

--- a/Library/Lands Out of Time/Races/Caveman.gct
+++ b/Library/Lands Out of Time/Races/Caveman.gct
@@ -5,7 +5,7 @@
 		{
 			"id": "TLV8dXp4gvHUpmJP0",
 			"name": "Caveman",
-			"reference": "LooT12",
+			"reference": "LOT12",
 			"ancestry": "Human",
 			"container_type": "ancestry",
 			"children": [
@@ -162,7 +162,7 @@
 				{
 					"id": "TSdq4SjDgRpArWoR-",
 					"name": "Primative Caveman",
-					"reference": "LooT13",
+					"reference": "LOT13",
 					"local_notes": "Add to normal Caveman",
 					"children": [
 						{

--- a/Library/Lands Out of Time/Races/Neanderthal.gct
+++ b/Library/Lands Out of Time/Races/Neanderthal.gct
@@ -5,7 +5,7 @@
 		{
 			"id": "TymD8hHtvgEUALoaJ",
 			"name": "Neanderthal",
-			"reference": "LooT13",
+			"reference": "LOT13",
 			"ancestry": "Human",
 			"container_type": "ancestry",
 			"children": [

--- a/Library/Lands Out of Time/Races/Protohumans.gct
+++ b/Library/Lands Out of Time/Races/Protohumans.gct
@@ -5,7 +5,7 @@
 		{
 			"id": "TolUzPulV_wJbZCVH",
 			"name": "Protohumans",
-			"reference": "LooT14",
+			"reference": "LOT14",
 			"ancestry": "Human",
 			"container_type": "ancestry",
 			"children": [
@@ -363,7 +363,7 @@
 		{
 			"id": "SPawi_e100Ci6LKhj",
 			"name": "Protohumans",
-			"reference": "LooT14",
+			"reference": "LOT14",
 			"children": [
 				{
 					"id": "Slgf-5Xj8h0p99JTN",

--- a/Library/Lands Out of Time/Races/Saurians.gct
+++ b/Library/Lands Out of Time/Races/Saurians.gct
@@ -11,7 +11,7 @@
 				{
 					"id": "TulRH6lGa6YU5KYry",
 					"name": "Advanced Saurians",
-					"reference": "LooT15",
+					"reference": "LOT15",
 					"children": [
 						{
 							"id": "TgzA-So_phaXtHHpB",
@@ -787,7 +787,7 @@
 				{
 					"id": "TBUPFoLk-2KBmNLeP",
 					"name": "Primative Saurians",
-					"reference": "LooT15",
+					"reference": "LOT15",
 					"children": [
 						{
 							"id": "TSJcld3Ndhd0vcboX",


### PR DESCRIPTION
The templates were using the incorrect "LooT" book code and should have been "LOT".