### PR TITLE
Tactical Shooting: Fixed techniques not requiring Guns specialties, and other fixes.

### DIFF
--- a/Library/Tactical Shooting/Tactical Shooting Skills.skl
+++ b/Library/Tactical Shooting/Tactical Shooting Skills.skl
@@ -14,6 +14,7 @@
 			"default": {
 				"type": "skill",
 				"name": "Guns",
+				"specialization": "@Guns specialty@",
 				"modifier": -7
 			},
 			"limit": -4,
@@ -32,6 +33,7 @@
 			"default": {
 				"type": "skill",
 				"name": "Guns",
+				"specialization": "@Guns specialty@",
 				"modifier": -2
 			},
 			"limit": 0,
@@ -63,9 +65,10 @@
 			"difficulty": "a",
 			"default": {
 				"type": "skill",
-				"name": "Guns"
+				"name": "Guns",
+				"specialization": "@Guns specialty@"
 			},
-			"limit": 4,
+			"limit": 3,
 			"points": 1
 		},
 		{
@@ -80,7 +83,8 @@
 			"difficulty": "a",
 			"default": {
 				"type": "skill",
-				"name": "Guns"
+				"name": "Guns",
+				"specialization": "@Guns specialty@"
 			},
 			"limit": 4,
 			"points": 1
@@ -97,8 +101,41 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Riding",
-				"modifier": -2
+				"name": "Riding"
+			},
+			"limit": 4,
+			"points": 2
+		},
+		{
+			"id": "qPo4uRZceRVdOV8jV",
+			"name": "Combat Driving",
+			"reference": "TS43",
+			"tags": [
+				"Firearms",
+				"Tactical Shooting",
+				"Technique"
+			],
+			"difficulty": "h",
+			"default": {
+				"type": "skill",
+				"name": "Driving"
+			},
+			"limit": 4,
+			"points": 2
+		},
+		{
+			"id": "qvUEJYL0_AP6-Smze",
+			"name": "Combat Piloting",
+			"reference": "TS43",
+			"tags": [
+				"Firearms",
+				"Tactical Shooting",
+				"Technique"
+			],
+			"difficulty": "h",
+			"default": {
+				"type": "skill",
+				"name": "Piloting"
 			},
 			"limit": 4,
 			"points": 2
@@ -123,7 +160,7 @@
 			"points": 1
 		},
 		{
-			"id": "qxG4CdpCcaXybBPNz",
+			"id": "qS-ki1Se2ThIf8XaM",
 			"name": "Dual-Weapon Attack",
 			"reference": "TS44",
 			"tags": [
@@ -134,7 +171,8 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Guns",
+				"name": "@Shooting skill@",
+				"specialization": "@Specialty@",
 				"modifier": -4
 			},
 			"limit": 0,
@@ -172,6 +210,7 @@
 			"default": {
 				"type": "skill",
 				"name": "Guns",
+				"specialization": "@Guns specialty@",
 				"modifier": -4
 			},
 			"limit": 0,
@@ -199,6 +238,7 @@
 			"id": "q54bz4KeTmXm77gz0",
 			"name": "Immediate Action",
 			"reference": "TS44",
+			"local_notes": "IQ-based (SL-\u003cscript\u003eMath.max(self.level-$dx+$iq,0)\u003c/script\u003e)",
 			"tags": [
 				"Firearms",
 				"Tactical Shooting",
@@ -207,11 +247,15 @@
 			"difficulty": "a",
 			"default": {
 				"type": "skill",
-				"name": "Guns",
+				"name": "@Shooting skill@",
+				"specialization": "@Specialty@",
 				"modifier": -4
 			},
 			"limit": 0,
-			"points": 1
+			"points": 1,
+			"calc": {
+				"resolved_notes": "IQ-based (SL-ReferenceError: $dx is not defined at \u003ceval\u003e:1:21(5))"
+			}
 		},
 		{
 			"id": "qPd95XaS8EVh8scve",
@@ -245,6 +289,7 @@
 			"default": {
 				"type": "skill",
 				"name": "Guns",
+				"specialization": "@Guns specialty@",
 				"modifier": -4
 			},
 			"limit": -2,
@@ -254,6 +299,7 @@
 			"id": "q6Bok1Vt12paqMLnC",
 			"name": "Mounted Shooting",
 			"reference": "TS44",
+			"local_notes": "@Riding/Vehicle skill@ (@Riding/Vehicle specialty@)",
 			"tags": [
 				"Firearms",
 				"Tactical Shooting",
@@ -263,6 +309,7 @@
 			"default": {
 				"type": "skill",
 				"name": "Guns",
+				"specialization": "@Guns specialty@",
 				"modifier": -4
 			},
 			"limit": 0,
@@ -275,23 +322,11 @@
 						"has": true,
 						"name": {
 							"compare": "is",
-							"qualifier": "Driving"
-						}
-					},
-					{
-						"type": "skill_prereq",
-						"has": true,
-						"name": {
+							"qualifier": "@Riding/Vehicle skill@"
+						},
+						"specialization": {
 							"compare": "is",
-							"qualifier": "Riding"
-						}
-					},
-					{
-						"type": "skill_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Bicycling"
+							"qualifier": "@Riding/Vehicle specialty@"
 						}
 					}
 				]
@@ -311,6 +346,7 @@
 			"default": {
 				"type": "skill",
 				"name": "Guns",
+				"specialization": "@Guns specialty@",
 				"modifier": -6
 			},
 			"limit": 0,
