### PR TITLE
High Tech: Amend Magazines for consistency with the names of their guns

### DIFF
--- a/Library/High Tech/High Tech Equipment.eqp
+++ b/Library/High Tech/High Tech Equipment.eqp
@@ -4217,7 +4217,7 @@
 		},
 		{
 			"id": "EckLmINt4nplZOd-H",
-			"description": "AAI XM19 SFR, 5.6x57mm 50-round magazine",
+			"description": "AAI XM19, 5.6x57mm 50-round magazine",
 			"reference": "HT116",
 			"local_notes": "Requires 5.6x57mm ammunition",
 			"tech_level": "7",
@@ -4240,7 +4240,7 @@
 		},
 		{
 			"id": "E5g6_r8J4Lc0tZhjV",
-			"description": "AAI XM19 SFR, 5.6x57mm 60-round drum magazine",
+			"description": "AAI XM19, 5.6x57mm 60-round drum magazine",
 			"reference": "HT116",
 			"local_notes": "Requires 5.6x57mm ammunition",
 			"tech_level": "7",
@@ -4976,7 +4976,7 @@
 		},
 		{
 			"id": "E2AePJgnPNp6oPkpm",
-			"description": "AI AWM, .300 Winchester Magnum 5-round magazine",
+			"description": "AI AWM-F, .300 WM 5-round magazine",
 			"reference": "HT118, HT119",
 			"local_notes": "Requires .300 Winchester Magnum ammunition",
 			"tech_level": "8",
@@ -7194,7 +7194,7 @@
 		},
 		{
 			"id": "EaV7_2Di4-0qMogQd",
-			"description": "Armalite AR-7 Explorer, .22 LR 8-round magazine",
+			"description": "ArmaLite AR-7, .22 LR 8-round magazine",
 			"reference": "HT115",
 			"local_notes": "Requires .22 LR ammunition",
 			"tech_level": "7",
@@ -7862,7 +7862,7 @@
 		},
 		{
 			"id": "E0K7D7iPLJV2qGkML",
-			"description": "Auto Ordinance M1921, .45 ACP 20-round magazine",
+			"description": "Auto-Ordnance M1921, .45 ACP 20-round magazine",
 			"reference": "HT122",
 			"local_notes": "Requires .45 ACP ammunition",
 			"tech_level": "6",
@@ -7885,7 +7885,7 @@
 		},
 		{
 			"id": "EXy9iVENk8FISllqn",
-			"description": "Auto Ordinance M1921, .45 ACP 30-round magazine",
+			"description": "Auto-Ordnance M1921, .45 ACP 30-round magazine",
 			"reference": "HT122",
 			"local_notes": "Requires .45 ACP ammunition",
 			"tech_level": "6",
@@ -7908,7 +7908,7 @@
 		},
 		{
 			"id": "E0LFvnJpSC0Tu12-R",
-			"description": "Auto Ordinance M1921, .45 ACP 50-round drum magazine",
+			"description": "Auto-Ordnance M1921, .45 ACP 50-round drum magazine",
 			"reference": "HT122",
 			"local_notes": "Requires .45 ACP ammunition",
 			"tech_level": "6",
@@ -7931,7 +7931,7 @@
 		},
 		{
 			"id": "ExPz04a-zJOwkJB3T",
-			"description": "Auto Ordinance M1921, .45 ACP 100-round drum magazine",
+			"description": "Auto-Ordnance M1921, .45 ACP 100-round drum magazine",
 			"reference": "HT122",
 			"local_notes": "Malf 16, -1 Bulk Requires .45 ACP ammunition",
 			"tech_level": "6",
@@ -10629,7 +10629,7 @@
 		},
 		{
 			"id": "Eu6BiVY37LuYGHZZG",
-			"description": "Bergmann MP18/1, 9x19mm 20-round magazine",
+			"description": "Bergmann MP18/I, 9x19mm 20-round magazine",
 			"reference": "HT122",
 			"local_notes": "Requires 9x19mm ammunition",
 			"tech_level": "6",
@@ -10652,7 +10652,7 @@
 		},
 		{
 			"id": "EaC1n8pNNoSRLSWJa",
-			"description": "Bergmann MP18/1, 9x19mm 32-round magazine",
+			"description": "Bergmann MP18/I, 9x19mm 32-round magazine",
 			"reference": "HT122",
 			"local_notes": "Requires 9x19mm ammunition",
 			"tech_level": "6",
@@ -10675,7 +10675,7 @@
 		},
 		{
 			"id": "E_jmulBJEVntrgJvv",
-			"description": "Bergmann MP18/1, 9x19mm 50-round magazine",
+			"description": "Bergmann MP18/I, 9x19mm 50-round magazine",
 			"reference": "HT122",
 			"local_notes": "Requires 9x19mm ammunition",
 			"tech_level": "6",
@@ -12186,7 +12186,7 @@
 		},
 		{
 			"id": "Etf7yzPC0VscmvR4_",
-			"description": "Browning M2HB, .50 Browning 100-round Can",
+			"description": "Browning M2HB, .50 Browning 100-round can",
 			"reference": "HT133",
 			"local_notes": "Requires .50 Browning ammunition, Contains Disintegrating Belt",
 			"tech_level": "6",
@@ -12209,7 +12209,7 @@
 		},
 		{
 			"id": "Es5kiJ1YzBdjIOMCa",
-			"description": "Browning M2HB, .50 Browning 100-round Disintegrating Belt",
+			"description": "Browning M2HB, .50 Browning 100-round disintegrating belt",
 			"reference": "HT133",
 			"local_notes": "Requires .50 Browning ammunition",
 			"tech_level": "6",
@@ -12232,7 +12232,7 @@
 		},
 		{
 			"id": "EsjoZXbkk9vgjPZZI",
-			"description": "Browning M2HB, .50 Browning 105-round Can",
+			"description": "Browning M2HB, .50 Browning 105-round can",
 			"reference": "HT133",
 			"local_notes": "Requires .50 Browning ammunition, Contains Disintegrating Belt",
 			"tech_level": "6",
@@ -12255,7 +12255,7 @@
 		},
 		{
 			"id": "EjmvSD6Hp0QJbYt5H",
-			"description": "Browning M2HB, .50 Browning 105-round Disintegrating Belt",
+			"description": "Browning M2HB, .50 Browning 105-round disintegrating belt",
 			"reference": "HT133",
 			"local_notes": "Requires .50 Browning ammunition",
 			"tech_level": "6",
@@ -12278,7 +12278,7 @@
 		},
 		{
 			"id": "EnilXQsR-qXez0-FL",
-			"description": "Browning M2HB, .50 Browning 210-round Can",
+			"description": "Browning M2HB, .50 Browning 210-round can",
 			"reference": "HT133",
 			"local_notes": "Requires .50 Browning ammunition, Contains 2 Disintegrating Belt",
 			"tech_level": "6",
@@ -12301,7 +12301,7 @@
 		},
 		{
 			"id": "EAQsZiWIpZlBsYK_q",
-			"description": "Browning M2HB, .50 Browning 225-round Box",
+			"description": "Browning M2HB, .50 Browning 225-round box",
 			"reference": "HT133",
 			"local_notes": "Requires .50 Browning ammunition, Contains Disintegrating Belt",
 			"tech_level": "7",
@@ -12324,7 +12324,7 @@
 		},
 		{
 			"id": "EJ_QxaYc8LxHeYn2K",
-			"description": "Browning M2HB, .50 Browning 225-round Disintegrating Belt",
+			"description": "Browning M2HB, .50 Browning 225-round disintegrating belt",
 			"reference": "HT133",
 			"local_notes": "Requires .50 Browning ammunition",
 			"tech_level": "7",
@@ -12402,7 +12402,7 @@
 		},
 		{
 			"id": "E_wipDteCHtZZDkcd",
-			"description": "Browning M1917, .30-06 Springfield 250-round Box",
+			"description": "Browning M1917, .30-06 Springfield 250-round box",
 			"reference": "HT131",
 			"local_notes": "Requires .30-06 Springfield ammunition, Contains Non-Disintegrating Cloth Belt",
 			"tech_level": "6",
@@ -12425,7 +12425,7 @@
 		},
 		{
 			"id": "Ew8EXSWDxLv9EPOLg",
-			"description": "Browning M1917, .30-06 Springfield 250-round Non-Disintegrating Cloth Belt",
+			"description": "Browning M1917, .30-06 Springfield 250-round non-disintegrating cloth belt",
 			"reference": "HT131",
 			"local_notes": "-1 Malf, Requires .30-06 Springfield ammunition",
 			"tech_level": "6",
@@ -12634,7 +12634,7 @@
 		},
 		{
 			"id": "E0jDz6is6RcRklVY2",
-			"description": "Browning M1919A4, .30-06 Springfield 250-round Box",
+			"description": "Browning M1919A4, .30-06 Springfield 250-round box",
 			"reference": "HT132",
 			"local_notes": "Requires .30-06 Springfield ammunition, Contains Non-Disintegrating Cloth Belt",
 			"tech_level": "6",
@@ -12657,7 +12657,7 @@
 		},
 		{
 			"id": "EetUXm8zGiehw3xp4",
-			"description": "Browning M1919A4, .30-06 Springfield 250-round Non-Disintegrating Cloth Belt",
+			"description": "Browning M1919A4, .30-06 Springfield 250-round non-disintegrating cloth belt",
 			"reference": "HT132",
 			"local_notes": "-1 Malf, Requires .30-06 Springfield ammunition",
 			"tech_level": "6",
@@ -15717,7 +15717,7 @@
 		},
 		{
 			"id": "EzfFBl22XbgiBStb5",
-			"description": "Colt .38 Super Auto, .38 Super Auto 9-round Magazine",
+			"description": "Colt .38 Super Auto, .38 Super Auto 9-round magazine",
 			"reference": "HT98",
 			"local_notes": "Requires .38 Super Auto ammunition",
 			"tech_level": "6",
@@ -15956,7 +15956,7 @@
 		},
 		{
 			"id": "EJqirI899e-5zrwWX",
-			"description": "Colt Delta Elite, 10x25mm Auto 8-round Magazine",
+			"description": "Colt Delta Elite, 10x25mm Auto 8-round magazine",
 			"reference": "HT99",
 			"local_notes": "Requires 10x25mm Auto ammunition",
 			"tech_level": "7",
@@ -21077,7 +21077,7 @@
 		},
 		{
 			"id": "EfeleRvE2ZuTwIR8m",
-			"description": "CZ Sa vz.61 Skorpion, .32 ACP 10-round magazine",
+			"description": "CZ Sa vz. 61 Skorpion, .32 ACP 10-round magazine",
 			"reference": "HT125",
 			"local_notes": "Requires .32 ACP ammunition",
 			"tech_level": "7",
@@ -21100,7 +21100,7 @@
 		},
 		{
 			"id": "Eq37uKfuTMmKrTIvy",
-			"description": "CZ Sa vz.61 Skorpion, .32 ACP 20-round magazine",
+			"description": "CZ Sa vz. 61 Skorpion, .32 ACP 20-round magazine",
 			"reference": "HT125",
 			"local_notes": "Requires .32 ACP ammunition",
 			"tech_level": "7",
@@ -21253,7 +21253,7 @@
 			}
 		},
 		{
-			"id": "eQecLZ6moAaufTm9W",
+			"id": "EQecLZ6moAaufTm9W",
 			"description": "Daewoo USAS-12, 12G 2.75\" 20-round drum magazine",
 			"reference": "HT107",
 			"local_notes": "-1 Bulk, Requires 12G 2.75\" ammunition",
@@ -24979,7 +24979,7 @@
 		},
 		{
 			"id": "EqUyRVnJB6tdK6XZl",
-			"description": "Enfield Bren Mk.1, .303 British 30-round Box Magazine",
+			"description": "Enfield Bren Mk I, .303 British 30-round box magazine",
 			"reference": "HT133",
 			"local_notes": "Requires .303 British ammunition",
 			"tech_level": "6",
@@ -25002,7 +25002,7 @@
 		},
 		{
 			"id": "E6f6pk9CND6vZLl3I",
-			"description": "Enfield Bren Mk.1, .303 British 100-round Pan Drum Magazine",
+			"description": "Enfield Bren Mk I, .303 British 100-round pan drum magazine",
 			"reference": "HT133",
 			"local_notes": "Requires .303 British ammunition",
 			"tech_level": "6",
@@ -26005,7 +26005,7 @@
 		},
 		{
 			"id": "E2LSfK-5phFTCI7E-",
-			"description": "Enfield Sten MkII, 9x19mm 32-round magazine",
+			"description": "Enfield Sten Mk II, 9x19mm 32-round magazine",
 			"reference": "HT124",
 			"local_notes": "Requires 9x19mm ammunition",
 			"tech_level": "7",
@@ -27862,8 +27862,8 @@
 		},
 		{
 			"id": "E4rhhgk7aSYGC3TzS",
-			"description": "FN Browning M1918 BAR, .300 Winchester Magnum 4-round magazine",
-			"reference": "HT112, HT113, HT117",
+			"description": "FN BAR Magnum, .300 WM 4-round magazine",
+			"reference": "HT117",
 			"local_notes": "Requires .300 Winchester Magnum ammunition",
 			"tech_level": "7",
 			"legality_class": "3",
@@ -28388,7 +28388,7 @@
 		},
 		{
 			"id": "EIYB5PRHDDsQY_2mp",
-			"description": "FN MAG, 7.62x51mm 100-round Disintegrating Belt",
+			"description": "FN MAG, 7.62x51mm 100-round disintegrating belt",
 			"reference": "HT134",
 			"local_notes": "Requires 7.62x51mm ammunition",
 			"tech_level": "7",
@@ -28411,7 +28411,7 @@
 		},
 		{
 			"id": "EmLhTr-7Ica5log2f",
-			"description": "FN MAG, 7.62x51mm 200-round Can",
+			"description": "FN MAG, 7.62x51mm 200-round can",
 			"reference": "HT134",
 			"local_notes": "Requires 7.62x51mm ammunition, Contains 2 Disintegrating Belts",
 			"tech_level": "7",
@@ -28542,7 +28542,7 @@
 		},
 		{
 			"id": "ECRPRLt74VgVr2MN_",
-			"description": "FN MINIMI, 5.56x45mm 100-round Disintegrating Belt",
+			"description": "FN MINIMI, 5.56x45mm 100-round disintegrating belt",
 			"reference": "HT136, HT137",
 			"local_notes": "Requires 5.56x45mm ammunition",
 			"tech_level": "8",
@@ -28565,7 +28565,7 @@
 		},
 		{
 			"id": "E5MsAaI2TYYP6PJB2",
-			"description": "FN MINIMI, 5.56x45mm 100-round Soft Pouch",
+			"description": "FN MINIMI, 5.56x45mm 100-round soft pouch",
 			"reference": "HT136, HT137",
 			"local_notes": "Requires 5.56x45mm ammunition, Contains Disintegrating Belt",
 			"tech_level": "8",
@@ -28588,7 +28588,7 @@
 		},
 		{
 			"id": "EDDEc2nze86SWHSP3",
-			"description": "FN MINIMI, 5.56x45mm 200-round Disintegrating Belt",
+			"description": "FN MINIMI, 5.56x45mm 200-round disintegrating belt",
 			"reference": "HT136, HT137",
 			"local_notes": "Requires 5.56x45mm ammunition",
 			"tech_level": "8",
@@ -28611,7 +28611,7 @@
 		},
 		{
 			"id": "Eo_5YdCfztQ69Cj1T",
-			"description": "FN MINIMI, 5.56x45mm 200-round Plastic Can",
+			"description": "FN MINIMI, 5.56x45mm 200-round plastic can",
 			"reference": "HT136, HT137",
 			"local_notes": "-1 Stealth, Requires 5.56x45mm ammunition, Contains Disintegrating Belt",
 			"tech_level": "8",
@@ -29299,7 +29299,7 @@
 		},
 		{
 			"id": "EBKdViKbWr-KR6t_2",
-			"description": "FN Mk.17, 7.62x51mm 20-round magazine",
+			"description": "FN MK 17 MOD 0, 7.62x51mm 20-round magazine",
 			"reference": "HT122",
 			"local_notes": "Requires 7.62x51mm ammunition",
 			"tech_level": "8",
@@ -29430,7 +29430,7 @@
 		},
 		{
 			"id": "E_q8mGmxBUmdOGPfh",
-			"description": "FN Mk.48 MOD 0, 7.62x51mm 100-round Disintegrating Belt",
+			"description": "FN MK 48 MOD 0, 7.62x51mm 100-round disintegrating belt",
 			"reference": "HT137",
 			"local_notes": "Requires 7.62x51mm ammunition",
 			"tech_level": "8",
@@ -30127,7 +30127,7 @@
 		},
 		{
 			"id": "E7GOmYdsPh8HeMu8-",
-			"description": "FN-Browning HP, 9x19mm Parabellum 13-round magazine",
+			"description": "FN-Browning HP, 9x19mm 13-round magazine",
 			"reference": "HT99",
 			"local_notes": "Requires 9x19mm Parabellum ammunition",
 			"tech_level": "6",
@@ -30149,23 +30149,25 @@
 			}
 		},
 		{
-			"id": "eYB6-cPq2a7ovA2FE",
-			"description": "FN-Browning High Power, 9x19mm 20-round magazine",
+			"id": "EYB6-cPq2a7ovA2FE",
+			"description": "FN-Browning HP, 9x19mm 20-round magazine",
 			"reference": "HT99",
-			"local_notes": "No lanyard ring.",
+			"local_notes": "Requires 9x19mm Parabellum ammunition",
 			"tech_level": "6",
 			"legality_class": "3",
 			"tags": [
-				"Firearms"
+				"Ammunition",
+				"Magazines",
+				"Pistol"
 			],
 			"base_value": "28",
-			"base_weight": "0.8 lb",
+			"base_weight": "0.28 lb",
 			"quantity": 1,
 			"calc": {
 				"value": 28,
 				"extended_value": 28,
-				"weight": "0.8 lb",
-				"extended_weight": "0.8 lb"
+				"weight": "0.28 lb",
+				"extended_weight": "0.28 lb"
 			}
 		},
 		{
@@ -30278,7 +30280,7 @@
 		},
 		{
 			"id": "EuiqWQWsZG_mYPiw4",
-			"description": "FN Browning Mle 1906 C25, .25 ACP 6-round Magazine",
+			"description": "FN Browning Mle 1906, .25 ACP 6-round magazine",
 			"reference": "HT97",
 			"local_notes": "Requires .25 ACP ammunition",
 			"tech_level": "6",
@@ -31564,7 +31566,7 @@
 		},
 		{
 			"id": "EiQIACQj1vXjJAQoG",
-			"description": "Gatling 1893, .30-40 Krag 104-round Accles Drum",
+			"description": "Gatling M1893, .30-40 Krag 104-round accles drum",
 			"reference": "HT135",
 			"local_notes": "Requires .30-40 Krag ammunition",
 			"tech_level": "6",
@@ -32418,7 +32420,7 @@
 		},
 		{
 			"id": "EUC4If37V_T4tJfns",
-			"description": "Glock 17, 9x19mm Parabellum 17-round magazine",
+			"description": "Glock 17, 9x19mm 17-round magazine",
 			"reference": "HT100",
 			"local_notes": "Requires 9x19mm Parabellum ammunition",
 			"tech_level": "8",
@@ -32440,8 +32442,8 @@
 			}
 		},
 		{
-			"id": "eeaduNb8xd0rLFpYz",
-			"description": "Glock 17, 9x19mm Parabellum 19-round magazine",
+			"id": "EeaduNb8xd0rLFpYz",
+			"description": "Glock 17, 9x19mm 19-round magazine",
 			"reference": "HT100",
 			"local_notes": "Requires 9x19mm Parabellum ammunition",
 			"tech_level": "8",
@@ -32464,7 +32466,7 @@
 		},
 		{
 			"id": "EGIyqfCGlt64Brh8z",
-			"description": "Glock 17, 9x19mm Parabellum 30-round magazine",
+			"description": "Glock 17, 9x19mm 31-round magazine",
 			"reference": "HT100, HT101",
 			"local_notes": "Requires 9x19mm Parabellum ammunition",
 			"tech_level": "8",
@@ -32703,7 +32705,7 @@
 		},
 		{
 			"id": "ER1hE1upxLPe3c1OV",
-			"description": "Glock 19, 9x19mm Parabellum 15-round magazine",
+			"description": "Glock 19, 9x19mm 15-round magazine",
 			"reference": "HT101",
 			"local_notes": "Requires 9x19mm Parabellum ammunition",
 			"tech_level": "8",
@@ -33489,7 +33491,7 @@
 		},
 		{
 			"id": "EixKDzdzlffvrejT1",
-			"description": "Glock 26, 9x19mm Parabellum 10-round magazine",
+			"description": "Glock 26, 9x19mm 10-round magazine",
 			"reference": "HT101",
 			"local_notes": "Requires 9x19mm Parabellum ammunition",
 			"tech_level": "8",
@@ -35364,7 +35366,7 @@
 		},
 		{
 			"id": "EvW0KRAQfmMrsKWVM",
-			"description": "H\u0026K G11, 4.73x33mm Dynamit-Nobel 15-round Reloading Unit",
+			"description": "H\u0026K G11, 4.73x33mm 15-round reloading unit",
 			"reference": "HT119",
 			"local_notes": "3 Ready Actions to empty into a magazine",
 			"tech_level": "8",
@@ -35387,7 +35389,7 @@
 		},
 		{
 			"id": "E2sYuxpI_nPA_g1D9",
-			"description": "H\u0026K G11, 4.73x33mm Dynamit-Nobel 45-round magazine",
+			"description": "H\u0026K G11, 4.73x33mm 45-round magazine",
 			"reference": "HT119",
 			"local_notes": "Requires 4.73x33mm Dynamit-Nobel ammunition, Requires Reloading Units",
 			"tech_level": "8",
@@ -35519,7 +35521,7 @@
 		},
 		{
 			"id": "EKvgW1elLWq4J9wrz",
-			"description": "H\u0026K G36 Magazine, 5.56x45mm 30-round magazine",
+			"description": "H\u0026K G36, 5.56x45mm 30-round magazine",
 			"reference": "HT121",
 			"local_notes": "Requires 5.56x45mm ammunition, can be coupled innately",
 			"tech_level": "8",
@@ -35977,7 +35979,7 @@
 		},
 		{
 			"id": "EnrvT1mlVO6pfDj5c",
-			"description": "H\u0026K HK21, 7.62x51mm 100-round Assault Can",
+			"description": "H\u0026K HK21A1, 7.62x51mm 100-round assault can",
 			"reference": "HT136",
 			"local_notes": "Requires 7.62x51mm ammunition, Contains Disintegrating Belt",
 			"tech_level": "7",
@@ -36000,7 +36002,7 @@
 		},
 		{
 			"id": "E_wv__N7mHJGStbvy",
-			"description": "H\u0026K HK21, 7.62x51mm 100-round Disintegrating Belt",
+			"description": "H\u0026K HK21A1, 7.62x51mm 100-round disintegrating belt",
 			"reference": "HT136",
 			"local_notes": "Requires 7.62x51mm ammunition",
 			"tech_level": "7",
@@ -36131,7 +36133,7 @@
 		},
 		{
 			"id": "EmvLtzTLojS3FCJd4",
-			"description": "H\u0026K HK23, 5.56x45mm 200-round Disintegrating Belt",
+			"description": "H\u0026K HK23E, 5.56x45mm 200-round disintegrating belt",
 			"reference": "HT136",
 			"local_notes": "Requires 5.56x45mm ammunition",
 			"tech_level": "7",
@@ -36262,9 +36264,9 @@
 		},
 		{
 			"id": "ECYPtA198KuBa_AJS",
-			"description": "H\u0026K 33, 5.56x45mm 25-round magazine",
+			"description": "H\u0026K HK33, .223 Remington 25-round magazine",
 			"reference": "HT116",
-			"local_notes": "Requires 5.56x45mm ammunition",
+			"local_notes": "Requires .223 Remington ammunition",
 			"tech_level": "7",
 			"legality_class": "3",
 			"tags": [
@@ -36285,9 +36287,9 @@
 		},
 		{
 			"id": "E6VIHRXa5UPR1MwCj",
-			"description": "H\u0026K 33, 5.56x45mm 40-round magazine",
+			"description": "H\u0026K HK33, .223 Remington 40-round magazine",
 			"reference": "HT116",
-			"local_notes": "Requires 5.56x45mm ammunition",
+			"local_notes": "Requires .223 Remington ammunition",
 			"tech_level": "7",
 			"legality_class": "3",
 			"tags": [
@@ -36478,7 +36480,7 @@
 		},
 		{
 			"id": "EYwhrAFYFySfVw2zM",
-			"description": "H\u0026K MP5, 9x19mm 15-round magazine",
+			"description": "H\u0026K MP5A3, 9x19mm 15-round magazine",
 			"reference": "HT123",
 			"local_notes": "Requires 9x19mm ammunition",
 			"tech_level": "7",
@@ -36501,7 +36503,7 @@
 		},
 		{
 			"id": "EDlNYo1n2ckFINtv_",
-			"description": "H\u0026K MP5, 9x19mm 30-round magazine",
+			"description": "H\u0026K MP5A3, 9x19mm 30-round magazine",
 			"reference": "HT123",
 			"local_notes": "Requires 9x19mm ammunition",
 			"tech_level": "7",
@@ -36524,7 +36526,7 @@
 		},
 		{
 			"id": "E4Ii5NWM8dtMm9lXf",
-			"description": "H\u0026K MP5, 9x19mm 100-round drum magazine",
+			"description": "H\u0026K MP5A3, 9x19mm 100-round drum magazine",
 			"reference": "HT123",
 			"local_notes": "-1 Bulk, Requires 9x19mm ammunition",
 			"tech_level": "7",
@@ -37136,7 +37138,7 @@
 		},
 		{
 			"id": "EwEX24ot2m5X-M3QF",
-			"description": "H\u0026K MP7a1, 4.6x30mm 20-round magazine",
+			"description": "H\u0026K MP7A1, 4.6x30mm 20-round magazine",
 			"reference": "HT126",
 			"local_notes": "Requires 4.6x30mm ammunition",
 			"tech_level": "8",
@@ -37159,7 +37161,7 @@
 		},
 		{
 			"id": "Ek7yxGd1M4QgD-eGP",
-			"description": "H\u0026K MP7a1, 4.6x30mm 40-round magazine",
+			"description": "H\u0026K MP7A1, 4.6x30mm 40-round magazine",
 			"reference": "HT126",
 			"local_notes": "-1 Bulk, Requires 4.6x30mm ammunition",
 			"tech_level": "8",
@@ -37291,7 +37293,7 @@
 		},
 		{
 			"id": "EHTOkTk7ayx_0pJC1",
-			"description": "H\u0026K USP, 9x19mm Parabellum 15-round magazine",
+			"description": "H\u0026K P8, 9x19mm 15-round magazine",
 			"reference": "HT102",
 			"local_notes": "Requires 9x19mm Parabellum ammunition",
 			"tech_level": "8",
@@ -37423,7 +37425,7 @@
 		},
 		{
 			"id": "EcjB6lt5kfmAdED2p",
-			"description": "H\u0026K USP Compact, 9x19mm Parabellum 13-round magazine",
+			"description": "H\u0026K P10, 9x19mm 13-round magazine",
 			"reference": "HT102",
 			"local_notes": "Requires 9x19mm Parabellum ammunition",
 			"tech_level": "8",
@@ -37563,12 +37565,15 @@
 				"Firearms"
 			],
 			"base_value": "75",
+			"base_weight": "1.1",
+			"max_uses": 5,
 			"quantity": 1,
+			"uses": 5,
 			"calc": {
 				"value": 75,
 				"extended_value": 75,
-				"weight": "0 lb",
-				"extended_weight": "0 lb"
+				"weight": "1.1 lb",
+				"extended_weight": "1.1 lb"
 			}
 		},
 		{
@@ -37681,7 +37686,7 @@
 		},
 		{
 			"id": "E2493x3WGymxYVj5U",
-			"description": "H\u0026K USP Tactical, .45 ACP 12-round magazine",
+			"description": "H\u0026K P12, .45 ACP 12-round magazine",
 			"reference": "HT102",
 			"local_notes": "Requires .45 ACP ammunition",
 			"tech_level": "8",
@@ -38714,7 +38719,7 @@
 		},
 		{
 			"id": "EBIHC1L_uvoeCtFX7",
-			"description": "H\u0026K VP70, 9x19mm Parabellum 18-round Magazine",
+			"description": "H\u0026K VP70, 9x19mm 18-round magazine",
 			"reference": "HT100",
 			"local_notes": "Requires 9x19mm Parabellum ammunition",
 			"tech_level": "7",
@@ -38955,7 +38960,7 @@
 		},
 		{
 			"id": "EcIHg9kSKFkgkU1R5",
-			"description": "Haenal STG44, 7.92x33mm Kurz 30-round magazine",
+			"description": "Haenel StG44, 7.92x33mm 30-round magazine",
 			"reference": "HT115",
 			"local_notes": "Requires 7.92x33mm Kurz ammunition",
 			"tech_level": "7",
@@ -40666,7 +40671,7 @@
 		},
 		{
 			"id": "EJNZtG-OI0Y_DgQBy",
-			"description": "Hotchkiss Mle 1914, 8x50mmR Lebel 24-round metal strip",
+			"description": "Hotchkiss Mle 1914, 8x50mmR 24-round metal strip",
 			"reference": "HT131",
 			"local_notes": "Requires 8x50mmR Lebel ammunition",
 			"tech_level": "6",
@@ -40689,7 +40694,7 @@
 		},
 		{
 			"id": "E8u6lB78u6NPNwGdK",
-			"description": "Hotchkiss Mle 1914, 8x50mmR Lebel 30-round metal strip",
+			"description": "Hotchkiss Mle 1914, 8x50mmR 30-round metal strip",
 			"reference": "HT131",
 			"local_notes": "Requires 8x50mmR Lebel ammunition",
 			"tech_level": "6",
@@ -41979,7 +41984,7 @@
 		},
 		{
 			"id": "EbcAFO_bPHfJdSQUe",
-			"description": "IMI Galil ARM, .223 Remington 30-round magazine",
+			"description": "IMI Galil ARM, .223 Remington 35-round magazine",
 			"reference": "HT117",
 			"local_notes": "Requires .223 Remington ammunition",
 			"tech_level": "7",
@@ -42133,7 +42138,7 @@
 		},
 		{
 			"id": "E8M-VZ_js_0RRnuJY",
-			"description": "IMI Galil ARM, 7.62x51mm 20-round magazine",
+			"description": "IMI Galil SR, 7.62x51mm 20-round magazine",
 			"reference": "HT117",
 			"local_notes": "Requires 7.62x51mm ammunition",
 			"tech_level": "7",
@@ -42264,7 +42269,7 @@
 		},
 		{
 			"id": "ETr608xMUm17CTJbe",
-			"description": "IMI Uzi, .9x19mm 20-round magazine",
+			"description": "IMI Uzi, 9x19mm 20-round magazine",
 			"reference": "HT125",
 			"local_notes": "Requires 9x19mm ammunition",
 			"tech_level": "7",
@@ -42287,7 +42292,7 @@
 		},
 		{
 			"id": "E2B5RaWJugu5yDm3Y",
-			"description": "IMI Uzi, .9x19mm 25-round magazine",
+			"description": "IMI Uzi, 9x19mm 25-round magazine",
 			"reference": "HT125",
 			"local_notes": "Requires 9x19mm ammunition",
 			"tech_level": "7",
@@ -42310,7 +42315,7 @@
 		},
 		{
 			"id": "E-XpIXkWIWOKWcV3g",
-			"description": "IMI Uzi, .9x19mm 32-round magazine",
+			"description": "IMI Uzi, 9x19mm 32-round magazine",
 			"reference": "HT125",
 			"local_notes": "Requires 9x19mm ammunition",
 			"tech_level": "7",
@@ -42864,7 +42869,7 @@
 			}
 		},
 		{
-			"id": "eMM1jCqGMIPoh9dwr",
+			"id": "EMM1jCqGMIPoh9dwr",
 			"description": "Intratec TEC-9, 9x19mm Parabellum 20-round magazine",
 			"reference": "HT102",
 			"local_notes": "Requires 9x19mm Parabellum ammunition",
@@ -42910,7 +42915,7 @@
 			}
 		},
 		{
-			"id": "e7zzZafW_oQJiAi1L",
+			"id": "E7zzZafW_oQJiAi1L",
 			"description": "Intratec TEC-9, 9x19mm Parabellum 50-round magazine",
 			"reference": "HT102",
 			"local_notes": "-1 Bulk, Requires 9x19mm Parabellum ammunition",
@@ -44008,7 +44013,7 @@
 		},
 		{
 			"id": "ET16X2M-ZPdLIU9R9",
-			"description": "Izmash AK-47, 7.62x39mm 30-round magazine",
+			"description": "Izhmash AK-47, 7.62x39mm 30-round magazine",
 			"reference": "HT114",
 			"local_notes": "Requires 7.62x39mm ammunition",
 			"tech_level": "7",
@@ -44031,7 +44036,7 @@
 		},
 		{
 			"id": "Ehjcffzi7DkHM9_8i",
-			"description": "Izmash AK-47, 7.62x39mm 40-round magazine",
+			"description": "Izhmash AK-47, 7.62x39mm 40-round magazine",
 			"reference": "HT114",
 			"local_notes": "Requires 7.62x39mm ammunition",
 			"tech_level": "7",
@@ -44054,7 +44059,7 @@
 		},
 		{
 			"id": "EL9efJ0-DlZIXs5Us",
-			"description": "Izmash AK-47, 7.62x39mm 75-round drum magazine",
+			"description": "Izhmash AK-47, 7.62x39mm 75-round drum magazine",
 			"reference": "HT114",
 			"local_notes": "-1 Bulk, Requires 7.62x39mm ammunition",
 			"tech_level": "7",
@@ -44185,7 +44190,7 @@
 		},
 		{
 			"id": "E_NkaQ6lSl7T2yeR_",
-			"description": "Izmash AK-74, 5.45x39mm 30-round magazine",
+			"description": "Izhmash AK-74, 5.45x39mm 30-round magazine",
 			"reference": "HT114",
 			"local_notes": "Requires 5.45x39mm ammunition",
 			"tech_level": "7",
@@ -44208,7 +44213,7 @@
 		},
 		{
 			"id": "EapJ0MwSI8u825Uf7",
-			"description": "Izmash AK-74, 5.45x39mm 45-round magazine",
+			"description": "Izhmash AK-74, 5.45x39mm 45-round magazine",
 			"reference": "HT114",
 			"local_notes": "Requires 5.45x39mm ammunition",
 			"tech_level": "7",
@@ -44231,7 +44236,7 @@
 		},
 		{
 			"id": "EALlTj4OSSanbiwG0",
-			"description": "Izmash AK-74, 5.45x39mm 60-round High Density magazine",
+			"description": "Izhmash AK-74, 5.45x39mm 60-round high density magazine",
 			"reference": "HT114",
 			"local_notes": "Requires 5.45x39mm ammunition",
 			"tech_level": "7",
@@ -44254,7 +44259,7 @@
 		},
 		{
 			"id": "EjDOx6FkR28p_3dbw",
-			"description": "Izmash AK-74, 5.45x39mm 90-round drum magazine",
+			"description": "Izhmash AK-74, 5.45x39mm 90-round drum magazine",
 			"reference": "HT114",
 			"local_notes": "-1 Bulk, Requires 5.45x39mm ammunition",
 			"tech_level": "7",
@@ -44385,7 +44390,7 @@
 		},
 		{
 			"id": "EGhhfAGLIe1G712qn",
-			"description": "Izmash AK-101, 5.56x45mm 30-round magazine",
+			"description": "Izhmash AK-101, 5.56x45mm 30-round magazine",
 			"reference": "HT114",
 			"local_notes": "Requires 5.56x45mm ammunition",
 			"tech_level": "7",
@@ -44516,7 +44521,7 @@
 		},
 		{
 			"id": "ESwv8r4HECKvy4XbI",
-			"description": "Izmash PP-19 Bizon-2, 9x18mm Makarov 64-round magazine",
+			"description": "Izhmash PP-19 Bizon-2, 9x18mm 64-round magazine",
 			"reference": "HT126",
 			"local_notes": "Requires 9x18mm ammunition",
 			"tech_level": "8",
@@ -44647,7 +44652,7 @@
 		},
 		{
 			"id": "EcIsRw5AICI8DnAPZ",
-			"description": "Izmash PP-19 Bizon-2-01, 9x19mm Parabellum 53-round magazine",
+			"description": "Izhmash PP-19 Bizon-2-01, 9x19mm 53-round magazine",
 			"reference": "HT126",
 			"local_notes": "Requires 9x19mm Parabellum ammunition",
 			"tech_level": "8",
@@ -44778,7 +44783,7 @@
 		},
 		{
 			"id": "EBAvRa97ftyLtNbJn",
-			"description": "Izmash SVD, 7.62x54mmR 10-round magazine",
+			"description": "Izhmash SVD, 7.62x54mmR 10-round magazine",
 			"reference": "HT116",
 			"local_notes": "Requires 7.62x54mmR ammunition",
 			"tech_level": "7",
@@ -45017,7 +45022,7 @@
 		},
 		{
 			"id": "EKyVV-94MPEiOSaej",
-			"description": "Izhmekh PM, 9x18mm Makarov 8-round Magazine",
+			"description": "Izhmekh PM, 9x18mm 8-round magazine",
 			"reference": "HT100",
 			"local_notes": "Requires 9x18mm Makarov ammunition",
 			"tech_level": "7",
@@ -45256,7 +45261,7 @@
 		},
 		{
 			"id": "EARKakTsmZo_ZgWuN",
-			"description": "Izhmekh PMM, 9x18mm Makarov 12-round Magazine",
+			"description": "Izhmekh PMM, 9x18mm 12-round magazine",
 			"reference": "HT100",
 			"local_notes": "Requires 9x18mm Makarov ammunition",
 			"tech_level": "7",
@@ -46196,7 +46201,7 @@
 		},
 		{
 			"id": "EBa-QIUuXdxSIvQxu",
-			"description": "ZiD PK, 7.62x54mmR 100-round Can",
+			"description": "KMZ PK, 7.62x54mmR 100-round can",
 			"reference": "HT135",
 			"local_notes": "Requires 7.62x54mmR ammunition, Contains Non-Disintegrating Belt",
 			"tech_level": "7",
@@ -46218,7 +46223,7 @@
 		},
 		{
 			"id": "EXqIAg0tZEJfC8yp7",
-			"description": "ZiD PK, 7.62x54mmR 100-round Non-Disintegrating Belt",
+			"description": "KMZ PK, 7.62x54mmR 100-round non-disintegrating belt",
 			"reference": "HT135",
 			"local_notes": "Requires 7.62x54mmR ammunition",
 			"tech_level": "7",
@@ -46240,7 +46245,7 @@
 		},
 		{
 			"id": "ELWBRwW_rLxQDIWVo",
-			"description": "ZiD PK, 7.62x54mmR 250-round Can",
+			"description": "KMZ PK, 7.62x54mmR 250-round can",
 			"reference": "HT135",
 			"local_notes": "Requires 7.62x54mmR ammunition, Contains Non-Disintegrating Belt",
 			"tech_level": "7",
@@ -46262,7 +46267,7 @@
 		},
 		{
 			"id": "E1izhABbmeC-ZAc2S",
-			"description": "ZiD PK, 7.62x54mmR 250-round Non-Disintegrating Belt",
+			"description": "KMZ PK, 7.62x54mmR 250-round non-disintegrating belt",
 			"reference": "HT135",
 			"local_notes": "Requires 7.62x54mmR ammunition",
 			"tech_level": "7",
@@ -46640,7 +46645,7 @@
 		},
 		{
 			"id": "E4sG6VvfM-MbYcIxL",
-			"description": "KPZ DShK-38, 12.7x108mm 50-round Box",
+			"description": "KPZ DShK-38, 12.7x108mm 50-round box",
 			"reference": "HT133",
 			"local_notes": "Requires 12.7x108mm ammunition, Contains Disintegrating Belt",
 			"tech_level": "6",
@@ -46663,7 +46668,7 @@
 		},
 		{
 			"id": "EWEJ0iE3MN3DlwTLq",
-			"description": "KPZ DShK-38, 12.7x108mm 50-round Disintegrating Belt",
+			"description": "KPZ DShK-38, 12.7x108mm 50-round disintegrating belt",
 			"reference": "HT133",
 			"local_notes": "Requires 12.7x108mm ammunition",
 			"tech_level": "6",
@@ -47809,7 +47814,7 @@
 		},
 		{
 			"id": "EoOS8M9AzIQ2Gy8s4",
-			"description": "Lebel Mle 1886, 8x50mmR Lebel 5-round stripper clip",
+			"description": "Lebel Mle 1886, 8x50mmR 5-round stripper clip",
 			"reference": "HT111",
 			"local_notes": "Requires 8x50mmR Lebel ammunition",
 			"tech_level": "6",
@@ -49068,9 +49073,9 @@
 		},
 		{
 			"id": "EpRAvh_6bN6jZiOnD",
-			"description": "Luger P08 Parabellum, 9x19mm 8-round magazine",
+			"description": "Luger P08, 9x19mm 8-round magazine",
 			"reference": "HT98",
-			"local_notes": "Requires 9x19mm ammunition",
+			"local_notes": "Requires 9x19mm Parabellum ammunition",
 			"tech_level": "6",
 			"legality_class": "3",
 			"tags": [
@@ -49884,7 +49889,7 @@
 		},
 		{
 			"id": "E55HBI7qSBo3LZvWU",
-			"description": "MAC AA7.62NF1, 7.62x51mm 50-round Disintegrating Belt",
+			"description": "MAC AA7.62NF1, 7.62x51mm 50-round disintegrating belt",
 			"reference": "HT135",
 			"local_notes": "Requires 7.62x51mm ammunition",
 			"tech_level": "7",
@@ -49907,7 +49912,7 @@
 		},
 		{
 			"id": "EYw3Ugu3ecyqacKMw",
-			"description": "MAC AA7.62NF1, 7.62x51mm 200-round Can",
+			"description": "MAC AA7.62NF1, 7.62x51mm 200-round can",
 			"reference": "HT135",
 			"local_notes": "Requires 7.62x51mm ammunition, Contains Disintegrating Belt",
 			"tech_level": "7",
@@ -50573,7 +50578,7 @@
 		},
 		{
 			"id": "EaiPAtkH_a3ECL_gG",
-			"description": "Madsen M/03, 8x58mmR Krag 30-round Box Magazine",
+			"description": "Madsen M/03, 8x58mmR 30-round box magazine",
 			"reference": "HT130",
 			"local_notes": "Requires 8x58mmR Krag ammunition",
 			"tech_level": "6",
@@ -51628,7 +51633,7 @@
 		},
 		{
 			"id": "EkeOlb5m8sTBs0vNj",
-			"description": "Mauser C96, 7.63x25mm 10-round Charger Clip",
+			"description": "Mauser C96, 7.63x25mm 10-round charger clip",
 			"reference": "HT97",
 			"local_notes": "Requires 7.63x25mm ammunition",
 			"tech_level": "6",
@@ -51650,8 +51655,8 @@
 			}
 		},
 		{
-			"id": "elpSHkigt-XBcbx7I",
-			"description": "Mauser C96, 7.63x25mm 10-round Magazine",
+			"id": "ElpSHkigt-XBcbx7I",
+			"description": "Mauser C96, 7.63x25mm 10-round magazine",
 			"reference": "HT97",
 			"local_notes": "Requires 7.63x25mm ammunition",
 			"tech_level": "6",
@@ -51674,7 +51679,7 @@
 		},
 		{
 			"id": "E8V-MVnwXlrOUmjAS",
-			"description": "Mauser C96, 7.63x25mm 20-round Magazine",
+			"description": "Mauser C96, 7.63x25mm 20-round magazine",
 			"reference": "HT97",
 			"local_notes": "Requires 7.63x25mm ammunition",
 			"tech_level": "6",
@@ -51805,7 +51810,7 @@
 		},
 		{
 			"id": "EuVL1yYj_dFcArcTn",
-			"description": "Mauser Gew98, 7.92x57mm Mauser 5-round stripper clip",
+			"description": "Mauser Gew98, 7.92x57mm 5-round stripper clip",
 			"reference": "HT111",
 			"local_notes": "Requires 7.92x57mm Mauser ammunition",
 			"tech_level": "6",
@@ -51897,7 +51902,7 @@
 		},
 		{
 			"id": "ElKk8ZI-XBKEL5Isv",
-			"description": "Mauser MG151/20, 20x82mm Mauser 60-round Disintegrating Belt",
+			"description": "Mauser MG151/20, 20x82mm 60-round disintegrating belt",
 			"reference": "HT133, HT134",
 			"local_notes": "Requires 20x82mm Mauser ammunition",
 			"tech_level": "6",
@@ -51920,7 +51925,7 @@
 		},
 		{
 			"id": "Eg50xZvNTgOESwjvH",
-			"description": "Mauser MG151/20, 20x82mm Mauser 200-round Box",
+			"description": "Mauser MG151/20, 20x82mm 200-round box",
 			"reference": "HT133, HT134",
 			"local_notes": "Requires 20x82mm Mauser ammunition, Contains Disintegrating Belt",
 			"tech_level": "6",
@@ -52178,7 +52183,7 @@
 		},
 		{
 			"id": "Eo4xl6w3k2BUGTiE9",
-			"description": "Maxim MG08, 7.92x57mm 250-round Can",
+			"description": "Maxim MG08, 7.92x57mm 250-round can",
 			"reference": "HT130",
 			"local_notes": "Requires 7.92x57mm ammunition, Contains Non-Disintegrating Cloth Belt",
 			"tech_level": "6",
@@ -52201,7 +52206,7 @@
 		},
 		{
 			"id": "Ej-QhzuwSlsr4uPsa",
-			"description": "Maxim MG08, 7.92x57mm 250-round Non-Disintegrating Cloth Belt",
+			"description": "Maxim MG08, 7.92x57mm 250-round non-disintegrating cloth belt",
 			"reference": "HT130",
 			"local_notes": "-1 Malf, Requires 7.92x57mm ammunition",
 			"tech_level": "6",
@@ -52279,7 +52284,7 @@
 		},
 		{
 			"id": "EDGg9U2nJPxArW16Q",
-			"description": "Maxim MG08/15, 7.92x57mm 50-round Can",
+			"description": "Maxim MG08/15, 7.92x57mm 50-round can",
 			"reference": "HT130",
 			"local_notes": "Requires 7.92x57mm ammunition, Contains Non-Disintegrating Cloth Belt",
 			"tech_level": "6",
@@ -52302,7 +52307,7 @@
 		},
 		{
 			"id": "EabagbPiUAEJozGBu",
-			"description": "Maxim MG08/15, 7.92x57mm 50-round Non-Disintegrating Cloth Belt",
+			"description": "Maxim MG08/15, 7.92x57mm 50-round non-disintegrating cloth belt",
 			"reference": "HT130",
 			"local_notes": "-1 Malf, Requires 7.92x57mm ammunition",
 			"tech_level": "6",
@@ -52381,7 +52386,7 @@
 		},
 		{
 			"id": "EecWx52TCye9buy3W",
-			"description": "Maxim Mk I, .450 MH 150-round Box",
+			"description": "Maxim Mk I, .450 MH 150-round box",
 			"reference": "HT129",
 			"local_notes": "Requires .450 MH ammunition, Contains Non-Disintegrating Cloth Belt",
 			"tech_level": "6",
@@ -52404,7 +52409,7 @@
 		},
 		{
 			"id": "EkatY3gljsGwsgPaI",
-			"description": "Maxim Mk I, .450 MH 150-round Non-Disintegrating Cloth Belt",
+			"description": "Maxim Mk I, .450 MH 150-round non-disintegrating cloth belt",
 			"reference": "HT129",
 			"local_notes": "-1 Malf, Requires .450 MH ammunition",
 			"tech_level": "6",
@@ -52427,7 +52432,7 @@
 		},
 		{
 			"id": "EKBEt1MDDSG7BzQ9n",
-			"description": "Maxim Mk I, .450 MH 250-round Box",
+			"description": "Maxim Mk I, .450 MH 250-round box",
 			"reference": "HT129",
 			"local_notes": "Requires .450 MH ammunition, Contains Non-Disintegrating Cloth Belt",
 			"tech_level": "6",
@@ -52450,7 +52455,7 @@
 		},
 		{
 			"id": "EADYPsl791zLcsJ6v",
-			"description": "Maxim Mk I, .450 MH 250-round Non-Disintegrating Cloth Belt",
+			"description": "Maxim Mk I, .450 MH 250-round non-disintegrating cloth belt",
 			"reference": "HT129",
 			"local_notes": "-1 Malf, Requires .450 MH ammunition",
 			"tech_level": "6",
@@ -54702,7 +54707,7 @@
 		},
 		{
 			"id": "EGG98osUVzkQaCY14",
-			"description": "Molot NSV-12.7 Utes, 12.7x108mm 50-round Can",
+			"description": "Molot NSV-12.7, 12.7x108mm 50-round can",
 			"reference": "HT136",
 			"local_notes": "Requires 12.7x108mm ammunition, Contains Disintegrating Belt",
 			"tech_level": "7",
@@ -54725,7 +54730,7 @@
 		},
 		{
 			"id": "EI5MHSMeC0JqcPPWE",
-			"description": "Molot NSV-12.7 Utes, 12.7x108mm 50-round Disintegrating Belt",
+			"description": "Molot NSV-12.7, 12.7x108mm 50-round disintegrating belt",
 			"reference": "HT136",
 			"local_notes": "Requires 12.7x108mm ammunition",
 			"tech_level": "7",
@@ -54875,7 +54880,7 @@
 		},
 		{
 			"id": "EobeDClugXe8ceuS5",
-			"description": "Mosin-Nagant obr. 1891g, 7.62x54mmR 5-round stripper clip",
+			"description": "Mosin-Nagant PV-1891, 7.62x54mmR 5-round stripper clip",
 			"reference": "HT111",
 			"local_notes": "Requires 7.62x54mmR ammunition",
 			"tech_level": "6",
@@ -55771,7 +55776,7 @@
 		},
 		{
 			"id": "ELIGgvwbNRfGH8ABV",
-			"description": "Nambu Taishou 14 Shiki, 8x21mm Nambu 8-round magazine",
+			"description": "Nambu 14 Shiki, 8x21mm 8-round magazine",
 			"reference": "HT99",
 			"local_notes": "Requires 8x21mm Nambu ammunition",
 			"tech_level": "6",
@@ -56256,7 +56261,7 @@
 		},
 		{
 			"id": "ExvRYvWKnZRk7_rxa",
-			"description": "Norinco QBZ95, 5.8x42mm 30-round magazine",
+			"description": "NORINCO QBZ95, 5.8x42mm 30-round magazine",
 			"reference": "HT121",
 			"local_notes": "Requires 5.45x39mm ammunition",
 			"tech_level": "8",
@@ -56387,7 +56392,7 @@
 		},
 		{
 			"id": "EE9Q8vQFBaIyn23GG",
-			"description": "Norinco QBZ95, 5.8x42mm 75-round drum magazine",
+			"description": "NORINCO QBZ95, 5.8x42mm 75-round drum magazine",
 			"reference": "HT121",
 			"local_notes": "-1 Bulk, Requires 5.45x39mm ammunition",
 			"tech_level": "8",
@@ -56924,7 +56929,7 @@
 		},
 		{
 			"id": "EcHdJY99NKrK_GTOe",
-			"description": "Oerlikon Typ S, 20x110mmRB 15-round Box Magazine",
+			"description": "Oerlikon Typ S, 20x110mmRB 15-round Box magazine",
 			"reference": "HT132",
 			"local_notes": "Requires 20x110mmRB ammunition",
 			"tech_level": "6",
@@ -56947,7 +56952,7 @@
 		},
 		{
 			"id": "EvaqQd2KUZnstAS_7",
-			"description": "Oerlikon Typ S, 20x110mmRB 60-round Drum Magazine",
+			"description": "Oerlikon Typ S, 20x110mmRB 60-round drum magazine",
 			"reference": "HT132",
 			"local_notes": "Requires 20x110mmRB ammunition",
 			"tech_level": "6",
@@ -57516,7 +57521,7 @@
 		},
 		{
 			"id": "E7rkAtY1sEFbKabYC",
-			"description": "Colt P14-45, .45 ACP 13-round Magazine",
+			"description": "Para-Ordinance P14-45, .45 ACP 13-round magazine",
 			"reference": "HT99",
 			"local_notes": "Requires .45 ACP ammunition",
 			"tech_level": "7",
@@ -63070,7 +63075,7 @@
 		},
 		{
 			"id": "EdcY50jXwrQVRCpT3",
-			"description": "Rheinmetall FG42, 7.92x57mm Mauser 10-round magazine",
+			"description": "Rheinmetall FG42, 7.92x57mm 10-round magazine",
 			"reference": "HT115",
 			"local_notes": "Requires 7.92x57 Mauser ammunition",
 			"tech_level": "7",
@@ -63093,7 +63098,7 @@
 		},
 		{
 			"id": "ErKGeJmksofha7pv5",
-			"description": "Rheinmetall FG42, 7.92x57mm Mauser 20-round magazine",
+			"description": "Rheinmetall FG42, 7.92x57mm 20-round magazine",
 			"reference": "HT115",
 			"local_notes": "Requires 7.92x57 Mauser ammunition",
 			"tech_level": "7",
@@ -63326,7 +63331,7 @@
 		},
 		{
 			"id": "EywjxJ9zmDM7NK9sw",
-			"description": "Rheinmetall MG3, 7.62x51mm 50-round Assault Can",
+			"description": "Rheinmetall MG3, 7.62x51mm 50-round assault can",
 			"reference": "HT134",
 			"local_notes": "Requires 7.62x51mm ammunition, Contains Disintegrating Belt",
 			"tech_level": "7",
@@ -63349,7 +63354,7 @@
 		},
 		{
 			"id": "ELGJj-9NCYL-X3AWk",
-			"description": "Rheinmetall MG3, 7.62x51mm 50-round Disintegrating Belt",
+			"description": "Rheinmetall MG3, 7.62x51mm 50-round disintegrating belt",
 			"reference": "HT134",
 			"local_notes": "Requires 7.62x51mm ammunition",
 			"tech_level": "7",
@@ -63372,7 +63377,7 @@
 		},
 		{
 			"id": "ED66SAcZmc5cxExWJ",
-			"description": "Rheinmetall MG3, 7.62x51mm 120-round Assault Can",
+			"description": "Rheinmetall MG3, 7.62x51mm 120-round assault can",
 			"reference": "HT134",
 			"local_notes": "Requires 7.62x51mm ammunition, Contains Disintegrating Belt",
 			"tech_level": "7",
@@ -63395,7 +63400,7 @@
 		},
 		{
 			"id": "EzASTn8iL1ktvH8kH",
-			"description": "Rheinmetall MG3, 7.62x51mm 120-round Disintegrating Belt",
+			"description": "Rheinmetall MG3, 7.62x51mm 120-round disintegrating belt",
 			"reference": "HT134",
 			"local_notes": "Requires 7.62x51mm ammunition",
 			"tech_level": "7",
@@ -63418,7 +63423,7 @@
 		},
 		{
 			"id": "Efo1jGSed9NYpExDS",
-			"description": "Rheinmetall MG3, 7.62x51mm 250-Round Can",
+			"description": "Rheinmetall MG3, 7.62x51mm 250-Round can",
 			"reference": "HT134",
 			"local_notes": "Requires 7.62x51mm ammunition, Contains Disintegrating Belt",
 			"tech_level": "7",
@@ -63441,7 +63446,7 @@
 		},
 		{
 			"id": "Eq358h0BLvUp1VwZn",
-			"description": "Rheinmetall MG3, 7.62x51mm 250-round Disintegrating Belt",
+			"description": "Rheinmetall MG3, 7.62x51mm 250-round disintegrating belt",
 			"reference": "HT134",
 			"local_notes": "Requires 7.62x51mm ammunition",
 			"tech_level": "7",
@@ -63572,7 +63577,7 @@
 		},
 		{
 			"id": "EnCwpdbXNBSt_TUka",
-			"description": "Rheinmetall MG34, 7.92x57mm 75-round Twin Saddle Drum Magazine",
+			"description": "Rheinmetall MG34, 7.92x57mm 75-round twin saddle drum magazine",
 			"reference": "HT132, HT133",
 			"local_notes": "Rare, Requires 7.92x57mm ammunition",
 			"tech_level": "6",
@@ -63703,7 +63708,7 @@
 		},
 		{
 			"id": "Ea1zUKACkhLQV1NmL",
-			"description": "Rheinmetall MG34/MG42, 7.92x57mm 50-round Assault Can",
+			"description": "Rheinmetall MG34/MG42, 7.92x57mm 50-round assault can",
 			"reference": "HT132, HT133, HT134",
 			"local_notes": "Requires 7.92x57mm ammunition, Contains Non-Disintegrating Belt",
 			"tech_level": "6",
@@ -63726,7 +63731,7 @@
 		},
 		{
 			"id": "E5UscUNwD5WxKny3u",
-			"description": "Rheinmetall MG34/MG42, 7.92x57mm 50-round Non-Disintegrating Belt",
+			"description": "Rheinmetall MG34/MG42, 7.92x57mm 50-round non-disintegrating belt",
 			"reference": "HT132, HT133, HT134",
 			"local_notes": "Requires 7.92x57mm ammunition",
 			"tech_level": "6",
@@ -63749,7 +63754,7 @@
 		},
 		{
 			"id": "EAAfgz18o4wmWxnq2",
-			"description": "Rheinmetall MG34/MG42, 7.92x57mm 300-round Can",
+			"description": "Rheinmetall MG34/MG42, 7.92x57mm 300-round can",
 			"reference": "HT132, HT133, HT134",
 			"local_notes": "Requires 7.92x57mm ammunition, Contains 4 Non-Disintegrating Belts",
 			"tech_level": "6",
@@ -65070,7 +65075,7 @@
 		},
 		{
 			"id": "EvigmmCdVGTOtylm1",
-			"description": "Ruger Standard Mk.I, .22 LR 9-round Magazine",
+			"description": "Ruger Standard MK1, .22 LR 9-round magazine",
 			"reference": "HT100",
 			"local_notes": "Requires 9x19mm Parabellum ammunition",
 			"tech_level": "7",
@@ -68025,7 +68030,7 @@
 		},
 		{
 			"id": "EGzzsuaokwlGhcwBj",
-			"description": "Saco M60, 7.62x51mm 100-round Disintegrating Belt",
+			"description": "Saco M60, 7.62x51mm 100-round disintegrating belt",
 			"reference": "HT134",
 			"local_notes": "Requires 7.62x51mm ammunition",
 			"tech_level": "7",
@@ -68048,7 +68053,7 @@
 		},
 		{
 			"id": "Edan8-zDHKl8XHDqM",
-			"description": "Saco M60, 7.62x51mm 100-round Nylon Carrier",
+			"description": "Saco M60, 7.62x51mm 100-round nylon carrier",
 			"reference": "HT134",
 			"local_notes": "Requires 7.62x51mm ammunition, Contains Disintegrating Belt",
 			"tech_level": "7",
@@ -68071,7 +68076,7 @@
 		},
 		{
 			"id": "EUnktnTbYLct0lFgL",
-			"description": "Saco M60, 7.62x51mm 200-round Can",
+			"description": "Saco M60, 7.62x51mm 200-round can",
 			"reference": "HT134",
 			"local_notes": "Requires 7.62x51mm ammunition, Contains 2 Disintegrating Belts",
 			"tech_level": "7",
@@ -69760,7 +69765,7 @@
 		},
 		{
 			"id": "E0NMVNg5nKhN4-iyv",
-			"description": "Sig Sauer P226, .40 S\u0026W 13-round magazine",
+			"description": "SIG-Sauer P226, .40 S\u0026W 13-round magazine",
 			"reference": "HT102",
 			"local_notes": "Requires .40 S\u0026W ammunition",
 			"tech_level": "8",
@@ -70022,7 +70027,7 @@
 		},
 		{
 			"id": "EjDXtSuyihRU5IlEE",
-			"description": "SIG-Sauer P226, 9x19mm Parabellum 15-round magazine",
+			"description": "SIG-Sauer P226, 9x19mm 15-round magazine",
 			"reference": "HT102",
 			"local_notes": "Requires 9x19mm Parabellum ammunition",
 			"tech_level": "8",
@@ -70044,8 +70049,8 @@
 			}
 		},
 		{
-			"id": "ejQVzC0GdWcRDVw24",
-			"description": "SIG-Sauer P226, 9x19mm Parabellum 20-round magazine",
+			"id": "EjQVzC0GdWcRDVw24",
+			"description": "SIG-Sauer P226, 9x19mm 20-round magazine",
 			"reference": "HT102",
 			"local_notes": "Requires 9x19mm Parabellum ammunition",
 			"tech_level": "8",
@@ -70176,7 +70181,7 @@
 		},
 		{
 			"id": "EnE9dfrw70Sy2ddhU",
-			"description": "SIG-Sauer P228, 9x19mm Parabellum 13-round magazine",
+			"description": "SIG-Sauer P228, 9x19mm 13-round magazine",
 			"reference": "HT102",
 			"local_notes": "Requires 9x19mm Parabellum ammunition",
 			"tech_level": "8",
@@ -72829,7 +72834,7 @@
 		},
 		{
 			"id": "E_bz0TRKKeGqvQSwi",
-			"description": "Springfield M1 Garand, .30-06 Springfield 8-round stripper clip",
+			"description": "Springfield M1 Garand, .30-06 8-round stripper clip",
 			"reference": "HT113",
 			"local_notes": "Requires .30-06 Springfield ammunition",
 			"tech_level": "6",
@@ -73199,7 +73204,7 @@
 		},
 		{
 			"id": "EBB738JlUrdlxyFn4",
-			"description": "Springfield M1903, .30-06 Springfield 5-round stripper clip",
+			"description": "Springfield M1903, .30-06 5-round stripper clip",
 			"reference": "HT112",
 			"local_notes": "Requires .30-06 Springfield ammunition",
 			"tech_level": "6",
@@ -74065,7 +74070,7 @@
 		},
 		{
 			"id": "ECg-U821iQnLVPMLZ",
-			"description": "Steyr AUG, 5.56x45mm 30-round magazine",
+			"description": "Steyr AUG A1, 5.56x45mm 30-round magazine",
 			"reference": "HT118",
 			"local_notes": "Requires 5.56x45mm ammunition",
 			"tech_level": "8",
@@ -74088,7 +74093,7 @@
 		},
 		{
 			"id": "Ecp0lhlH6e0gDt8E4",
-			"description": "Steyr AUG, 5.56x45mm 42-round magazine",
+			"description": "Steyr AUG A1, 5.56x45mm 42-round magazine",
 			"reference": "HT118",
 			"local_notes": "Requires 5.56x45mm ammunition",
 			"tech_level": "8",
@@ -74219,7 +74224,7 @@
 		},
 		{
 			"id": "EJhqtT7SF7R3TOCjy",
-			"description": "Steyr AUG, 9x19mm Parabellum 25-round magazine",
+			"description": "Steyr AUG A1, 9x19mm 25-round magazine",
 			"reference": "HT118",
 			"local_notes": "Requires 9x19mm Parabellum ammunition",
 			"tech_level": "8",
@@ -74773,8 +74778,8 @@
 		},
 		{
 			"id": "EhplWLv6HWdnyUOnG",
-			"description": "Steyr Solothurn S18-1000, 20x138mmB 10-round magazine",
-			"reference": "HT99",
+			"description": "Steyr-Solothurn S18-1000, 20x138mmB 10-round magazine",
+			"reference": "HT113",
 			"local_notes": "Requires 20x138mm ammunition",
 			"tech_level": "6",
 			"legality_class": "3",
@@ -77952,7 +77957,7 @@
 		},
 		{
 			"id": "Eiw2xczNviX25jzRf",
-			"description": "Tikkakoski KP/31 Suomi, 9x19mm 20-round magazine",
+			"description": "Tikkakoski KP/31, 9x19mm 20-round magazine",
 			"reference": "HT124",
 			"local_notes": "Requires 9x19mm ammunition",
 			"tech_level": "6",
@@ -77975,7 +77980,7 @@
 		},
 		{
 			"id": "Ej9o89DA4ENEQrOn8",
-			"description": "Tikkakoski KP/31 Suomi, 9x19mm 40-round drum magazine",
+			"description": "Tikkakoski KP/31, 9x19mm 40-round drum magazine",
 			"reference": "HT122",
 			"local_notes": "Requires 9x19mm ammunition",
 			"tech_level": "6",
@@ -77998,7 +78003,7 @@
 		},
 		{
 			"id": "EzxlS-PUjkwNwZZMG",
-			"description": "Tikkakoski KP/31 Suomi, 9x19mm 50-round magazine",
+			"description": "Tikkakoski KP/31, 9x19mm 50-round magazine",
 			"reference": "HT124",
 			"local_notes": "Requires 9x19mm ammunition",
 			"tech_level": "6",
@@ -78021,7 +78026,7 @@
 		},
 		{
 			"id": "EA1HCFBAYt6sabfYo",
-			"description": "Tikkakoski KP/31 Suomi, 9x19mm 70-round drum magazine",
+			"description": "Tikkakoski KP/31, 9x19mm 70-round drum magazine",
 			"reference": "HT122",
 			"local_notes": "Requires 9x19mm ammunition",
 			"tech_level": "6",
@@ -78951,9 +78956,9 @@
 		},
 		{
 			"id": "EQm9JJl61CF4PhrMO",
-			"description": "TOZ SKS-45, 7x39mm 10-round charger clip",
+			"description": "TOZ SKS-45, 7.62x39mm 10-round charger clip",
 			"reference": "HT115",
-			"local_notes": "Requires 7x39mm ammunition",
+			"local_notes": "Requires 7.62x39mm ammunition",
 			"tech_level": "7",
 			"legality_class": "3",
 			"tags": [
@@ -79082,7 +79087,7 @@
 		},
 		{
 			"id": "Eg60H0GGuklSpHmAo",
-			"description": "TOZ TT-33, 7.62x25mm Tokarev 8-round magazine",
+			"description": "TOZ TT-33, 7.62x25mm 8-round magazine",
 			"reference": "HT99",
 			"local_notes": "Requires 7.62x25mm Tokarev ammunition",
 			"tech_level": "6",
@@ -79670,7 +79675,7 @@
 		},
 		{
 			"id": "E_23ghQI3BaYd4m1j",
-			"description": "TsNIITochMash AS VAL , 9x39mm 10-round magazine",
+			"description": "TsNIITochMash AS Val , 9x39mm 10-round magazine",
 			"reference": "HT118",
 			"local_notes": "Requires 9x39mm ammunition",
 			"tech_level": "8",
@@ -79693,7 +79698,7 @@
 		},
 		{
 			"id": "EMYDAoq-F0nOtYsfl",
-			"description": "TsNIITochMash AS VAL , 9x39mm 20-round magazine",
+			"description": "TsNIITochMash AS Val , 9x39mm 20-round magazine",
 			"reference": "HT118",
 			"local_notes": "Requires 9x39mm ammunition",
 			"tech_level": "8",
@@ -80131,7 +80136,7 @@
 		},
 		{
 			"id": "Ez1164oIlwPX6ziIT",
-			"description": "TsNIITochMash SPS Gyurza, 9x21mm Gyurza 18-round magazine",
+			"description": "TsNIITochMash SPS, 9x21mm 18-round magazine",
 			"reference": "HT102",
 			"local_notes": "Requires 9x21mm Gyurza ammunition",
 			"tech_level": "8",
@@ -80264,7 +80269,7 @@
 		},
 		{
 			"id": "EIt88QnqF2XPSwVsj",
-			"description": "TsNIITochMash SR-2 Veresk , 9x21mm Gyurza 30-round magazine",
+			"description": "TsNIITochMash SR-2 Veresk, 9x21mm 30-round magazine",
 			"reference": "HT126",
 			"local_notes": "Requires 9x21mm Gyurza ammunition",
 			"tech_level": "8",
@@ -80919,7 +80924,7 @@
 		},
 		{
 			"id": "E9H64ypT6GBS7DZIb",
-			"description": "Vickers Mk I, .303 British 250-round Box",
+			"description": "Vickers Mk I, .303 250-round box",
 			"reference": "HT131",
 			"local_notes": "Requires .303 British ammunition, Contains Non-Disintegrating Cloth Belt",
 			"tech_level": "6",
@@ -80942,7 +80947,7 @@
 		},
 		{
 			"id": "ECg5nlBo9bxwRj5K7",
-			"description": "Vickers Mk I, .303 British 250-round Non-Disintegrating Cloth Belt",
+			"description": "Vickers Mk I, .303 250-round non-disintegrating cloth belt",
 			"reference": "HT131",
 			"local_notes": "-1 Malf, Requires .303 British ammunition",
 			"tech_level": "6",
@@ -81733,7 +81738,7 @@
 		},
 		{
 			"id": "Em5V7N3bc079sG2hC",
-			"description": "Walther P38, 9x19mm Parabellum 8-round magazine",
+			"description": "Walther P38, 9x19mm 8-round magazine",
 			"reference": "HT100",
 			"local_notes": "Requires 9x19mm Parabellum ammunition",
 			"tech_level": "7",
@@ -81865,7 +81870,7 @@
 		},
 		{
 			"id": "EY1nKmHlo0VMwtMZ8",
-			"description": "Walther P99 Compact, 9x19mm Parabellum 10-round magazine",
+			"description": "Walther P99 Compact, 9x19mm 10-round magazine",
 			"reference": "HT103",
 			"local_notes": "Requires 9x19mm ammunition",
 			"tech_level": "8",
@@ -82129,7 +82134,7 @@
 		},
 		{
 			"id": "EhNrMAt2WKLHw9pk7",
-			"description": "Walther P99, 9x19mm Parabellum 16-round magazine",
+			"description": "Walther P99, 9x19mm 16-round magazine",
 			"reference": "HT103",
 			"local_notes": "Requires 9x19mm ammunition",
 			"tech_level": "8",
@@ -82525,9 +82530,9 @@
 		},
 		{
 			"id": "Ep7BH2_WlNeiGOQbk",
-			"description": "Walther PP, .38 Auto 7-round magazine",
+			"description": "Walther PP, .380 ACP 7-round magazine",
 			"reference": "HT99",
-			"local_notes": "Requires .38 Auto ammunition",
+			"local_notes": "Requires .380 ACP ammunition",
 			"tech_level": "6",
 			"legality_class": "3",
 			"tags": [
@@ -85153,7 +85158,7 @@
 		},
 		{
 			"id": "Ey9XGPUbuFyIGlfN5",
-			"description": "Winchester M1, .30 MI 15-round magazine",
+			"description": "Winchester M1, .30 M1 15-round magazine",
 			"reference": "HT113",
 			"local_notes": "Requires .30 MI ammunition",
 			"tech_level": "6",
@@ -85176,7 +85181,7 @@
 		},
 		{
 			"id": "EsbvvfJ0YcrBCb-2M",
-			"description": "Winchester M1, .30 MI 30-round magazine",
+			"description": "Winchester M1, .30 M1 30-round magazine",
 			"reference": "HT113",
 			"local_notes": "Requires .30 MI ammunition",
 			"tech_level": "6",
@@ -86853,7 +86858,7 @@
 		},
 		{
 			"id": "EyAuhrtaszmO-JqAR",
-			"description": "ZB ZB26, 7.92x57mm 20-round Box Magazine",
+			"description": "ZB ZB26, 7.92x57mm 20-round box magazine",
 			"reference": "HT132",
 			"local_notes": "Requires 7.92x57mm ammunition",
 			"tech_level": "6",
@@ -86984,7 +86989,7 @@
 		},
 		{
 			"id": "ECQqA7W0hKGJ0q_9t",
-			"description": "ZiD DP, 7.62x54mmR 47-round Pan Drum Magazine",
+			"description": "ZiD DP, 7.62x54mmR 47-round pan drum magazine",
 			"reference": "HT132",
 			"local_notes": "Requires 7.62x54mmR ammunition",
 			"tech_level": "6",
@@ -87063,7 +87068,7 @@
 		},
 		{
 			"id": "EtOnixl9EeaDsTKfr",
-			"description": "ZiD KPV, 14.5x114mm 40-round Can",
+			"description": "ZiD KPV, 14.5x114mm 40-round can",
 			"reference": "HT134",
 			"local_notes": "Requires 14.5x114mm ammunition, Contains Disintegrating Belt",
 			"tech_level": "7",
@@ -87086,7 +87091,7 @@
 		},
 		{
 			"id": "E-JlAMNuGOsUv2cFE",
-			"description": "ZiD KPV, 14.5x114mm 40-round Disintegrating Belt",
+			"description": "ZiD KPV, 14.5x114mm 40-round disintegrating belt",
 			"reference": "HT134",
 			"local_notes": "Requires 14.5x114mm ammunition",
 			"tech_level": "7",
@@ -87218,7 +87223,7 @@
 		},
 		{
 			"id": "EjoWGg3Lo-DYBis5z",
-			"description": "ZiD PPSh-41, 7.62x25mm Tokarev 35-round magazine",
+			"description": "ZiD PPSh-41, 7.62x25mm 35-round magazine",
 			"reference": "HT124",
 			"local_notes": "Malf 17, Requires 7.62x25mm Tokarev ammunition",
 			"tech_level": "7",
@@ -87241,7 +87246,7 @@
 		},
 		{
 			"id": "EFWhO5GIpfdAR33FP",
-			"description": "ZiD PPSh-41, 7.62x25mm Tokarev 71-round drum magazine",
+			"description": "ZiD PPSh-41, 7.62x25mm 71-round drum magazine",
 			"reference": "HT124",
 			"local_notes": "Malf 16, Requires 7.62x25mm Tokarev ammunition",
 			"tech_level": "7",
@@ -87372,7 +87377,7 @@
 		},
 		{
 			"id": "E_2oZmfUxtAzBVy9P",
-			"description": "ZiD RPD, 7.62x39mm 100-round Box",
+			"description": "ZiD RPD, 7.62x39mm 100-round box",
 			"reference": "HT134",
 			"local_notes": "Requires 7.62x39mm ammunition, Contains Non-Disintegrating Belt",
 			"tech_level": "7",
@@ -87395,7 +87400,7 @@
 		},
 		{
 			"id": "EWKXEEmfa5OkQGVTI",
-			"description": "ZiD RPD, 7.62x39mm 100-round Non-Disintegrating Belt",
+			"description": "ZiD RPD, 7.62x39mm 100-round non-disintegrating belt",
 			"reference": "HT134",
 			"local_notes": "Requires 7.62x39mm ammunition",
 			"tech_level": "7",


### PR DESCRIPTION
This normalises capitalisation of terms like Drum and Magazine to lowercase to match existing items, the names of the magazines to match their weapons, and corrects some cases where a magazine appeared to have the wrong capacity.