### PR TITLE
High Tech: Corrections and more Gun variants

### DIFF
--- a/Library/High Tech/High Tech Equipment.eqp
+++ b/Library/High Tech/High Tech Equipment.eqp
@@ -4775,7 +4775,7 @@
 		},
 		{
 			"id": "egUgbaL4hr4lHFFUp",
-			"description": "AI AWM-F, .300 Winchester Magnum",
+			"description": "AI AWM-F, .300 WM",
 			"reference": "HT118",
 			"local_notes": "Fine (accurate).",
 			"tech_level": "8",
@@ -6625,7 +6625,7 @@
 		},
 		{
 			"id": "e2FbHF1dYhKiBp3vf",
-			"description": "APX SA17, 37X94mmR",
+			"description": "APX SA17, 37x94mmR",
 			"reference": "HT140",
 			"tech_level": "6",
 			"legality_class": "1",
@@ -6947,7 +6947,7 @@
 		},
 		{
 			"id": "e8V2n7gx0NEXjTD54",
-			"description": "ArmaLite AR-7, .22 Long Rifle",
+			"description": "ArmaLite AR-7, .22 LR",
 			"reference": "HT120",
 			"local_notes": "Lacks sling swivels.",
 			"tech_level": "7",
@@ -15113,7 +15113,7 @@
 		{
 			"id": "eIhIolFwzBQJEgjvn",
 			"description": "Colt Delta Elite, 10x25mm Auto",
-			"reference": "HT98",
+			"reference": "HT99",
 			"tech_level": "6",
 			"legality_class": "3",
 			"tags": [
@@ -15221,7 +15221,7 @@
 		{
 			"id": "eN-vMI_5GVfc1xA8O",
 			"description": "Colt Government Officer's Model, .45 ACP",
-			"reference": "HT101",
+			"reference": "HT98",
 			"tech_level": "6",
 			"legality_class": "3",
 			"tags": [
@@ -15329,7 +15329,7 @@
 		{
 			"id": "ewyeAyQD8Hy4A4-Mm",
 			"description": "Colt Government, .45 ACP",
-			"reference": "HT98",
+			"reference": "HT101",
 			"tech_level": "6",
 			"legality_class": "3",
 			"tags": [
@@ -26847,7 +26847,7 @@
 		},
 		{
 			"id": "ed3ioYrUkJ0WeHY2j",
-			"description": "FN FAL, 7.62X51mm",
+			"description": "FN FAL, 7.62x51mm",
 			"reference": "HT120",
 			"tech_level": "7",
 			"legality_class": "2",
@@ -26955,7 +26955,7 @@
 		},
 		{
 			"id": "ejE2toBjxdjbpqm5_",
-			"description": "FN FAL Para, 7.62X51mm",
+			"description": "FN FAL Para, 7.62x51mm",
 			"reference": "HT115",
 			"tech_level": "7",
 			"legality_class": "2",
@@ -28042,6 +28042,114 @@
 			}
 		},
 		{
+			"id": "eWzTZZqnI8nnNjHE5",
+			"description": "FN MK 48 MOD 0, 7.62x51mm",
+			"reference": "HT137",
+			"tech_level": "8",
+			"legality_class": "1",
+			"tags": [
+				"Firearms"
+			],
+			"base_value": "8000",
+			"base_weight": "25.3 lb",
+			"weapons": [
+				{
+					"id": "Wj3jJL9MMv0gR2ixs",
+					"sv": 1,
+					"damage": {
+						"type": "pi",
+						"base": "6d+1"
+					},
+					"strength": "11B†",
+					"accuracy": "5",
+					"range": "900/3,750",
+					"rate_of_fire": "12!",
+					"shots": "100(5)",
+					"bulk": "-6",
+					"recoil": "2",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Light Machine Gun"
+						},
+						{
+							"type": "dx",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Pistol",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Rifle",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Musket",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Shotgun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Light Machine Gun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Submachine Gun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Gun!"
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Grenade Launcher",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Gyroc",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Light Anti-Armor Weapon",
+							"modifier": -4
+						}
+					],
+					"calc": {
+						"damage": "6d+1 pi"
+					}
+				}
+			],
+			"quantity": 1,
+			"calc": {
+				"value": 8000,
+				"extended_value": 8000,
+				"weight": "25.3 lb",
+				"extended_weight": "25.3 lb"
+			}
+		},
+		{
 			"id": "ehBuYZAToUHeC-gMC",
 			"description": "FN P90, 5.7x28mm",
 			"reference": "HT124",
@@ -28585,7 +28693,7 @@
 		},
 		{
 			"id": "eWccfhyqe_46s-pno",
-			"description": "FN-Browning High Power, 9x19mm",
+			"description": "FN-Browning HP, 9x19mm",
 			"reference": "HT101",
 			"local_notes": "No lanyard ring.",
 			"tech_level": "6",
@@ -29995,6 +30103,62 @@
 					"accuracy": "4",
 					"range": "470/3,000",
 					"rate_of_fire": "15",
+					"shots": "40(5)",
+					"bulk": "-10",
+					"recoil": "2",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Gunner",
+							"specialization": "Machine Gun"
+						},
+						{
+							"type": "dx",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Gunner",
+							"modifier": -4
+						}
+					],
+					"calc": {
+						"damage": "4d+1 pi+"
+					}
+				}
+			],
+			"quantity": 1,
+			"calc": {
+				"value": 16000,
+				"extended_value": 16000,
+				"weight": "200 lb",
+				"extended_weight": "200 lb"
+			}
+		},
+		{
+			"id": "ekB2EBva1kaDAduId",
+			"description": "Gatling M1893, .30-40 Krag",
+			"reference": "HT135",
+			"local_notes": "Malf 15.",
+			"tech_level": "6",
+			"legality_class": "2",
+			"tags": [
+				"Firearms"
+			],
+			"base_value": "16000",
+			"base_weight": "200 lb",
+			"weapons": [
+				{
+					"id": "W8ePHcBW1sdR_E43o",
+					"sv": 1,
+					"damage": {
+						"type": "pi+",
+						"base": "4d+1"
+					},
+					"strength": "26M",
+					"accuracy": "4",
+					"range": "470/3,000",
+					"rate_of_fire": "50",
 					"shots": "40(5)",
 					"bulk": "-10",
 					"recoil": "2",
@@ -31971,6 +32135,7 @@
 			"weapons": [
 				{
 					"id": "Wdy6D2i4F4lrckvQ-",
+					"sv": 1,
 					"damage": {
 						"type": "pi+",
 						"base": "2d-1"
@@ -33930,6 +34095,222 @@
 			}
 		},
 		{
+			"id": "eSWdVQTNcN18xMyT5",
+			"description": "H\u0026K HK23E, 5.56x45mm",
+			"reference": "HT136",
+			"tech_level": "7",
+			"legality_class": "1",
+			"tags": [
+				"Firearms"
+			],
+			"base_value": "5800",
+			"base_weight": "26.8 lb",
+			"weapons": [
+				{
+					"id": "W7VFPxmI09n3hIWSK",
+					"sv": 1,
+					"damage": {
+						"type": "pi",
+						"base": "5d-1"
+					},
+					"strength": "11B†",
+					"accuracy": "5",
+					"range": "750/3,100",
+					"rate_of_fire": "9/13",
+					"shots": "200(5)",
+					"bulk": "-6",
+					"recoil": "2",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Light Machine Gun"
+						},
+						{
+							"type": "dx",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Pistol",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Rifle",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Musket",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Shotgun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Light Machine Gun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Submachine Gun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Gun!"
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Grenade Launcher",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Gyroc",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Light Anti-Armor Weapon",
+							"modifier": -4
+						}
+					],
+					"calc": {
+						"damage": "5d-1 pi"
+					}
+				}
+			],
+			"quantity": 1,
+			"calc": {
+				"value": 5800,
+				"extended_value": 5800,
+				"weight": "26.8 lb",
+				"extended_weight": "26.8 lb"
+			}
+		},
+		{
+			"id": "eJ9J2UXz1kOqweEzY",
+			"description": "H\u0026K HK33, .223 Remington",
+			"reference": "HT116",
+			"tech_level": "7",
+			"legality_class": "2",
+			"tags": [
+				"Firearms"
+			],
+			"base_value": "1200",
+			"base_weight": "9.5lb",
+			"weapons": [
+				{
+					"id": "WGK9g3-H8Vl91frsr",
+					"sv": 1,
+					"damage": {
+						"type": "pi",
+						"base": "4d+2"
+					},
+					"strength": "9†",
+					"accuracy": "5",
+					"range": "460/2,900",
+					"rate_of_fire": "12",
+					"shots": "25+1(3)",
+					"bulk": "-5",
+					"recoil": "2",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Rifle"
+						},
+						{
+							"type": "dx",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Pistol",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Rifle",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Musket",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Shotgun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Light Machine Gun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Submachine Gun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Gun!"
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Grenade Launcher",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Gyroc",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Light Anti-Armor Weapon",
+							"modifier": -4
+						}
+					],
+					"calc": {
+						"damage": "4d+2 pi"
+					}
+				}
+			],
+			"quantity": 1,
+			"calc": {
+				"value": 1200,
+				"extended_value": 1200,
+				"weight": "9.5 lb",
+				"extended_weight": "9.5 lb"
+			}
+		},
+		{
 			"id": "eYnlgtvQMgH99LYQy",
 			"description": "H\u0026K HK69A1, 40x46mmSR",
 			"reference": "HT145",
@@ -34097,6 +34478,224 @@
 				"extended_value": 1500,
 				"weight": "7.5 lb",
 				"extended_weight": "7.5 lb"
+			}
+		},
+		{
+			"id": "eEVzZpYA2XGfo8vbC",
+			"description": "H\u0026K MP5/10A3, 10x25mm Auto",
+			"reference": "HT123",
+			"reference_highlight": "MP5/10A3",
+			"tech_level": "7",
+			"legality_class": "2",
+			"tags": [
+				"Firearms"
+			],
+			"base_value": "1500",
+			"base_weight": "7.8 lb",
+			"weapons": [
+				{
+					"id": "WVtT-EgKdTwSphS5r",
+					"sv": 1,
+					"damage": {
+						"type": "pi+",
+						"base": "3d+2"
+					},
+					"strength": "9†",
+					"accuracy": "4",
+					"range": "280/3,100",
+					"rate_of_fire": "6/13",
+					"shots": "30+1(3)",
+					"bulk": "-4*",
+					"recoil": "3",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Submachine Gun"
+						},
+						{
+							"type": "dx",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Pistol",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Rifle",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Musket",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Shotgun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Light Machine Gun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Submachine Gun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Gun!"
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Grenade Launcher",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Gyroc",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Light Anti-Armor Weapon",
+							"modifier": -4
+						}
+					],
+					"calc": {
+						"damage": "3d+2 pi+"
+					}
+				}
+			],
+			"quantity": 1,
+			"calc": {
+				"value": 1500,
+				"extended_value": 1500,
+				"weight": "7.8 lb",
+				"extended_weight": "7.8 lb"
+			}
+		},
+		{
+			"id": "eWGQntJM_z94VQvUC",
+			"description": "H\u0026K MP5/40A3, .40 S\u0026W",
+			"reference": "HT124",
+			"reference_highlight": "MP5/40A3",
+			"tech_level": "7",
+			"legality_class": "2",
+			"tags": [
+				"Firearms"
+			],
+			"base_value": "1500",
+			"base_weight": "7.6 lb",
+			"weapons": [
+				{
+					"id": "WRlgzGquq7_683mec",
+					"sv": 1,
+					"damage": {
+						"type": "pi+",
+						"base": "3d-1"
+					},
+					"strength": "8†",
+					"accuracy": "4",
+					"range": "190/2,000",
+					"rate_of_fire": "6/13",
+					"shots": "30+1(3)",
+					"bulk": "-4*",
+					"recoil": "2",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Submachine Gun"
+						},
+						{
+							"type": "dx",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Pistol",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Rifle",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Musket",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Shotgun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Light Machine Gun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Submachine Gun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Gun!"
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Grenade Launcher",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Gyroc",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Light Anti-Armor Weapon",
+							"modifier": -4
+						}
+					],
+					"calc": {
+						"damage": "3d-1 pi+"
+					}
+				}
+			],
+			"quantity": 1,
+			"calc": {
+				"value": 1500,
+				"extended_value": 1500,
+				"weight": "7.6 lb",
+				"extended_weight": "7.6 lb"
 			}
 		},
 		{
@@ -34426,8 +35025,9 @@
 		},
 		{
 			"id": "eglZzU7IGaZxnKTft",
-			"description": "H\u0026K P8, 9x19",
+			"description": "H\u0026K P8, 9x19mm",
 			"reference": "HT102",
+			"reference_highlight": "P8",
 			"tech_level": "8",
 			"legality_class": "3",
 			"tags": [
@@ -34437,7 +35037,7 @@
 			"base_weight": "2.1 lb",
 			"weapons": [
 				{
-					"id": "WFfq66HVBPBt_TcNb",
+					"id": "WcuqCAfFgppiCdhxg",
 					"sv": 1,
 					"damage": {
 						"type": "pi",
@@ -34533,8 +35133,117 @@
 			}
 		},
 		{
+			"id": "e1zuk-fngGpFqwqWJ",
+			"description": "H\u0026K P10, 9x19mm",
+			"reference": "HT102",
+			"reference_highlight": "P10",
+			"tech_level": "8",
+			"legality_class": "3",
+			"tags": [
+				"Firearms"
+			],
+			"base_value": "800",
+			"base_weight": "2 lb",
+			"weapons": [
+				{
+					"id": "WzrrfhCoFWsHNAQc5",
+					"sv": 1,
+					"damage": {
+						"type": "pi",
+						"base": "2d+1"
+					},
+					"strength": "9",
+					"accuracy": "2",
+					"range": "160/1,800",
+					"rate_of_fire": "3",
+					"shots": "13+1(3)",
+					"bulk": "-2",
+					"recoil": "2",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Pistol"
+						},
+						{
+							"type": "dx",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Pistol",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Rifle",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Musket",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Shotgun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Light Machine Gun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Submachine Gun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Gun!"
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Grenade Launcher",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Gyroc",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Light Anti-Armor Weapon",
+							"modifier": -4
+						}
+					],
+					"calc": {
+						"damage": "2d+1 pi"
+					}
+				}
+			],
+			"quantity": 1,
+			"calc": {
+				"value": 800,
+				"extended_value": 800,
+				"weight": "2 lb",
+				"extended_weight": "2 lb"
+			}
+		},
+		{
 			"id": "eyxPZZZru8UywSLVk",
-			"description": "H\u0026K P11, 7.62X36mm",
+			"description": "H\u0026K P11, 7.62x36mm",
 			"reference": "HT91",
 			"local_notes": "2xXS/5,000 shots.",
 			"tech_level": "7",
@@ -34639,24 +35348,6 @@
 				"extended_value": 1500,
 				"weight": "75 lb",
 				"extended_weight": "75 lb"
-			}
-		},
-		{
-			"id": "eEQYDoDWZp4GQZEw6",
-			"description": "H\u0026K P11, 7.62x36mm magazine",
-			"reference": "HT91",
-			"tech_level": "7",
-			"legality_class": "2",
-			"tags": [
-				"Firearms"
-			],
-			"base_value": "75",
-			"quantity": 1,
-			"calc": {
-				"value": 75,
-				"extended_value": 75,
-				"weight": "0 lb",
-				"extended_weight": "0 lb"
 			}
 		},
 		{
@@ -34765,6 +35456,133 @@
 				"extended_value": 1100,
 				"weight": "2.5 lb",
 				"extended_weight": "2.5 lb"
+			}
+		},
+		{
+			"id": "eEQYDoDWZp4GQZEw6",
+			"description": "H\u0026K P11, 7.62x36mm magazine",
+			"reference": "HT91",
+			"tech_level": "7",
+			"legality_class": "2",
+			"tags": [
+				"Firearms"
+			],
+			"base_value": "75",
+			"quantity": 1,
+			"calc": {
+				"value": 75,
+				"extended_value": 75,
+				"weight": "0 lb",
+				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "eW69mERi9zZcSfsCG",
+			"description": "H\u0026K UMP, .40 S\u0026W",
+			"reference": "HT126",
+			"local_notes": "Accessory rail.",
+			"tech_level": "8",
+			"legality_class": "2",
+			"tags": [
+				"Firearms"
+			],
+			"base_value": "900",
+			"base_weight": "6 lb",
+			"weapons": [
+				{
+					"id": "W-YmLwkNyorv_bjIQ",
+					"sv": 1,
+					"damage": {
+						"type": "pi+",
+						"base": "3d-1"
+					},
+					"strength": "8†",
+					"accuracy": "4",
+					"range": "190/2,000",
+					"rate_of_fire": "12",
+					"shots": "30+1(3)",
+					"bulk": "-4*",
+					"recoil": "2",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Submachine Gun"
+						},
+						{
+							"type": "dx",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Pistol",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Rifle",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Musket",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Shotgun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Light Machine Gun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Submachine Gun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Gun!"
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Grenade Launcher",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Gyroc",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Light Anti-Armor Weapon",
+							"modifier": -4
+						}
+					],
+					"calc": {
+						"damage": "3d-1 pi+"
+					}
+				}
+			],
+			"quantity": 1,
+			"calc": {
+				"value": 900,
+				"extended_value": 900,
+				"weight": "6 lb",
+				"extended_weight": "6 lb"
 			}
 		},
 		{
@@ -38395,6 +39213,115 @@
 			}
 		},
 		{
+			"id": "eZji3LilFkAnS0Otu",
+			"description": "IMI Galil ARM, 7.62x51mm",
+			"reference": "HT117",
+			"reference_highlight": "The Galil ARM is also available in 7.62¥51mm NATO",
+			"tech_level": "7",
+			"legality_class": "2",
+			"tags": [
+				"Firearms"
+			],
+			"base_value": "1350",
+			"base_weight": "11.5 lb",
+			"weapons": [
+				{
+					"id": "WvZ14MmBYRpaft4EB",
+					"sv": 1,
+					"damage": {
+						"type": "pi",
+						"base": "7d"
+					},
+					"strength": "10B†",
+					"accuracy": "5",
+					"range": "1,000/4,200",
+					"rate_of_fire": "10",
+					"shots": "25+1(3)",
+					"bulk": "-5*",
+					"recoil": "3",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Rifle"
+						},
+						{
+							"type": "dx",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Pistol",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Rifle",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Musket",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Shotgun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Light Machine Gun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Submachine Gun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Gun!"
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Grenade Launcher",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Gyroc",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Light Anti-Armor Weapon",
+							"modifier": -4
+						}
+					],
+					"calc": {
+						"damage": "7d pi"
+					}
+				}
+			],
+			"quantity": 1,
+			"calc": {
+				"value": 1350,
+				"extended_value": 1350,
+				"weight": "11.5 lb",
+				"extended_weight": "11.5 lb"
+			}
+		},
+		{
 			"id": "e67zCZr-Pud7CFltf",
 			"description": "IMI Galil ARM, .223 Remington",
 			"reference": "HT120",
@@ -38500,6 +39427,114 @@
 				"extended_value": 1100,
 				"weight": "11.3 lb",
 				"extended_weight": "11.3 lb"
+			}
+		},
+		{
+			"id": "e6AxDhCs4UiwTfAQz",
+			"description": "IMI Galil SR, 7.62x51mm",
+			"reference": "HT117",
+			"tech_level": "7",
+			"legality_class": "3",
+			"tags": [
+				"Firearms"
+			],
+			"base_value": "5600",
+			"base_weight": "15.6 lb",
+			"weapons": [
+				{
+					"id": "WzpajmMegwEjhOBLp",
+					"sv": 1,
+					"damage": {
+						"type": "pi",
+						"base": "7d"
+					},
+					"strength": "1B†",
+					"accuracy": "5+2",
+					"range": "1,000/4,200",
+					"rate_of_fire": "3",
+					"shots": "20+1(3)",
+					"bulk": "-6*",
+					"recoil": "3",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Rifle"
+						},
+						{
+							"type": "dx",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Pistol",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Rifle",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Musket",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Shotgun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Light Machine Gun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Submachine Gun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Gun!"
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Grenade Launcher",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Gyroc",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Light Anti-Armor Weapon",
+							"modifier": -4
+						}
+					],
+					"calc": {
+						"damage": "7d pi"
+					}
+				}
+			],
+			"quantity": 1,
+			"calc": {
+				"value": 5600,
+				"extended_value": 5600,
+				"weight": "15.6 lb",
+				"extended_weight": "15.6 lb"
 			}
 		},
 		{
@@ -38927,7 +39962,7 @@
 		{
 			"id": "egoHIkCp5i8EKEf15",
 			"description": "Intratec MP-9, 9x19mm",
-			"reference": "HT101",
+			"reference": "HT102",
 			"local_notes": "Sling swivels. Malf 16.",
 			"tech_level": "8",
 			"legality_class": "2",
@@ -40364,6 +41399,114 @@
 			}
 		},
 		{
+			"id": "escplyUOQkRQ6JZ0A",
+			"description": "Izhmash AK-101, 5.56x45mm",
+			"reference": "HT114",
+			"tech_level": "8",
+			"legality_class": "2",
+			"tags": [
+				"Firearms"
+			],
+			"base_value": "400",
+			"base_weight": "8.3 lb",
+			"weapons": [
+				{
+					"id": "WjxcIRDrnsZQ8MCNP",
+					"sv": 1,
+					"damage": {
+						"type": "pi",
+						"base": "4d+2"
+					},
+					"strength": "9†",
+					"accuracy": "4",
+					"range": "440/3,000",
+					"rate_of_fire": "11",
+					"shots": "30+1(3)",
+					"bulk": "-5*",
+					"recoil": "2",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Rifle"
+						},
+						{
+							"type": "dx",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Pistol",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Rifle",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Musket",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Shotgun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Light Machine Gun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Submachine Gun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Gun!"
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Grenade Launcher",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Gyroc",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Light Anti-Armor Weapon",
+							"modifier": -4
+						}
+					],
+					"calc": {
+						"damage": "4d+2 pi"
+					}
+				}
+			],
+			"quantity": 1,
+			"calc": {
+				"value": 400,
+				"extended_value": 400,
+				"weight": "8.3 lb",
+				"extended_weight": "8.3 lb"
+			}
+		},
+		{
 			"id": "eOVTpR5qj7r7tXK4t",
 			"description": "Izhmash PP-19 Bizon-2, 9x18mm",
 			"reference": "HT124",
@@ -40472,8 +41615,116 @@
 			}
 		},
 		{
+			"id": "ecLxFjjM1mMVWoAGP",
+			"description": "Izhmash PP-19 Bizon-2-01, 9x19mm",
+			"reference": "HT126",
+			"tech_level": "8",
+			"legality_class": "2",
+			"tags": [
+				"Firearms"
+			],
+			"base_value": "450",
+			"base_weight": "8 lb",
+			"weapons": [
+				{
+					"id": "WvKQctidMRVYJO9En",
+					"sv": 1,
+					"damage": {
+						"type": "pi",
+						"base": "3d-1"
+					},
+					"strength": "8†",
+					"accuracy": "3",
+					"range": "170/1,900",
+					"rate_of_fire": "12",
+					"shots": "53(5)",
+					"bulk": "-4*",
+					"recoil": "2",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Submachine Gun"
+						},
+						{
+							"type": "dx",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Pistol",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Rifle",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Musket",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Shotgun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Light Machine Gun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Submachine Gun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Gun!"
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Grenade Launcher",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Gyroc",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Light Anti-Armor Weapon",
+							"modifier": -4
+						}
+					],
+					"calc": {
+						"damage": "3d-1 pi"
+					}
+				}
+			],
+			"quantity": 1,
+			"calc": {
+				"value": 450,
+				"extended_value": 450,
+				"weight": "8 lb",
+				"extended_weight": "8 lb"
+			}
+		},
+		{
 			"id": "e3tnTlTqlfBqks9Ep",
-			"description": "Izhmash SVD, 7.62X54mmR",
+			"description": "Izhmash SVD, 7.62x54mmR",
 			"reference": "HT120",
 			"tech_level": "7",
 			"legality_class": "2",
@@ -40484,7 +41735,7 @@
 			"base_weight": "10.1 lb",
 			"weapons": [
 				{
-					"id": "WGL6nf9ylqH5zOcwH",
+					"id": "WXeKV09s2F9CHqR8X",
 					"sv": 1,
 					"damage": {
 						"type": "pi",
@@ -44252,7 +45503,7 @@
 		},
 		{
 			"id": "eLuev-cAnAt8HlrcB",
-			"description": "Luger LP08 Artillerie, 9X19mm",
+			"description": "Luger LP08 Artillerie, 9x19mm",
 			"reference": "HT98",
 			"tech_level": "6",
 			"legality_class": "3",
@@ -44468,7 +45719,7 @@
 		},
 		{
 			"id": "eI7Ks4a5VsC5SvIj6",
-			"description": "Luger P08, 9X19mm",
+			"description": "Luger P08, 9x19mm",
 			"reference": "HT101",
 			"tech_level": "6",
 			"legality_class": "3",
@@ -45369,7 +46620,7 @@
 		},
 		{
 			"id": "eA7bP8bsmcjZ_t7oj",
-			"description": "MAC-Ingram M10, 9X19mm",
+			"description": "MAC-Ingram M10, 9x19mm",
 			"reference": "HT124",
 			"tech_level": "7",
 			"legality_class": "2",
@@ -45473,6 +46724,222 @@
 				"extended_value": 425,
 				"weight": "7.5 lb",
 				"extended_weight": "7.5 lb"
+			}
+		},
+		{
+			"id": "e30AeQCWBcbyGEg5_",
+			"description": "MAC-Ingram M10, .45 ACP",
+			"reference": "HT126",
+			"tech_level": "7",
+			"legality_class": "2",
+			"tags": [
+				"Firearms"
+			],
+			"base_value": "425",
+			"base_weight": "8.4 lb",
+			"weapons": [
+				{
+					"id": "Weabg66VWNz5qUeh6",
+					"sv": 1,
+					"damage": {
+						"type": "pi+",
+						"base": "2d+1"
+					},
+					"strength": "8†",
+					"accuracy": "3",
+					"range": "140/1,500",
+					"rate_of_fire": "19",
+					"shots": "30(3)",
+					"bulk": "-3*",
+					"recoil": "2",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Submachine Gun"
+						},
+						{
+							"type": "dx",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Pistol",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Rifle",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Musket",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Shotgun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Light Machine Gun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Submachine Gun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Gun!"
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Grenade Launcher",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Gyroc",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Light Anti-Armor Weapon",
+							"modifier": -4
+						}
+					],
+					"calc": {
+						"damage": "2d+1 pi+"
+					}
+				}
+			],
+			"quantity": 1,
+			"calc": {
+				"value": 425,
+				"extended_value": 425,
+				"weight": "8.4 lb",
+				"extended_weight": "8.4 lb"
+			}
+		},
+		{
+			"id": "eMM09B_Dll6_5XloZ",
+			"description": "MAC-Ingram M11, .380 ACP",
+			"reference": "HT124",
+			"tech_level": "7",
+			"legality_class": "2",
+			"tags": [
+				"Firearms"
+			],
+			"base_value": "425",
+			"base_weight": "4.6 lb",
+			"weapons": [
+				{
+					"id": "WB1p0Uc3XjeRZsDXz",
+					"sv": 1,
+					"damage": {
+						"type": "pi",
+						"base": "2d-1"
+					},
+					"strength": "7†",
+					"accuracy": "3",
+					"range": "110/1,100",
+					"rate_of_fire": "26",
+					"shots": "32(3)",
+					"bulk": "-3*",
+					"recoil": "2",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Submachine Gun"
+						},
+						{
+							"type": "dx",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Pistol",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Rifle",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Musket",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Shotgun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Light Machine Gun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Submachine Gun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Gun!"
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Grenade Launcher",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Gyroc",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Light Anti-Armor Weapon",
+							"modifier": -4
+						}
+					],
+					"calc": {
+						"damage": "2d-1 pi"
+					}
+				}
+			],
+			"quantity": 1,
+			"calc": {
+				"value": 425,
+				"extended_value": 425,
+				"weight": "4.6 lb",
+				"extended_weight": "4.6 lb"
 			}
 		},
 		{
@@ -45596,7 +47063,7 @@
 		},
 		{
 			"id": "elw1UjTxoiPrsgtjo",
-			"description": "Madsen M/03, 8x50mmR",
+			"description": "Madsen M/03, 8x58mmR",
 			"reference": "HT137",
 			"tech_level": "6",
 			"legality_class": "1",
@@ -47182,6 +48649,61 @@
 				"extended_value": 7000,
 				"weight": "59.4 lb",
 				"extended_weight": "59.4 lb"
+			}
+		},
+		{
+			"id": "eXZINE1_8btVlqKh-",
+			"description": "Maxim MG08/15, 7.92x57mm",
+			"reference": "HT137",
+			"tech_level": "6",
+			"legality_class": "1",
+			"tags": [
+				"Firearms"
+			],
+			"base_value": "7000",
+			"base_weight": "45.8 lb",
+			"weapons": [
+				{
+					"id": "WlQsQ_9ixJsVqq-r_",
+					"sv": 1,
+					"damage": {
+						"type": "pi",
+						"base": "7d+1"
+					},
+					"strength": "13B†",
+					"accuracy": "6",
+					"range": "1,000/4,400",
+					"rate_of_fire": "8!",
+					"shots": "50(5)",
+					"bulk": "-8",
+					"recoil": "2",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Gunner",
+							"specialization": "Machine Gun"
+						},
+						{
+							"type": "dx",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Gunner",
+							"modifier": -4
+						}
+					],
+					"calc": {
+						"damage": "7d+1 pi"
+					}
+				}
+			],
+			"quantity": 1,
+			"calc": {
+				"value": 7000,
+				"extended_value": 7000,
+				"weight": "45.8 lb",
+				"extended_weight": "45.8 lb"
 			}
 		},
 		{
@@ -49490,7 +51012,7 @@
 		},
 		{
 			"id": "ewGBW813Dt91YuMPF",
-			"description": "Mosin-Nagant PV-1891, 7.62X54mmR",
+			"description": "Mosin-Nagant PV-1891, 7.62x54mmR",
 			"reference": "HT120",
 			"tech_level": "6",
 			"legality_class": "3",
@@ -51994,7 +53516,7 @@
 		{
 			"id": "ejuWqhj9NkSuiqYHb",
 			"description": "Para-Ordinance P14-45, .45 ACP",
-			"reference": "HT98",
+			"reference": "HT99",
 			"tech_level": "6",
 			"legality_class": "3",
 			"tags": [
@@ -57733,6 +59255,114 @@
 			}
 		},
 		{
+			"id": "e56ncIcaArvfuNeRw",
+			"description": "Rheinmetall MG3, 7.62x51mm",
+			"reference": "HT137",
+			"tech_level": "6",
+			"legality_class": "1",
+			"tags": [
+				"Firearms"
+			],
+			"base_value": "4200",
+			"base_weight": "27.6 lb",
+			"weapons": [
+				{
+					"id": "WV3R9h_xsF40dTXLH",
+					"sv": 1,
+					"damage": {
+						"type": "pi",
+						"base": "7d"
+					},
+					"strength": "12B†",
+					"accuracy": "5",
+					"range": "1,100/4,400",
+					"rate_of_fire": "15",
+					"shots": "50(5)",
+					"bulk": "-7",
+					"recoil": "2",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Light Machine Gun"
+						},
+						{
+							"type": "dx",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Pistol",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Rifle",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Musket",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Shotgun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Light Machine Gun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Submachine Gun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Gun!"
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Grenade Launcher",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Gyroc",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Light Anti-Armor Weapon",
+							"modifier": -4
+						}
+					],
+					"calc": {
+						"damage": "7d pi"
+					}
+				}
+			],
+			"quantity": 1,
+			"calc": {
+				"value": 4200,
+				"extended_value": 4200,
+				"weight": "27.6 lb",
+				"extended_weight": "27.6 lb"
+			}
+		},
+		{
 			"id": "eHecPjpRFap20yY6n",
 			"description": "Rheinmetall MG34, 7.92x57mm",
 			"reference": "HT137",
@@ -59024,7 +60654,7 @@
 		},
 		{
 			"id": "ezn4GA-5Q5h8PEy1V",
-			"description": "Ruger Standard MK1, .22 Long Rifle",
+			"description": "Ruger Standard MK1, .22 LR",
 			"reference": "HT101",
 			"local_notes": "No lanyard ring.",
 			"tech_level": "7",
@@ -59133,7 +60763,7 @@
 		},
 		{
 			"id": "eSaSqH1J0NwjkUTPC",
-			"description": "Ruger Standard MK2, .22 Long Rifle",
+			"description": "Ruger Standard MK2, .22 LR",
 			"reference": "HT100",
 			"local_notes": "No lanyard ring.",
 			"tech_level": "7",
@@ -67777,6 +69407,114 @@
 			}
 		},
 		{
+			"id": "eMjASu8wlqnTL6W9T",
+			"description": "Steyr AUG A1, 9x19mm",
+			"reference": "HT118",
+			"tech_level": "8",
+			"legality_class": "2",
+			"tags": [
+				"Firearms"
+			],
+			"base_value": "1250",
+			"base_weight": "8.4 lb",
+			"weapons": [
+				{
+					"id": "WI2W4a1s8A56kLD-l",
+					"sv": 1,
+					"damage": {
+						"type": "pi",
+						"base": "3d-1"
+					},
+					"strength": "9†",
+					"accuracy": "4",
+					"range": "170/1,900",
+					"rate_of_fire": "11",
+					"shots": "25+1(3)",
+					"bulk": "-4",
+					"recoil": "2",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Rifle"
+						},
+						{
+							"type": "dx",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Pistol",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Rifle",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Musket",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Shotgun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Light Machine Gun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Submachine Gun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Gun!"
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Grenade Launcher",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Gyroc",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Light Anti-Armor Weapon",
+							"modifier": -4
+						}
+					],
+					"calc": {
+						"damage": "3d-1 pi"
+					}
+				}
+			],
+			"quantity": 1,
+			"calc": {
+				"value": 1250,
+				"extended_value": 1250,
+				"weight": "8.4 lb",
+				"extended_weight": "8.4 lb"
+			}
+		},
+		{
 			"id": "e3wCfboFFWR9cPrL0",
 			"description": "Steyr TMP, 9x19mm",
 			"reference": "HT124",
@@ -71311,7 +73049,7 @@
 		},
 		{
 			"id": "eMZlKZB0G8CUGPnxH",
-			"description": "Tikkakoski KP/31, 9X19mm",
+			"description": "Tikkakoski KP/31, 9x19mm",
 			"reference": "HT124",
 			"tech_level": "6",
 			"legality_class": "2",
@@ -72753,6 +74491,116 @@
 				"extended_value": 10,
 				"weight": "0 lb",
 				"extended_weight": "0 lb"
+			}
+		},
+		{
+			"id": "ei3jkhu0d09YO3j9F",
+			"description": "TsNIITochMash APS, 5.66x39mm",
+			"reference": "HT120",
+			"reference_highlight": "TsNIITochMash APS, 5.66¥39mm",
+			"tech_level": "7",
+			"legality_class": "2",
+			"tags": [
+				"Firearms"
+			],
+			"base_value": "750",
+			"base_weight": "8.2",
+			"weapons": [
+				{
+					"id": "W10jqOZ0kjeSuoY3C",
+					"sv": 1,
+					"damage": {
+						"type": "imp",
+						"base": "5d"
+					},
+					"strength": "9†",
+					"accuracy": "2",
+					"range": "750/3,200",
+					"rate_of_fire": "10",
+					"shots": "26+1(3)",
+					"bulk": "-5*",
+					"recoil": "3",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Rifle"
+						},
+						{
+							"type": "dx",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Pistol",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Rifle",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Musket",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Shotgun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Light Machine Gun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Submachine Gun",
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": "Gun!"
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Grenade Launcher",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Gyroc",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": "Guns",
+							"specialization": "Light Anti-Armor Weapon",
+							"modifier": -4
+						}
+					],
+					"calc": {
+						"damage": "5d imp"
+					}
+				}
+			],
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"value": 750,
+				"extended_value": 750,
+				"weight": "8.2 lb",
+				"extended_weight": "8.2 lb"
 			}
 		},
 		{
@@ -74575,7 +76423,7 @@
 		},
 		{
 			"id": "eUFaNUMN3CAe9jlaI",
-			"description": "Walther P38, 9X19mm",
+			"description": "Walther P38, 9x19mm",
 			"reference": "HT101",
 			"tech_level": "7",
 			"legality_class": "3",
@@ -74683,7 +76531,7 @@
 		},
 		{
 			"id": "eIK1fulUKYPVEx2CS",
-			"description": "Walther P38K, 9X19mm",
+			"description": "Walther P38K, 9x19mm",
 			"reference": "HT100",
 			"tech_level": "7",
 			"legality_class": "3",
@@ -75118,8 +76966,8 @@
 		},
 		{
 			"id": "eyN6iYurcjg8_7LTi",
-			"description": "Walther PP, .22 Long Rifle",
-			"reference": "HT101",
+			"description": "Walther PP, .22 LR",
+			"reference": "HT99",
 			"local_notes": "No lanyard ring.",
 			"tech_level": "6",
 			"legality_class": "3",
@@ -75228,7 +77076,7 @@
 		{
 			"id": "eDlnd6vsRjF1kGU7k",
 			"description": "Walther PP, .32 ACP",
-			"reference": "HT101",
+			"reference": "HT99",
 			"local_notes": "No lanyard ring.",
 			"tech_level": "6",
 			"legality_class": "3",
@@ -75337,7 +77185,7 @@
 		{
 			"id": "eTjU-bDioazP_I-BL",
 			"description": "Walther PP, .380 ACP",
-			"reference": "HT101",
+			"reference": "HT99",
 			"local_notes": "No lanyard ring.",
 			"tech_level": "6",
 			"legality_class": "3",
@@ -75445,8 +77293,8 @@
 		},
 		{
 			"id": "eiLRa7M9mFn_zzZOY",
-			"description": "Walther PPK, .22 Long Rifle",
-			"reference": "HT101",
+			"description": "Walther PPK, .22 LR",
+			"reference": "HT99",
 			"local_notes": "No lanyard ring.",
 			"tech_level": "6",
 			"legality_class": "3",
@@ -75664,7 +77512,7 @@
 		{
 			"id": "esC9A8riENYon2OAM",
 			"description": "Walther PPK, .380 ACP",
-			"reference": "HT101",
+			"reference": "HT99",
 			"local_notes": "No lanyard ring.",
 			"tech_level": "6",
 			"legality_class": "3",


### PR DESCRIPTION
The changes are a mixture of:

1. Renaming weapons with bullet diameters of the form AXBmm to AxBmm.
2. Renaming weapons to match their name in the table. Usually abbreviating by multi-word to initials or removing parts, but occasionally other divergences.
3. Fixing page references where observed.
4. Adding gun variants that are used by contributed magazines