@@ -343,6 +379,7 @@
 			"default": {
 				"type": "skill",
 				"name": "Guns",
+				"specialization": "@Guns specialty@",
 				"modifier": -6
 			},
 			"limit": 0,
@@ -352,6 +389,7 @@
 			"id": "qoIFwXNm8XIxlKI_T",
 			"name": "Retain Weapon",
 			"reference": "TS45",
+			"local_notes": "Guns (@Guns specialty@)",
 			"tags": [
 				"Firearms",
 				"Tactical Shooting",
@@ -359,25 +397,9 @@
 			],
 			"difficulty": "h",
 			"default": {
-				"type": "skill",
-				"name": "Guns",
-				"modifier": -6
+				"type": "dx"
 			},
-			"limit": 0,
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "skill_prereq",
-						"has": true,
-						"name": {
-							"compare": "is",
-							"qualifier": "Observation"
-						}
-					}
-				]
-			},
+			"limit": 5,
 			"points": 2
 		},
 		{
@@ -392,8 +414,8 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Guns",
-				"specialization": "@Guns@",
+				"name": "@Guns/Gunner/Liquid Projector@",
+				"specialization": "@Specialty@",
 				"modifier": -2
 			},
 			"limit": -1,
@@ -401,7 +423,7 @@
 		},
 		{
 			"id": "q7rtXH4enF38Qi8HI",
-			"name": "Targeted Attack (Chinks in armor)",
+			"name": "Targeted Attack (Chinks in @Location@ armor)",
 			"reference": "TS45",
 			"tags": [
 				"Firearms",
@@ -411,8 +433,8 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Guns",
-				"specialization": "@Guns@",
+				"name": "@Guns/Gunner/Liquid Projector@",
+				"specialization": "@Specialty@",
 				"modifier": -10
 			},
 			"limit": -5,
@@ -430,8 +452,8 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Guns",
-				"specialization": "@Guns@",
+				"name": "@Guns/Gunner/Liquid Projector@",
+				"specialization": "@Specialty@",
 				"modifier": -8
 			},
 			"limit": -4,
@@ -449,8 +471,8 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Guns",
-				"specialization": "@Guns@",
+				"name": "@Guns/Gunner/Liquid Projector@",
+				"specialization": "@Specialty@",
 				"modifier": -9
 			},
 			"limit": -4,
@@ -468,8 +490,8 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Guns",
-				"specialization": "@Guns@",
+				"name": "@Guns/Gunner/Liquid Projector@",
+				"specialization": "@Specialty@",
 				"modifier": -5
 			},
 			"limit": -2,
@@ -487,8 +509,8 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Guns",
-				"specialization": "@Guns@",
+				"name": "@Guns/Gunner/Liquid Projector@",
+				"specialization": "@Specialty@",
 				"modifier": -4
 			},
 			"limit": -2,
@@ -506,8 +528,8 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Guns",
-				"specialization": "@Guns@",
+				"name": "@Guns/Gunner/Liquid Projector@",
+				"specialization": "@Specialty@",
 				"modifier": -3
 			},
 			"limit": -1,
@@ -525,8 +547,8 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Guns",
-				"specialization": "@Guns@",
+				"name": "@Guns/Gunner/Liquid Projector@",
+				"specialization": "@Specialty@",
 				"modifier": -4
 			},
 			"limit": -2,
@@ -544,8 +566,8 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Guns",
-				"specialization": "@Guns@",
+				"name": "@Guns/Gunner/Liquid Projector@",
+				"specialization": "@Specialty@",
 				"modifier": -2
 			},
 			"limit": -1,
@@ -563,8 +585,8 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Guns",
-				"specialization": "@Guns@",
+				"name": "@Guns/Gunner/Liquid Projector@",
+				"specialization": "@Specialty@",
 				"modifier": -5
 			},
 			"limit": -2,
@@ -582,8 +604,8 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Guns",
-				"specialization": "@Guns@",
+				"name": "@Guns/Gunner/Liquid Projector@",
+				"specialization": "@Specialty@",
 				"modifier": -3
 			},
 			"limit": -1,
@@ -601,8 +623,8 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Guns",
-				"specialization": "@Guns@",
+				"name": "@Guns/Gunner/Liquid Projector@",
+				"specialization": "@Specialty@",
 				"modifier": -7
 			},
 			"limit": -3,
@@ -620,8 +642,8 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Guns",
-				"specialization": "@Guns@",
+				"name": "@Guns/Gunner/Liquid Projector@",
+				"specialization": "@Specialty@",
 				"modifier": -3
 			},
 			"limit": -1,


### PR DESCRIPTION
Changes based on TS43-45
Full changelog:
- Techniques defaulting to Guns now require Specialties thereof, per TS43.
- Targeted Attack to non-torso armor chinks specializes by chink location.
- Targeted Attack allows Gunner and Liquid Projector.
- Retain Weapon is based on DX, specializing by Guns skill but not requiring it.
- Mounted Shooting specializes and requires a chosen riding/vehicle skill and specialty.
- Immediate Action's variant defaults to IQ-based shooting skill (makeshift fix; currently unsupported feature; see: richardwilkes/gcs#1022).
- Dual-Weapon Attack can default to any chosen shooting skill.
- Added Combat Driving and Combat Piloting

As it is not stated if Combat Riding should specialize by mount/vehicle type like the base skill, I've left it as-is. I personally think it should, but that's a question for the writers.