### PR TITLE
Psi-Tech Equipment: fix typo in psychotronic bodyshield

### DIFF
--- a/Library/Psionics/Psi-Tech Equipment.eqp
+++ b/Library/Psionics/Psi-Tech Equipment.eqp
@@ -4667,7 +4667,7 @@
 			"id": "eWWL2ieUN9wiwBSpH",
 			"description": "Psychotronic Bodyshield",
 			"reference": "PT25",
-			"local_notes": "Doubes the wearer's PK Shield or EK Shield DR (set equipment level to shield level). 2XS/1min. or 4B/4min.",
+			"local_notes": "Doubles the wearer's PK Shield or EK Shield DR (set equipment level to shield level). 2XS/1min. or 4B/4min.",
 			"tech_level": "^",
 			"legality_class": "3",
 			"tags": [


### PR DESCRIPTION
This was the only typo I could spot, it should say "doubles", not "doubes"