### PR TITLE
Update Low-Tech Instant Armor and list them by type and by material

### DIFF
--- a/Library/Low Tech/Low Tech Instant Armor.eqp
+++ b/Library/Low Tech/Low Tech Instant Armor.eqp
@@ -21,7 +21,8 @@
 					"locations": [
 						"abdomen",
 						"arm",
-						"torso"
+						"torso",
+						"vitals"
 					],
 					"amount": 0
 				}
@@ -52,7 +53,7 @@
 					"type": "dr_bonus",
 					"locations": [
 						"groin",
-						"hand"
+						"leg"
 					],
 					"amount": 0
 				}

--- a/Library/Low Tech/Low Tech Instant Armor.eqp
+++ b/Library/Low Tech/Low Tech Instant Armor.eqp
@@ -5375,7 +5375,7 @@
 			"description": "Leather, Heavy Groin Armor",
 			"reference": "LTIA7",
 			"reference_highlight": "Leather, Heavy",
-			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
+			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Groin Only",
@@ -5836,7 +5836,7 @@
 			"description": "Leather, Light Groin Armor",
 			"reference": "LTIA7",
 			"reference_highlight": "Leather, Light",
-			"local_notes": "Don: 3 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
+			"local_notes": "Don: 3 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
@@ -6289,7 +6289,7 @@
 			"description": "Leather, Medium Groin Armor",
 			"reference": "LTIA7",
 			"reference_highlight": "Leather, Medium",
-			"local_notes": "Don: 3 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
+			"local_notes": "Don: 3 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Groin Only",
@@ -6749,7 +6749,7 @@
 			"description": "Mail and Plates Groin Armor",
 			"reference": "LTIA7",
 			"reference_highlight": "Mail and Plates",
-			"local_notes": "Don: 3 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. crushing.",
+			"local_notes": "Don: 3 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -7128,7 +7128,7 @@
 			"description": "Mail, Fine Groin Armor",
 			"reference": "LTIA7",
 			"reference_highlight": "Mail, Fine",
-			"local_notes": "Don: 3 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "Don: 3 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -7515,7 +7515,7 @@
 			"description": "Mail, Heavy Groin Armor",
 			"reference": "LTIA7",
 			"reference_highlight": "Mail, Heavy",
-			"local_notes": "Don: 3 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "Don: 3 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -7539,6 +7539,7 @@
 					"locations": [
 						"groin"
 					],
+					"specialization": "crushing",
 					"amount": -2
 				}
 			],
@@ -8100,7 +8101,7 @@
 			"description": "Mail, Light Groin Armor",
 			"reference": "LTIA7",
 			"reference_highlight": "Mail, Light",
-			"local_notes": "Don: 3 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "Don: 3 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "2",
 			"tags": [
 				"Groin Only",
@@ -10345,7 +10346,7 @@
 			"description": "Scale, Light Groin Armor",
 			"reference": "LTIA7",
 			"reference_highlight": "Scale, Light",
-			"local_notes": "Don: 3 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. crushing.",
+			"local_notes": "Don: 3 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Groin Only",
@@ -10806,7 +10807,7 @@
 			"description": "Scale, Medium Groin Armor",
 			"reference": "LTIA7",
 			"reference_highlight": "Scale, Medium",
-			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
+			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [

--- a/Library/Low Tech/Low Tech Instant Armor.eqp
+++ b/Library/Low Tech/Low Tech Instant Armor.eqp
@@ -5495,7 +5495,7 @@
 			"description": "Leather, Heavy Pot Helm",
 			"reference": "LTIA13",
 			"reference_highlight": "Leather, Heavy",
-			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. impaling.",
+			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Head (Skull + Face + Neck)",
@@ -5536,7 +5536,7 @@
 			"description": "Leather, Heavy Pot Helm, Padded",
 			"reference": "LTIA13",
 			"reference_highlight": "Leather, Heavy",
-			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. impaling.",
+			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Head (Skull + Face + Neck)",
@@ -5959,7 +5959,7 @@
 			"description": "Leather, Light Pot Helm",
 			"reference": "LTIA13",
 			"reference_highlight": "Leather, Light",
-			"local_notes": "Don: 6 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
+			"local_notes": "Don: 6 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
@@ -6001,7 +6001,7 @@
 			"description": "Leather, Light Pot Helm, Padded",
 			"reference": "LTIA13",
 			"reference_highlight": "Leather, Light",
-			"local_notes": "Don: 6 secs; Holdout: -1;); +1 DR vs. cutting.",
+			"local_notes": "Don: 6 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
@@ -6409,7 +6409,7 @@
 			"description": "Leather, Medium Pot Helm",
 			"reference": "LTIA13",
 			"reference_highlight": "Leather, Medium",
-			"local_notes": "Don: 6 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
+			"local_notes": "Don: 6 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Head (Skull + Face + Neck)",
@@ -6450,7 +6450,7 @@
 			"description": "Leather, Medium Pot Helm, Padded",
 			"reference": "LTIA13",
 			"reference_highlight": "Leather, Medium",
-			"local_notes": "Don: 6 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. impaling.",
+			"local_notes": "Don: 6 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Head (Skull + Face + Neck)",
@@ -8463,7 +8463,7 @@
 			"description": "Paper, Proofed Pot Helm, Padded",
 			"reference": "LTIA13",
 			"reference_highlight": "Paper, Proofed",
-			"local_notes": "Don: 4 secs; Holdout: -7; Reaction Pen.-1",
+			"local_notes": "Don: 4 secs; Holdout: -7; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433); treat as resistant.",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -10468,7 +10468,7 @@
 			"description": "Scale, Light Pot Helm",
 			"reference": "LTIA13",
 			"reference_highlight": "Scale, Light",
-			"local_notes": "Don: 6 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
+			"local_notes": "Don: 6 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Head (Skull + Face + Neck)",
@@ -10509,7 +10509,7 @@
 			"description": "Scale, Light Pot Helm, Padded",
 			"reference": "LTIA13",
 			"reference_highlight": "Scale, Light",
-			"local_notes": "Don: 6 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
+			"local_notes": "Don: 6 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Head (Skull + Face + Neck)",
@@ -10932,7 +10932,7 @@
 			"description": "Scale, Medium Pot Helm",
 			"reference": "LTIA13",
 			"reference_highlight": "Scale, Medium",
-			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. crushing.",
+			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
@@ -10973,7 +10973,7 @@
 			"id": "eE6QMo6IVPQLFjnsj",
 			"description": "Scale, Medium Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. crushing.",
+			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
@@ -12242,7 +12242,7 @@
 			"description": "Wood Pot Helm, Padded",
 			"reference": "LTIA13",
 			"reference_highlight": "Wood",
-			"local_notes": "Don: 6 secs; Holdout: -9; Reaction Pen.-1",
+			"local_notes": "Don: 6 secs; Holdout: -9; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
 			"tech_level": "0",
 			"tags": [
 				"Head (Skull + Face + Neck)",

--- a/Library/Low Tech/Low Tech Instant Armor.eqp
+++ b/Library/Low Tech/Low Tech Instant Armor.eqp
@@ -229,6 +229,14 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
 						"skull"
 					],
 					"amount": 3
@@ -259,6 +267,14 @@
 			"base_value": "238",
 			"base_weight": "2.7 lb",
 			"features": [
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 4
+				},
 				{
 					"type": "dr_bonus",
 					"locations": [
@@ -594,6 +610,14 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 5
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
 						"skull"
 					],
 					"amount": 5
@@ -625,6 +649,14 @@
 			"base_value": "463",
 			"base_weight": "5.2 lb",
 			"features": [
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 6
+				},
 				{
 					"type": "dr_bonus",
 					"locations": [
@@ -958,6 +990,14 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 1
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
 						"skull"
 					],
 					"amount": 1
@@ -986,6 +1026,14 @@
 			"base_value": "22",
 			"base_weight": "3.2 lb",
 			"features": [
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 2
+				},
 				{
 					"type": "dr_bonus",
 					"locations": [
@@ -1271,6 +1319,14 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 1
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
 						"skull"
 					],
 					"amount": 1
@@ -1300,6 +1356,14 @@
 			"base_value": "26",
 			"base_weight": "1.7 lb",
 			"features": [
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 2
+				},
 				{
 					"type": "dr_bonus",
 					"locations": [
@@ -2028,6 +2092,14 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
 						"skull"
 					],
 					"amount": 3
@@ -2057,6 +2129,14 @@
 			"base_value": "76",
 			"base_weight": "6.5 lb",
 			"features": [
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 4
+				},
 				{
 					"type": "dr_bonus",
 					"locations": [
@@ -2445,6 +2525,14 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 2
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
 						"skull"
 					],
 					"amount": 2
@@ -2474,6 +2562,14 @@
 			"base_value": "44",
 			"base_weight": "4 lb",
 			"features": [
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 3
+				},
 				{
 					"type": "dr_bonus",
 					"locations": [
@@ -2874,6 +2970,14 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
 						"skull"
 					],
 					"amount": 3
@@ -2903,6 +3007,14 @@
 			"base_value": "76",
 			"base_weight": "6.5 lb",
 			"features": [
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 4
+				},
 				{
 					"type": "dr_bonus",
 					"locations": [
@@ -3606,6 +3718,14 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 2
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
 						"skull"
 					],
 					"amount": 2
@@ -3636,6 +3756,14 @@
 			"base_value": "51",
 			"base_weight": "3.2 lb",
 			"features": [
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 3
+				},
 				{
 					"type": "dr_bonus",
 					"locations": [
@@ -3968,6 +4096,14 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
 						"skull"
 					],
 					"amount": 3
@@ -3998,6 +4134,14 @@
 			"base_value": "101",
 			"base_weight": "5.2 lb",
 			"features": [
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 4
+				},
 				{
 					"type": "dr_bonus",
 					"locations": [
@@ -4524,6 +4668,14 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 2
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
 						"skull"
 					],
 					"amount": 2
@@ -4554,6 +4706,14 @@
 			"base_value": "43",
 			"base_weight": "4 lb",
 			"features": [
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 3
+				},
 				{
 					"type": "dr_bonus",
 					"locations": [
@@ -4886,6 +5046,14 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
 						"skull"
 					],
 					"amount": 3
@@ -4916,6 +5084,14 @@
 			"base_value": "68",
 			"base_weight": "6.7 lb",
 			"features": [
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 4
+				},
 				{
 					"type": "dr_bonus",
 					"locations": [
@@ -5267,6 +5443,22 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"face"
+					],
+					"specialization": "back impaling",
+					"amount": -1
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
 						"skull"
 					],
 					"amount": 3
@@ -5305,6 +5497,22 @@
 			"base_value": "63",
 			"base_weight": "5.2 lb",
 			"features": [
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 4
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"face"
+					],
+					"specialization": "back impaling",
+					"amount": -1
+				},
 				{
 					"type": "dr_bonus",
 					"locations": [
@@ -5726,6 +5934,22 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 0
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"face"
+					],
+					"specialization": "back cutting",
+					"amount": 1
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
 						"skull"
 					],
 					"amount": 0
@@ -5765,6 +5989,22 @@
 			"base_value": "58",
 			"base_weight": "1 lb",
 			"features": [
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 1
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"face"
+					],
+					"specialization": "back cutting",
+					"amount": 1
+				},
 				{
 					"type": "dr_bonus",
 					"locations": [
@@ -6179,6 +6419,22 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 2
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"face"
+					],
+					"specialization": "back impaling",
+					"amount": -1
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
 						"skull"
 					],
 					"amount": 2
@@ -6217,6 +6473,22 @@
 			"base_value": "38",
 			"base_weight": "3.2 lb",
 			"features": [
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"face"
+					],
+					"specialization": "back impaling",
+					"amount": -1
+				},
 				{
 					"type": "dr_bonus",
 					"locations": [
@@ -8543,6 +8815,14 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 9
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
 						"skull"
 					],
 					"amount": 9
@@ -8574,6 +8854,14 @@
 			"base_value": "1013",
 			"base_weight": "8.2 lb",
 			"features": [
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 10
+				},
 				{
 					"type": "dr_bonus",
 					"locations": [
@@ -8917,6 +9205,14 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
 						"skull"
 					],
 					"amount": 3
@@ -8947,6 +9243,14 @@
 			"base_value": "263",
 			"base_weight": "2.2 lb",
 			"features": [
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 4
+				},
 				{
 					"type": "dr_bonus",
 					"locations": [
@@ -9348,6 +9652,14 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 6
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
 						"skull"
 					],
 					"amount": 6
@@ -9379,6 +9691,14 @@
 			"base_value": "638",
 			"base_weight": "5.2 lb",
 			"features": [
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 7
+				},
 				{
 					"type": "dr_bonus",
 					"locations": [
@@ -10239,6 +10559,22 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"face"
+					],
+					"specialization": "back crushing",
+					"amount": -1
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
 						"skull"
 					],
 					"amount": 3
@@ -10277,6 +10613,22 @@
 			"base_value": "93",
 			"base_weight": "4.2 lb",
 			"features": [
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 4
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"face"
+					],
+					"specialization": "back crushing",
+					"amount": -1
+				},
 				{
 					"type": "dr_bonus",
 					"locations": [
@@ -10698,6 +11050,22 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 4
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"face"
+					],
+					"specialization": "back crushing",
+					"amount": -1
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
 						"skull"
 					],
 					"amount": 4
@@ -10737,6 +11105,22 @@
 			"base_value": "151",
 			"base_weight": "7.2 lb",
 			"features": [
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 5
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"face"
+					],
+					"specialization": "back crushing",
+					"amount": -1
+				},
 				{
 					"type": "dr_bonus",
 					"locations": [
@@ -11968,6 +12352,14 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
 						"skull"
 					],
 					"amount": 3
@@ -11997,6 +12389,14 @@
 			"base_value": "38",
 			"base_weight": "7.7 lb",
 			"features": [
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 4
+				},
 				{
 					"type": "dr_bonus",
 					"locations": [

--- a/Library/Low Tech/Low Tech Instant Armor.eqp
+++ b/Library/Low Tech/Low Tech Instant Armor.eqp
@@ -3128,7 +3128,7 @@
 			"description": "Jack of Plates Arm Armor",
 			"reference": "LTIA7",
 			"reference_highlight": "Jack of Plates",
-			"local_notes": "Don: 15 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. crushing.",
+			"local_notes": "Don: 15 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "2",
 			"tags": [
 				"Arms",
@@ -5212,7 +5212,7 @@
 			"description": "Leather, Heavy Arm Armor",
 			"reference": "LTIA7",
 			"reference_highlight": "Leather, Heavy",
-			"local_notes": "Don: 15 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. impaling.",
+			"local_notes": "Don: 15 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Arms",
@@ -5669,7 +5669,7 @@
 			"description": "Leather, Light Arm Armor",
 			"reference": "LTIA7",
 			"reference_highlight": "Leather, Light",
-			"local_notes": "Don: 15 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
+			"local_notes": "Don: 15 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
@@ -6124,7 +6124,7 @@
 			"description": "Leather, Medium Arm Armor",
 			"reference": "LTIA7",
 			"reference_highlight": "Leather, Medium",
-			"local_notes": "Don: 15 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
+			"local_notes": "Don: 15 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Arms",
@@ -6582,7 +6582,7 @@
 			"description": "Mail and Plates Arm Armor",
 			"reference": "LTIA8",
 			"reference_highlight": "Mail and Plates",
-			"local_notes": "Don: 10 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. crushing.",
+			"local_notes": "Don: 10 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -6960,7 +6960,7 @@
 			"description": "Mail, Fine Arm Armor",
 			"reference": "LTIA8",
 			"reference_highlight": "Mail, Fine",
-			"local_notes": "Don: 8 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "Don: 8 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -6984,6 +6984,7 @@
 					"locations": [
 						"arm"
 					],
+					"specialization": "crushing",
 					"amount": -2
 				}
 			],
@@ -7344,7 +7345,7 @@
 			"description": "Mail, Heavy Arm Armor",
 			"reference": "LTIA8",
 			"reference_highlight": "Mail, Heavy",
-			"local_notes": "Don: 8 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "Don: 8 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379);",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -7962,6 +7963,7 @@
 					"locations": [
 						"arm"
 					],
+					"specialization": "crushing",
 					"amount": -2
 				}
 			],
@@ -10184,7 +10186,7 @@
 			"description": "Scale, Light Arm Armor",
 			"reference": "LTIA7",
 			"reference_highlight": "Scale, Light",
-			"local_notes": "Don: 15 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. crushing.",
+			"local_notes": "Don: 15 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Arms",
@@ -10640,7 +10642,7 @@
 			"description": "Scale, Medium Arm Armor",
 			"reference": "LTIA7",
 			"reference_highlight": "Scale, Medium",
-			"local_notes": "Don: 15 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
+			"local_notes": "Don: 15 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [

--- a/Library/Low Tech/Low Tech Instant Armor.eqp
+++ b/Library/Low Tech/Low Tech Instant Armor.eqp
@@ -17,20 +17,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"arm"
-					],
-					"amount": 0
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"abdomen"
-					],
-					"amount": 0
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
+						"abdomen",
+						"arm",
 						"torso"
 					],
 					"amount": 0
@@ -61,14 +49,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"groin"
-					],
-					"amount": 0
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"leg"
+						"groin",
+						"hand"
 					],
 					"amount": 0
 				}
@@ -86,7 +68,7 @@
 			"id": "e8lwgtkMSuZ5kldYB",
 			"description": "Boots, Leather ",
 			"reference": "LTIA16",
-			"local_notes": "DR: 2; Don: 6 secs; Holdout: -4; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
+			"local_notes": "Don: 6 secs; Holdout: -4; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "1",
 			"tags": [
 				"Footwear"
@@ -97,8 +79,7 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"foot",
-						"torso"
+						"foot"
 					],
 					"amount": 2
 				},
@@ -123,7 +104,7 @@
 			"id": "edcVYnWCsEfIfsJWy",
 			"description": "Boots, Light Leather ",
 			"reference": "LTIA16",
-			"local_notes": "DR: 0; Don: 6 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
+			"local_notes": "Don: 6 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "1",
 			"legality_class": "5",
 			"tags": [
@@ -160,7 +141,8 @@
 			"id": "eh8J5xpu8ruZebKhw",
 			"description": "Brigandine, Light Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "DR: 3; Don: 23 secs; Holdout: -2; Reaction Pen.-2",
+			"reference_highlight": "Brigandine, Light",
+			"local_notes": "Don: 23 secs; Holdout: -2; Reaction Pen.-2",
 			"tech_level": "4",
 			"tags": [
 				"Body Armor"
@@ -182,14 +164,14 @@
 				"extended_value": 225,
 				"weight": "2.5 lb",
 				"extended_weight": "2.5 lb"
-			},
-			"reference_highlight": "Brigandine, Light"
+			}
 		},
 		{
 			"id": "edQLWsYSLTmQwbhyU",
 			"description": "Brigandine, Light Arm Armor",
 			"reference": "LTIA8",
-			"local_notes": "DR: 3; Don: 15 secs; Holdout: -2; Reaction Pen.-1",
+			"reference_highlight": "Brigandine, Light",
+			"local_notes": "Don: 15 secs; Holdout: -2; Reaction Pen.-1",
 			"tech_level": "4",
 			"tags": [
 				"Limb Armor"
@@ -211,14 +193,14 @@
 				"extended_value": 450,
 				"weight": "5 lb",
 				"extended_weight": "5 lb"
-			},
-			"reference_highlight": "Brigandine, Light"
+			}
 		},
 		{
 			"id": "eUYpAPhKkq9FESYpi",
 			"description": "Brigandine, Light Bascinet",
 			"reference": "LTIA14",
-			"local_notes": "DR: 3; Don: 8 secs; Holdout: -3; Reaction Pen.-1",
+			"reference_highlight": "Brigandine, Light",
+			"local_notes": "Don: 8 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "4",
 			"tags": [
 				"Bascinet"
@@ -240,14 +222,14 @@
 				"extended_value": 225,
 				"weight": "2.5 lb",
 				"extended_weight": "2.5 lb"
-			},
-			"reference_highlight": "Brigandine, Light"
+			}
 		},
 		{
 			"id": "eJ-0v_Th7Clbbzelr",
 			"description": "Brigandine, Light Bascinet, Padded",
 			"reference": "LTIA14",
-			"local_notes": "DR: 3; Don: 8 secs; Holdout: -3; Reaction Pen.-1",
+			"reference_highlight": "Brigandine, Light",
+			"local_notes": "Don: 8 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "4",
 			"tags": [
 				"Bascinet"
@@ -269,14 +251,14 @@
 				"extended_value": 238,
 				"weight": "2.7 lb",
 				"extended_weight": "2.7 lb"
-			},
-			"reference_highlight": "Brigandine, Light"
+			}
 		},
 		{
 			"id": "eTf_SIoh9R449QM0q",
 			"description": "Brigandine, Light Chest Armor",
 			"reference": "LTIA6",
-			"local_notes": "DR: 3; Don: 23 secs; Holdout: -2; Reaction Pen.-2",
+			"reference_highlight": "Brigandine, Light",
+			"local_notes": "Don: 23 secs; Holdout: -2; Reaction Pen.-2",
 			"tech_level": "4",
 			"tags": [
 				"Body Armor"
@@ -298,14 +280,14 @@
 				"extended_value": 675,
 				"weight": "7.5 lb",
 				"extended_weight": "7.5 lb"
-			},
-			"reference_highlight": "Brigandine, Light"
+			}
 		},
 		{
 			"id": "e3vThWxETJmvPpEFF",
 			"description": "Brigandine, Light Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "DR: 3; Don: 3 secs; Holdout: -2; Reaction Pen.-1",
+			"reference_highlight": "Brigandine, Light",
+			"local_notes": "Don: 3 secs; Holdout: -2; Reaction Pen.-1",
 			"tech_level": "4",
 			"tags": [
 				"Groin Armor"
@@ -327,14 +309,14 @@
 				"extended_value": 45,
 				"weight": "0.5 lb",
 				"extended_weight": "0.5 lb"
-			},
-			"reference_highlight": "Brigandine, Light"
+			}
 		},
 		{
 			"id": "ek4BPKf7q8Kvff9Ec",
 			"description": "Brigandine, Light Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "DR: 3; Don: 30 secs; Holdout: -2; Reaction Pen.-1",
+			"reference_highlight": "Brigandine, Light",
+			"local_notes": "Don: 30 secs; Holdout: -2; Reaction Pen.-1",
 			"tech_level": "4",
 			"tags": [
 				"Limb Armor"
@@ -356,14 +338,14 @@
 				"extended_value": 900,
 				"weight": "10 lb",
 				"extended_weight": "10 lb"
-			},
-			"reference_highlight": "Brigandine, Light"
+			}
 		},
 		{
 			"id": "eEpQhVdPZNyFI7WHy",
 			"description": "Brigandine, Light Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "DR: 3; Don: 3 secs; Holdout: -3; Reaction Pen.-1",
+			"reference_highlight": "Brigandine, Light",
+			"local_notes": "Don: 3 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "4",
 			"tags": [
 				"Neck Armor"
@@ -385,14 +367,14 @@
 				"extended_value": 45,
 				"weight": "0.5 lb",
 				"extended_weight": "0.5 lb"
-			},
-			"reference_highlight": "Brigandine, Light"
+			}
 		},
 		{
 			"id": "e8kCpa3uNZ-_5p1rv",
 			"description": "Brigandine, Light Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "DR: 3; Don: 6 secs; Holdout: -3; Reaction Pen.-1",
+			"reference_highlight": "Brigandine, Light",
+			"local_notes": "Don: 6 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "4",
 			"tags": [
 				"Pot Helm"
@@ -414,14 +396,14 @@
 				"extended_value": 180,
 				"weight": "2 lb",
 				"extended_weight": "2 lb"
-			},
-			"reference_highlight": "Brigandine, Light"
+			}
 		},
 		{
 			"id": "e_0wrPWRg4T9zCtTS",
 			"description": "Brigandine, Light Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "DR: 4; Don: 6 secs; Holdout: -3; Reaction Pen.-1",
+			"reference_highlight": "Brigandine, Light",
+			"local_notes": "Don: 6 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "4",
 			"tags": [
 				"Pot Helm"
@@ -443,14 +425,14 @@
 				"extended_value": 190,
 				"weight": "3.2 lb",
 				"extended_weight": "3.2 lb"
-			},
-			"reference_highlight": "Brigandine, Light"
+			}
 		},
 		{
 			"id": "eAYZJ6GspGEexUw2b",
 			"description": "Brigandine, Light Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "DR: 3; Don: 30 secs; Holdout: -2; Reaction Pen.-2",
+			"reference_highlight": "Brigandine, Light",
+			"local_notes": "Don: 30 secs; Holdout: -2; Reaction Pen.-2",
 			"tech_level": "4",
 			"tags": [
 				"Body Armor"
@@ -473,14 +455,14 @@
 				"extended_value": 900,
 				"weight": "10 lb",
 				"extended_weight": "10 lb"
-			},
-			"reference_highlight": "Brigandine, Light"
+			}
 		},
 		{
 			"id": "eQ6f2HunYAOa--mb4",
 			"description": "Brigandine, Medium Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "DR: 5; Don: 23 secs; Holdout: -4; Reaction Pen.-2",
+			"reference_highlight": "Brigandine, Medium",
+			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -503,14 +485,14 @@
 				"extended_value": 450,
 				"weight": "5 lb",
 				"extended_weight": "5 lb"
-			},
-			"reference_highlight": "Brigandine, Medium"
+			}
 		},
 		{
 			"id": "e1FLTlv1-MCiK9A_I",
 			"description": "Brigandine, Medium Arm Armor",
 			"reference": "LTIA8",
-			"local_notes": "DR: 5; Don: 15 secs; Holdout: -4; Reaction Pen.-1",
+			"reference_highlight": "Brigandine, Medium",
+			"local_notes": "Don: 15 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -533,14 +515,14 @@
 				"extended_value": 900,
 				"weight": "10 lb",
 				"extended_weight": "10 lb"
-			},
-			"reference_highlight": "Brigandine, Medium"
+			}
 		},
 		{
 			"id": "enY4fk3DuAzhTGCqt",
 			"description": "Brigandine, Medium Bascinet",
 			"reference": "LTIA14",
-			"local_notes": "DR: 5; Don: 8 secs; Holdout: -5; Reaction Pen.-1",
+			"reference_highlight": "Brigandine, Medium",
+			"local_notes": "Don: 8 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -563,14 +545,14 @@
 				"extended_value": 450,
 				"weight": "5 lb",
 				"extended_weight": "5 lb"
-			},
-			"reference_highlight": "Brigandine, Medium"
+			}
 		},
 		{
 			"id": "eTC8_mSTNuLBuBO_f",
 			"description": "Brigandine, Medium Bascinet, Padded",
 			"reference": "LTIA14",
-			"local_notes": "DR: 6; Don: 8 secs; Holdout: -5; Reaction Pen.-1",
+			"reference_highlight": "Brigandine, Medium",
+			"local_notes": "Don: 8 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -593,14 +575,14 @@
 				"extended_value": 463,
 				"weight": "5.2 lb",
 				"extended_weight": "5.2 lb"
-			},
-			"reference_highlight": "Brigandine, Medium"
+			}
 		},
 		{
 			"id": "e8Q_xoWvIetlKUBa1",
 			"description": "Brigandine, Medium Chest Armor",
 			"reference": "LTIA6",
-			"local_notes": "DR: 5; Don: 23 secs; Holdout: -4; Reaction Pen.-2",
+			"reference_highlight": "Brigandine, Medium",
+			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -623,14 +605,14 @@
 				"extended_value": 1350,
 				"weight": "15 lb",
 				"extended_weight": "15 lb"
-			},
-			"reference_highlight": "Brigandine, Medium"
+			}
 		},
 		{
 			"id": "ewKGGF29AjbqQWGOC",
 			"description": "Brigandine, Medium Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "DR: 5; Don: 3 secs; Holdout: -4; Reaction Pen.-1",
+			"reference_highlight": "Brigandine, Medium",
+			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -653,14 +635,14 @@
 				"extended_value": 90,
 				"weight": "1 lb",
 				"extended_weight": "1 lb"
-			},
-			"reference_highlight": "Brigandine, Medium"
+			}
 		},
 		{
 			"id": "etJ5XdwTGD6cJhN5a",
 			"description": "Brigandine, Medium Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "DR: 5; Don: 30 secs; Holdout: -4; Reaction Pen.-1",
+			"reference_highlight": "Brigandine, Medium",
+			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -683,14 +665,14 @@
 				"extended_value": 1800,
 				"weight": "20 lb",
 				"extended_weight": "20 lb"
-			},
-			"reference_highlight": "Brigandine, Medium"
+			}
 		},
 		{
 			"id": "esyl3QigpPqsFsDNg",
 			"description": "Brigandine, Medium Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "DR: 5; Don: 3 secs; Holdout: -5; Reaction Pen.-1",
+			"reference_highlight": "Brigandine, Medium",
+			"local_notes": "Don: 3 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -713,14 +695,14 @@
 				"extended_value": 90,
 				"weight": "1 lb",
 				"extended_weight": "1 lb"
-			},
-			"reference_highlight": "Brigandine, Medium"
+			}
 		},
 		{
 			"id": "e-4FTDCDKuqROsiK4",
 			"description": "Brigandine, Medium Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "DR: 5; Don: 6 secs; Holdout: -5; Reaction Pen.-1",
+			"reference_highlight": "Brigandine, Medium",
+			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -743,14 +725,14 @@
 				"extended_value": 360,
 				"weight": "4 lb",
 				"extended_weight": "4 lb"
-			},
-			"reference_highlight": "Brigandine, Medium"
+			}
 		},
 		{
 			"id": "e7Ih5HMRDrnu2R6cL",
 			"description": "Brigandine, Medium Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "DR: 6; Don: 6 secs; Holdout: -5; Reaction Pen.-1",
+			"reference_highlight": "Brigandine, Medium",
+			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -773,14 +755,14 @@
 				"extended_value": 370,
 				"weight": "5.2 lb",
 				"extended_weight": "5.2 lb"
-			},
-			"reference_highlight": "Brigandine, Medium"
+			}
 		},
 		{
 			"id": "ehhvva799mVxX6d2f",
 			"description": "Brigandine, Medium Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "DR: 5; Don: 30 secs; Holdout: -4; Reaction Pen.-2",
+			"reference_highlight": "Brigandine, Medium",
+			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -804,14 +786,13 @@
 				"extended_value": 1800,
 				"weight": "20 lb",
 				"extended_weight": "20 lb"
-			},
-			"reference_highlight": "Brigandine, Medium"
+			}
 		},
 		{
 			"id": "emRv3QKih2dvu3w1P",
 			"description": "Cane Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "DR: 1; Don: 23 secs; Holdout: -4; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433); treat as resistant.",
+			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433); treat as resistant.",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -839,7 +820,7 @@
 			"id": "e4yOdbY3C6Ta2th6I",
 			"description": "Cane Arm Armor",
 			"reference": "LTIA7",
-			"local_notes": "DR: 1; Don: 15 secs; Holdout: -4; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433); treat as resistant.",
+			"local_notes": "Don: 15 secs; Holdout: -4; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433); treat as resistant.",
 			"tech_level": "0",
 			"tags": [
 				"Limb Armor"
@@ -867,7 +848,7 @@
 			"id": "eWRN91wMSfgFHEOCA",
 			"description": "Cane Bascinet",
 			"reference": "LTIA14",
-			"local_notes": "DR: 1; Don: 8 secs; Holdout: -5; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433); treat as resistant.",
+			"local_notes": "Don: 8 secs; Holdout: -5; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433); treat as resistant.",
 			"tech_level": "0",
 			"tags": [
 				"Bascinet"
@@ -895,7 +876,7 @@
 			"id": "eE_c-yz5FS0yXCxiX",
 			"description": "Cane Bascinet, Padded",
 			"reference": "LTIA14",
-			"local_notes": "DR: 2; Don: 8 secs; Holdout: -5; Reaction Pen.-1",
+			"local_notes": "Don: 8 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Bascinet"
@@ -923,7 +904,7 @@
 			"id": "eobg1Tm37CBN13eUE",
 			"description": "Cane Chest Armor",
 			"reference": "LTIA5",
-			"local_notes": "DR: 1; Don: 23 secs; Holdout: -4; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433); treat as resistant.",
+			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433); treat as resistant.",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -951,7 +932,7 @@
 			"id": "etVn1-1taVlfhJ88F",
 			"description": "Cane Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "DR: 1; Don: 30 secs; Holdout: -4; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433); treat as resistant.",
+			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433); treat as resistant.",
 			"tech_level": "0",
 			"tags": [
 				"Limb Armor"
@@ -979,7 +960,7 @@
 			"id": "enBusL9f1xeI5VP0Z",
 			"description": "Cane Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "DR: 1; Don: 3 secs; Holdout: -5; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433); treat as resistant.",
+			"local_notes": "Don: 3 secs; Holdout: -5; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433); treat as resistant.",
 			"tech_level": "0",
 			"tags": [
 				"Neck Armor"
@@ -1007,7 +988,7 @@
 			"id": "ei2PivGavZyeZbtMD",
 			"description": "Cane Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "DR: 1; Don: 6 secs; Holdout: -5; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433); treat as resistant.",
+			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433); treat as resistant.",
 			"tech_level": "0",
 			"tags": [
 				"Pot Helm"
@@ -1035,7 +1016,7 @@
 			"id": "e200eWmzf_iU8dDv9",
 			"description": "Cane Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "DR: 2; Don: 6 secs; Holdout: -5; Reaction Pen.-1",
+			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Pot Helm"
@@ -1063,7 +1044,7 @@
 			"id": "eK_Ju4UXUveLhfdPM",
 			"description": "Cane Torso Armor",
 			"reference": "LTIA4",
-			"local_notes": "DR: 1; Don: 30 secs; Holdout: -4; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433); treat as resistant.",
+			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433); treat as resistant.",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -1092,7 +1073,7 @@
 			"id": "eeGYAyjcVLFROfzcB",
 			"description": "Cloth, Padded Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "DR: 1; Don: 11 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
+			"local_notes": "Don: 11 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -1120,7 +1101,7 @@
 			"id": "eIbb_FaAxSB5N__Hl",
 			"description": "Cloth, Padded Arm Armor",
 			"reference": "LTIA7",
-			"local_notes": "DR: 1; Don: 8 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
+			"local_notes": "Don: 8 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Limb Armor"
@@ -1148,7 +1129,7 @@
 			"id": "e9XLFiOrvY0PZD9C3",
 			"description": "Cloth, Padded Bascinet",
 			"reference": "LTIA14",
-			"local_notes": "DR: 1; Don: 4 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379)",
+			"local_notes": "Don: 4 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Bascinet"
@@ -1176,7 +1157,7 @@
 			"id": "e2htbNlX1xn4-u6x7",
 			"description": "Cloth, Padded Bascinet, Padded",
 			"reference": "LTIA14",
-			"local_notes": "DR: 2; Don: 4 secs; Holdout: -1",
+			"local_notes": "Don: 4 secs; Holdout: -1",
 			"tech_level": "0",
 			"tags": [
 				"Bascinet"
@@ -1204,7 +1185,7 @@
 			"id": "er3ATQBwPc4AXWcU-",
 			"description": "Cloth, Padded Chest Armor",
 			"reference": "LTIA5",
-			"local_notes": "DR: 1; Don: 11secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
+			"local_notes": "Don: 11secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -1232,7 +1213,7 @@
 			"id": "e4tTAtQSyCIraf-sh",
 			"description": "Cloth, Padded Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "DR: 1; Don: 3 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
+			"local_notes": "Don: 3 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Groin Armor"
@@ -1260,7 +1241,7 @@
 			"id": "eJMxpJMaSa34R5HeL",
 			"description": "Cloth, Padded Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "DR: 1; Don: 15 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
+			"local_notes": "Don: 15 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Limb Armor"
@@ -1288,7 +1269,7 @@
 			"id": "euHHcEqbF20IqHTdX",
 			"description": "Cloth, Padded Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "DR: 1; Don: 3 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379)",
+			"local_notes": "Don: 3 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Neck Armor"
@@ -1316,7 +1297,7 @@
 			"id": "eDPknyvFhTUn3xLLn",
 			"description": "Cloth, Padded Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "DR: 1; Don: 3 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379)",
+			"local_notes": "Don: 3 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Pot Helm"
@@ -1344,7 +1325,7 @@
 			"id": "e0XgEoxlybGM1sxmW",
 			"description": "Cloth, Padded Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "DR: 2; Don: 3 secs; Holdout: -1",
+			"local_notes": "Don: 3 secs; Holdout: -1",
 			"tech_level": "0",
 			"tags": [
 				"Pot Helm"
@@ -1372,7 +1353,7 @@
 			"id": "ercQVz3m__twBvKjH",
 			"description": "Cloth, Padded Torso Armor",
 			"reference": "LTIA4",
-			"local_notes": "DR: 1; Don: 15 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
+			"local_notes": "Don: 15 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -1401,7 +1382,7 @@
 			"id": "eAGTRRqWt8WZIVwP9",
 			"description": "Gauntlets, Hardened Leather ",
 			"reference": "LTIA15",
-			"local_notes": "DR: 2; Don: 10 secs; Holdout: -4; Gives Ham-Fisted 2 (p. B138).",
+			"local_notes": "Don: 10 secs; Holdout: -4; Gives Ham-Fisted 2 (p. B138).",
 			"tech_level": "1",
 			"tags": [
 				"Gloves"
@@ -1429,7 +1410,7 @@
 			"id": "eur06_PfX8L-FrAdE",
 			"description": "Gauntlets, Heavy Mail ",
 			"reference": "LTIA15",
-			"local_notes": "DR: 5; Don: 10 secs; Holdout: -4; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing; Gives Ham-Fisted 2 (p. B138).",
+			"local_notes": "Don: 10 secs; Holdout: -4; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing; Gives Ham-Fisted 2 (p. B138).",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -1466,7 +1447,7 @@
 			"id": "e6hR_7K5Y4ELg8ouw",
 			"description": "Gauntlets, Light Plate ",
 			"reference": "LTIA15",
-			"local_notes": "DR: 3; Don: 10 secs; Holdout: -4; Gives Ham-Fisted 2 (p. B138).",
+			"local_notes": "Don: 10 secs; Holdout: -4; Gives Ham-Fisted 2 (p. B138).",
 			"tech_level": "4",
 			"tags": [
 				"Gloves"
@@ -1494,7 +1475,7 @@
 			"id": "e1Jc9oibz_7Se4NSl",
 			"description": "Gauntlets, Light Segmented ",
 			"reference": "LTIA15",
-			"local_notes": "DR: 3; Don: 10 secs; Holdout: -4; Gives Ham-Fisted 2 (p. B138).",
+			"local_notes": "Don: 10 secs; Holdout: -4; Gives Ham-Fisted 2 (p. B138).",
 			"tech_level": "3",
 			"tags": [
 				"Gloves"
@@ -1522,7 +1503,7 @@
 			"id": "eXb29dBeGn2jiLwyd",
 			"description": "Gauntlets, Medium Plate ",
 			"reference": "LTIA15",
-			"local_notes": "DR: 6; Don: 10 secs; Holdout: -6; Gives Ham-Fisted 2 (p. B138).",
+			"local_notes": "Don: 10 secs; Holdout: -6; Gives Ham-Fisted 2 (p. B138).",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -1551,7 +1532,7 @@
 			"id": "elLRNlQeA1ZIzjwDY",
 			"description": "Gauntlets, Medium Segmented ",
 			"reference": "LTIA15",
-			"local_notes": "DR: 4; Don: 10 secs; Holdout: -5; Gives Ham-Fisted 2 (p. B138).",
+			"local_notes": "Don: 10 secs; Holdout: -5; Gives Ham-Fisted 2 (p. B138).",
 			"tech_level": "3",
 			"tags": [
 				"Gloves"
@@ -1579,7 +1560,7 @@
 			"id": "eUyhaqVa7eSPWoDtB",
 			"description": "Gauntlets, Padded Cloth ",
 			"reference": "LTIA15",
-			"local_notes": "DR: 1; Don: 10 secs; Holdout: -2; Flexible and susceptible to blunt trauma (p. B379); Gives Ham-Fisted 1 (p. B138).",
+			"local_notes": "Don: 10 secs; Holdout: -2; Flexible and susceptible to blunt trauma (p. B379); Gives Ham-Fisted 1 (p. B138).",
 			"tech_level": "1",
 			"tags": [
 				"Gloves"
@@ -1607,7 +1588,7 @@
 			"id": "eYtckk0_SxXIvwCEl",
 			"description": "Gauntlets,Fine Mail ",
 			"reference": "LTIA15",
-			"local_notes": "DR: 4; Don: 10 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing; Gives Ham-Fisted 2 (p. B138).",
+			"local_notes": "Don: 10 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing; Gives Ham-Fisted 2 (p. B138).",
 			"tech_level": "2",
 			"tags": [
 				"Gloves"
@@ -1643,7 +1624,7 @@
 			"id": "e55lxLmwMaK_c-XHw",
 			"description": "Gauntlets,Light Mail ",
 			"reference": "LTIA15",
-			"local_notes": "DR: 3; Don: 10 secs; Holdout: -2; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing; Gives Ham-Fisted 2 (p. B138).",
+			"local_notes": "Don: 10 secs; Holdout: -2; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing; Gives Ham-Fisted 2 (p. B138).",
 			"tech_level": "2",
 			"tags": [
 				"Gloves"
@@ -1679,7 +1660,7 @@
 			"id": "eixxfx23rzXgQ7VXP",
 			"description": "Gauntlets, Light Scale ",
 			"reference": "LTIA15",
-			"local_notes": "DR: 3; Don: 10 secs; Holdout: -4; -1 DR vs. crushing; Gives Ham-Fisted 2 (p. B138).",
+			"local_notes": "Don: 10 secs; Holdout: -4; -1 DR vs. crushing; Gives Ham-Fisted 2 (p. B138).",
 			"tech_level": "1",
 			"tags": [
 				"Gloves"
@@ -1707,7 +1688,7 @@
 			"id": "e_1tXA6dcIPkbkkIa",
 			"description": "Gloves, Cloth ",
 			"reference": "LTIA15",
-			"local_notes": "DR: 1; Don: 10 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting; Enclosedmittens andgloves protectvs.cold,heat,contactpoison,etc.,but giveBadGrip1(p.B123); Gives Ham-Fisted 1 (p. B138).",
+			"local_notes": "Don: 10 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting; Enclosedmittens andgloves protectvs.cold,heat,contactpoison,etc.,but giveBadGrip1(p.B123); Gives Ham-Fisted 1 (p. B138).",
 			"tech_level": "1",
 			"legality_class": "5",
 			"tags": [
@@ -1744,7 +1725,7 @@
 			"id": "en60StSySCEyH7YVO",
 			"description": "Gloves, Light Leather ",
 			"reference": "LTIA15",
-			"local_notes": "DR: 0; Don: 10 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting; Enclosedmittens andgloves protectvs.cold,heat,contactpoison,etc.,but giveBadGrip1(p.B123); Gives Ham-Fisted 1 (p. B138).",
+			"local_notes": "Don: 10 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting; Enclosedmittens andgloves protectvs.cold,heat,contactpoison,etc.,but giveBadGrip1(p.B123); Gives Ham-Fisted 1 (p. B138).",
 			"tech_level": "1",
 			"legality_class": "5",
 			"tags": [
@@ -1781,7 +1762,7 @@
 			"id": "e16kkxLZFbx6VLlAd",
 			"description": "Hardened Leather, Heavy Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "DR: 3; Don: 23 secs; Holdout: -4; Reaction Pen.-2",
+			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "1",
 			"tags": [
 				"Body Armor"
@@ -1809,7 +1790,7 @@
 			"id": "evHTYfJ7jKI6fwE0-",
 			"description": "Hardened Leather, Heavy Arm Armor",
 			"reference": "LTIA7",
-			"local_notes": "DR: 3; Don: 15 secs; Holdout: -4; Reaction Pen.-1",
+			"local_notes": "Don: 15 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Limb Armor"
@@ -1837,7 +1818,7 @@
 			"id": "eMMyaOaVHKzQRweKQ",
 			"description": "Hardened Leather, Heavy Bascinet",
 			"reference": "LTIA14",
-			"local_notes": "DR: 3; Don: 8 secs; Holdout: -5; Reaction Pen.-1",
+			"local_notes": "Don: 8 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Bascinet"
@@ -1865,7 +1846,7 @@
 			"id": "eS7ZawHm2T4dmz1F5",
 			"description": "Hardened Leather, Heavy Bascinet, Padded",
 			"reference": "LTIA14",
-			"local_notes": "DR: 3; Don: 8 secs; Holdout: -5; Reaction Pen.-1",
+			"local_notes": "Don: 8 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Bascinet"
@@ -1893,7 +1874,7 @@
 			"id": "eKjAtjY6WdKLQyyOo",
 			"description": "Hardened Leather, Heavy Chest Armor",
 			"reference": "LTIA5",
-			"local_notes": "DR: 3; Don: 23 secs; Holdout: -4; Reaction Pen.-2",
+			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "1",
 			"tags": [
 				"Body Armor"
@@ -1921,7 +1902,7 @@
 			"id": "eaPOJRkSRRhw_v1Ii",
 			"description": "Hardened Leather, Heavy Full Helm",
 			"reference": "LTIA14",
-			"local_notes": "DR: 3; Don: 9 secs; Holdout: -5; Reaction Pen.-1",
+			"local_notes": "Don: 9 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Full Helm"
@@ -1950,7 +1931,7 @@
 			"id": "eCPh_o0H1tNS_2pD6",
 			"description": "Hardened Leather, Heavy Full Helm, Padded",
 			"reference": "LTIA14",
-			"local_notes": "DR: 4; Don: 9 secs; Holdout: -5; Reaction Pen.-1",
+			"local_notes": "Don: 9 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Full Helm"
@@ -1979,7 +1960,7 @@
 			"id": "euWzxEa4wC6RFa8rj",
 			"description": "Hardened Leather, Heavy Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "DR: 3; Don: 3 secs; Holdout: -4; Reaction Pen.-1",
+			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Groin Armor"
@@ -2007,7 +1988,7 @@
 			"id": "e8HwxRzeqYA0G-95c",
 			"description": "Hardened Leather, Heavy Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "DR: 3; Don: 30 secs; Holdout: -4; Reaction Pen.-1",
+			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Limb Armor"
@@ -2035,7 +2016,7 @@
 			"id": "eXMPN2mxCgZ4R0scc",
 			"description": "Hardened Leather, Heavy Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "DR: 3; Don: 3 secs; Holdout: -5; Reaction Pen.-1",
+			"local_notes": "Don: 3 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Neck Armor"
@@ -2063,7 +2044,7 @@
 			"id": "eLCqzw-Br3WmlHiBh",
 			"description": "Hardened Leather, Heavy Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "DR: 3; Don: 6 secs; Holdout: -5; Reaction Pen.-1",
+			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Pot Helm"
@@ -2091,7 +2072,7 @@
 			"id": "e_pOsR_mGuKMmsD-4",
 			"description": "Hardened Leather, Heavy Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "DR: 4; Don: 6 secs; Holdout: -5; Reaction Pen.-1",
+			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Pot Helm"
@@ -2119,7 +2100,7 @@
 			"id": "eQvSPTA9uJm1p6hWS",
 			"description": "Hardened Leather, Heavy Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "DR: 3; Don: 30 secs; Holdout: -4; Reaction Pen.-2",
+			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "1",
 			"tags": [
 				"Body Armor"
@@ -2148,7 +2129,7 @@
 			"id": "efhSMYdar0FA330XF",
 			"description": "Hardened Leather, Medium Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "DR: 2; Don: 23 secs; Holdout: -3; Reaction Pen.-2",
+			"local_notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-2",
 			"tech_level": "1",
 			"tags": [
 				"Body Armor"
@@ -2176,7 +2157,7 @@
 			"id": "eZ52fni9bDiz7STYh",
 			"description": "Hardened Leather, Medium Arm Armor",
 			"reference": "LTIA7",
-			"local_notes": "DR: 2; Don: 15 secs; Holdout: -3; Reaction Pen.-1",
+			"local_notes": "Don: 15 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Limb Armor"
@@ -2204,7 +2185,7 @@
 			"id": "e_8g7sSqp7H2fsdKu",
 			"description": "Hardened Leather, Medium Bascinet",
 			"reference": "LTIA14",
-			"local_notes": "DR: 2; Don: 8 secs; Holdout: -4; Reaction Pen.-1",
+			"local_notes": "Don: 8 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Bascinet"
@@ -2232,7 +2213,7 @@
 			"id": "e7wVrvuC3-DCpiaux",
 			"description": "Hardened Leather, Medium Bascinet, Padded",
 			"reference": "LTIA14",
-			"local_notes": "DR: 3; Don: 8 secs; Holdout: -4; Reaction Pen.-1",
+			"local_notes": "Don: 8 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Bascinet"
@@ -2260,7 +2241,7 @@
 			"id": "eeUmKAG5phe6Mm6HT",
 			"description": "Hardened Leather, Medium Chest Armor",
 			"reference": "LTIA5",
-			"local_notes": "DR: 2; Don: 23 secs; Holdout: -3; Reaction Pen.-2",
+			"local_notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-2",
 			"tech_level": "1",
 			"tags": [
 				"Body Armor"
@@ -2288,7 +2269,7 @@
 			"id": "e7EekFtyJyxUBJg9F",
 			"description": "Hardened Leather, Medium Full Helm",
 			"reference": "LTIA14",
-			"local_notes": "DR: 2; Don: 9 secs; Holdout: -4; Reaction Pen.-1",
+			"local_notes": "Don: 9 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Full Helm"
@@ -2323,7 +2304,7 @@
 			"id": "e6yVOb-hB8iwKeFEX",
 			"description": "Hardened Leather, Medium Full Helm, Padded",
 			"reference": "LTIA14",
-			"local_notes": "DR: 3; Don: 9 secs; Holdout: -4; Reaction Pen.-1",
+			"local_notes": "Don: 9 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Full Helm"
@@ -2358,7 +2339,7 @@
 			"id": "esRD0en0BEoii6nVr",
 			"description": "Hardened Leather, Medium Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "DR: 2; Don: 3 secs; Holdout: -3; Reaction Pen.-1",
+			"local_notes": "Don: 3 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Groin Armor"
@@ -2386,7 +2367,7 @@
 			"id": "eV1KAi8XLJ8MmCuX2",
 			"description": "Hardened Leather, Medium Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "DR: 2; Don: 30 secs; Holdout: -3; Reaction Pen.-1",
+			"local_notes": "Don: 30 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Limb Armor"
@@ -2414,7 +2395,7 @@
 			"id": "e4uRf4z5Sb2Py2SY7",
 			"description": "Hardened Leather, Medium Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "DR: 2; Don: 3 secs; Holdout: -4; Reaction Pen.-1",
+			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Neck Armor"
@@ -2442,7 +2423,7 @@
 			"id": "ez68BX8J4tGtQJGCt",
 			"description": "Hardened Leather, Medium Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "DR: 2; Don: 6 secs; Holdout: -4; Reaction Pen.-1",
+			"local_notes": "Don: 6 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Pot Helm"
@@ -2470,7 +2451,7 @@
 			"id": "eNG45AsyS4h9gG1MU",
 			"description": "Hardened Leather, Medium Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "DR: 3; Don: 6 secs; Holdout: -4; Reaction Pen.-1",
+			"local_notes": "Don: 6 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Pot Helm"
@@ -2498,7 +2479,7 @@
 			"id": "elCA18hfudd_BMLop",
 			"description": "Hardened Leather, Medium Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "DR: 2; Don: 30 secs; Holdout: -3; Reaction Pen.-2",
+			"local_notes": "Don: 30 secs; Holdout: -3; Reaction Pen.-2",
 			"tech_level": "1",
 			"tags": [
 				"Body Armor"
@@ -2527,7 +2508,8 @@
 			"id": "eunx1n_InxG6k0vgu",
 			"description": "Horn Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "DR: 3; Don: 23 secs; Holdout: -4; Reaction Pen.-2",
+			"reference_highlight": "Horn",
+			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -2549,14 +2531,14 @@
 				"extended_value": 63,
 				"weight": "6.3 lb",
 				"extended_weight": "6.3 lb"
-			},
-			"reference_highlight": "Horn"
+			}
 		},
 		{
 			"id": "eHBwk15zjqvDJhSB-",
 			"description": "Horn Arm Armor",
 			"reference": "LTIA7",
-			"local_notes": "DR: 3; Don: 15 secs; Holdout: -4; Reaction Pen.-1",
+			"reference_highlight": "Horn",
+			"local_notes": "Don: 15 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Limb Armor"
@@ -2578,14 +2560,14 @@
 				"extended_value": 125,
 				"weight": "12.5 lb",
 				"extended_weight": "12.5 lb"
-			},
-			"reference_highlight": "Horn"
+			}
 		},
 		{
 			"id": "ezuM-8PavGZ1GQQqr",
 			"description": "Horn Bascinet",
 			"reference": "LTIA14",
-			"local_notes": "DR: 3; Don: 8 secs; Holdout: -5; Reaction Pen.-1",
+			"reference_highlight": "Horn",
+			"local_notes": "Don: 8 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Bascinet"
@@ -2607,14 +2589,14 @@
 				"extended_value": 63,
 				"weight": "6.3 lb",
 				"extended_weight": "6.3 lb"
-			},
-			"reference_highlight": "Horn"
+			}
 		},
 		{
 			"id": "eohEoKoYouJwovovn",
 			"description": "Horn Bascinet, Padded",
 			"reference": "LTIA14",
-			"local_notes": "DR: 4; Don: 8 secs; Holdout: -5; Reaction Pen.-1",
+			"reference_highlight": "Horn",
+			"local_notes": "Don: 8 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Bascinet"
@@ -2636,14 +2618,14 @@
 				"extended_value": 76,
 				"weight": "6.5 lb",
 				"extended_weight": "6.5 lb"
-			},
-			"reference_highlight": "Horn"
+			}
 		},
 		{
 			"id": "eP5ORoksZZb-z7z4G",
 			"description": "Horn Chest Armor",
 			"reference": "LTIA5",
-			"local_notes": "DR: 3; Don: 23 secs; Holdout: -4; Reaction Pen.-2",
+			"reference_highlight": "Horn",
+			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -2665,14 +2647,14 @@
 				"extended_value": 188,
 				"weight": "18.8 lb",
 				"extended_weight": "18.8 lb"
-			},
-			"reference_highlight": "Horn"
+			}
 		},
 		{
 			"id": "efLNC-5ZptA7THAKL",
 			"description": "Horn Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "DR: 3; Don: 30 secs; Holdout: -4; Reaction Pen.-1",
+			"reference_highlight": "Horn",
+			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Limb Armor"
@@ -2694,14 +2676,14 @@
 				"extended_value": 250,
 				"weight": "25 lb",
 				"extended_weight": "25 lb"
-			},
-			"reference_highlight": "Horn"
+			}
 		},
 		{
 			"id": "e4kU-W11qtGSzwt7j",
 			"description": "Horn Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "DR: 3; Don: 6 secs; Holdout: -5; Reaction Pen.-1",
+			"reference_highlight": "Horn",
+			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Pot Helm"
@@ -2723,14 +2705,14 @@
 				"extended_value": 50,
 				"weight": "5 lb",
 				"extended_weight": "5 lb"
-			},
-			"reference_highlight": "Horn"
+			}
 		},
 		{
 			"id": "e61dm8dSt3eJ3Io0J",
 			"description": "Horn Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "DR: 4; Don: 6 secs; Holdout: -5; Reaction Pen.-1",
+			"reference_highlight": "Horn",
+			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Pot Helm"
@@ -2752,14 +2734,14 @@
 				"extended_value": 60,
 				"weight": "6.2 lb",
 				"extended_weight": "6.2 lb"
-			},
-			"reference_highlight": "Horn"
+			}
 		},
 		{
 			"id": "e8q3YV3JQ4N4VQ1Yg",
 			"description": "Horn Torso Armor",
 			"reference": "LTIA4",
-			"local_notes": "DR: 3; Don: 30 secs; Holdout: -4; Reaction Pen.-2",
+			"reference_highlight": "Horn",
+			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -2782,14 +2764,14 @@
 				"extended_value": 250,
 				"weight": "25 lb",
 				"extended_weight": "25 lb"
-			},
-			"reference_highlight": "Horn"
+			}
 		},
 		{
 			"id": "enNvcIY2S3c33od6g",
 			"description": "Jack of Plates Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "DR: 3; Don: 23 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
+			"reference_highlight": "Jack of Plates",
+			"local_notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
 				"Body Armor"
@@ -2814,20 +2796,20 @@
 				}
 			],
 			"quantity": 1,
+			"equipped": true,
 			"calc": {
 				"value": 75,
 				"extended_value": 75,
 				"weight": "4.5 lb",
 				"extended_weight": "4.5 lb"
-			},
-			"reference_highlight": "Jack of Plates",
-			"equipped": true
+			}
 		},
 		{
 			"id": "efwmSWbFtEXQ0koTT",
 			"description": "Jack of Plates Arm Armor",
 			"reference": "LTIA7",
-			"local_notes": "DR: 3; Don: 15 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. crushing.",
+			"reference_highlight": "Jack of Plates",
+			"local_notes": "Don: 15 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
 				"Limb Armor"
@@ -2857,14 +2839,14 @@
 				"extended_value": 150,
 				"weight": "9 lb",
 				"extended_weight": "9 lb"
-			},
-			"reference_highlight": "Jack of Plates"
+			}
 		},
 		{
 			"id": "eCrDGygCzExaNqkdi",
 			"description": "Jack of Plates Chest Armor",
 			"reference": "LTIA6",
-			"local_notes": "DR: 3; Don: 23 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
+			"reference_highlight": "Jack of Plates",
+			"local_notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
 				"Body Armor"
@@ -2894,14 +2876,14 @@
 				"extended_value": 225,
 				"weight": "13.5 lb",
 				"extended_weight": "13.5 lb"
-			},
-			"reference_highlight": "Jack of Plates"
+			}
 		},
 		{
 			"id": "emKh8YH7nJ1ryspvd",
 			"description": "Jack of Plates Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "DR: 3; Don: 30 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. crushing.",
+			"reference_highlight": "Jack of Plates",
+			"local_notes": "Don: 30 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
 				"Limb Armor"
@@ -2931,14 +2913,14 @@
 				"extended_value": 300,
 				"weight": "18 lb",
 				"extended_weight": "18 lb"
-			},
-			"reference_highlight": "Jack of Plates"
+			}
 		},
 		{
 			"id": "e8QIE4XCHZCVo34Ez",
 			"description": "Jack of Plates Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "DR: 3; Don: 3 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
+			"reference_highlight": "Jack of Plates",
+			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
 				"Neck Armor"
@@ -2968,14 +2950,14 @@
 				"extended_value": 15,
 				"weight": "0.9 lb",
 				"extended_weight": "0.9 lb"
-			},
-			"reference_highlight": "Jack of Plates"
+			}
 		},
 		{
 			"id": "ef02FE59Rj44fzzZG",
 			"description": "Jack of Plates Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "DR: 3; Don: 30 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
+			"reference_highlight": "Jack of Plates",
+			"local_notes": "Don: 30 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
 				"Body Armor"
@@ -3002,20 +2984,19 @@
 				}
 			],
 			"quantity": 1,
+			"equipped": true,
 			"calc": {
 				"value": 300,
 				"extended_value": 300,
 				"weight": "18 lb",
 				"extended_weight": "18 lb"
-			},
-			"reference_highlight": "Jack of Plates",
-			"equipped": true
+			}
 		},
 		{
 			"id": "e_-u-endgf7TOnFDC",
 			"description": "Layered Cloth, Heavy Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "DR: 4; Don: 30 secs; Holdout: -4; Reaction Pen.-2",
+			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -3043,7 +3024,7 @@
 			"id": "etN6nmxSqDcics-UH",
 			"description": "Layered Cloth, Heavy Chest Armor",
 			"reference": "LTIA5",
-			"local_notes": "DR: 4; Don: 23 secs; Holdout: -4; Reaction Pen.-2",
+			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -3071,7 +3052,7 @@
 			"id": "eIwkMRp6HlCKh2QPH",
 			"description": "Layered Cloth, Heavy Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "DR: 4; Don: 3 secs; Holdout: -4; Reaction Pen.-1",
+			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Groin Armor"
@@ -3099,7 +3080,7 @@
 			"id": "epFA5vnFQLu-IKc4g",
 			"description": "Layered Cloth, Heavy Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "DR: 4; Don: 6 secs; Holdout: -5; Reaction Pen.-1",
+			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Pot Helm"
@@ -3127,7 +3108,7 @@
 			"id": "eyeqUe-3_guizOOHF",
 			"description": "Layered Cloth, Heavy Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "DR: 5; Don: 6 secs; Holdout: -5; Reaction Pen.-1",
+			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Pot Helm"
@@ -3155,7 +3136,7 @@
 			"id": "eW9tzFd6eHEUVDGv-",
 			"description": "Layered Cloth, Heavy Torso Armor",
 			"reference": "LTIA4",
-			"local_notes": "DR: 4; Don: 30 secs; Holdout: -4; Reaction Pen.-2",
+			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -3184,7 +3165,8 @@
 			"id": "eRewQ5l2r2OZfGEON",
 			"description": "Layered Cloth, Light Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "DR: 2; Don: 15 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
+			"reference_highlight": "Layered Cloth, Light",
+			"local_notes": "Don: 15 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -3206,14 +3188,14 @@
 				"extended_value": 38,
 				"weight": "3 lb",
 				"extended_weight": "3 lb"
-			},
-			"reference_highlight": "Layered Cloth, Light"
+			}
 		},
 		{
 			"id": "eO8eIsQI8mq28cq_4",
 			"description": "Layered Cloth, Light Arm Armor",
 			"reference": "LTIA7",
-			"local_notes": "DR: 2; Don: 10 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
+			"reference_highlight": "Layered Cloth, Light",
+			"local_notes": "Don: 10 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Limb Armor"
@@ -3235,14 +3217,14 @@
 				"extended_value": 75,
 				"weight": "6 lb",
 				"extended_weight": "6 lb"
-			},
-			"reference_highlight": "Layered Cloth, Light"
+			}
 		},
 		{
 			"id": "eVS_9h4tgtl3JdeEa",
 			"description": "Layered Cloth, Light Bascinet",
 			"reference": "LTIA14",
-			"local_notes": "DR: 2; Don: 5 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
+			"reference_highlight": "Layered Cloth, Light",
+			"local_notes": "Don: 5 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Bascinet"
@@ -3264,14 +3246,14 @@
 				"extended_value": 38,
 				"weight": "3 lb",
 				"extended_weight": "3 lb"
-			},
-			"reference_highlight": "Layered Cloth, Light"
+			}
 		},
 		{
 			"id": "ebCzm68m75MA5QK4A",
 			"description": "Layered Cloth, Light Bascinet, Padded",
 			"reference": "LTIA14",
-			"local_notes": "DR: 3; Don: 5 secs; Holdout: -1; Reaction Pen.-1",
+			"reference_highlight": "Layered Cloth, Light",
+			"local_notes": "Don: 5 secs; Holdout: -1; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Bascinet"
@@ -3293,14 +3275,14 @@
 				"extended_value": 51,
 				"weight": "3.2 lb",
 				"extended_weight": "3.2 lb"
-			},
-			"reference_highlight": "Layered Cloth, Light"
+			}
 		},
 		{
 			"id": "eqtNoj9CQrr5DtXup",
 			"description": "Layered Cloth, Light Chest Armor",
 			"reference": "LTIA5",
-			"local_notes": "DR: 2; Don: 15 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
+			"reference_highlight": "Layered Cloth, Light",
+			"local_notes": "Don: 15 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -3322,14 +3304,14 @@
 				"extended_value": 113,
 				"weight": "9 lb",
 				"extended_weight": "9 lb"
-			},
-			"reference_highlight": "Layered Cloth, Light"
+			}
 		},
 		{
 			"id": "eAsoTn4m8QX6gaCkQ",
 			"description": "Layered Cloth, Light Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "DR: 2; Don: 3 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
+			"reference_highlight": "Layered Cloth, Light",
+			"local_notes": "Don: 3 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Groin Armor"
@@ -3351,14 +3333,14 @@
 				"extended_value": 8,
 				"weight": "0.6 lb",
 				"extended_weight": "0.6 lb"
-			},
-			"reference_highlight": "Layered Cloth, Light"
+			}
 		},
 		{
 			"id": "eDxZS_xQS0yjzq_1_",
 			"description": "Layered Cloth, Light Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "DR: 2; Don: 20 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
+			"reference_highlight": "Layered Cloth, Light",
+			"local_notes": "Don: 20 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Limb Armor"
@@ -3380,14 +3362,14 @@
 				"extended_value": 150,
 				"weight": "12 lb",
 				"extended_weight": "12 lb"
-			},
-			"reference_highlight": "Layered Cloth, Light"
+			}
 		},
 		{
 			"id": "eQ0PPUUwkr1Wa7xWU",
 			"description": "Layered Cloth, Light Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "DR: 2; Don: 3 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
+			"reference_highlight": "Layered Cloth, Light",
+			"local_notes": "Don: 3 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Neck Armor"
@@ -3409,14 +3391,14 @@
 				"extended_value": 8,
 				"weight": "0.6 lb",
 				"extended_weight": "0.6 lb"
-			},
-			"reference_highlight": "Layered Cloth, Light"
+			}
 		},
 		{
 			"id": "etqzkbO5Zn8XNQspE",
 			"description": "Layered Cloth, Light Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "DR: 2; Don: 4 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
+			"reference_highlight": "Layered Cloth, Light",
+			"local_notes": "Don: 4 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Pot Helm"
@@ -3438,14 +3420,14 @@
 				"extended_value": 30,
 				"weight": "2.4 lb",
 				"extended_weight": "2.4 lb"
-			},
-			"reference_highlight": "Layered Cloth, Light"
+			}
 		},
 		{
 			"id": "e0dO3s-Pq7oqs0TLo",
 			"description": "Layered Cloth, Light Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "DR: 3; Don: 4 secs; Holdout: -1; Reaction Pen.-1",
+			"reference_highlight": "Layered Cloth, Light",
+			"local_notes": "Don: 4 secs; Holdout: -1; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Pot Helm"
@@ -3467,14 +3449,14 @@
 				"extended_value": 40,
 				"weight": "3.6 lb",
 				"extended_weight": "3.6 lb"
-			},
-			"reference_highlight": "Layered Cloth, Light"
+			}
 		},
 		{
 			"id": "ex24F6fRCdgFJDPND",
 			"description": "Layered Cloth, Light Torso Armor",
 			"reference": "LTIA4",
-			"local_notes": "DR: 2; Don: 20 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
+			"reference_highlight": "Layered Cloth, Light",
+			"local_notes": "Don: 20 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -3497,14 +3479,14 @@
 				"extended_value": 150,
 				"weight": "12 lb",
 				"extended_weight": "12 lb"
-			},
-			"reference_highlight": "Layered Cloth, Light"
+			}
 		},
 		{
 			"id": "e2c3pP3BXvpSce74U",
 			"description": "Layered Cloth, Medium Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "DR: 3; Don: 23 secs; Holdout: -2; Reaction Pen.-2",
+			"reference_highlight": "Layered Cloth, Medium",
+			"local_notes": "Don: 23 secs; Holdout: -2; Reaction Pen.-2",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -3526,14 +3508,14 @@
 				"extended_value": 88,
 				"weight": "5 lb",
 				"extended_weight": "5 lb"
-			},
-			"reference_highlight": "Layered Cloth, Medium"
+			}
 		},
 		{
 			"id": "e2Y40PgPmWiM6X4pF",
 			"description": "Layered Cloth, Medium Arm Armor",
 			"reference": "LTIA7",
-			"local_notes": "DR: 3; Don: 15 secs; Holdout: -2; Reaction Pen.-1",
+			"reference_highlight": "Layered Cloth, Medium",
+			"local_notes": "Don: 15 secs; Holdout: -2; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Limb Armor"
@@ -3555,14 +3537,14 @@
 				"extended_value": 175,
 				"weight": "10 lb",
 				"extended_weight": "10 lb"
-			},
-			"reference_highlight": "Layered Cloth, Medium"
+			}
 		},
 		{
 			"id": "eJzb7koEoc2mT0eWV",
 			"description": "Layered Cloth, Medium Bascinet",
 			"reference": "LTIA14",
-			"local_notes": "DR: 3; Don: 8 secs; Holdout: -3; Reaction Pen.-1",
+			"reference_highlight": "Layered Cloth, Medium",
+			"local_notes": "Don: 8 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Bascinet"
@@ -3584,14 +3566,14 @@
 				"extended_value": 88,
 				"weight": "5 lb",
 				"extended_weight": "5 lb"
-			},
-			"reference_highlight": "Layered Cloth, Medium"
+			}
 		},
 		{
 			"id": "eJgTWmG6sKucbJVoN",
 			"description": "Layered Cloth, Medium Bascinet, Padded",
 			"reference": "LTIA14",
-			"local_notes": "DR: 4; Don: 8 secs; Holdout: -3; Reaction Pen.-1",
+			"reference_highlight": "Layered Cloth, Medium",
+			"local_notes": "Don: 8 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Bascinet"
@@ -3613,14 +3595,14 @@
 				"extended_value": 101,
 				"weight": "5.2 lb",
 				"extended_weight": "5.2 lb"
-			},
-			"reference_highlight": "Layered Cloth, Medium"
+			}
 		},
 		{
 			"id": "ehLf5QWJswG7A4jPI",
 			"description": "Layered Cloth, Medium Chest Armor",
 			"reference": "LTIA5",
-			"local_notes": "DR: 3; Don: 23 secs; Holdout: -2; Reaction Pen.-2",
+			"reference_highlight": "Layered Cloth, Medium",
+			"local_notes": "Don: 23 secs; Holdout: -2; Reaction Pen.-2",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -3642,14 +3624,14 @@
 				"extended_value": 263,
 				"weight": "15 lb",
 				"extended_weight": "15 lb"
-			},
-			"reference_highlight": "Layered Cloth, Medium"
+			}
 		},
 		{
 			"id": "eRws2Kp2skgEZOpW_",
 			"description": "Layered Cloth, Medium Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "DR: 3; Don: 3 secs; Holdout: -2; Reaction Pen.-1",
+			"reference_highlight": "Layered Cloth, Medium",
+			"local_notes": "Don: 3 secs; Holdout: -2; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Groin Armor"
@@ -3671,14 +3653,14 @@
 				"extended_value": 18,
 				"weight": "1 lb",
 				"extended_weight": "1 lb"
-			},
-			"reference_highlight": "Layered Cloth, Medium"
+			}
 		},
 		{
 			"id": "eFRDrCxj7VHl4hGbI",
 			"description": "Layered Cloth, Medium Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "DR: 3; Don: 30 secs; Holdout: -2; Reaction Pen.-1",
+			"reference_highlight": "Layered Cloth, Medium",
+			"local_notes": "Don: 30 secs; Holdout: -2; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Limb Armor"
@@ -3700,14 +3682,14 @@
 				"extended_value": 350,
 				"weight": "20 lb",
 				"extended_weight": "20 lb"
-			},
-			"reference_highlight": "Layered Cloth, Medium"
+			}
 		},
 		{
 			"id": "ex8b6RNRlFNmh6eqn",
 			"description": "Layered Cloth, Medium Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "DR: 3; Don: 3 secs; Holdout: -3; Reaction Pen.-1",
+			"reference_highlight": "Layered Cloth, Medium",
+			"local_notes": "Don: 3 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Neck Armor"
@@ -3729,14 +3711,14 @@
 				"extended_value": 18,
 				"weight": "1 lb",
 				"extended_weight": "1 lb"
-			},
-			"reference_highlight": "Layered Cloth, Medium"
+			}
 		},
 		{
 			"id": "eDAOlQlpXC8x8seQi",
 			"description": "Layered Cloth, Medium Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "DR: 3; Don: 6 secs; Holdout: -3; Reaction Pen.-1",
+			"reference_highlight": "Layered Cloth, Medium",
+			"local_notes": "Don: 6 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Pot Helm"
@@ -3758,14 +3740,14 @@
 				"extended_value": 70,
 				"weight": "4 lb",
 				"extended_weight": "4 lb"
-			},
-			"reference_highlight": "Layered Cloth, Medium"
+			}
 		},
 		{
 			"id": "eyLdJreRGFxBI-yNZ",
 			"description": "Layered Cloth, Medium Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "DR: 4; Don: 6 secs; Holdout: -3; Reaction Pen.-1",
+			"reference_highlight": "Layered Cloth, Medium",
+			"local_notes": "Don: 6 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Pot Helm"
@@ -3787,14 +3769,14 @@
 				"extended_value": 80,
 				"weight": "5.2 lb",
 				"extended_weight": "5.2 lb"
-			},
-			"reference_highlight": "Layered Cloth, Medium"
+			}
 		},
 		{
 			"id": "eEkkfvOlSnxHxsG3V",
 			"description": "Layered Cloth, Medium Torso Armor",
 			"reference": "LTIA4",
-			"local_notes": "DR: 3; Don: 30 secs; Holdout: -2; Reaction Pen.-2",
+			"reference_highlight": "Layered Cloth, Medium",
+			"local_notes": "Don: 30 secs; Holdout: -2; Reaction Pen.-2",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -3817,14 +3799,13 @@
 				"extended_value": 350,
 				"weight": "20 lb",
 				"extended_weight": "20 lb"
-			},
-			"reference_highlight": "Layered Cloth, Medium"
+			}
 		},
 		{
 			"id": "eq-oFm99ByTPArbht",
 			"description": "Layered Leather, Heavy Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "DR: 4; Don: 23 secs; Holdout: -4; Reaction Pen.-2",
+			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "1",
 			"tags": [
 				"Body Armor"
@@ -3852,7 +3833,7 @@
 			"id": "eu3Ecr1nsfFd4pUkb",
 			"description": "Layered Leather, Heavy Chest Armor",
 			"reference": "LTIA5",
-			"local_notes": "DR: 4; Don: 23 secs; Holdout: -4; Reaction Pen.-2",
+			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "1",
 			"tags": [
 				"Body Armor"
@@ -3880,7 +3861,7 @@
 			"id": "eVM85UppCKo4UR7ga",
 			"description": "Layered Leather, Heavy Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "DR: 4; Don: 3 secs; Holdout: -4; Reaction Pen.-1",
+			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Groin Armor"
@@ -3908,7 +3889,7 @@
 			"id": "eMZZwm6MVGi2GjBYk",
 			"description": "Layered Leather, Heavy Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "DR: 4; Don: 6 secs; Holdout: -5; Reaction Pen.-1",
+			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Pot Helm"
@@ -3936,7 +3917,7 @@
 			"id": "ejuQLpRFHdhrt6BsA",
 			"description": "Layered Leather, Heavy Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "DR: 5; Don: 6 secs; Holdout: -5; Reaction Pen.-1",
+			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Pot Helm"
@@ -3964,7 +3945,7 @@
 			"id": "eMEOIb6u--dMdFVw0",
 			"description": "Layered Leather, Heavy Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "DR: 4; Don: 30 secs; Holdout: -4; Reaction Pen.-2",
+			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "1",
 			"tags": [
 				"Body Armor"
@@ -3993,7 +3974,8 @@
 			"id": "eD0V53gj-_JleBE3H",
 			"description": "Layered Leather, Light Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "DR: 2; Don: 15 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
+			"reference_highlight": "Layered Leather, Light",
+			"local_notes": "Don: 15 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "1",
 			"tags": [
 				"Body Armor"
@@ -4015,14 +3997,14 @@
 				"extended_value": 30,
 				"weight": "3.8 lb",
 				"extended_weight": "3.8 lb"
-			},
-			"reference_highlight": "Layered Leather, Light"
+			}
 		},
 		{
 			"id": "egW-xZpY1EJ4JOjQx",
 			"description": "Layered Leather, Light Arm Armor",
 			"reference": "LTIA7",
-			"local_notes": "DR: 2; Don: 10 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
+			"reference_highlight": "Layered Leather, Light",
+			"local_notes": "Don: 10 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "1",
 			"tags": [
 				"Limb Armor"
@@ -4044,14 +4026,14 @@
 				"extended_value": 60,
 				"weight": "7.5 lb",
 				"extended_weight": "7.5 lb"
-			},
-			"reference_highlight": "Layered Leather, Light"
+			}
 		},
 		{
 			"id": "elRjj_n4d_oWgSj9T",
 			"description": "Layered Leather, Light Bascinet",
 			"reference": "LTIA14",
-			"local_notes": "DR: 2; Don: 5 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
+			"reference_highlight": "Layered Leather, Light",
+			"local_notes": "Don: 5 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "1",
 			"tags": [
 				"Bascinet"
@@ -4073,14 +4055,14 @@
 				"extended_value": 30,
 				"weight": "3.8 lb",
 				"extended_weight": "3.8 lb"
-			},
-			"reference_highlight": "Layered Leather, Light"
+			}
 		},
 		{
 			"id": "ei6dU9mXX-OVMSOVb",
 			"description": "Layered Leather, Light Bascinet, Padded",
 			"reference": "LTIA14",
-			"local_notes": "DR: 3; Don: 5 secs; Holdout: -2; Reaction Pen.-1",
+			"reference_highlight": "Layered Leather, Light",
+			"local_notes": "Don: 5 secs; Holdout: -2; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Bascinet"
@@ -4102,14 +4084,14 @@
 				"extended_value": 43,
 				"weight": "4 lb",
 				"extended_weight": "4 lb"
-			},
-			"reference_highlight": "Layered Leather, Light"
+			}
 		},
 		{
 			"id": "eLJKJqjstq_4KaKM8",
 			"description": "Layered Leather, Light Chest Armor",
 			"reference": "LTIA5",
-			"local_notes": "DR: 2; Don: 15 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
+			"reference_highlight": "Layered Leather, Light",
+			"local_notes": "Don: 15 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "1",
 			"tags": [
 				"Body Armor"
@@ -4131,14 +4113,14 @@
 				"extended_value": 90,
 				"weight": "11.3 lb",
 				"extended_weight": "11.3 lb"
-			},
-			"reference_highlight": "Layered Leather, Light"
+			}
 		},
 		{
 			"id": "eATWANWr0WjH9JqQH",
 			"description": "Layered Leather, Light Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "DR: 2; Don: 3 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
+			"reference_highlight": "Layered Leather, Light",
+			"local_notes": "Don: 3 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "1",
 			"tags": [
 				"Groin Armor"
@@ -4160,14 +4142,14 @@
 				"extended_value": 6,
 				"weight": "0.8 lb",
 				"extended_weight": "0.8 lb"
-			},
-			"reference_highlight": "Layered Leather, Light"
+			}
 		},
 		{
 			"id": "ef1ze9jlHZ0EJTIMe",
 			"description": "Layered Leather, Light Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "DR: 2; Don: 20 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
+			"reference_highlight": "Layered Leather, Light",
+			"local_notes": "Don: 20 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "1",
 			"tags": [
 				"Limb Armor"
@@ -4189,14 +4171,14 @@
 				"extended_value": 120,
 				"weight": "15 lb",
 				"extended_weight": "15 lb"
-			},
-			"reference_highlight": "Layered Leather, Light"
+			}
 		},
 		{
 			"id": "etecXtCsHF7Xg09bh",
 			"description": "Layered Leather, Light Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "DR: 2; Don: 3 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
+			"reference_highlight": "Layered Leather, Light",
+			"local_notes": "Don: 3 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "1",
 			"tags": [
 				"Neck Armor"
@@ -4218,14 +4200,14 @@
 				"extended_value": 6,
 				"weight": "0.8 lb",
 				"extended_weight": "0.8 lb"
-			},
-			"reference_highlight": "Layered Leather, Light"
+			}
 		},
 		{
 			"id": "e3j1GLu-Dmcw2qzol",
 			"description": "Layered Leather, Light Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "DR: 2; Don: 4 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
+			"reference_highlight": "Layered Leather, Light",
+			"local_notes": "Don: 4 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "1",
 			"tags": [
 				"Pot Helm"
@@ -4247,14 +4229,14 @@
 				"extended_value": 24,
 				"weight": "3 lb",
 				"extended_weight": "3 lb"
-			},
-			"reference_highlight": "Layered Leather, Light"
+			}
 		},
 		{
 			"id": "elNb33zRTYIGNTeSi",
 			"description": "Layered Leather, Light Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "DR: 3; Don: 4 secs; Holdout: -2; Reaction Pen.-1",
+			"reference_highlight": "Layered Leather, Light",
+			"local_notes": "Don: 4 secs; Holdout: -2; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Pot Helm"
@@ -4276,14 +4258,14 @@
 				"extended_value": 34,
 				"weight": "4.2 lb",
 				"extended_weight": "4.2 lb"
-			},
-			"reference_highlight": "Layered Leather, Light"
+			}
 		},
 		{
 			"id": "e2XHaZCl0fWHh0kHU",
 			"description": "Layered Leather, Light Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "DR: 2; Don: 20 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
+			"reference_highlight": "Layered Leather, Light",
+			"local_notes": "Don: 20 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "1",
 			"tags": [
 				"Body Armor"
@@ -4306,14 +4288,14 @@
 				"extended_value": 120,
 				"weight": "15 lb",
 				"extended_weight": "15 lb"
-			},
-			"reference_highlight": "Layered Leather, Light"
+			}
 		},
 		{
 			"id": "exISuisb8GZtzeL3M",
 			"description": "Layered Leather, Medium Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "DR: 3; Don: 23 secs; Holdout: -2; Reaction Pen.-2",
+			"reference_highlight": "Layered Leather, Medium",
+			"local_notes": "Don: 23 secs; Holdout: -2; Reaction Pen.-2",
 			"tech_level": "1",
 			"tags": [
 				"Body Armor"
@@ -4335,14 +4317,14 @@
 				"extended_value": 55,
 				"weight": "6.5 lb",
 				"extended_weight": "6.5 lb"
-			},
-			"reference_highlight": "Layered Leather, Medium"
+			}
 		},
 		{
 			"id": "eQQeeqMGzpx15iqIy",
 			"description": "Layered Leather, Medium Arm Armor",
 			"reference": "LTIA7",
-			"local_notes": "DR: 3; Don: 15 secs; Holdout: -2; Reaction Pen.-1",
+			"reference_highlight": "Layered Leather, Medium",
+			"local_notes": "Don: 15 secs; Holdout: -2; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Limb Armor"
@@ -4364,14 +4346,14 @@
 				"extended_value": 110,
 				"weight": "13 lb",
 				"extended_weight": "13 lb"
-			},
-			"reference_highlight": "Layered Leather, Medium"
+			}
 		},
 		{
 			"id": "erH1vNaUqqmSU_ohV",
 			"description": "Layered Leather, Medium Bascinet",
 			"reference": "LTIA14",
-			"local_notes": "DR: 3; Don: 8 secs; Holdout: -3; Reaction Pen.-1",
+			"reference_highlight": "Layered Leather, Medium",
+			"local_notes": "Don: 8 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Bascinet"
@@ -4393,13 +4375,13 @@
 				"extended_value": 55,
 				"weight": "6.5 lb",
 				"extended_weight": "6.5 lb"
-			},
-			"reference_highlight": "Layered Leather, Medium"
+			}
 		},
 		{
 			"id": "eDjkccvqZxqYTUrQn",
 			"description": "Layered Leather, Medium Bascinet, Padded",
 			"reference": "LTIA14",
+			"reference_highlight": "Layered Leather, Medium",
 			"local_notes": "DR:4; Don: 8 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
@@ -4422,14 +4404,14 @@
 				"extended_value": 68,
 				"weight": "6.7 lb",
 				"extended_weight": "6.7 lb"
-			},
-			"reference_highlight": "Layered Leather, Medium"
+			}
 		},
 		{
 			"id": "eJ8PsIcWRvCYxB_B9",
 			"description": "Layered Leather, Medium Chest Armor",
 			"reference": "LTIA5",
-			"local_notes": "DR: 3; Don: 23 secs; Holdout: -2; Reaction Pen.-2",
+			"reference_highlight": "Layered Leather, Medium",
+			"local_notes": "Don: 23 secs; Holdout: -2; Reaction Pen.-2",
 			"tech_level": "1",
 			"tags": [
 				"Body Armor"
@@ -4451,14 +4433,14 @@
 				"extended_value": 165,
 				"weight": "19.5 lb",
 				"extended_weight": "19.5 lb"
-			},
-			"reference_highlight": "Layered Leather, Medium"
+			}
 		},
 		{
 			"id": "eGfmrV9Nid0lrAt93",
 			"description": "Layered Leather, Medium Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "DR: 3; Don: 3 secs; Holdout: -2; Reaction Pen.-1",
+			"reference_highlight": "Layered Leather, Medium",
+			"local_notes": "Don: 3 secs; Holdout: -2; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Groin Armor"
@@ -4480,14 +4462,14 @@
 				"extended_value": 11,
 				"weight": "1.3 lb",
 				"extended_weight": "1.3 lb"
-			},
-			"reference_highlight": "Layered Leather, Medium"
+			}
 		},
 		{
 			"id": "e7DiJ7pNjLhFjxhi2",
 			"description": "Layered Leather, Medium Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "DR: 3; Don: 30 secs; Holdout: -2; Reaction Pen.-1",
+			"reference_highlight": "Layered Leather, Medium",
+			"local_notes": "Don: 30 secs; Holdout: -2; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Limb Armor"
@@ -4509,14 +4491,14 @@
 				"extended_value": 220,
 				"weight": "26 lb",
 				"extended_weight": "26 lb"
-			},
-			"reference_highlight": "Layered Leather, Medium"
+			}
 		},
 		{
 			"id": "efFjfnFTqDehDe_QT",
 			"description": "Layered Leather, Medium Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "DR: 3; Don: 3 secs; Holdout: -3; Reaction Pen.-1",
+			"reference_highlight": "Layered Leather, Medium",
+			"local_notes": "Don: 3 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Neck Armor"
@@ -4538,14 +4520,14 @@
 				"extended_value": 11,
 				"weight": "1.3 lb",
 				"extended_weight": "1.3 lb"
-			},
-			"reference_highlight": "Layered Leather, Medium"
+			}
 		},
 		{
 			"id": "eOp-NghFwmoPjo5rI",
 			"description": "Layered Leather, Medium Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "DR: 3; Don: 6 secs; Holdout: -3; Reaction Pen.-1",
+			"reference_highlight": "Layered Leather, Medium",
+			"local_notes": "Don: 6 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Pot Helm"
@@ -4567,14 +4549,14 @@
 				"extended_value": 44,
 				"weight": "5.2 lb",
 				"extended_weight": "5.2 lb"
-			},
-			"reference_highlight": "Layered Leather, Medium"
+			}
 		},
 		{
 			"id": "eZljD7c4Tny6mETRJ",
 			"description": "Layered Leather, Medium Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "DR: 4; Don: 6 secs; Holdout: -3; Reaction Pen.-1",
+			"reference_highlight": "Layered Leather, Medium",
+			"local_notes": "Don: 6 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Pot Helm"
@@ -4596,14 +4578,14 @@
 				"extended_value": 54,
 				"weight": "6.4 lb",
 				"extended_weight": "6.4 lb"
-			},
-			"reference_highlight": "Layered Leather, Medium"
+			}
 		},
 		{
 			"id": "eemt2cZZmG4uczLmU",
 			"description": "Layered Leather, Medium Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "DR: 3; Don: 30 secs; Holdout: -2; Reaction Pen.-2",
+			"reference_highlight": "Layered Leather, Medium",
+			"local_notes": "Don: 30 secs; Holdout: -2; Reaction Pen.-2",
 			"tech_level": "1",
 			"tags": [
 				"Body Armor"
@@ -4621,20 +4603,20 @@
 				}
 			],
 			"quantity": 1,
+			"equipped": true,
 			"calc": {
 				"value": 220,
 				"extended_value": 220,
 				"weight": "26 lb",
 				"extended_weight": "26 lb"
-			},
-			"reference_highlight": "Layered Leather, Medium",
-			"equipped": true
+			}
 		},
 		{
 			"id": "e2tjMsdI7Gc1rAB71",
 			"description": "Leather, Heavy Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "DR: 3; Don: 23 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. impaling.",
+			"reference_highlight": "Leather, Heavy",
+			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -4659,20 +4641,20 @@
 				}
 			],
 			"quantity": 1,
+			"equipped": true,
 			"calc": {
 				"value": 50,
 				"extended_value": 50,
 				"weight": "5 lb",
 				"extended_weight": "5 lb"
-			},
-			"reference_highlight": "Leather, Heavy",
-			"equipped": true
+			}
 		},
 		{
 			"id": "ebuaR7H-dCDdAqGZB",
 			"description": "Leather, Heavy Arm Armor",
 			"reference": "LTIA7",
-			"local_notes": "DR: 3; Don: 15 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. impaling.",
+			"reference_highlight": "Leather, Heavy",
+			"local_notes": "Don: 15 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
 				"Limb Armor"
@@ -4702,14 +4684,14 @@
 				"extended_value": 100,
 				"weight": "10 lb",
 				"extended_weight": "10 lb"
-			},
-			"reference_highlight": "Leather, Heavy"
+			}
 		},
 		{
 			"id": "eWLr_x_jq7y_T3gdO",
 			"description": "Leather, Heavy Bascinet",
 			"reference": "LTIA14",
-			"local_notes": "DR: 3; Don: 8 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. impaling.",
+			"reference_highlight": "Leather, Heavy",
+			"local_notes": "Don: 8 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
 				"Bascinet"
@@ -4739,14 +4721,14 @@
 				"extended_value": 50,
 				"weight": "5 lb",
 				"extended_weight": "5 lb"
-			},
-			"reference_highlight": "Leather, Heavy"
+			}
 		},
 		{
 			"id": "eyN3zEZ-ozBZWuulc",
 			"description": "Leather, Heavy Bascinet, Padded",
 			"reference": "LTIA14",
-			"local_notes": "DR: 4; Don: 8 secs; Holdout: -5; Reaction Pen.-1",
+			"reference_highlight": "Leather, Heavy",
+			"local_notes": "Don: 8 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Bascinet"
@@ -4776,14 +4758,14 @@
 				"extended_value": 63,
 				"weight": "5.2 lb",
 				"extended_weight": "5.2 lb"
-			},
-			"reference_highlight": "Leather, Heavy"
+			}
 		},
 		{
 			"id": "eTFDFr4DO79S3J7VG",
 			"description": "Leather, Heavy Chest Armor",
 			"reference": "LTIA5",
-			"local_notes": "DR: 3; Don: 23 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. impaling.",
+			"reference_highlight": "Leather, Heavy",
+			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -4813,14 +4795,14 @@
 				"extended_value": 150,
 				"weight": "15 lb",
 				"extended_weight": "15 lb"
-			},
-			"reference_highlight": "Leather, Heavy"
+			}
 		},
 		{
 			"id": "eemHTivaF_oqw6MHc",
 			"description": "Leather, Heavy Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "DR: 3; Don: 3 secs; Holdout: -4; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
+			"reference_highlight": "Leather, Heavy",
+			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
 				"Groin Armor"
@@ -4850,14 +4832,14 @@
 				"extended_value": 10,
 				"weight": "1 lb",
 				"extended_weight": "1 lb"
-			},
-			"reference_highlight": "Leather, Heavy"
+			}
 		},
 		{
 			"id": "elIoEW-WlZQ8RRGbG",
 			"description": "Leather, Heavy Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "DR: 3; Don: 30 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. impaling.",
+			"reference_highlight": "Leather, Heavy",
+			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
 				"Limb Armor"
@@ -4887,14 +4869,14 @@
 				"extended_value": 200,
 				"weight": "20 lb",
 				"extended_weight": "20 lb"
-			},
-			"reference_highlight": "Leather, Heavy"
+			}
 		},
 		{
 			"id": "erF1B9st1qI7Bel1L",
 			"description": "Leather, Heavy Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "DR: 3; Don: 3 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. impaling.",
+			"reference_highlight": "Leather, Heavy",
+			"local_notes": "Don: 3 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
 				"Neck Armor"
@@ -4924,14 +4906,14 @@
 				"extended_value": 10,
 				"weight": "1 lb",
 				"extended_weight": "1 lb"
-			},
-			"reference_highlight": "Leather, Heavy"
+			}
 		},
 		{
 			"id": "e13inmfMvaXMS0T1l",
 			"description": "Leather, Heavy Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "DR: 3; Don: 6 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. impaling.",
+			"reference_highlight": "Leather, Heavy",
+			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
 				"Pot Helm"
@@ -4961,14 +4943,14 @@
 				"extended_value": 40,
 				"weight": "4 lb",
 				"extended_weight": "4 lb"
-			},
-			"reference_highlight": "Leather, Heavy"
+			}
 		},
 		{
 			"id": "e98z6kdl_i80ALHzs",
 			"description": "Leather, Heavy Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "DR: 4; Don: 6 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. impaling.",
+			"reference_highlight": "Leather, Heavy",
+			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
 				"Pot Helm"
@@ -4998,14 +4980,14 @@
 				"extended_value": 50,
 				"weight": "5.2 lb",
 				"extended_weight": "5.2 lb"
-			},
-			"reference_highlight": "Leather, Heavy"
+			}
 		},
 		{
 			"id": "eLGD5FImjYouo3aVi",
 			"description": "Leather, Heavy Torso Armor",
 			"reference": "LTIA4",
-			"local_notes": "DR: 3; Don: 30 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. impaling.",
+			"reference_highlight": "Leather, Heavy",
+			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -5032,20 +5014,20 @@
 				}
 			],
 			"quantity": 1,
+			"equipped": true,
 			"calc": {
 				"value": 200,
 				"extended_value": 200,
 				"weight": "20 lb",
 				"extended_weight": "20 lb"
-			},
-			"reference_highlight": "Leather, Heavy",
-			"equipped": true
+			}
 		},
 		{
 			"id": "erPJ9-24FrX-a-6fk",
 			"description": "Leather, Light Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "DR: 0; Don: 23 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
+			"reference_highlight": "Leather, Light",
+			"local_notes": "Don: 23 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
@@ -5070,20 +5052,20 @@
 				}
 			],
 			"quantity": 1,
+			"equipped": true,
 			"calc": {
 				"value": 45,
 				"extended_value": 45,
 				"weight": "0.8 lb",
 				"extended_weight": "0.8 lb"
-			},
-			"reference_highlight": "Leather, Light",
-			"equipped": true
+			}
 		},
 		{
 			"id": "esCvFaeEcOdZguNfO",
 			"description": "Leather, Light Arm Armor",
 			"reference": "LTIA7",
-			"local_notes": "DR: 0; Don: 15 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
+			"reference_highlight": "Leather, Light",
+			"local_notes": "Don: 15 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
@@ -5114,14 +5096,14 @@
 				"extended_value": 90,
 				"weight": "1.7 lb",
 				"extended_weight": "1.7 lb"
-			},
-			"reference_highlight": "Leather, Light"
+			}
 		},
 		{
 			"id": "e7W3Pxjpuol4ihIyU",
 			"description": "Leather, Light Bascinet",
 			"reference": "LTIA14",
-			"local_notes": "DR: 0; Don: 8 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
+			"reference_highlight": "Leather, Light",
+			"local_notes": "Don: 8 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
@@ -5152,14 +5134,14 @@
 				"extended_value": 45,
 				"weight": "0.8 lb",
 				"extended_weight": "0.8 lb"
-			},
-			"reference_highlight": "Leather, Light"
+			}
 		},
 		{
 			"id": "eLQKo46IiPNTjU-gP",
 			"description": "Leather, Light Bascinet, Padded",
 			"reference": "LTIA14",
-			"local_notes": "DR: 1; Don: 8 secs; Holdout: -1; +1 DR vs. cutting.",
+			"reference_highlight": "Leather, Light",
+			"local_notes": "Don: 8 secs; Holdout: -1; +1 DR vs. cutting.",
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
@@ -5190,14 +5172,14 @@
 				"extended_value": 58,
 				"weight": "1 lb",
 				"extended_weight": "1 lb"
-			},
-			"reference_highlight": "Leather, Light"
+			}
 		},
 		{
 			"id": "ePTRpsjywLitmZs6D",
 			"description": "Leather, Light Chest Armor",
 			"reference": "LTIA5",
-			"local_notes": "DR: 0; Don: 23 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
+			"reference_highlight": "Leather, Light",
+			"local_notes": "Don: 23 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
@@ -5228,14 +5210,14 @@
 				"extended_value": 135,
 				"weight": "2.5 lb",
 				"extended_weight": "2.5 lb"
-			},
-			"reference_highlight": "Leather, Light"
+			}
 		},
 		{
 			"id": "eZUl5szL_x96oCYIx",
 			"description": "Leather, Light Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "DR: 0; Don: 3 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
+			"reference_highlight": "Leather, Light",
+			"local_notes": "Don: 3 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
@@ -5266,14 +5248,14 @@
 				"extended_value": 9,
 				"weight": "0.2 lb",
 				"extended_weight": "0.2 lb"
-			},
-			"reference_highlight": "Leather, Light"
+			}
 		},
 		{
 			"id": "edmy8u8OPjQLLEDrD",
 			"description": "Leather, Light Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "DR: 0; Don: 30 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
+			"reference_highlight": "Leather, Light",
+			"local_notes": "Don: 30 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
@@ -5304,13 +5286,13 @@
 				"extended_value": 180,
 				"weight": "3.3 lb",
 				"extended_weight": "3.3 lb"
-			},
-			"reference_highlight": "Leather, Light"
+			}
 		},
 		{
 			"id": "eSrct3SwevnON9KLP",
 			"description": "Leather, Light Neck Armor",
 			"reference": "LTIA15",
+			"reference_highlight": "Leather, Light",
 			"local_notes": "Don: 3 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
 			"tech_level": "0",
 			"legality_class": "5",
@@ -5342,14 +5324,14 @@
 				"extended_value": 9,
 				"weight": "0.2 lb",
 				"extended_weight": "0.2 lb"
-			},
-			"reference_highlight": "Leather, Light"
+			}
 		},
 		{
 			"id": "epbGTJIrWJFdueow5",
 			"description": "Leather, Light Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "DR: 0; Don: 6 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
+			"reference_highlight": "Leather, Light",
+			"local_notes": "Don: 6 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
@@ -5380,14 +5362,14 @@
 				"extended_value": 36,
 				"weight": "0.7 lb",
 				"extended_weight": "0.7 lb"
-			},
-			"reference_highlight": "Leather, Light"
+			}
 		},
 		{
 			"id": "ekMsdKM0wi44zwEK3",
 			"description": "Leather, Light Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "DR: 1; Don: 6 secs; Holdout: -1;); +1 DR vs. cutting.",
+			"reference_highlight": "Leather, Light",
+			"local_notes": "Don: 6 secs; Holdout: -1;); +1 DR vs. cutting.",
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
@@ -5418,14 +5400,14 @@
 				"extended_value": 46,
 				"weight": "1.9 lb",
 				"extended_weight": "1.9 lb"
-			},
-			"reference_highlight": "Leather, Light"
+			}
 		},
 		{
 			"id": "eHdT0Pk0ZZrVyMnb3",
 			"description": "Leather, Light Torso Armor",
 			"reference": "LTIA4",
-			"local_notes": "DR: 0; Don: 30 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
+			"reference_highlight": "Leather, Light",
+			"local_notes": "Don: 30 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
@@ -5455,14 +5437,14 @@
 				"extended_value": 180,
 				"weight": "3.3 lb",
 				"extended_weight": "3.3 lb"
-			},
-			"reference_highlight": "Leather, Light"
+			}
 		},
 		{
 			"id": "eL3IW6V5IHvALbscX",
 			"description": "Leather, Medium Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "DR: 2; Don: 23 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
+			"reference_highlight": "Leather, Medium",
+			"local_notes": "Don: 23 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -5487,20 +5469,20 @@
 				}
 			],
 			"quantity": 1,
+			"equipped": true,
 			"calc": {
 				"value": 25,
 				"extended_value": 25,
 				"weight": "3 lb",
 				"extended_weight": "3 lb"
-			},
-			"reference_highlight": "Leather, Medium",
-			"equipped": true
+			}
 		},
 		{
 			"id": "eq4m7g07RpfHhiPn1",
 			"description": "Leather, Medium Arm Armor",
 			"reference": "LTIA7",
-			"local_notes": "DR: 2; Don: 15 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
+			"reference_highlight": "Leather, Medium",
+			"local_notes": "Don: 15 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
 				"Limb Armor"
@@ -5530,14 +5512,14 @@
 				"extended_value": 50,
 				"weight": "6 lb",
 				"extended_weight": "6 lb"
-			},
-			"reference_highlight": "Leather, Medium"
+			}
 		},
 		{
 			"id": "eyc_cvEtss7XhrWx2",
 			"description": "Leather, Medium Bascinet",
 			"reference": "LTIA14",
-			"local_notes": "DR: 2; Don: 8 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
+			"reference_highlight": "Leather, Medium",
+			"local_notes": "Don: 8 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
 				"Bascinet"
@@ -5568,14 +5550,14 @@
 				"extended_value": 25,
 				"weight": "3 lb",
 				"extended_weight": "3 lb"
-			},
-			"reference_highlight": "Leather, Medium"
+			}
 		},
 		{
 			"id": "esCuxTwLqlDWr2vO4",
 			"description": "Leather, Medium Bascinet, Padded",
 			"reference": "LTIA14",
-			"local_notes": "DR: 3; Don: 8 secs; Holdout: -3; Reaction Pen.-1",
+			"reference_highlight": "Leather, Medium",
+			"local_notes": "Don: 8 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Bascinet"
@@ -5606,14 +5588,14 @@
 				"extended_value": 38,
 				"weight": "3.2 lb",
 				"extended_weight": "3.2 lb"
-			},
-			"reference_highlight": "Leather, Medium"
+			}
 		},
 		{
 			"id": "eArMaKp-rMS2oJhl9",
 			"description": "Leather, Medium Chest Armor",
 			"reference": "LTIA5",
-			"local_notes": "DR: 2; Don: 23 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
+			"reference_highlight": "Leather, Medium",
+			"local_notes": "Don: 23 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -5643,14 +5625,14 @@
 				"extended_value": 75,
 				"weight": "9 lb",
 				"extended_weight": "9 lb"
-			},
-			"reference_highlight": "Leather, Medium"
+			}
 		},
 		{
 			"id": "eVV2h6xOUC_avcFWt",
 			"description": "Leather, Medium Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "DR: 2; Don: 3 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
+			"reference_highlight": "Leather, Medium",
+			"local_notes": "Don: 3 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
 				"Groin Armor"
@@ -5680,14 +5662,14 @@
 				"extended_value": 5,
 				"weight": "0.6 lb",
 				"extended_weight": "0.6 lb"
-			},
-			"reference_highlight": "Leather, Medium"
+			}
 		},
 		{
 			"id": "e3sk4bn1Qscq7Oknr",
 			"description": "Leather, Medium Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "DR: 2; Don: 30 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
+			"reference_highlight": "Leather, Medium",
+			"local_notes": "Don: 30 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
 				"Limb Armor"
@@ -5717,14 +5699,14 @@
 				"extended_value": 100,
 				"weight": "12 lb",
 				"extended_weight": "12 lb"
-			},
-			"reference_highlight": "Leather, Medium"
+			}
 		},
 		{
 			"id": "e4sMNP0uwIF31RD0i",
 			"description": "Leather, Medium Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "DR: 2; Don: 3 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
+			"reference_highlight": "Leather, Medium",
+			"local_notes": "Don: 3 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
 				"Neck Armor"
@@ -5754,14 +5736,14 @@
 				"extended_value": 5,
 				"weight": "0.6 lb",
 				"extended_weight": "0.6 lb"
-			},
-			"reference_highlight": "Leather, Medium"
+			}
 		},
 		{
 			"id": "eCP0-MYEzTfBFZ2ey",
 			"description": "Leather, Medium Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "DR: 2; Don: 6 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
+			"reference_highlight": "Leather, Medium",
+			"local_notes": "Don: 6 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
 				"Pot Helm"
@@ -5791,14 +5773,14 @@
 				"extended_value": 20,
 				"weight": "2.4 lb",
 				"extended_weight": "2.4 lb"
-			},
-			"reference_highlight": "Leather, Medium"
+			}
 		},
 		{
 			"id": "eX9hlHfaEFyrCEQzG",
 			"description": "Leather, Medium Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "DR: 3; Don: 6 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. impaling.",
+			"reference_highlight": "Leather, Medium",
+			"local_notes": "Don: 6 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
 				"Pot Helm"
@@ -5828,14 +5810,14 @@
 				"extended_value": 30,
 				"weight": "3.6 lb",
 				"extended_weight": "3.6 lb"
-			},
-			"reference_highlight": "Leather, Medium"
+			}
 		},
 		{
 			"id": "esNSFZ1QbPc0bJLdN",
 			"description": "Leather, Medium Torso Armor",
 			"reference": "LTIA4",
-			"local_notes": "DR: 2; Don: 30 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
+			"reference_highlight": "Leather, Medium",
+			"local_notes": "Don: 30 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -5862,20 +5844,20 @@
 				}
 			],
 			"quantity": 1,
+			"equipped": true,
 			"calc": {
 				"value": 100,
 				"extended_value": 100,
 				"weight": "12 lb",
 				"extended_weight": "12 lb"
-			},
-			"reference_highlight": "Leather, Medium",
-			"equipped": true
+			}
 		},
 		{
 			"id": "eoX-uDlkBy6UiZe9Z",
 			"description": "Mail and Plates Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "DR: 5; Don: 15 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
+			"reference_highlight": "Mail and Plates",
+			"local_notes": "Don: 15 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -5901,20 +5883,20 @@
 				}
 			],
 			"quantity": 1,
+			"equipped": true,
 			"calc": {
 				"value": 250,
 				"extended_value": 250,
 				"weight": "5 lb",
 				"extended_weight": "5 lb"
-			},
-			"reference_highlight": "Mail and Plates",
-			"equipped": true
+			}
 		},
 		{
 			"id": "equiQ74l80RrdI_o0",
 			"description": "Mail and Plates Arm Armor",
 			"reference": "LTIA8",
-			"local_notes": "DR: 5; Don: 10 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. crushing.",
+			"reference_highlight": "Mail and Plates",
+			"local_notes": "Don: 10 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -5945,14 +5927,14 @@
 				"extended_value": 500,
 				"weight": "10 lb",
 				"extended_weight": "10 lb"
-			},
-			"reference_highlight": "Mail and Plates"
+			}
 		},
 		{
 			"id": "eDxjNLHVLldDnU8s1",
 			"description": "Mail and Plates Chest Armor",
 			"reference": "LTIA6",
-			"local_notes": "DR: 5; Don: 15 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
+			"reference_highlight": "Mail and Plates",
+			"local_notes": "Don: 15 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -5983,14 +5965,14 @@
 				"extended_value": 750,
 				"weight": "15 lb",
 				"extended_weight": "15 lb"
-			},
-			"reference_highlight": "Mail and Plates"
+			}
 		},
 		{
 			"id": "eTxJnsnJbV-89dbBx",
 			"description": "Mail and Plates Coif",
 			"reference": "LTIA14",
-			"local_notes": "DR: 5; Don: 6 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. crushing.",
+			"reference_highlight": "Mail and Plates",
+			"local_notes": "Don: 6 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. crushing.",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -6023,14 +6005,14 @@
 				"extended_value": 300,
 				"weight": "6 lb",
 				"extended_weight": "6 lb"
-			},
-			"reference_highlight": "Mail and Plates"
+			}
 		},
 		{
 			"id": "eIa44NdHEJl6s8Iv8",
 			"description": "Mail and Plates Coif, Padded",
 			"reference": "LTIA14",
-			"local_notes": "DR: 6; Don: 6 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. crushing.",
+			"reference_highlight": "Mail and Plates",
+			"local_notes": "Don: 6 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. crushing.",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -6063,14 +6045,14 @@
 				"extended_value": 315,
 				"weight": "7.8 lb",
 				"extended_weight": "7.8 lb"
-			},
-			"reference_highlight": "Mail and Plates"
+			}
 		},
 		{
 			"id": "evJZuNe8RKgj7TXTx",
 			"description": "Mail and Plates Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "DR: 5; Don: 3 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. crushing.",
+			"reference_highlight": "Mail and Plates",
+			"local_notes": "Don: 3 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -6101,14 +6083,14 @@
 				"extended_value": 50,
 				"weight": "1 lb",
 				"extended_weight": "1 lb"
-			},
-			"reference_highlight": "Mail and Plates"
+			}
 		},
 		{
 			"id": "emcqbP2aJJH-Xqtp0",
 			"description": "Mail and Plates Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "DR: 5; Don: 20 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. crushing.",
+			"reference_highlight": "Mail and Plates",
+			"local_notes": "Don: 20 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -6139,14 +6121,14 @@
 				"extended_value": 1000,
 				"weight": "20 lb",
 				"extended_weight": "20 lb"
-			},
-			"reference_highlight": "Mail and Plates"
+			}
 		},
 		{
 			"id": "ei88t5qNycYMu3OTN",
 			"description": "Mail and Plates Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "DR: 5; Don: 3 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
+			"reference_highlight": "Mail and Plates",
+			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -6177,14 +6159,13 @@
 				"extended_value": 50,
 				"weight": "1 lb",
 				"extended_weight": "1 lb"
-			},
-			"reference_highlight": "Mail and Plates"
+			}
 		},
 		{
 			"id": "el4FE1v8UbU14sUxT",
 			"description": "Mail and Plates Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "DR: 5; Don: 20 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
+			"local_notes": "Don: 20 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -6212,19 +6193,20 @@
 				}
 			],
 			"quantity": 1,
+			"equipped": true,
 			"calc": {
 				"value": 1000,
 				"extended_value": 1000,
 				"weight": "20 lb",
 				"extended_weight": "20 lb"
-			},
-			"equipped": true
+			}
 		},
 		{
 			"id": "eLChp1jhVkkXwtQna",
 			"description": "Mail, Fine Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "DR: 4; Don: 11 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"reference_highlight": "Mail, Fine",
+			"local_notes": "Don: 11 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -6249,20 +6231,20 @@
 				}
 			],
 			"quantity": 1,
+			"equipped": true,
 			"calc": {
 				"value": 225,
 				"extended_value": 225,
 				"weight": "3.8 lb",
 				"extended_weight": "3.8 lb"
-			},
-			"reference_highlight": "Mail, Fine",
-			"equipped": true
+			}
 		},
 		{
 			"id": "e0BT5_lQ7JdML2zyQ",
 			"description": "Mail, Fine Arm Armor",
 			"reference": "LTIA8",
-			"local_notes": "DR: 4; Don: 8 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"reference_highlight": "Mail, Fine",
+			"local_notes": "Don: 8 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -6292,14 +6274,14 @@
 				"extended_value": 450,
 				"weight": "7.5 lb",
 				"extended_weight": "7.5 lb"
-			},
-			"reference_highlight": "Mail, Fine"
+			}
 		},
 		{
 			"id": "eIHnqIu8W4pIpKWzv",
 			"description": "Mail, Fine Chest Armor",
 			"reference": "LTIA6",
-			"local_notes": "DR: 4; Don: 11 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"reference_highlight": "Mail, Fine",
+			"local_notes": "Don: 11 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -6330,14 +6312,14 @@
 				"extended_value": 675,
 				"weight": "11.3 lb",
 				"extended_weight": "11.3 lb"
-			},
-			"reference_highlight": "Mail, Fine"
+			}
 		},
 		{
 			"id": "eSA89RtNAwHO30FRp",
 			"description": "Mail, Fine Coif",
 			"reference": "LTIA14",
-			"local_notes": "DR: 4; Don: 5 secs; Holdout: -3; Reaction Pen.-2; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"reference_highlight": "Mail, Fine",
+			"local_notes": "Don: 5 secs; Holdout: -3; Reaction Pen.-2; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
 				"Coif"
@@ -6369,14 +6351,14 @@
 				"extended_value": 270,
 				"weight": "4.5 lb",
 				"extended_weight": "4.5 lb"
-			},
-			"reference_highlight": "Mail, Fine"
+			}
 		},
 		{
 			"id": "ekcJlcv2b2UfLhSpa",
 			"description": "Mail, Fine Coif, Padded",
 			"reference": "LTIA14",
-			"local_notes": "DR: 5; Don: 5 secs; Holdout: -3; Reaction Pen.-2",
+			"reference_highlight": "Mail, Fine",
+			"local_notes": "Don: 5 secs; Holdout: -3; Reaction Pen.-2",
 			"tech_level": "2",
 			"tags": [
 				"Coif"
@@ -6408,14 +6390,14 @@
 				"extended_value": 285,
 				"weight": "6.3 lb",
 				"extended_weight": "6.3 lb"
-			},
-			"reference_highlight": "Mail, Fine"
+			}
 		},
 		{
 			"id": "ewNuOFXRK8Ov7sD7i",
 			"description": "Mail, Fine Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "DR: 4; Don: 3 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"reference_highlight": "Mail, Fine",
+			"local_notes": "Don: 3 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -6446,14 +6428,14 @@
 				"extended_value": 45,
 				"weight": "0.8 lb",
 				"extended_weight": "0.8 lb"
-			},
-			"reference_highlight": "Mail, Fine"
+			}
 		},
 		{
 			"id": "ecd5FPkCxIy4aJxI0",
 			"description": "Mail, Fine Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "DR: 4; Don: 15 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"reference_highlight": "Mail, Fine",
+			"local_notes": "Don: 15 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -6484,14 +6466,14 @@
 				"extended_value": 900,
 				"weight": "15 lb",
 				"extended_weight": "15 lb"
-			},
-			"reference_highlight": "Mail, Fine"
+			}
 		},
 		{
 			"id": "eWM1WKWDkP3XeB_c_",
 			"description": "Mail, Fine Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "DR: 4; Don: 3 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"reference_highlight": "Mail, Fine",
+			"local_notes": "Don: 3 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -6522,14 +6504,14 @@
 				"extended_value": 45,
 				"weight": "0.8 lb",
 				"extended_weight": "0.8 lb"
-			},
-			"reference_highlight": "Mail, Fine"
+			}
 		},
 		{
 			"id": "ego9KduSjlTDHNw4N",
 			"description": "Mail, Fine Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "DR: 4; Don: 15 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"reference_highlight": "Mail, Fine",
+			"local_notes": "Don: 15 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -6557,20 +6539,20 @@
 				}
 			],
 			"quantity": 1,
+			"equipped": true,
 			"calc": {
 				"value": 900,
 				"extended_value": 900,
 				"weight": "15 lb",
 				"extended_weight": "15 lb"
-			},
-			"reference_highlight": "Mail, Fine",
-			"equipped": true
+			}
 		},
 		{
 			"id": "eu_IgT6hdI_zY1cNT",
 			"description": "Mail, Heavy Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "DR: 5; Don: 11 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"reference_highlight": "Mail, Heavy",
+			"local_notes": "Don: 11 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -6596,20 +6578,20 @@
 				}
 			],
 			"quantity": 1,
+			"equipped": true,
 			"calc": {
 				"value": 300,
 				"extended_value": 300,
 				"weight": "4.5 lb",
 				"extended_weight": "4.5 lb"
-			},
-			"reference_highlight": "Mail, Heavy",
-			"equipped": true
+			}
 		},
 		{
 			"id": "eBEaqPyzL72SWYqTt",
 			"description": "Mail, Heavy Arm Armor",
 			"reference": "LTIA8",
-			"local_notes": "DR: 5; Don: 8 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"reference_highlight": "Mail, Heavy",
+			"local_notes": "Don: 8 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -6640,14 +6622,14 @@
 				"extended_value": 600,
 				"weight": "9 lb",
 				"extended_weight": "9 lb"
-			},
-			"reference_highlight": "Mail, Heavy"
+			}
 		},
 		{
 			"id": "eCNiTOK-N0P8b_VKg",
 			"description": "Mail, Heavy Chest Armor",
 			"reference": "LTIA6",
-			"local_notes": "DR: 5; Don: 11 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"reference_highlight": "Mail, Heavy",
+			"local_notes": "Don: 11 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -6678,14 +6660,14 @@
 				"extended_value": 900,
 				"weight": "13.5 lb",
 				"extended_weight": "13.5 lb"
-			},
-			"reference_highlight": "Mail, Heavy"
+			}
 		},
 		{
 			"id": "e14eDo__h7uuoG7Th",
 			"description": "Mail, Heavy Coif",
 			"reference": "LTIA14",
-			"local_notes": "DR: 5; Don: 5 secs; Holdout: -4; Reaction Pen.-2; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"reference_highlight": "Mail, Heavy",
+			"local_notes": "Don: 5 secs; Holdout: -4; Reaction Pen.-2; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -6718,14 +6700,14 @@
 				"extended_value": 360,
 				"weight": "5.4 lb",
 				"extended_weight": "5.4 lb"
-			},
-			"reference_highlight": "Mail, Heavy"
+			}
 		},
 		{
 			"id": "eKw6D5EO_-AkM4coQ",
 			"description": "Mail, Heavy Coif, Padded",
 			"reference": "LTIA14",
-			"local_notes": "DR: 6; Don: 5 secs; Holdout: -4; Reaction Pen.-2; -2 DR vs. crushing.",
+			"reference_highlight": "Mail, Heavy",
+			"local_notes": "Don: 5 secs; Holdout: -4; Reaction Pen.-2; -2 DR vs. crushing.",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -6758,14 +6740,14 @@
 				"extended_value": 375,
 				"weight": "7.2 lb",
 				"extended_weight": "7.2 lb"
-			},
-			"reference_highlight": "Mail, Heavy"
+			}
 		},
 		{
 			"id": "es8ckqkoj4tcBOtlV",
 			"description": "Mail, Heavy Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "DR: 5; Don: 3 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"reference_highlight": "Mail, Heavy",
+			"local_notes": "Don: 3 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -6795,14 +6777,14 @@
 				"extended_value": 60,
 				"weight": "0.9 lb",
 				"extended_weight": "0.9 lb"
-			},
-			"reference_highlight": "Mail, Heavy"
+			}
 		},
 		{
 			"id": "egukSMdPerl9EQWiW",
 			"description": "Mail, Heavy Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "DR: 5; Don: 15 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"reference_highlight": "Mail, Heavy",
+			"local_notes": "Don: 15 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -6834,14 +6816,14 @@
 				"extended_value": 1200,
 				"weight": "18 lb",
 				"extended_weight": "18 lb"
-			},
-			"reference_highlight": "Mail, Heavy"
+			}
 		},
 		{
 			"id": "ebZL7HJUf6CcXwETk",
 			"description": "Mail, Heavy Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "DR: 5; Don: 3 secs; Holdout: -4; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"reference_highlight": "Mail, Heavy",
+			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -6872,14 +6854,14 @@
 				"extended_value": 60,
 				"weight": "0.9 lb",
 				"extended_weight": "0.9 lb"
-			},
-			"reference_highlight": "Mail, Heavy"
+			}
 		},
 		{
 			"id": "eKsm1jE9uJPd4vJuq",
 			"description": "Mail, Heavy Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "DR: 5; Don: 15 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"reference_highlight": "Mail, Heavy",
+			"local_notes": "Don: 15 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -6907,20 +6889,20 @@
 				}
 			],
 			"quantity": 1,
+			"equipped": true,
 			"calc": {
 				"value": 1200,
 				"extended_value": 1200,
 				"weight": "18 lb",
 				"extended_weight": "18 lb"
-			},
-			"reference_highlight": "Mail, Heavy",
-			"equipped": true
+			}
 		},
 		{
 			"id": "eSljEfwttEnNTgP5X",
 			"description": "Mail, Jousting Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "DR: 6; Don: 23 secs; Holdout: -3; Reaction Pen.-2; Gives -1 DX, except for Lance skill.",
+			"reference_highlight": "Mail, Jousting",
+			"local_notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-2; Gives -1 DX, except for Lance skill.",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -6943,14 +6925,14 @@
 				"extended_value": 375,
 				"weight": "7.5 lb",
 				"extended_weight": "7.5 lb"
-			},
-			"reference_highlight": "Mail, Jousting"
+			}
 		},
 		{
 			"id": "evEo56xzlIaJq1RRf",
 			"description": "Mail, Jousting Chest Armor",
 			"reference": "LTIA6",
-			"local_notes": "DR: 6; Don: 23 secs; Holdout: -3; Reaction Pen.-2; Gives -1 DX, except for Lance skill.",
+			"reference_highlight": "Mail, Jousting",
+			"local_notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-2; Gives -1 DX, except for Lance skill.",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -6973,14 +6955,14 @@
 				"extended_value": 1125,
 				"weight": "22.5 lb",
 				"extended_weight": "22.5 lb"
-			},
-			"reference_highlight": "Mail, Jousting"
+			}
 		},
 		{
 			"id": "eVPDWR5DI3Vcc_y9p",
 			"description": "Mail, Jousting Coif",
 			"reference": "LTIA14",
-			"local_notes": "DR: 6; Don: 9 secs; Holdout: -4; Reaction Pen.-2; Gives -1 DX, except for Lance skill.",
+			"reference_highlight": "Mail, Jousting",
+			"local_notes": "Don: 9 secs; Holdout: -4; Reaction Pen.-2; Gives -1 DX, except for Lance skill.",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -7004,14 +6986,14 @@
 				"extended_value": 450,
 				"weight": "9 lb",
 				"extended_weight": "9 lb"
-			},
-			"reference_highlight": "Mail, Jousting"
+			}
 		},
 		{
 			"id": "eH-hT0pxpq2KT9E9h",
 			"description": "Mail, Jousting Coif, Padded",
 			"reference": "LTIA14",
-			"local_notes": "DR: 7; Don: 9 secs; Holdout: -4; Reaction Pen.-2; Gives -1 DX, except for Lance skill.",
+			"reference_highlight": "Mail, Jousting",
+			"local_notes": "Don: 9 secs; Holdout: -4; Reaction Pen.-2; Gives -1 DX, except for Lance skill.",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -7035,14 +7017,14 @@
 				"extended_value": 465,
 				"weight": "10.8 lb",
 				"extended_weight": "10.8 lb"
-			},
-			"reference_highlight": "Mail, Jousting"
+			}
 		},
 		{
 			"id": "ehmd2Bb57t0IGDCpt",
 			"description": "Mail, Jousting Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "DR: 6; Don: 3 secs; Holdout: -3; Reaction Pen.-1; Gives -1 DX, except for Lance skill.",
+			"reference_highlight": "Mail, Jousting",
+			"local_notes": "Don: 3 secs; Holdout: -3; Reaction Pen.-1; Gives -1 DX, except for Lance skill.",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -7065,14 +7047,14 @@
 				"extended_value": 75,
 				"weight": "1.5 lb",
 				"extended_weight": "1.5 lb"
-			},
-			"reference_highlight": "Mail, Jousting"
+			}
 		},
 		{
 			"id": "ed-XbrQV0LA4W99A4",
 			"description": "Mail, Jousting Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "DR: 6; Don: 30 secs; Holdout: -3; Reaction Pen.-2; Gives -1 DX, except for Lance skill.",
+			"reference_highlight": "Mail, Jousting",
+			"local_notes": "Don: 30 secs; Holdout: -3; Reaction Pen.-2; Gives -1 DX, except for Lance skill.",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -7096,13 +7078,13 @@
 				"extended_value": 1500,
 				"weight": "30 lb",
 				"extended_weight": "30 lb"
-			},
-			"reference_highlight": "Mail, Jousting"
+			}
 		},
 		{
 			"id": "eLQpfHd9nYHBu0Gm_",
 			"description": "Mail, Light Abdomen Armor",
 			"reference": "LTIA6",
+			"reference_highlight": "Mail, Light",
 			"local_notes": "Don: 11 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
@@ -7127,20 +7109,20 @@
 				}
 			],
 			"quantity": 1,
+			"equipped": true,
 			"calc": {
 				"value": 125,
 				"extended_value": 125,
 				"weight": "3 lb",
 				"extended_weight": "3 lb"
-			},
-			"reference_highlight": "Mail, Light",
-			"equipped": true
+			}
 		},
 		{
 			"id": "e3T2ZQ6SMRyhLPDP4",
 			"description": "Mail, Light Arm Armor",
 			"reference": "LTIA7",
-			"local_notes": "DR: 3; Don: 8 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"reference_highlight": "Mail, Light",
+			"local_notes": "Don: 8 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
 				"Limb Armor"
@@ -7169,14 +7151,14 @@
 				"extended_value": 250,
 				"weight": "6 lb",
 				"extended_weight": "6 lb"
-			},
-			"reference_highlight": "Mail, Light"
+			}
 		},
 		{
 			"id": "enJd0OIRYoJnM3vyy",
 			"description": "Mail, Light Chest Armor",
 			"reference": "LTIA6",
-			"local_notes": "DR: 3; Don: 11 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"reference_highlight": "Mail, Light",
+			"local_notes": "Don: 11 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
 				"Body Armor"
@@ -7206,14 +7188,14 @@
 				"extended_value": 375,
 				"weight": "9 lb",
 				"extended_weight": "9 lb"
-			},
-			"reference_highlight": "Mail, Light"
+			}
 		},
 		{
 			"id": "eeCc0DmBTNmI9t_a6",
 			"description": "Mail, Light Coif",
 			"reference": "LTIA14",
-			"local_notes": "DR: 3; Don: 5 secs; Holdout: -2; Reaction Pen.-2; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"reference_highlight": "Mail, Light",
+			"local_notes": "Don: 5 secs; Holdout: -2; Reaction Pen.-2; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
 				"Coif"
@@ -7241,14 +7223,14 @@
 				"extended_value": 150,
 				"weight": "3.6 lb",
 				"extended_weight": "3.6 lb"
-			},
-			"reference_highlight": "Mail, Light"
+			}
 		},
 		{
 			"id": "eHqQRwQ5pNSBH_jfX",
 			"description": "Mail, Light Coif, Padded",
 			"reference": "LTIA14",
-			"local_notes": "DR: 4; Don: 5 secs; Holdout: -2; Reaction Pen.-2; -2 DR vs. crushing.",
+			"reference_highlight": "Mail, Light",
+			"local_notes": "Don: 5 secs; Holdout: -2; Reaction Pen.-2; -2 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
 				"Coif"
@@ -7280,14 +7262,14 @@
 				"extended_value": 165,
 				"weight": "5.4 lb",
 				"extended_weight": "5.4 lb"
-			},
-			"reference_highlight": "Mail, Light"
+			}
 		},
 		{
 			"id": "ezR2F0wvIcPwu9XCd",
 			"description": "Mail, Light Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "DR: 3; Don: 3 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"reference_highlight": "Mail, Light",
+			"local_notes": "Don: 3 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
 				"Groin Armor"
@@ -7317,14 +7299,14 @@
 				"extended_value": 25,
 				"weight": "0.6 lb",
 				"extended_weight": "0.6 lb"
-			},
-			"reference_highlight": "Mail, Light"
+			}
 		},
 		{
 			"id": "ehr15A_0VXHx9XAF3",
 			"description": "Mail, Light Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "DR: 3; Don: 15 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"reference_highlight": "Mail, Light",
+			"local_notes": "Don: 15 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
 				"Limb Armor"
@@ -7354,14 +7336,14 @@
 				"extended_value": 500,
 				"weight": "12 lb",
 				"extended_weight": "12 lb"
-			},
-			"reference_highlight": "Mail, Light"
+			}
 		},
 		{
 			"id": "eEg5JQunwpt50hSF9",
 			"description": "Mail, Light Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "DR: 3; Don: 3 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"reference_highlight": "Mail, Light",
+			"local_notes": "Don: 3 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
 				"Neck Armor"
@@ -7392,14 +7374,14 @@
 				"extended_value": 25,
 				"weight": "0.6 lb",
 				"extended_weight": "0.6 lb"
-			},
-			"reference_highlight": "Mail, Light"
+			}
 		},
 		{
 			"id": "e11EeWVcRnmM5RzWO",
 			"description": "Mail, Light Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "DR: 3; Don: 15 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"reference_highlight": "Mail, Light",
+			"local_notes": "Don: 15 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
 				"Body Armor"
@@ -7426,20 +7408,19 @@
 				}
 			],
 			"quantity": 1,
+			"equipped": true,
 			"calc": {
 				"value": 500,
 				"extended_value": 500,
 				"weight": "12 lb",
 				"extended_weight": "12 lb"
-			},
-			"reference_highlight": "Mail, Light",
-			"equipped": true
+			}
 		},
 		{
 			"id": "eJZyW8py6OBUqMrwN",
 			"description": "Mittens ",
 			"reference": "LTIA15",
-			"local_notes": "DR: 0; Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting; Enclosedmittens andgloves protectvs.cold,heat,contactpoison,etc.,but giveBadGrip1(p.B123); Gives Ham-Fisted 2 (p. B138).",
+			"local_notes": "Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting; Enclosedmittens andgloves protectvs.cold,heat,contactpoison,etc.,but giveBadGrip1(p.B123); Gives Ham-Fisted 2 (p. B138).",
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
@@ -7476,7 +7457,7 @@
 			"id": "eAVm_WBOK8kNRrPbc",
 			"description": "Mittens, Padded Cloth ",
 			"reference": "LTIA15",
-			"local_notes": "DR: 1; Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); Enclosedmittens andgloves protectvs.cold,heat,contactpoison,etc.,but giveBadGrip1(p.B123); Gives Ham-Fisted 2 (p. B138).",
+			"local_notes": "Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); Enclosedmittens andgloves protectvs.cold,heat,contactpoison,etc.,but giveBadGrip1(p.B123); Gives Ham-Fisted 2 (p. B138).",
 			"tech_level": "1",
 			"tags": [
 				"Gloves"
@@ -7504,7 +7485,7 @@
 			"id": "e2Oo1VPjY4Qqt622p",
 			"description": "Moccasins ",
 			"reference": "LTIA16",
-			"local_notes": "DR: 1; Don: 6 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379); Gives +1 to Stealth.",
+			"local_notes": "Don: 6 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379); Gives +1 to Stealth.",
 			"tech_level": "0",
 			"tags": [
 				"Footwear"
@@ -7532,7 +7513,7 @@
 			"id": "eGJEpXOubDzKed8ZB",
 			"description": "Mukluks ",
 			"reference": "LTIA16",
-			"local_notes": "DR: 1; Don: 6 secs; Holdout: -5; Flexible and susceptible to blunt trauma (p. B379); Erases -2 in Stealth penalties when walking on snow.",
+			"local_notes": "Don: 6 secs; Holdout: -5; Flexible and susceptible to blunt trauma (p. B379); Erases -2 in Stealth penalties when walking on snow.",
 			"tech_level": "0",
 			"tags": [
 				"Footwear"
@@ -7560,7 +7541,8 @@
 			"id": "egiUnA-e61m5IgCbw",
 			"description": "Paper, Proofed Chest Armor",
 			"reference": "LTIA6",
-			"local_notes": "DR: 6; Don: 15 secs; Holdout: -6; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433); treat as resistant.",
+			"reference_highlight": "Paper, Proofed",
+			"local_notes": "Don: 15 secs; Holdout: -6; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433); treat as resistant.",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -7583,14 +7565,14 @@
 				"extended_value": 1500,
 				"weight": "33.8 lb",
 				"extended_weight": "33.8 lb"
-			},
-			"reference_highlight": "Paper, Proofed"
+			}
 		},
 		{
 			"id": "e5-lnqp9GuQ_UY40I",
 			"description": "Paper, Proofed Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "DR: 6; Don: 4 secs; Holdout: -7; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433); treat as resistant.",
+			"reference_highlight": "Paper, Proofed",
+			"local_notes": "Don: 4 secs; Holdout: -7; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433); treat as resistant.",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -7613,14 +7595,14 @@
 				"extended_value": 400,
 				"weight": "9 lb",
 				"extended_weight": "9 lb"
-			},
-			"reference_highlight": "Paper, Proofed"
+			}
 		},
 		{
 			"id": "ebMc2OANQrLdqy-y5",
 			"description": "Paper, Proofed Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "DR: 7; Don: 4 secs; Holdout: -7; Reaction Pen.-1",
+			"reference_highlight": "Paper, Proofed",
+			"local_notes": "Don: 4 secs; Holdout: -7; Reaction Pen.-1",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -7643,14 +7625,14 @@
 				"extended_value": 410,
 				"weight": "10.2 lb",
 				"extended_weight": "10.2 lb"
-			},
-			"reference_highlight": "Paper, Proofed"
+			}
 		},
 		{
 			"id": "eVXuB56-MvjvAlHl6",
 			"description": "Paper, Proofed Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "DR: 6; Don: 20 secs; Holdout: -6; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433); treat as resistant.",
+			"reference_highlight": "Paper, Proofed",
+			"local_notes": "Don: 20 secs; Holdout: -6; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433); treat as resistant.",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -7674,14 +7656,14 @@
 				"extended_value": 2000,
 				"weight": "45 lb",
 				"extended_weight": "45 lb"
-			},
-			"reference_highlight": "Paper, Proofed"
+			}
 		},
 		{
 			"id": "e8HbtIDjjWatM7iLz",
 			"description": "Plate, Heavy Bascinet",
 			"reference": "LTIA14",
-			"local_notes": "DR: 9; Don: 11 secs; Holdout: -8; Reaction Pen.-1",
+			"reference_highlight": "Plate, Heavy",
+			"local_notes": "Don: 11 secs; Holdout: -8; Reaction Pen.-1",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -7704,14 +7686,14 @@
 				"extended_value": 1000,
 				"weight": "8 lb",
 				"extended_weight": "8 lb"
-			},
-			"reference_highlight": "Plate, Heavy"
+			}
 		},
 		{
 			"id": "eVkbak8FPV5rDs4jS",
 			"description": "Plate, Heavy Bascinet, Padded",
 			"reference": "LTIA14",
-			"local_notes": "DR: 10; Don: 11 secs; Holdout: -8; Reaction Pen.-1",
+			"reference_highlight": "Plate, Heavy",
+			"local_notes": "Don: 11 secs; Holdout: -8; Reaction Pen.-1",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -7734,14 +7716,14 @@
 				"extended_value": 1013,
 				"weight": "8.2 lb",
 				"extended_weight": "8.2 lb"
-			},
-			"reference_highlight": "Plate, Heavy"
+			}
 		},
 		{
 			"id": "eB9yJS7RfP1fr9NRY",
 			"description": "Plate, Heavy Chest Armor",
 			"reference": "LTIA6",
-			"local_notes": "DR: 9; Don: 34 secs; Holdout: -7; Reaction Pen.-2",
+			"reference_highlight": "Plate, Heavy",
+			"local_notes": "Don: 34 secs; Holdout: -7; Reaction Pen.-2",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -7764,14 +7746,14 @@
 				"extended_value": 3000,
 				"weight": "24 lb",
 				"extended_weight": "24 lb"
-			},
-			"reference_highlight": "Plate, Heavy"
+			}
 		},
 		{
 			"id": "eW8-cIDc0M2hpmI0_",
 			"description": "Plate, Heavy Full Helm",
 			"reference": "LTIA14",
-			"local_notes": "DR: 9; Don: 14 secs; Holdout: -8; Reaction Pen.-1",
+			"reference_highlight": "Plate, Heavy",
+			"local_notes": "Don: 14 secs; Holdout: -8; Reaction Pen.-1",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -7795,14 +7777,14 @@
 				"extended_value": 1200,
 				"weight": "9.6 lb",
 				"extended_weight": "9.6 lb"
-			},
-			"reference_highlight": "Plate, Heavy"
+			}
 		},
 		{
 			"id": "emcjmXCtyll2tktFu",
 			"description": "Plate, Heavy Full Helm, Padded",
 			"reference": "LTIA14",
-			"local_notes": "DR: 10; Don: 14 secs; Holdout: -8; Reaction Pen.-1",
+			"reference_highlight": "Plate, Heavy",
+			"local_notes": "Don: 14 secs; Holdout: -8; Reaction Pen.-1",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -7826,14 +7808,14 @@
 				"extended_value": 1215,
 				"weight": "11.4 lb",
 				"extended_weight": "11.4 lb"
-			},
-			"reference_highlight": "Plate, Heavy"
+			}
 		},
 		{
 			"id": "e9H2n10sfSoXCIqZK",
 			"description": "Plate, Heavy Greathelm",
 			"reference": "LTIA14",
-			"local_notes": "DR: 9; Don: 16 secs; Holdout: 0; Reaction Pen.-2",
+			"reference_highlight": "Plate, Heavy",
+			"local_notes": "Don: 16 secs; Holdout: 0; Reaction Pen.-2",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -7858,14 +7840,14 @@
 				"extended_value": 1400,
 				"weight": "11.2 lb",
 				"extended_weight": "11.2 lb"
-			},
-			"reference_highlight": "Plate, Heavy"
+			}
 		},
 		{
 			"id": "e4h902l7Yrrtzo2zO",
 			"description": "Plate, Heavy Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "DR: 9; Don: 3 secs; Holdout: -7; Reaction Pen.-1",
+			"reference_highlight": "Plate, Heavy",
+			"local_notes": "Don: 3 secs; Holdout: -7; Reaction Pen.-1",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -7888,14 +7870,14 @@
 				"extended_value": 200,
 				"weight": "1.6 lb",
 				"extended_weight": "1.6 lb"
-			},
-			"reference_highlight": "Plate, Heavy"
+			}
 		},
 		{
 			"id": "estCTGqLmg_EgA-h0",
 			"description": "Plate, Heavy Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "DR: 9; Don: 9 secs; Holdout: -8; Reaction Pen.-1",
+			"reference_highlight": "Plate, Heavy",
+			"local_notes": "Don: 9 secs; Holdout: -8; Reaction Pen.-1",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -7918,14 +7900,14 @@
 				"extended_value": 800,
 				"weight": "6.4 lb",
 				"extended_weight": "6.4 lb"
-			},
-			"reference_highlight": "Plate, Heavy"
+			}
 		},
 		{
 			"id": "eq2-smtts4BIi2y_d",
 			"description": "Plate, Heavy Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "DR: 10; Don: 9 secs; Holdout: -8; Reaction Pen.-1",
+			"reference_highlight": "Plate, Heavy",
+			"local_notes": "Don: 9 secs; Holdout: -8; Reaction Pen.-1",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -7948,14 +7930,14 @@
 				"extended_value": 810,
 				"weight": "7.6 lb",
 				"extended_weight": "7.6 lb"
-			},
-			"reference_highlight": "Plate, Heavy"
+			}
 		},
 		{
 			"id": "eF4gWjAAWTqodS7v8",
 			"description": "Plate, Heavy Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "DR: 9; Don: 45 secs; Holdout: -7; Reaction Pen.-2",
+			"reference_highlight": "Plate, Heavy",
+			"local_notes": "Don: 45 secs; Holdout: -7; Reaction Pen.-2",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -7979,14 +7961,13 @@
 				"extended_value": 4000,
 				"weight": "32 lb",
 				"extended_weight": "32 lb"
-			},
-			"reference_highlight": "Plate, Heavy"
+			}
 		},
 		{
 			"id": "eSHH3OxXNE-wBwXbS",
 			"description": "Plate, Light Arm Armor",
 			"reference": "LTIA8",
-			"local_notes": "DR: 3; Don: 23 secs; Holdout: -3; Reaction Pen.-1",
+			"local_notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "4",
 			"tags": [
 				"Limb Armor"
@@ -8014,7 +7995,8 @@
 			"id": "elLPutR9mlpXPjG8k",
 			"description": "Plate, Light Bascinet",
 			"reference": "LTIA14",
-			"local_notes": "DR: 3; Don: 11 secs; Holdout: -4; Reaction Pen.-1",
+			"reference_highlight": "Plate, Light",
+			"local_notes": "Don: 11 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "3",
 			"tags": [
 				"Bascinet"
@@ -8036,14 +8018,14 @@
 				"extended_value": 250,
 				"weight": "2 lb",
 				"extended_weight": "2 lb"
-			},
-			"reference_highlight": "Plate, Light"
+			}
 		},
 		{
 			"id": "eSzAgwvmhzcidbo4-",
 			"description": "Plate, Light Bascinet, Padded",
 			"reference": "LTIA14",
-			"local_notes": "DR: 4; Don: 11 secs; Holdout: -4; Reaction Pen.-1",
+			"reference_highlight": "Plate, Light",
+			"local_notes": "Don: 11 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "3",
 			"tags": [
 				"Bascinet"
@@ -8065,14 +8047,14 @@
 				"extended_value": 263,
 				"weight": "2.2 lb",
 				"extended_weight": "2.2 lb"
-			},
-			"reference_highlight": "Plate, Light"
+			}
 		},
 		{
 			"id": "ek0MHkUn38Ro0gdwd",
 			"description": "Plate, Light Chest Armor",
 			"reference": "LTIA6",
-			"local_notes": "DR: 3; Don: 34 secs; Holdout: -3; Reaction Pen.-2",
+			"reference_highlight": "Plate, Light",
+			"local_notes": "Don: 34 secs; Holdout: -3; Reaction Pen.-2",
 			"tech_level": "4",
 			"tags": [
 				"Body Armor"
@@ -8094,14 +8076,14 @@
 				"extended_value": 750,
 				"weight": "6 lb",
 				"extended_weight": "6 lb"
-			},
-			"reference_highlight": "Plate, Light"
+			}
 		},
 		{
 			"id": "e43dIt6gMMjKvx5-K",
 			"description": "Plate, Light Full Helm",
 			"reference": "LTIA14",
-			"local_notes": "DR: 3; Don: 14 secs; Holdout: -4; Reaction Pen.-1",
+			"reference_highlight": "Plate, Light",
+			"local_notes": "Don: 14 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "3",
 			"tags": [
 				"Full Helm"
@@ -8124,14 +8106,14 @@
 				"extended_value": 300,
 				"weight": "2.4 lb",
 				"extended_weight": "2.4 lb"
-			},
-			"reference_highlight": "Plate, Light"
+			}
 		},
 		{
 			"id": "egKoEnWG0C8O2co8s",
 			"description": "Plate, Light Full Helm, Padded",
 			"reference": "LTIA14",
-			"local_notes": "DR: 4; Don: 14 secs; Holdout: -4; Reaction Pen.-1",
+			"reference_highlight": "Plate, Light",
+			"local_notes": "Don: 14 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "3",
 			"tags": [
 				"Full Helm"
@@ -8154,14 +8136,14 @@
 				"extended_value": 315,
 				"weight": "4.2 lb",
 				"extended_weight": "4.2 lb"
-			},
-			"reference_highlight": "Plate, Light"
+			}
 		},
 		{
 			"id": "emmiIu3Gd_B88IQKM",
 			"description": "Plate, Light Greathelm",
 			"reference": "LTIA14",
-			"local_notes": "DR: 3; Don: 16 secs; Holdout: 0; Reaction Pen.-2",
+			"reference_highlight": "Plate, Light",
+			"local_notes": "Don: 16 secs; Holdout: 0; Reaction Pen.-2",
 			"tech_level": "3",
 			"tags": [
 				"Greathelm"
@@ -8184,14 +8166,14 @@
 				"extended_value": 350,
 				"weight": "2.8 lb",
 				"extended_weight": "2.8 lb"
-			},
-			"reference_highlight": "Plate, Light"
+			}
 		},
 		{
 			"id": "e789qFrPdk5pIikCP",
 			"description": "Plate, Light Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "DR: 3; Don: 3 secs; Holdout: -3; Reaction Pen.-1",
+			"reference_highlight": "Plate, Light",
+			"local_notes": "Don: 3 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "3",
 			"tags": [
 				"Groin Armor"
@@ -8213,14 +8195,14 @@
 				"extended_value": 50,
 				"weight": "0.4 lb",
 				"extended_weight": "0.4 lb"
-			},
-			"reference_highlight": "Plate, Light"
+			}
 		},
 		{
 			"id": "eTWxBJoMLyST_CigB",
 			"description": "Plate, Light Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "DR: 3; Don: 45 secs; Holdout: -3; Reaction Pen.-1",
+			"reference_highlight": "Plate, Light",
+			"local_notes": "Don: 45 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "4",
 			"tags": [
 				"Limb Armor"
@@ -8242,14 +8224,14 @@
 				"extended_value": 1000,
 				"weight": "8 lb",
 				"extended_weight": "8 lb"
-			},
-			"reference_highlight": "Plate, Light"
+			}
 		},
 		{
 			"id": "enmhXuFhrJi9OYitn",
 			"description": "Plate, Light Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "DR: 3; Don: 3 secs; Holdout: -4; Reaction Pen.-1",
+			"reference_highlight": "Plate, Light",
+			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "4",
 			"tags": [
 				"Neck Armor"
@@ -8271,14 +8253,14 @@
 				"extended_value": 50,
 				"weight": "0.4 lb",
 				"extended_weight": "0.4 lb"
-			},
-			"reference_highlight": "Plate, Light"
+			}
 		},
 		{
 			"id": "e4oAdGvTrNEwrC-Jl",
 			"description": "Plate, Light Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "DR: 3; Don: 9 secs; Holdout: -4; Reaction Pen.-1",
+			"reference_highlight": "Plate, Light",
+			"local_notes": "Don: 9 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "2",
 			"tags": [
 				"Pot Helm"
@@ -8300,14 +8282,14 @@
 				"extended_value": 200,
 				"weight": "1.6 lb",
 				"extended_weight": "1.6 lb"
-			},
-			"reference_highlight": "Plate, Light"
+			}
 		},
 		{
 			"id": "exDKnMhaEphzFBvPP",
 			"description": "Plate, Light Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "DR: 4; Don: 9 secs; Holdout: -4; Reaction Pen.-1",
+			"reference_highlight": "Plate, Light",
+			"local_notes": "Don: 9 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "2",
 			"tags": [
 				"Pot Helm"
@@ -8329,14 +8311,14 @@
 				"extended_value": 210,
 				"weight": "2.8 lb",
 				"extended_weight": "2.8 lb"
-			},
-			"reference_highlight": "Plate, Light"
+			}
 		},
 		{
 			"id": "eq4FLzmH6-khjku_D",
 			"description": "Plate, Light Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "DR: 3; Don: 45 secs; Holdout: -3; Reaction Pen.-2",
+			"reference_highlight": "Plate, Light",
+			"local_notes": "Don: 45 secs; Holdout: -3; Reaction Pen.-2",
 			"tech_level": "4",
 			"tags": [
 				"Body Armor"
@@ -8359,14 +8341,14 @@
 				"extended_value": 1000,
 				"weight": "8 lb",
 				"extended_weight": "8 lb"
-			},
-			"reference_highlight": "Plate, Light"
+			}
 		},
 		{
 			"id": "eU8gXroF2Ar9g2s52",
 			"description": "Plate, Medium Arm Armor",
 			"reference": "LTIA8",
-			"local_notes": "DR: 6; Don: 23 secs; Holdout: -5; Reaction Pen.-1",
+			"reference_highlight": "Plate, Medium",
+			"local_notes": "Don: 23 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -8389,14 +8371,14 @@
 				"extended_value": 1250,
 				"weight": "10 lb",
 				"extended_weight": "10 lb"
-			},
-			"reference_highlight": "Plate, Medium"
+			}
 		},
 		{
 			"id": "eSgqI8fP4XLtHv1XE",
 			"description": "Plate, Medium Bascinet",
 			"reference": "LTIA14",
-			"local_notes": "DR: 6; Don: 11 secs; Holdout: -6; Reaction Pen.-1",
+			"reference_highlight": "Plate, Medium",
+			"local_notes": "Don: 11 secs; Holdout: -6; Reaction Pen.-1",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -8419,14 +8401,14 @@
 				"extended_value": 625,
 				"weight": "5 lb",
 				"extended_weight": "5 lb"
-			},
-			"reference_highlight": "Plate, Medium"
+			}
 		},
 		{
 			"id": "eTVRaLKRUOad-KLqv",
 			"description": "Plate, Medium Bascinet, Padded",
 			"reference": "LTIA14",
-			"local_notes": "DR: 7; Don: 11 secs; Holdout: -6; Reaction Pen.-1",
+			"reference_highlight": "Plate, Medium",
+			"local_notes": "Don: 11 secs; Holdout: -6; Reaction Pen.-1",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -8449,14 +8431,14 @@
 				"extended_value": 638,
 				"weight": "5.2 lb",
 				"extended_weight": "5.2 lb"
-			},
-			"reference_highlight": "Plate, Medium"
+			}
 		},
 		{
 			"id": "eB4qsIQ65iOFalimp",
 			"description": "Plate, Medium Chest Armor",
 			"reference": "LTIA6",
-			"local_notes": "DR: 6; Don: 34 secs; Holdout: -5; Reaction Pen.-2",
+			"reference_highlight": "Plate, Medium",
+			"local_notes": "Don: 34 secs; Holdout: -5; Reaction Pen.-2",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -8479,14 +8461,14 @@
 				"extended_value": 1875,
 				"weight": "15 lb",
 				"extended_weight": "15 lb"
-			},
-			"reference_highlight": "Plate, Medium"
+			}
 		},
 		{
 			"id": "eBqY20s40LSNgJ5IP",
 			"description": "Plate, Medium Full Helm",
 			"reference": "LTIA14",
-			"local_notes": "DR: 6; Don: 14 secs; Holdout: -6; Reaction Pen.-1",
+			"reference_highlight": "Plate, Medium",
+			"local_notes": "Don: 14 secs; Holdout: -6; Reaction Pen.-1",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -8510,14 +8492,14 @@
 				"extended_value": 750,
 				"weight": "6 lb",
 				"extended_weight": "6 lb"
-			},
-			"reference_highlight": "Plate, Medium"
+			}
 		},
 		{
 			"id": "eHZgRpXXrzpDqxppa",
 			"description": "Plate, Medium Full Helm, Padded",
 			"reference": "LTIA14",
-			"local_notes": "DR: 7; Don: 14 secs; Holdout: -6; Reaction Pen.-1",
+			"reference_highlight": "Plate, Medium",
+			"local_notes": "Don: 14 secs; Holdout: -6; Reaction Pen.-1",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -8541,14 +8523,14 @@
 				"extended_value": 765,
 				"weight": "7.8 lb",
 				"extended_weight": "7.8 lb"
-			},
-			"reference_highlight": "Plate, Medium"
+			}
 		},
 		{
 			"id": "ep_vtRtAlV0LJUH4h",
 			"description": "Plate, Medium Greathelm",
 			"reference": "LTIA14",
-			"local_notes": "DR: 6; Don: 16 secs; Holdout: 0; Reaction Pen.-2",
+			"reference_highlight": "Plate, Medium",
+			"local_notes": "Don: 16 secs; Holdout: 0; Reaction Pen.-2",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -8585,14 +8567,14 @@
 				"extended_value": 875,
 				"weight": "7 lb",
 				"extended_weight": "7 lb"
-			},
-			"reference_highlight": "Plate, Medium"
+			}
 		},
 		{
 			"id": "eimn0d1MaS7YhKnWy",
 			"description": "Plate, Medium Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "DR: 6; Don: 3 secs; Holdout: -5; Reaction Pen.-1",
+			"reference_highlight": "Plate, Medium",
+			"local_notes": "Don: 3 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -8615,14 +8597,14 @@
 				"extended_value": 125,
 				"weight": "1 lb",
 				"extended_weight": "1 lb"
-			},
-			"reference_highlight": "Plate, Medium"
+			}
 		},
 		{
 			"id": "eZWYtiMbNI35xOp5O",
 			"description": "Plate, Medium Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "DR: 6; Don: 45 secs; Holdout: -5; Reaction Pen.-1",
+			"reference_highlight": "Plate, Medium",
+			"local_notes": "Don: 45 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -8645,14 +8627,14 @@
 				"extended_value": 2500,
 				"weight": "20 lb",
 				"extended_weight": "20 lb"
-			},
-			"reference_highlight": "Plate, Medium"
+			}
 		},
 		{
 			"id": "eQpccQp1v_uzxzArM",
 			"description": "Plate, Medium Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "DR: 6; Don: 3 secs; Holdout: -6; Reaction Pen.-1",
+			"reference_highlight": "Plate, Medium",
+			"local_notes": "Don: 3 secs; Holdout: -6; Reaction Pen.-1",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -8675,14 +8657,14 @@
 				"extended_value": 125,
 				"weight": "1 lb",
 				"extended_weight": "1 lb"
-			},
-			"reference_highlight": "Plate, Medium"
+			}
 		},
 		{
 			"id": "eOqepFwku-XinkaNS",
 			"description": "Plate, Medium Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "DR: 6; Don: 9 secs; Holdout: -6; Reaction Pen.-1",
+			"reference_highlight": "Plate, Medium",
+			"local_notes": "Don: 9 secs; Holdout: -6; Reaction Pen.-1",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -8705,14 +8687,14 @@
 				"extended_value": 500,
 				"weight": "4 lb",
 				"extended_weight": "4 lb"
-			},
-			"reference_highlight": "Plate, Medium"
+			}
 		},
 		{
 			"id": "eF_SWl1Q1gh-tLy0_",
 			"description": "Plate, Medium Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "DR: 7; Don: 9 secs; Holdout: -6; Reaction Pen.-1",
+			"reference_highlight": "Plate, Medium",
+			"local_notes": "Don: 9 secs; Holdout: -6; Reaction Pen.-1",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -8735,14 +8717,14 @@
 				"extended_value": 510,
 				"weight": "5.2 lb",
 				"extended_weight": "5.2 lb"
-			},
-			"reference_highlight": "Plate, Medium"
+			}
 		},
 		{
 			"id": "eyVvxYjv3gQTO6zY5",
 			"description": "Plate, Medium Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "DR: 6; Don: 45 secs; Holdout: -5; Reaction Pen.-2",
+			"reference_highlight": "Plate, Medium",
+			"local_notes": "Don: 45 secs; Holdout: -5; Reaction Pen.-2",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -8766,14 +8748,13 @@
 				"extended_value": 2500,
 				"weight": "20 lb",
 				"extended_weight": "20 lb"
-			},
-			"reference_highlight": "Plate, Medium"
+			}
 		},
 		{
 			"id": "ecX489d3HkDaxCgzV",
 			"description": "Sabatons, Light Plate ",
 			"reference": "LTIA16",
-			"local_notes": "DR: 3; Don: 10 secs; Holdout: -4",
+			"local_notes": "Don: 10 secs; Holdout: -4",
 			"tech_level": "4",
 			"tags": [
 				"Footwear"
@@ -8801,7 +8782,7 @@
 			"id": "euszDR29gjpuJCuGx",
 			"description": "Sabatons, Light Segmented ",
 			"reference": "LTIA16",
-			"local_notes": "DR: 3; Don: 10 secs; Holdout: -4",
+			"local_notes": "Don: 10 secs; Holdout: -4",
 			"tech_level": "3",
 			"tags": [
 				"Footwear"
@@ -8829,7 +8810,7 @@
 			"id": "efZ1g8nFsdzNr9dsR",
 			"description": "Sabatons, Medium Plate ",
 			"reference": "LTIA16",
-			"local_notes": "DR: 6; Don: 10 secs; Holdout: -6",
+			"local_notes": "Don: 10 secs; Holdout: -6",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -8858,7 +8839,7 @@
 			"id": "eQSlhhXKSGEOEYR6K",
 			"description": "Sabatons, Medium Segmented ",
 			"reference": "LTIA16",
-			"local_notes": "DR: 4; Don: 10 secs; Holdout: -5",
+			"local_notes": "Don: 10 secs; Holdout: -5",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -8887,7 +8868,7 @@
 			"id": "eHeqzBzX8BvvEYC4T",
 			"description": "Sandals ",
 			"reference": "LTIA16",
-			"local_notes": "DR: 1; Don: 10 secs; Holdout: -2; Flexible and susceptible to blunt trauma (p. B379); DR applies to underside only.",
+			"local_notes": "Don: 10 secs; Holdout: -2; Flexible and susceptible to blunt trauma (p. B379); DR applies to underside only.",
 			"tech_level": "0",
 			"tags": [
 				"Footwear"
@@ -8915,7 +8896,7 @@
 			"id": "eluvVD7j_wcbJxlCb",
 			"description": "Sandals, Hobnailed ",
 			"reference": "LTIA16",
-			"local_notes": "DR: 1; Don: 10 secs; Holdout: -2; Flexible and susceptible to blunt trauma (p. B379); DR applies to underside only; Lets wearer ignore -2 to attacks and -1 to defenses for bad terrain.",
+			"local_notes": "Don: 10 secs; Holdout: -2; Flexible and susceptible to blunt trauma (p. B379); DR applies to underside only; Lets wearer ignore -2 to attacks and -1 to defenses for bad terrain.",
 			"tech_level": "1",
 			"tags": [
 				"Footwear"
@@ -8943,7 +8924,7 @@
 			"id": "eMXjmd-ADIy8x6Phw",
 			"description": "Scale, Heavy Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "DR: 5; Don: 23 secs; Holdout: -6; Reaction Pen.-2",
+			"local_notes": "Don: 23 secs; Holdout: -6; Reaction Pen.-2",
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
@@ -8972,7 +8953,7 @@
 			"id": "eDVDLpJZFw2VME1fD",
 			"description": "Scale, Heavy Chest Armor",
 			"reference": "LTIA6",
-			"local_notes": "DR: 5; Don: 23 secs; Holdout: -6; Reaction Pen.-2",
+			"local_notes": "Don: 23 secs; Holdout: -6; Reaction Pen.-2",
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
@@ -9001,7 +8982,7 @@
 			"id": "e-BjR07h0b9k0Oy3l",
 			"description": "Scale, Heavy Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "DR: 5; Don: 3 secs; Holdout: -6; Reaction Pen.-1",
+			"local_notes": "Don: 3 secs; Holdout: -6; Reaction Pen.-1",
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
@@ -9030,7 +9011,7 @@
 			"id": "eIImVdjJvldhfxwLN",
 			"description": "Scale, Heavy Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "DR: 5; Don: 6 secs; Holdout: -7; Reaction Pen.-1",
+			"local_notes": "Don: 6 secs; Holdout: -7; Reaction Pen.-1",
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
@@ -9059,7 +9040,7 @@
 			"id": "exAfTgYIySnecu67O",
 			"description": "Scale, Heavy Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "DR: 6; Don: 6 secs; Holdout: -7; Reaction Pen.-1",
+			"local_notes": "Don: 6 secs; Holdout: -7; Reaction Pen.-1",
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
@@ -9088,7 +9069,7 @@
 			"id": "eIkvGk7LHLOhOJ7fE",
 			"description": "Scale, Heavy Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "DR: 5; Don: 30 secs; Holdout: -6; Reaction Pen.-2",
+			"local_notes": "Don: 30 secs; Holdout: -6; Reaction Pen.-2",
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
@@ -9122,7 +9103,8 @@
 			"id": "eInlCNpHFJATpgf-F",
 			"description": "Scale, Light Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "DR: 3; Don: 23 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
+			"reference_highlight": "Scale, Light",
+			"local_notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"tags": [
 				"Body Armor"
@@ -9147,20 +9129,20 @@
 				}
 			],
 			"quantity": 1,
+			"equipped": true,
 			"calc": {
 				"value": 80,
 				"extended_value": 80,
 				"weight": "4 lb",
 				"extended_weight": "4 lb"
-			},
-			"reference_highlight": "Scale, Light",
-			"equipped": true
+			}
 		},
 		{
 			"id": "eV9pLntTjHGa9INll",
 			"description": "Scale, Light Arm Armor",
 			"reference": "LTIA7",
-			"local_notes": "DR: 3; Don: 15 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. crushing.",
+			"reference_highlight": "Scale, Light",
+			"local_notes": "Don: 15 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"tags": [
 				"Limb Armor"
@@ -9190,14 +9172,14 @@
 				"extended_value": 160,
 				"weight": "8 lb",
 				"extended_weight": "8 lb"
-			},
-			"reference_highlight": "Scale, Light"
+			}
 		},
 		{
 			"id": "eueJbKkWLyQaVuzGx",
 			"description": "Scale, Light Bascinet",
 			"reference": "LTIA14",
-			"local_notes": "DR: 3; Don: 8 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
+			"reference_highlight": "Scale, Light",
+			"local_notes": "Don: 8 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"tags": [
 				"Bascinet"
@@ -9227,14 +9209,14 @@
 				"extended_value": 80,
 				"weight": "4 lb",
 				"extended_weight": "4 lb"
-			},
-			"reference_highlight": "Scale, Light"
+			}
 		},
 		{
 			"id": "ecRkAiTcRaZzsqZ6D",
 			"description": "Scale, Light Bascinet, Padded",
 			"reference": "LTIA14",
-			"local_notes": "DR: 4; Don: 8 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
+			"reference_highlight": "Scale, Light",
+			"local_notes": "Don: 8 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"tags": [
 				"Bascinet"
@@ -9263,14 +9245,14 @@
 				"extended_value": 93,
 				"weight": "4.2 lb",
 				"extended_weight": "4.2 lb"
-			},
-			"reference_highlight": "Scale, Light"
+			}
 		},
 		{
 			"id": "eWgVQ72kUVCiHuUXm",
 			"description": "Scale, Light Chest Armor",
 			"reference": "LTIA5",
-			"local_notes": "DR: 3; Don: 23 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
+			"reference_highlight": "Scale, Light",
+			"local_notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"tags": [
 				"Body Armor"
@@ -9300,14 +9282,14 @@
 				"extended_value": 240,
 				"weight": "12 lb",
 				"extended_weight": "12 lb"
-			},
-			"reference_highlight": "Scale, Light"
+			}
 		},
 		{
 			"id": "eM05bTktNP1mmKvf7",
 			"description": "Scale, Light Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "DR: 3; Don: 3 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. crushing.",
+			"reference_highlight": "Scale, Light",
+			"local_notes": "Don: 3 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"tags": [
 				"Groin Armor"
@@ -9337,14 +9319,14 @@
 				"extended_value": 16,
 				"weight": "0.8 lb",
 				"extended_weight": "0.8 lb"
-			},
-			"reference_highlight": "Scale, Light"
+			}
 		},
 		{
 			"id": "eJrQfgf3JY2K_Xlm2",
 			"description": "Scale, Light Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "DR: 3; Don: 30 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. crushing.",
+			"reference_highlight": "Scale, Light",
+			"local_notes": "Don: 30 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"tags": [
 				"Limb Armor"
@@ -9374,14 +9356,14 @@
 				"extended_value": 320,
 				"weight": "16 lb",
 				"extended_weight": "16 lb"
-			},
-			"reference_highlight": "Scale, Light"
+			}
 		},
 		{
 			"id": "e1xZcuI0APh-WdpPe",
 			"description": "Scale, Light Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "DR: 3; Don: 3 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
+			"reference_highlight": "Scale, Light",
+			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"tags": [
 				"Neck Armor"
@@ -9411,14 +9393,14 @@
 				"extended_value": 16,
 				"weight": "0.8 lb",
 				"extended_weight": "0.8 lb"
-			},
-			"reference_highlight": "Scale, Light"
+			}
 		},
 		{
 			"id": "eyPMigE5TtFBXNRSm",
 			"description": "Scale, Light Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "DR: 3; Don: 6 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
+			"reference_highlight": "Scale, Light",
+			"local_notes": "Don: 6 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"tags": [
 				"Pot Helm"
@@ -9448,14 +9430,14 @@
 				"extended_value": 64,
 				"weight": "3.2 lb",
 				"extended_weight": "3.2 lb"
-			},
-			"reference_highlight": "Scale, Light"
+			}
 		},
 		{
 			"id": "eT4N9iY28y7o6jcGc",
 			"description": "Scale, Light Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "DR: 4; Don: 6 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
+			"reference_highlight": "Scale, Light",
+			"local_notes": "Don: 6 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"tags": [
 				"Pot Helm"
@@ -9485,14 +9467,14 @@
 				"extended_value": 74,
 				"weight": "4.4 lb",
 				"extended_weight": "4.4 lb"
-			},
-			"reference_highlight": "Scale, Light"
+			}
 		},
 		{
 			"id": "eHtBmi24bkKaPXYCa",
 			"description": "Scale, Light Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "DR: 3; Don: 30 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
+			"reference_highlight": "Scale, Light",
+			"local_notes": "Don: 30 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"tags": [
 				"Body Armor"
@@ -9519,20 +9501,20 @@
 				}
 			],
 			"quantity": 1,
+			"equipped": true,
 			"calc": {
 				"value": 320,
 				"extended_value": 320,
 				"weight": "16 lb",
 				"extended_weight": "16 lb"
-			},
-			"reference_highlight": "Scale, Light",
-			"equipped": true
+			}
 		},
 		{
 			"id": "eKHaM65tTQquvHfTA",
 			"description": "Scale, Medium Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "DR: 4; Don: 23 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. crushing.",
+			"reference_highlight": "Scale, Medium",
+			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
@@ -9558,20 +9540,20 @@
 				}
 			],
 			"quantity": 1,
+			"equipped": true,
 			"calc": {
 				"value": 138,
 				"extended_value": 138,
 				"weight": "7 lb",
 				"extended_weight": "7 lb"
-			},
-			"reference_highlight": "Scale, Medium",
-			"equipped": true
+			}
 		},
 		{
 			"id": "ediSlzetGlHz5VPkK",
 			"description": "Scale, Medium Arm Armor",
 			"reference": "LTIA7",
-			"local_notes": "DR: 5; Don: 15 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
+			"reference_highlight": "Scale, Medium",
+			"local_notes": "Don: 15 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
@@ -9602,14 +9584,14 @@
 				"extended_value": 275,
 				"weight": "14 lb",
 				"extended_weight": "14 lb"
-			},
-			"reference_highlight": "Scale, Medium"
+			}
 		},
 		{
 			"id": "ejQkt1FZJhIab-EUJ",
 			"description": "Scale, Medium Bascinet",
 			"reference": "LTIA14",
-			"local_notes": "DR: 4; Don: 8 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. crushing.",
+			"reference_highlight": "Scale, Medium",
+			"local_notes": "Don: 8 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
@@ -9640,14 +9622,14 @@
 				"extended_value": 138,
 				"weight": "7 lb",
 				"extended_weight": "7 lb"
-			},
-			"reference_highlight": "Scale, Medium"
+			}
 		},
 		{
 			"id": "e9l4x1i0lcA_9j7z0",
 			"description": "Scale, Medium Bascinet, Padded",
 			"reference": "LTIA14",
-			"local_notes": "DR: 5; Don: 8 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. crushing.",
+			"reference_highlight": "Scale, Medium",
+			"local_notes": "Don: 8 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
@@ -9678,14 +9660,14 @@
 				"extended_value": 151,
 				"weight": "7.2 lb",
 				"extended_weight": "7.2 lb"
-			},
-			"reference_highlight": "Scale, Medium"
+			}
 		},
 		{
 			"id": "ePqMK0y3IqW5TsApE",
 			"description": "Scale, Medium Chest Armor",
 			"reference": "LTIA5",
-			"local_notes": "DR: 4; Don: 23 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. crushing.",
+			"reference_highlight": "Scale, Medium",
+			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
@@ -9716,14 +9698,14 @@
 				"extended_value": 413,
 				"weight": "21 lb",
 				"extended_weight": "21 lb"
-			},
-			"reference_highlight": "Scale, Medium"
+			}
 		},
 		{
 			"id": "eiWPwRu2oMKLdjmkh",
 			"description": "Scale, Medium Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "DR: 4; Don: 3 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
+			"reference_highlight": "Scale, Medium",
+			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
@@ -9754,14 +9736,14 @@
 				"extended_value": 28,
 				"weight": "1.4 lb",
 				"extended_weight": "1.4 lb"
-			},
-			"reference_highlight": "Scale, Medium"
+			}
 		},
 		{
 			"id": "e5eMN8Q0jGQMUV1KQ",
 			"description": "Scale, Medium Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "DR: 4; Don: 30 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
+			"reference_highlight": "Scale, Medium",
+			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
@@ -9792,14 +9774,14 @@
 				"extended_value": 550,
 				"weight": "28 lb",
 				"extended_weight": "28 lb"
-			},
-			"reference_highlight": "Scale, Medium"
+			}
 		},
 		{
 			"id": "e9xGHIfd-iEwpZDG6",
 			"description": "Scale, Medium Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "DR: 4; Don: 3 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. crushing.",
+			"reference_highlight": "Scale, Medium",
+			"local_notes": "Don: 3 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
@@ -9830,14 +9812,14 @@
 				"extended_value": 28,
 				"weight": "1.4 lb",
 				"extended_weight": "1.4 lb"
-			},
-			"reference_highlight": "Scale, Medium"
+			}
 		},
 		{
 			"id": "eGO1Mu7zXur3_R4OX",
 			"description": "Scale, Medium Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "DR: 4; Don: 6 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. crushing.",
+			"reference_highlight": "Scale, Medium",
+			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
@@ -9868,14 +9850,13 @@
 				"extended_value": 110,
 				"weight": "5.6 lb",
 				"extended_weight": "5.6 lb"
-			},
-			"reference_highlight": "Scale, Medium"
+			}
 		},
 		{
 			"id": "eE6QMo6IVPQLFjnsj",
 			"description": "Scale, Medium Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "DR: 5; Don: 6 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. crushing.",
+			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
@@ -9912,7 +9893,8 @@
 			"id": "e_688YS_xwW2sOaG_",
 			"description": "Scale, Medium Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "DR: 4; Don: 30 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. crushing.",
+			"reference_highlight": "Scale, Medium",
+			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
@@ -9940,20 +9922,20 @@
 				}
 			],
 			"quantity": 1,
+			"equipped": true,
 			"calc": {
 				"value": 550,
 				"extended_value": 550,
 				"weight": "28 lb",
 				"extended_weight": "28 lb"
-			},
-			"reference_highlight": "Scale, Medium",
-			"equipped": true
+			}
 		},
 		{
 			"id": "e41EAFyohdSBaDnTZ",
 			"description": "Segmented Plate, Heavy Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "DR: 5; Don: 34 secs; Holdout: -5; Reaction Pen.-2",
+			"reference_highlight": "Segmented Plate, Heavy",
+			"local_notes": "Don: 34 secs; Holdout: -5; Reaction Pen.-2",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -9976,14 +9958,14 @@
 				"extended_value": 300,
 				"weight": "8 lb",
 				"extended_weight": "8 lb"
-			},
-			"reference_highlight": "Segmented Plate, Heavy"
+			}
 		},
 		{
 			"id": "eNwSHF3PAzU8PpITj",
 			"description": "Segmented Plate, Heavy Chest Armor",
 			"reference": "LTIA6",
-			"local_notes": "DR: 5; Don: 34 secs; Holdout: -5; Reaction Pen.-2",
+			"reference_highlight": "Segmented Plate, Heavy",
+			"local_notes": "Don: 34 secs; Holdout: -5; Reaction Pen.-2",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -10006,14 +9988,14 @@
 				"extended_value": 900,
 				"weight": "24 lb",
 				"extended_weight": "24 lb"
-			},
-			"reference_highlight": "Segmented Plate, Heavy"
+			}
 		},
 		{
 			"id": "efschvai3wvmBvBI0",
 			"description": "Segmented Plate, Heavy Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "DR: 5; Don: 45 secs; Holdout: -5; Reaction Pen.-2",
+			"reference_highlight": "Segmented Plate, Heavy",
+			"local_notes": "Don: 45 secs; Holdout: -5; Reaction Pen.-2",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -10037,14 +10019,14 @@
 				"extended_value": 1200,
 				"weight": "32 lb",
 				"extended_weight": "32 lb"
-			},
-			"reference_highlight": "Segmented Plate, Heavy"
+			}
 		},
 		{
 			"id": "egyBoFUfG5LApFnpl",
 			"description": "Segmented Plate, Light Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "DR: 3; Don: 34 secs; Holdout: -3; Reaction Pen.-2",
+			"reference_highlight": "Segmented Plate, Light",
+			"local_notes": "Don: 34 secs; Holdout: -3; Reaction Pen.-2",
 			"tech_level": "2",
 			"tags": [
 				"Body Armor"
@@ -10066,14 +10048,14 @@
 				"extended_value": 150,
 				"weight": "4 lb",
 				"extended_weight": "4 lb"
-			},
-			"reference_highlight": "Segmented Plate, Light"
+			}
 		},
 		{
 			"id": "e0PTX0iu7j42pisvr",
 			"description": "Segmented Plate, Light Arm Armor",
 			"reference": "LTIA8",
-			"local_notes": "DR: 3; Don: 23 secs; Holdout: -3; Reaction Pen.-1",
+			"reference_highlight": "Segmented Plate, Light",
+			"local_notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "2",
 			"tags": [
 				"Limb Armor"
@@ -10095,14 +10077,14 @@
 				"extended_value": 300,
 				"weight": "8 lb",
 				"extended_weight": "8 lb"
-			},
-			"reference_highlight": "Segmented Plate, Light"
+			}
 		},
 		{
 			"id": "e93oswSEv2yhtD9Vd",
 			"description": "Segmented Plate, Light Chest Armor",
 			"reference": "LTIA6",
-			"local_notes": "DR: 3; Don: 34 secs; Holdout: -3; Reaction Pen.-2",
+			"reference_highlight": "Segmented Plate, Light",
+			"local_notes": "Don: 34 secs; Holdout: -3; Reaction Pen.-2",
 			"tech_level": "2",
 			"tags": [
 				"Body Armor"
@@ -10124,14 +10106,14 @@
 				"extended_value": 450,
 				"weight": "12 lb",
 				"extended_weight": "12 lb"
-			},
-			"reference_highlight": "Segmented Plate, Light"
+			}
 		},
 		{
 			"id": "eRl5wBIgYZid8aUHX",
 			"description": "Segmented Plate, Light Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "DR: 3; Don: 45 secs; Holdout: -3; Reaction Pen.-1",
+			"reference_highlight": "Segmented Plate, Light",
+			"local_notes": "Don: 45 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "2",
 			"tags": [
 				"Limb Armor"
@@ -10153,14 +10135,14 @@
 				"extended_value": 600,
 				"weight": "16 lb",
 				"extended_weight": "16 lb"
-			},
-			"reference_highlight": "Segmented Plate, Light"
+			}
 		},
 		{
 			"id": "eNKr5lN8xEyENHaiR",
 			"description": "Segmented Plate, Light Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "DR: 3; Don: 3 secs; Holdout: -4; Reaction Pen.-1",
+			"reference_highlight": "Segmented Plate, Light",
+			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "2",
 			"tags": [
 				"Neck Armor"
@@ -10182,14 +10164,14 @@
 				"extended_value": 30,
 				"weight": "0.8 lb",
 				"extended_weight": "0.8 lb"
-			},
-			"reference_highlight": "Segmented Plate, Light"
+			}
 		},
 		{
 			"id": "eF_jnAdG1YlykDoEZ",
 			"description": "Segmented Plate, Light Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "DR: 3; Don: 45 secs; Holdout: -3; Reaction Pen.-2",
+			"reference_highlight": "Segmented Plate, Light",
+			"local_notes": "Don: 45 secs; Holdout: -3; Reaction Pen.-2",
 			"tech_level": "2",
 			"tags": [
 				"Body Armor"
@@ -10212,14 +10194,14 @@
 				"extended_value": 600,
 				"weight": "16 lb",
 				"extended_weight": "16 lb"
-			},
-			"reference_highlight": "Segmented Plate, Light"
+			}
 		},
 		{
 			"id": "eElThcQrhgSlvInYE",
 			"description": "Segmented Plate, Medium Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "DR: 4; Don: 34 secs; Holdout: -4; Reaction Pen.-2",
+			"reference_highlight": "Segmented Plate, Medium",
+			"local_notes": "Don: 34 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -10242,14 +10224,14 @@
 				"extended_value": 225,
 				"weight": "6 lb",
 				"extended_weight": "6 lb"
-			},
-			"reference_highlight": "Segmented Plate, Medium"
+			}
 		},
 		{
 			"id": "eotWFK_7_1sswtH74",
 			"description": "Segmented Plate, Medium Arm Armor",
 			"reference": "LTIA8",
-			"local_notes": "DR: 4; Don: 23 secs; Holdout: -4; Reaction Pen.-1",
+			"reference_highlight": "Segmented Plate, Medium",
+			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -10272,14 +10254,14 @@
 				"extended_value": 450,
 				"weight": "12 lb",
 				"extended_weight": "12 lb"
-			},
-			"reference_highlight": "Segmented Plate, Medium"
+			}
 		},
 		{
 			"id": "eTNKzCK4BlFqPe0lm",
 			"description": "Segmented Plate, Medium Chest Armor",
 			"reference": "LTIA6",
-			"local_notes": "DR: 4; Don: 34 secs; Holdout: -4; Reaction Pen.-2",
+			"reference_highlight": "Segmented Plate, Medium",
+			"local_notes": "Don: 34 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -10302,14 +10284,14 @@
 				"extended_value": 675,
 				"weight": "18 lb",
 				"extended_weight": "18 lb"
-			},
-			"reference_highlight": "Segmented Plate, Medium"
+			}
 		},
 		{
 			"id": "e_sIKH4GUMH9UP6iz",
 			"description": "Segmented Plate, Medium Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "DR: 4; Don: 45 secs; Holdout: -4; Reaction Pen.-1",
+			"reference_highlight": "Segmented Plate, Medium",
+			"local_notes": "Don: 45 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -10332,14 +10314,14 @@
 				"extended_value": 900,
 				"weight": "24 lb",
 				"extended_weight": "24 lb"
-			},
-			"reference_highlight": "Segmented Plate, Medium"
+			}
 		},
 		{
 			"id": "eEvehkdxlR5AgyyYh",
 			"description": "Segmented Plate, Medium Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "DR: 4; Don: 3 secs; Holdout: -5; Reaction Pen.-1",
+			"reference_highlight": "Segmented Plate, Medium",
+			"local_notes": "Don: 3 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -10362,14 +10344,14 @@
 				"extended_value": 45,
 				"weight": "1.2 lb",
 				"extended_weight": "1.2 lb"
-			},
-			"reference_highlight": "Segmented Plate, Medium"
+			}
 		},
 		{
 			"id": "egokUQ1Ycemmd59A6",
 			"description": "Segmented Plate, Medium Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "DR: 4; Don: 45 secs; Holdout: -4; Reaction Pen.-2",
+			"reference_highlight": "Segmented Plate, Medium",
+			"local_notes": "Don: 45 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -10393,14 +10375,13 @@
 				"extended_value": 900,
 				"weight": "24 lb",
 				"extended_weight": "24 lb"
-			},
-			"reference_highlight": "Segmented Plate, Medium"
+			}
 		},
 		{
 			"id": "eDBbcETSyRQ1HZJFH",
 			"description": "Shoes ",
 			"reference": "LTIA16",
-			"local_notes": "DR: 1; Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
+			"local_notes": "Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
 			"tech_level": "1",
 			"tags": [
 				"Footwear"
@@ -10428,7 +10409,7 @@
 			"id": "eEVj7rSYpu5Jt4-yF",
 			"description": "Shoes, Hobnailed ",
 			"reference": "LTIA16",
-			"local_notes": "DR: 1; Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling; Lets wearer ignore -2 to attacks and -1 to defenses for bad terrain.",
+			"local_notes": "Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling; Lets wearer ignore -2 to attacks and -1 to defenses for bad terrain.",
 			"tech_level": "1",
 			"tags": [
 				"Footwear"
@@ -10456,7 +10437,7 @@
 			"id": "eJhyyjnFo7KmWVJTd",
 			"description": "Shoes, Medium Leather ",
 			"reference": "LTIA16",
-			"local_notes": "DR: 2; Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
+			"local_notes": "Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
 			"tech_level": "1",
 			"tags": [
 				"Footwear"
@@ -10492,7 +10473,7 @@
 			"id": "e5oPk4D93B4R-kmaI",
 			"description": "Sollerets, Fine Mail ",
 			"reference": "LTIA16",
-			"local_notes": "DR: 4;  Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": " Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -10529,7 +10510,7 @@
 			"id": "eP-s_FvhbTPwA79h5",
 			"description": "Sollerets, Heavy Mail ",
 			"reference": "LTIA16",
-			"local_notes": "DR: 5; Don: 6 secs; Holdout: -4; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "Don: 6 secs; Holdout: -4; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -10566,7 +10547,7 @@
 			"id": "evSioPxb1AeVS_V4J",
 			"description": "Sollerets, Light Mail ",
 			"reference": "LTIA16",
-			"local_notes": "DR: 3; Don: 6 secs; Holdout: -2; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "Don: 6 secs; Holdout: -2; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
 				"Footwear"
@@ -10602,7 +10583,7 @@
 			"id": "ea8f_-UbJnObc_qCO",
 			"description": "Sollerets, Light Scale ",
 			"reference": "LTIA16",
-			"local_notes": "DR: 3; Don: 10 secs; Holdout: -4; -1 DR vs. crushing.",
+			"local_notes": "Don: 10 secs; Holdout: -4; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"tags": [
 				"Footwear"
@@ -10638,7 +10619,8 @@
 			"id": "eJCPVLRUSXkOWzrU9",
 			"description": "Straw Chest Armor",
 			"reference": "LTIA5",
-			"local_notes": "DR: 2; Don: 23 secs; Holdout: -9; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433); treat as resistant.",
+			"reference_highlight": "Straw",
+			"local_notes": "Don: 23 secs; Holdout: -9; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433); treat as resistant.",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -10660,14 +10642,14 @@
 				"extended_value": 38,
 				"weight": "15 lb",
 				"extended_weight": "15 lb"
-			},
-			"reference_highlight": "Straw"
+			}
 		},
 		{
 			"id": "eHWDufm50qX7ve6XM",
 			"description": "Straw Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "DR: 2; Don: 30 secs; Holdout: -9; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433); treat as resistant.",
+			"reference_highlight": "Straw",
+			"local_notes": "Don: 30 secs; Holdout: -9; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433); treat as resistant.",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -10690,14 +10672,14 @@
 				"extended_value": 50,
 				"weight": "20 lb",
 				"extended_weight": "20 lb"
-			},
-			"reference_highlight": "Straw"
+			}
 		},
 		{
 			"id": "eXqk6jUDaoovt3TX2",
 			"description": "Wood Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "DR: 3; Don: 23 secs; Holdout: -8; Reaction Pen.-2; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
+			"reference_highlight": "Wood",
+			"local_notes": "Don: 23 secs; Holdout: -8; Reaction Pen.-2; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -10719,14 +10701,14 @@
 				"extended_value": 25,
 				"weight": "7.5 lb",
 				"extended_weight": "7.5 lb"
-			},
-			"reference_highlight": "Wood"
+			}
 		},
 		{
 			"id": "evbmfkuOcotZ1SaFH",
 			"description": "Wood Arm Armor",
 			"reference": "LTIA7",
-			"local_notes": "DR: 3; Don: 15 secs; Holdout: -8; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
+			"reference_highlight": "Wood",
+			"local_notes": "Don: 15 secs; Holdout: -8; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
 			"tech_level": "0",
 			"tags": [
 				"Limb Armor"
@@ -10748,14 +10730,14 @@
 				"extended_value": 50,
 				"weight": "15 lb",
 				"extended_weight": "15 lb"
-			},
-			"reference_highlight": "Wood"
+			}
 		},
 		{
 			"id": "eRjTsahXPehU4NPAr",
 			"description": "Wood Bascinet",
 			"reference": "LTIA14",
-			"local_notes": "DR: 3; Don: 8 secs; Holdout: -9; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
+			"reference_highlight": "Wood",
+			"local_notes": "Don: 8 secs; Holdout: -9; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
 			"tech_level": "0",
 			"tags": [
 				"Bascinet"
@@ -10777,14 +10759,14 @@
 				"extended_value": 25,
 				"weight": "7.5 lb",
 				"extended_weight": "7.5 lb"
-			},
-			"reference_highlight": "Wood"
+			}
 		},
 		{
 			"id": "e3CfPmi1OTlf4bBlh",
 			"description": "Wood Bascinet, Padded",
 			"reference": "LTIA14",
-			"local_notes": "DR: 4; Don: 8 secs; Holdout: -9; Reaction Pen.-1",
+			"reference_highlight": "Wood",
+			"local_notes": "Don: 8 secs; Holdout: -9; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Bascinet"
@@ -10806,14 +10788,14 @@
 				"extended_value": 38,
 				"weight": "7.7 lb",
 				"extended_weight": "7.7 lb"
-			},
-			"reference_highlight": "Wood"
+			}
 		},
 		{
 			"id": "eJsFACim5oxpPKgDL",
 			"description": "Wood Chest Armor",
 			"reference": "LTIA5",
-			"local_notes": "DR: 3; Don: 23 secs; Holdout: -8; Reaction Pen.-2; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
+			"reference_highlight": "Wood",
+			"local_notes": "Don: 23 secs; Holdout: -8; Reaction Pen.-2; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -10835,14 +10817,14 @@
 				"extended_value": 75,
 				"weight": "22.5 lb",
 				"extended_weight": "22.5 lb"
-			},
-			"reference_highlight": "Wood"
+			}
 		},
 		{
 			"id": "erIHG_oNy3N-8mtKA",
 			"description": "Wood Full Helm",
 			"reference": "LTIA14",
-			"local_notes": "DR: 3; Don: 9 secs; Holdout: -9; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
+			"reference_highlight": "Wood",
+			"local_notes": "Don: 9 secs; Holdout: -9; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
 			"tech_level": "0",
 			"tags": [
 				"Full Helm"
@@ -10865,14 +10847,14 @@
 				"extended_value": 30,
 				"weight": "9 lb",
 				"extended_weight": "9 lb"
-			},
-			"reference_highlight": "Wood"
+			}
 		},
 		{
 			"id": "eiFFxgMBPCmki24Au",
 			"description": "Wood Full Helm, Padded",
 			"reference": "LTIA14",
-			"local_notes": "DR: 4; Don: 9 secs; Holdout: -9; Reaction Pen.-1",
+			"reference_highlight": "Wood",
+			"local_notes": "Don: 9 secs; Holdout: -9; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Full Helm"
@@ -10895,14 +10877,14 @@
 				"extended_value": 45,
 				"weight": "10.8 lb",
 				"extended_weight": "10.8 lb"
-			},
-			"reference_highlight": "Wood"
+			}
 		},
 		{
 			"id": "erUX9_wGlTyut4Ut4",
 			"description": "Wood Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "DR: 3; Don: 3 secs; Holdout: -8; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
+			"reference_highlight": "Wood",
+			"local_notes": "Don: 3 secs; Holdout: -8; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
 			"tech_level": "0",
 			"tags": [
 				"Groin Armor"
@@ -10924,14 +10906,14 @@
 				"extended_value": 5,
 				"weight": "1.5 lb",
 				"extended_weight": "1.5 lb"
-			},
-			"reference_highlight": "Wood"
+			}
 		},
 		{
 			"id": "e7mbWAM5FpI8u21CM",
 			"description": "Wood Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "DR: 3; Don: 30 secs; Holdout: -9; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
+			"reference_highlight": "Wood",
+			"local_notes": "Don: 30 secs; Holdout: -9; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
 			"tech_level": "0",
 			"tags": [
 				"Limb Armor"
@@ -10953,14 +10935,14 @@
 				"extended_value": 100,
 				"weight": "30 lb",
 				"extended_weight": "30 lb"
-			},
-			"reference_highlight": "Wood"
+			}
 		},
 		{
 			"id": "eZfn53cRkDwwUH58k",
 			"description": "Wood Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "DR: 3; Don: 3 secs; Holdout: -9; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
+			"reference_highlight": "Wood",
+			"local_notes": "Don: 3 secs; Holdout: -9; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
 			"tech_level": "0",
 			"tags": [
 				"Neck Armor"
@@ -10982,14 +10964,14 @@
 				"extended_value": 5,
 				"weight": "1.5 lb",
 				"extended_weight": "1.5 lb"
-			},
-			"reference_highlight": "Wood"
+			}
 		},
 		{
 			"id": "ee3XbnV86ynYB5GUV",
 			"description": "Wood Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "DR: 3; Don: 6 secs; Holdout: -9; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
+			"reference_highlight": "Wood",
+			"local_notes": "Don: 6 secs; Holdout: -9; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
 			"tech_level": "0",
 			"tags": [
 				"Pot Helm"
@@ -11011,14 +10993,14 @@
 				"extended_value": 20,
 				"weight": "6 lb",
 				"extended_weight": "6 lb"
-			},
-			"reference_highlight": "Wood"
+			}
 		},
 		{
 			"id": "eHTAMmt2o-uUY65T2",
 			"description": "Wood Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "DR: 4; Don: 6 secs; Holdout: -9; Reaction Pen.-1",
+			"reference_highlight": "Wood",
+			"local_notes": "Don: 6 secs; Holdout: -9; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Pot Helm"
@@ -11040,14 +11022,14 @@
 				"extended_value": 30,
 				"weight": "7.2 lb",
 				"extended_weight": "7.2 lb"
-			},
-			"reference_highlight": "Wood"
+			}
 		},
 		{
 			"id": "eXH4Ev7TYnWF90i53",
 			"description": "Wood Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "DR: 3; Don: 30 secs; Holdout: -8; Reaction Pen.-2; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
+			"reference_highlight": "Wood",
+			"local_notes": "Don: 30 secs; Holdout: -8; Reaction Pen.-2; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -11070,8 +11052,7 @@
 				"extended_value": 100,
 				"weight": "30 lb",
 				"extended_weight": "30 lb"
-			},
-			"reference_highlight": "Wood"
+			}
 		}
 	]
 }

--- a/Library/Low Tech/Low Tech Instant Armor.eqp
+++ b/Library/Low Tech/Low Tech Instant Armor.eqp
@@ -74,6 +74,8 @@
 			"local_notes": "Don: 6 secs; Holdout: -4; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "1",
 			"tags": [
+				"Limbs",
+				"Feet",
 				"Leather"
 			],
 			"base_value": "80",
@@ -1610,8 +1612,8 @@
 			"local_notes": "Don: 10 secs; Holdout: -4; Gives Ham-Fisted 2 (p. B138).",
 			"tech_level": "1",
 			"tags": [
-				"Hardened Leather",
 				"Hands",
+				"Hardened Leather",
 				"Limbs"
 			],
 			"base_value": "13",
@@ -1641,10 +1643,10 @@
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
-				"Heavy Mail",
-				"Mail",
 				"Hands",
-				"Limbs"
+				"Heavy Mail",
+				"Limbs",
+				"Mail"
 			],
 			"base_value": "120",
 			"base_weight": "1.8 lb",
@@ -1837,9 +1839,9 @@
 			"tech_level": "2",
 			"tags": [
 				"Fine Mail",
-				"Mail",
 				"Hands",
-				"Limbs"
+				"Limbs",
+				"Mail"
 			],
 			"base_value": "90",
 			"base_weight": "1.5 lb",
@@ -8735,9 +8737,9 @@
 			"tech_level": "1",
 			"tags": [
 				"Cloth",
-				"Padded Cloth",
 				"Hands",
-				"Limbs"
+				"Limbs",
+				"Padded Cloth"
 			],
 			"base_value": "20",
 			"base_weight": "1 lb",
@@ -8762,7 +8764,7 @@
 			"id": "e2Oo1VPjY4Qqt622p",
 			"description": "Moccasins ",
 			"reference": "LTIA16",
-			"local_notes": "Don: 6 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379); Gives +1 to Stealth.",
+			"local_notes": "Don: 6 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Feet",
@@ -8772,6 +8774,15 @@
 			"base_value": "40",
 			"base_weight": "1 lb",
 			"features": [
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Stealth"
+					},
+					"amount": 1
+				},
 				{
 					"type": "dr_bonus",
 					"locations": [
@@ -8792,7 +8803,7 @@
 			"id": "eGJEpXOubDzKed8ZB",
 			"description": "Mukluks ",
 			"reference": "LTIA16",
-			"local_notes": "Don: 6 secs; Holdout: -5; Flexible and susceptible to blunt trauma (p. B379); Erases -2 in Stealth penalties when walking on snow.",
+			"local_notes": "Don: 6 secs; Holdout: -5; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Feet",
@@ -8802,6 +8813,11 @@
 			"base_value": "50",
 			"base_weight": "2 lb",
 			"features": [
+				{
+					"type": "conditional_modifier",
+					"situation": "to counteract stealth penalties when walking in snow",
+					"amount": 2
+				},
 				{
 					"type": "dr_bonus",
 					"locations": [
@@ -10342,7 +10358,7 @@
 			"id": "eHeqzBzX8BvvEYC4T",
 			"description": "Sandals ",
 			"reference": "LTIA16",
-			"local_notes": "Don: 10 secs; Holdout: -2; Flexible and susceptible to blunt trauma (p. B379); DR applies to underside only.",
+			"local_notes": "Don: 10 secs; Holdout: -2; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Feet",
@@ -10357,6 +10373,7 @@
 					"locations": [
 						"foot"
 					],
+					"specialization": "underside",
 					"amount": 1
 				}
 			],
@@ -10372,7 +10389,7 @@
 			"id": "eluvVD7j_wcbJxlCb",
 			"description": "Sandals, Hobnailed ",
 			"reference": "LTIA16",
-			"local_notes": "Don: 10 secs; Holdout: -2; Flexible and susceptible to blunt trauma (p. B379); DR applies to underside only; Lets wearer ignore -2 to attacks and -1 to defenses for bad terrain.",
+			"local_notes": "Don: 10 secs; Holdout: -2; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "1",
 			"tags": [
 				"Feet",
@@ -10383,10 +10400,21 @@
 			"base_weight": "1.5 lb",
 			"features": [
 				{
+					"type": "conditional_modifier",
+					"situation": "to counteract attack penalties from bad terrain",
+					"amount": 2
+				},
+				{
+					"type": "conditional_modifier",
+					"situation": "to counteract defense penalties from bad terrain",
+					"amount": 1
+				},
+				{
 					"type": "dr_bonus",
 					"locations": [
 						"foot"
 					],
+					"specialization": "underside",
 					"amount": 1
 				}
 			],
@@ -12095,7 +12123,7 @@
 			"id": "eDBbcETSyRQ1HZJFH",
 			"description": "Shoes ",
 			"reference": "LTIA16",
-			"local_notes": "Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
+			"local_notes": "Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "1",
 			"tags": [
 				"Feet",
@@ -12105,6 +12133,14 @@
 			"base_value": "40",
 			"base_weight": "2 lb",
 			"features": [
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"foot"
+					],
+					"specialization": "impaling",
+					"amount": -1
+				},
 				{
 					"type": "dr_bonus",
 					"locations": [
@@ -12125,7 +12161,7 @@
 			"id": "eEVj7rSYpu5Jt4-yF",
 			"description": "Shoes, Hobnailed ",
 			"reference": "LTIA16",
-			"local_notes": "Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling; Lets wearer ignore -2 to attacks and -1 to defenses for bad terrain.",
+			"local_notes": "Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "1",
 			"tags": [
 				"Feet",
@@ -12135,6 +12171,24 @@
 			"base_value": "65",
 			"base_weight": "3 lb",
 			"features": [
+				{
+					"type": "conditional_modifier",
+					"situation": "to counteract attack penalties from bad terrain",
+					"amount": 2
+				},
+				{
+					"type": "conditional_modifier",
+					"situation": "to counteract defense penalties from bad terrain",
+					"amount": 1
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"foot"
+					],
+					"specialization": "impaling",
+					"amount": -1
+				},
 				{
 					"type": "dr_bonus",
 					"locations": [
@@ -12155,9 +12209,11 @@
 			"id": "eJhyyjnFo7KmWVJTd",
 			"description": "Shoes, Medium Leather ",
 			"reference": "LTIA16",
-			"local_notes": "Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
+			"local_notes": "Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "1",
 			"tags": [
+				"Feet",
+				"Limbs",
 				"Leather",
 				"Medium Leather"
 			],
@@ -12192,7 +12248,7 @@
 			"id": "e5oPk4D93B4R-kmaI",
 			"description": "Sollerets, Fine Mail ",
 			"reference": "LTIA16",
-			"local_notes": " Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": " Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -12207,8 +12263,7 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"foot",
-						"torso"
+						"foot"
 					],
 					"amount": 4
 				},
@@ -12217,7 +12272,8 @@
 					"locations": [
 						"foot"
 					],
-					"amount": -1
+					"specialization": "crushing",
+					"amount": -2
 				}
 			],
 			"quantity": 1,
@@ -12232,7 +12288,7 @@
 			"id": "eP-s_FvhbTPwA79h5",
 			"description": "Sollerets, Heavy Mail ",
 			"reference": "LTIA16",
-			"local_notes": "Don: 6 secs; Holdout: -4; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "Don: 6 secs; Holdout: -4; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -12272,7 +12328,7 @@
 			"id": "evSioPxb1AeVS_V4J",
 			"description": "Sollerets, Light Mail ",
 			"reference": "LTIA16",
-			"local_notes": "Don: 6 secs; Holdout: -2; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "Don: 6 secs; Holdout: -2; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "2",
 			"tags": [
 				"Feet",
@@ -12311,7 +12367,7 @@
 			"id": "ea8f_-UbJnObc_qCO",
 			"description": "Sollerets, Light Scale ",
 			"reference": "LTIA16",
-			"local_notes": "Don: 10 secs; Holdout: -4; -1 DR vs. crushing.",
+			"local_notes": "Don: 10 secs; Holdout: -4",
 			"tech_level": "1",
 			"tags": [
 				"Feet",

--- a/Library/Low Tech/Low Tech Instant Armor.eqp
+++ b/Library/Low Tech/Low Tech Instant Armor.eqp
@@ -3,7 +3,7 @@
 	"rows": [
 		{
 			"id": "eK0vVICVdJg4PfVcP",
-			"description": "Arming Doublet Torso Armor",
+			"description": "Arming Doublet",
 			"reference": "LTIA5",
 			"local_notes": "Don: 15 secs; Holdout: 0; Required for suit of plate. Light mail protects armpits and inside elbows.",
 			"tech_level": "4",

--- a/Library/Low Tech/Low Tech Instant Armor.eqp
+++ b/Library/Low Tech/Low Tech Instant Armor.eqp
@@ -3207,7 +3207,7 @@
 			"description": "Jack of Plates Leg Armor",
 			"reference": "LTIA10",
 			"reference_highlight": "Jack of Plates",
-			"local_notes": "Don: 30 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. crushing.",
+			"local_notes": "Don: 30 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "2",
 			"tags": [
 				"Jack of Plates",
@@ -5415,7 +5415,7 @@
 			"description": "Leather, Heavy Leg Armor",
 			"reference": "LTIA10",
 			"reference_highlight": "Leather, Heavy",
-			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. impaling.",
+			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Heavy Leather",
@@ -5877,7 +5877,7 @@
 			"description": "Leather, Light Leg Armor",
 			"reference": "LTIA10",
 			"reference_highlight": "Leather, Light",
-			"local_notes": "Don: 30 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
+			"local_notes": "Don: 30 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
@@ -6329,7 +6329,7 @@
 			"description": "Leather, Medium Leg Armor",
 			"reference": "LTIA10",
 			"reference_highlight": "Leather, Medium",
-			"local_notes": "Don: 30 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
+			"local_notes": "Don: 30 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Leather",
@@ -6345,7 +6345,7 @@
 					"locations": [
 						"leg"
 					],
-					"amount": 1
+					"amount": 2
 				},
 				{
 					"type": "dr_bonus",
@@ -6789,7 +6789,7 @@
 			"description": "Mail and Plates Leg Armor",
 			"reference": "LTIA10",
 			"reference_highlight": "Mail and Plates",
-			"local_notes": "Don: 20 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. crushing.",
+			"local_notes": "Don: 20 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -7170,7 +7170,7 @@
 			"description": "Mail, Fine Leg Armor",
 			"reference": "LTIA10",
 			"reference_highlight": "Mail, Fine",
-			"local_notes": "Don: 15 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "Don: 15 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -7557,7 +7557,7 @@
 			"description": "Mail, Heavy Leg Armor",
 			"reference": "LTIA10",
 			"reference_highlight": "Mail, Heavy",
-			"local_notes": "Don: 15 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "Don: 15 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -8143,7 +8143,7 @@
 			"description": "Mail, Light Leg Armor",
 			"reference": "LTIA10",
 			"reference_highlight": "Mail, Light",
-			"local_notes": "Don: 15 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "Don: 15 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "2",
 			"tags": [
 				"Legs",
@@ -10388,7 +10388,7 @@
 			"description": "Scale, Light Leg Armor",
 			"reference": "LTIA10",
 			"reference_highlight": "Scale, Light",
-			"local_notes": "Don: 30 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. crushing.",
+			"local_notes": "Don: 30 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Legs",
@@ -10850,7 +10850,7 @@
 			"description": "Scale, Medium Leg Armor",
 			"reference": "LTIA10",
 			"reference_highlight": "Scale, Medium",
-			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
+			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [

--- a/Library/Low Tech/Low Tech Instant Armor.eqp
+++ b/Library/Low Tech/Low Tech Instant Armor.eqp
@@ -5317,7 +5317,7 @@
 			"description": "Leather, Heavy Chest Armor",
 			"reference": "LTIA5",
 			"reference_highlight": "Leather, Heavy",
-			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. impaling.",
+			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor",
@@ -5342,7 +5342,7 @@
 						"torso"
 					],
 					"specialization": "impaling",
-					"amount": 1
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -5774,7 +5774,7 @@
 			"description": "Leather, Light Chest Armor",
 			"reference": "LTIA5",
 			"reference_highlight": "Leather, Light",
-			"local_notes": "Don: 23 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
+			"local_notes": "Don: 23 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
@@ -6226,7 +6226,7 @@
 			"description": "Leather, Medium Chest Armor",
 			"reference": "LTIA5",
 			"reference_highlight": "Leather, Medium",
-			"local_notes": "Don: 23 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
+			"local_notes": "Don: 23 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor",
@@ -6598,7 +6598,7 @@
 			"description": "Mail and Plates Chest Armor",
 			"reference": "LTIA6",
 			"reference_highlight": "Mail and Plates",
-			"local_notes": "Don: 15 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
+			"local_notes": "Don: 15 secs; Holdout: -3; Reaction Pen.-2",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -6973,7 +6973,7 @@
 			"description": "Mail, Fine Chest Armor",
 			"reference": "LTIA6",
 			"reference_highlight": "Mail, Fine",
-			"local_notes": "Don: 11 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "Don: 11 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -7356,7 +7356,7 @@
 			"description": "Mail, Heavy Chest Armor",
 			"reference": "LTIA6",
 			"reference_highlight": "Mail, Heavy",
-			"local_notes": "Don: 11 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "Don: 11 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -7944,7 +7944,7 @@
 			"description": "Mail, Light Chest Armor",
 			"reference": "LTIA6",
 			"reference_highlight": "Mail, Light",
-			"local_notes": "Don: 11 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "Don: 11 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "2",
 			"tags": [
 				"Body Armor",
@@ -10268,7 +10268,7 @@
 			"description": "Scale, Light Chest Armor",
 			"reference": "LTIA5",
 			"reference_highlight": "Scale, Light",
-			"local_notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
+			"local_notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-2",
 			"tech_level": "1",
 			"tags": [
 				"Body Armor",
@@ -10726,7 +10726,7 @@
 			"description": "Scale, Medium Chest Armor",
 			"reference": "LTIA5",
 			"reference_highlight": "Scale, Medium",
-			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. crushing.",
+			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [

--- a/Library/Low Tech/Low Tech Instant Armor.eqp
+++ b/Library/Low Tech/Low Tech Instant Armor.eqp
@@ -163,7 +163,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
+						"abdomen",
+						"groin"
 					],
 					"amount": 3
 				}
@@ -525,7 +526,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
+						"abdomen",
+						"groin"
 					],
 					"amount": 5
 				}
@@ -894,7 +896,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
+						"abdomen",
+						"groin"
 					],
 					"amount": 1
 				}
@@ -1204,7 +1207,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
+						"abdomen",
+						"groin"
 					],
 					"amount": 1
 				}
@@ -1960,7 +1964,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
+						"abdomen",
+						"groin"
 					],
 					"amount": 3
 				}
@@ -2376,7 +2381,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
+						"abdomen",
+						"groin"
 					],
 					"amount": 2
 				}
@@ -2804,7 +2810,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
+						"abdomen",
+						"groin"
 					],
 					"amount": 3
 				}
@@ -3078,7 +3085,7 @@
 			"description": "Jack of Plates Abdomen Armor",
 			"reference": "LTIA6",
 			"reference_highlight": "Jack of Plates",
-			"local_notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
+			"local_notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-2",
 			"tech_level": "2",
 			"tags": [
 				"Abdomen Only Armor",
@@ -3092,14 +3099,16 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
+						"abdomen",
+						"groin"
 					],
 					"amount": 3
 				},
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
+						"abdomen",
+						"groin"
 					],
 					"specialization": "crushing",
 					"amount": -1
@@ -3336,7 +3345,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
+						"abdomen",
+						"groin"
 					],
 					"amount": 4
 				}
@@ -3530,7 +3540,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
+						"abdomen",
+						"groin"
 					],
 					"amount": 2
 				}
@@ -3891,7 +3902,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
+						"abdomen",
+						"groin"
 					],
 					"amount": 3
 				}
@@ -4251,7 +4263,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
+						"abdomen",
+						"groin"
 					],
 					"amount": 4
 				}
@@ -4445,7 +4458,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
+						"abdomen",
+						"groin"
 					],
 					"amount": 2
 				}
@@ -4806,7 +4820,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
+						"abdomen",
+						"groin"
 					],
 					"amount": 3
 				}
@@ -5153,7 +5168,7 @@
 			"description": "Leather, Heavy Abdomen Armor",
 			"reference": "LTIA6",
 			"reference_highlight": "Leather, Heavy",
-			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. impaling.",
+			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "0",
 			"tags": [
 				"Abdomen Only Armor",
@@ -5168,14 +5183,16 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
+						"abdomen",
+						"groin"
 					],
 					"amount": 3
 				},
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
+						"abdomen",
+						"groin"
 					],
 					"specialization": "impaling",
 					"amount": -1
@@ -5607,7 +5624,7 @@
 			"description": "Leather, Light Abdomen Armor",
 			"reference": "LTIA6",
 			"reference_highlight": "Leather, Light",
-			"local_notes": "Don: 23 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
+			"local_notes": "Don: 23 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
@@ -5623,15 +5640,18 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
+						"abdomen",
+						"groin"
 					],
 					"amount": 0
 				},
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
+						"abdomen",
+						"groin"
 					],
+					"specialization": "cutting",
 					"amount": 1
 				}
 			],
@@ -6060,7 +6080,7 @@
 			"description": "Leather, Medium Abdomen Armor",
 			"reference": "LTIA6",
 			"reference_highlight": "Leather, Medium",
-			"local_notes": "Don: 23 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
+			"local_notes": "Don: 23 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Abdomen Only Armor",
@@ -6075,14 +6095,16 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
+						"abdomen",
+						"groin"
 					],
 					"amount": 2
 				},
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
+						"abdomen",
+						"groin"
 					],
 					"specialization": "impaling",
 					"amount": -1
@@ -6516,7 +6538,7 @@
 			"description": "Mail and Plates Abdomen Armor",
 			"reference": "LTIA6",
 			"reference_highlight": "Mail and Plates",
-			"local_notes": "Don: 15 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
+			"local_notes": "Don: 15 secs; Holdout: -3; Reaction Pen.-2",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -6531,14 +6553,16 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
+						"abdomen",
+						"groin"
 					],
 					"amount": 5
 				},
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
+						"abdomen",
+						"groin"
 					],
 					"specialization": "crushing",
 					"amount": -1
@@ -6891,7 +6915,7 @@
 			"description": "Mail, Fine Abdomen Armor",
 			"reference": "LTIA6",
 			"reference_highlight": "Mail, Fine",
-			"local_notes": "Don: 11 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "Don: 11 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -6907,15 +6931,18 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
+						"abdomen",
+						"groin"
 					],
 					"amount": 4
 				},
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
+						"abdomen",
+						"groin"
 					],
+					"specialization": "crushing",
 					"amount": -2
 				}
 			],
@@ -7272,7 +7299,7 @@
 			"description": "Mail, Heavy Abdomen Armor",
 			"reference": "LTIA6",
 			"reference_highlight": "Mail, Heavy",
-			"local_notes": "Don: 11 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "Don: 11 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -7288,14 +7315,16 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
+						"abdomen",
+						"groin"
 					],
 					"amount": 5
 				},
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
+						"abdomen",
+						"groin"
 					],
 					"specialization": "crushing",
 					"amount": -2
@@ -7673,7 +7702,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
+						"abdomen",
+						"groin"
 					],
 					"amount": 6
 				}
@@ -7864,7 +7894,7 @@
 			"description": "Mail, Light Abdomen Armor",
 			"reference": "LTIA6",
 			"reference_highlight": "Mail, Light",
-			"local_notes": "Don: 11 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "Don: 11 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "2",
 			"tags": [
 				"Abdomen Only Armor",
@@ -7879,15 +7909,18 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
+						"abdomen",
+						"groin"
 					],
 					"amount": 3
 				},
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
+						"abdomen",
+						"groin"
 					],
+					"specialization": "crushing",
 					"amount": -2
 				}
 			],
@@ -9921,7 +9954,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
+						"abdomen",
+						"groin"
 					],
 					"amount": 5
 				}
@@ -10105,7 +10139,7 @@
 			"description": "Scale, Light Abdomen Armor",
 			"reference": "LTIA6",
 			"reference_highlight": "Scale, Light",
-			"local_notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
+			"local_notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-2",
 			"tech_level": "1",
 			"tags": [
 				"Abdomen Only Armor",
@@ -10120,14 +10154,16 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
+						"abdomen",
+						"groin"
 					],
 					"amount": 3
 				},
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
+						"abdomen",
+						"groin"
 					],
 					"specialization": "crushing",
 					"amount": -1
@@ -10558,7 +10594,7 @@
 			"description": "Scale, Medium Abdomen Armor",
 			"reference": "LTIA6",
 			"reference_highlight": "Scale, Medium",
-			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. crushing.",
+			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
@@ -10574,14 +10610,16 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
+						"abdomen",
+						"groin"
 					],
 					"amount": 4
 				},
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
+						"abdomen",
+						"groin"
 					],
 					"specialization": "crushing",
 					"amount": -1
@@ -11038,7 +11076,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
+						"abdomen",
+						"groin"
 					],
 					"amount": 5
 				}
@@ -11141,7 +11180,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
+						"abdomen",
+						"groin"
 					],
 					"amount": 3
 				}
@@ -11339,7 +11379,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
+						"abdomen",
+						"groin"
 					],
 					"amount": 4
 				}
@@ -11861,7 +11902,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
+						"abdomen",
+						"groin"
 					],
 					"amount": 3
 				}

--- a/Library/Low Tech/Low Tech Instant Armor.eqp
+++ b/Library/Low Tech/Low Tech Instant Armor.eqp
@@ -2637,14 +2637,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"face",
 						"skull"
-					],
-					"amount": 2
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
 					],
 					"amount": 2
 				}
@@ -2676,14 +2670,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"face",
 						"skull"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
 					],
 					"amount": 3
 				}
@@ -12631,7 +12619,7 @@
 			"description": "Wood Full Helm, Padded",
 			"reference": "LTIA14",
 			"reference_highlight": "Wood",
-			"local_notes": "Don: 9 secs; Holdout: -9; Reaction Pen.-1",
+			"local_notes": "Don: 9 secs; Holdout: -9; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
 			"tech_level": "0",
 			"tags": [
 				"Full Helms (Skull + Face)",

--- a/Library/Low Tech/Low Tech Instant Armor.eqp
+++ b/Library/Low Tech/Low Tech Instant Armor.eqp
@@ -1605,12 +1605,14 @@
 		},
 		{
 			"id": "eAGTRRqWt8WZIVwP9",
-			"description": "Gauntlets, Hardened Leather ",
+			"description": "Gauntlets, Hardened Leather",
 			"reference": "LTIA15",
 			"local_notes": "Don: 10 secs; Holdout: -4; Gives Ham-Fisted 2 (p. B138).",
 			"tech_level": "1",
 			"tags": [
-				"Hardened Leather"
+				"Hardened Leather",
+				"Hands",
+				"Limbs"
 			],
 			"base_value": "13",
 			"base_weight": "1.5 lb",
@@ -1633,14 +1635,16 @@
 		},
 		{
 			"id": "eur06_PfX8L-FrAdE",
-			"description": "Gauntlets, Heavy Mail ",
+			"description": "Gauntlets, Heavy Mail",
 			"reference": "LTIA15",
-			"local_notes": "Don: 10 secs; Holdout: -4; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing; Gives Ham-Fisted 2 (p. B138).",
+			"local_notes": "Don: 10 secs; Holdout: -4; Flexible and susceptible to blunt trauma (p. B379); Gives Ham-Fisted 2 (p. B138).",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
 				"Heavy Mail",
-				"Mail"
+				"Mail",
+				"Hands",
+				"Limbs"
 			],
 			"base_value": "120",
 			"base_weight": "1.8 lb",
@@ -1671,7 +1675,7 @@
 		},
 		{
 			"id": "e6hR_7K5Y4ELg8ouw",
-			"description": "Gauntlets, Light Plate ",
+			"description": "Gauntlets, Light Plate",
 			"reference": "LTIA15",
 			"local_notes": "Don: 10 secs; Holdout: -4; Gives Ham-Fisted 2 (p. B138).",
 			"tech_level": "4",
@@ -1702,7 +1706,7 @@
 		},
 		{
 			"id": "e1Jc9oibz_7Se4NSl",
-			"description": "Gauntlets, Light Segmented ",
+			"description": "Gauntlets, Light Segmented",
 			"reference": "LTIA15",
 			"local_notes": "Don: 10 secs; Holdout: -4; Gives Ham-Fisted 2 (p. B138).",
 			"tech_level": "3",
@@ -1733,7 +1737,7 @@
 		},
 		{
 			"id": "eXb29dBeGn2jiLwyd",
-			"description": "Gauntlets, Medium Plate ",
+			"description": "Gauntlets, Medium Plate",
 			"reference": "LTIA15",
 			"local_notes": "Don: 10 secs; Holdout: -6; Gives Ham-Fisted 2 (p. B138).",
 			"tech_level": "4",
@@ -1765,7 +1769,7 @@
 		},
 		{
 			"id": "elLRNlQeA1ZIzjwDY",
-			"description": "Gauntlets, Medium Segmented ",
+			"description": "Gauntlets, Medium Segmented",
 			"reference": "LTIA15",
 			"local_notes": "Don: 10 secs; Holdout: -5; Gives Ham-Fisted 2 (p. B138).",
 			"tech_level": "3",
@@ -1796,7 +1800,7 @@
 		},
 		{
 			"id": "eUyhaqVa7eSPWoDtB",
-			"description": "Gauntlets, Padded Cloth ",
+			"description": "Gauntlets, Padded Cloth",
 			"reference": "LTIA15",
 			"local_notes": "Don: 10 secs; Holdout: -2; Flexible and susceptible to blunt trauma (p. B379); Gives Ham-Fisted 1 (p. B138).",
 			"tech_level": "1",
@@ -1827,13 +1831,15 @@
 		},
 		{
 			"id": "eYtckk0_SxXIvwCEl",
-			"description": "Gauntlets,Fine Mail ",
+			"description": "Gauntlets, Fine Mail",
 			"reference": "LTIA15",
-			"local_notes": "Don: 10 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing; Gives Ham-Fisted 2 (p. B138).",
+			"local_notes": "Don: 10 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); Gives Ham-Fisted 2 (p. B138).",
 			"tech_level": "2",
 			"tags": [
 				"Fine Mail",
-				"Mail"
+				"Mail",
+				"Hands",
+				"Limbs"
 			],
 			"base_value": "90",
 			"base_weight": "1.5 lb",
@@ -1864,9 +1870,9 @@
 		},
 		{
 			"id": "e55lxLmwMaK_c-XHw",
-			"description": "Gauntlets,Light Mail ",
+			"description": "Gauntlets, Light Mail",
 			"reference": "LTIA15",
-			"local_notes": "Don: 10 secs; Holdout: -2; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing; Gives Ham-Fisted 2 (p. B138).",
+			"local_notes": "Don: 10 secs; Holdout: -2; Flexible and susceptible to blunt trauma (p. B379); Gives Ham-Fisted 2 (p. B138).",
 			"tech_level": "2",
 			"tags": [
 				"Hands",
@@ -1903,9 +1909,9 @@
 		},
 		{
 			"id": "eixxfx23rzXgQ7VXP",
-			"description": "Gauntlets, Light Scale ",
+			"description": "Gauntlets, Light Scale",
 			"reference": "LTIA15",
-			"local_notes": "Don: 10 secs; Holdout: -4; -1 DR vs. crushing; Gives Ham-Fisted 2 (p. B138).",
+			"local_notes": "Don: 10 secs; Holdout: -4; Gives Ham-Fisted 2 (p. B138).",
 			"tech_level": "1",
 			"tags": [
 				"Hands",
@@ -1916,6 +1922,14 @@
 			"base_value": "32",
 			"base_weight": "1.6 lb",
 			"features": [
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"hand"
+					],
+					"specialization": "crushing",
+					"amount": -1
+				},
 				{
 					"type": "dr_bonus",
 					"locations": [
@@ -1934,13 +1948,15 @@
 		},
 		{
 			"id": "e_1tXA6dcIPkbkkIa",
-			"description": "Gloves, Cloth ",
+			"description": "Gloves, Cloth",
 			"reference": "LTIA15",
-			"local_notes": "Don: 10 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting; Enclosedmittens andgloves protectvs.cold,heat,contactpoison,etc.,but giveBadGrip1(p.B123); Gives Ham-Fisted 1 (p. B138).",
+			"local_notes": "Don: 10 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379); Protects vs. cold, heat and contact poisons; Gives Bad Grip 1(p.B123); Gives Ham-Fisted 1 (p. B138).",
 			"tech_level": "1",
 			"legality_class": "5",
 			"tags": [
-				"Cloth"
+				"Cloth",
+				"Hands",
+				"Limbs"
 			],
 			"base_value": "15",
 			"base_weight": "0.5 lb",
@@ -1971,9 +1987,9 @@
 		},
 		{
 			"id": "en60StSySCEyH7YVO",
-			"description": "Gloves, Light Leather ",
+			"description": "Gloves, Light Leather",
 			"reference": "LTIA15",
-			"local_notes": "Don: 10 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting; Enclosedmittens andgloves protectvs.cold,heat,contactpoison,etc.,but giveBadGrip1(p.B123); Gives Ham-Fisted 1 (p. B138).",
+			"local_notes": "Don: 10 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379); Protects vs. cold, heat and contact poisons; Gives Bad Grip 1(p.B123); Gives Ham-Fisted 1 (p. B138).",
 			"tech_level": "1",
 			"legality_class": "5",
 			"tags": [
@@ -8674,9 +8690,9 @@
 		},
 		{
 			"id": "eJZyW8py6OBUqMrwN",
-			"description": "Mittens ",
+			"description": "Mittens",
 			"reference": "LTIA15",
-			"local_notes": "Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting; Enclosedmittens andgloves protectvs.cold,heat,contactpoison,etc.,but giveBadGrip1(p.B123); Gives Ham-Fisted 2 (p. B138).",
+			"local_notes": "Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); Protects vs. cold, heat and contact poisons; Gives Bad Grip 1(p.B123); Gives Ham-Fisted 2 (p. B138).",
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
@@ -8713,13 +8729,15 @@
 		},
 		{
 			"id": "eAVm_WBOK8kNRrPbc",
-			"description": "Mittens, Padded Cloth ",
+			"description": "Mittens, Padded Cloth",
 			"reference": "LTIA15",
-			"local_notes": "Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); Enclosedmittens andgloves protectvs.cold,heat,contactpoison,etc.,but giveBadGrip1(p.B123); Gives Ham-Fisted 2 (p. B138).",
+			"local_notes": "Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); Protects vs. cold, heat and contact poisons; Gives Bad Grip 1(p.B123); Gives Ham-Fisted 2 (p. B138).",
 			"tech_level": "1",
 			"tags": [
 				"Cloth",
-				"Padded Cloth"
+				"Padded Cloth",
+				"Hands",
+				"Limbs"
 			],
 			"base_value": "20",
 			"base_weight": "1 lb",

--- a/Library/Low Tech/Low Tech Instant Armor.eqp
+++ b/Library/Low Tech/Low Tech Instant Armor.eqp
@@ -1775,7 +1775,7 @@
 		},
 		{
 			"id": "eixxfx23rzXgQ7VXP",
-			"description": "Gauntlets,Light Scale ",
+			"description": "Gauntlets, Light Scale ",
 			"reference": "LTIA15",
 			"local_notes": "Don: 10 secs; Holdout: -4; -1 DR vs. crushing; Gives Ham-Fisted 2 (p. B138).",
 			"tech_level": "1",

--- a/Library/Low Tech/Low Tech Instant Armor.eqp
+++ b/Library/Low Tech/Low Tech Instant Armor.eqp
@@ -1288,7 +1288,7 @@
 			"id": "e2htbNlX1xn4-u6x7",
 			"description": "Cloth, Padded Bascinet, Padded",
 			"reference": "LTIA14",
-			"local_notes": "Don: 4 secs; Holdout: -1",
+			"local_notes": "Don: 4 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Bascinet (Skull + Back Face)",
@@ -3624,7 +3624,7 @@
 			"description": "Layered Cloth, Light Bascinet, Padded",
 			"reference": "LTIA14",
 			"reference_highlight": "Layered Cloth, Light",
-			"local_notes": "Don: 5 secs; Holdout: -1; Reaction Pen.-1",
+			"local_notes": "Don: 5 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Bascinet (Skull + Back Face)",
@@ -4542,7 +4542,7 @@
 			"description": "Layered Leather, Light Bascinet, Padded",
 			"reference": "LTIA14",
 			"reference_highlight": "Layered Leather, Light",
-			"local_notes": "Don: 5 secs; Holdout: -2; Reaction Pen.-1",
+			"local_notes": "Don: 5 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "1",
 			"tags": [
 				"Bascinet (Skull + Back Face)",
@@ -5252,7 +5252,7 @@
 			"description": "Leather, Heavy Bascinet",
 			"reference": "LTIA14",
 			"reference_highlight": "Leather, Heavy",
-			"local_notes": "Don: 8 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. impaling.",
+			"local_notes": "Don: 8 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Head (Skull + Face + Neck)",
@@ -5710,7 +5710,7 @@
 			"description": "Leather, Light Bascinet",
 			"reference": "LTIA14",
 			"reference_highlight": "Leather, Light",
-			"local_notes": "Don: 8 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
+			"local_notes": "Don: 8 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
@@ -5752,7 +5752,7 @@
 			"description": "Leather, Light Bascinet, Padded",
 			"reference": "LTIA14",
 			"reference_highlight": "Leather, Light",
-			"local_notes": "Don: 8 secs; Holdout: -1; +1 DR vs. cutting.",
+			"local_notes": "Don: 8 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
@@ -6164,7 +6164,7 @@
 			"description": "Leather, Medium Bascinet",
 			"reference": "LTIA14",
 			"reference_highlight": "Leather, Medium",
-			"local_notes": "Don: 8 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
+			"local_notes": "Don: 8 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Bascinet (Skull + Back Face)",
@@ -6179,8 +6179,7 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"skull",
-						"torso"
+						"skull"
 					],
 					"amount": 2
 				},
@@ -6206,7 +6205,7 @@
 			"description": "Leather, Medium Bascinet, Padded",
 			"reference": "LTIA14",
 			"reference_highlight": "Leather, Medium",
-			"local_notes": "Don: 8 secs; Holdout: -3; Reaction Pen.-1",
+			"local_notes": "Don: 8 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Bascinet (Skull + Back Face)",
@@ -6221,8 +6220,7 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"skull",
-						"torso"
+						"skull"
 					],
 					"amount": 3
 				},
@@ -10226,7 +10224,7 @@
 			"description": "Scale, Light Bascinet",
 			"reference": "LTIA14",
 			"reference_highlight": "Scale, Light",
-			"local_notes": "Don: 8 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
+			"local_notes": "Don: 8 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Bascinet (Skull + Back Face)",
@@ -10241,7 +10239,7 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"torso"
+						"skull"
 					],
 					"amount": 3
 				},
@@ -10267,7 +10265,7 @@
 			"description": "Scale, Light Bascinet, Padded",
 			"reference": "LTIA14",
 			"reference_highlight": "Scale, Light",
-			"local_notes": "Don: 8 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
+			"local_notes": "Don: 8 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Bascinet (Skull + Back Face)",
@@ -10291,6 +10289,7 @@
 					"locations": [
 						"skull"
 					],
+					"specialization": "crushing",
 					"amount": -1
 				}
 			],
@@ -10683,7 +10682,7 @@
 			"description": "Scale, Medium Bascinet",
 			"reference": "LTIA14",
 			"reference_highlight": "Scale, Medium",
-			"local_notes": "Don: 8 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. crushing.",
+			"local_notes": "Don: 8 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
@@ -10725,7 +10724,7 @@
 			"description": "Scale, Medium Bascinet, Padded",
 			"reference": "LTIA14",
 			"reference_highlight": "Scale, Medium",
-			"local_notes": "Don: 8 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. crushing.",
+			"local_notes": "Don: 8 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
@@ -11987,7 +11986,7 @@
 			"description": "Wood Bascinet, Padded",
 			"reference": "LTIA14",
 			"reference_highlight": "Wood",
-			"local_notes": "Don: 8 secs; Holdout: -9; Reaction Pen.-1",
+			"local_notes": "Don: 8 secs; Holdout: -9; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
 			"tech_level": "0",
 			"tags": [
 				"Bascinet (Skull + Back Face)",

--- a/Library/Low Tech/Low Tech Instant Armor.eqp
+++ b/Library/Low Tech/Low Tech Instant Armor.eqp
@@ -3346,7 +3346,7 @@
 			"description": "Jack of Plates Neck Armor",
 			"reference": "LTIA15",
 			"reference_highlight": "Jack of Plates",
-			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
+			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "2",
 			"tags": [
 				"Head (Skull + Face + Neck)",
@@ -5651,7 +5651,7 @@
 			"description": "Leather, Heavy Neck Armor",
 			"reference": "LTIA15",
 			"reference_highlight": "Leather, Heavy",
-			"local_notes": "Don: 3 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. impaling.",
+			"local_notes": "Don: 3 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Head (Skull + Face + Neck)",
@@ -6146,7 +6146,7 @@
 			"description": "Leather, Light Neck Armor",
 			"reference": "LTIA15",
 			"reference_highlight": "Leather, Light",
-			"local_notes": "Don: 3 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
+			"local_notes": "Don: 3 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
@@ -6627,7 +6627,7 @@
 			"description": "Leather, Medium Neck Armor",
 			"reference": "LTIA15",
 			"reference_highlight": "Leather, Medium",
-			"local_notes": "Don: 3 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
+			"local_notes": "Don: 3 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Head (Skull + Face + Neck)",
@@ -7119,7 +7119,7 @@
 			"description": "Mail and Plates Neck Armor",
 			"reference": "LTIA15",
 			"reference_highlight": "Mail and Plates",
-			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
+			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -7533,7 +7533,7 @@
 			"description": "Mail, Fine Neck Armor",
 			"reference": "LTIA15",
 			"reference_highlight": "Mail, Fine",
-			"local_notes": "Don: 3 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "Don: 3 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -7953,7 +7953,7 @@
 			"description": "Mail, Heavy Neck Armor",
 			"reference": "LTIA15",
 			"reference_highlight": "Mail, Heavy",
-			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -8589,7 +8589,7 @@
 			"description": "Mail, Light Neck Armor",
 			"reference": "LTIA15",
 			"reference_highlight": "Mail, Light",
-			"local_notes": "Don: 3 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "Don: 3 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "2",
 			"tags": [
 				"Head (Skull + Face + Neck)",
@@ -10904,7 +10904,7 @@
 			"description": "Scale, Light Neck Armor",
 			"reference": "LTIA15",
 			"reference_highlight": "Scale, Light",
-			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
+			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Head (Skull + Face + Neck)",
@@ -11399,7 +11399,7 @@
 			"description": "Scale, Medium Neck Armor",
 			"reference": "LTIA15",
 			"reference_highlight": "Scale, Medium",
-			"local_notes": "Don: 3 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. crushing.",
+			"local_notes": "Don: 3 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [

--- a/Library/Low Tech/Low Tech Instant Armor.eqp
+++ b/Library/Low Tech/Low Tech Instant Armor.eqp
@@ -9524,6 +9524,7 @@
 					"type": "dr_bonus",
 					"locations": [
 						"face",
+						"neck",
 						"skull"
 					],
 					"amount": 3
@@ -9975,21 +9976,9 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"face",
+						"neck",
 						"skull"
-					],
-					"amount": 6
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
-					],
-					"amount": 6
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"neck"
 					],
 					"amount": 6
 				}

--- a/Library/Low Tech/Low Tech Instant Armor.eqp
+++ b/Library/Low Tech/Low Tech Instant Armor.eqp
@@ -489,7 +489,9 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen",
-						"torso"
+						"groin",
+						"torso",
+						"vitals"
 					],
 					"amount": 3
 				}
@@ -859,7 +861,9 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen",
-						"torso"
+						"groin",
+						"torso",
+						"vitals"
 					],
 					"amount": 5
 				}
@@ -1166,7 +1170,9 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen",
-						"torso"
+						"groin",
+						"torso",
+						"vitals"
 					],
 					"amount": 1
 				}
@@ -1514,7 +1520,9 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen",
-						"torso"
+						"groin",
+						"torso",
+						"vitals"
 					],
 					"amount": 1
 				}
@@ -2334,7 +2342,9 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen",
-						"torso"
+						"groin",
+						"torso",
+						"vitals"
 					],
 					"amount": 3
 				}
@@ -2760,7 +2770,9 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen",
-						"torso"
+						"groin",
+						"torso",
+						"vitals"
 					],
 					"amount": 2
 				}
@@ -3046,7 +3058,9 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen",
-						"torso"
+						"groin",
+						"torso",
+						"vitals"
 					],
 					"amount": 3
 				}
@@ -3276,7 +3290,9 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen",
-						"torso"
+						"groin",
+						"torso",
+						"vitals"
 					],
 					"amount": 3
 				},
@@ -3284,7 +3300,9 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen",
-						"torso"
+						"groin",
+						"torso",
+						"vitals"
 					],
 					"specialization": "crushing",
 					"amount": -1
@@ -3477,7 +3495,9 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen",
-						"torso"
+						"groin",
+						"torso",
+						"vitals"
 					],
 					"amount": 4
 				}
@@ -3836,7 +3856,9 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen",
-						"torso"
+						"groin",
+						"torso",
+						"vitals"
 					],
 					"amount": 2
 				}
@@ -4195,7 +4217,9 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen",
-						"torso"
+						"groin",
+						"torso",
+						"vitals"
 					],
 					"amount": 3
 				}
@@ -4386,7 +4410,9 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen",
-						"torso"
+						"groin",
+						"torso",
+						"vitals"
 					],
 					"amount": 4
 				}
@@ -4745,7 +4771,9 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen",
-						"torso"
+						"groin",
+						"torso",
+						"vitals"
 					],
 					"amount": 2
 				}
@@ -5104,7 +5132,9 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen",
-						"torso"
+						"groin",
+						"torso",
+						"vitals"
 					],
 					"amount": 3
 				}
@@ -5530,7 +5560,7 @@
 			"description": "Leather, Heavy Torso Armor",
 			"reference": "LTIA4",
 			"reference_highlight": "Leather, Heavy",
-			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. impaling.",
+			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor",
@@ -5545,7 +5575,9 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen",
-						"torso"
+						"groin",
+						"torso",
+						"vitals"
 					],
 					"amount": 3
 				},
@@ -5553,7 +5585,9 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen",
-						"torso"
+						"groin",
+						"torso",
+						"vitals"
 					],
 					"specialization": "impaling",
 					"amount": -1
@@ -5989,7 +6023,7 @@
 			"description": "Leather, Light Torso Armor",
 			"reference": "LTIA4",
 			"reference_highlight": "Leather, Light",
-			"local_notes": "Don: 30 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
+			"local_notes": "Don: 30 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
@@ -6004,15 +6038,12 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
+						"abdomen",
+						"groin",
+						"torso",
+						"vitals"
 					],
-					"amount": 0
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"torso"
-					],
+					"specialization": "cutting",
 					"amount": 0
 				}
 			],
@@ -6438,7 +6469,7 @@
 			"description": "Leather, Medium Torso Armor",
 			"reference": "LTIA4",
 			"reference_highlight": "Leather, Medium",
-			"local_notes": "Don: 30 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
+			"local_notes": "Don: 30 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor",
@@ -6453,7 +6484,9 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen",
-						"torso"
+						"groin",
+						"torso",
+						"vitals"
 					],
 					"amount": 2
 				},
@@ -6461,7 +6494,9 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen",
-						"torso"
+						"groin",
+						"torso",
+						"vitals"
 					],
 					"specialization": "impaling",
 					"amount": -1
@@ -6809,7 +6844,7 @@
 			"id": "el4FE1v8UbU14sUxT",
 			"description": "Mail and Plates Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 20 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
+			"local_notes": "Don: 20 secs; Holdout: -3; Reaction Pen.-2",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -6824,7 +6859,9 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen",
-						"torso"
+						"groin",
+						"torso",
+						"vitals"
 					],
 					"amount": 5
 				},
@@ -6832,7 +6869,9 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen",
-						"torso"
+						"groin",
+						"torso",
+						"vitals"
 					],
 					"specialization": "crushing",
 					"amount": -1
@@ -7185,7 +7224,7 @@
 			"description": "Mail, Fine Torso Armor",
 			"reference": "LTIA5",
 			"reference_highlight": "Mail, Fine",
-			"local_notes": "Don: 15 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "Don: 15 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -7201,7 +7240,9 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen",
-						"torso"
+						"groin",
+						"torso",
+						"vitals"
 					],
 					"amount": 4
 				},
@@ -7209,7 +7250,9 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen",
-						"torso"
+						"groin",
+						"torso",
+						"vitals"
 					],
 					"specialization": "crushing",
 					"amount": -2
@@ -7566,7 +7609,7 @@
 			"description": "Mail, Heavy Torso Armor",
 			"reference": "LTIA5",
 			"reference_highlight": "Mail, Heavy",
-			"local_notes": "Don: 15 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "Don: 15 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -7582,7 +7625,9 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen",
-						"torso"
+						"groin",
+						"torso",
+						"vitals"
 					],
 					"amount": 5
 				},
@@ -7590,7 +7635,9 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen",
-						"torso"
+						"groin",
+						"torso",
+						"vitals"
 					],
 					"specialization": "crushing",
 					"amount": -2
@@ -7797,7 +7844,9 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen",
-						"torso"
+						"groin",
+						"torso",
+						"vitals"
 					],
 					"amount": 6
 				}
@@ -8139,7 +8188,7 @@
 			"description": "Mail, Light Torso Armor",
 			"reference": "LTIA5",
 			"reference_highlight": "Mail, Light",
-			"local_notes": "Don: 15 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "Don: 15 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "2",
 			"tags": [
 				"Body Armor",
@@ -8154,7 +8203,9 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen",
-						"torso"
+						"groin",
+						"torso",
+						"vitals"
 					],
 					"amount": 3
 				},
@@ -8162,7 +8213,9 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen",
-						"torso"
+						"groin",
+						"torso",
+						"vitals"
 					],
 					"specialization": "crushing",
 					"amount": -2
@@ -8420,7 +8473,9 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen",
-						"torso"
+						"groin",
+						"torso",
+						"vitals"
 					],
 					"amount": 6
 				}
@@ -8762,7 +8817,9 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen",
-						"torso"
+						"groin",
+						"torso",
+						"vitals"
 					],
 					"amount": 9
 				}
@@ -9188,7 +9245,9 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen",
-						"torso"
+						"groin",
+						"torso",
+						"vitals"
 					],
 					"amount": 3
 				}
@@ -9641,7 +9700,9 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen",
-						"torso"
+						"groin",
+						"torso",
+						"vitals"
 					],
 					"amount": 6
 				}
@@ -10024,12 +10085,10 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen",
-						"torso"
+						"groin",
+						"torso",
+						"vitals"
 					],
-					"amount": 5
-				},
-				{
-					"type": "dr_bonus",
 					"amount": 5
 				}
 			],
@@ -10452,7 +10511,7 @@
 			"description": "Scale, Light Torso Armor",
 			"reference": "LTIA5",
 			"reference_highlight": "Scale, Light",
-			"local_notes": "Don: 30 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
+			"local_notes": "Don: 30 secs; Holdout: -3; Reaction Pen.-2",
 			"tech_level": "1",
 			"tags": [
 				"Body Armor",
@@ -10467,7 +10526,9 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen",
-						"torso"
+						"groin",
+						"torso",
+						"vitals"
 					],
 					"amount": 3
 				},
@@ -10475,7 +10536,9 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen",
-						"torso"
+						"groin",
+						"torso",
+						"vitals"
 					],
 					"specialization": "crushing",
 					"amount": -1
@@ -10911,7 +10974,7 @@
 			"description": "Scale, Medium Torso Armor",
 			"reference": "LTIA5",
 			"reference_highlight": "Scale, Medium",
-			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. crushing.",
+			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
@@ -10927,7 +10990,9 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen",
-						"torso"
+						"groin",
+						"torso",
+						"vitals"
 					],
 					"amount": 4
 				},
@@ -10935,7 +11000,9 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen",
-						"torso"
+						"groin",
+						"torso",
+						"vitals"
 					],
 					"specialization": "crushing",
 					"amount": -1
@@ -11039,7 +11106,9 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen",
-						"torso"
+						"groin",
+						"torso",
+						"vitals"
 					],
 					"amount": 5
 				}
@@ -11234,7 +11303,9 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen",
-						"torso"
+						"groin",
+						"torso",
+						"vitals"
 					],
 					"amount": 3
 				}
@@ -11435,7 +11506,9 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen",
-						"torso"
+						"groin",
+						"torso",
+						"vitals"
 					],
 					"amount": 4
 				}
@@ -11754,7 +11827,9 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen",
-						"torso"
+						"groin",
+						"torso",
+						"vitals"
 					],
 					"amount": 2
 				}
@@ -12168,7 +12243,9 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen",
-						"torso"
+						"groin",
+						"torso",
+						"vitals"
 					],
 					"amount": 3
 				}

--- a/Library/Low Tech/Low Tech Instant Armor.eqp
+++ b/Library/Low Tech/Low Tech Instant Armor.eqp
@@ -9,7 +9,9 @@
 			"tech_level": "4",
 			"legality_class": "5",
 			"tags": [
-				"Body Armor"
+				"Arming Garments",
+				"Body Armor",
+				"Plate"
 			],
 			"base_value": "160",
 			"base_weight": "3 lb",
@@ -40,8 +42,8 @@
 			"tech_level": "4",
 			"legality_class": "4",
 			"tags": [
-				"Groin Armor",
-				"Limb Armor"
+				"Arming Garments",
+				"Plate"
 			],
 			"base_value": "160",
 			"base_weight": "3 lb",
@@ -71,7 +73,7 @@
 			"local_notes": "Don: 6 secs; Holdout: -4; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "1",
 			"tags": [
-				"Footwear"
+				"Leather"
 			],
 			"base_value": "80",
 			"base_weight": "3 lb",
@@ -108,7 +110,10 @@
 			"tech_level": "1",
 			"legality_class": "5",
 			"tags": [
-				"Footwear"
+				"Feet",
+				"Leather",
+				"Light Leather",
+				"Limbs"
 			],
 			"base_value": "50",
 			"base_weight": "1.5 lb",
@@ -145,7 +150,11 @@
 			"local_notes": "Don: 23 secs; Holdout: -2; Reaction Pen.-2",
 			"tech_level": "4",
 			"tags": [
-				"Body Armor"
+				"Abdomen Only Armor",
+				"Body Armor",
+				"Brigandine",
+				"Light Brigandine",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "225",
 			"base_weight": "2.5 lb",
@@ -174,7 +183,10 @@
 			"local_notes": "Don: 15 secs; Holdout: -2; Reaction Pen.-1",
 			"tech_level": "4",
 			"tags": [
-				"Limb Armor"
+				"Arms",
+				"Brigandine",
+				"Light Brigandine",
+				"Limbs"
 			],
 			"base_value": "450",
 			"base_weight": "5 lb",
@@ -203,7 +215,11 @@
 			"local_notes": "Don: 8 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "4",
 			"tags": [
-				"Bascinet"
+				"Bascinet (Skull + Back Face)",
+				"Brigandine",
+				"Head (Skull + Face + Neck)",
+				"Light Brigandine",
+				"Non-Padded"
 			],
 			"base_value": "225",
 			"base_weight": "2.5 lb",
@@ -232,7 +248,11 @@
 			"local_notes": "Don: 8 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "4",
 			"tags": [
-				"Bascinet"
+				"Bascinet (Skull + Back Face)",
+				"Brigandine",
+				"Head (Skull + Face + Neck)",
+				"Light Brigandine",
+				"Padded"
 			],
 			"base_value": "238",
 			"base_weight": "2.7 lb",
@@ -261,7 +281,11 @@
 			"local_notes": "Don: 23 secs; Holdout: -2; Reaction Pen.-2",
 			"tech_level": "4",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Brigandine",
+				"Chest Only Armor",
+				"Light Brigandine",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "675",
 			"base_weight": "7.5 lb",
@@ -290,7 +314,10 @@
 			"local_notes": "Don: 3 secs; Holdout: -2; Reaction Pen.-1",
 			"tech_level": "4",
 			"tags": [
-				"Groin Armor"
+				"Brigandine",
+				"Groin Only",
+				"Light Brigandine",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "45",
 			"base_weight": "0.5 lb",
@@ -319,7 +346,10 @@
 			"local_notes": "Don: 30 secs; Holdout: -2; Reaction Pen.-1",
 			"tech_level": "4",
 			"tags": [
-				"Limb Armor"
+				"Brigandine",
+				"Legs",
+				"Light Brigandine",
+				"Limbs"
 			],
 			"base_value": "900",
 			"base_weight": "10 lb",
@@ -348,7 +378,10 @@
 			"local_notes": "Don: 3 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "4",
 			"tags": [
-				"Neck Armor"
+				"Brigandine",
+				"Head (Skull + Face + Neck)",
+				"Light Brigandine",
+				"Neck"
 			],
 			"base_value": "45",
 			"base_weight": "0.5 lb",
@@ -377,7 +410,11 @@
 			"local_notes": "Don: 6 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "4",
 			"tags": [
-				"Pot Helm"
+				"Brigandine",
+				"Head (Skull + Face + Neck)",
+				"Light Brigandine",
+				"Non-Padded",
+				"Pot Helm (Skull)"
 			],
 			"base_value": "180",
 			"base_weight": "2 lb",
@@ -406,7 +443,11 @@
 			"local_notes": "Don: 6 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "4",
 			"tags": [
-				"Pot Helm"
+				"Brigandine",
+				"Head (Skull + Face + Neck)",
+				"Light Brigandine",
+				"Padded",
+				"Pot Helm (Skull)"
 			],
 			"base_value": "190",
 			"base_weight": "3.2 lb",
@@ -435,7 +476,10 @@
 			"local_notes": "Don: 30 secs; Holdout: -2; Reaction Pen.-2",
 			"tech_level": "4",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Brigandine",
+				"Light Brigandine",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "900",
 			"base_weight": "10 lb",
@@ -466,7 +510,11 @@
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
-				"Body Armor"
+				"Abdomen Only Armor",
+				"Body Armor",
+				"Brigandine",
+				"Medium Brigandine",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "450",
 			"base_weight": "5 lb",
@@ -496,7 +544,10 @@
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
-				"Limb Armor"
+				"Arms",
+				"Brigandine",
+				"Limbs",
+				"Medium Brigandine"
 			],
 			"base_value": "900",
 			"base_weight": "10 lb",
@@ -526,7 +577,11 @@
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
-				"Bascinet"
+				"Bascinet (Skull + Back Face)",
+				"Brigandine",
+				"Head (Skull + Face + Neck)",
+				"Medium Brigandine",
+				"Non-Padded"
 			],
 			"base_value": "450",
 			"base_weight": "5 lb",
@@ -556,7 +611,11 @@
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
-				"Bascinet"
+				"Bascinet (Skull + Back Face)",
+				"Brigandine",
+				"Head (Skull + Face + Neck)",
+				"Medium Brigandine",
+				"Padded"
 			],
 			"base_value": "463",
 			"base_weight": "5.2 lb",
@@ -586,7 +645,11 @@
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Brigandine",
+				"Chest Only Armor",
+				"Medium Brigandine",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "1350",
 			"base_weight": "15 lb",
@@ -616,7 +679,10 @@
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
-				"Groin Armor"
+				"Brigandine",
+				"Groin Only",
+				"Medium Brigandine",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "90",
 			"base_weight": "1 lb",
@@ -646,7 +712,10 @@
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
-				"Limb Armor"
+				"Brigandine",
+				"Legs",
+				"Limbs",
+				"Medium Brigandine"
 			],
 			"base_value": "1800",
 			"base_weight": "20 lb",
@@ -676,7 +745,10 @@
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
-				"Neck Armor"
+				"Brigandine",
+				"Head (Skull + Face + Neck)",
+				"Medium Brigandine",
+				"Neck"
 			],
 			"base_value": "90",
 			"base_weight": "1 lb",
@@ -706,7 +778,11 @@
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
-				"Pot Helm"
+				"Brigandine",
+				"Head (Skull + Face + Neck)",
+				"Medium Brigandine",
+				"Non-Padded",
+				"Pot Helm (Skull)"
 			],
 			"base_value": "360",
 			"base_weight": "4 lb",
@@ -736,7 +812,11 @@
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
-				"Pot Helm"
+				"Brigandine",
+				"Head (Skull + Face + Neck)",
+				"Medium Brigandine",
+				"Padded",
+				"Pot Helm (Skull)"
 			],
 			"base_value": "370",
 			"base_weight": "5.2 lb",
@@ -766,7 +846,10 @@
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Brigandine",
+				"Medium Brigandine",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "1800",
 			"base_weight": "20 lb",
@@ -795,7 +878,10 @@
 			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433); treat as resistant.",
 			"tech_level": "0",
 			"tags": [
-				"Body Armor"
+				"Abdomen Only Armor",
+				"Body Armor",
+				"Cane",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "9",
 			"base_weight": "3 lb",
@@ -823,7 +909,9 @@
 			"local_notes": "Don: 15 secs; Holdout: -4; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433); treat as resistant.",
 			"tech_level": "0",
 			"tags": [
-				"Limb Armor"
+				"Arms",
+				"Cane",
+				"Limbs"
 			],
 			"base_value": "18",
 			"base_weight": "6 lb",
@@ -851,7 +939,10 @@
 			"local_notes": "Don: 8 secs; Holdout: -5; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433); treat as resistant.",
 			"tech_level": "0",
 			"tags": [
-				"Bascinet"
+				"Bascinet (Skull + Back Face)",
+				"Cane",
+				"Head (Skull + Face + Neck)",
+				"Non-Padded"
 			],
 			"base_value": "9",
 			"base_weight": "3 lb",
@@ -879,7 +970,10 @@
 			"local_notes": "Don: 8 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
-				"Bascinet"
+				"Bascinet (Skull + Back Face)",
+				"Cane",
+				"Head (Skull + Face + Neck)",
+				"Padded"
 			],
 			"base_value": "22",
 			"base_weight": "3.2 lb",
@@ -907,7 +1001,10 @@
 			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433); treat as resistant.",
 			"tech_level": "0",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Cane",
+				"Chest Only Armor",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "26",
 			"base_weight": "9 lb",
@@ -935,7 +1032,9 @@
 			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433); treat as resistant.",
 			"tech_level": "0",
 			"tags": [
-				"Limb Armor"
+				"Cane",
+				"Legs",
+				"Limbs"
 			],
 			"base_value": "35",
 			"base_weight": "12 lb",
@@ -963,7 +1062,9 @@
 			"local_notes": "Don: 3 secs; Holdout: -5; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433); treat as resistant.",
 			"tech_level": "0",
 			"tags": [
-				"Neck Armor"
+				"Cane",
+				"Head (Skull + Face + Neck)",
+				"Neck"
 			],
 			"base_value": "2",
 			"base_weight": "0.6 lb",
@@ -991,7 +1092,10 @@
 			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433); treat as resistant.",
 			"tech_level": "0",
 			"tags": [
-				"Pot Helm"
+				"Cane",
+				"Head (Skull + Face + Neck)",
+				"Non-Padded",
+				"Pot Helm (Skull)"
 			],
 			"base_value": "7",
 			"base_weight": "2.4 lb",
@@ -1019,7 +1123,10 @@
 			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
-				"Pot Helm"
+				"Cane",
+				"Head (Skull + Face + Neck)",
+				"Padded",
+				"Pot Helm (Skull)"
 			],
 			"base_value": "17",
 			"base_weight": "3.6 lb",
@@ -1047,7 +1154,9 @@
 			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433); treat as resistant.",
 			"tech_level": "0",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Cane",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "35",
 			"base_weight": "12 lb",
@@ -1076,7 +1185,11 @@
 			"local_notes": "Don: 11 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
-				"Body Armor"
+				"Abdomen Only Armor",
+				"Body Armor",
+				"Cloth",
+				"Padded Cloth",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "13",
 			"base_weight": "1.5 lb",
@@ -1104,7 +1217,10 @@
 			"local_notes": "Don: 8 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
-				"Limb Armor"
+				"Arms",
+				"Cloth",
+				"Limbs",
+				"Padded Cloth"
 			],
 			"base_value": "25",
 			"base_weight": "3 lb",
@@ -1132,7 +1248,11 @@
 			"local_notes": "Don: 4 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
-				"Bascinet"
+				"Bascinet (Skull + Back Face)",
+				"Cloth",
+				"Head (Skull + Face + Neck)",
+				"Non-Padded",
+				"Padded Cloth"
 			],
 			"base_value": "13",
 			"base_weight": "1.5 lb",
@@ -1160,7 +1280,11 @@
 			"local_notes": "Don: 4 secs; Holdout: -1",
 			"tech_level": "0",
 			"tags": [
-				"Bascinet"
+				"Bascinet (Skull + Back Face)",
+				"Cloth",
+				"Head (Skull + Face + Neck)",
+				"Padded",
+				"Padded Cloth"
 			],
 			"base_value": "26",
 			"base_weight": "1.7 lb",
@@ -1188,7 +1312,11 @@
 			"local_notes": "Don: 11secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Chest Only Armor",
+				"Cloth",
+				"Padded Cloth",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "38",
 			"base_weight": "4.5 lb",
@@ -1216,7 +1344,10 @@
 			"local_notes": "Don: 3 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
-				"Groin Armor"
+				"Cloth",
+				"Groin Only",
+				"Padded Cloth",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "3",
 			"base_weight": "0.3 lb",
@@ -1244,7 +1375,10 @@
 			"local_notes": "Don: 15 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
-				"Limb Armor"
+				"Cloth",
+				"Legs",
+				"Limbs",
+				"Padded Cloth"
 			],
 			"base_value": "50",
 			"base_weight": "6 lb",
@@ -1272,7 +1406,10 @@
 			"local_notes": "Don: 3 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
-				"Neck Armor"
+				"Cloth",
+				"Head (Skull + Face + Neck)",
+				"Neck",
+				"Padded Cloth"
 			],
 			"base_value": "3",
 			"base_weight": "0.3 lb",
@@ -1300,7 +1437,11 @@
 			"local_notes": "Don: 3 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
-				"Pot Helm"
+				"Cloth",
+				"Head (Skull + Face + Neck)",
+				"Non-Padded",
+				"Padded Cloth",
+				"Pot Helm (Skull)"
 			],
 			"base_value": "10",
 			"base_weight": "1.2 lb",
@@ -1328,7 +1469,11 @@
 			"local_notes": "Don: 3 secs; Holdout: -1",
 			"tech_level": "0",
 			"tags": [
-				"Pot Helm"
+				"Cloth",
+				"Head (Skull + Face + Neck)",
+				"Padded",
+				"Padded Cloth",
+				"Pot Helm (Skull)"
 			],
 			"base_value": "20",
 			"base_weight": "2.4 lb",
@@ -1356,7 +1501,10 @@
 			"local_notes": "Don: 15 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Cloth",
+				"Padded Cloth",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "50",
 			"base_weight": "6 lb",
@@ -1385,7 +1533,7 @@
 			"local_notes": "Don: 10 secs; Holdout: -4; Gives Ham-Fisted 2 (p. B138).",
 			"tech_level": "1",
 			"tags": [
-				"Gloves"
+				"Hardened Leather"
 			],
 			"base_value": "13",
 			"base_weight": "1.5 lb",
@@ -1414,7 +1562,8 @@
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
-				"Gloves"
+				"Heavy Mail",
+				"Mail"
 			],
 			"base_value": "120",
 			"base_weight": "1.8 lb",
@@ -1450,7 +1599,10 @@
 			"local_notes": "Don: 10 secs; Holdout: -4; Gives Ham-Fisted 2 (p. B138).",
 			"tech_level": "4",
 			"tags": [
-				"Gloves"
+				"Hands",
+				"Light Plate",
+				"Limbs",
+				"Plate"
 			],
 			"base_value": "100",
 			"base_weight": "0.8 lb",
@@ -1478,7 +1630,10 @@
 			"local_notes": "Don: 10 secs; Holdout: -4; Gives Ham-Fisted 2 (p. B138).",
 			"tech_level": "3",
 			"tags": [
-				"Gloves"
+				"Hands",
+				"Light Segmented Plate",
+				"Limbs",
+				"Segmented Plate"
 			],
 			"base_value": "60",
 			"base_weight": "1.6 lb",
@@ -1507,7 +1662,10 @@
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
-				"Gloves"
+				"Hands",
+				"Limbs",
+				"Medium Plate",
+				"Plate"
 			],
 			"base_value": "250",
 			"base_weight": "2 lb",
@@ -1535,7 +1693,10 @@
 			"local_notes": "Don: 10 secs; Holdout: -5; Gives Ham-Fisted 2 (p. B138).",
 			"tech_level": "3",
 			"tags": [
-				"Gloves"
+				"Hands",
+				"Limbs",
+				"Medium Segmented Plate",
+				"Segmented Plate"
 			],
 			"base_value": "90",
 			"base_weight": "2.4 lb",
@@ -1563,7 +1724,10 @@
 			"local_notes": "Don: 10 secs; Holdout: -2; Flexible and susceptible to blunt trauma (p. B379); Gives Ham-Fisted 1 (p. B138).",
 			"tech_level": "1",
 			"tags": [
-				"Gloves"
+				"Cloth",
+				"Hands",
+				"Limbs",
+				"Padded Cloth"
 			],
 			"base_value": "5",
 			"base_weight": "0.6 lb",
@@ -1591,7 +1755,8 @@
 			"local_notes": "Don: 10 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing; Gives Ham-Fisted 2 (p. B138).",
 			"tech_level": "2",
 			"tags": [
-				"Gloves"
+				"Fine Mail",
+				"Mail"
 			],
 			"base_value": "90",
 			"base_weight": "1.5 lb",
@@ -1627,7 +1792,10 @@
 			"local_notes": "Don: 10 secs; Holdout: -2; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing; Gives Ham-Fisted 2 (p. B138).",
 			"tech_level": "2",
 			"tags": [
-				"Gloves"
+				"Hands",
+				"Light Mail",
+				"Limbs",
+				"Mail"
 			],
 			"base_value": "50",
 			"base_weight": "1.2 lb",
@@ -1663,7 +1831,10 @@
 			"local_notes": "Don: 10 secs; Holdout: -4; -1 DR vs. crushing; Gives Ham-Fisted 2 (p. B138).",
 			"tech_level": "1",
 			"tags": [
-				"Gloves"
+				"Hands",
+				"Light Scale",
+				"Limbs",
+				"Scale"
 			],
 			"base_value": "32",
 			"base_weight": "1.6 lb",
@@ -1692,7 +1863,7 @@
 			"tech_level": "1",
 			"legality_class": "5",
 			"tags": [
-				"Gloves"
+				"Cloth"
 			],
 			"base_value": "15",
 			"base_weight": "0.5 lb",
@@ -1729,7 +1900,10 @@
 			"tech_level": "1",
 			"legality_class": "5",
 			"tags": [
-				"Gloves"
+				"Hands",
+				"Leather",
+				"Light Leather",
+				"Limbs"
 			],
 			"base_value": "15",
 			"base_weight": "0.5 lb",
@@ -1765,7 +1939,11 @@
 			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "1",
 			"tags": [
-				"Body Armor"
+				"Abdomen Only Armor",
+				"Body Armor",
+				"Hardened Leather",
+				"Heavy Hardened Leather",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "63",
 			"base_weight": "6.3 lb",
@@ -1793,7 +1971,10 @@
 			"local_notes": "Don: 15 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
-				"Limb Armor"
+				"Arms",
+				"Hardened Leather",
+				"Heavy Hardened Leather",
+				"Limbs"
 			],
 			"base_value": "125",
 			"base_weight": "12.5 lb",
@@ -1821,7 +2002,11 @@
 			"local_notes": "Don: 8 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
-				"Bascinet"
+				"Bascinet (Skull + Back Face)",
+				"Hardened Leather",
+				"Head (Skull + Face + Neck)",
+				"Heavy Hardened Leather",
+				"Non-Padded"
 			],
 			"base_value": "63",
 			"base_weight": "6.3 lb",
@@ -1849,7 +2034,11 @@
 			"local_notes": "Don: 8 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
-				"Bascinet"
+				"Bascinet (Skull + Back Face)",
+				"Hardened Leather",
+				"Head (Skull + Face + Neck)",
+				"Heavy Hardened Leather",
+				"Padded"
 			],
 			"base_value": "76",
 			"base_weight": "6.5 lb",
@@ -1877,7 +2066,11 @@
 			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "1",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Chest Only Armor",
+				"Hardened Leather",
+				"Heavy Hardened Leather",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "188",
 			"base_weight": "18.8 lb",
@@ -1905,7 +2098,11 @@
 			"local_notes": "Don: 9 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
-				"Full Helm"
+				"Full Helms (Skull + Face)",
+				"Hardened Leather",
+				"Head (Skull + Face + Neck)",
+				"Heavy Hardened Leather",
+				"Non-Padded"
 			],
 			"base_value": "75",
 			"base_weight": "7.5 lb",
@@ -1934,7 +2131,11 @@
 			"local_notes": "Don: 9 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
-				"Full Helm"
+				"Full Helms (Skull + Face)",
+				"Hardened Leather",
+				"Head (Skull + Face + Neck)",
+				"Heavy Hardened Leather",
+				"Padded"
 			],
 			"base_value": "90",
 			"base_weight": "9.3 lb",
@@ -1963,7 +2164,10 @@
 			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
-				"Groin Armor"
+				"Groin Only",
+				"Hardened Leather",
+				"Heavy Hardened Leather",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "13",
 			"base_weight": "1.3 lb",
@@ -1991,7 +2195,10 @@
 			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
-				"Limb Armor"
+				"Hardened Leather",
+				"Heavy Hardened Leather",
+				"Legs",
+				"Limbs"
 			],
 			"base_value": "250",
 			"base_weight": "25 lb",
@@ -2019,7 +2226,10 @@
 			"local_notes": "Don: 3 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
-				"Neck Armor"
+				"Hardened Leather",
+				"Head (Skull + Face + Neck)",
+				"Heavy Hardened Leather",
+				"Neck"
 			],
 			"base_value": "13",
 			"base_weight": "1.3 lb",
@@ -2047,7 +2257,11 @@
 			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
-				"Pot Helm"
+				"Hardened Leather",
+				"Head (Skull + Face + Neck)",
+				"Heavy Hardened Leather",
+				"Non-Padded",
+				"Pot Helm (Skull)"
 			],
 			"base_value": "50",
 			"base_weight": "5 lb",
@@ -2075,7 +2289,11 @@
 			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
-				"Pot Helm"
+				"Hardened Leather",
+				"Head (Skull + Face + Neck)",
+				"Heavy Hardened Leather",
+				"Padded",
+				"Pot Helm (Skull)"
 			],
 			"base_value": "60",
 			"base_weight": "6.2 lb",
@@ -2103,7 +2321,10 @@
 			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "1",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Hardened Leather",
+				"Heavy Hardened Leather",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "250",
 			"base_weight": "25 lb",
@@ -2132,7 +2353,11 @@
 			"local_notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-2",
 			"tech_level": "1",
 			"tags": [
-				"Body Armor"
+				"Abdomen Only Armor",
+				"Body Armor",
+				"Hardened Leather",
+				"Medium Hardened Leather",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "31",
 			"base_weight": "3.8 lb",
@@ -2160,7 +2385,10 @@
 			"local_notes": "Don: 15 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
-				"Limb Armor"
+				"Arms",
+				"Hardened Leather",
+				"Limbs",
+				"Medium Hardened Leather"
 			],
 			"base_value": "63",
 			"base_weight": "7.5 lb",
@@ -2188,7 +2416,11 @@
 			"local_notes": "Don: 8 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
-				"Bascinet"
+				"Bascinet (Skull + Back Face)",
+				"Hardened Leather",
+				"Head (Skull + Face + Neck)",
+				"Medium Hardened Leather",
+				"Non-Padded"
 			],
 			"base_value": "31",
 			"base_weight": "3.8 lb",
@@ -2216,7 +2448,11 @@
 			"local_notes": "Don: 8 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
-				"Bascinet"
+				"Bascinet (Skull + Back Face)",
+				"Hardened Leather",
+				"Head (Skull + Face + Neck)",
+				"Medium Hardened Leather",
+				"Padded"
 			],
 			"base_value": "44",
 			"base_weight": "4 lb",
@@ -2244,7 +2480,11 @@
 			"local_notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-2",
 			"tech_level": "1",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Chest Only Armor",
+				"Hardened Leather",
+				"Medium Hardened Leather",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "94",
 			"base_weight": "11.3 lb",
@@ -2272,7 +2512,11 @@
 			"local_notes": "Don: 9 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
-				"Full Helm"
+				"Full Helms (Skull + Face)",
+				"Hardened Leather",
+				"Head (Skull + Face + Neck)",
+				"Medium Hardened Leather",
+				"Non-Padded"
 			],
 			"base_value": "38",
 			"base_weight": "4.5 lb",
@@ -2307,7 +2551,11 @@
 			"local_notes": "Don: 9 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
-				"Full Helm"
+				"Full Helms (Skull + Face)",
+				"Hardened Leather",
+				"Head (Skull + Face + Neck)",
+				"Medium Hardened Leather",
+				"Padded"
 			],
 			"base_value": "53",
 			"base_weight": "6.3 lb",
@@ -2342,7 +2590,10 @@
 			"local_notes": "Don: 3 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
-				"Groin Armor"
+				"Groin Only",
+				"Hardened Leather",
+				"Medium Hardened Leather",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "6",
 			"base_weight": "0.8 lb",
@@ -2370,7 +2621,10 @@
 			"local_notes": "Don: 30 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
-				"Limb Armor"
+				"Hardened Leather",
+				"Legs",
+				"Limbs",
+				"Medium Hardened Leather"
 			],
 			"base_value": "125",
 			"base_weight": "15 lb",
@@ -2398,7 +2652,10 @@
 			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
-				"Neck Armor"
+				"Hardened Leather",
+				"Head (Skull + Face + Neck)",
+				"Medium Hardened Leather",
+				"Neck"
 			],
 			"base_value": "6",
 			"base_weight": "0.8 lb",
@@ -2426,7 +2683,11 @@
 			"local_notes": "Don: 6 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
-				"Pot Helm"
+				"Hardened Leather",
+				"Head (Skull + Face + Neck)",
+				"Medium Hardened Leather",
+				"Non-Padded",
+				"Pot Helm (Skull)"
 			],
 			"base_value": "25",
 			"base_weight": "3 lb",
@@ -2454,7 +2715,11 @@
 			"local_notes": "Don: 6 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
-				"Pot Helm"
+				"Hardened Leather",
+				"Head (Skull + Face + Neck)",
+				"Medium Hardened Leather",
+				"Padded",
+				"Pot Helm (Skull)"
 			],
 			"base_value": "35",
 			"base_weight": "4.2 lb",
@@ -2482,7 +2747,10 @@
 			"local_notes": "Don: 30 secs; Holdout: -3; Reaction Pen.-2",
 			"tech_level": "1",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Hardened Leather",
+				"Medium Hardened Leather",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "125",
 			"base_weight": "15 lb",
@@ -2512,7 +2780,10 @@
 			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "0",
 			"tags": [
-				"Body Armor"
+				"Abdomen Only Armor",
+				"Body Armor",
+				"Horn",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "63",
 			"base_weight": "6.3 lb",
@@ -2541,7 +2812,9 @@
 			"local_notes": "Don: 15 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
-				"Limb Armor"
+				"Arms",
+				"Horn",
+				"Limbs"
 			],
 			"base_value": "125",
 			"base_weight": "12.5 lb",
@@ -2570,7 +2843,10 @@
 			"local_notes": "Don: 8 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
-				"Bascinet"
+				"Bascinet (Skull + Back Face)",
+				"Head (Skull + Face + Neck)",
+				"Horn",
+				"Non-Padded"
 			],
 			"base_value": "63",
 			"base_weight": "6.3 lb",
@@ -2599,7 +2875,10 @@
 			"local_notes": "Don: 8 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
-				"Bascinet"
+				"Bascinet (Skull + Back Face)",
+				"Head (Skull + Face + Neck)",
+				"Horn",
+				"Padded"
 			],
 			"base_value": "76",
 			"base_weight": "6.5 lb",
@@ -2628,7 +2907,10 @@
 			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "0",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Chest Only Armor",
+				"Horn",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "188",
 			"base_weight": "18.8 lb",
@@ -2657,7 +2939,9 @@
 			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
-				"Limb Armor"
+				"Horn",
+				"Legs",
+				"Limbs"
 			],
 			"base_value": "250",
 			"base_weight": "25 lb",
@@ -2686,7 +2970,10 @@
 			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
-				"Pot Helm"
+				"Head (Skull + Face + Neck)",
+				"Horn",
+				"Non-Padded",
+				"Pot Helm (Skull)"
 			],
 			"base_value": "50",
 			"base_weight": "5 lb",
@@ -2715,7 +3002,10 @@
 			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
-				"Pot Helm"
+				"Head (Skull + Face + Neck)",
+				"Horn",
+				"Padded",
+				"Pot Helm (Skull)"
 			],
 			"base_value": "60",
 			"base_weight": "6.2 lb",
@@ -2744,7 +3034,9 @@
 			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "0",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Horn",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "250",
 			"base_weight": "25 lb",
@@ -2774,7 +3066,10 @@
 			"local_notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
-				"Body Armor"
+				"Abdomen Only Armor",
+				"Body Armor",
+				"Jack of Plates",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "75",
 			"base_weight": "4.5 lb",
@@ -2812,7 +3107,9 @@
 			"local_notes": "Don: 15 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
-				"Limb Armor"
+				"Arms",
+				"Jack of Plates",
+				"Limbs"
 			],
 			"base_value": "150",
 			"base_weight": "9 lb",
@@ -2849,7 +3146,10 @@
 			"local_notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Chest Only Armor",
+				"Jack of Plates",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "225",
 			"base_weight": "13.5 lb",
@@ -2886,7 +3186,9 @@
 			"local_notes": "Don: 30 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
-				"Limb Armor"
+				"Jack of Plates",
+				"Legs",
+				"Limbs"
 			],
 			"base_value": "300",
 			"base_weight": "18 lb",
@@ -2923,7 +3225,9 @@
 			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
-				"Neck Armor"
+				"Head (Skull + Face + Neck)",
+				"Jack of Plates",
+				"Neck"
 			],
 			"base_value": "15",
 			"base_weight": "0.9 lb",
@@ -2960,7 +3264,9 @@
 			"local_notes": "Don: 30 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Jack of Plates",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "300",
 			"base_weight": "18 lb",
@@ -2999,7 +3305,11 @@
 			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "0",
 			"tags": [
-				"Body Armor"
+				"Abdomen Only Armor",
+				"Body Armor",
+				"Heavy Layered Cloth",
+				"Layered Cloth",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "150",
 			"base_weight": "7 lb",
@@ -3027,7 +3337,11 @@
 			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "0",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Chest Only Armor",
+				"Heavy Layered Cloth",
+				"Layered Cloth",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "450",
 			"base_weight": "21 lb",
@@ -3055,7 +3369,10 @@
 			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
-				"Groin Armor"
+				"Groin Only",
+				"Heavy Layered Cloth",
+				"Layered Cloth",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "30",
 			"base_weight": "1.4 lb",
@@ -3083,7 +3400,11 @@
 			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
-				"Pot Helm"
+				"Head (Skull + Face + Neck)",
+				"Heavy Layered Cloth",
+				"Layered Cloth",
+				"Non-Padded",
+				"Pot Helm (Skull)"
 			],
 			"base_value": "120",
 			"base_weight": "5.6 lb",
@@ -3111,7 +3432,11 @@
 			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
-				"Pot Helm"
+				"Head (Skull + Face + Neck)",
+				"Heavy Layered Cloth",
+				"Layered Cloth",
+				"Padded",
+				"Pot Helm (Skull)"
 			],
 			"base_value": "130",
 			"base_weight": "6.8 lb",
@@ -3139,7 +3464,10 @@
 			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "0",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Heavy Layered Cloth",
+				"Layered Cloth",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "600",
 			"base_weight": "28 lb",
@@ -3169,7 +3497,11 @@
 			"local_notes": "Don: 15 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
-				"Body Armor"
+				"Abdomen Only Armor",
+				"Body Armor",
+				"Layered Cloth",
+				"Light Layered Cloth",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "38",
 			"base_weight": "3 lb",
@@ -3198,7 +3530,10 @@
 			"local_notes": "Don: 10 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
-				"Limb Armor"
+				"Arms",
+				"Layered Cloth",
+				"Light Layered Cloth",
+				"Limbs"
 			],
 			"base_value": "75",
 			"base_weight": "6 lb",
@@ -3227,7 +3562,11 @@
 			"local_notes": "Don: 5 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
-				"Bascinet"
+				"Bascinet (Skull + Back Face)",
+				"Head (Skull + Face + Neck)",
+				"Layered Cloth",
+				"Light Layered Cloth",
+				"Non-Padded"
 			],
 			"base_value": "38",
 			"base_weight": "3 lb",
@@ -3256,7 +3595,11 @@
 			"local_notes": "Don: 5 secs; Holdout: -1; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
-				"Bascinet"
+				"Bascinet (Skull + Back Face)",
+				"Head (Skull + Face + Neck)",
+				"Layered Cloth",
+				"Light Layered Cloth",
+				"Padded"
 			],
 			"base_value": "51",
 			"base_weight": "3.2 lb",
@@ -3285,7 +3628,11 @@
 			"local_notes": "Don: 15 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Chest Only Armor",
+				"Layered Cloth",
+				"Light Layered Cloth",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "113",
 			"base_weight": "9 lb",
@@ -3314,7 +3661,10 @@
 			"local_notes": "Don: 3 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
-				"Groin Armor"
+				"Groin Only",
+				"Layered Cloth",
+				"Light Layered Cloth",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "8",
 			"base_weight": "0.6 lb",
@@ -3343,7 +3693,10 @@
 			"local_notes": "Don: 20 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
-				"Limb Armor"
+				"Layered Cloth",
+				"Legs",
+				"Light Layered Cloth",
+				"Limbs"
 			],
 			"base_value": "150",
 			"base_weight": "12 lb",
@@ -3372,7 +3725,10 @@
 			"local_notes": "Don: 3 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
-				"Neck Armor"
+				"Head (Skull + Face + Neck)",
+				"Layered Cloth",
+				"Light Layered Cloth",
+				"Neck"
 			],
 			"base_value": "8",
 			"base_weight": "0.6 lb",
@@ -3401,7 +3757,11 @@
 			"local_notes": "Don: 4 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
-				"Pot Helm"
+				"Head (Skull + Face + Neck)",
+				"Layered Cloth",
+				"Light Layered Cloth",
+				"Non-Padded",
+				"Pot Helm (Skull)"
 			],
 			"base_value": "30",
 			"base_weight": "2.4 lb",
@@ -3430,7 +3790,11 @@
 			"local_notes": "Don: 4 secs; Holdout: -1; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
-				"Pot Helm"
+				"Head (Skull + Face + Neck)",
+				"Layered Cloth",
+				"Light Layered Cloth",
+				"Padded",
+				"Pot Helm (Skull)"
 			],
 			"base_value": "40",
 			"base_weight": "3.6 lb",
@@ -3459,7 +3823,10 @@
 			"local_notes": "Don: 20 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Layered Cloth",
+				"Light Layered Cloth",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "150",
 			"base_weight": "12 lb",
@@ -3489,7 +3856,11 @@
 			"local_notes": "Don: 23 secs; Holdout: -2; Reaction Pen.-2",
 			"tech_level": "0",
 			"tags": [
-				"Body Armor"
+				"Abdomen Only Armor",
+				"Body Armor",
+				"Layered Cloth",
+				"Medium Layered Cloth",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "88",
 			"base_weight": "5 lb",
@@ -3518,7 +3889,10 @@
 			"local_notes": "Don: 15 secs; Holdout: -2; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
-				"Limb Armor"
+				"Arms",
+				"Layered Cloth",
+				"Limbs",
+				"Medium Layered Cloth"
 			],
 			"base_value": "175",
 			"base_weight": "10 lb",
@@ -3547,7 +3921,11 @@
 			"local_notes": "Don: 8 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
-				"Bascinet"
+				"Bascinet (Skull + Back Face)",
+				"Head (Skull + Face + Neck)",
+				"Layered Cloth",
+				"Medium Layered Cloth",
+				"Non-Padded"
 			],
 			"base_value": "88",
 			"base_weight": "5 lb",
@@ -3576,7 +3954,11 @@
 			"local_notes": "Don: 8 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
-				"Bascinet"
+				"Bascinet (Skull + Back Face)",
+				"Head (Skull + Face + Neck)",
+				"Layered Cloth",
+				"Medium Layered Cloth",
+				"Padded"
 			],
 			"base_value": "101",
 			"base_weight": "5.2 lb",
@@ -3605,7 +3987,11 @@
 			"local_notes": "Don: 23 secs; Holdout: -2; Reaction Pen.-2",
 			"tech_level": "0",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Chest Only Armor",
+				"Layered Cloth",
+				"Medium Layered Cloth",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "263",
 			"base_weight": "15 lb",
@@ -3634,7 +4020,10 @@
 			"local_notes": "Don: 3 secs; Holdout: -2; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
-				"Groin Armor"
+				"Groin Only",
+				"Layered Cloth",
+				"Medium Layered Cloth",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "18",
 			"base_weight": "1 lb",
@@ -3663,7 +4052,10 @@
 			"local_notes": "Don: 30 secs; Holdout: -2; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
-				"Limb Armor"
+				"Layered Cloth",
+				"Legs",
+				"Limbs",
+				"Medium Layered Cloth"
 			],
 			"base_value": "350",
 			"base_weight": "20 lb",
@@ -3692,7 +4084,10 @@
 			"local_notes": "Don: 3 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
-				"Neck Armor"
+				"Head (Skull + Face + Neck)",
+				"Layered Cloth",
+				"Medium Layered Cloth",
+				"Neck"
 			],
 			"base_value": "18",
 			"base_weight": "1 lb",
@@ -3721,7 +4116,11 @@
 			"local_notes": "Don: 6 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
-				"Pot Helm"
+				"Head (Skull + Face + Neck)",
+				"Layered Cloth",
+				"Medium Layered Cloth",
+				"Non-Padded",
+				"Pot Helm (Skull)"
 			],
 			"base_value": "70",
 			"base_weight": "4 lb",
@@ -3750,7 +4149,11 @@
 			"local_notes": "Don: 6 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
-				"Pot Helm"
+				"Head (Skull + Face + Neck)",
+				"Layered Cloth",
+				"Medium Layered Cloth",
+				"Padded",
+				"Pot Helm (Skull)"
 			],
 			"base_value": "80",
 			"base_weight": "5.2 lb",
@@ -3779,7 +4182,10 @@
 			"local_notes": "Don: 30 secs; Holdout: -2; Reaction Pen.-2",
 			"tech_level": "0",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Layered Cloth",
+				"Medium Layered Cloth",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "350",
 			"base_weight": "20 lb",
@@ -3808,7 +4214,11 @@
 			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "1",
 			"tags": [
-				"Body Armor"
+				"Abdomen Only Armor",
+				"Body Armor",
+				"Heavy Layered Leather",
+				"Layered Leather",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "131",
 			"base_weight": "8.8 lb",
@@ -3836,7 +4246,11 @@
 			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "1",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Chest Only Armor",
+				"Heavy Layered Leather",
+				"Layered Leather",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "394",
 			"base_weight": "26.3 lb",
@@ -3864,7 +4278,10 @@
 			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
-				"Groin Armor"
+				"Groin Only",
+				"Heavy Layered Leather",
+				"Layered Leather",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "26",
 			"base_weight": "1.8 lb",
@@ -3892,7 +4309,11 @@
 			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
-				"Pot Helm"
+				"Head (Skull + Face + Neck)",
+				"Heavy Layered Leather",
+				"Layered Leather",
+				"Non-Padded",
+				"Pot Helm (Skull)"
 			],
 			"base_value": "105",
 			"base_weight": "7 lb",
@@ -3920,7 +4341,11 @@
 			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
-				"Pot Helm"
+				"Head (Skull + Face + Neck)",
+				"Heavy Layered Leather",
+				"Layered Leather",
+				"Padded",
+				"Pot Helm (Skull)"
 			],
 			"base_value": "115",
 			"base_weight": "8.2 lb",
@@ -3948,7 +4373,10 @@
 			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "1",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Heavy Layered Leather",
+				"Layered Leather",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "525",
 			"base_weight": "35 lb",
@@ -3978,7 +4406,11 @@
 			"local_notes": "Don: 15 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "1",
 			"tags": [
-				"Body Armor"
+				"Abdomen Only Armor",
+				"Body Armor",
+				"Layered Leather",
+				"Light Layered Leather",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "30",
 			"base_weight": "3.8 lb",
@@ -4007,7 +4439,10 @@
 			"local_notes": "Don: 10 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "1",
 			"tags": [
-				"Limb Armor"
+				"Arms",
+				"Layered Leather",
+				"Light Layered Leather",
+				"Limbs"
 			],
 			"base_value": "60",
 			"base_weight": "7.5 lb",
@@ -4036,7 +4471,11 @@
 			"local_notes": "Don: 5 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "1",
 			"tags": [
-				"Bascinet"
+				"Bascinet (Skull + Back Face)",
+				"Head (Skull + Face + Neck)",
+				"Layered Leather",
+				"Light Layered Leather",
+				"Non-Padded"
 			],
 			"base_value": "30",
 			"base_weight": "3.8 lb",
@@ -4065,7 +4504,11 @@
 			"local_notes": "Don: 5 secs; Holdout: -2; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
-				"Bascinet"
+				"Bascinet (Skull + Back Face)",
+				"Head (Skull + Face + Neck)",
+				"Layered Leather",
+				"Light Layered Leather",
+				"Padded"
 			],
 			"base_value": "43",
 			"base_weight": "4 lb",
@@ -4094,7 +4537,11 @@
 			"local_notes": "Don: 15 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "1",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Chest Only Armor",
+				"Layered Leather",
+				"Light Layered Leather",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "90",
 			"base_weight": "11.3 lb",
@@ -4123,7 +4570,10 @@
 			"local_notes": "Don: 3 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "1",
 			"tags": [
-				"Groin Armor"
+				"Groin Only",
+				"Layered Leather",
+				"Light Layered Leather",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "6",
 			"base_weight": "0.8 lb",
@@ -4152,7 +4602,10 @@
 			"local_notes": "Don: 20 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "1",
 			"tags": [
-				"Limb Armor"
+				"Layered Leather",
+				"Legs",
+				"Light Layered Leather",
+				"Limbs"
 			],
 			"base_value": "120",
 			"base_weight": "15 lb",
@@ -4181,7 +4634,10 @@
 			"local_notes": "Don: 3 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "1",
 			"tags": [
-				"Neck Armor"
+				"Head (Skull + Face + Neck)",
+				"Layered Leather",
+				"Light Layered Leather",
+				"Neck"
 			],
 			"base_value": "6",
 			"base_weight": "0.8 lb",
@@ -4210,7 +4666,11 @@
 			"local_notes": "Don: 4 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "1",
 			"tags": [
-				"Pot Helm"
+				"Head (Skull + Face + Neck)",
+				"Layered Leather",
+				"Light Layered Leather",
+				"Non-Padded",
+				"Pot Helm (Skull)"
 			],
 			"base_value": "24",
 			"base_weight": "3 lb",
@@ -4239,7 +4699,11 @@
 			"local_notes": "Don: 4 secs; Holdout: -2; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
-				"Pot Helm"
+				"Head (Skull + Face + Neck)",
+				"Layered Leather",
+				"Light Layered Leather",
+				"Padded",
+				"Pot Helm (Skull)"
 			],
 			"base_value": "34",
 			"base_weight": "4.2 lb",
@@ -4268,7 +4732,10 @@
 			"local_notes": "Don: 20 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "1",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Layered Leather",
+				"Light Layered Leather",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "120",
 			"base_weight": "15 lb",
@@ -4298,7 +4765,11 @@
 			"local_notes": "Don: 23 secs; Holdout: -2; Reaction Pen.-2",
 			"tech_level": "1",
 			"tags": [
-				"Body Armor"
+				"Abdomen Only Armor",
+				"Body Armor",
+				"Layered Leather",
+				"Medium Layered Leather",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "55",
 			"base_weight": "6.5 lb",
@@ -4327,7 +4798,10 @@
 			"local_notes": "Don: 15 secs; Holdout: -2; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
-				"Limb Armor"
+				"Arms",
+				"Layered Leather",
+				"Limbs",
+				"Medium Layered Leather"
 			],
 			"base_value": "110",
 			"base_weight": "13 lb",
@@ -4356,7 +4830,11 @@
 			"local_notes": "Don: 8 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
-				"Bascinet"
+				"Bascinet (Skull + Back Face)",
+				"Head (Skull + Face + Neck)",
+				"Layered Leather",
+				"Medium Layered Leather",
+				"Non-Padded"
 			],
 			"base_value": "55",
 			"base_weight": "6.5 lb",
@@ -4385,7 +4863,11 @@
 			"local_notes": "DR:4; Don: 8 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
-				"Bascinet"
+				"Bascinet (Skull + Back Face)",
+				"Head (Skull + Face + Neck)",
+				"Layered Leather",
+				"Medium Layered Leather",
+				"Padded"
 			],
 			"base_value": "68",
 			"base_weight": "6.7 lb",
@@ -4414,7 +4896,11 @@
 			"local_notes": "Don: 23 secs; Holdout: -2; Reaction Pen.-2",
 			"tech_level": "1",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Chest Only Armor",
+				"Layered Leather",
+				"Medium Layered Leather",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "165",
 			"base_weight": "19.5 lb",
@@ -4443,7 +4929,10 @@
 			"local_notes": "Don: 3 secs; Holdout: -2; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
-				"Groin Armor"
+				"Groin Only",
+				"Layered Leather",
+				"Medium Layered Leather",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "11",
 			"base_weight": "1.3 lb",
@@ -4472,7 +4961,10 @@
 			"local_notes": "Don: 30 secs; Holdout: -2; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
-				"Limb Armor"
+				"Layered Leather",
+				"Legs",
+				"Limbs",
+				"Medium Layered Leather"
 			],
 			"base_value": "220",
 			"base_weight": "26 lb",
@@ -4501,7 +4993,10 @@
 			"local_notes": "Don: 3 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
-				"Neck Armor"
+				"Head (Skull + Face + Neck)",
+				"Layered Leather",
+				"Medium Layered Leather",
+				"Neck"
 			],
 			"base_value": "11",
 			"base_weight": "1.3 lb",
@@ -4530,7 +5025,11 @@
 			"local_notes": "Don: 6 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
-				"Pot Helm"
+				"Head (Skull + Face + Neck)",
+				"Layered Leather",
+				"Medium Layered Leather",
+				"Non-Padded",
+				"Pot Helm (Skull)"
 			],
 			"base_value": "44",
 			"base_weight": "5.2 lb",
@@ -4559,7 +5058,11 @@
 			"local_notes": "Don: 6 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
-				"Pot Helm"
+				"Head (Skull + Face + Neck)",
+				"Layered Leather",
+				"Medium Layered Leather",
+				"Padded",
+				"Pot Helm (Skull)"
 			],
 			"base_value": "54",
 			"base_weight": "6.4 lb",
@@ -4588,7 +5091,10 @@
 			"local_notes": "Don: 30 secs; Holdout: -2; Reaction Pen.-2",
 			"tech_level": "1",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Layered Leather",
+				"Medium Layered Leather",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "220",
 			"base_weight": "26 lb",
@@ -4619,7 +5125,11 @@
 			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
-				"Body Armor"
+				"Abdomen Only Armor",
+				"Body Armor",
+				"Heavy Leather",
+				"Leather",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "50",
 			"base_weight": "5 lb",
@@ -4657,7 +5167,10 @@
 			"local_notes": "Don: 15 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
-				"Limb Armor"
+				"Arms",
+				"Heavy Leather",
+				"Leather",
+				"Limbs"
 			],
 			"base_value": "100",
 			"base_weight": "10 lb",
@@ -4694,7 +5207,11 @@
 			"local_notes": "Don: 8 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
-				"Bascinet"
+				"Head (Skull + Face + Neck)",
+				"Heavy Leather",
+				"Leather",
+				"Non-Padded",
+				"Pot Helm (Skull)"
 			],
 			"base_value": "50",
 			"base_weight": "5 lb",
@@ -4731,7 +5248,11 @@
 			"local_notes": "Don: 8 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
-				"Bascinet"
+				"Bascinet (Skull + Back Face)",
+				"Head (Skull + Face + Neck)",
+				"Heavy Leather",
+				"Leather",
+				"Padded"
 			],
 			"base_value": "63",
 			"base_weight": "5.2 lb",
@@ -4768,7 +5289,11 @@
 			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Chest Only Armor",
+				"Heavy Leather",
+				"Leather",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "150",
 			"base_weight": "15 lb",
@@ -4805,7 +5330,10 @@
 			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
-				"Groin Armor"
+				"Groin Only",
+				"Heavy Leather",
+				"Leather",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "10",
 			"base_weight": "1 lb",
@@ -4842,7 +5370,10 @@
 			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
-				"Limb Armor"
+				"Heavy Leather",
+				"Leather",
+				"Legs",
+				"Limbs"
 			],
 			"base_value": "200",
 			"base_weight": "20 lb",
@@ -4879,7 +5410,10 @@
 			"local_notes": "Don: 3 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
-				"Neck Armor"
+				"Head (Skull + Face + Neck)",
+				"Heavy Leather",
+				"Leather",
+				"Neck"
 			],
 			"base_value": "10",
 			"base_weight": "1 lb",
@@ -4916,7 +5450,11 @@
 			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
-				"Pot Helm"
+				"Head (Skull + Face + Neck)",
+				"Heavy Leather",
+				"Leather",
+				"Non-Padded",
+				"Pot Helm (Skull)"
 			],
 			"base_value": "40",
 			"base_weight": "4 lb",
@@ -4953,7 +5491,11 @@
 			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
-				"Pot Helm"
+				"Head (Skull + Face + Neck)",
+				"Heavy Leather",
+				"Leather",
+				"Padded",
+				"Pot Helm (Skull)"
 			],
 			"base_value": "50",
 			"base_weight": "5.2 lb",
@@ -4990,7 +5532,10 @@
 			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Heavy Leather",
+				"Leather",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "200",
 			"base_weight": "20 lb",
@@ -5031,7 +5576,11 @@
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
-				"Body Armor"
+				"Abdomen Only Armor",
+				"Body Armor",
+				"Leather",
+				"Light Leather",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "45",
 			"base_weight": "0.8 lb",
@@ -5069,7 +5618,10 @@
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
-				"Limb Armor"
+				"Arms",
+				"Leather",
+				"Light Leather",
+				"Limbs"
 			],
 			"base_value": "90",
 			"base_weight": "1.7 lb",
@@ -5107,7 +5659,11 @@
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
-				"Bascinet"
+				"Bascinet (Skull + Back Face)",
+				"Head (Skull + Face + Neck)",
+				"Leather",
+				"Light Leather",
+				"Non-Padded"
 			],
 			"base_value": "45",
 			"base_weight": "0.8 lb",
@@ -5145,7 +5701,11 @@
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
-				"Bascinet"
+				"Bascinet (Skull + Back Face)",
+				"Head (Skull + Face + Neck)",
+				"Leather",
+				"Light Leather",
+				"Padded"
 			],
 			"base_value": "58",
 			"base_weight": "1 lb",
@@ -5183,7 +5743,11 @@
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Chest Only Armor",
+				"Leather",
+				"Light Leather",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "135",
 			"base_weight": "2.5 lb",
@@ -5221,7 +5785,10 @@
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
-				"Groin Armor"
+				"Groin Only",
+				"Leather",
+				"Light Leather",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "9",
 			"base_weight": "0.2 lb",
@@ -5259,7 +5826,10 @@
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
-				"Limb Armor"
+				"Leather",
+				"Legs",
+				"Light Leather",
+				"Limbs"
 			],
 			"base_value": "180",
 			"base_weight": "3.3 lb",
@@ -5297,7 +5867,10 @@
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
-				"Neck Armor"
+				"Head (Skull + Face + Neck)",
+				"Leather",
+				"Light Leather",
+				"Neck"
 			],
 			"base_value": "9",
 			"base_weight": "0.2 lb",
@@ -5335,7 +5908,11 @@
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
-				"Pot Helm"
+				"Head (Skull + Face + Neck)",
+				"Leather",
+				"Light Leather",
+				"Non-Padded",
+				"Pot Helm (Skull)"
 			],
 			"base_value": "36",
 			"base_weight": "0.7 lb",
@@ -5373,7 +5950,11 @@
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
-				"Pot Helm"
+				"Head (Skull + Face + Neck)",
+				"Leather",
+				"Light Leather",
+				"Padded",
+				"Pot Helm (Skull)"
 			],
 			"base_value": "46",
 			"base_weight": "1.9 lb",
@@ -5411,7 +5992,10 @@
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Leather",
+				"Light Leather",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "180",
 			"base_weight": "3.3 lb",
@@ -5447,7 +6031,11 @@
 			"local_notes": "Don: 23 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
-				"Body Armor"
+				"Abdomen Only Armor",
+				"Body Armor",
+				"Leather",
+				"Medium Leather",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "25",
 			"base_weight": "3 lb",
@@ -5485,7 +6073,10 @@
 			"local_notes": "Don: 15 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
-				"Limb Armor"
+				"Arms",
+				"Leather",
+				"Limbs",
+				"Medium Leather"
 			],
 			"base_value": "50",
 			"base_weight": "6 lb",
@@ -5522,7 +6113,11 @@
 			"local_notes": "Don: 8 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
-				"Bascinet"
+				"Bascinet (Skull + Back Face)",
+				"Head (Skull + Face + Neck)",
+				"Leather",
+				"Medium Leather",
+				"Non-Padded"
 			],
 			"base_value": "25",
 			"base_weight": "3 lb",
@@ -5560,7 +6155,11 @@
 			"local_notes": "Don: 8 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
-				"Bascinet"
+				"Bascinet (Skull + Back Face)",
+				"Head (Skull + Face + Neck)",
+				"Leather",
+				"Medium Leather",
+				"Padded"
 			],
 			"base_value": "38",
 			"base_weight": "3.2 lb",
@@ -5598,7 +6197,11 @@
 			"local_notes": "Don: 23 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Chest Only Armor",
+				"Leather",
+				"Medium Leather",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "75",
 			"base_weight": "9 lb",
@@ -5635,7 +6238,10 @@
 			"local_notes": "Don: 3 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
-				"Groin Armor"
+				"Groin Only",
+				"Leather",
+				"Medium Leather",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "5",
 			"base_weight": "0.6 lb",
@@ -5672,7 +6278,10 @@
 			"local_notes": "Don: 30 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
-				"Limb Armor"
+				"Leather",
+				"Legs",
+				"Limbs",
+				"Medium Leather"
 			],
 			"base_value": "100",
 			"base_weight": "12 lb",
@@ -5709,7 +6318,10 @@
 			"local_notes": "Don: 3 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
-				"Neck Armor"
+				"Head (Skull + Face + Neck)",
+				"Leather",
+				"Medium Leather",
+				"Neck"
 			],
 			"base_value": "5",
 			"base_weight": "0.6 lb",
@@ -5746,7 +6358,11 @@
 			"local_notes": "Don: 6 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
-				"Pot Helm"
+				"Head (Skull + Face + Neck)",
+				"Leather",
+				"Medium Leather",
+				"Non-Padded",
+				"Pot Helm (Skull)"
 			],
 			"base_value": "20",
 			"base_weight": "2.4 lb",
@@ -5783,7 +6399,11 @@
 			"local_notes": "Don: 6 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
-				"Pot Helm"
+				"Head (Skull + Face + Neck)",
+				"Leather",
+				"Medium Leather",
+				"Padded",
+				"Pot Helm (Skull)"
 			],
 			"base_value": "30",
 			"base_weight": "3.6 lb",
@@ -5820,7 +6440,10 @@
 			"local_notes": "Don: 30 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Leather",
+				"Medium Leather",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "100",
 			"base_weight": "12 lb",
@@ -5861,7 +6484,10 @@
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
-				"Body Armor"
+				"Abdomen Only Armor",
+				"Body Armor",
+				"Mail and Plates",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "250",
 			"base_weight": "5 lb",
@@ -5900,7 +6526,9 @@
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
-				"Limb Armor"
+				"Arms",
+				"Limbs",
+				"Mail and Plates"
 			],
 			"base_value": "500",
 			"base_weight": "10 lb",
@@ -5938,7 +6566,10 @@
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Chest Only Armor",
+				"Mail and Plates",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "750",
 			"base_weight": "15 lb",
@@ -5976,7 +6607,10 @@
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
-				"Coif"
+				"Coif (Skull + Neck + Back Face)",
+				"Head (Skull + Face + Neck)",
+				"Mail and Plates",
+				"Non-Padded"
 			],
 			"base_value": "300",
 			"base_weight": "6 lb",
@@ -6016,7 +6650,10 @@
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
-				"Coif"
+				"Coif (Skull + Neck + Back Face)",
+				"Head (Skull + Face + Neck)",
+				"Mail and Plates",
+				"Padded"
 			],
 			"base_value": "315",
 			"base_weight": "7.8 lb",
@@ -6056,7 +6693,9 @@
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
-				"Groin Armor"
+				"Groin Only",
+				"Mail and Plates",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "50",
 			"base_weight": "1 lb",
@@ -6094,7 +6733,9 @@
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
-				"Limb Armor"
+				"Legs",
+				"Limbs",
+				"Mail and Plates"
 			],
 			"base_value": "1000",
 			"base_weight": "20 lb",
@@ -6132,7 +6773,9 @@
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
-				"Neck Armor"
+				"Head (Skull + Face + Neck)",
+				"Mail and Plates",
+				"Neck"
 			],
 			"base_value": "50",
 			"base_weight": "1 lb",
@@ -6169,7 +6812,9 @@
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Mail and Plates",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "1000",
 			"base_weight": "20 lb",
@@ -6210,7 +6855,11 @@
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
-				"Body Armor"
+				"Abdomen Only Armor",
+				"Body Armor",
+				"Fine Mail",
+				"Mail",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "225",
 			"base_weight": "3.8 lb",
@@ -6248,7 +6897,10 @@
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
-				"Limb Armor"
+				"Arms",
+				"Fine Mail",
+				"Limbs",
+				"Mail"
 			],
 			"base_value": "450",
 			"base_weight": "7.5 lb",
@@ -6285,7 +6937,11 @@
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Chest Only Armor",
+				"Fine Mail",
+				"Mail",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "675",
 			"base_weight": "11.3 lb",
@@ -6322,7 +6978,11 @@
 			"local_notes": "Don: 5 secs; Holdout: -3; Reaction Pen.-2; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
-				"Coif"
+				"Coif (Skull + Neck + Back Face)",
+				"Fine Mail",
+				"Head (Skull + Face + Neck)",
+				"Mail",
+				"Non-Padded"
 			],
 			"base_value": "270",
 			"base_weight": "4.5 lb",
@@ -6361,7 +7021,11 @@
 			"local_notes": "Don: 5 secs; Holdout: -3; Reaction Pen.-2",
 			"tech_level": "2",
 			"tags": [
-				"Coif"
+				"Coif (Skull + Neck + Back Face)",
+				"Fine Mail",
+				"Head (Skull + Face + Neck)",
+				"Mail",
+				"Padded"
 			],
 			"base_value": "285",
 			"base_weight": "6.3 lb",
@@ -6401,7 +7065,10 @@
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
-				"Groin Armor"
+				"Fine Mail",
+				"Groin Only",
+				"Mail",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "45",
 			"base_weight": "0.8 lb",
@@ -6439,7 +7106,10 @@
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
-				"Limb Armor"
+				"Fine Mail",
+				"Legs",
+				"Limbs",
+				"Mail"
 			],
 			"base_value": "900",
 			"base_weight": "15 lb",
@@ -6477,7 +7147,10 @@
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
-				"Neck Armor"
+				"Fine Mail",
+				"Head (Skull + Face + Neck)",
+				"Mail",
+				"Neck"
 			],
 			"base_value": "45",
 			"base_weight": "0.8 lb",
@@ -6515,7 +7188,10 @@
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Fine Mail",
+				"Mail",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "900",
 			"base_weight": "15 lb",
@@ -6556,7 +7232,11 @@
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
-				"Body Armor"
+				"Abdomen Only Armor",
+				"Body Armor",
+				"Heavy Mail",
+				"Mail",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "300",
 			"base_weight": "4.5 lb",
@@ -6595,7 +7275,10 @@
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
-				"Limb Armor"
+				"Arms",
+				"Heavy Mail",
+				"Limbs",
+				"Mail"
 			],
 			"base_value": "600",
 			"base_weight": "9 lb",
@@ -6633,7 +7316,11 @@
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Chest Only Armor",
+				"Heavy Mail",
+				"Mail",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "900",
 			"base_weight": "13.5 lb",
@@ -6671,7 +7358,11 @@
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
-				"Coif"
+				"Coif (Skull + Neck + Back Face)",
+				"Head (Skull + Face + Neck)",
+				"Heavy Mail",
+				"Mail",
+				"Non-Padded"
 			],
 			"base_value": "360",
 			"base_weight": "5.4 lb",
@@ -6711,7 +7402,11 @@
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
-				"Coif"
+				"Coif (Skull + Neck + Back Face)",
+				"Head (Skull + Face + Neck)",
+				"Heavy Mail",
+				"Mail",
+				"Padded"
 			],
 			"base_value": "375",
 			"base_weight": "7.2 lb",
@@ -6751,7 +7446,10 @@
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
-				"Groin Armor"
+				"Groin Only",
+				"Heavy Mail",
+				"Mail",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "60",
 			"base_weight": "0.9 lb",
@@ -6788,7 +7486,10 @@
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
-				"Limb Armor"
+				"Heavy Mail",
+				"Legs",
+				"Limbs",
+				"Mail"
 			],
 			"base_value": "1200",
 			"base_weight": "18 lb",
@@ -6827,7 +7528,10 @@
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
-				"Neck Armor"
+				"Head (Skull + Face + Neck)",
+				"Heavy Mail",
+				"Mail",
+				"Neck"
 			],
 			"base_value": "60",
 			"base_weight": "0.9 lb",
@@ -6865,7 +7569,10 @@
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Heavy Mail",
+				"Mail",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "1200",
 			"base_weight": "18 lb",
@@ -6906,7 +7613,11 @@
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
-				"Body Armor"
+				"Abdomen Only Armor",
+				"Body Armor",
+				"Jousting Mail",
+				"Mail",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "375",
 			"base_weight": "7.5 lb",
@@ -6936,7 +7647,11 @@
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Chest Only Armor",
+				"Jousting Mail",
+				"Mail",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "1125",
 			"base_weight": "22.5 lb",
@@ -6966,7 +7681,11 @@
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
-				"Coif"
+				"Coif (Skull + Neck + Back Face)",
+				"Head (Skull + Face + Neck)",
+				"Jousting Mail",
+				"Mail",
+				"Non-Padded"
 			],
 			"base_value": "450",
 			"base_weight": "9 lb",
@@ -6997,7 +7716,11 @@
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
-				"Coif"
+				"Coif (Skull + Neck + Back Face)",
+				"Head (Skull + Face + Neck)",
+				"Jousting Mail",
+				"Mail",
+				"Padded"
 			],
 			"base_value": "465",
 			"base_weight": "10.8 lb",
@@ -7028,7 +7751,10 @@
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
-				"Groin Armor"
+				"Groin Only",
+				"Jousting Mail",
+				"Mail",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "75",
 			"base_weight": "1.5 lb",
@@ -7058,7 +7784,10 @@
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Jousting Mail",
+				"Mail",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "1500",
 			"base_weight": "30 lb",
@@ -7088,7 +7817,11 @@
 			"local_notes": "Don: 11 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
-				"Body Armor"
+				"Abdomen Only Armor",
+				"Body Armor",
+				"Light Mail",
+				"Mail",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "125",
 			"base_weight": "3 lb",
@@ -7125,7 +7858,10 @@
 			"local_notes": "Don: 8 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
-				"Limb Armor"
+				"Arms",
+				"Light Mail",
+				"Limbs",
+				"Mail"
 			],
 			"base_value": "250",
 			"base_weight": "6 lb",
@@ -7161,7 +7897,11 @@
 			"local_notes": "Don: 11 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Chest Only Armor",
+				"Light Mail",
+				"Mail",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "375",
 			"base_weight": "9 lb",
@@ -7198,7 +7938,11 @@
 			"local_notes": "Don: 5 secs; Holdout: -2; Reaction Pen.-2; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
-				"Coif"
+				"Coif (Skull + Neck + Back Face)",
+				"Head (Skull + Face + Neck)",
+				"Light Mail",
+				"Mail",
+				"Non-Padded"
 			],
 			"base_value": "150",
 			"base_weight": "3.6 lb",
@@ -7233,7 +7977,11 @@
 			"local_notes": "Don: 5 secs; Holdout: -2; Reaction Pen.-2; -2 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
-				"Coif"
+				"Coif (Skull + Neck + Back Face)",
+				"Head (Skull + Face + Neck)",
+				"Light Mail",
+				"Mail",
+				"Padded"
 			],
 			"base_value": "165",
 			"base_weight": "5.4 lb",
@@ -7272,7 +8020,10 @@
 			"local_notes": "Don: 3 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
-				"Groin Armor"
+				"Groin Only",
+				"Light Mail",
+				"Mail",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "25",
 			"base_weight": "0.6 lb",
@@ -7309,7 +8060,10 @@
 			"local_notes": "Don: 15 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
-				"Limb Armor"
+				"Legs",
+				"Light Mail",
+				"Limbs",
+				"Mail"
 			],
 			"base_value": "500",
 			"base_weight": "12 lb",
@@ -7346,7 +8100,10 @@
 			"local_notes": "Don: 3 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
-				"Neck Armor"
+				"Head (Skull + Face + Neck)",
+				"Light Mail",
+				"Mail",
+				"Neck"
 			],
 			"base_value": "25",
 			"base_weight": "0.6 lb",
@@ -7384,7 +8141,10 @@
 			"local_notes": "Don: 15 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Light Mail",
+				"Mail",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "500",
 			"base_weight": "12 lb",
@@ -7424,7 +8184,9 @@
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
-				"Gloves"
+				"Hands",
+				"Limbs",
+				"No specified material"
 			],
 			"base_value": "8",
 			"base_weight": "0.5 lb",
@@ -7460,7 +8222,8 @@
 			"local_notes": "Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); Enclosedmittens andgloves protectvs.cold,heat,contactpoison,etc.,but giveBadGrip1(p.B123); Gives Ham-Fisted 2 (p. B138).",
 			"tech_level": "1",
 			"tags": [
-				"Gloves"
+				"Cloth",
+				"Padded Cloth"
 			],
 			"base_value": "20",
 			"base_weight": "1 lb",
@@ -7488,7 +8251,9 @@
 			"local_notes": "Don: 6 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379); Gives +1 to Stealth.",
 			"tech_level": "0",
 			"tags": [
-				"Footwear"
+				"Feet",
+				"Limbs",
+				"No specified material"
 			],
 			"base_value": "40",
 			"base_weight": "1 lb",
@@ -7516,7 +8281,9 @@
 			"local_notes": "Don: 6 secs; Holdout: -5; Flexible and susceptible to blunt trauma (p. B379); Erases -2 in Stealth penalties when walking on snow.",
 			"tech_level": "0",
 			"tags": [
-				"Footwear"
+				"Feet",
+				"Limbs",
+				"No specified material"
 			],
 			"base_value": "50",
 			"base_weight": "2 lb",
@@ -7546,7 +8313,9 @@
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Chest Only Armor",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "1500",
 			"base_weight": "33.8 lb",
@@ -7576,7 +8345,9 @@
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
-				"Pot Helm"
+				"Head (Skull + Face + Neck)",
+				"Non-Padded",
+				"Pot Helm (Skull)"
 			],
 			"base_value": "400",
 			"base_weight": "9 lb",
@@ -7606,7 +8377,9 @@
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
-				"Pot Helm"
+				"Head (Skull + Face + Neck)",
+				"Padded",
+				"Pot Helm (Skull)"
 			],
 			"base_value": "410",
 			"base_weight": "10.2 lb",
@@ -7636,7 +8409,8 @@
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "2000",
 			"base_weight": "45 lb",
@@ -7667,7 +8441,11 @@
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
-				"Bascinet"
+				"Bascinet (Skull + Back Face)",
+				"Head (Skull + Face + Neck)",
+				"Heavy Plate",
+				"Non-Padded",
+				"Plate"
 			],
 			"base_value": "1000",
 			"base_weight": "8 lb",
@@ -7697,7 +8475,11 @@
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
-				"Bascinet"
+				"Bascinet (Skull + Back Face)",
+				"Head (Skull + Face + Neck)",
+				"Heavy Plate",
+				"Padded",
+				"Plate"
 			],
 			"base_value": "1013",
 			"base_weight": "8.2 lb",
@@ -7727,7 +8509,11 @@
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Chest Only Armor",
+				"Heavy Plate",
+				"Plate",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "3000",
 			"base_weight": "24 lb",
@@ -7757,7 +8543,11 @@
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
-				"Full Helm"
+				"Full Helms (Skull + Face)",
+				"Head (Skull + Face + Neck)",
+				"Heavy Plate",
+				"Non-Padded",
+				"Plate"
 			],
 			"base_value": "1200",
 			"base_weight": "9.6 lb",
@@ -7788,7 +8578,11 @@
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
-				"Full Helm"
+				"Full Helms (Skull + Face)",
+				"Head (Skull + Face + Neck)",
+				"Heavy Plate",
+				"Padded",
+				"Plate"
 			],
 			"base_value": "1215",
 			"base_weight": "11.4 lb",
@@ -7819,7 +8613,10 @@
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
-				"Greathelm"
+				"Greathelm (Skull + Face + Neck)",
+				"Head (Skull + Face + Neck)",
+				"Heavy Plate",
+				"Plate"
 			],
 			"base_value": "1400",
 			"base_weight": "11.2 lb",
@@ -7851,7 +8648,10 @@
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
-				"Groin Armor"
+				"Groin Only",
+				"Heavy Plate",
+				"Plate",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "200",
 			"base_weight": "1.6 lb",
@@ -7881,7 +8681,11 @@
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
-				"Pot Helm"
+				"Head (Skull + Face + Neck)",
+				"Heavy Plate",
+				"Non-Padded",
+				"Plate",
+				"Pot Helm (Skull)"
 			],
 			"base_value": "800",
 			"base_weight": "6.4 lb",
@@ -7911,7 +8715,11 @@
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
-				"Pot Helm"
+				"Head (Skull + Face + Neck)",
+				"Heavy Plate",
+				"Padded",
+				"Plate",
+				"Pot Helm (Skull)"
 			],
 			"base_value": "810",
 			"base_weight": "7.6 lb",
@@ -7941,7 +8749,10 @@
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Heavy Plate",
+				"Plate",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "4000",
 			"base_weight": "32 lb",
@@ -7970,7 +8781,10 @@
 			"local_notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "4",
 			"tags": [
-				"Limb Armor"
+				"Arms",
+				"Light Plate",
+				"Limbs",
+				"Plate"
 			],
 			"base_value": "500",
 			"base_weight": "4 lb",
@@ -7999,7 +8813,11 @@
 			"local_notes": "Don: 11 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "3",
 			"tags": [
-				"Bascinet"
+				"Bascinet (Skull + Back Face)",
+				"Head (Skull + Face + Neck)",
+				"Light Plate",
+				"Non-Padded",
+				"Plate"
 			],
 			"base_value": "250",
 			"base_weight": "2 lb",
@@ -8028,7 +8846,11 @@
 			"local_notes": "Don: 11 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "3",
 			"tags": [
-				"Bascinet"
+				"Bascinet (Skull + Back Face)",
+				"Head (Skull + Face + Neck)",
+				"Light Plate",
+				"Padded",
+				"Plate"
 			],
 			"base_value": "263",
 			"base_weight": "2.2 lb",
@@ -8057,7 +8879,11 @@
 			"local_notes": "Don: 34 secs; Holdout: -3; Reaction Pen.-2",
 			"tech_level": "4",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Chest Only Armor",
+				"Light Plate",
+				"Plate",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "750",
 			"base_weight": "6 lb",
@@ -8086,7 +8912,11 @@
 			"local_notes": "Don: 14 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "3",
 			"tags": [
-				"Full Helm"
+				"Full Helms (Skull + Face)",
+				"Head (Skull + Face + Neck)",
+				"Light Plate",
+				"Non-Padded",
+				"Plate"
 			],
 			"base_value": "300",
 			"base_weight": "2.4 lb",
@@ -8116,7 +8946,11 @@
 			"local_notes": "Don: 14 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "3",
 			"tags": [
-				"Full Helm"
+				"Full Helms (Skull + Face)",
+				"Head (Skull + Face + Neck)",
+				"Light Plate",
+				"Padded",
+				"Plate"
 			],
 			"base_value": "315",
 			"base_weight": "4.2 lb",
@@ -8146,7 +8980,10 @@
 			"local_notes": "Don: 16 secs; Holdout: 0; Reaction Pen.-2",
 			"tech_level": "3",
 			"tags": [
-				"Greathelm"
+				"Greathelm (Skull + Face + Neck)",
+				"Head (Skull + Face + Neck)",
+				"Light Plate",
+				"Plate"
 			],
 			"base_value": "350",
 			"base_weight": "2.8 lb",
@@ -8176,7 +9013,10 @@
 			"local_notes": "Don: 3 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "3",
 			"tags": [
-				"Groin Armor"
+				"Groin Only",
+				"Light Plate",
+				"Plate",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "50",
 			"base_weight": "0.4 lb",
@@ -8205,7 +9045,10 @@
 			"local_notes": "Don: 45 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "4",
 			"tags": [
-				"Limb Armor"
+				"Legs",
+				"Light Plate",
+				"Limbs",
+				"Plate"
 			],
 			"base_value": "1000",
 			"base_weight": "8 lb",
@@ -8234,7 +9077,10 @@
 			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "4",
 			"tags": [
-				"Neck Armor"
+				"Head (Skull + Face + Neck)",
+				"Light Plate",
+				"Neck",
+				"Plate"
 			],
 			"base_value": "50",
 			"base_weight": "0.4 lb",
@@ -8263,7 +9109,11 @@
 			"local_notes": "Don: 9 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "2",
 			"tags": [
-				"Pot Helm"
+				"Head (Skull + Face + Neck)",
+				"Light Plate",
+				"Non-Padded",
+				"Plate",
+				"Pot Helm (Skull)"
 			],
 			"base_value": "200",
 			"base_weight": "1.6 lb",
@@ -8292,7 +9142,11 @@
 			"local_notes": "Don: 9 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "2",
 			"tags": [
-				"Pot Helm"
+				"Head (Skull + Face + Neck)",
+				"Light Plate",
+				"Padded",
+				"Plate",
+				"Pot Helm (Skull)"
 			],
 			"base_value": "210",
 			"base_weight": "2.8 lb",
@@ -8321,7 +9175,10 @@
 			"local_notes": "Don: 45 secs; Holdout: -3; Reaction Pen.-2",
 			"tech_level": "4",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Light Plate",
+				"Plate",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "1000",
 			"base_weight": "8 lb",
@@ -8352,7 +9209,10 @@
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
-				"Limb Armor"
+				"Arms",
+				"Limbs",
+				"Medium Plate",
+				"Plate"
 			],
 			"base_value": "1250",
 			"base_weight": "10 lb",
@@ -8382,7 +9242,11 @@
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
-				"Bascinet"
+				"Bascinet (Skull + Back Face)",
+				"Head (Skull + Face + Neck)",
+				"Medium Plate",
+				"Non-Padded",
+				"Plate"
 			],
 			"base_value": "625",
 			"base_weight": "5 lb",
@@ -8412,7 +9276,11 @@
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
-				"Bascinet"
+				"Bascinet (Skull + Back Face)",
+				"Head (Skull + Face + Neck)",
+				"Medium Plate",
+				"Padded",
+				"Plate"
 			],
 			"base_value": "638",
 			"base_weight": "5.2 lb",
@@ -8442,7 +9310,11 @@
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Chest Only Armor",
+				"Medium Plate",
+				"Plate",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "1875",
 			"base_weight": "15 lb",
@@ -8472,7 +9344,11 @@
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
-				"Full Helm"
+				"Full Helms (Skull + Face)",
+				"Head (Skull + Face + Neck)",
+				"Medium Plate",
+				"Non-Padded",
+				"Plate"
 			],
 			"base_value": "750",
 			"base_weight": "6 lb",
@@ -8503,7 +9379,11 @@
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
-				"Full Helm"
+				"Full Helms (Skull + Face)",
+				"Head (Skull + Face + Neck)",
+				"Medium Plate",
+				"Padded",
+				"Plate"
 			],
 			"base_value": "765",
 			"base_weight": "7.8 lb",
@@ -8534,7 +9414,10 @@
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
-				"Greathelm"
+				"Greathelm (Skull + Face + Neck)",
+				"Head (Skull + Face + Neck)",
+				"Medium Plate",
+				"Plate"
 			],
 			"base_value": "875",
 			"base_weight": "7 lb",
@@ -8578,7 +9461,10 @@
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
-				"Groin Armor"
+				"Groin Only",
+				"Medium Plate",
+				"Plate",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "125",
 			"base_weight": "1 lb",
@@ -8608,7 +9494,10 @@
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
-				"Limb Armor"
+				"Legs",
+				"Limbs",
+				"Medium Plate",
+				"Plate"
 			],
 			"base_value": "2500",
 			"base_weight": "20 lb",
@@ -8638,7 +9527,10 @@
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
-				"Neck Armor"
+				"Head (Skull + Face + Neck)",
+				"Medium Plate",
+				"Neck",
+				"Plate"
 			],
 			"base_value": "125",
 			"base_weight": "1 lb",
@@ -8668,7 +9560,11 @@
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
-				"Pot Helm"
+				"Head (Skull + Face + Neck)",
+				"Medium Plate",
+				"Non-Padded",
+				"Plate",
+				"Pot Helm (Skull)"
 			],
 			"base_value": "500",
 			"base_weight": "4 lb",
@@ -8698,7 +9594,11 @@
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
-				"Pot Helm"
+				"Head (Skull + Face + Neck)",
+				"Medium Plate",
+				"Padded",
+				"Plate",
+				"Pot Helm (Skull)"
 			],
 			"base_value": "510",
 			"base_weight": "5.2 lb",
@@ -8728,7 +9628,10 @@
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Medium Plate",
+				"Plate",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "2500",
 			"base_weight": "20 lb",
@@ -8757,7 +9660,10 @@
 			"local_notes": "Don: 10 secs; Holdout: -4",
 			"tech_level": "4",
 			"tags": [
-				"Footwear"
+				"Feet",
+				"Light Plate",
+				"Limbs",
+				"Plate"
 			],
 			"base_value": "100",
 			"base_weight": "0.8 lb",
@@ -8785,7 +9691,10 @@
 			"local_notes": "Don: 10 secs; Holdout: -4",
 			"tech_level": "3",
 			"tags": [
-				"Footwear"
+				"Feet",
+				"Light Segmented Plate",
+				"Limbs",
+				"Segmented Plate"
 			],
 			"base_value": "60",
 			"base_weight": "1.6 lb",
@@ -8814,7 +9723,10 @@
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
-				"Footwear"
+				"Feet",
+				"Limbs",
+				"Medium Plate",
+				"Plate"
 			],
 			"base_value": "250",
 			"base_weight": "2 lb",
@@ -8843,7 +9755,10 @@
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
-				"Footwear"
+				"Feet",
+				"Limbs",
+				"Medium Segmented Plate",
+				"Segmented Plate"
 			],
 			"base_value": "90",
 			"base_weight": "2.4 lb",
@@ -8871,7 +9786,9 @@
 			"local_notes": "Don: 10 secs; Holdout: -2; Flexible and susceptible to blunt trauma (p. B379); DR applies to underside only.",
 			"tech_level": "0",
 			"tags": [
-				"Footwear"
+				"Feet",
+				"Limbs",
+				"No specified material"
 			],
 			"base_value": "25",
 			"base_weight": "0.5 lb",
@@ -8899,7 +9816,9 @@
 			"local_notes": "Don: 10 secs; Holdout: -2; Flexible and susceptible to blunt trauma (p. B379); DR applies to underside only; Lets wearer ignore -2 to attacks and -1 to defenses for bad terrain.",
 			"tech_level": "1",
 			"tags": [
-				"Footwear"
+				"Feet",
+				"Limbs",
+				"No specified material"
 			],
 			"base_value": "50",
 			"base_weight": "1.5 lb",
@@ -8928,7 +9847,11 @@
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
-				"Body Armor"
+				"Abdomen Only Armor",
+				"Body Armor",
+				"Heavy Scale",
+				"Scale",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "275",
 			"base_weight": "10 lb",
@@ -8957,7 +9880,11 @@
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Chest Only Armor",
+				"Heavy Scale",
+				"Scale",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "825",
 			"base_weight": "30 lb",
@@ -8986,7 +9913,10 @@
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
-				"Groin Armor"
+				"Groin Only",
+				"Heavy Scale",
+				"Scale",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "55",
 			"base_weight": "2 lb",
@@ -9015,7 +9945,11 @@
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
-				"Pot Helm"
+				"Head (Skull + Face + Neck)",
+				"Heavy Scale",
+				"Non-Padded",
+				"Pot Helm (Skull)",
+				"Scale"
 			],
 			"base_value": "220",
 			"base_weight": "8 lb",
@@ -9044,7 +9978,11 @@
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
-				"Pot Helm"
+				"Head (Skull + Face + Neck)",
+				"Heavy Scale",
+				"Padded",
+				"Pot Helm (Skull)",
+				"Scale"
 			],
 			"base_value": "230",
 			"base_weight": "9.2 lb",
@@ -9073,7 +10011,10 @@
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Heavy Scale",
+				"Scale",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "1100",
 			"base_weight": "40 lb",
@@ -9107,7 +10048,11 @@
 			"local_notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"tags": [
-				"Body Armor"
+				"Abdomen Only Armor",
+				"Body Armor",
+				"Light Scale",
+				"Scale",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "80",
 			"base_weight": "4 lb",
@@ -9145,7 +10090,10 @@
 			"local_notes": "Don: 15 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"tags": [
-				"Limb Armor"
+				"Arms",
+				"Light Scale",
+				"Limbs",
+				"Scale"
 			],
 			"base_value": "160",
 			"base_weight": "8 lb",
@@ -9182,7 +10130,11 @@
 			"local_notes": "Don: 8 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"tags": [
-				"Bascinet"
+				"Bascinet (Skull + Back Face)",
+				"Head (Skull + Face + Neck)",
+				"Light Scale",
+				"Non-Padded",
+				"Scale"
 			],
 			"base_value": "80",
 			"base_weight": "4 lb",
@@ -9219,7 +10171,11 @@
 			"local_notes": "Don: 8 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"tags": [
-				"Bascinet"
+				"Bascinet (Skull + Back Face)",
+				"Head (Skull + Face + Neck)",
+				"Light Scale",
+				"Padded",
+				"Scale"
 			],
 			"base_value": "93",
 			"base_weight": "4.2 lb",
@@ -9255,7 +10211,11 @@
 			"local_notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Chest Only Armor",
+				"Light Scale",
+				"Scale",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "240",
 			"base_weight": "12 lb",
@@ -9292,7 +10252,10 @@
 			"local_notes": "Don: 3 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"tags": [
-				"Groin Armor"
+				"Groin Only",
+				"Light Scale",
+				"Scale",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "16",
 			"base_weight": "0.8 lb",
@@ -9329,7 +10292,10 @@
 			"local_notes": "Don: 30 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"tags": [
-				"Limb Armor"
+				"Legs",
+				"Light Scale",
+				"Limbs",
+				"Scale"
 			],
 			"base_value": "320",
 			"base_weight": "16 lb",
@@ -9366,7 +10332,10 @@
 			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"tags": [
-				"Neck Armor"
+				"Head (Skull + Face + Neck)",
+				"Light Scale",
+				"Neck",
+				"Scale"
 			],
 			"base_value": "16",
 			"base_weight": "0.8 lb",
@@ -9403,7 +10372,11 @@
 			"local_notes": "Don: 6 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"tags": [
-				"Pot Helm"
+				"Head (Skull + Face + Neck)",
+				"Light Scale",
+				"Non-Padded",
+				"Pot Helm (Skull)",
+				"Scale"
 			],
 			"base_value": "64",
 			"base_weight": "3.2 lb",
@@ -9440,7 +10413,11 @@
 			"local_notes": "Don: 6 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"tags": [
-				"Pot Helm"
+				"Head (Skull + Face + Neck)",
+				"Light Scale",
+				"Padded",
+				"Pot Helm (Skull)",
+				"Scale"
 			],
 			"base_value": "74",
 			"base_weight": "4.4 lb",
@@ -9477,7 +10454,10 @@
 			"local_notes": "Don: 30 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Light Scale",
+				"Scale",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "320",
 			"base_weight": "16 lb",
@@ -9518,7 +10498,11 @@
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
-				"Body Armor"
+				"Abdomen Only Armor",
+				"Body Armor",
+				"Medium Scale",
+				"Scale",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "138",
 			"base_weight": "7 lb",
@@ -9557,7 +10541,10 @@
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
-				"Limb Armor"
+				"Arms",
+				"Limbs",
+				"Medium Scale",
+				"Scale"
 			],
 			"base_value": "275",
 			"base_weight": "14 lb",
@@ -9595,7 +10582,11 @@
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
-				"Bascinet"
+				"Bascinet (Skull + Back Face)",
+				"Head (Skull + Face + Neck)",
+				"Medium Scale",
+				"Non-Padded",
+				"Scale"
 			],
 			"base_value": "138",
 			"base_weight": "7 lb",
@@ -9633,7 +10624,11 @@
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
-				"Bascinet"
+				"Bascinet (Skull + Back Face)",
+				"Head (Skull + Face + Neck)",
+				"Medium Scale",
+				"Padded",
+				"Scale"
 			],
 			"base_value": "151",
 			"base_weight": "7.2 lb",
@@ -9671,7 +10666,11 @@
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Chest Only Armor",
+				"Medium Scale",
+				"Scale",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "413",
 			"base_weight": "21 lb",
@@ -9709,7 +10708,10 @@
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
-				"Groin Armor"
+				"Groin Only",
+				"Medium Scale",
+				"Scale",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "28",
 			"base_weight": "1.4 lb",
@@ -9747,7 +10749,10 @@
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
-				"Limb Armor"
+				"Legs",
+				"Limbs",
+				"Medium Scale",
+				"Scale"
 			],
 			"base_value": "550",
 			"base_weight": "28 lb",
@@ -9785,7 +10790,10 @@
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
-				"Neck Armor"
+				"Head (Skull + Face + Neck)",
+				"Medium Scale",
+				"Neck",
+				"Scale"
 			],
 			"base_value": "28",
 			"base_weight": "1.4 lb",
@@ -9823,7 +10831,11 @@
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
-				"Pot Helm"
+				"Head (Skull + Face + Neck)",
+				"Medium Scale",
+				"Non-Padded",
+				"Pot Helm (Skull)",
+				"Scale"
 			],
 			"base_value": "110",
 			"base_weight": "5.6 lb",
@@ -9860,7 +10872,11 @@
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
-				"Pot Helm"
+				"Head (Skull + Face + Neck)",
+				"Medium Scale",
+				"Padded",
+				"Pot Helm (Skull)",
+				"Scale"
 			],
 			"base_value": "120",
 			"base_weight": "6.8 lb",
@@ -9898,7 +10914,10 @@
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Medium Scale",
+				"Scale",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "550",
 			"base_weight": "28 lb",
@@ -9939,7 +10958,11 @@
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
-				"Body Armor"
+				"Abdomen Only Armor",
+				"Body Armor",
+				"Heavy Segmented Plate",
+				"Segmented Plate",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "300",
 			"base_weight": "8 lb",
@@ -9969,7 +10992,11 @@
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Chest Only Armor",
+				"Heavy Segmented Plate",
+				"Segmented Plate",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "900",
 			"base_weight": "24 lb",
@@ -9999,7 +11026,10 @@
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Heavy Segmented Plate",
+				"Segmented Plate",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "1200",
 			"base_weight": "32 lb",
@@ -10029,7 +11059,11 @@
 			"local_notes": "Don: 34 secs; Holdout: -3; Reaction Pen.-2",
 			"tech_level": "2",
 			"tags": [
-				"Body Armor"
+				"Abdomen Only Armor",
+				"Body Armor",
+				"Light Segmented Plate",
+				"Segmented Plate",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "150",
 			"base_weight": "4 lb",
@@ -10058,7 +11092,10 @@
 			"local_notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "2",
 			"tags": [
-				"Limb Armor"
+				"Arms",
+				"Light Segmented Plate",
+				"Limbs",
+				"Segmented Plate"
 			],
 			"base_value": "300",
 			"base_weight": "8 lb",
@@ -10087,7 +11124,11 @@
 			"local_notes": "Don: 34 secs; Holdout: -3; Reaction Pen.-2",
 			"tech_level": "2",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Chest Only Armor",
+				"Light Segmented Plate",
+				"Segmented Plate",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "450",
 			"base_weight": "12 lb",
@@ -10116,7 +11157,10 @@
 			"local_notes": "Don: 45 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "2",
 			"tags": [
-				"Limb Armor"
+				"Legs",
+				"Light Segmented Plate",
+				"Limbs",
+				"Segmented Plate"
 			],
 			"base_value": "600",
 			"base_weight": "16 lb",
@@ -10145,7 +11189,10 @@
 			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "2",
 			"tags": [
-				"Neck Armor"
+				"Head (Skull + Face + Neck)",
+				"Light Segmented Plate",
+				"Neck",
+				"Segmented Plate"
 			],
 			"base_value": "30",
 			"base_weight": "0.8 lb",
@@ -10174,7 +11221,10 @@
 			"local_notes": "Don: 45 secs; Holdout: -3; Reaction Pen.-2",
 			"tech_level": "2",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Light Segmented Plate",
+				"Segmented Plate",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "600",
 			"base_weight": "16 lb",
@@ -10205,7 +11255,11 @@
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
-				"Body Armor"
+				"Abdomen Only Armor",
+				"Body Armor",
+				"Medium Segmented Plate",
+				"Segmented Plate",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "225",
 			"base_weight": "6 lb",
@@ -10235,7 +11289,10 @@
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
-				"Limb Armor"
+				"Arms",
+				"Limbs",
+				"Medium Segmented Plate",
+				"Segmented Plate"
 			],
 			"base_value": "450",
 			"base_weight": "12 lb",
@@ -10265,7 +11322,11 @@
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Chest Only Armor",
+				"Medium Segmented Plate",
+				"Segmented Plate",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "675",
 			"base_weight": "18 lb",
@@ -10295,7 +11356,10 @@
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
-				"Limb Armor"
+				"Legs",
+				"Limbs",
+				"Medium Segmented Plate",
+				"Segmented Plate"
 			],
 			"base_value": "900",
 			"base_weight": "24 lb",
@@ -10325,7 +11389,10 @@
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
-				"Neck Armor"
+				"Head (Skull + Face + Neck)",
+				"Medium Segmented Plate",
+				"Neck",
+				"Segmented Plate"
 			],
 			"base_value": "45",
 			"base_weight": "1.2 lb",
@@ -10355,7 +11422,10 @@
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Medium Segmented Plate",
+				"Segmented Plate",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "900",
 			"base_weight": "24 lb",
@@ -10384,7 +11454,9 @@
 			"local_notes": "Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
 			"tech_level": "1",
 			"tags": [
-				"Footwear"
+				"Feet",
+				"Limbs",
+				"No specified material"
 			],
 			"base_value": "40",
 			"base_weight": "2 lb",
@@ -10412,7 +11484,9 @@
 			"local_notes": "Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling; Lets wearer ignore -2 to attacks and -1 to defenses for bad terrain.",
 			"tech_level": "1",
 			"tags": [
-				"Footwear"
+				"Feet",
+				"Limbs",
+				"No specified material"
 			],
 			"base_value": "65",
 			"base_weight": "3 lb",
@@ -10440,7 +11514,8 @@
 			"local_notes": "Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
 			"tech_level": "1",
 			"tags": [
-				"Footwear"
+				"Leather",
+				"Medium Leather"
 			],
 			"base_value": "45",
 			"base_weight": "2.5 lb",
@@ -10477,7 +11552,10 @@
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
-				"Footwear"
+				"Feet",
+				"Fine Mail",
+				"Limbs",
+				"Mail"
 			],
 			"base_value": "90",
 			"base_weight": "1.5 lb",
@@ -10514,7 +11592,10 @@
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
-				"Footwear"
+				"Feet",
+				"Heavy Mail",
+				"Limbs",
+				"Mail"
 			],
 			"base_value": "120",
 			"base_weight": "1.8 lb",
@@ -10550,7 +11631,10 @@
 			"local_notes": "Don: 6 secs; Holdout: -2; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
-				"Footwear"
+				"Feet",
+				"Light Mail",
+				"Limbs",
+				"Mail"
 			],
 			"base_value": "50",
 			"base_weight": "1.2 lb",
@@ -10586,7 +11670,10 @@
 			"local_notes": "Don: 10 secs; Holdout: -4; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"tags": [
-				"Footwear"
+				"Feet",
+				"Light Scale",
+				"Limbs",
+				"Scale"
 			],
 			"base_value": "32",
 			"base_weight": "1.6 lb",
@@ -10623,7 +11710,10 @@
 			"local_notes": "Don: 23 secs; Holdout: -9; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433); treat as resistant.",
 			"tech_level": "0",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Chest Only Armor",
+				"Straw",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "38",
 			"base_weight": "15 lb",
@@ -10652,7 +11742,9 @@
 			"local_notes": "Don: 30 secs; Holdout: -9; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433); treat as resistant.",
 			"tech_level": "0",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Straw",
+				"Torso (Chest + Abdomen)"
 			],
 			"base_value": "50",
 			"base_weight": "20 lb",
@@ -10682,7 +11774,10 @@
 			"local_notes": "Don: 23 secs; Holdout: -8; Reaction Pen.-2; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
 			"tech_level": "0",
 			"tags": [
-				"Body Armor"
+				"Abdomen Only Armor",
+				"Body Armor",
+				"Torso (Chest + Abdomen)",
+				"Wood"
 			],
 			"base_value": "25",
 			"base_weight": "7.5 lb",
@@ -10711,7 +11806,9 @@
 			"local_notes": "Don: 15 secs; Holdout: -8; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
 			"tech_level": "0",
 			"tags": [
-				"Limb Armor"
+				"Arms",
+				"Limbs",
+				"Wood"
 			],
 			"base_value": "50",
 			"base_weight": "15 lb",
@@ -10740,7 +11837,10 @@
 			"local_notes": "Don: 8 secs; Holdout: -9; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
 			"tech_level": "0",
 			"tags": [
-				"Bascinet"
+				"Bascinet (Skull + Back Face)",
+				"Head (Skull + Face + Neck)",
+				"Non-Padded",
+				"Wood"
 			],
 			"base_value": "25",
 			"base_weight": "7.5 lb",
@@ -10769,7 +11869,10 @@
 			"local_notes": "Don: 8 secs; Holdout: -9; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
-				"Bascinet"
+				"Bascinet (Skull + Back Face)",
+				"Head (Skull + Face + Neck)",
+				"Padded",
+				"Wood"
 			],
 			"base_value": "38",
 			"base_weight": "7.7 lb",
@@ -10798,7 +11901,10 @@
 			"local_notes": "Don: 23 secs; Holdout: -8; Reaction Pen.-2; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
 			"tech_level": "0",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Chest Only Armor",
+				"Torso (Chest + Abdomen)",
+				"Wood"
 			],
 			"base_value": "75",
 			"base_weight": "22.5 lb",
@@ -10827,7 +11933,10 @@
 			"local_notes": "Don: 9 secs; Holdout: -9; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
 			"tech_level": "0",
 			"tags": [
-				"Full Helm"
+				"Full Helms (Skull + Face)",
+				"Head (Skull + Face + Neck)",
+				"Non-Padded",
+				"Wood"
 			],
 			"base_value": "30",
 			"base_weight": "9 lb",
@@ -10857,7 +11966,10 @@
 			"local_notes": "Don: 9 secs; Holdout: -9; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
-				"Full Helm"
+				"Full Helms (Skull + Face)",
+				"Head (Skull + Face + Neck)",
+				"Padded",
+				"Wood"
 			],
 			"base_value": "45",
 			"base_weight": "10.8 lb",
@@ -10887,7 +11999,9 @@
 			"local_notes": "Don: 3 secs; Holdout: -8; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
 			"tech_level": "0",
 			"tags": [
-				"Groin Armor"
+				"Groin Only",
+				"Torso (Chest + Abdomen)",
+				"Wood"
 			],
 			"base_value": "5",
 			"base_weight": "1.5 lb",
@@ -10916,7 +12030,9 @@
 			"local_notes": "Don: 30 secs; Holdout: -9; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
 			"tech_level": "0",
 			"tags": [
-				"Limb Armor"
+				"Legs",
+				"Limbs",
+				"Wood"
 			],
 			"base_value": "100",
 			"base_weight": "30 lb",
@@ -10945,7 +12061,9 @@
 			"local_notes": "Don: 3 secs; Holdout: -9; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
 			"tech_level": "0",
 			"tags": [
-				"Neck Armor"
+				"Head (Skull + Face + Neck)",
+				"Neck",
+				"Wood"
 			],
 			"base_value": "5",
 			"base_weight": "1.5 lb",
@@ -10974,7 +12092,10 @@
 			"local_notes": "Don: 6 secs; Holdout: -9; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
 			"tech_level": "0",
 			"tags": [
-				"Pot Helm"
+				"Head (Skull + Face + Neck)",
+				"Non-Padded",
+				"Pot Helm (Skull)",
+				"Wood"
 			],
 			"base_value": "20",
 			"base_weight": "6 lb",
@@ -11003,7 +12124,10 @@
 			"local_notes": "Don: 6 secs; Holdout: -9; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
-				"Pot Helm"
+				"Head (Skull + Face + Neck)",
+				"Padded",
+				"Pot Helm (Skull)",
+				"Wood"
 			],
 			"base_value": "30",
 			"base_weight": "7.2 lb",
@@ -11032,7 +12156,9 @@
 			"local_notes": "Don: 30 secs; Holdout: -8; Reaction Pen.-2; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
 			"tech_level": "0",
 			"tags": [
-				"Body Armor"
+				"Body Armor",
+				"Torso (Chest + Abdomen)",
+				"Wood"
 			],
 			"base_value": "100",
 			"base_weight": "30 lb",

--- a/Library/Low Tech/Low Tech Instant Armor.eqp
+++ b/Library/Low Tech/Low Tech Instant Armor.eqp
@@ -52,6 +52,44 @@
 			}
 		},
 		{
+			"id": "e6CMStLxGST6IT-W3",
+			"description": "Arming Hose",
+			"reference": "LTIA19",
+			"local_notes": "Don: 15 secs; Holdout: 0; Required for suit of plate. Light mail protects groin and back of knees.",
+			"tech_level": "4",
+			"legality_class": "4",
+			"tags": [
+				"Groin Armor",
+				"Limb Armor"
+			],
+			"base_value": "160",
+			"base_weight": "3 lb",
+			"features": [
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"groin"
+					],
+					"amount": 0
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"leg"
+					],
+					"amount": 0
+				}
+			],
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"value": 160,
+				"extended_value": 160,
+				"weight": "3 lb",
+				"extended_weight": "3 lb"
+			}
+		},
+		{
 			"id": "e8lwgtkMSuZ5kldYB",
 			"description": "Boots, Leather ",
 			"reference": "LTIA16",

--- a/Library/Low Tech/Low Tech Instant Armor.eqp
+++ b/Library/Low Tech/Low Tech Instant Armor.eqp
@@ -17,6 +17,13 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"arm"
+					],
+					"amount": 0
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
 						"abdomen"
 					],
 					"amount": 0
@@ -25,20 +32,6 @@
 					"type": "dr_bonus",
 					"locations": [
 						"torso"
-					],
-					"amount": 0
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
-					],
-					"amount": 0
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
 					],
 					"amount": 0
 				}
@@ -93,7 +86,7 @@
 			"id": "e8lwgtkMSuZ5kldYB",
 			"description": "Boots, Leather ",
 			"reference": "LTIA16",
-			"local_notes": "Don: 6 secs; Holdout: -4; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
+			"local_notes": "DR: 2; Don: 6 secs; Holdout: -4; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
 			"tech_level": "1",
 			"tags": [
 				"Footwear"
@@ -104,9 +97,18 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"foot"
+						"foot",
+						"torso"
 					],
 					"amount": 2
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"foot"
+					],
+					"specialization": "impaling",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -121,7 +123,7 @@
 			"id": "edcVYnWCsEfIfsJWy",
 			"description": "Boots, Light Leather ",
 			"reference": "LTIA16",
-			"local_notes": "Don: 6 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
+			"local_notes": "DR: 0; Don: 6 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
 			"tech_level": "1",
 			"legality_class": "5",
 			"tags": [
@@ -136,6 +138,14 @@
 						"foot"
 					],
 					"amount": 0
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"foot"
+					],
+					"specialization": "cutting",
+					"amount": 1
 				}
 			],
 			"quantity": 1,
@@ -150,7 +160,7 @@
 			"id": "eh8J5xpu8ruZebKhw",
 			"description": "Brigandine, Light Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "Don: 23 secs; Holdout: -2; Reaction Pen.-2",
+			"local_notes": "DR: 3; Don: 23 secs; Holdout: -2; Reaction Pen.-2",
 			"tech_level": "4",
 			"tags": [
 				"Body Armor"
@@ -164,13 +174,6 @@
 						"abdomen"
 					],
 					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
-					],
-					"amount": 3
 				}
 			],
 			"quantity": 1,
@@ -179,13 +182,14 @@
 				"extended_value": 225,
 				"weight": "2.5 lb",
 				"extended_weight": "2.5 lb"
-			}
+			},
+			"reference_highlight": "Brigandine, Light"
 		},
 		{
 			"id": "edQLWsYSLTmQwbhyU",
 			"description": "Brigandine, Light Arm Armor",
 			"reference": "LTIA8",
-			"local_notes": "Don: 15 secs; Holdout: -2; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 15 secs; Holdout: -2; Reaction Pen.-1",
 			"tech_level": "4",
 			"tags": [
 				"Limb Armor"
@@ -207,13 +211,14 @@
 				"extended_value": 450,
 				"weight": "5 lb",
 				"extended_weight": "5 lb"
-			}
+			},
+			"reference_highlight": "Brigandine, Light"
 		},
 		{
 			"id": "eUYpAPhKkq9FESYpi",
 			"description": "Brigandine, Light Bascinet",
 			"reference": "LTIA14",
-			"local_notes": "Don: 8 secs; Holdout: -3; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 8 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "4",
 			"tags": [
 				"Bascinet"
@@ -227,13 +232,6 @@
 						"skull"
 					],
 					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
-					],
-					"amount": 3
 				}
 			],
 			"quantity": 1,
@@ -242,13 +240,14 @@
 				"extended_value": 225,
 				"weight": "2.5 lb",
 				"extended_weight": "2.5 lb"
-			}
+			},
+			"reference_highlight": "Brigandine, Light"
 		},
 		{
 			"id": "eJ-0v_Th7Clbbzelr",
 			"description": "Brigandine, Light Bascinet, Padded",
 			"reference": "LTIA14",
-			"local_notes": "Don: 8 secs; Holdout: -3; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 8 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "4",
 			"tags": [
 				"Bascinet"
@@ -262,13 +261,6 @@
 						"skull"
 					],
 					"amount": 4
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
-					],
-					"amount": 4
 				}
 			],
 			"quantity": 1,
@@ -277,13 +269,14 @@
 				"extended_value": 238,
 				"weight": "2.7 lb",
 				"extended_weight": "2.7 lb"
-			}
+			},
+			"reference_highlight": "Brigandine, Light"
 		},
 		{
 			"id": "eTf_SIoh9R449QM0q",
 			"description": "Brigandine, Light Chest Armor",
 			"reference": "LTIA6",
-			"local_notes": "Don: 23 secs; Holdout: -2; Reaction Pen.-2",
+			"local_notes": "DR: 3; Don: 23 secs; Holdout: -2; Reaction Pen.-2",
 			"tech_level": "4",
 			"tags": [
 				"Body Armor"
@@ -297,13 +290,6 @@
 						"torso"
 					],
 					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
-					],
-					"amount": 3
 				}
 			],
 			"quantity": 1,
@@ -312,13 +298,14 @@
 				"extended_value": 675,
 				"weight": "7.5 lb",
 				"extended_weight": "7.5 lb"
-			}
+			},
+			"reference_highlight": "Brigandine, Light"
 		},
 		{
 			"id": "e3vThWxETJmvPpEFF",
 			"description": "Brigandine, Light Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "Don: 3 secs; Holdout: -2; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 3 secs; Holdout: -2; Reaction Pen.-1",
 			"tech_level": "4",
 			"tags": [
 				"Groin Armor"
@@ -340,13 +327,14 @@
 				"extended_value": 45,
 				"weight": "0.5 lb",
 				"extended_weight": "0.5 lb"
-			}
+			},
+			"reference_highlight": "Brigandine, Light"
 		},
 		{
 			"id": "ek4BPKf7q8Kvff9Ec",
 			"description": "Brigandine, Light Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "Don: 30 secs; Holdout: -2; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 30 secs; Holdout: -2; Reaction Pen.-1",
 			"tech_level": "4",
 			"tags": [
 				"Limb Armor"
@@ -368,13 +356,14 @@
 				"extended_value": 900,
 				"weight": "10 lb",
 				"extended_weight": "10 lb"
-			}
+			},
+			"reference_highlight": "Brigandine, Light"
 		},
 		{
 			"id": "eEpQhVdPZNyFI7WHy",
 			"description": "Brigandine, Light Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "Don: 3 secs; Holdout: -3; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 3 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "4",
 			"tags": [
 				"Neck Armor"
@@ -396,13 +385,14 @@
 				"extended_value": 45,
 				"weight": "0.5 lb",
 				"extended_weight": "0.5 lb"
-			}
+			},
+			"reference_highlight": "Brigandine, Light"
 		},
 		{
 			"id": "e8kCpa3uNZ-_5p1rv",
 			"description": "Brigandine, Light Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "Don: 6 secs; Holdout: -3; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 6 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "4",
 			"tags": [
 				"Pot Helm"
@@ -424,13 +414,14 @@
 				"extended_value": 180,
 				"weight": "2 lb",
 				"extended_weight": "2 lb"
-			}
+			},
+			"reference_highlight": "Brigandine, Light"
 		},
 		{
 			"id": "e_0wrPWRg4T9zCtTS",
 			"description": "Brigandine, Light Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "Don: 6 secs; Holdout: -3; Reaction Pen.-1",
+			"local_notes": "DR: 4; Don: 6 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "4",
 			"tags": [
 				"Pot Helm"
@@ -452,13 +443,14 @@
 				"extended_value": 190,
 				"weight": "3.2 lb",
 				"extended_weight": "3.2 lb"
-			}
+			},
+			"reference_highlight": "Brigandine, Light"
 		},
 		{
 			"id": "eAYZJ6GspGEexUw2b",
 			"description": "Brigandine, Light Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 30 secs; Holdout: -2; Reaction Pen.-2",
+			"local_notes": "DR: 3; Don: 30 secs; Holdout: -2; Reaction Pen.-2",
 			"tech_level": "4",
 			"tags": [
 				"Body Armor"
@@ -469,28 +461,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
+						"abdomen",
 						"torso"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
 					],
 					"amount": 3
 				}
@@ -501,13 +473,14 @@
 				"extended_value": 900,
 				"weight": "10 lb",
 				"extended_weight": "10 lb"
-			}
+			},
+			"reference_highlight": "Brigandine, Light"
 		},
 		{
 			"id": "eQ6f2HunYAOa--mb4",
 			"description": "Brigandine, Medium Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2",
+			"local_notes": "DR: 5; Don: 23 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -522,13 +495,6 @@
 						"abdomen"
 					],
 					"amount": 5
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
-					],
-					"amount": 5
 				}
 			],
 			"quantity": 1,
@@ -537,13 +503,14 @@
 				"extended_value": 450,
 				"weight": "5 lb",
 				"extended_weight": "5 lb"
-			}
+			},
+			"reference_highlight": "Brigandine, Medium"
 		},
 		{
 			"id": "e1FLTlv1-MCiK9A_I",
 			"description": "Brigandine, Medium Arm Armor",
 			"reference": "LTIA8",
-			"local_notes": "Don: 15 secs; Holdout: -4; Reaction Pen.-1",
+			"local_notes": "DR: 5; Don: 15 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -566,13 +533,14 @@
 				"extended_value": 900,
 				"weight": "10 lb",
 				"extended_weight": "10 lb"
-			}
+			},
+			"reference_highlight": "Brigandine, Medium"
 		},
 		{
 			"id": "enY4fk3DuAzhTGCqt",
 			"description": "Brigandine, Medium Bascinet",
 			"reference": "LTIA14",
-			"local_notes": "Don: 8 secs; Holdout: -5; Reaction Pen.-1",
+			"local_notes": "DR: 5; Don: 8 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -587,13 +555,6 @@
 						"skull"
 					],
 					"amount": 5
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
-					],
-					"amount": 5
 				}
 			],
 			"quantity": 1,
@@ -602,13 +563,14 @@
 				"extended_value": 450,
 				"weight": "5 lb",
 				"extended_weight": "5 lb"
-			}
+			},
+			"reference_highlight": "Brigandine, Medium"
 		},
 		{
 			"id": "eTC8_mSTNuLBuBO_f",
 			"description": "Brigandine, Medium Bascinet, Padded",
 			"reference": "LTIA14",
-			"local_notes": "Don: 8 secs; Holdout: -5; Reaction Pen.-1",
+			"local_notes": "DR: 6; Don: 8 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -623,13 +585,6 @@
 						"skull"
 					],
 					"amount": 6
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
-					],
-					"amount": 6
 				}
 			],
 			"quantity": 1,
@@ -638,13 +593,14 @@
 				"extended_value": 463,
 				"weight": "5.2 lb",
 				"extended_weight": "5.2 lb"
-			}
+			},
+			"reference_highlight": "Brigandine, Medium"
 		},
 		{
 			"id": "e8Q_xoWvIetlKUBa1",
 			"description": "Brigandine, Medium Chest Armor",
 			"reference": "LTIA6",
-			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2",
+			"local_notes": "DR: 5; Don: 23 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -659,13 +615,6 @@
 						"torso"
 					],
 					"amount": 5
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
-					],
-					"amount": 5
 				}
 			],
 			"quantity": 1,
@@ -674,13 +623,14 @@
 				"extended_value": 1350,
 				"weight": "15 lb",
 				"extended_weight": "15 lb"
-			}
+			},
+			"reference_highlight": "Brigandine, Medium"
 		},
 		{
 			"id": "ewKGGF29AjbqQWGOC",
 			"description": "Brigandine, Medium Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1",
+			"local_notes": "DR: 5; Don: 3 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -703,13 +653,14 @@
 				"extended_value": 90,
 				"weight": "1 lb",
 				"extended_weight": "1 lb"
-			}
+			},
+			"reference_highlight": "Brigandine, Medium"
 		},
 		{
 			"id": "etJ5XdwTGD6cJhN5a",
 			"description": "Brigandine, Medium Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-1",
+			"local_notes": "DR: 5; Don: 30 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -732,13 +683,14 @@
 				"extended_value": 1800,
 				"weight": "20 lb",
 				"extended_weight": "20 lb"
-			}
+			},
+			"reference_highlight": "Brigandine, Medium"
 		},
 		{
 			"id": "esyl3QigpPqsFsDNg",
 			"description": "Brigandine, Medium Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "Don: 3 secs; Holdout: -5; Reaction Pen.-1",
+			"local_notes": "DR: 5; Don: 3 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -761,13 +713,14 @@
 				"extended_value": 90,
 				"weight": "1 lb",
 				"extended_weight": "1 lb"
-			}
+			},
+			"reference_highlight": "Brigandine, Medium"
 		},
 		{
 			"id": "e-4FTDCDKuqROsiK4",
 			"description": "Brigandine, Medium Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1",
+			"local_notes": "DR: 5; Don: 6 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -790,13 +743,14 @@
 				"extended_value": 360,
 				"weight": "4 lb",
 				"extended_weight": "4 lb"
-			}
+			},
+			"reference_highlight": "Brigandine, Medium"
 		},
 		{
 			"id": "e7Ih5HMRDrnu2R6cL",
 			"description": "Brigandine, Medium Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1",
+			"local_notes": "DR: 6; Don: 6 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -819,13 +773,14 @@
 				"extended_value": 370,
 				"weight": "5.2 lb",
 				"extended_weight": "5.2 lb"
-			}
+			},
+			"reference_highlight": "Brigandine, Medium"
 		},
 		{
 			"id": "ehhvva799mVxX6d2f",
 			"description": "Brigandine, Medium Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-2",
+			"local_notes": "DR: 5; Don: 30 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -837,28 +792,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
-					],
-					"amount": 5
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
+						"abdomen",
 						"torso"
-					],
-					"amount": 5
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
-					],
-					"amount": 5
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
 					],
 					"amount": 5
 				}
@@ -869,13 +804,14 @@
 				"extended_value": 1800,
 				"weight": "20 lb",
 				"extended_weight": "20 lb"
-			}
+			},
+			"reference_highlight": "Brigandine, Medium"
 		},
 		{
 			"id": "emRv3QKih2dvu3w1P",
 			"description": "Cane Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433); treat as resistant.",
+			"local_notes": "DR: 1; Don: 23 secs; Holdout: -4; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433); treat as resistant.",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -887,13 +823,6 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen"
-					],
-					"amount": 1
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
 					],
 					"amount": 1
 				}
@@ -910,7 +839,7 @@
 			"id": "e4yOdbY3C6Ta2th6I",
 			"description": "Cane Arm Armor",
 			"reference": "LTIA7",
-			"local_notes": "Don: 15 secs; Holdout: -4; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433); treat as resistant.",
+			"local_notes": "DR: 1; Don: 15 secs; Holdout: -4; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433); treat as resistant.",
 			"tech_level": "0",
 			"tags": [
 				"Limb Armor"
@@ -938,7 +867,7 @@
 			"id": "eWRN91wMSfgFHEOCA",
 			"description": "Cane Bascinet",
 			"reference": "LTIA14",
-			"local_notes": "Don: 8 secs; Holdout: -5; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433); treat as resistant.",
+			"local_notes": "DR: 1; Don: 8 secs; Holdout: -5; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433); treat as resistant.",
 			"tech_level": "0",
 			"tags": [
 				"Bascinet"
@@ -950,13 +879,6 @@
 					"type": "dr_bonus",
 					"locations": [
 						"skull"
-					],
-					"amount": 1
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
 					],
 					"amount": 1
 				}
@@ -973,7 +895,7 @@
 			"id": "eE_c-yz5FS0yXCxiX",
 			"description": "Cane Bascinet, Padded",
 			"reference": "LTIA14",
-			"local_notes": "Don: 8 secs; Holdout: -5; Reaction Pen.-1",
+			"local_notes": "DR: 2; Don: 8 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Bascinet"
@@ -985,13 +907,6 @@
 					"type": "dr_bonus",
 					"locations": [
 						"skull"
-					],
-					"amount": 2
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
 					],
 					"amount": 2
 				}
@@ -1008,7 +923,7 @@
 			"id": "eobg1Tm37CBN13eUE",
 			"description": "Cane Chest Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433); treat as resistant.",
+			"local_notes": "DR: 1; Don: 23 secs; Holdout: -4; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433); treat as resistant.",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -1020,13 +935,6 @@
 					"type": "dr_bonus",
 					"locations": [
 						"torso"
-					],
-					"amount": 1
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
 					],
 					"amount": 1
 				}
@@ -1043,7 +951,7 @@
 			"id": "etVn1-1taVlfhJ88F",
 			"description": "Cane Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433); treat as resistant.",
+			"local_notes": "DR: 1; Don: 30 secs; Holdout: -4; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433); treat as resistant.",
 			"tech_level": "0",
 			"tags": [
 				"Limb Armor"
@@ -1071,7 +979,7 @@
 			"id": "enBusL9f1xeI5VP0Z",
 			"description": "Cane Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "Don: 3 secs; Holdout: -5; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433); treat as resistant.",
+			"local_notes": "DR: 1; Don: 3 secs; Holdout: -5; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433); treat as resistant.",
 			"tech_level": "0",
 			"tags": [
 				"Neck Armor"
@@ -1099,7 +1007,7 @@
 			"id": "ei2PivGavZyeZbtMD",
 			"description": "Cane Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433); treat as resistant.",
+			"local_notes": "DR: 1; Don: 6 secs; Holdout: -5; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433); treat as resistant.",
 			"tech_level": "0",
 			"tags": [
 				"Pot Helm"
@@ -1127,7 +1035,7 @@
 			"id": "e200eWmzf_iU8dDv9",
 			"description": "Cane Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1",
+			"local_notes": "DR: 2; Don: 6 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Pot Helm"
@@ -1155,7 +1063,7 @@
 			"id": "eK_Ju4UXUveLhfdPM",
 			"description": "Cane Torso Armor",
 			"reference": "LTIA4",
-			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433); treat as resistant.",
+			"local_notes": "DR: 1; Don: 30 secs; Holdout: -4; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433); treat as resistant.",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -1166,28 +1074,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
-					],
-					"amount": 1
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
+						"abdomen",
 						"torso"
-					],
-					"amount": 1
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
-					],
-					"amount": 1
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
 					],
 					"amount": 1
 				}
@@ -1204,7 +1092,7 @@
 			"id": "eeGYAyjcVLFROfzcB",
 			"description": "Cloth, Padded Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "Don: 11 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
+			"local_notes": "DR: 1; Don: 11 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -1216,13 +1104,6 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen"
-					],
-					"amount": 1
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
 					],
 					"amount": 1
 				}
@@ -1239,7 +1120,7 @@
 			"id": "eIbb_FaAxSB5N__Hl",
 			"description": "Cloth, Padded Arm Armor",
 			"reference": "LTIA7",
-			"local_notes": "Don: 8 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
+			"local_notes": "DR: 1; Don: 8 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Limb Armor"
@@ -1267,7 +1148,7 @@
 			"id": "e9XLFiOrvY0PZD9C3",
 			"description": "Cloth, Padded Bascinet",
 			"reference": "LTIA14",
-			"local_notes": "Don: 4 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379)",
+			"local_notes": "DR: 1; Don: 4 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Bascinet"
@@ -1279,13 +1160,6 @@
 					"type": "dr_bonus",
 					"locations": [
 						"skull"
-					],
-					"amount": 1
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
 					],
 					"amount": 1
 				}
@@ -1302,7 +1176,7 @@
 			"id": "e2htbNlX1xn4-u6x7",
 			"description": "Cloth, Padded Bascinet, Padded",
 			"reference": "LTIA14",
-			"local_notes": "Don: 4 secs; Holdout: -1",
+			"local_notes": "DR: 2; Don: 4 secs; Holdout: -1",
 			"tech_level": "0",
 			"tags": [
 				"Bascinet"
@@ -1314,13 +1188,6 @@
 					"type": "dr_bonus",
 					"locations": [
 						"skull"
-					],
-					"amount": 2
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
 					],
 					"amount": 2
 				}
@@ -1337,7 +1204,7 @@
 			"id": "er3ATQBwPc4AXWcU-",
 			"description": "Cloth, Padded Chest Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 11secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
+			"local_notes": "DR: 1; Don: 11secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -1349,13 +1216,6 @@
 					"type": "dr_bonus",
 					"locations": [
 						"torso"
-					],
-					"amount": 1
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
 					],
 					"amount": 1
 				}
@@ -1372,7 +1232,7 @@
 			"id": "e4tTAtQSyCIraf-sh",
 			"description": "Cloth, Padded Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "Don: 3 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
+			"local_notes": "DR: 1; Don: 3 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Groin Armor"
@@ -1400,7 +1260,7 @@
 			"id": "eJMxpJMaSa34R5HeL",
 			"description": "Cloth, Padded Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "Don: 15 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
+			"local_notes": "DR: 1; Don: 15 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Limb Armor"
@@ -1428,7 +1288,7 @@
 			"id": "euHHcEqbF20IqHTdX",
 			"description": "Cloth, Padded Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "Don: 3 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379)",
+			"local_notes": "DR: 1; Don: 3 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Neck Armor"
@@ -1456,7 +1316,7 @@
 			"id": "eDPknyvFhTUn3xLLn",
 			"description": "Cloth, Padded Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "Don: 3 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379)",
+			"local_notes": "DR: 1; Don: 3 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Pot Helm"
@@ -1484,7 +1344,7 @@
 			"id": "e0XgEoxlybGM1sxmW",
 			"description": "Cloth, Padded Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "Don: 3 secs; Holdout: -1",
+			"local_notes": "DR: 2; Don: 3 secs; Holdout: -1",
 			"tech_level": "0",
 			"tags": [
 				"Pot Helm"
@@ -1512,7 +1372,7 @@
 			"id": "ercQVz3m__twBvKjH",
 			"description": "Cloth, Padded Torso Armor",
 			"reference": "LTIA4",
-			"local_notes": "Don: 15 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
+			"local_notes": "DR: 1; Don: 15 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -1523,28 +1383,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
-					],
-					"amount": 1
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
+						"abdomen",
 						"torso"
-					],
-					"amount": 1
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
-					],
-					"amount": 1
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
 					],
 					"amount": 1
 				}
@@ -1561,7 +1401,7 @@
 			"id": "eAGTRRqWt8WZIVwP9",
 			"description": "Gauntlets, Hardened Leather ",
 			"reference": "LTIA15",
-			"local_notes": "Don: 10 secs; Holdout: -4; Gives Ham-Fisted 2 (p. B138).",
+			"local_notes": "DR: 2; Don: 10 secs; Holdout: -4; Gives Ham-Fisted 2 (p. B138).",
 			"tech_level": "1",
 			"tags": [
 				"Gloves"
@@ -1589,7 +1429,7 @@
 			"id": "eur06_PfX8L-FrAdE",
 			"description": "Gauntlets, Heavy Mail ",
 			"reference": "LTIA15",
-			"local_notes": "Don: 10 secs; Holdout: -4; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing; Gives Ham-Fisted 2 (p. B138).",
+			"local_notes": "DR: 5; Don: 10 secs; Holdout: -4; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing; Gives Ham-Fisted 2 (p. B138).",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -1604,6 +1444,14 @@
 						"hand"
 					],
 					"amount": 5
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"hand"
+					],
+					"specialization": "crushing",
+					"amount": -2
 				}
 			],
 			"quantity": 1,
@@ -1618,7 +1466,7 @@
 			"id": "e6hR_7K5Y4ELg8ouw",
 			"description": "Gauntlets, Light Plate ",
 			"reference": "LTIA15",
-			"local_notes": "Don: 10 secs; Holdout: -4; Gives Ham-Fisted 2 (p. B138).",
+			"local_notes": "DR: 3; Don: 10 secs; Holdout: -4; Gives Ham-Fisted 2 (p. B138).",
 			"tech_level": "4",
 			"tags": [
 				"Gloves"
@@ -1646,7 +1494,7 @@
 			"id": "e1Jc9oibz_7Se4NSl",
 			"description": "Gauntlets, Light Segmented ",
 			"reference": "LTIA15",
-			"local_notes": "Don: 10 secs; Holdout: -4; Gives Ham-Fisted 2 (p. B138).",
+			"local_notes": "DR: 3; Don: 10 secs; Holdout: -4; Gives Ham-Fisted 2 (p. B138).",
 			"tech_level": "3",
 			"tags": [
 				"Gloves"
@@ -1674,7 +1522,7 @@
 			"id": "eXb29dBeGn2jiLwyd",
 			"description": "Gauntlets, Medium Plate ",
 			"reference": "LTIA15",
-			"local_notes": "Don: 10 secs; Holdout: -6; Gives Ham-Fisted 2 (p. B138).",
+			"local_notes": "DR: 6; Don: 10 secs; Holdout: -6; Gives Ham-Fisted 2 (p. B138).",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -1703,7 +1551,7 @@
 			"id": "elLRNlQeA1ZIzjwDY",
 			"description": "Gauntlets, Medium Segmented ",
 			"reference": "LTIA15",
-			"local_notes": "Don: 10 secs; Holdout: -5; Gives Ham-Fisted 2 (p. B138).",
+			"local_notes": "DR: 4; Don: 10 secs; Holdout: -5; Gives Ham-Fisted 2 (p. B138).",
 			"tech_level": "3",
 			"tags": [
 				"Gloves"
@@ -1731,7 +1579,7 @@
 			"id": "eUyhaqVa7eSPWoDtB",
 			"description": "Gauntlets, Padded Cloth ",
 			"reference": "LTIA15",
-			"local_notes": "Don: 10 secs; Holdout: -2; Flexible and susceptible to blunt trauma (p. B379); Gives Ham-Fisted 1 (p. B138).",
+			"local_notes": "DR: 1; Don: 10 secs; Holdout: -2; Flexible and susceptible to blunt trauma (p. B379); Gives Ham-Fisted 1 (p. B138).",
 			"tech_level": "1",
 			"tags": [
 				"Gloves"
@@ -1759,7 +1607,7 @@
 			"id": "eYtckk0_SxXIvwCEl",
 			"description": "Gauntlets,Fine Mail ",
 			"reference": "LTIA15",
-			"local_notes": "Don: 10 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing; Gives Ham-Fisted 2 (p. B138).",
+			"local_notes": "DR: 4; Don: 10 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing; Gives Ham-Fisted 2 (p. B138).",
 			"tech_level": "2",
 			"tags": [
 				"Gloves"
@@ -1773,6 +1621,14 @@
 						"hand"
 					],
 					"amount": 4
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"hand"
+					],
+					"specialization": "crushing",
+					"amount": -2
 				}
 			],
 			"quantity": 1,
@@ -1787,7 +1643,7 @@
 			"id": "e55lxLmwMaK_c-XHw",
 			"description": "Gauntlets,Light Mail ",
 			"reference": "LTIA15",
-			"local_notes": "Don: 10 secs; Holdout: -2; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing; Gives Ham-Fisted 2 (p. B138).",
+			"local_notes": "DR: 3; Don: 10 secs; Holdout: -2; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing; Gives Ham-Fisted 2 (p. B138).",
 			"tech_level": "2",
 			"tags": [
 				"Gloves"
@@ -1801,6 +1657,14 @@
 						"hand"
 					],
 					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"hand"
+					],
+					"specialization": "crushing",
+					"amount": -2
 				}
 			],
 			"quantity": 1,
@@ -1815,7 +1679,7 @@
 			"id": "eixxfx23rzXgQ7VXP",
 			"description": "Gauntlets, Light Scale ",
 			"reference": "LTIA15",
-			"local_notes": "Don: 10 secs; Holdout: -4; -1 DR vs. crushing; Gives Ham-Fisted 2 (p. B138).",
+			"local_notes": "DR: 3; Don: 10 secs; Holdout: -4; -1 DR vs. crushing; Gives Ham-Fisted 2 (p. B138).",
 			"tech_level": "1",
 			"tags": [
 				"Gloves"
@@ -1843,7 +1707,7 @@
 			"id": "e_1tXA6dcIPkbkkIa",
 			"description": "Gloves, Cloth ",
 			"reference": "LTIA15",
-			"local_notes": "Don: 10 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting; Enclosedmittens andgloves protectvs.cold,heat,contactpoison,etc.,but giveBadGrip1(p.B123); Gives Ham-Fisted 1 (p. B138).",
+			"local_notes": "DR: 1; Don: 10 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting; Enclosedmittens andgloves protectvs.cold,heat,contactpoison,etc.,but giveBadGrip1(p.B123); Gives Ham-Fisted 1 (p. B138).",
 			"tech_level": "1",
 			"legality_class": "5",
 			"tags": [
@@ -1858,6 +1722,14 @@
 						"hand"
 					],
 					"amount": 0
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"hand"
+					],
+					"specialization": "cutting",
+					"amount": 1
 				}
 			],
 			"quantity": 1,
@@ -1872,7 +1744,7 @@
 			"id": "en60StSySCEyH7YVO",
 			"description": "Gloves, Light Leather ",
 			"reference": "LTIA15",
-			"local_notes": "Don: 10 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting; Enclosedmittens andgloves protectvs.cold,heat,contactpoison,etc.,but giveBadGrip1(p.B123); Gives Ham-Fisted 1 (p. B138).",
+			"local_notes": "DR: 0; Don: 10 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting; Enclosedmittens andgloves protectvs.cold,heat,contactpoison,etc.,but giveBadGrip1(p.B123); Gives Ham-Fisted 1 (p. B138).",
 			"tech_level": "1",
 			"legality_class": "5",
 			"tags": [
@@ -1887,6 +1759,14 @@
 						"hand"
 					],
 					"amount": 0
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"hand"
+					],
+					"specialization": "cutting",
+					"amount": 1
 				}
 			],
 			"quantity": 1,
@@ -1901,7 +1781,7 @@
 			"id": "e16kkxLZFbx6VLlAd",
 			"description": "Hardened Leather, Heavy Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2",
+			"local_notes": "DR: 3; Don: 23 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "1",
 			"tags": [
 				"Body Armor"
@@ -1913,13 +1793,6 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
 					],
 					"amount": 3
 				}
@@ -1936,7 +1809,7 @@
 			"id": "evHTYfJ7jKI6fwE0-",
 			"description": "Hardened Leather, Heavy Arm Armor",
 			"reference": "LTIA7",
-			"local_notes": "Don: 15 secs; Holdout: -4; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 15 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Limb Armor"
@@ -1964,7 +1837,7 @@
 			"id": "eMMyaOaVHKzQRweKQ",
 			"description": "Hardened Leather, Heavy Bascinet",
 			"reference": "LTIA14",
-			"local_notes": "Don: 8 secs; Holdout: -5; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 8 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Bascinet"
@@ -1976,13 +1849,6 @@
 					"type": "dr_bonus",
 					"locations": [
 						"skull"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
 					],
 					"amount": 3
 				}
@@ -1999,7 +1865,7 @@
 			"id": "eS7ZawHm2T4dmz1F5",
 			"description": "Hardened Leather, Heavy Bascinet, Padded",
 			"reference": "LTIA14",
-			"local_notes": "Don: 8 secs; Holdout: -5; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 8 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Bascinet"
@@ -2011,13 +1877,6 @@
 					"type": "dr_bonus",
 					"locations": [
 						"skull"
-					],
-					"amount": 4
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
 					],
 					"amount": 4
 				}
@@ -2034,7 +1893,7 @@
 			"id": "eKjAtjY6WdKLQyyOo",
 			"description": "Hardened Leather, Heavy Chest Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2",
+			"local_notes": "DR: 3; Don: 23 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "1",
 			"tags": [
 				"Body Armor"
@@ -2046,13 +1905,6 @@
 					"type": "dr_bonus",
 					"locations": [
 						"torso"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
 					],
 					"amount": 3
 				}
@@ -2069,7 +1921,7 @@
 			"id": "eaPOJRkSRRhw_v1Ii",
 			"description": "Hardened Leather, Heavy Full Helm",
 			"reference": "LTIA14",
-			"local_notes": "Don: 9 secs; Holdout: -5; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 9 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Full Helm"
@@ -2080,14 +1932,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"face",
 						"skull"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
 					],
 					"amount": 3
 				}
@@ -2104,7 +1950,7 @@
 			"id": "eCPh_o0H1tNS_2pD6",
 			"description": "Hardened Leather, Heavy Full Helm, Padded",
 			"reference": "LTIA14",
-			"local_notes": "Don: 9 secs; Holdout: -5; Reaction Pen.-1",
+			"local_notes": "DR: 4; Don: 9 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Full Helm"
@@ -2115,14 +1961,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"face",
 						"skull"
-					],
-					"amount": 4
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
 					],
 					"amount": 4
 				}
@@ -2139,7 +1979,7 @@
 			"id": "euWzxEa4wC6RFa8rj",
 			"description": "Hardened Leather, Heavy Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 3 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Groin Armor"
@@ -2167,7 +2007,7 @@
 			"id": "e8HwxRzeqYA0G-95c",
 			"description": "Hardened Leather, Heavy Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 30 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Limb Armor"
@@ -2195,7 +2035,7 @@
 			"id": "eXMPN2mxCgZ4R0scc",
 			"description": "Hardened Leather, Heavy Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "Don: 3 secs; Holdout: -5; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 3 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Neck Armor"
@@ -2223,7 +2063,7 @@
 			"id": "eLCqzw-Br3WmlHiBh",
 			"description": "Hardened Leather, Heavy Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 6 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Pot Helm"
@@ -2251,7 +2091,7 @@
 			"id": "e_pOsR_mGuKMmsD-4",
 			"description": "Hardened Leather, Heavy Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1",
+			"local_notes": "DR: 4; Don: 6 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Pot Helm"
@@ -2279,7 +2119,7 @@
 			"id": "eQvSPTA9uJm1p6hWS",
 			"description": "Hardened Leather, Heavy Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-2",
+			"local_notes": "DR: 3; Don: 30 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "1",
 			"tags": [
 				"Body Armor"
@@ -2290,28 +2130,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
+						"abdomen",
 						"torso"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
 					],
 					"amount": 3
 				}
@@ -2328,7 +2148,7 @@
 			"id": "efhSMYdar0FA330XF",
 			"description": "Hardened Leather, Medium Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-2",
+			"local_notes": "DR: 2; Don: 23 secs; Holdout: -3; Reaction Pen.-2",
 			"tech_level": "1",
 			"tags": [
 				"Body Armor"
@@ -2340,13 +2160,6 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen"
-					],
-					"amount": 2
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
 					],
 					"amount": 2
 				}
@@ -2363,7 +2176,7 @@
 			"id": "eZ52fni9bDiz7STYh",
 			"description": "Hardened Leather, Medium Arm Armor",
 			"reference": "LTIA7",
-			"local_notes": "Don: 15 secs; Holdout: -3; Reaction Pen.-1",
+			"local_notes": "DR: 2; Don: 15 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Limb Armor"
@@ -2391,7 +2204,7 @@
 			"id": "e_8g7sSqp7H2fsdKu",
 			"description": "Hardened Leather, Medium Bascinet",
 			"reference": "LTIA14",
-			"local_notes": "Don: 8 secs; Holdout: -4; Reaction Pen.-1",
+			"local_notes": "DR: 2; Don: 8 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Bascinet"
@@ -2403,13 +2216,6 @@
 					"type": "dr_bonus",
 					"locations": [
 						"skull"
-					],
-					"amount": 2
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
 					],
 					"amount": 2
 				}
@@ -2426,7 +2232,7 @@
 			"id": "e7wVrvuC3-DCpiaux",
 			"description": "Hardened Leather, Medium Bascinet, Padded",
 			"reference": "LTIA14",
-			"local_notes": "Don: 8 secs; Holdout: -4; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 8 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Bascinet"
@@ -2438,13 +2244,6 @@
 					"type": "dr_bonus",
 					"locations": [
 						"skull"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
 					],
 					"amount": 3
 				}
@@ -2461,7 +2260,7 @@
 			"id": "eeUmKAG5phe6Mm6HT",
 			"description": "Hardened Leather, Medium Chest Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-2",
+			"local_notes": "DR: 2; Don: 23 secs; Holdout: -3; Reaction Pen.-2",
 			"tech_level": "1",
 			"tags": [
 				"Body Armor"
@@ -2473,13 +2272,6 @@
 					"type": "dr_bonus",
 					"locations": [
 						"torso"
-					],
-					"amount": 2
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
 					],
 					"amount": 2
 				}
@@ -2496,7 +2288,7 @@
 			"id": "e7EekFtyJyxUBJg9F",
 			"description": "Hardened Leather, Medium Full Helm",
 			"reference": "LTIA14",
-			"local_notes": "Don: 9 secs; Holdout: -4; Reaction Pen.-1",
+			"local_notes": "DR: 2; Don: 9 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Full Helm"
@@ -2531,7 +2323,7 @@
 			"id": "e6yVOb-hB8iwKeFEX",
 			"description": "Hardened Leather, Medium Full Helm, Padded",
 			"reference": "LTIA14",
-			"local_notes": "Don: 9 secs; Holdout: -4; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 9 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Full Helm"
@@ -2566,7 +2358,7 @@
 			"id": "esRD0en0BEoii6nVr",
 			"description": "Hardened Leather, Medium Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "Don: 3 secs; Holdout: -3; Reaction Pen.-1",
+			"local_notes": "DR: 2; Don: 3 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Groin Armor"
@@ -2594,7 +2386,7 @@
 			"id": "eV1KAi8XLJ8MmCuX2",
 			"description": "Hardened Leather, Medium Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "Don: 30 secs; Holdout: -3; Reaction Pen.-1",
+			"local_notes": "DR: 2; Don: 30 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Limb Armor"
@@ -2622,7 +2414,7 @@
 			"id": "e4uRf4z5Sb2Py2SY7",
 			"description": "Hardened Leather, Medium Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1",
+			"local_notes": "DR: 2; Don: 3 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Neck Armor"
@@ -2650,7 +2442,7 @@
 			"id": "ez68BX8J4tGtQJGCt",
 			"description": "Hardened Leather, Medium Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "Don: 6 secs; Holdout: -4; Reaction Pen.-1",
+			"local_notes": "DR: 2; Don: 6 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Pot Helm"
@@ -2678,7 +2470,7 @@
 			"id": "eNG45AsyS4h9gG1MU",
 			"description": "Hardened Leather, Medium Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "Don: 6 secs; Holdout: -4; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 6 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Pot Helm"
@@ -2706,7 +2498,7 @@
 			"id": "elCA18hfudd_BMLop",
 			"description": "Hardened Leather, Medium Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 30 secs; Holdout: -3; Reaction Pen.-2",
+			"local_notes": "DR: 2; Don: 30 secs; Holdout: -3; Reaction Pen.-2",
 			"tech_level": "1",
 			"tags": [
 				"Body Armor"
@@ -2717,28 +2509,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
-					],
-					"amount": 2
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
+						"abdomen",
 						"torso"
-					],
-					"amount": 2
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
-					],
-					"amount": 2
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
 					],
 					"amount": 2
 				}
@@ -2755,7 +2527,7 @@
 			"id": "eunx1n_InxG6k0vgu",
 			"description": "Horn Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2",
+			"local_notes": "DR: 3; Don: 23 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -2769,13 +2541,6 @@
 						"abdomen"
 					],
 					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
-					],
-					"amount": 3
 				}
 			],
 			"quantity": 1,
@@ -2784,13 +2549,14 @@
 				"extended_value": 63,
 				"weight": "6.3 lb",
 				"extended_weight": "6.3 lb"
-			}
+			},
+			"reference_highlight": "Horn"
 		},
 		{
 			"id": "eHBwk15zjqvDJhSB-",
 			"description": "Horn Arm Armor",
 			"reference": "LTIA7",
-			"local_notes": "Don: 15 secs; Holdout: -4; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 15 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Limb Armor"
@@ -2812,13 +2578,14 @@
 				"extended_value": 125,
 				"weight": "12.5 lb",
 				"extended_weight": "12.5 lb"
-			}
+			},
+			"reference_highlight": "Horn"
 		},
 		{
 			"id": "ezuM-8PavGZ1GQQqr",
 			"description": "Horn Bascinet",
 			"reference": "LTIA14",
-			"local_notes": "Don: 8 secs; Holdout: -5; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 8 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Bascinet"
@@ -2832,13 +2599,6 @@
 						"skull"
 					],
 					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
-					],
-					"amount": 3
 				}
 			],
 			"quantity": 1,
@@ -2847,13 +2607,14 @@
 				"extended_value": 63,
 				"weight": "6.3 lb",
 				"extended_weight": "6.3 lb"
-			}
+			},
+			"reference_highlight": "Horn"
 		},
 		{
 			"id": "eohEoKoYouJwovovn",
 			"description": "Horn Bascinet, Padded",
 			"reference": "LTIA14",
-			"local_notes": "Don: 8 secs; Holdout: -5; Reaction Pen.-1",
+			"local_notes": "DR: 4; Don: 8 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Bascinet"
@@ -2867,13 +2628,6 @@
 						"skull"
 					],
 					"amount": 4
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
-					],
-					"amount": 4
 				}
 			],
 			"quantity": 1,
@@ -2882,13 +2636,14 @@
 				"extended_value": 76,
 				"weight": "6.5 lb",
 				"extended_weight": "6.5 lb"
-			}
+			},
+			"reference_highlight": "Horn"
 		},
 		{
 			"id": "eP5ORoksZZb-z7z4G",
 			"description": "Horn Chest Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2",
+			"local_notes": "DR: 3; Don: 23 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -2902,13 +2657,6 @@
 						"torso"
 					],
 					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
-					],
-					"amount": 3
 				}
 			],
 			"quantity": 1,
@@ -2917,13 +2665,14 @@
 				"extended_value": 188,
 				"weight": "18.8 lb",
 				"extended_weight": "18.8 lb"
-			}
+			},
+			"reference_highlight": "Horn"
 		},
 		{
 			"id": "efLNC-5ZptA7THAKL",
 			"description": "Horn Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 30 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Limb Armor"
@@ -2945,13 +2694,14 @@
 				"extended_value": 250,
 				"weight": "25 lb",
 				"extended_weight": "25 lb"
-			}
+			},
+			"reference_highlight": "Horn"
 		},
 		{
 			"id": "e4kU-W11qtGSzwt7j",
 			"description": "Horn Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 6 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Pot Helm"
@@ -2973,13 +2723,14 @@
 				"extended_value": 50,
 				"weight": "5 lb",
 				"extended_weight": "5 lb"
-			}
+			},
+			"reference_highlight": "Horn"
 		},
 		{
 			"id": "e61dm8dSt3eJ3Io0J",
 			"description": "Horn Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1",
+			"local_notes": "DR: 4; Don: 6 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Pot Helm"
@@ -3001,13 +2752,14 @@
 				"extended_value": 60,
 				"weight": "6.2 lb",
 				"extended_weight": "6.2 lb"
-			}
+			},
+			"reference_highlight": "Horn"
 		},
 		{
 			"id": "e8q3YV3JQ4N4VQ1Yg",
 			"description": "Horn Torso Armor",
 			"reference": "LTIA4",
-			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-2",
+			"local_notes": "DR: 3; Don: 30 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -3018,28 +2770,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
+						"abdomen",
 						"torso"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
 					],
 					"amount": 3
 				}
@@ -3050,13 +2782,14 @@
 				"extended_value": 250,
 				"weight": "25 lb",
 				"extended_weight": "25 lb"
-			}
+			},
+			"reference_highlight": "Horn"
 		},
 		{
 			"id": "enNvcIY2S3c33od6g",
 			"description": "Jack of Plates Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
+			"local_notes": "DR: 3; Don: 23 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
 				"Body Armor"
@@ -3074,9 +2807,10 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"groin"
+						"abdomen"
 					],
-					"amount": 3
+					"specialization": "crushing",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -3085,13 +2819,15 @@
 				"extended_value": 75,
 				"weight": "4.5 lb",
 				"extended_weight": "4.5 lb"
-			}
+			},
+			"reference_highlight": "Jack of Plates",
+			"equipped": true
 		},
 		{
 			"id": "efwmSWbFtEXQ0koTT",
 			"description": "Jack of Plates Arm Armor",
 			"reference": "LTIA7",
-			"local_notes": "Don: 15 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. crushing.",
+			"local_notes": "DR: 3; Don: 15 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
 				"Limb Armor"
@@ -3105,6 +2841,14 @@
 						"arm"
 					],
 					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"arm"
+					],
+					"specialization": "crushing",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -3113,13 +2857,14 @@
 				"extended_value": 150,
 				"weight": "9 lb",
 				"extended_weight": "9 lb"
-			}
+			},
+			"reference_highlight": "Jack of Plates"
 		},
 		{
 			"id": "eCrDGygCzExaNqkdi",
 			"description": "Jack of Plates Chest Armor",
 			"reference": "LTIA6",
-			"local_notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
+			"local_notes": "DR: 3; Don: 23 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
 				"Body Armor"
@@ -3137,9 +2882,10 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"vitals"
+						"torso"
 					],
-					"amount": 3
+					"specialization": "crushing",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -3148,13 +2894,14 @@
 				"extended_value": 225,
 				"weight": "13.5 lb",
 				"extended_weight": "13.5 lb"
-			}
+			},
+			"reference_highlight": "Jack of Plates"
 		},
 		{
 			"id": "emKh8YH7nJ1ryspvd",
 			"description": "Jack of Plates Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "Don: 30 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. crushing.",
+			"local_notes": "DR: 3; Don: 30 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
 				"Limb Armor"
@@ -3168,6 +2915,14 @@
 						"leg"
 					],
 					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"leg"
+					],
+					"specialization": "crushing",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -3176,13 +2931,14 @@
 				"extended_value": 300,
 				"weight": "18 lb",
 				"extended_weight": "18 lb"
-			}
+			},
+			"reference_highlight": "Jack of Plates"
 		},
 		{
 			"id": "e8QIE4XCHZCVo34Ez",
 			"description": "Jack of Plates Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
+			"local_notes": "DR: 3; Don: 3 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
 				"Neck Armor"
@@ -3196,6 +2952,14 @@
 						"neck"
 					],
 					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"neck"
+					],
+					"specialization": "crushing",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -3204,13 +2968,14 @@
 				"extended_value": 15,
 				"weight": "0.9 lb",
 				"extended_weight": "0.9 lb"
-			}
+			},
+			"reference_highlight": "Jack of Plates"
 		},
 		{
 			"id": "ef02FE59Rj44fzzZG",
 			"description": "Jack of Plates Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 30 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
+			"local_notes": "DR: 3; Don: 30 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
 				"Body Armor"
@@ -3221,13 +2986,7 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
+						"abdomen",
 						"torso"
 					],
 					"amount": 3
@@ -3235,16 +2994,11 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"vitals"
+						"abdomen",
+						"torso"
 					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
-					],
-					"amount": 3
+					"specialization": "crushing",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -3253,13 +3007,15 @@
 				"extended_value": 300,
 				"weight": "18 lb",
 				"extended_weight": "18 lb"
-			}
+			},
+			"reference_highlight": "Jack of Plates",
+			"equipped": true
 		},
 		{
 			"id": "e_-u-endgf7TOnFDC",
 			"description": "Layered Cloth, Heavy Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-2",
+			"local_notes": "DR: 4; Don: 30 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -3271,13 +3027,6 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen"
-					],
-					"amount": 4
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
 					],
 					"amount": 4
 				}
@@ -3294,7 +3043,7 @@
 			"id": "etN6nmxSqDcics-UH",
 			"description": "Layered Cloth, Heavy Chest Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2",
+			"local_notes": "DR: 4; Don: 23 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -3306,13 +3055,6 @@
 					"type": "dr_bonus",
 					"locations": [
 						"torso"
-					],
-					"amount": 4
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
 					],
 					"amount": 4
 				}
@@ -3329,7 +3071,7 @@
 			"id": "eIwkMRp6HlCKh2QPH",
 			"description": "Layered Cloth, Heavy Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1",
+			"local_notes": "DR: 4; Don: 3 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Groin Armor"
@@ -3357,7 +3099,7 @@
 			"id": "epFA5vnFQLu-IKc4g",
 			"description": "Layered Cloth, Heavy Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1",
+			"local_notes": "DR: 4; Don: 6 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Pot Helm"
@@ -3385,7 +3127,7 @@
 			"id": "eyeqUe-3_guizOOHF",
 			"description": "Layered Cloth, Heavy Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1",
+			"local_notes": "DR: 5; Don: 6 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Pot Helm"
@@ -3413,7 +3155,7 @@
 			"id": "eW9tzFd6eHEUVDGv-",
 			"description": "Layered Cloth, Heavy Torso Armor",
 			"reference": "LTIA4",
-			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-2",
+			"local_notes": "DR: 4; Don: 30 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -3424,28 +3166,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
-					],
-					"amount": 4
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
+						"abdomen",
 						"torso"
-					],
-					"amount": 4
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
-					],
-					"amount": 4
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
 					],
 					"amount": 4
 				}
@@ -3462,7 +3184,7 @@
 			"id": "eRewQ5l2r2OZfGEON",
 			"description": "Layered Cloth, Light Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "Don: 15 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
+			"local_notes": "DR: 2; Don: 15 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -3476,13 +3198,6 @@
 						"abdomen"
 					],
 					"amount": 2
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
-					],
-					"amount": 2
 				}
 			],
 			"quantity": 1,
@@ -3491,13 +3206,14 @@
 				"extended_value": 38,
 				"weight": "3 lb",
 				"extended_weight": "3 lb"
-			}
+			},
+			"reference_highlight": "Layered Cloth, Light"
 		},
 		{
 			"id": "eO8eIsQI8mq28cq_4",
 			"description": "Layered Cloth, Light Arm Armor",
 			"reference": "LTIA7",
-			"local_notes": "Don: 10 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
+			"local_notes": "DR: 2; Don: 10 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Limb Armor"
@@ -3519,13 +3235,14 @@
 				"extended_value": 75,
 				"weight": "6 lb",
 				"extended_weight": "6 lb"
-			}
+			},
+			"reference_highlight": "Layered Cloth, Light"
 		},
 		{
 			"id": "eVS_9h4tgtl3JdeEa",
 			"description": "Layered Cloth, Light Bascinet",
 			"reference": "LTIA14",
-			"local_notes": "Don: 5 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
+			"local_notes": "DR: 2; Don: 5 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Bascinet"
@@ -3539,13 +3256,6 @@
 						"skull"
 					],
 					"amount": 2
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
-					],
-					"amount": 2
 				}
 			],
 			"quantity": 1,
@@ -3554,13 +3264,14 @@
 				"extended_value": 38,
 				"weight": "3 lb",
 				"extended_weight": "3 lb"
-			}
+			},
+			"reference_highlight": "Layered Cloth, Light"
 		},
 		{
 			"id": "ebCzm68m75MA5QK4A",
 			"description": "Layered Cloth, Light Bascinet, Padded",
 			"reference": "LTIA14",
-			"local_notes": "Don: 5 secs; Holdout: -1; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 5 secs; Holdout: -1; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Bascinet"
@@ -3574,13 +3285,6 @@
 						"skull"
 					],
 					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
-					],
-					"amount": 3
 				}
 			],
 			"quantity": 1,
@@ -3589,13 +3293,14 @@
 				"extended_value": 51,
 				"weight": "3.2 lb",
 				"extended_weight": "3.2 lb"
-			}
+			},
+			"reference_highlight": "Layered Cloth, Light"
 		},
 		{
 			"id": "eqtNoj9CQrr5DtXup",
 			"description": "Layered Cloth, Light Chest Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 15 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
+			"local_notes": "DR: 2; Don: 15 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -3609,13 +3314,6 @@
 						"torso"
 					],
 					"amount": 2
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
-					],
-					"amount": 2
 				}
 			],
 			"quantity": 1,
@@ -3624,13 +3322,14 @@
 				"extended_value": 113,
 				"weight": "9 lb",
 				"extended_weight": "9 lb"
-			}
+			},
+			"reference_highlight": "Layered Cloth, Light"
 		},
 		{
 			"id": "eAsoTn4m8QX6gaCkQ",
 			"description": "Layered Cloth, Light Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "Don: 3 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
+			"local_notes": "DR: 2; Don: 3 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Groin Armor"
@@ -3652,13 +3351,14 @@
 				"extended_value": 8,
 				"weight": "0.6 lb",
 				"extended_weight": "0.6 lb"
-			}
+			},
+			"reference_highlight": "Layered Cloth, Light"
 		},
 		{
 			"id": "eDxZS_xQS0yjzq_1_",
 			"description": "Layered Cloth, Light Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "Don: 20 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
+			"local_notes": "DR: 2; Don: 20 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Limb Armor"
@@ -3680,13 +3380,14 @@
 				"extended_value": 150,
 				"weight": "12 lb",
 				"extended_weight": "12 lb"
-			}
+			},
+			"reference_highlight": "Layered Cloth, Light"
 		},
 		{
 			"id": "eQ0PPUUwkr1Wa7xWU",
 			"description": "Layered Cloth, Light Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "Don: 3 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
+			"local_notes": "DR: 2; Don: 3 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Neck Armor"
@@ -3708,13 +3409,14 @@
 				"extended_value": 8,
 				"weight": "0.6 lb",
 				"extended_weight": "0.6 lb"
-			}
+			},
+			"reference_highlight": "Layered Cloth, Light"
 		},
 		{
 			"id": "etqzkbO5Zn8XNQspE",
 			"description": "Layered Cloth, Light Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "Don: 4 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
+			"local_notes": "DR: 2; Don: 4 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Pot Helm"
@@ -3736,13 +3438,14 @@
 				"extended_value": 30,
 				"weight": "2.4 lb",
 				"extended_weight": "2.4 lb"
-			}
+			},
+			"reference_highlight": "Layered Cloth, Light"
 		},
 		{
 			"id": "e0dO3s-Pq7oqs0TLo",
 			"description": "Layered Cloth, Light Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "Don: 4 secs; Holdout: -1; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 4 secs; Holdout: -1; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Pot Helm"
@@ -3764,13 +3467,14 @@
 				"extended_value": 40,
 				"weight": "3.6 lb",
 				"extended_weight": "3.6 lb"
-			}
+			},
+			"reference_highlight": "Layered Cloth, Light"
 		},
 		{
 			"id": "ex24F6fRCdgFJDPND",
 			"description": "Layered Cloth, Light Torso Armor",
 			"reference": "LTIA4",
-			"local_notes": "Don: 20 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
+			"local_notes": "DR: 2; Don: 20 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -3781,28 +3485,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
-					],
-					"amount": 2
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
+						"abdomen",
 						"torso"
-					],
-					"amount": 2
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
-					],
-					"amount": 2
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
 					],
 					"amount": 2
 				}
@@ -3813,13 +3497,14 @@
 				"extended_value": 150,
 				"weight": "12 lb",
 				"extended_weight": "12 lb"
-			}
+			},
+			"reference_highlight": "Layered Cloth, Light"
 		},
 		{
 			"id": "e2c3pP3BXvpSce74U",
 			"description": "Layered Cloth, Medium Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "Don: 23 secs; Holdout: -2; Reaction Pen.-2",
+			"local_notes": "DR: 3; Don: 23 secs; Holdout: -2; Reaction Pen.-2",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -3833,13 +3518,6 @@
 						"abdomen"
 					],
 					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
-					],
-					"amount": 3
 				}
 			],
 			"quantity": 1,
@@ -3848,13 +3526,14 @@
 				"extended_value": 88,
 				"weight": "5 lb",
 				"extended_weight": "5 lb"
-			}
+			},
+			"reference_highlight": "Layered Cloth, Medium"
 		},
 		{
 			"id": "e2Y40PgPmWiM6X4pF",
 			"description": "Layered Cloth, Medium Arm Armor",
 			"reference": "LTIA7",
-			"local_notes": "Don: 15 secs; Holdout: -2; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 15 secs; Holdout: -2; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Limb Armor"
@@ -3876,13 +3555,14 @@
 				"extended_value": 175,
 				"weight": "10 lb",
 				"extended_weight": "10 lb"
-			}
+			},
+			"reference_highlight": "Layered Cloth, Medium"
 		},
 		{
 			"id": "eJzb7koEoc2mT0eWV",
 			"description": "Layered Cloth, Medium Bascinet",
 			"reference": "LTIA14",
-			"local_notes": "Don: 8 secs; Holdout: -3; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 8 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Bascinet"
@@ -3896,13 +3576,6 @@
 						"skull"
 					],
 					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
-					],
-					"amount": 3
 				}
 			],
 			"quantity": 1,
@@ -3911,13 +3584,14 @@
 				"extended_value": 88,
 				"weight": "5 lb",
 				"extended_weight": "5 lb"
-			}
+			},
+			"reference_highlight": "Layered Cloth, Medium"
 		},
 		{
 			"id": "eJgTWmG6sKucbJVoN",
 			"description": "Layered Cloth, Medium Bascinet, Padded",
 			"reference": "LTIA14",
-			"local_notes": "Don: 8 secs; Holdout: -3; Reaction Pen.-1",
+			"local_notes": "DR: 4; Don: 8 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Bascinet"
@@ -3931,13 +3605,6 @@
 						"skull"
 					],
 					"amount": 4
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
-					],
-					"amount": 4
 				}
 			],
 			"quantity": 1,
@@ -3946,13 +3613,14 @@
 				"extended_value": 101,
 				"weight": "5.2 lb",
 				"extended_weight": "5.2 lb"
-			}
+			},
+			"reference_highlight": "Layered Cloth, Medium"
 		},
 		{
 			"id": "ehLf5QWJswG7A4jPI",
 			"description": "Layered Cloth, Medium Chest Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 23 secs; Holdout: -2; Reaction Pen.-2",
+			"local_notes": "DR: 3; Don: 23 secs; Holdout: -2; Reaction Pen.-2",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -3966,13 +3634,6 @@
 						"torso"
 					],
 					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
-					],
-					"amount": 3
 				}
 			],
 			"quantity": 1,
@@ -3981,13 +3642,14 @@
 				"extended_value": 263,
 				"weight": "15 lb",
 				"extended_weight": "15 lb"
-			}
+			},
+			"reference_highlight": "Layered Cloth, Medium"
 		},
 		{
 			"id": "eRws2Kp2skgEZOpW_",
 			"description": "Layered Cloth, Medium Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "Don: 3 secs; Holdout: -2; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 3 secs; Holdout: -2; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Groin Armor"
@@ -4009,13 +3671,14 @@
 				"extended_value": 18,
 				"weight": "1 lb",
 				"extended_weight": "1 lb"
-			}
+			},
+			"reference_highlight": "Layered Cloth, Medium"
 		},
 		{
 			"id": "eFRDrCxj7VHl4hGbI",
 			"description": "Layered Cloth, Medium Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "Don: 30 secs; Holdout: -2; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 30 secs; Holdout: -2; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Limb Armor"
@@ -4037,13 +3700,14 @@
 				"extended_value": 350,
 				"weight": "20 lb",
 				"extended_weight": "20 lb"
-			}
+			},
+			"reference_highlight": "Layered Cloth, Medium"
 		},
 		{
 			"id": "ex8b6RNRlFNmh6eqn",
 			"description": "Layered Cloth, Medium Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "Don: 3 secs; Holdout: -3; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 3 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Neck Armor"
@@ -4065,13 +3729,14 @@
 				"extended_value": 18,
 				"weight": "1 lb",
 				"extended_weight": "1 lb"
-			}
+			},
+			"reference_highlight": "Layered Cloth, Medium"
 		},
 		{
 			"id": "eDAOlQlpXC8x8seQi",
 			"description": "Layered Cloth, Medium Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "Don: 6 secs; Holdout: -3; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 6 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Pot Helm"
@@ -4093,13 +3758,14 @@
 				"extended_value": 70,
 				"weight": "4 lb",
 				"extended_weight": "4 lb"
-			}
+			},
+			"reference_highlight": "Layered Cloth, Medium"
 		},
 		{
 			"id": "eyLdJreRGFxBI-yNZ",
 			"description": "Layered Cloth, Medium Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "Don: 6 secs; Holdout: -3; Reaction Pen.-1",
+			"local_notes": "DR: 4; Don: 6 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Pot Helm"
@@ -4121,13 +3787,14 @@
 				"extended_value": 80,
 				"weight": "5.2 lb",
 				"extended_weight": "5.2 lb"
-			}
+			},
+			"reference_highlight": "Layered Cloth, Medium"
 		},
 		{
 			"id": "eEkkfvOlSnxHxsG3V",
 			"description": "Layered Cloth, Medium Torso Armor",
 			"reference": "LTIA4",
-			"local_notes": "Don: 30 secs; Holdout: -2; Reaction Pen.-2",
+			"local_notes": "DR: 3; Don: 30 secs; Holdout: -2; Reaction Pen.-2",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -4138,28 +3805,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
+						"abdomen",
 						"torso"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
 					],
 					"amount": 3
 				}
@@ -4170,13 +3817,14 @@
 				"extended_value": 350,
 				"weight": "20 lb",
 				"extended_weight": "20 lb"
-			}
+			},
+			"reference_highlight": "Layered Cloth, Medium"
 		},
 		{
 			"id": "eq-oFm99ByTPArbht",
 			"description": "Layered Leather, Heavy Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2",
+			"local_notes": "DR: 4; Don: 23 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "1",
 			"tags": [
 				"Body Armor"
@@ -4188,13 +3836,6 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen"
-					],
-					"amount": 4
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
 					],
 					"amount": 4
 				}
@@ -4211,7 +3852,7 @@
 			"id": "eu3Ecr1nsfFd4pUkb",
 			"description": "Layered Leather, Heavy Chest Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2",
+			"local_notes": "DR: 4; Don: 23 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "1",
 			"tags": [
 				"Body Armor"
@@ -4223,13 +3864,6 @@
 					"type": "dr_bonus",
 					"locations": [
 						"torso"
-					],
-					"amount": 4
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
 					],
 					"amount": 4
 				}
@@ -4246,7 +3880,7 @@
 			"id": "eVM85UppCKo4UR7ga",
 			"description": "Layered Leather, Heavy Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1",
+			"local_notes": "DR: 4; Don: 3 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Groin Armor"
@@ -4274,7 +3908,7 @@
 			"id": "eMZZwm6MVGi2GjBYk",
 			"description": "Layered Leather, Heavy Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1",
+			"local_notes": "DR: 4; Don: 6 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Pot Helm"
@@ -4302,7 +3936,7 @@
 			"id": "ejuQLpRFHdhrt6BsA",
 			"description": "Layered Leather, Heavy Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1",
+			"local_notes": "DR: 5; Don: 6 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Pot Helm"
@@ -4330,7 +3964,7 @@
 			"id": "eMEOIb6u--dMdFVw0",
 			"description": "Layered Leather, Heavy Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-2",
+			"local_notes": "DR: 4; Don: 30 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "1",
 			"tags": [
 				"Body Armor"
@@ -4341,28 +3975,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
-					],
-					"amount": 4
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
+						"abdomen",
 						"torso"
-					],
-					"amount": 4
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
-					],
-					"amount": 4
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
 					],
 					"amount": 4
 				}
@@ -4379,7 +3993,7 @@
 			"id": "eD0V53gj-_JleBE3H",
 			"description": "Layered Leather, Light Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "Don: 15 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
+			"local_notes": "DR: 2; Don: 15 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "1",
 			"tags": [
 				"Body Armor"
@@ -4393,13 +4007,6 @@
 						"abdomen"
 					],
 					"amount": 2
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
-					],
-					"amount": 2
 				}
 			],
 			"quantity": 1,
@@ -4408,13 +4015,14 @@
 				"extended_value": 30,
 				"weight": "3.8 lb",
 				"extended_weight": "3.8 lb"
-			}
+			},
+			"reference_highlight": "Layered Leather, Light"
 		},
 		{
 			"id": "egW-xZpY1EJ4JOjQx",
 			"description": "Layered Leather, Light Arm Armor",
 			"reference": "LTIA7",
-			"local_notes": "Don: 10 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
+			"local_notes": "DR: 2; Don: 10 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "1",
 			"tags": [
 				"Limb Armor"
@@ -4436,13 +4044,14 @@
 				"extended_value": 60,
 				"weight": "7.5 lb",
 				"extended_weight": "7.5 lb"
-			}
+			},
+			"reference_highlight": "Layered Leather, Light"
 		},
 		{
 			"id": "elRjj_n4d_oWgSj9T",
 			"description": "Layered Leather, Light Bascinet",
 			"reference": "LTIA14",
-			"local_notes": "Don: 5 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
+			"local_notes": "DR: 2; Don: 5 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "1",
 			"tags": [
 				"Bascinet"
@@ -4456,13 +4065,6 @@
 						"skull"
 					],
 					"amount": 2
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
-					],
-					"amount": 2
 				}
 			],
 			"quantity": 1,
@@ -4471,13 +4073,14 @@
 				"extended_value": 30,
 				"weight": "3.8 lb",
 				"extended_weight": "3.8 lb"
-			}
+			},
+			"reference_highlight": "Layered Leather, Light"
 		},
 		{
 			"id": "ei6dU9mXX-OVMSOVb",
 			"description": "Layered Leather, Light Bascinet, Padded",
 			"reference": "LTIA14",
-			"local_notes": "Don: 5 secs; Holdout: -2; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 5 secs; Holdout: -2; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Bascinet"
@@ -4491,13 +4094,6 @@
 						"skull"
 					],
 					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
-					],
-					"amount": 3
 				}
 			],
 			"quantity": 1,
@@ -4506,13 +4102,14 @@
 				"extended_value": 43,
 				"weight": "4 lb",
 				"extended_weight": "4 lb"
-			}
+			},
+			"reference_highlight": "Layered Leather, Light"
 		},
 		{
 			"id": "eLJKJqjstq_4KaKM8",
 			"description": "Layered Leather, Light Chest Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 15 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
+			"local_notes": "DR: 2; Don: 15 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "1",
 			"tags": [
 				"Body Armor"
@@ -4526,13 +4123,6 @@
 						"torso"
 					],
 					"amount": 2
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
-					],
-					"amount": 2
 				}
 			],
 			"quantity": 1,
@@ -4541,13 +4131,14 @@
 				"extended_value": 90,
 				"weight": "11.3 lb",
 				"extended_weight": "11.3 lb"
-			}
+			},
+			"reference_highlight": "Layered Leather, Light"
 		},
 		{
 			"id": "eATWANWr0WjH9JqQH",
 			"description": "Layered Leather, Light Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "Don: 3 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
+			"local_notes": "DR: 2; Don: 3 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "1",
 			"tags": [
 				"Groin Armor"
@@ -4569,13 +4160,14 @@
 				"extended_value": 6,
 				"weight": "0.8 lb",
 				"extended_weight": "0.8 lb"
-			}
+			},
+			"reference_highlight": "Layered Leather, Light"
 		},
 		{
 			"id": "ef1ze9jlHZ0EJTIMe",
 			"description": "Layered Leather, Light Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "Don: 20 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
+			"local_notes": "DR: 2; Don: 20 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "1",
 			"tags": [
 				"Limb Armor"
@@ -4597,13 +4189,14 @@
 				"extended_value": 120,
 				"weight": "15 lb",
 				"extended_weight": "15 lb"
-			}
+			},
+			"reference_highlight": "Layered Leather, Light"
 		},
 		{
 			"id": "etecXtCsHF7Xg09bh",
 			"description": "Layered Leather, Light Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "Don: 3 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
+			"local_notes": "DR: 2; Don: 3 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "1",
 			"tags": [
 				"Neck Armor"
@@ -4625,13 +4218,14 @@
 				"extended_value": 6,
 				"weight": "0.8 lb",
 				"extended_weight": "0.8 lb"
-			}
+			},
+			"reference_highlight": "Layered Leather, Light"
 		},
 		{
 			"id": "e3j1GLu-Dmcw2qzol",
 			"description": "Layered Leather, Light Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "Don: 4 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
+			"local_notes": "DR: 2; Don: 4 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "1",
 			"tags": [
 				"Pot Helm"
@@ -4653,13 +4247,14 @@
 				"extended_value": 24,
 				"weight": "3 lb",
 				"extended_weight": "3 lb"
-			}
+			},
+			"reference_highlight": "Layered Leather, Light"
 		},
 		{
 			"id": "elNb33zRTYIGNTeSi",
 			"description": "Layered Leather, Light Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "Don: 4 secs; Holdout: -2; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 4 secs; Holdout: -2; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Pot Helm"
@@ -4681,13 +4276,14 @@
 				"extended_value": 34,
 				"weight": "4.2 lb",
 				"extended_weight": "4.2 lb"
-			}
+			},
+			"reference_highlight": "Layered Leather, Light"
 		},
 		{
 			"id": "e2XHaZCl0fWHh0kHU",
 			"description": "Layered Leather, Light Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 20 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
+			"local_notes": "DR: 2; Don: 20 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "1",
 			"tags": [
 				"Body Armor"
@@ -4698,28 +4294,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
-					],
-					"amount": 2
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
+						"abdomen",
 						"torso"
-					],
-					"amount": 2
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
-					],
-					"amount": 2
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
 					],
 					"amount": 2
 				}
@@ -4730,13 +4306,14 @@
 				"extended_value": 120,
 				"weight": "15 lb",
 				"extended_weight": "15 lb"
-			}
+			},
+			"reference_highlight": "Layered Leather, Light"
 		},
 		{
 			"id": "exISuisb8GZtzeL3M",
 			"description": "Layered Leather, Medium Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "Don: 23 secs; Holdout: -2; Reaction Pen.-2",
+			"local_notes": "DR: 3; Don: 23 secs; Holdout: -2; Reaction Pen.-2",
 			"tech_level": "1",
 			"tags": [
 				"Body Armor"
@@ -4750,13 +4327,6 @@
 						"abdomen"
 					],
 					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
-					],
-					"amount": 3
 				}
 			],
 			"quantity": 1,
@@ -4765,13 +4335,14 @@
 				"extended_value": 55,
 				"weight": "6.5 lb",
 				"extended_weight": "6.5 lb"
-			}
+			},
+			"reference_highlight": "Layered Leather, Medium"
 		},
 		{
 			"id": "eQQeeqMGzpx15iqIy",
 			"description": "Layered Leather, Medium Arm Armor",
 			"reference": "LTIA7",
-			"local_notes": "Don: 15 secs; Holdout: -2; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 15 secs; Holdout: -2; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Limb Armor"
@@ -4793,13 +4364,14 @@
 				"extended_value": 110,
 				"weight": "13 lb",
 				"extended_weight": "13 lb"
-			}
+			},
+			"reference_highlight": "Layered Leather, Medium"
 		},
 		{
 			"id": "erH1vNaUqqmSU_ohV",
 			"description": "Layered Leather, Medium Bascinet",
 			"reference": "LTIA14",
-			"local_notes": "Don: 8 secs; Holdout: -3; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 8 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Bascinet"
@@ -4813,13 +4385,6 @@
 						"skull"
 					],
 					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
-					],
-					"amount": 3
 				}
 			],
 			"quantity": 1,
@@ -4828,13 +4393,14 @@
 				"extended_value": 55,
 				"weight": "6.5 lb",
 				"extended_weight": "6.5 lb"
-			}
+			},
+			"reference_highlight": "Layered Leather, Medium"
 		},
 		{
 			"id": "eDjkccvqZxqYTUrQn",
 			"description": "Layered Leather, Medium Bascinet, Padded",
 			"reference": "LTIA14",
-			"local_notes": "Don: 8 secs; Holdout: -3; Reaction Pen.-1",
+			"local_notes": "DR:4; Don: 8 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Bascinet"
@@ -4848,13 +4414,6 @@
 						"skull"
 					],
 					"amount": 4
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
-					],
-					"amount": 4
 				}
 			],
 			"quantity": 1,
@@ -4863,13 +4422,14 @@
 				"extended_value": 68,
 				"weight": "6.7 lb",
 				"extended_weight": "6.7 lb"
-			}
+			},
+			"reference_highlight": "Layered Leather, Medium"
 		},
 		{
 			"id": "eJ8PsIcWRvCYxB_B9",
 			"description": "Layered Leather, Medium Chest Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 23 secs; Holdout: -2; Reaction Pen.-2",
+			"local_notes": "DR: 3; Don: 23 secs; Holdout: -2; Reaction Pen.-2",
 			"tech_level": "1",
 			"tags": [
 				"Body Armor"
@@ -4883,13 +4443,6 @@
 						"torso"
 					],
 					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
-					],
-					"amount": 3
 				}
 			],
 			"quantity": 1,
@@ -4898,13 +4451,14 @@
 				"extended_value": 165,
 				"weight": "19.5 lb",
 				"extended_weight": "19.5 lb"
-			}
+			},
+			"reference_highlight": "Layered Leather, Medium"
 		},
 		{
 			"id": "eGfmrV9Nid0lrAt93",
 			"description": "Layered Leather, Medium Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "Don: 3 secs; Holdout: -2; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 3 secs; Holdout: -2; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Groin Armor"
@@ -4926,13 +4480,14 @@
 				"extended_value": 11,
 				"weight": "1.3 lb",
 				"extended_weight": "1.3 lb"
-			}
+			},
+			"reference_highlight": "Layered Leather, Medium"
 		},
 		{
 			"id": "e7DiJ7pNjLhFjxhi2",
 			"description": "Layered Leather, Medium Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "Don: 30 secs; Holdout: -2; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 30 secs; Holdout: -2; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Limb Armor"
@@ -4954,13 +4509,14 @@
 				"extended_value": 220,
 				"weight": "26 lb",
 				"extended_weight": "26 lb"
-			}
+			},
+			"reference_highlight": "Layered Leather, Medium"
 		},
 		{
 			"id": "efFjfnFTqDehDe_QT",
 			"description": "Layered Leather, Medium Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "Don: 3 secs; Holdout: -3; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 3 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Neck Armor"
@@ -4982,13 +4538,14 @@
 				"extended_value": 11,
 				"weight": "1.3 lb",
 				"extended_weight": "1.3 lb"
-			}
+			},
+			"reference_highlight": "Layered Leather, Medium"
 		},
 		{
 			"id": "eOp-NghFwmoPjo5rI",
 			"description": "Layered Leather, Medium Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "Don: 6 secs; Holdout: -3; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 6 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Pot Helm"
@@ -5010,13 +4567,14 @@
 				"extended_value": 44,
 				"weight": "5.2 lb",
 				"extended_weight": "5.2 lb"
-			}
+			},
+			"reference_highlight": "Layered Leather, Medium"
 		},
 		{
 			"id": "eZljD7c4Tny6mETRJ",
 			"description": "Layered Leather, Medium Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "Don: 6 secs; Holdout: -3; Reaction Pen.-1",
+			"local_notes": "DR: 4; Don: 6 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "1",
 			"tags": [
 				"Pot Helm"
@@ -5038,13 +4596,14 @@
 				"extended_value": 54,
 				"weight": "6.4 lb",
 				"extended_weight": "6.4 lb"
-			}
+			},
+			"reference_highlight": "Layered Leather, Medium"
 		},
 		{
 			"id": "eemt2cZZmG4uczLmU",
 			"description": "Layered Leather, Medium Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 30 secs; Holdout: -2; Reaction Pen.-2",
+			"local_notes": "DR: 3; Don: 30 secs; Holdout: -2; Reaction Pen.-2",
 			"tech_level": "1",
 			"tags": [
 				"Body Armor"
@@ -5055,28 +4614,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
+						"abdomen",
 						"torso"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
 					],
 					"amount": 3
 				}
@@ -5087,13 +4626,15 @@
 				"extended_value": 220,
 				"weight": "26 lb",
 				"extended_weight": "26 lb"
-			}
+			},
+			"reference_highlight": "Layered Leather, Medium",
+			"equipped": true
 		},
 		{
 			"id": "e2tjMsdI7Gc1rAB71",
 			"description": "Leather, Heavy Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. impaling.",
+			"local_notes": "DR: 3; Don: 23 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -5111,9 +4652,10 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"groin"
+						"abdomen"
 					],
-					"amount": 3
+					"specialization": "impaling",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -5122,13 +4664,15 @@
 				"extended_value": 50,
 				"weight": "5 lb",
 				"extended_weight": "5 lb"
-			}
+			},
+			"reference_highlight": "Leather, Heavy",
+			"equipped": true
 		},
 		{
 			"id": "ebuaR7H-dCDdAqGZB",
 			"description": "Leather, Heavy Arm Armor",
 			"reference": "LTIA7",
-			"local_notes": "Don: 15 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. impaling.",
+			"local_notes": "DR: 3; Don: 15 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
 				"Limb Armor"
@@ -5142,6 +4686,14 @@
 						"arm"
 					],
 					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"arm"
+					],
+					"specialization": "impaling",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -5150,13 +4702,14 @@
 				"extended_value": 100,
 				"weight": "10 lb",
 				"extended_weight": "10 lb"
-			}
+			},
+			"reference_highlight": "Leather, Heavy"
 		},
 		{
 			"id": "eWLr_x_jq7y_T3gdO",
 			"description": "Leather, Heavy Bascinet",
 			"reference": "LTIA14",
-			"local_notes": "Don: 8 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. impaling.",
+			"local_notes": "DR: 3; Don: 8 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
 				"Bascinet"
@@ -5174,9 +4727,10 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"face"
+						"skull"
 					],
-					"amount": 3
+					"specialization": "impaling",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -5185,13 +4739,14 @@
 				"extended_value": 50,
 				"weight": "5 lb",
 				"extended_weight": "5 lb"
-			}
+			},
+			"reference_highlight": "Leather, Heavy"
 		},
 		{
 			"id": "eyN3zEZ-ozBZWuulc",
 			"description": "Leather, Heavy Bascinet, Padded",
 			"reference": "LTIA14",
-			"local_notes": "Don: 8 secs; Holdout: -5; Reaction Pen.-1",
+			"local_notes": "DR: 4; Don: 8 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Bascinet"
@@ -5209,9 +4764,10 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"face"
+						"skull"
 					],
-					"amount": 4
+					"specialization": "impaling",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -5220,13 +4776,14 @@
 				"extended_value": 63,
 				"weight": "5.2 lb",
 				"extended_weight": "5.2 lb"
-			}
+			},
+			"reference_highlight": "Leather, Heavy"
 		},
 		{
 			"id": "eTFDFr4DO79S3J7VG",
 			"description": "Leather, Heavy Chest Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. impaling.",
+			"local_notes": "DR: 3; Don: 23 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -5244,9 +4801,10 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"vitals"
+						"torso"
 					],
-					"amount": 3
+					"specialization": "impaling",
+					"amount": 1
 				}
 			],
 			"quantity": 1,
@@ -5255,13 +4813,14 @@
 				"extended_value": 150,
 				"weight": "15 lb",
 				"extended_weight": "15 lb"
-			}
+			},
+			"reference_highlight": "Leather, Heavy"
 		},
 		{
 			"id": "eemHTivaF_oqw6MHc",
 			"description": "Leather, Heavy Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
+			"local_notes": "DR: 3; Don: 3 secs; Holdout: -4; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
 				"Groin Armor"
@@ -5275,6 +4834,14 @@
 						"groin"
 					],
 					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"groin"
+					],
+					"specialization": "impaling",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -5283,13 +4850,14 @@
 				"extended_value": 10,
 				"weight": "1 lb",
 				"extended_weight": "1 lb"
-			}
+			},
+			"reference_highlight": "Leather, Heavy"
 		},
 		{
 			"id": "elIoEW-WlZQ8RRGbG",
 			"description": "Leather, Heavy Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. impaling.",
+			"local_notes": "DR: 3; Don: 30 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
 				"Limb Armor"
@@ -5303,6 +4871,14 @@
 						"leg"
 					],
 					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"leg"
+					],
+					"specialization": "impaling",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -5311,13 +4887,14 @@
 				"extended_value": 200,
 				"weight": "20 lb",
 				"extended_weight": "20 lb"
-			}
+			},
+			"reference_highlight": "Leather, Heavy"
 		},
 		{
 			"id": "erF1B9st1qI7Bel1L",
 			"description": "Leather, Heavy Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "Don: 3 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. impaling.",
+			"local_notes": "DR: 3; Don: 3 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
 				"Neck Armor"
@@ -5331,6 +4908,14 @@
 						"neck"
 					],
 					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"neck"
+					],
+					"specialization": "impaling",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -5339,13 +4924,14 @@
 				"extended_value": 10,
 				"weight": "1 lb",
 				"extended_weight": "1 lb"
-			}
+			},
+			"reference_highlight": "Leather, Heavy"
 		},
 		{
 			"id": "e13inmfMvaXMS0T1l",
 			"description": "Leather, Heavy Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. impaling.",
+			"local_notes": "DR: 3; Don: 6 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
 				"Pot Helm"
@@ -5359,6 +4945,14 @@
 						"skull"
 					],
 					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"skull"
+					],
+					"specialization": "impaling",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -5367,13 +4961,14 @@
 				"extended_value": 40,
 				"weight": "4 lb",
 				"extended_weight": "4 lb"
-			}
+			},
+			"reference_highlight": "Leather, Heavy"
 		},
 		{
 			"id": "e98z6kdl_i80ALHzs",
 			"description": "Leather, Heavy Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1",
+			"local_notes": "DR: 4; Don: 6 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
 				"Pot Helm"
@@ -5387,6 +4982,14 @@
 						"skull"
 					],
 					"amount": 4
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"skull"
+					],
+					"specialization": "impaling",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -5395,13 +4998,14 @@
 				"extended_value": 50,
 				"weight": "5.2 lb",
 				"extended_weight": "5.2 lb"
-			}
+			},
+			"reference_highlight": "Leather, Heavy"
 		},
 		{
 			"id": "eLGD5FImjYouo3aVi",
 			"description": "Leather, Heavy Torso Armor",
 			"reference": "LTIA4",
-			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. impaling.",
+			"local_notes": "DR: 3; Don: 30 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -5412,13 +5016,7 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
+						"abdomen",
 						"torso"
 					],
 					"amount": 3
@@ -5426,16 +5024,11 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"vitals"
+						"abdomen",
+						"torso"
 					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
-					],
-					"amount": 3
+					"specialization": "impaling",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -5444,13 +5037,15 @@
 				"extended_value": 200,
 				"weight": "20 lb",
 				"extended_weight": "20 lb"
-			}
+			},
+			"reference_highlight": "Leather, Heavy",
+			"equipped": true
 		},
 		{
 			"id": "erPJ9-24FrX-a-6fk",
 			"description": "Leather, Light Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "Don: 23 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
+			"local_notes": "DR: 0; Don: 23 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
@@ -5469,9 +5064,9 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"groin"
+						"abdomen"
 					],
-					"amount": 0
+					"amount": 1
 				}
 			],
 			"quantity": 1,
@@ -5480,13 +5075,15 @@
 				"extended_value": 45,
 				"weight": "0.8 lb",
 				"extended_weight": "0.8 lb"
-			}
+			},
+			"reference_highlight": "Leather, Light",
+			"equipped": true
 		},
 		{
 			"id": "esCvFaeEcOdZguNfO",
 			"description": "Leather, Light Arm Armor",
 			"reference": "LTIA7",
-			"local_notes": "Don: 15 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
+			"local_notes": "DR: 0; Don: 15 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
@@ -5501,6 +5098,14 @@
 						"arm"
 					],
 					"amount": 0
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"arm"
+					],
+					"specialization": "cutting",
+					"amount": 1
 				}
 			],
 			"quantity": 1,
@@ -5509,13 +5114,14 @@
 				"extended_value": 90,
 				"weight": "1.7 lb",
 				"extended_weight": "1.7 lb"
-			}
+			},
+			"reference_highlight": "Leather, Light"
 		},
 		{
 			"id": "e7W3Pxjpuol4ihIyU",
 			"description": "Leather, Light Bascinet",
 			"reference": "LTIA14",
-			"local_notes": "Don: 8 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
+			"local_notes": "DR: 0; Don: 8 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
@@ -5534,9 +5140,10 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"face"
+						"skull"
 					],
-					"amount": 0
+					"specialization": "cutting",
+					"amount": 1
 				}
 			],
 			"quantity": 1,
@@ -5545,13 +5152,14 @@
 				"extended_value": 45,
 				"weight": "0.8 lb",
 				"extended_weight": "0.8 lb"
-			}
+			},
+			"reference_highlight": "Leather, Light"
 		},
 		{
 			"id": "eLQKo46IiPNTjU-gP",
 			"description": "Leather, Light Bascinet, Padded",
 			"reference": "LTIA14",
-			"local_notes": "Don: 8 secs; Holdout: -1",
+			"local_notes": "DR: 1; Don: 8 secs; Holdout: -1; +1 DR vs. cutting.",
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
@@ -5570,8 +5178,9 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"face"
+						"skull"
 					],
+					"specialization": "cutting",
 					"amount": 1
 				}
 			],
@@ -5581,13 +5190,14 @@
 				"extended_value": 58,
 				"weight": "1 lb",
 				"extended_weight": "1 lb"
-			}
+			},
+			"reference_highlight": "Leather, Light"
 		},
 		{
 			"id": "ePTRpsjywLitmZs6D",
 			"description": "Leather, Light Chest Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 23 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
+			"local_notes": "DR: 0; Don: 23 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
@@ -5606,9 +5216,10 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"vitals"
+						"torso"
 					],
-					"amount": 0
+					"specialization": "cutting",
+					"amount": 1
 				}
 			],
 			"quantity": 1,
@@ -5617,13 +5228,14 @@
 				"extended_value": 135,
 				"weight": "2.5 lb",
 				"extended_weight": "2.5 lb"
-			}
+			},
+			"reference_highlight": "Leather, Light"
 		},
 		{
 			"id": "eZUl5szL_x96oCYIx",
 			"description": "Leather, Light Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "Don: 3 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
+			"local_notes": "DR: 0; Don: 3 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
@@ -5638,6 +5250,14 @@
 						"groin"
 					],
 					"amount": 0
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"groin"
+					],
+					"specialization": "cutting",
+					"amount": 1
 				}
 			],
 			"quantity": 1,
@@ -5646,13 +5266,14 @@
 				"extended_value": 9,
 				"weight": "0.2 lb",
 				"extended_weight": "0.2 lb"
-			}
+			},
+			"reference_highlight": "Leather, Light"
 		},
 		{
 			"id": "edmy8u8OPjQLLEDrD",
 			"description": "Leather, Light Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "Don: 30 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
+			"local_notes": "DR: 0; Don: 30 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
@@ -5667,6 +5288,14 @@
 						"leg"
 					],
 					"amount": 0
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"leg"
+					],
+					"specialization": "cutting",
+					"amount": 1
 				}
 			],
 			"quantity": 1,
@@ -5675,7 +5304,8 @@
 				"extended_value": 180,
 				"weight": "3.3 lb",
 				"extended_weight": "3.3 lb"
-			}
+			},
+			"reference_highlight": "Leather, Light"
 		},
 		{
 			"id": "eSrct3SwevnON9KLP",
@@ -5696,6 +5326,14 @@
 						"neck"
 					],
 					"amount": 0
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"neck"
+					],
+					"specialization": "cutting",
+					"amount": 1
 				}
 			],
 			"quantity": 1,
@@ -5704,13 +5342,14 @@
 				"extended_value": 9,
 				"weight": "0.2 lb",
 				"extended_weight": "0.2 lb"
-			}
+			},
+			"reference_highlight": "Leather, Light"
 		},
 		{
 			"id": "epbGTJIrWJFdueow5",
 			"description": "Leather, Light Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "Don: 6 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
+			"local_notes": "DR: 0; Don: 6 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
@@ -5725,6 +5364,14 @@
 						"skull"
 					],
 					"amount": 0
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"skull"
+					],
+					"specialization": "cutting",
+					"amount": 1
 				}
 			],
 			"quantity": 1,
@@ -5733,13 +5380,14 @@
 				"extended_value": 36,
 				"weight": "0.7 lb",
 				"extended_weight": "0.7 lb"
-			}
+			},
+			"reference_highlight": "Leather, Light"
 		},
 		{
 			"id": "ekMsdKM0wi44zwEK3",
 			"description": "Leather, Light Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "Don: 6 secs; Holdout: -1",
+			"local_notes": "DR: 1; Don: 6 secs; Holdout: -1;); +1 DR vs. cutting.",
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
@@ -5754,6 +5402,14 @@
 						"skull"
 					],
 					"amount": 1
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"skull"
+					],
+					"specialization": "cutting",
+					"amount": 1
 				}
 			],
 			"quantity": 1,
@@ -5762,13 +5418,14 @@
 				"extended_value": 46,
 				"weight": "1.9 lb",
 				"extended_weight": "1.9 lb"
-			}
+			},
+			"reference_highlight": "Leather, Light"
 		},
 		{
 			"id": "eHdT0Pk0ZZrVyMnb3",
 			"description": "Leather, Light Torso Armor",
 			"reference": "LTIA4",
-			"local_notes": "Don: 30 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
+			"local_notes": "DR: 0; Don: 30 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting.",
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
@@ -5790,20 +5447,6 @@
 						"torso"
 					],
 					"amount": 0
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
-					],
-					"amount": 0
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
-					],
-					"amount": 0
 				}
 			],
 			"quantity": 1,
@@ -5812,13 +5455,14 @@
 				"extended_value": 180,
 				"weight": "3.3 lb",
 				"extended_weight": "3.3 lb"
-			}
+			},
+			"reference_highlight": "Leather, Light"
 		},
 		{
 			"id": "eL3IW6V5IHvALbscX",
 			"description": "Leather, Medium Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "Don: 23 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
+			"local_notes": "DR: 2; Don: 23 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -5836,9 +5480,10 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"groin"
+						"abdomen"
 					],
-					"amount": 2
+					"specialization": "impaling",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -5847,13 +5492,15 @@
 				"extended_value": 25,
 				"weight": "3 lb",
 				"extended_weight": "3 lb"
-			}
+			},
+			"reference_highlight": "Leather, Medium",
+			"equipped": true
 		},
 		{
 			"id": "eq4m7g07RpfHhiPn1",
 			"description": "Leather, Medium Arm Armor",
 			"reference": "LTIA7",
-			"local_notes": "Don: 15 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
+			"local_notes": "DR: 2; Don: 15 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
 				"Limb Armor"
@@ -5867,6 +5514,14 @@
 						"arm"
 					],
 					"amount": 2
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"arm"
+					],
+					"specialization": "impaling",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -5875,13 +5530,14 @@
 				"extended_value": 50,
 				"weight": "6 lb",
 				"extended_weight": "6 lb"
-			}
+			},
+			"reference_highlight": "Leather, Medium"
 		},
 		{
 			"id": "eyc_cvEtss7XhrWx2",
 			"description": "Leather, Medium Bascinet",
 			"reference": "LTIA14",
-			"local_notes": "Don: 8 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
+			"local_notes": "DR: 2; Don: 8 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
 				"Bascinet"
@@ -5892,16 +5548,18 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"skull"
+						"skull",
+						"torso"
 					],
 					"amount": 2
 				},
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"face"
+						"skull"
 					],
-					"amount": 2
+					"specialization": "impaling",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -5910,13 +5568,14 @@
 				"extended_value": 25,
 				"weight": "3 lb",
 				"extended_weight": "3 lb"
-			}
+			},
+			"reference_highlight": "Leather, Medium"
 		},
 		{
 			"id": "esCuxTwLqlDWr2vO4",
 			"description": "Leather, Medium Bascinet, Padded",
 			"reference": "LTIA14",
-			"local_notes": "Don: 8 secs; Holdout: -3; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 8 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Bascinet"
@@ -5927,16 +5586,18 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"skull"
+						"skull",
+						"torso"
 					],
 					"amount": 3
 				},
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"face"
+						"skull"
 					],
-					"amount": 3
+					"specialization": "impaling",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -5945,13 +5606,14 @@
 				"extended_value": 38,
 				"weight": "3.2 lb",
 				"extended_weight": "3.2 lb"
-			}
+			},
+			"reference_highlight": "Leather, Medium"
 		},
 		{
 			"id": "eArMaKp-rMS2oJhl9",
 			"description": "Leather, Medium Chest Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 23 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
+			"local_notes": "DR: 2; Don: 23 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -5969,9 +5631,10 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"vitals"
+						"torso"
 					],
-					"amount": 2
+					"specialization": "impaling",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -5980,13 +5643,14 @@
 				"extended_value": 75,
 				"weight": "9 lb",
 				"extended_weight": "9 lb"
-			}
+			},
+			"reference_highlight": "Leather, Medium"
 		},
 		{
 			"id": "eVV2h6xOUC_avcFWt",
 			"description": "Leather, Medium Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "Don: 3 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
+			"local_notes": "DR: 2; Don: 3 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
 				"Groin Armor"
@@ -6000,6 +5664,14 @@
 						"groin"
 					],
 					"amount": 2
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"groin"
+					],
+					"specialization": "impaling",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -6008,13 +5680,14 @@
 				"extended_value": 5,
 				"weight": "0.6 lb",
 				"extended_weight": "0.6 lb"
-			}
+			},
+			"reference_highlight": "Leather, Medium"
 		},
 		{
 			"id": "e3sk4bn1Qscq7Oknr",
 			"description": "Leather, Medium Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "Don: 30 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
+			"local_notes": "DR: 2; Don: 30 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
 				"Limb Armor"
@@ -6027,7 +5700,15 @@
 					"locations": [
 						"leg"
 					],
-					"amount": 2
+					"amount": 1
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"leg"
+					],
+					"specialization": "impaling",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -6036,13 +5717,14 @@
 				"extended_value": 100,
 				"weight": "12 lb",
 				"extended_weight": "12 lb"
-			}
+			},
+			"reference_highlight": "Leather, Medium"
 		},
 		{
 			"id": "e4sMNP0uwIF31RD0i",
 			"description": "Leather, Medium Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "Don: 3 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
+			"local_notes": "DR: 2; Don: 3 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
 				"Neck Armor"
@@ -6056,6 +5738,14 @@
 						"neck"
 					],
 					"amount": 2
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"neck"
+					],
+					"specialization": "impaling",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -6064,13 +5754,14 @@
 				"extended_value": 5,
 				"weight": "0.6 lb",
 				"extended_weight": "0.6 lb"
-			}
+			},
+			"reference_highlight": "Leather, Medium"
 		},
 		{
 			"id": "eCP0-MYEzTfBFZ2ey",
 			"description": "Leather, Medium Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "Don: 6 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
+			"local_notes": "DR: 2; Don: 6 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
 				"Pot Helm"
@@ -6084,6 +5775,14 @@
 						"skull"
 					],
 					"amount": 2
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"skull"
+					],
+					"specialization": "impaling",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -6092,13 +5791,14 @@
 				"extended_value": 20,
 				"weight": "2.4 lb",
 				"extended_weight": "2.4 lb"
-			}
+			},
+			"reference_highlight": "Leather, Medium"
 		},
 		{
 			"id": "eX9hlHfaEFyrCEQzG",
 			"description": "Leather, Medium Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "Don: 6 secs; Holdout: -3; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 6 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
 				"Pot Helm"
@@ -6112,6 +5812,14 @@
 						"skull"
 					],
 					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"skull"
+					],
+					"specialization": "impaling",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -6120,13 +5828,14 @@
 				"extended_value": 30,
 				"weight": "3.6 lb",
 				"extended_weight": "3.6 lb"
-			}
+			},
+			"reference_highlight": "Leather, Medium"
 		},
 		{
 			"id": "esNSFZ1QbPc0bJLdN",
 			"description": "Leather, Medium Torso Armor",
 			"reference": "LTIA4",
-			"local_notes": "Don: 30 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
+			"local_notes": "DR: 2; Don: 30 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -6137,13 +5846,7 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
-					],
-					"amount": 2
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
+						"abdomen",
 						"torso"
 					],
 					"amount": 2
@@ -6151,16 +5854,11 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"vitals"
+						"abdomen",
+						"torso"
 					],
-					"amount": 2
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
-					],
-					"amount": 2
+					"specialization": "impaling",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -6169,13 +5867,15 @@
 				"extended_value": 100,
 				"weight": "12 lb",
 				"extended_weight": "12 lb"
-			}
+			},
+			"reference_highlight": "Leather, Medium",
+			"equipped": true
 		},
 		{
 			"id": "eoX-uDlkBy6UiZe9Z",
 			"description": "Mail and Plates Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "Don: 15 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
+			"local_notes": "DR: 5; Don: 15 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -6194,9 +5894,10 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"groin"
+						"abdomen"
 					],
-					"amount": 5
+					"specialization": "crushing",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -6205,13 +5906,15 @@
 				"extended_value": 250,
 				"weight": "5 lb",
 				"extended_weight": "5 lb"
-			}
+			},
+			"reference_highlight": "Mail and Plates",
+			"equipped": true
 		},
 		{
 			"id": "equiQ74l80RrdI_o0",
 			"description": "Mail and Plates Arm Armor",
 			"reference": "LTIA8",
-			"local_notes": "Don: 10 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. crushing.",
+			"local_notes": "DR: 5; Don: 10 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -6226,6 +5929,14 @@
 						"arm"
 					],
 					"amount": 5
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"arm"
+					],
+					"specialization": "crushing",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -6234,13 +5945,14 @@
 				"extended_value": 500,
 				"weight": "10 lb",
 				"extended_weight": "10 lb"
-			}
+			},
+			"reference_highlight": "Mail and Plates"
 		},
 		{
 			"id": "eDxjNLHVLldDnU8s1",
 			"description": "Mail and Plates Chest Armor",
 			"reference": "LTIA6",
-			"local_notes": "Don: 15 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
+			"local_notes": "DR: 5; Don: 15 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -6259,9 +5971,10 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"vitals"
+						"torso"
 					],
-					"amount": 5
+					"specialization": "crushing",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -6270,13 +5983,14 @@
 				"extended_value": 750,
 				"weight": "15 lb",
 				"extended_weight": "15 lb"
-			}
+			},
+			"reference_highlight": "Mail and Plates"
 		},
 		{
 			"id": "eTxJnsnJbV-89dbBx",
 			"description": "Mail and Plates Coif",
 			"reference": "LTIA14",
-			"local_notes": "Don: 6 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. crushing.",
+			"local_notes": "DR: 5; Don: 6 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. crushing.",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -6288,6 +6002,7 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"neck",
 						"skull"
 					],
 					"amount": 5
@@ -6295,16 +6010,11 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"face"
+						"neck",
+						"skull"
 					],
-					"amount": 5
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"neck"
-					],
-					"amount": 5
+					"specialization": "crushing",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -6313,13 +6023,14 @@
 				"extended_value": 300,
 				"weight": "6 lb",
 				"extended_weight": "6 lb"
-			}
+			},
+			"reference_highlight": "Mail and Plates"
 		},
 		{
 			"id": "eIa44NdHEJl6s8Iv8",
 			"description": "Mail and Plates Coif, Padded",
 			"reference": "LTIA14",
-			"local_notes": "Don: 6 secs; Holdout: -4; Reaction Pen.-2",
+			"local_notes": "DR: 6; Don: 6 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. crushing.",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -6331,6 +6042,7 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"neck",
 						"skull"
 					],
 					"amount": 6
@@ -6338,16 +6050,11 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"face"
+						"neck",
+						"skull"
 					],
-					"amount": 6
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"neck"
-					],
-					"amount": 6
+					"specialization": "crushing",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -6356,13 +6063,14 @@
 				"extended_value": 315,
 				"weight": "7.8 lb",
 				"extended_weight": "7.8 lb"
-			}
+			},
+			"reference_highlight": "Mail and Plates"
 		},
 		{
 			"id": "evJZuNe8RKgj7TXTx",
 			"description": "Mail and Plates Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "Don: 3 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. crushing.",
+			"local_notes": "DR: 5; Don: 3 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -6377,6 +6085,14 @@
 						"groin"
 					],
 					"amount": 5
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"groin"
+					],
+					"specialization": "crushing",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -6385,13 +6101,14 @@
 				"extended_value": 50,
 				"weight": "1 lb",
 				"extended_weight": "1 lb"
-			}
+			},
+			"reference_highlight": "Mail and Plates"
 		},
 		{
 			"id": "emcqbP2aJJH-Xqtp0",
 			"description": "Mail and Plates Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "Don: 20 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. crushing.",
+			"local_notes": "DR: 5; Don: 20 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -6406,6 +6123,14 @@
 						"leg"
 					],
 					"amount": 5
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"leg"
+					],
+					"specialization": "crushing",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -6414,13 +6139,14 @@
 				"extended_value": 1000,
 				"weight": "20 lb",
 				"extended_weight": "20 lb"
-			}
+			},
+			"reference_highlight": "Mail and Plates"
 		},
 		{
 			"id": "ei88t5qNycYMu3OTN",
 			"description": "Mail and Plates Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
+			"local_notes": "DR: 5; Don: 3 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -6435,6 +6161,14 @@
 						"neck"
 					],
 					"amount": 5
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"neck"
+					],
+					"specialization": "crushing",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -6443,13 +6177,14 @@
 				"extended_value": 50,
 				"weight": "1 lb",
 				"extended_weight": "1 lb"
-			}
+			},
+			"reference_highlight": "Mail and Plates"
 		},
 		{
 			"id": "el4FE1v8UbU14sUxT",
 			"description": "Mail and Plates Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 20 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
+			"local_notes": "DR: 5; Don: 20 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -6461,13 +6196,7 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
-					],
-					"amount": 5
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
+						"abdomen",
 						"torso"
 					],
 					"amount": 5
@@ -6475,16 +6204,11 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"vitals"
+						"abdomen",
+						"torso"
 					],
-					"amount": 5
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
-					],
-					"amount": 5
+					"specialization": "crushing",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -6493,13 +6217,14 @@
 				"extended_value": 1000,
 				"weight": "20 lb",
 				"extended_weight": "20 lb"
-			}
+			},
+			"equipped": true
 		},
 		{
 			"id": "eLChp1jhVkkXwtQna",
 			"description": "Mail, Fine Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "Don: 11 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "DR: 4; Don: 11 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -6518,9 +6243,9 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"groin"
+						"abdomen"
 					],
-					"amount": 4
+					"amount": -2
 				}
 			],
 			"quantity": 1,
@@ -6529,13 +6254,15 @@
 				"extended_value": 225,
 				"weight": "3.8 lb",
 				"extended_weight": "3.8 lb"
-			}
+			},
+			"reference_highlight": "Mail, Fine",
+			"equipped": true
 		},
 		{
 			"id": "e0BT5_lQ7JdML2zyQ",
 			"description": "Mail, Fine Arm Armor",
 			"reference": "LTIA8",
-			"local_notes": "Don: 8 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "DR: 4; Don: 8 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -6550,6 +6277,13 @@
 						"arm"
 					],
 					"amount": 4
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"arm"
+					],
+					"amount": -2
 				}
 			],
 			"quantity": 1,
@@ -6558,13 +6292,14 @@
 				"extended_value": 450,
 				"weight": "7.5 lb",
 				"extended_weight": "7.5 lb"
-			}
+			},
+			"reference_highlight": "Mail, Fine"
 		},
 		{
 			"id": "eIHnqIu8W4pIpKWzv",
 			"description": "Mail, Fine Chest Armor",
 			"reference": "LTIA6",
-			"local_notes": "Don: 11 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "DR: 4; Don: 11 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -6583,9 +6318,10 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"vitals"
+						"torso"
 					],
-					"amount": 4
+					"specialization": "crushing",
+					"amount": -2
 				}
 			],
 			"quantity": 1,
@@ -6594,13 +6330,14 @@
 				"extended_value": 675,
 				"weight": "11.3 lb",
 				"extended_weight": "11.3 lb"
-			}
+			},
+			"reference_highlight": "Mail, Fine"
 		},
 		{
 			"id": "eSA89RtNAwHO30FRp",
 			"description": "Mail, Fine Coif",
 			"reference": "LTIA14",
-			"local_notes": "Don: 5 secs; Holdout: -3; Reaction Pen.-2; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "DR: 4; Don: 5 secs; Holdout: -3; Reaction Pen.-2; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
 				"Coif"
@@ -6611,6 +6348,7 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"neck",
 						"skull"
 					],
 					"amount": 4
@@ -6618,16 +6356,11 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"face"
+						"neck",
+						"skull"
 					],
-					"amount": 4
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"neck"
-					],
-					"amount": 4
+					"specialization": "crushing",
+					"amount": -2
 				}
 			],
 			"quantity": 1,
@@ -6636,13 +6369,14 @@
 				"extended_value": 270,
 				"weight": "4.5 lb",
 				"extended_weight": "4.5 lb"
-			}
+			},
+			"reference_highlight": "Mail, Fine"
 		},
 		{
 			"id": "ekcJlcv2b2UfLhSpa",
 			"description": "Mail, Fine Coif, Padded",
 			"reference": "LTIA14",
-			"local_notes": "Don: 5 secs; Holdout: -3; Reaction Pen.-2",
+			"local_notes": "DR: 5; Don: 5 secs; Holdout: -3; Reaction Pen.-2",
 			"tech_level": "2",
 			"tags": [
 				"Coif"
@@ -6653,6 +6387,7 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"neck",
 						"skull"
 					],
 					"amount": 5
@@ -6660,16 +6395,11 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"face"
+						"neck",
+						"skull"
 					],
-					"amount": 5
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"neck"
-					],
-					"amount": 5
+					"specialization": "crushing",
+					"amount": -2
 				}
 			],
 			"quantity": 1,
@@ -6678,13 +6408,14 @@
 				"extended_value": 285,
 				"weight": "6.3 lb",
 				"extended_weight": "6.3 lb"
-			}
+			},
+			"reference_highlight": "Mail, Fine"
 		},
 		{
 			"id": "ewNuOFXRK8Ov7sD7i",
 			"description": "Mail, Fine Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "Don: 3 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "DR: 4; Don: 3 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -6699,6 +6430,14 @@
 						"groin"
 					],
 					"amount": 4
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"groin"
+					],
+					"specialization": "crushing",
+					"amount": -2
 				}
 			],
 			"quantity": 1,
@@ -6707,13 +6446,14 @@
 				"extended_value": 45,
 				"weight": "0.8 lb",
 				"extended_weight": "0.8 lb"
-			}
+			},
+			"reference_highlight": "Mail, Fine"
 		},
 		{
 			"id": "ecd5FPkCxIy4aJxI0",
 			"description": "Mail, Fine Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "Don: 15 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "DR: 4; Don: 15 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -6728,6 +6468,14 @@
 						"leg"
 					],
 					"amount": 4
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"leg"
+					],
+					"specialization": "crushing",
+					"amount": -2
 				}
 			],
 			"quantity": 1,
@@ -6736,13 +6484,14 @@
 				"extended_value": 900,
 				"weight": "15 lb",
 				"extended_weight": "15 lb"
-			}
+			},
+			"reference_highlight": "Mail, Fine"
 		},
 		{
 			"id": "eWM1WKWDkP3XeB_c_",
 			"description": "Mail, Fine Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "Don: 3 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "DR: 4; Don: 3 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -6757,6 +6506,14 @@
 						"neck"
 					],
 					"amount": 4
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"neck"
+					],
+					"specialization": "crushing",
+					"amount": -2
 				}
 			],
 			"quantity": 1,
@@ -6765,13 +6522,14 @@
 				"extended_value": 45,
 				"weight": "0.8 lb",
 				"extended_weight": "0.8 lb"
-			}
+			},
+			"reference_highlight": "Mail, Fine"
 		},
 		{
 			"id": "ego9KduSjlTDHNw4N",
 			"description": "Mail, Fine Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 15 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "DR: 4; Don: 15 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -6783,13 +6541,7 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
-					],
-					"amount": 4
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
+						"abdomen",
 						"torso"
 					],
 					"amount": 4
@@ -6797,16 +6549,11 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"vitals"
+						"abdomen",
+						"torso"
 					],
-					"amount": 4
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
-					],
-					"amount": 4
+					"specialization": "crushing",
+					"amount": -2
 				}
 			],
 			"quantity": 1,
@@ -6815,13 +6562,15 @@
 				"extended_value": 900,
 				"weight": "15 lb",
 				"extended_weight": "15 lb"
-			}
+			},
+			"reference_highlight": "Mail, Fine",
+			"equipped": true
 		},
 		{
 			"id": "eu_IgT6hdI_zY1cNT",
 			"description": "Mail, Heavy Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "Don: 11 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "DR: 5; Don: 11 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -6840,9 +6589,10 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"groin"
+						"abdomen"
 					],
-					"amount": 5
+					"specialization": "crushing",
+					"amount": -2
 				}
 			],
 			"quantity": 1,
@@ -6851,13 +6601,15 @@
 				"extended_value": 300,
 				"weight": "4.5 lb",
 				"extended_weight": "4.5 lb"
-			}
+			},
+			"reference_highlight": "Mail, Heavy",
+			"equipped": true
 		},
 		{
 			"id": "eBEaqPyzL72SWYqTt",
 			"description": "Mail, Heavy Arm Armor",
 			"reference": "LTIA8",
-			"local_notes": "Don: 8 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "DR: 5; Don: 8 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -6872,6 +6624,14 @@
 						"arm"
 					],
 					"amount": 5
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"arm"
+					],
+					"specialization": "crushing",
+					"amount": -2
 				}
 			],
 			"quantity": 1,
@@ -6880,13 +6640,14 @@
 				"extended_value": 600,
 				"weight": "9 lb",
 				"extended_weight": "9 lb"
-			}
+			},
+			"reference_highlight": "Mail, Heavy"
 		},
 		{
 			"id": "eCNiTOK-N0P8b_VKg",
 			"description": "Mail, Heavy Chest Armor",
 			"reference": "LTIA6",
-			"local_notes": "Don: 11 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "DR: 5; Don: 11 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -6905,9 +6666,10 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"vitals"
+						"torso"
 					],
-					"amount": 5
+					"specialization": "crushing",
+					"amount": -2
 				}
 			],
 			"quantity": 1,
@@ -6916,13 +6678,14 @@
 				"extended_value": 900,
 				"weight": "13.5 lb",
 				"extended_weight": "13.5 lb"
-			}
+			},
+			"reference_highlight": "Mail, Heavy"
 		},
 		{
 			"id": "e14eDo__h7uuoG7Th",
 			"description": "Mail, Heavy Coif",
 			"reference": "LTIA14",
-			"local_notes": "Don: 5 secs; Holdout: -4; Reaction Pen.-2; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "DR: 5; Don: 5 secs; Holdout: -4; Reaction Pen.-2; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -6934,6 +6697,7 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"neck",
 						"skull"
 					],
 					"amount": 5
@@ -6941,16 +6705,11 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"face"
+						"neck",
+						"skull"
 					],
-					"amount": 5
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"neck"
-					],
-					"amount": 5
+					"specialization": "crushing",
+					"amount": -2
 				}
 			],
 			"quantity": 1,
@@ -6959,13 +6718,14 @@
 				"extended_value": 360,
 				"weight": "5.4 lb",
 				"extended_weight": "5.4 lb"
-			}
+			},
+			"reference_highlight": "Mail, Heavy"
 		},
 		{
 			"id": "eKw6D5EO_-AkM4coQ",
 			"description": "Mail, Heavy Coif, Padded",
 			"reference": "LTIA14",
-			"local_notes": "Don: 5 secs; Holdout: -4; Reaction Pen.-2",
+			"local_notes": "DR: 6; Don: 5 secs; Holdout: -4; Reaction Pen.-2; -2 DR vs. crushing.",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -6977,6 +6737,7 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"neck",
 						"skull"
 					],
 					"amount": 6
@@ -6984,16 +6745,11 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"face"
+						"neck",
+						"skull"
 					],
-					"amount": 6
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"neck"
-					],
-					"amount": 6
+					"specialization": "crushing",
+					"amount": -2
 				}
 			],
 			"quantity": 1,
@@ -7002,13 +6758,14 @@
 				"extended_value": 375,
 				"weight": "7.2 lb",
 				"extended_weight": "7.2 lb"
-			}
+			},
+			"reference_highlight": "Mail, Heavy"
 		},
 		{
 			"id": "es8ckqkoj4tcBOtlV",
 			"description": "Mail, Heavy Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "Don: 3 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "DR: 5; Don: 3 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -7023,6 +6780,13 @@
 						"groin"
 					],
 					"amount": 5
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"groin"
+					],
+					"amount": -2
 				}
 			],
 			"quantity": 1,
@@ -7031,13 +6795,14 @@
 				"extended_value": 60,
 				"weight": "0.9 lb",
 				"extended_weight": "0.9 lb"
-			}
+			},
+			"reference_highlight": "Mail, Heavy"
 		},
 		{
 			"id": "egukSMdPerl9EQWiW",
 			"description": "Mail, Heavy Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "Don: 15 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "DR: 5; Don: 15 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -7049,9 +6814,18 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"leg"
+						"leg",
+						"torso"
 					],
 					"amount": 5
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"leg"
+					],
+					"specialization": "crushing",
+					"amount": -2
 				}
 			],
 			"quantity": 1,
@@ -7060,13 +6834,14 @@
 				"extended_value": 1200,
 				"weight": "18 lb",
 				"extended_weight": "18 lb"
-			}
+			},
+			"reference_highlight": "Mail, Heavy"
 		},
 		{
 			"id": "ebZL7HJUf6CcXwETk",
 			"description": "Mail, Heavy Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "DR: 5; Don: 3 secs; Holdout: -4; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -7081,6 +6856,14 @@
 						"neck"
 					],
 					"amount": 5
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"neck"
+					],
+					"specialization": "crushing",
+					"amount": -2
 				}
 			],
 			"quantity": 1,
@@ -7089,13 +6872,14 @@
 				"extended_value": 60,
 				"weight": "0.9 lb",
 				"extended_weight": "0.9 lb"
-			}
+			},
+			"reference_highlight": "Mail, Heavy"
 		},
 		{
 			"id": "eKsm1jE9uJPd4vJuq",
 			"description": "Mail, Heavy Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 15 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "DR: 5; Don: 15 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -7107,13 +6891,7 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
-					],
-					"amount": 5
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
+						"abdomen",
 						"torso"
 					],
 					"amount": 5
@@ -7121,16 +6899,11 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"vitals"
+						"abdomen",
+						"torso"
 					],
-					"amount": 5
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
-					],
-					"amount": 5
+					"specialization": "crushing",
+					"amount": -2
 				}
 			],
 			"quantity": 1,
@@ -7139,13 +6912,15 @@
 				"extended_value": 1200,
 				"weight": "18 lb",
 				"extended_weight": "18 lb"
-			}
+			},
+			"reference_highlight": "Mail, Heavy",
+			"equipped": true
 		},
 		{
 			"id": "eSljEfwttEnNTgP5X",
 			"description": "Mail, Jousting Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-2; Gives -1 DX, except for Lance skill.ushing",
+			"local_notes": "DR: 6; Don: 23 secs; Holdout: -3; Reaction Pen.-2; Gives -1 DX, except for Lance skill.",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -7160,13 +6935,6 @@
 						"abdomen"
 					],
 					"amount": 6
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
-					],
-					"amount": 6
 				}
 			],
 			"quantity": 1,
@@ -7175,13 +6943,14 @@
 				"extended_value": 375,
 				"weight": "7.5 lb",
 				"extended_weight": "7.5 lb"
-			}
+			},
+			"reference_highlight": "Mail, Jousting"
 		},
 		{
 			"id": "evEo56xzlIaJq1RRf",
 			"description": "Mail, Jousting Chest Armor",
 			"reference": "LTIA6",
-			"local_notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-2; Gives -1 DX, except for Lance skill.ushing",
+			"local_notes": "DR: 6; Don: 23 secs; Holdout: -3; Reaction Pen.-2; Gives -1 DX, except for Lance skill.",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -7196,13 +6965,6 @@
 						"torso"
 					],
 					"amount": 6
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
-					],
-					"amount": 6
 				}
 			],
 			"quantity": 1,
@@ -7211,13 +6973,14 @@
 				"extended_value": 1125,
 				"weight": "22.5 lb",
 				"extended_weight": "22.5 lb"
-			}
+			},
+			"reference_highlight": "Mail, Jousting"
 		},
 		{
 			"id": "eVPDWR5DI3Vcc_y9p",
 			"description": "Mail, Jousting Coif",
 			"reference": "LTIA14",
-			"local_notes": "Don: 9 secs; Holdout: -4; Reaction Pen.-2; Gives -1 DX, except for Lance skill.ushing",
+			"local_notes": "DR: 6; Don: 9 secs; Holdout: -4; Reaction Pen.-2; Gives -1 DX, except for Lance skill.",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -7229,21 +6992,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"neck",
 						"skull"
-					],
-					"amount": 6
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
-					],
-					"amount": 6
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"neck"
 					],
 					"amount": 6
 				}
@@ -7254,13 +7004,14 @@
 				"extended_value": 450,
 				"weight": "9 lb",
 				"extended_weight": "9 lb"
-			}
+			},
+			"reference_highlight": "Mail, Jousting"
 		},
 		{
 			"id": "eH-hT0pxpq2KT9E9h",
 			"description": "Mail, Jousting Coif, Padded",
 			"reference": "LTIA14",
-			"local_notes": "Don: 9 secs; Holdout: -4; Reaction Pen.-2",
+			"local_notes": "DR: 7; Don: 9 secs; Holdout: -4; Reaction Pen.-2; Gives -1 DX, except for Lance skill.",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -7272,21 +7023,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"neck",
 						"skull"
-					],
-					"amount": 7
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
-					],
-					"amount": 7
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"neck"
 					],
 					"amount": 7
 				}
@@ -7297,13 +7035,14 @@
 				"extended_value": 465,
 				"weight": "10.8 lb",
 				"extended_weight": "10.8 lb"
-			}
+			},
+			"reference_highlight": "Mail, Jousting"
 		},
 		{
 			"id": "ehmd2Bb57t0IGDCpt",
 			"description": "Mail, Jousting Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "Don: 3 secs; Holdout: -3; Reaction Pen.-1; Gives -1 DX, except for Lance skill.ushing",
+			"local_notes": "DR: 6; Don: 3 secs; Holdout: -3; Reaction Pen.-1; Gives -1 DX, except for Lance skill.",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -7326,13 +7065,14 @@
 				"extended_value": 75,
 				"weight": "1.5 lb",
 				"extended_weight": "1.5 lb"
-			}
+			},
+			"reference_highlight": "Mail, Jousting"
 		},
 		{
 			"id": "ed-XbrQV0LA4W99A4",
 			"description": "Mail, Jousting Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 30 secs; Holdout: -3; Reaction Pen.-2; Gives -1 DX, except for Lance skill.ushing",
+			"local_notes": "DR: 6; Don: 30 secs; Holdout: -3; Reaction Pen.-2; Gives -1 DX, except for Lance skill.",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -7344,28 +7084,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
-					],
-					"amount": 6
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
+						"abdomen",
 						"torso"
-					],
-					"amount": 6
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
-					],
-					"amount": 6
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
 					],
 					"amount": 6
 				}
@@ -7376,7 +7096,8 @@
 				"extended_value": 1500,
 				"weight": "30 lb",
 				"extended_weight": "30 lb"
-			}
+			},
+			"reference_highlight": "Mail, Jousting"
 		},
 		{
 			"id": "eLQpfHd9nYHBu0Gm_",
@@ -7400,9 +7121,9 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"groin"
+						"abdomen"
 					],
-					"amount": 3
+					"amount": -2
 				}
 			],
 			"quantity": 1,
@@ -7411,13 +7132,15 @@
 				"extended_value": 125,
 				"weight": "3 lb",
 				"extended_weight": "3 lb"
-			}
+			},
+			"reference_highlight": "Mail, Light",
+			"equipped": true
 		},
 		{
 			"id": "e3T2ZQ6SMRyhLPDP4",
 			"description": "Mail, Light Arm Armor",
 			"reference": "LTIA7",
-			"local_notes": "Don: 8 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "DR: 3; Don: 8 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
 				"Limb Armor"
@@ -7431,6 +7154,13 @@
 						"arm"
 					],
 					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"arm"
+					],
+					"amount": -2
 				}
 			],
 			"quantity": 1,
@@ -7439,13 +7169,14 @@
 				"extended_value": 250,
 				"weight": "6 lb",
 				"extended_weight": "6 lb"
-			}
+			},
+			"reference_highlight": "Mail, Light"
 		},
 		{
 			"id": "enJd0OIRYoJnM3vyy",
 			"description": "Mail, Light Chest Armor",
 			"reference": "LTIA6",
-			"local_notes": "Don: 11 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "DR: 3; Don: 11 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
 				"Body Armor"
@@ -7463,9 +7194,10 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"vitals"
+						"torso"
 					],
-					"amount": 3
+					"specialization": "crushing",
+					"amount": -2
 				}
 			],
 			"quantity": 1,
@@ -7474,13 +7206,14 @@
 				"extended_value": 375,
 				"weight": "9 lb",
 				"extended_weight": "9 lb"
-			}
+			},
+			"reference_highlight": "Mail, Light"
 		},
 		{
 			"id": "eeCc0DmBTNmI9t_a6",
 			"description": "Mail, Light Coif",
 			"reference": "LTIA14",
-			"local_notes": "Don: 5 secs; Holdout: -2; Reaction Pen.-2; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "DR: 3; Don: 5 secs; Holdout: -2; Reaction Pen.-2; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
 				"Coif"
@@ -7491,23 +7224,15 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"neck",
 						"skull"
 					],
 					"amount": 3
 				},
 				{
 					"type": "dr_bonus",
-					"locations": [
-						"face"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"neck"
-					],
-					"amount": 3
+					"specialization": "crushing",
+					"amount": -2
 				}
 			],
 			"quantity": 1,
@@ -7516,13 +7241,14 @@
 				"extended_value": 150,
 				"weight": "3.6 lb",
 				"extended_weight": "3.6 lb"
-			}
+			},
+			"reference_highlight": "Mail, Light"
 		},
 		{
 			"id": "eHqQRwQ5pNSBH_jfX",
 			"description": "Mail, Light Coif, Padded",
 			"reference": "LTIA14",
-			"local_notes": "Don: 5 secs; Holdout: -2; Reaction Pen.-2",
+			"local_notes": "DR: 4; Don: 5 secs; Holdout: -2; Reaction Pen.-2; -2 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
 				"Coif"
@@ -7533,6 +7259,7 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"neck",
 						"skull"
 					],
 					"amount": 4
@@ -7540,16 +7267,11 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"face"
+						"neck",
+						"skull"
 					],
-					"amount": 4
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"neck"
-					],
-					"amount": 4
+					"specialization": "crushing",
+					"amount": -2
 				}
 			],
 			"quantity": 1,
@@ -7558,13 +7280,14 @@
 				"extended_value": 165,
 				"weight": "5.4 lb",
 				"extended_weight": "5.4 lb"
-			}
+			},
+			"reference_highlight": "Mail, Light"
 		},
 		{
 			"id": "ezR2F0wvIcPwu9XCd",
 			"description": "Mail, Light Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "Don: 3 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "DR: 3; Don: 3 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
 				"Groin Armor"
@@ -7578,6 +7301,14 @@
 						"groin"
 					],
 					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"groin"
+					],
+					"specialization": "crushing",
+					"amount": -2
 				}
 			],
 			"quantity": 1,
@@ -7586,13 +7317,14 @@
 				"extended_value": 25,
 				"weight": "0.6 lb",
 				"extended_weight": "0.6 lb"
-			}
+			},
+			"reference_highlight": "Mail, Light"
 		},
 		{
 			"id": "ehr15A_0VXHx9XAF3",
 			"description": "Mail, Light Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "Don: 15 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "DR: 3; Don: 15 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
 				"Limb Armor"
@@ -7606,6 +7338,14 @@
 						"leg"
 					],
 					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"leg"
+					],
+					"specialization": "crushing",
+					"amount": -2
 				}
 			],
 			"quantity": 1,
@@ -7614,13 +7354,14 @@
 				"extended_value": 500,
 				"weight": "12 lb",
 				"extended_weight": "12 lb"
-			}
+			},
+			"reference_highlight": "Mail, Light"
 		},
 		{
 			"id": "eEg5JQunwpt50hSF9",
 			"description": "Mail, Light Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "Don: 3 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "DR: 3; Don: 3 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
 				"Neck Armor"
@@ -7631,9 +7372,18 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"neck"
+						"neck",
+						"torso"
 					],
 					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"neck"
+					],
+					"specialization": "crushing",
+					"amount": -2
 				}
 			],
 			"quantity": 1,
@@ -7642,13 +7392,14 @@
 				"extended_value": 25,
 				"weight": "0.6 lb",
 				"extended_weight": "0.6 lb"
-			}
+			},
+			"reference_highlight": "Mail, Light"
 		},
 		{
 			"id": "e11EeWVcRnmM5RzWO",
 			"description": "Mail, Light Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 15 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "DR: 3; Don: 15 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
 				"Body Armor"
@@ -7659,13 +7410,7 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
+						"abdomen",
 						"torso"
 					],
 					"amount": 3
@@ -7673,16 +7418,11 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"vitals"
+						"abdomen",
+						"torso"
 					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
-					],
-					"amount": 3
+					"specialization": "crushing",
+					"amount": -2
 				}
 			],
 			"quantity": 1,
@@ -7691,13 +7431,15 @@
 				"extended_value": 500,
 				"weight": "12 lb",
 				"extended_weight": "12 lb"
-			}
+			},
+			"reference_highlight": "Mail, Light",
+			"equipped": true
 		},
 		{
 			"id": "eJZyW8py6OBUqMrwN",
 			"description": "Mittens ",
 			"reference": "LTIA15",
-			"local_notes": "Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting; Enclosedmittens andgloves protectvs.cold,heat,contactpoison,etc.,but giveBadGrip1(p.B123); Gives Ham-Fisted 2 (p. B138).",
+			"local_notes": "DR: 0; Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); +1 DR vs. cutting; Enclosedmittens andgloves protectvs.cold,heat,contactpoison,etc.,but giveBadGrip1(p.B123); Gives Ham-Fisted 2 (p. B138).",
 			"tech_level": "0",
 			"legality_class": "5",
 			"tags": [
@@ -7712,6 +7454,14 @@
 						"hand"
 					],
 					"amount": 0
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"hand"
+					],
+					"specialization": "cutting",
+					"amount": 1
 				}
 			],
 			"quantity": 1,
@@ -7726,7 +7476,7 @@
 			"id": "eAVm_WBOK8kNRrPbc",
 			"description": "Mittens, Padded Cloth ",
 			"reference": "LTIA15",
-			"local_notes": "Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); Enclosedmittens andgloves protectvs.cold,heat,contactpoison,etc.,but giveBadGrip1(p.B123); Gives Ham-Fisted 2 (p. B138).",
+			"local_notes": "DR: 1; Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); Enclosedmittens andgloves protectvs.cold,heat,contactpoison,etc.,but giveBadGrip1(p.B123); Gives Ham-Fisted 2 (p. B138).",
 			"tech_level": "1",
 			"tags": [
 				"Gloves"
@@ -7754,7 +7504,7 @@
 			"id": "e2Oo1VPjY4Qqt622p",
 			"description": "Moccasins ",
 			"reference": "LTIA16",
-			"local_notes": "Don: 6 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379); Gives +1 to Stealth.",
+			"local_notes": "DR: 1; Don: 6 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379); Gives +1 to Stealth.",
 			"tech_level": "0",
 			"tags": [
 				"Footwear"
@@ -7782,7 +7532,7 @@
 			"id": "eGJEpXOubDzKed8ZB",
 			"description": "Mukluks ",
 			"reference": "LTIA16",
-			"local_notes": "Don: 6 secs; Holdout: -5; Flexible and susceptible to blunt trauma (p. B379); Erases -2 in Stealth penalties when walking on snow.",
+			"local_notes": "DR: 1; Don: 6 secs; Holdout: -5; Flexible and susceptible to blunt trauma (p. B379); Erases -2 in Stealth penalties when walking on snow.",
 			"tech_level": "0",
 			"tags": [
 				"Footwear"
@@ -7810,7 +7560,7 @@
 			"id": "egiUnA-e61m5IgCbw",
 			"description": "Paper, Proofed Chest Armor",
 			"reference": "LTIA6",
-			"local_notes": "Don: 15 secs; Holdout: -6; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433); treat as resistant.",
+			"local_notes": "DR: 6; Don: 15 secs; Holdout: -6; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433); treat as resistant.",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -7825,13 +7575,6 @@
 						"torso"
 					],
 					"amount": 6
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
-					],
-					"amount": 6
 				}
 			],
 			"quantity": 1,
@@ -7840,13 +7583,14 @@
 				"extended_value": 1500,
 				"weight": "33.8 lb",
 				"extended_weight": "33.8 lb"
-			}
+			},
+			"reference_highlight": "Paper, Proofed"
 		},
 		{
 			"id": "e5-lnqp9GuQ_UY40I",
 			"description": "Paper, Proofed Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "Don: 4 secs; Holdout: -7; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433); treat as resistant.",
+			"local_notes": "DR: 6; Don: 4 secs; Holdout: -7; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433); treat as resistant.",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -7869,13 +7613,14 @@
 				"extended_value": 400,
 				"weight": "9 lb",
 				"extended_weight": "9 lb"
-			}
+			},
+			"reference_highlight": "Paper, Proofed"
 		},
 		{
 			"id": "ebMc2OANQrLdqy-y5",
 			"description": "Paper, Proofed Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "Don: 4 secs; Holdout: -7; Reaction Pen.-1",
+			"local_notes": "DR: 7; Don: 4 secs; Holdout: -7; Reaction Pen.-1",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -7898,13 +7643,14 @@
 				"extended_value": 410,
 				"weight": "10.2 lb",
 				"extended_weight": "10.2 lb"
-			}
+			},
+			"reference_highlight": "Paper, Proofed"
 		},
 		{
 			"id": "eVXuB56-MvjvAlHl6",
 			"description": "Paper, Proofed Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 20 secs; Holdout: -6; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433); treat as resistant.",
+			"local_notes": "DR: 6; Don: 20 secs; Holdout: -6; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433); treat as resistant.",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -7916,28 +7662,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
-					],
-					"amount": 6
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
+						"abdomen",
 						"torso"
-					],
-					"amount": 6
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
-					],
-					"amount": 6
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
 					],
 					"amount": 6
 				}
@@ -7948,13 +7674,14 @@
 				"extended_value": 2000,
 				"weight": "45 lb",
 				"extended_weight": "45 lb"
-			}
+			},
+			"reference_highlight": "Paper, Proofed"
 		},
 		{
 			"id": "e8HbtIDjjWatM7iLz",
 			"description": "Plate, Heavy Bascinet",
 			"reference": "LTIA14",
-			"local_notes": "Don: 11 secs; Holdout: -8; Reaction Pen.-1",
+			"local_notes": "DR: 9; Don: 11 secs; Holdout: -8; Reaction Pen.-1",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -7969,13 +7696,6 @@
 						"skull"
 					],
 					"amount": 9
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
-					],
-					"amount": 9
 				}
 			],
 			"quantity": 1,
@@ -7984,13 +7704,14 @@
 				"extended_value": 1000,
 				"weight": "8 lb",
 				"extended_weight": "8 lb"
-			}
+			},
+			"reference_highlight": "Plate, Heavy"
 		},
 		{
 			"id": "eVkbak8FPV5rDs4jS",
 			"description": "Plate, Heavy Bascinet, Padded",
 			"reference": "LTIA14",
-			"local_notes": "Don: 11 secs; Holdout: -8; Reaction Pen.-1",
+			"local_notes": "DR: 10; Don: 11 secs; Holdout: -8; Reaction Pen.-1",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -8005,13 +7726,6 @@
 						"skull"
 					],
 					"amount": 10
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
-					],
-					"amount": 10
 				}
 			],
 			"quantity": 1,
@@ -8020,13 +7734,14 @@
 				"extended_value": 1013,
 				"weight": "8.2 lb",
 				"extended_weight": "8.2 lb"
-			}
+			},
+			"reference_highlight": "Plate, Heavy"
 		},
 		{
 			"id": "eB9yJS7RfP1fr9NRY",
 			"description": "Plate, Heavy Chest Armor",
 			"reference": "LTIA6",
-			"local_notes": "Don: 34 secs; Holdout: -7; Reaction Pen.-2",
+			"local_notes": "DR: 9; Don: 34 secs; Holdout: -7; Reaction Pen.-2",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -8041,13 +7756,6 @@
 						"torso"
 					],
 					"amount": 9
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
-					],
-					"amount": 9
 				}
 			],
 			"quantity": 1,
@@ -8056,13 +7764,14 @@
 				"extended_value": 3000,
 				"weight": "24 lb",
 				"extended_weight": "24 lb"
-			}
+			},
+			"reference_highlight": "Plate, Heavy"
 		},
 		{
 			"id": "eW8-cIDc0M2hpmI0_",
 			"description": "Plate, Heavy Full Helm",
 			"reference": "LTIA14",
-			"local_notes": "Don: 14 secs; Holdout: -8; Reaction Pen.-1",
+			"local_notes": "DR: 9; Don: 14 secs; Holdout: -8; Reaction Pen.-1",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -8074,14 +7783,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"face",
 						"skull"
-					],
-					"amount": 9
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
 					],
 					"amount": 9
 				}
@@ -8092,13 +7795,14 @@
 				"extended_value": 1200,
 				"weight": "9.6 lb",
 				"extended_weight": "9.6 lb"
-			}
+			},
+			"reference_highlight": "Plate, Heavy"
 		},
 		{
 			"id": "emcjmXCtyll2tktFu",
 			"description": "Plate, Heavy Full Helm, Padded",
 			"reference": "LTIA14",
-			"local_notes": "Don: 14 secs; Holdout: -8; Reaction Pen.-1",
+			"local_notes": "DR: 10; Don: 14 secs; Holdout: -8; Reaction Pen.-1",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -8110,14 +7814,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"face",
 						"skull"
-					],
-					"amount": 10
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
 					],
 					"amount": 10
 				}
@@ -8128,13 +7826,14 @@
 				"extended_value": 1215,
 				"weight": "11.4 lb",
 				"extended_weight": "11.4 lb"
-			}
+			},
+			"reference_highlight": "Plate, Heavy"
 		},
 		{
 			"id": "e9H2n10sfSoXCIqZK",
 			"description": "Plate, Heavy Greathelm",
 			"reference": "LTIA14",
-			"local_notes": "Don: 16 secs; Holdout: 0; Reaction Pen.-2",
+			"local_notes": "DR: 9; Don: 16 secs; Holdout: 0; Reaction Pen.-2",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -8146,21 +7845,9 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"face",
+						"neck",
 						"skull"
-					],
-					"amount": 9
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
-					],
-					"amount": 9
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"neck"
 					],
 					"amount": 9
 				}
@@ -8171,13 +7858,14 @@
 				"extended_value": 1400,
 				"weight": "11.2 lb",
 				"extended_weight": "11.2 lb"
-			}
+			},
+			"reference_highlight": "Plate, Heavy"
 		},
 		{
 			"id": "e4h902l7Yrrtzo2zO",
 			"description": "Plate, Heavy Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "Don: 3 secs; Holdout: -7; Reaction Pen.-1",
+			"local_notes": "DR: 9; Don: 3 secs; Holdout: -7; Reaction Pen.-1",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -8200,13 +7888,14 @@
 				"extended_value": 200,
 				"weight": "1.6 lb",
 				"extended_weight": "1.6 lb"
-			}
+			},
+			"reference_highlight": "Plate, Heavy"
 		},
 		{
 			"id": "estCTGqLmg_EgA-h0",
 			"description": "Plate, Heavy Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "Don: 9 secs; Holdout: -8; Reaction Pen.-1",
+			"local_notes": "DR: 9; Don: 9 secs; Holdout: -8; Reaction Pen.-1",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -8229,13 +7918,14 @@
 				"extended_value": 800,
 				"weight": "6.4 lb",
 				"extended_weight": "6.4 lb"
-			}
+			},
+			"reference_highlight": "Plate, Heavy"
 		},
 		{
 			"id": "eq2-smtts4BIi2y_d",
 			"description": "Plate, Heavy Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "Don: 9 secs; Holdout: -8; Reaction Pen.-1",
+			"local_notes": "DR: 10; Don: 9 secs; Holdout: -8; Reaction Pen.-1",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -8258,13 +7948,14 @@
 				"extended_value": 810,
 				"weight": "7.6 lb",
 				"extended_weight": "7.6 lb"
-			}
+			},
+			"reference_highlight": "Plate, Heavy"
 		},
 		{
 			"id": "eF4gWjAAWTqodS7v8",
 			"description": "Plate, Heavy Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 45 secs; Holdout: -7; Reaction Pen.-2",
+			"local_notes": "DR: 9; Don: 45 secs; Holdout: -7; Reaction Pen.-2",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -8276,28 +7967,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
-					],
-					"amount": 9
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
+						"abdomen",
 						"torso"
-					],
-					"amount": 9
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
-					],
-					"amount": 9
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
 					],
 					"amount": 9
 				}
@@ -8308,13 +7979,14 @@
 				"extended_value": 4000,
 				"weight": "32 lb",
 				"extended_weight": "32 lb"
-			}
+			},
+			"reference_highlight": "Plate, Heavy"
 		},
 		{
 			"id": "eSHH3OxXNE-wBwXbS",
 			"description": "Plate, Light Arm Armor",
 			"reference": "LTIA8",
-			"local_notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 23 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "4",
 			"tags": [
 				"Limb Armor"
@@ -8342,7 +8014,7 @@
 			"id": "elLPutR9mlpXPjG8k",
 			"description": "Plate, Light Bascinet",
 			"reference": "LTIA14",
-			"local_notes": "Don: 11 secs; Holdout: -4; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 11 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "3",
 			"tags": [
 				"Bascinet"
@@ -8356,13 +8028,6 @@
 						"skull"
 					],
 					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
-					],
-					"amount": 3
 				}
 			],
 			"quantity": 1,
@@ -8371,13 +8036,14 @@
 				"extended_value": 250,
 				"weight": "2 lb",
 				"extended_weight": "2 lb"
-			}
+			},
+			"reference_highlight": "Plate, Light"
 		},
 		{
 			"id": "eSzAgwvmhzcidbo4-",
 			"description": "Plate, Light Bascinet, Padded",
 			"reference": "LTIA14",
-			"local_notes": "Don: 11 secs; Holdout: -4; Reaction Pen.-1",
+			"local_notes": "DR: 4; Don: 11 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "3",
 			"tags": [
 				"Bascinet"
@@ -8391,13 +8057,6 @@
 						"skull"
 					],
 					"amount": 4
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
-					],
-					"amount": 4
 				}
 			],
 			"quantity": 1,
@@ -8406,13 +8065,14 @@
 				"extended_value": 263,
 				"weight": "2.2 lb",
 				"extended_weight": "2.2 lb"
-			}
+			},
+			"reference_highlight": "Plate, Light"
 		},
 		{
 			"id": "ek0MHkUn38Ro0gdwd",
 			"description": "Plate, Light Chest Armor",
 			"reference": "LTIA6",
-			"local_notes": "Don: 34 secs; Holdout: -3; Reaction Pen.-2",
+			"local_notes": "DR: 3; Don: 34 secs; Holdout: -3; Reaction Pen.-2",
 			"tech_level": "4",
 			"tags": [
 				"Body Armor"
@@ -8426,13 +8086,6 @@
 						"torso"
 					],
 					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
-					],
-					"amount": 3
 				}
 			],
 			"quantity": 1,
@@ -8441,13 +8094,14 @@
 				"extended_value": 750,
 				"weight": "6 lb",
 				"extended_weight": "6 lb"
-			}
+			},
+			"reference_highlight": "Plate, Light"
 		},
 		{
 			"id": "e43dIt6gMMjKvx5-K",
 			"description": "Plate, Light Full Helm",
 			"reference": "LTIA14",
-			"local_notes": "Don: 14 secs; Holdout: -4; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 14 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "3",
 			"tags": [
 				"Full Helm"
@@ -8458,14 +8112,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"face",
 						"skull"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
 					],
 					"amount": 3
 				}
@@ -8476,13 +8124,14 @@
 				"extended_value": 300,
 				"weight": "2.4 lb",
 				"extended_weight": "2.4 lb"
-			}
+			},
+			"reference_highlight": "Plate, Light"
 		},
 		{
 			"id": "egKoEnWG0C8O2co8s",
 			"description": "Plate, Light Full Helm, Padded",
 			"reference": "LTIA14",
-			"local_notes": "Don: 14 secs; Holdout: -4; Reaction Pen.-1",
+			"local_notes": "DR: 4; Don: 14 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "3",
 			"tags": [
 				"Full Helm"
@@ -8493,14 +8142,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"face",
 						"skull"
-					],
-					"amount": 4
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
 					],
 					"amount": 4
 				}
@@ -8511,13 +8154,14 @@
 				"extended_value": 315,
 				"weight": "4.2 lb",
 				"extended_weight": "4.2 lb"
-			}
+			},
+			"reference_highlight": "Plate, Light"
 		},
 		{
 			"id": "emmiIu3Gd_B88IQKM",
 			"description": "Plate, Light Greathelm",
 			"reference": "LTIA14",
-			"local_notes": "Don: 16 secs; Holdout: 0; Reaction Pen.-2",
+			"local_notes": "DR: 3; Don: 16 secs; Holdout: 0; Reaction Pen.-2",
 			"tech_level": "3",
 			"tags": [
 				"Greathelm"
@@ -8528,21 +8172,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"face",
 						"skull"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"neck"
 					],
 					"amount": 3
 				}
@@ -8553,13 +8184,14 @@
 				"extended_value": 350,
 				"weight": "2.8 lb",
 				"extended_weight": "2.8 lb"
-			}
+			},
+			"reference_highlight": "Plate, Light"
 		},
 		{
 			"id": "e789qFrPdk5pIikCP",
 			"description": "Plate, Light Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "Don: 3 secs; Holdout: -3; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 3 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "3",
 			"tags": [
 				"Groin Armor"
@@ -8581,13 +8213,14 @@
 				"extended_value": 50,
 				"weight": "0.4 lb",
 				"extended_weight": "0.4 lb"
-			}
+			},
+			"reference_highlight": "Plate, Light"
 		},
 		{
 			"id": "eTWxBJoMLyST_CigB",
 			"description": "Plate, Light Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "Don: 45 secs; Holdout: -3; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 45 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "4",
 			"tags": [
 				"Limb Armor"
@@ -8609,13 +8242,14 @@
 				"extended_value": 1000,
 				"weight": "8 lb",
 				"extended_weight": "8 lb"
-			}
+			},
+			"reference_highlight": "Plate, Light"
 		},
 		{
 			"id": "enmhXuFhrJi9OYitn",
 			"description": "Plate, Light Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 3 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "4",
 			"tags": [
 				"Neck Armor"
@@ -8637,13 +8271,14 @@
 				"extended_value": 50,
 				"weight": "0.4 lb",
 				"extended_weight": "0.4 lb"
-			}
+			},
+			"reference_highlight": "Plate, Light"
 		},
 		{
 			"id": "e4oAdGvTrNEwrC-Jl",
 			"description": "Plate, Light Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "Don: 9 secs; Holdout: -4; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 9 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "2",
 			"tags": [
 				"Pot Helm"
@@ -8665,13 +8300,14 @@
 				"extended_value": 200,
 				"weight": "1.6 lb",
 				"extended_weight": "1.6 lb"
-			}
+			},
+			"reference_highlight": "Plate, Light"
 		},
 		{
 			"id": "exDKnMhaEphzFBvPP",
 			"description": "Plate, Light Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "Don: 9 secs; Holdout: -4; Reaction Pen.-1",
+			"local_notes": "DR: 4; Don: 9 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "2",
 			"tags": [
 				"Pot Helm"
@@ -8693,13 +8329,14 @@
 				"extended_value": 210,
 				"weight": "2.8 lb",
 				"extended_weight": "2.8 lb"
-			}
+			},
+			"reference_highlight": "Plate, Light"
 		},
 		{
 			"id": "eq4FLzmH6-khjku_D",
 			"description": "Plate, Light Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 45 secs; Holdout: -3; Reaction Pen.-2",
+			"local_notes": "DR: 3; Don: 45 secs; Holdout: -3; Reaction Pen.-2",
 			"tech_level": "4",
 			"tags": [
 				"Body Armor"
@@ -8710,28 +8347,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
+						"abdomen",
 						"torso"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
 					],
 					"amount": 3
 				}
@@ -8742,13 +8359,14 @@
 				"extended_value": 1000,
 				"weight": "8 lb",
 				"extended_weight": "8 lb"
-			}
+			},
+			"reference_highlight": "Plate, Light"
 		},
 		{
 			"id": "eU8gXroF2Ar9g2s52",
 			"description": "Plate, Medium Arm Armor",
 			"reference": "LTIA8",
-			"local_notes": "Don: 23 secs; Holdout: -5; Reaction Pen.-1",
+			"local_notes": "DR: 6; Don: 23 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -8771,13 +8389,14 @@
 				"extended_value": 1250,
 				"weight": "10 lb",
 				"extended_weight": "10 lb"
-			}
+			},
+			"reference_highlight": "Plate, Medium"
 		},
 		{
 			"id": "eSgqI8fP4XLtHv1XE",
 			"description": "Plate, Medium Bascinet",
 			"reference": "LTIA14",
-			"local_notes": "Don: 11 secs; Holdout: -6; Reaction Pen.-1",
+			"local_notes": "DR: 6; Don: 11 secs; Holdout: -6; Reaction Pen.-1",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -8792,13 +8411,6 @@
 						"skull"
 					],
 					"amount": 6
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
-					],
-					"amount": 6
 				}
 			],
 			"quantity": 1,
@@ -8807,13 +8419,14 @@
 				"extended_value": 625,
 				"weight": "5 lb",
 				"extended_weight": "5 lb"
-			}
+			},
+			"reference_highlight": "Plate, Medium"
 		},
 		{
 			"id": "eTVRaLKRUOad-KLqv",
 			"description": "Plate, Medium Bascinet, Padded",
 			"reference": "LTIA14",
-			"local_notes": "Don: 11 secs; Holdout: -6; Reaction Pen.-1",
+			"local_notes": "DR: 7; Don: 11 secs; Holdout: -6; Reaction Pen.-1",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -8828,13 +8441,6 @@
 						"skull"
 					],
 					"amount": 7
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
-					],
-					"amount": 7
 				}
 			],
 			"quantity": 1,
@@ -8843,13 +8449,14 @@
 				"extended_value": 638,
 				"weight": "5.2 lb",
 				"extended_weight": "5.2 lb"
-			}
+			},
+			"reference_highlight": "Plate, Medium"
 		},
 		{
 			"id": "eB4qsIQ65iOFalimp",
 			"description": "Plate, Medium Chest Armor",
 			"reference": "LTIA6",
-			"local_notes": "Don: 34 secs; Holdout: -5; Reaction Pen.-2",
+			"local_notes": "DR: 6; Don: 34 secs; Holdout: -5; Reaction Pen.-2",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -8864,13 +8471,6 @@
 						"torso"
 					],
 					"amount": 6
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
-					],
-					"amount": 6
 				}
 			],
 			"quantity": 1,
@@ -8879,13 +8479,14 @@
 				"extended_value": 1875,
 				"weight": "15 lb",
 				"extended_weight": "15 lb"
-			}
+			},
+			"reference_highlight": "Plate, Medium"
 		},
 		{
 			"id": "eBqY20s40LSNgJ5IP",
 			"description": "Plate, Medium Full Helm",
 			"reference": "LTIA14",
-			"local_notes": "Don: 14 secs; Holdout: -6; Reaction Pen.-1",
+			"local_notes": "DR: 6; Don: 14 secs; Holdout: -6; Reaction Pen.-1",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -8897,14 +8498,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"face",
 						"skull"
-					],
-					"amount": 6
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
 					],
 					"amount": 6
 				}
@@ -8915,13 +8510,14 @@
 				"extended_value": 750,
 				"weight": "6 lb",
 				"extended_weight": "6 lb"
-			}
+			},
+			"reference_highlight": "Plate, Medium"
 		},
 		{
 			"id": "eHZgRpXXrzpDqxppa",
 			"description": "Plate, Medium Full Helm, Padded",
 			"reference": "LTIA14",
-			"local_notes": "Don: 14 secs; Holdout: -6; Reaction Pen.-1",
+			"local_notes": "DR: 7; Don: 14 secs; Holdout: -6; Reaction Pen.-1",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -8933,14 +8529,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"face",
 						"skull"
-					],
-					"amount": 7
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
 					],
 					"amount": 7
 				}
@@ -8951,13 +8541,14 @@
 				"extended_value": 765,
 				"weight": "7.8 lb",
 				"extended_weight": "7.8 lb"
-			}
+			},
+			"reference_highlight": "Plate, Medium"
 		},
 		{
 			"id": "ep_vtRtAlV0LJUH4h",
 			"description": "Plate, Medium Greathelm",
 			"reference": "LTIA14",
-			"local_notes": "Don: 16 secs; Holdout: 0; Reaction Pen.-2",
+			"local_notes": "DR: 6; Don: 16 secs; Holdout: 0; Reaction Pen.-2",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -8994,13 +8585,14 @@
 				"extended_value": 875,
 				"weight": "7 lb",
 				"extended_weight": "7 lb"
-			}
+			},
+			"reference_highlight": "Plate, Medium"
 		},
 		{
 			"id": "eimn0d1MaS7YhKnWy",
 			"description": "Plate, Medium Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "Don: 3 secs; Holdout: -5; Reaction Pen.-1",
+			"local_notes": "DR: 6; Don: 3 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -9023,13 +8615,14 @@
 				"extended_value": 125,
 				"weight": "1 lb",
 				"extended_weight": "1 lb"
-			}
+			},
+			"reference_highlight": "Plate, Medium"
 		},
 		{
 			"id": "eZWYtiMbNI35xOp5O",
 			"description": "Plate, Medium Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "Don: 45 secs; Holdout: -5; Reaction Pen.-1",
+			"local_notes": "DR: 6; Don: 45 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -9052,13 +8645,14 @@
 				"extended_value": 2500,
 				"weight": "20 lb",
 				"extended_weight": "20 lb"
-			}
+			},
+			"reference_highlight": "Plate, Medium"
 		},
 		{
 			"id": "eQpccQp1v_uzxzArM",
 			"description": "Plate, Medium Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "Don: 3 secs; Holdout: -6; Reaction Pen.-1",
+			"local_notes": "DR: 6; Don: 3 secs; Holdout: -6; Reaction Pen.-1",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -9081,13 +8675,14 @@
 				"extended_value": 125,
 				"weight": "1 lb",
 				"extended_weight": "1 lb"
-			}
+			},
+			"reference_highlight": "Plate, Medium"
 		},
 		{
 			"id": "eOqepFwku-XinkaNS",
 			"description": "Plate, Medium Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "Don: 9 secs; Holdout: -6; Reaction Pen.-1",
+			"local_notes": "DR: 6; Don: 9 secs; Holdout: -6; Reaction Pen.-1",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -9110,13 +8705,14 @@
 				"extended_value": 500,
 				"weight": "4 lb",
 				"extended_weight": "4 lb"
-			}
+			},
+			"reference_highlight": "Plate, Medium"
 		},
 		{
 			"id": "eF_SWl1Q1gh-tLy0_",
 			"description": "Plate, Medium Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "Don: 9 secs; Holdout: -6; Reaction Pen.-1",
+			"local_notes": "DR: 7; Don: 9 secs; Holdout: -6; Reaction Pen.-1",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -9139,13 +8735,14 @@
 				"extended_value": 510,
 				"weight": "5.2 lb",
 				"extended_weight": "5.2 lb"
-			}
+			},
+			"reference_highlight": "Plate, Medium"
 		},
 		{
 			"id": "eyVvxYjv3gQTO6zY5",
 			"description": "Plate, Medium Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 45 secs; Holdout: -5; Reaction Pen.-2",
+			"local_notes": "DR: 6; Don: 45 secs; Holdout: -5; Reaction Pen.-2",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -9157,28 +8754,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
-					],
-					"amount": 6
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
+						"abdomen",
 						"torso"
-					],
-					"amount": 6
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
-					],
-					"amount": 6
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
 					],
 					"amount": 6
 				}
@@ -9189,13 +8766,14 @@
 				"extended_value": 2500,
 				"weight": "20 lb",
 				"extended_weight": "20 lb"
-			}
+			},
+			"reference_highlight": "Plate, Medium"
 		},
 		{
 			"id": "ecX489d3HkDaxCgzV",
 			"description": "Sabatons, Light Plate ",
 			"reference": "LTIA16",
-			"local_notes": "Don: 10 secs; Holdout: -4",
+			"local_notes": "DR: 3; Don: 10 secs; Holdout: -4",
 			"tech_level": "4",
 			"tags": [
 				"Footwear"
@@ -9223,7 +8801,7 @@
 			"id": "euszDR29gjpuJCuGx",
 			"description": "Sabatons, Light Segmented ",
 			"reference": "LTIA16",
-			"local_notes": "Don: 10 secs; Holdout: -4",
+			"local_notes": "DR: 3; Don: 10 secs; Holdout: -4",
 			"tech_level": "3",
 			"tags": [
 				"Footwear"
@@ -9251,7 +8829,7 @@
 			"id": "efZ1g8nFsdzNr9dsR",
 			"description": "Sabatons, Medium Plate ",
 			"reference": "LTIA16",
-			"local_notes": "Don: 10 secs; Holdout: -6",
+			"local_notes": "DR: 6; Don: 10 secs; Holdout: -6",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -9280,7 +8858,7 @@
 			"id": "eQSlhhXKSGEOEYR6K",
 			"description": "Sabatons, Medium Segmented ",
 			"reference": "LTIA16",
-			"local_notes": "Don: 10 secs; Holdout: -5",
+			"local_notes": "DR: 4; Don: 10 secs; Holdout: -5",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -9309,7 +8887,7 @@
 			"id": "eHeqzBzX8BvvEYC4T",
 			"description": "Sandals ",
 			"reference": "LTIA16",
-			"local_notes": "Don: 10 secs; Holdout: -2; Flexible and susceptible to blunt trauma (p. B379); DR applies to underside only.",
+			"local_notes": "DR: 1; Don: 10 secs; Holdout: -2; Flexible and susceptible to blunt trauma (p. B379); DR applies to underside only.",
 			"tech_level": "0",
 			"tags": [
 				"Footwear"
@@ -9337,7 +8915,7 @@
 			"id": "eluvVD7j_wcbJxlCb",
 			"description": "Sandals, Hobnailed ",
 			"reference": "LTIA16",
-			"local_notes": "Don: 10 secs; Holdout: -2; Flexible and susceptible to blunt trauma (p. B379); DR applies to underside only; Lets wearer ignore -2 to attacks and -1 to defenses for bad terrain.",
+			"local_notes": "DR: 1; Don: 10 secs; Holdout: -2; Flexible and susceptible to blunt trauma (p. B379); DR applies to underside only; Lets wearer ignore -2 to attacks and -1 to defenses for bad terrain.",
 			"tech_level": "1",
 			"tags": [
 				"Footwear"
@@ -9365,7 +8943,7 @@
 			"id": "eMXjmd-ADIy8x6Phw",
 			"description": "Scale, Heavy Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "Don: 23 secs; Holdout: -6; Reaction Pen.-2",
+			"local_notes": "DR: 5; Don: 23 secs; Holdout: -6; Reaction Pen.-2",
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
@@ -9378,13 +8956,6 @@
 					"type": "dr_bonus",
 					"locations": [
 						"abdomen"
-					],
-					"amount": 5
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
 					],
 					"amount": 5
 				}
@@ -9401,7 +8972,7 @@
 			"id": "eDVDLpJZFw2VME1fD",
 			"description": "Scale, Heavy Chest Armor",
 			"reference": "LTIA6",
-			"local_notes": "Don: 23 secs; Holdout: -6; Reaction Pen.-2",
+			"local_notes": "DR: 5; Don: 23 secs; Holdout: -6; Reaction Pen.-2",
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
@@ -9414,13 +8985,6 @@
 					"type": "dr_bonus",
 					"locations": [
 						"torso"
-					],
-					"amount": 5
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
 					],
 					"amount": 5
 				}
@@ -9437,7 +9001,7 @@
 			"id": "e-BjR07h0b9k0Oy3l",
 			"description": "Scale, Heavy Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "Don: 3 secs; Holdout: -6; Reaction Pen.-1",
+			"local_notes": "DR: 5; Don: 3 secs; Holdout: -6; Reaction Pen.-1",
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
@@ -9466,7 +9030,7 @@
 			"id": "eIImVdjJvldhfxwLN",
 			"description": "Scale, Heavy Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "Don: 6 secs; Holdout: -7; Reaction Pen.-1",
+			"local_notes": "DR: 5; Don: 6 secs; Holdout: -7; Reaction Pen.-1",
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
@@ -9495,7 +9059,7 @@
 			"id": "exAfTgYIySnecu67O",
 			"description": "Scale, Heavy Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "Don: 6 secs; Holdout: -7; Reaction Pen.-1",
+			"local_notes": "DR: 6; Don: 6 secs; Holdout: -7; Reaction Pen.-1",
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
@@ -9524,7 +9088,7 @@
 			"id": "eIkvGk7LHLOhOJ7fE",
 			"description": "Scale, Heavy Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 30 secs; Holdout: -6; Reaction Pen.-2",
+			"local_notes": "DR: 5; Don: 30 secs; Holdout: -6; Reaction Pen.-2",
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
@@ -9536,29 +9100,13 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
-					],
-					"amount": 5
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
+						"abdomen",
 						"torso"
 					],
 					"amount": 5
 				},
 				{
 					"type": "dr_bonus",
-					"locations": [
-						"vitals"
-					],
-					"amount": 5
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
-					],
 					"amount": 5
 				}
 			],
@@ -9574,7 +9122,7 @@
 			"id": "eInlCNpHFJATpgf-F",
 			"description": "Scale, Light Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
+			"local_notes": "DR: 3; Don: 23 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"tags": [
 				"Body Armor"
@@ -9592,9 +9140,10 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"groin"
+						"abdomen"
 					],
-					"amount": 3
+					"specialization": "crushing",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -9603,13 +9152,15 @@
 				"extended_value": 80,
 				"weight": "4 lb",
 				"extended_weight": "4 lb"
-			}
+			},
+			"reference_highlight": "Scale, Light",
+			"equipped": true
 		},
 		{
 			"id": "eV9pLntTjHGa9INll",
 			"description": "Scale, Light Arm Armor",
 			"reference": "LTIA7",
-			"local_notes": "Don: 15 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. crushing.",
+			"local_notes": "DR: 3; Don: 15 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"tags": [
 				"Limb Armor"
@@ -9620,9 +9171,17 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"arm"
+						"torso"
 					],
 					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"arm"
+					],
+					"specialization": "crushing",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -9631,13 +9190,14 @@
 				"extended_value": 160,
 				"weight": "8 lb",
 				"extended_weight": "8 lb"
-			}
+			},
+			"reference_highlight": "Scale, Light"
 		},
 		{
 			"id": "eueJbKkWLyQaVuzGx",
 			"description": "Scale, Light Bascinet",
 			"reference": "LTIA14",
-			"local_notes": "Don: 8 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
+			"local_notes": "DR: 3; Don: 8 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"tags": [
 				"Bascinet"
@@ -9648,16 +9208,17 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"skull"
+						"torso"
 					],
 					"amount": 3
 				},
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"face"
+						"skull"
 					],
-					"amount": 3
+					"specialization": "crushing",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -9666,13 +9227,14 @@
 				"extended_value": 80,
 				"weight": "4 lb",
 				"extended_weight": "4 lb"
-			}
+			},
+			"reference_highlight": "Scale, Light"
 		},
 		{
 			"id": "ecRkAiTcRaZzsqZ6D",
 			"description": "Scale, Light Bascinet, Padded",
 			"reference": "LTIA14",
-			"local_notes": "Don: 8 secs; Holdout: -4; Reaction Pen.-1",
+			"local_notes": "DR: 4; Don: 8 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"tags": [
 				"Bascinet"
@@ -9690,9 +9252,9 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"face"
+						"skull"
 					],
-					"amount": 4
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -9701,13 +9263,14 @@
 				"extended_value": 93,
 				"weight": "4.2 lb",
 				"extended_weight": "4.2 lb"
-			}
+			},
+			"reference_highlight": "Scale, Light"
 		},
 		{
 			"id": "eWgVQ72kUVCiHuUXm",
 			"description": "Scale, Light Chest Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
+			"local_notes": "DR: 3; Don: 23 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"tags": [
 				"Body Armor"
@@ -9725,9 +9288,10 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"vitals"
+						"torso"
 					],
-					"amount": 3
+					"specialization": "crushing",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -9736,13 +9300,14 @@
 				"extended_value": 240,
 				"weight": "12 lb",
 				"extended_weight": "12 lb"
-			}
+			},
+			"reference_highlight": "Scale, Light"
 		},
 		{
 			"id": "eM05bTktNP1mmKvf7",
 			"description": "Scale, Light Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "Don: 3 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. crushing.",
+			"local_notes": "DR: 3; Don: 3 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"tags": [
 				"Groin Armor"
@@ -9756,6 +9321,14 @@
 						"groin"
 					],
 					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"groin"
+					],
+					"specialization": "crushing",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -9764,13 +9337,14 @@
 				"extended_value": 16,
 				"weight": "0.8 lb",
 				"extended_weight": "0.8 lb"
-			}
+			},
+			"reference_highlight": "Scale, Light"
 		},
 		{
 			"id": "eJrQfgf3JY2K_Xlm2",
 			"description": "Scale, Light Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "Don: 30 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. crushing.",
+			"local_notes": "DR: 3; Don: 30 secs; Holdout: -3; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"tags": [
 				"Limb Armor"
@@ -9784,6 +9358,14 @@
 						"leg"
 					],
 					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"leg"
+					],
+					"specialization": "crushing",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -9792,13 +9374,14 @@
 				"extended_value": 320,
 				"weight": "16 lb",
 				"extended_weight": "16 lb"
-			}
+			},
+			"reference_highlight": "Scale, Light"
 		},
 		{
 			"id": "e1xZcuI0APh-WdpPe",
 			"description": "Scale, Light Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
+			"local_notes": "DR: 3; Don: 3 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"tags": [
 				"Neck Armor"
@@ -9812,6 +9395,14 @@
 						"neck"
 					],
 					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"neck"
+					],
+					"specialization": "crushing",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -9820,13 +9411,14 @@
 				"extended_value": 16,
 				"weight": "0.8 lb",
 				"extended_weight": "0.8 lb"
-			}
+			},
+			"reference_highlight": "Scale, Light"
 		},
 		{
 			"id": "eyPMigE5TtFBXNRSm",
 			"description": "Scale, Light Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "Don: 6 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
+			"local_notes": "DR: 3; Don: 6 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"tags": [
 				"Pot Helm"
@@ -9840,6 +9432,14 @@
 						"skull"
 					],
 					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"skull"
+					],
+					"specialization": "crushing",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -9848,13 +9448,14 @@
 				"extended_value": 64,
 				"weight": "3.2 lb",
 				"extended_weight": "3.2 lb"
-			}
+			},
+			"reference_highlight": "Scale, Light"
 		},
 		{
 			"id": "eT4N9iY28y7o6jcGc",
 			"description": "Scale, Light Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "Don: 6 secs; Holdout: -4; Reaction Pen.-1",
+			"local_notes": "DR: 4; Don: 6 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"tags": [
 				"Pot Helm"
@@ -9868,6 +9469,14 @@
 						"skull"
 					],
 					"amount": 4
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"skull"
+					],
+					"specialization": "crushing",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -9876,13 +9485,14 @@
 				"extended_value": 74,
 				"weight": "4.4 lb",
 				"extended_weight": "4.4 lb"
-			}
+			},
+			"reference_highlight": "Scale, Light"
 		},
 		{
 			"id": "eHtBmi24bkKaPXYCa",
 			"description": "Scale, Light Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 30 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
+			"local_notes": "DR: 3; Don: 30 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"tags": [
 				"Body Armor"
@@ -9893,13 +9503,7 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
+						"abdomen",
 						"torso"
 					],
 					"amount": 3
@@ -9907,16 +9511,11 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"vitals"
+						"abdomen",
+						"torso"
 					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
-					],
-					"amount": 3
+					"specialization": "crushing",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -9925,13 +9524,15 @@
 				"extended_value": 320,
 				"weight": "16 lb",
 				"extended_weight": "16 lb"
-			}
+			},
+			"reference_highlight": "Scale, Light",
+			"equipped": true
 		},
 		{
 			"id": "eKHaM65tTQquvHfTA",
 			"description": "Scale, Medium Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. crushing.",
+			"local_notes": "DR: 4; Don: 23 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
@@ -9950,9 +9551,10 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"groin"
+						"abdomen"
 					],
-					"amount": 4
+					"specialization": "crushing",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -9961,13 +9563,15 @@
 				"extended_value": 138,
 				"weight": "7 lb",
 				"extended_weight": "7 lb"
-			}
+			},
+			"reference_highlight": "Scale, Medium",
+			"equipped": true
 		},
 		{
 			"id": "ediSlzetGlHz5VPkK",
 			"description": "Scale, Medium Arm Armor",
 			"reference": "LTIA7",
-			"local_notes": "Don: 15 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
+			"local_notes": "DR: 5; Don: 15 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
@@ -9982,6 +9586,14 @@
 						"arm"
 					],
 					"amount": 4
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"arm"
+					],
+					"specialization": "crushing",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -9990,13 +9602,14 @@
 				"extended_value": 275,
 				"weight": "14 lb",
 				"extended_weight": "14 lb"
-			}
+			},
+			"reference_highlight": "Scale, Medium"
 		},
 		{
 			"id": "ejQkt1FZJhIab-EUJ",
 			"description": "Scale, Medium Bascinet",
 			"reference": "LTIA14",
-			"local_notes": "Don: 8 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. crushing.",
+			"local_notes": "DR: 4; Don: 8 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
@@ -10015,9 +9628,10 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"face"
+						"skull"
 					],
-					"amount": 4
+					"specialization": "crushing",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -10026,13 +9640,14 @@
 				"extended_value": 138,
 				"weight": "7 lb",
 				"extended_weight": "7 lb"
-			}
+			},
+			"reference_highlight": "Scale, Medium"
 		},
 		{
 			"id": "e9l4x1i0lcA_9j7z0",
 			"description": "Scale, Medium Bascinet, Padded",
 			"reference": "LTIA14",
-			"local_notes": "Don: 8 secs; Holdout: -5; Reaction Pen.-1",
+			"local_notes": "DR: 5; Don: 8 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
@@ -10051,9 +9666,10 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"face"
+						"skull"
 					],
-					"amount": 5
+					"specialization": "crushing",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -10062,13 +9678,14 @@
 				"extended_value": 151,
 				"weight": "7.2 lb",
 				"extended_weight": "7.2 lb"
-			}
+			},
+			"reference_highlight": "Scale, Medium"
 		},
 		{
 			"id": "ePqMK0y3IqW5TsApE",
 			"description": "Scale, Medium Chest Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. crushing.",
+			"local_notes": "DR: 4; Don: 23 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
@@ -10087,9 +9704,10 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"vitals"
+						"torso"
 					],
-					"amount": 4
+					"specialization": "crushing",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -10098,13 +9716,14 @@
 				"extended_value": 413,
 				"weight": "21 lb",
 				"extended_weight": "21 lb"
-			}
+			},
+			"reference_highlight": "Scale, Medium"
 		},
 		{
 			"id": "eiWPwRu2oMKLdjmkh",
 			"description": "Scale, Medium Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
+			"local_notes": "DR: 4; Don: 3 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
@@ -10119,6 +9738,14 @@
 						"groin"
 					],
 					"amount": 4
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"groin"
+					],
+					"specialization": "crushing",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -10127,13 +9754,14 @@
 				"extended_value": 28,
 				"weight": "1.4 lb",
 				"extended_weight": "1.4 lb"
-			}
+			},
+			"reference_highlight": "Scale, Medium"
 		},
 		{
 			"id": "e5eMN8Q0jGQMUV1KQ",
 			"description": "Scale, Medium Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
+			"local_notes": "DR: 4; Don: 30 secs; Holdout: -4; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
@@ -10148,6 +9776,14 @@
 						"leg"
 					],
 					"amount": 4
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"leg"
+					],
+					"specialization": "crushing",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -10156,13 +9792,14 @@
 				"extended_value": 550,
 				"weight": "28 lb",
 				"extended_weight": "28 lb"
-			}
+			},
+			"reference_highlight": "Scale, Medium"
 		},
 		{
 			"id": "e9xGHIfd-iEwpZDG6",
 			"description": "Scale, Medium Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "Don: 3 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. crushing.",
+			"local_notes": "DR: 4; Don: 3 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
@@ -10177,6 +9814,14 @@
 						"neck"
 					],
 					"amount": 4
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"neck"
+					],
+					"specialization": "crushing",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -10185,13 +9830,14 @@
 				"extended_value": 28,
 				"weight": "1.4 lb",
 				"extended_weight": "1.4 lb"
-			}
+			},
+			"reference_highlight": "Scale, Medium"
 		},
 		{
 			"id": "eGO1Mu7zXur3_R4OX",
 			"description": "Scale, Medium Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. crushing.",
+			"local_notes": "DR: 4; Don: 6 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
@@ -10206,6 +9852,14 @@
 						"skull"
 					],
 					"amount": 4
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"skull"
+					],
+					"specialization": "crushing",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -10214,13 +9868,14 @@
 				"extended_value": 110,
 				"weight": "5.6 lb",
 				"extended_weight": "5.6 lb"
-			}
+			},
+			"reference_highlight": "Scale, Medium"
 		},
 		{
 			"id": "eE6QMo6IVPQLFjnsj",
 			"description": "Scale, Medium Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1",
+			"local_notes": "DR: 5; Don: 6 secs; Holdout: -5; Reaction Pen.-1; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
@@ -10235,6 +9890,14 @@
 						"skull"
 					],
 					"amount": 5
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"skull"
+					],
+					"specialization": "crushing",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -10249,7 +9912,7 @@
 			"id": "e_688YS_xwW2sOaG_",
 			"description": "Scale, Medium Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. crushing.",
+			"local_notes": "DR: 4; Don: 30 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"legality_class": "3",
 			"tags": [
@@ -10261,13 +9924,7 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
-					],
-					"amount": 4
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
+						"abdomen",
 						"torso"
 					],
 					"amount": 4
@@ -10275,16 +9932,11 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"vitals"
+						"abdomen",
+						"torso"
 					],
-					"amount": 4
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
-					],
-					"amount": 4
+					"specialization": "crushing",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -10293,13 +9945,15 @@
 				"extended_value": 550,
 				"weight": "28 lb",
 				"extended_weight": "28 lb"
-			}
+			},
+			"reference_highlight": "Scale, Medium",
+			"equipped": true
 		},
 		{
 			"id": "e41EAFyohdSBaDnTZ",
 			"description": "Segmented Plate, Heavy Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "Don: 34 secs; Holdout: -5; Reaction Pen.-2",
+			"local_notes": "DR: 5; Don: 34 secs; Holdout: -5; Reaction Pen.-2",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -10314,13 +9968,6 @@
 						"abdomen"
 					],
 					"amount": 5
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
-					],
-					"amount": 5
 				}
 			],
 			"quantity": 1,
@@ -10329,13 +9976,14 @@
 				"extended_value": 300,
 				"weight": "8 lb",
 				"extended_weight": "8 lb"
-			}
+			},
+			"reference_highlight": "Segmented Plate, Heavy"
 		},
 		{
 			"id": "eNwSHF3PAzU8PpITj",
 			"description": "Segmented Plate, Heavy Chest Armor",
 			"reference": "LTIA6",
-			"local_notes": "Don: 34 secs; Holdout: -5; Reaction Pen.-2",
+			"local_notes": "DR: 5; Don: 34 secs; Holdout: -5; Reaction Pen.-2",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -10350,13 +9998,6 @@
 						"torso"
 					],
 					"amount": 5
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
-					],
-					"amount": 5
 				}
 			],
 			"quantity": 1,
@@ -10365,13 +10006,14 @@
 				"extended_value": 900,
 				"weight": "24 lb",
 				"extended_weight": "24 lb"
-			}
+			},
+			"reference_highlight": "Segmented Plate, Heavy"
 		},
 		{
 			"id": "efschvai3wvmBvBI0",
 			"description": "Segmented Plate, Heavy Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 45 secs; Holdout: -5; Reaction Pen.-2",
+			"local_notes": "DR: 5; Don: 45 secs; Holdout: -5; Reaction Pen.-2",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -10383,28 +10025,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
-					],
-					"amount": 5
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
+						"abdomen",
 						"torso"
-					],
-					"amount": 5
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
-					],
-					"amount": 5
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
 					],
 					"amount": 5
 				}
@@ -10415,13 +10037,14 @@
 				"extended_value": 1200,
 				"weight": "32 lb",
 				"extended_weight": "32 lb"
-			}
+			},
+			"reference_highlight": "Segmented Plate, Heavy"
 		},
 		{
 			"id": "egyBoFUfG5LApFnpl",
 			"description": "Segmented Plate, Light Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "Don: 34 secs; Holdout: -3; Reaction Pen.-2",
+			"local_notes": "DR: 3; Don: 34 secs; Holdout: -3; Reaction Pen.-2",
 			"tech_level": "2",
 			"tags": [
 				"Body Armor"
@@ -10435,13 +10058,6 @@
 						"abdomen"
 					],
 					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
-					],
-					"amount": 3
 				}
 			],
 			"quantity": 1,
@@ -10450,13 +10066,14 @@
 				"extended_value": 150,
 				"weight": "4 lb",
 				"extended_weight": "4 lb"
-			}
+			},
+			"reference_highlight": "Segmented Plate, Light"
 		},
 		{
 			"id": "e0PTX0iu7j42pisvr",
 			"description": "Segmented Plate, Light Arm Armor",
 			"reference": "LTIA8",
-			"local_notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 23 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "2",
 			"tags": [
 				"Limb Armor"
@@ -10478,13 +10095,14 @@
 				"extended_value": 300,
 				"weight": "8 lb",
 				"extended_weight": "8 lb"
-			}
+			},
+			"reference_highlight": "Segmented Plate, Light"
 		},
 		{
 			"id": "e93oswSEv2yhtD9Vd",
 			"description": "Segmented Plate, Light Chest Armor",
 			"reference": "LTIA6",
-			"local_notes": "Don: 34 secs; Holdout: -3; Reaction Pen.-2",
+			"local_notes": "DR: 3; Don: 34 secs; Holdout: -3; Reaction Pen.-2",
 			"tech_level": "2",
 			"tags": [
 				"Body Armor"
@@ -10498,13 +10116,6 @@
 						"torso"
 					],
 					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
-					],
-					"amount": 3
 				}
 			],
 			"quantity": 1,
@@ -10513,13 +10124,14 @@
 				"extended_value": 450,
 				"weight": "12 lb",
 				"extended_weight": "12 lb"
-			}
+			},
+			"reference_highlight": "Segmented Plate, Light"
 		},
 		{
 			"id": "eRl5wBIgYZid8aUHX",
 			"description": "Segmented Plate, Light Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "Don: 45 secs; Holdout: -3; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 45 secs; Holdout: -3; Reaction Pen.-1",
 			"tech_level": "2",
 			"tags": [
 				"Limb Armor"
@@ -10541,13 +10153,14 @@
 				"extended_value": 600,
 				"weight": "16 lb",
 				"extended_weight": "16 lb"
-			}
+			},
+			"reference_highlight": "Segmented Plate, Light"
 		},
 		{
 			"id": "eNKr5lN8xEyENHaiR",
 			"description": "Segmented Plate, Light Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "Don: 3 secs; Holdout: -4; Reaction Pen.-1",
+			"local_notes": "DR: 3; Don: 3 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "2",
 			"tags": [
 				"Neck Armor"
@@ -10569,13 +10182,14 @@
 				"extended_value": 30,
 				"weight": "0.8 lb",
 				"extended_weight": "0.8 lb"
-			}
+			},
+			"reference_highlight": "Segmented Plate, Light"
 		},
 		{
 			"id": "eF_jnAdG1YlykDoEZ",
 			"description": "Segmented Plate, Light Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 45 secs; Holdout: -3; Reaction Pen.-2",
+			"local_notes": "DR: 3; Don: 45 secs; Holdout: -3; Reaction Pen.-2",
 			"tech_level": "2",
 			"tags": [
 				"Body Armor"
@@ -10586,28 +10200,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
+						"abdomen",
 						"torso"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
 					],
 					"amount": 3
 				}
@@ -10618,13 +10212,14 @@
 				"extended_value": 600,
 				"weight": "16 lb",
 				"extended_weight": "16 lb"
-			}
+			},
+			"reference_highlight": "Segmented Plate, Light"
 		},
 		{
 			"id": "eElThcQrhgSlvInYE",
 			"description": "Segmented Plate, Medium Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "Don: 34 secs; Holdout: -4; Reaction Pen.-2",
+			"local_notes": "DR: 4; Don: 34 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -10639,13 +10234,6 @@
 						"abdomen"
 					],
 					"amount": 4
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
-					],
-					"amount": 4
 				}
 			],
 			"quantity": 1,
@@ -10654,13 +10242,14 @@
 				"extended_value": 225,
 				"weight": "6 lb",
 				"extended_weight": "6 lb"
-			}
+			},
+			"reference_highlight": "Segmented Plate, Medium"
 		},
 		{
 			"id": "eotWFK_7_1sswtH74",
 			"description": "Segmented Plate, Medium Arm Armor",
 			"reference": "LTIA8",
-			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-1",
+			"local_notes": "DR: 4; Don: 23 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -10683,13 +10272,14 @@
 				"extended_value": 450,
 				"weight": "12 lb",
 				"extended_weight": "12 lb"
-			}
+			},
+			"reference_highlight": "Segmented Plate, Medium"
 		},
 		{
 			"id": "eTNKzCK4BlFqPe0lm",
 			"description": "Segmented Plate, Medium Chest Armor",
 			"reference": "LTIA6",
-			"local_notes": "Don: 34 secs; Holdout: -4; Reaction Pen.-2",
+			"local_notes": "DR: 4; Don: 34 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -10704,13 +10294,6 @@
 						"torso"
 					],
 					"amount": 4
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
-					],
-					"amount": 4
 				}
 			],
 			"quantity": 1,
@@ -10719,13 +10302,14 @@
 				"extended_value": 675,
 				"weight": "18 lb",
 				"extended_weight": "18 lb"
-			}
+			},
+			"reference_highlight": "Segmented Plate, Medium"
 		},
 		{
 			"id": "e_sIKH4GUMH9UP6iz",
 			"description": "Segmented Plate, Medium Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "Don: 45 secs; Holdout: -4; Reaction Pen.-1",
+			"local_notes": "DR: 4; Don: 45 secs; Holdout: -4; Reaction Pen.-1",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -10748,13 +10332,14 @@
 				"extended_value": 900,
 				"weight": "24 lb",
 				"extended_weight": "24 lb"
-			}
+			},
+			"reference_highlight": "Segmented Plate, Medium"
 		},
 		{
 			"id": "eEvehkdxlR5AgyyYh",
 			"description": "Segmented Plate, Medium Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "Don: 3 secs; Holdout: -5; Reaction Pen.-1",
+			"local_notes": "DR: 4; Don: 3 secs; Holdout: -5; Reaction Pen.-1",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -10777,13 +10362,14 @@
 				"extended_value": 45,
 				"weight": "1.2 lb",
 				"extended_weight": "1.2 lb"
-			}
+			},
+			"reference_highlight": "Segmented Plate, Medium"
 		},
 		{
 			"id": "egokUQ1Ycemmd59A6",
 			"description": "Segmented Plate, Medium Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 45 secs; Holdout: -4; Reaction Pen.-2",
+			"local_notes": "DR: 4; Don: 45 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -10795,28 +10381,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
-					],
-					"amount": 4
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
+						"abdomen",
 						"torso"
-					],
-					"amount": 4
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
-					],
-					"amount": 4
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
 					],
 					"amount": 4
 				}
@@ -10827,13 +10393,14 @@
 				"extended_value": 900,
 				"weight": "24 lb",
 				"extended_weight": "24 lb"
-			}
+			},
+			"reference_highlight": "Segmented Plate, Medium"
 		},
 		{
 			"id": "eDBbcETSyRQ1HZJFH",
 			"description": "Shoes ",
 			"reference": "LTIA16",
-			"local_notes": "Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
+			"local_notes": "DR: 1; Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
 			"tech_level": "1",
 			"tags": [
 				"Footwear"
@@ -10861,7 +10428,7 @@
 			"id": "eEVj7rSYpu5Jt4-yF",
 			"description": "Shoes, Hobnailed ",
 			"reference": "LTIA16",
-			"local_notes": "Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling; Lets wearer ignore -2 to attacks and -1 to defenses for bad terrain.",
+			"local_notes": "DR: 1; Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling; Lets wearer ignore -2 to attacks and -1 to defenses for bad terrain.",
 			"tech_level": "1",
 			"tags": [
 				"Footwear"
@@ -10889,7 +10456,7 @@
 			"id": "eJhyyjnFo7KmWVJTd",
 			"description": "Shoes, Medium Leather ",
 			"reference": "LTIA16",
-			"local_notes": "Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
+			"local_notes": "DR: 2; Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); -1 DR vs. impaling.",
 			"tech_level": "1",
 			"tags": [
 				"Footwear"
@@ -10903,6 +10470,14 @@
 						"foot"
 					],
 					"amount": 2
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"foot"
+					],
+					"specialization": "impaling",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -10917,7 +10492,7 @@
 			"id": "e5oPk4D93B4R-kmaI",
 			"description": "Sollerets, Fine Mail ",
 			"reference": "LTIA16",
-			"local_notes": "Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "DR: 4;  Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -10929,9 +10504,17 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"foot"
+						"foot",
+						"torso"
 					],
 					"amount": 4
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"foot"
+					],
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -10946,7 +10529,7 @@
 			"id": "eP-s_FvhbTPwA79h5",
 			"description": "Sollerets, Heavy Mail ",
 			"reference": "LTIA16",
-			"local_notes": "Don: 6 secs; Holdout: -4; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "DR: 5; Don: 6 secs; Holdout: -4; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -10961,6 +10544,14 @@
 						"foot"
 					],
 					"amount": 5
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"foot"
+					],
+					"specialization": "crushing",
+					"amount": -2
 				}
 			],
 			"quantity": 1,
@@ -10975,7 +10566,7 @@
 			"id": "evSioPxb1AeVS_V4J",
 			"description": "Sollerets, Light Mail ",
 			"reference": "LTIA16",
-			"local_notes": "Don: 6 secs; Holdout: -2; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "DR: 3; Don: 6 secs; Holdout: -2; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
 			"tech_level": "2",
 			"tags": [
 				"Footwear"
@@ -10989,6 +10580,14 @@
 						"foot"
 					],
 					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"foot"
+					],
+					"specialization": "crushing",
+					"amount": -2
 				}
 			],
 			"quantity": 1,
@@ -11003,7 +10602,7 @@
 			"id": "ea8f_-UbJnObc_qCO",
 			"description": "Sollerets, Light Scale ",
 			"reference": "LTIA16",
-			"local_notes": "Don: 10 secs; Holdout: -4; -1 DR vs. crushing.",
+			"local_notes": "DR: 3; Don: 10 secs; Holdout: -4; -1 DR vs. crushing.",
 			"tech_level": "1",
 			"tags": [
 				"Footwear"
@@ -11017,6 +10616,14 @@
 						"foot"
 					],
 					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"foot"
+					],
+					"specialization": "crushing",
+					"amount": -1
 				}
 			],
 			"quantity": 1,
@@ -11031,7 +10638,7 @@
 			"id": "eJCPVLRUSXkOWzrU9",
 			"description": "Straw Chest Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 23 secs; Holdout: -9; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433); treat as resistant.",
+			"local_notes": "DR: 2; Don: 23 secs; Holdout: -9; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433); treat as resistant.",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -11045,13 +10652,6 @@
 						"torso"
 					],
 					"amount": 2
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
-					],
-					"amount": 2
 				}
 			],
 			"quantity": 1,
@@ -11060,13 +10660,14 @@
 				"extended_value": 38,
 				"weight": "15 lb",
 				"extended_weight": "15 lb"
-			}
+			},
+			"reference_highlight": "Straw"
 		},
 		{
 			"id": "eHWDufm50qX7ve6XM",
 			"description": "Straw Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 30 secs; Holdout: -9; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433); treat as resistant.",
+			"local_notes": "DR: 2; Don: 30 secs; Holdout: -9; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433); treat as resistant.",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -11077,28 +10678,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
-					],
-					"amount": 2
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
+						"abdomen",
 						"torso"
-					],
-					"amount": 2
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
-					],
-					"amount": 2
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
 					],
 					"amount": 2
 				}
@@ -11109,13 +10690,14 @@
 				"extended_value": 50,
 				"weight": "20 lb",
 				"extended_weight": "20 lb"
-			}
+			},
+			"reference_highlight": "Straw"
 		},
 		{
 			"id": "eXqk6jUDaoovt3TX2",
 			"description": "Wood Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "Don: 23 secs; Holdout: -8; Reaction Pen.-2; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
+			"local_notes": "DR: 3; Don: 23 secs; Holdout: -8; Reaction Pen.-2; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -11129,13 +10711,6 @@
 						"abdomen"
 					],
 					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
-					],
-					"amount": 3
 				}
 			],
 			"quantity": 1,
@@ -11144,13 +10719,14 @@
 				"extended_value": 25,
 				"weight": "7.5 lb",
 				"extended_weight": "7.5 lb"
-			}
+			},
+			"reference_highlight": "Wood"
 		},
 		{
 			"id": "evbmfkuOcotZ1SaFH",
 			"description": "Wood Arm Armor",
 			"reference": "LTIA7",
-			"local_notes": "Don: 15 secs; Holdout: -8; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
+			"local_notes": "DR: 3; Don: 15 secs; Holdout: -8; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
 			"tech_level": "0",
 			"tags": [
 				"Limb Armor"
@@ -11172,13 +10748,14 @@
 				"extended_value": 50,
 				"weight": "15 lb",
 				"extended_weight": "15 lb"
-			}
+			},
+			"reference_highlight": "Wood"
 		},
 		{
 			"id": "eRjTsahXPehU4NPAr",
 			"description": "Wood Bascinet",
 			"reference": "LTIA14",
-			"local_notes": "Don: 8 secs; Holdout: -9; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
+			"local_notes": "DR: 3; Don: 8 secs; Holdout: -9; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
 			"tech_level": "0",
 			"tags": [
 				"Bascinet"
@@ -11192,13 +10769,6 @@
 						"skull"
 					],
 					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
-					],
-					"amount": 3
 				}
 			],
 			"quantity": 1,
@@ -11207,13 +10777,14 @@
 				"extended_value": 25,
 				"weight": "7.5 lb",
 				"extended_weight": "7.5 lb"
-			}
+			},
+			"reference_highlight": "Wood"
 		},
 		{
 			"id": "e3CfPmi1OTlf4bBlh",
 			"description": "Wood Bascinet, Padded",
 			"reference": "LTIA14",
-			"local_notes": "Don: 8 secs; Holdout: -9; Reaction Pen.-1",
+			"local_notes": "DR: 4; Don: 8 secs; Holdout: -9; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Bascinet"
@@ -11227,13 +10798,6 @@
 						"skull"
 					],
 					"amount": 4
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
-					],
-					"amount": 4
 				}
 			],
 			"quantity": 1,
@@ -11242,13 +10806,14 @@
 				"extended_value": 38,
 				"weight": "7.7 lb",
 				"extended_weight": "7.7 lb"
-			}
+			},
+			"reference_highlight": "Wood"
 		},
 		{
 			"id": "eJsFACim5oxpPKgDL",
 			"description": "Wood Chest Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 23 secs; Holdout: -8; Reaction Pen.-2; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
+			"local_notes": "DR: 3; Don: 23 secs; Holdout: -8; Reaction Pen.-2; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -11262,13 +10827,6 @@
 						"torso"
 					],
 					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
-					],
-					"amount": 3
 				}
 			],
 			"quantity": 1,
@@ -11277,13 +10835,14 @@
 				"extended_value": 75,
 				"weight": "22.5 lb",
 				"extended_weight": "22.5 lb"
-			}
+			},
+			"reference_highlight": "Wood"
 		},
 		{
 			"id": "erIHG_oNy3N-8mtKA",
 			"description": "Wood Full Helm",
 			"reference": "LTIA14",
-			"local_notes": "Don: 9 secs; Holdout: -9; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
+			"local_notes": "DR: 3; Don: 9 secs; Holdout: -9; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
 			"tech_level": "0",
 			"tags": [
 				"Full Helm"
@@ -11294,14 +10853,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"face",
 						"skull"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
 					],
 					"amount": 3
 				}
@@ -11312,13 +10865,14 @@
 				"extended_value": 30,
 				"weight": "9 lb",
 				"extended_weight": "9 lb"
-			}
+			},
+			"reference_highlight": "Wood"
 		},
 		{
 			"id": "eiFFxgMBPCmki24Au",
 			"description": "Wood Full Helm, Padded",
 			"reference": "LTIA14",
-			"local_notes": "Don: 9 secs; Holdout: -9; Reaction Pen.-1",
+			"local_notes": "DR: 4; Don: 9 secs; Holdout: -9; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Full Helm"
@@ -11329,14 +10883,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"face",
 						"skull"
-					],
-					"amount": 4
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"face"
 					],
 					"amount": 4
 				}
@@ -11347,13 +10895,14 @@
 				"extended_value": 45,
 				"weight": "10.8 lb",
 				"extended_weight": "10.8 lb"
-			}
+			},
+			"reference_highlight": "Wood"
 		},
 		{
 			"id": "erUX9_wGlTyut4Ut4",
 			"description": "Wood Groin Armor",
 			"reference": "LTIA7",
-			"local_notes": "Don: 3 secs; Holdout: -8; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
+			"local_notes": "DR: 3; Don: 3 secs; Holdout: -8; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
 			"tech_level": "0",
 			"tags": [
 				"Groin Armor"
@@ -11375,13 +10924,14 @@
 				"extended_value": 5,
 				"weight": "1.5 lb",
 				"extended_weight": "1.5 lb"
-			}
+			},
+			"reference_highlight": "Wood"
 		},
 		{
 			"id": "e7mbWAM5FpI8u21CM",
 			"description": "Wood Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "Don: 30 secs; Holdout: -9; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
+			"local_notes": "DR: 3; Don: 30 secs; Holdout: -9; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
 			"tech_level": "0",
 			"tags": [
 				"Limb Armor"
@@ -11403,13 +10953,14 @@
 				"extended_value": 100,
 				"weight": "30 lb",
 				"extended_weight": "30 lb"
-			}
+			},
+			"reference_highlight": "Wood"
 		},
 		{
 			"id": "eZfn53cRkDwwUH58k",
 			"description": "Wood Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "Don: 3 secs; Holdout: -9; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
+			"local_notes": "DR: 3; Don: 3 secs; Holdout: -9; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
 			"tech_level": "0",
 			"tags": [
 				"Neck Armor"
@@ -11431,13 +10982,14 @@
 				"extended_value": 5,
 				"weight": "1.5 lb",
 				"extended_weight": "1.5 lb"
-			}
+			},
+			"reference_highlight": "Wood"
 		},
 		{
 			"id": "ee3XbnV86ynYB5GUV",
 			"description": "Wood Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "Don: 6 secs; Holdout: -9; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
+			"local_notes": "DR: 3; Don: 6 secs; Holdout: -9; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
 			"tech_level": "0",
 			"tags": [
 				"Pot Helm"
@@ -11459,13 +11011,14 @@
 				"extended_value": 20,
 				"weight": "6 lb",
 				"extended_weight": "6 lb"
-			}
+			},
+			"reference_highlight": "Wood"
 		},
 		{
 			"id": "eHTAMmt2o-uUY65T2",
 			"description": "Wood Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "Don: 6 secs; Holdout: -9; Reaction Pen.-1",
+			"local_notes": "DR: 4; Don: 6 secs; Holdout: -9; Reaction Pen.-1",
 			"tech_level": "0",
 			"tags": [
 				"Pot Helm"
@@ -11487,13 +11040,14 @@
 				"extended_value": 30,
 				"weight": "7.2 lb",
 				"extended_weight": "7.2 lb"
-			}
+			},
+			"reference_highlight": "Wood"
 		},
 		{
 			"id": "eXH4Ev7TYnWF90i53",
 			"description": "Wood Torso Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 30 secs; Holdout: -8; Reaction Pen.-2; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
+			"local_notes": "DR: 3; Don: 30 secs; Holdout: -8; Reaction Pen.-2; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor"
@@ -11504,28 +11058,8 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
-						"abdomen"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
+						"abdomen",
 						"torso"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"vitals"
-					],
-					"amount": 3
-				},
-				{
-					"type": "dr_bonus",
-					"locations": [
-						"groin"
 					],
 					"amount": 3
 				}
@@ -11536,7 +11070,8 @@
 				"extended_value": 100,
 				"weight": "30 lb",
 				"extended_weight": "30 lb"
-			}
+			},
+			"reference_highlight": "Wood"
 		}
 	]
 }

--- a/Library/Low Tech/Low Tech Instant Armor.eqp
+++ b/Library/Low Tech/Low Tech Instant Armor.eqp
@@ -6948,6 +6948,22 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 5
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"face"
+					],
+					"specialization": "back crushing",
+					"amount": -1
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
 						"neck",
 						"skull"
 					],
@@ -6988,6 +7004,22 @@
 			"base_value": "315",
 			"base_weight": "7.8 lb",
 			"features": [
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 6
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"face"
+					],
+					"specialization": "back crushing",
+					"amount": -1
+				},
 				{
 					"type": "dr_bonus",
 					"locations": [
@@ -7328,6 +7360,22 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 4
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"face"
+					],
+					"specialization": "back crushing",
+					"amount": -2
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
 						"neck",
 						"skull"
 					],
@@ -7368,6 +7416,22 @@
 			"base_value": "285",
 			"base_weight": "6.3 lb",
 			"features": [
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 5
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"face"
+					],
+					"specialization": "back crushing",
+					"amount": -2
+				},
 				{
 					"type": "dr_bonus",
 					"locations": [
@@ -7714,6 +7778,22 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 5
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"face"
+					],
+					"specialization": "back crushing",
+					"amount": -2
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
 						"neck",
 						"skull"
 					],
@@ -7755,6 +7835,22 @@
 			"base_value": "375",
 			"base_weight": "7.2 lb",
 			"features": [
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 6
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"face"
+					],
+					"specialization": "back crushing",
+					"amount": -2
+				},
 				{
 					"type": "dr_bonus",
 					"locations": [
@@ -8043,6 +8139,14 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 6
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
 						"neck",
 						"skull"
 					],
@@ -8075,6 +8179,14 @@
 			"base_value": "465",
 			"base_weight": "10.8 lb",
 			"features": [
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 7
+				},
 				{
 					"type": "dr_bonus",
 					"locations": [
@@ -8306,6 +8418,22 @@
 				{
 					"type": "dr_bonus",
 					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 3
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"face"
+					],
+					"specialization": "back crushing",
+					"amount": -2
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
 						"neck",
 						"skull"
 					],
@@ -8346,6 +8474,22 @@
 			"base_value": "165",
 			"base_weight": "5.4 lb",
 			"features": [
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"face"
+					],
+					"specialization": "back",
+					"amount": 4
+				},
+				{
+					"type": "dr_bonus",
+					"locations": [
+						"face"
+					],
+					"specialization": "back crushing",
+					"amount": -2
+				},
 				{
 					"type": "dr_bonus",
 					"locations": [

--- a/Library/Low Tech/Low Tech Instant Armor.eqp
+++ b/Library/Low Tech/Low Tech Instant Armor.eqp
@@ -6933,7 +6933,7 @@
 			"description": "Mail and Plates Coif",
 			"reference": "LTIA14",
 			"reference_highlight": "Mail and Plates",
-			"local_notes": "Don: 6 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. crushing.",
+			"local_notes": "Don: 6 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -6976,7 +6976,7 @@
 			"description": "Mail and Plates Coif, Padded",
 			"reference": "LTIA14",
 			"reference_highlight": "Mail and Plates",
-			"local_notes": "Don: 6 secs; Holdout: -4; Reaction Pen.-2; -1 DR vs. crushing.",
+			"local_notes": "Don: 6 secs; Holdout: -4; Reaction Pen.-2",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -7313,7 +7313,7 @@
 			"description": "Mail, Fine Coif",
 			"reference": "LTIA14",
 			"reference_highlight": "Mail, Fine",
-			"local_notes": "Don: 5 secs; Holdout: -3; Reaction Pen.-2; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "Don: 5 secs; Holdout: -3; Reaction Pen.-2; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "2",
 			"tags": [
 				"Coif (Skull + Neck + Back Face)",
@@ -7356,7 +7356,7 @@
 			"description": "Mail, Fine Coif, Padded",
 			"reference": "LTIA14",
 			"reference_highlight": "Mail, Fine",
-			"local_notes": "Don: 5 secs; Holdout: -3; Reaction Pen.-2",
+			"local_notes": "Don: 5 secs; Holdout: -3; Reaction Pen.-2; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "2",
 			"tags": [
 				"Coif (Skull + Neck + Back Face)",
@@ -7698,7 +7698,7 @@
 			"description": "Mail, Heavy Coif",
 			"reference": "LTIA14",
 			"reference_highlight": "Mail, Heavy",
-			"local_notes": "Don: 5 secs; Holdout: -4; Reaction Pen.-2; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "Don: 5 secs; Holdout: -4; Reaction Pen.-2; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -7742,7 +7742,7 @@
 			"description": "Mail, Heavy Coif, Padded",
 			"reference": "LTIA14",
 			"reference_highlight": "Mail, Heavy",
-			"local_notes": "Don: 5 secs; Holdout: -4; Reaction Pen.-2; -2 DR vs. crushing.",
+			"local_notes": "Don: 5 secs; Holdout: -4; Reaction Pen.-2; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -8291,7 +8291,7 @@
 			"description": "Mail, Light Coif",
 			"reference": "LTIA14",
 			"reference_highlight": "Mail, Light",
-			"local_notes": "Don: 5 secs; Holdout: -2; Reaction Pen.-2; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "Don: 5 secs; Holdout: -2; Reaction Pen.-2; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "2",
 			"tags": [
 				"Coif (Skull + Neck + Back Face)",
@@ -8313,6 +8313,10 @@
 				},
 				{
 					"type": "dr_bonus",
+					"locations": [
+						"neck",
+						"skull"
+					],
 					"specialization": "crushing",
 					"amount": -2
 				}
@@ -8330,7 +8334,7 @@
 			"description": "Mail, Light Coif, Padded",
 			"reference": "LTIA14",
 			"reference_highlight": "Mail, Light",
-			"local_notes": "Don: 5 secs; Holdout: -2; Reaction Pen.-2; -2 DR vs. crushing.",
+			"local_notes": "Don: 5 secs; Holdout: -2; Reaction Pen.-2; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "2",
 			"tags": [
 				"Coif (Skull + Neck + Back Face)",

--- a/Library/Low Tech/Low Tech Instant Armor.eqp
+++ b/Library/Low Tech/Low Tech Instant Armor.eqp
@@ -74,9 +74,9 @@
 			"local_notes": "Don: 6 secs; Holdout: -4; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "1",
 			"tags": [
-				"Limbs",
 				"Feet",
-				"Leather"
+				"Leather",
+				"Limbs"
 			],
 			"base_value": "80",
 			"base_weight": "3 lb",
@@ -12213,8 +12213,8 @@
 			"tech_level": "1",
 			"tags": [
 				"Feet",
-				"Limbs",
 				"Leather",
+				"Limbs",
 				"Medium Leather"
 			],
 			"base_value": "45",

--- a/Library/Low Tech/Low Tech Instant Armor.eqp
+++ b/Library/Low Tech/Low Tech Instant Armor.eqp
@@ -1386,7 +1386,7 @@
 			"id": "er3ATQBwPc4AXWcU-",
 			"description": "Cloth, Padded Chest Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 11secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
+			"local_notes": "Don: 11 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor",

--- a/Library/Low Tech/Low Tech Instant Armor.eqp
+++ b/Library/Low Tech/Low Tech Instant Armor.eqp
@@ -5,7 +5,7 @@
 			"id": "eK0vVICVdJg4PfVcP",
 			"description": "Arming Doublet",
 			"reference": "LTIA5",
-			"local_notes": "Don: 15 secs; Holdout: 0; Required for suit of plate. Light mail protects armpits and inside elbows.",
+			"local_notes": "Don: 15 secs; Holdout: 0; Required for suit of plate. Light mail protects armpits and inside elbows",
 			"tech_level": "4",
 			"legality_class": "4",
 			"tags": [
@@ -39,7 +39,7 @@
 			"id": "e6CMStLxGST6IT-W3",
 			"description": "Arming Hose",
 			"reference": "LTIA19",
-			"local_notes": "Don: 15 secs; Holdout: 0; Required for suit of plate. Light mail protects groin and back of knees.",
+			"local_notes": "Don: 15 secs; Holdout: 0; Required for suit of plate. Light mail protects groin and back of knees",
 			"tech_level": "4",
 			"legality_class": "4",
 			"tags": [
@@ -915,7 +915,7 @@
 			"id": "emRv3QKih2dvu3w1P",
 			"description": "Cane Abdomen Armor",
 			"reference": "LTIA6",
-			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433); treat as resistant.",
+			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433), treat as resistant",
 			"tech_level": "0",
 			"tags": [
 				"Abdomen Only Armor",
@@ -947,7 +947,7 @@
 			"id": "e4yOdbY3C6Ta2th6I",
 			"description": "Cane Arm Armor",
 			"reference": "LTIA7",
-			"local_notes": "Don: 15 secs; Holdout: -4; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433); treat as resistant.",
+			"local_notes": "Don: 15 secs; Holdout: -4; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433), treat as resistant",
 			"tech_level": "0",
 			"tags": [
 				"Arms",
@@ -977,7 +977,7 @@
 			"id": "eWRN91wMSfgFHEOCA",
 			"description": "Cane Bascinet",
 			"reference": "LTIA14",
-			"local_notes": "Don: 8 secs; Holdout: -5; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433); treat as resistant.",
+			"local_notes": "Don: 8 secs; Holdout: -5; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433), treat as resistant",
 			"tech_level": "0",
 			"tags": [
 				"Bascinet (Skull + Back Face)",
@@ -1016,7 +1016,7 @@
 			"id": "eE_c-yz5FS0yXCxiX",
 			"description": "Cane Bascinet, Padded",
 			"reference": "LTIA14",
-			"local_notes": "Don: 8 secs; Holdout: -5; Reaction Pen.-1",
+			"local_notes": "Don: 8 secs; Holdout: -5; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433), treat as resistant",
 			"tech_level": "0",
 			"tags": [
 				"Bascinet (Skull + Back Face)",
@@ -1055,7 +1055,7 @@
 			"id": "eobg1Tm37CBN13eUE",
 			"description": "Cane Chest Armor",
 			"reference": "LTIA5",
-			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433); treat as resistant.",
+			"local_notes": "Don: 23 secs; Holdout: -4; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433), treat as resistant",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor",
@@ -1086,7 +1086,7 @@
 			"id": "etVn1-1taVlfhJ88F",
 			"description": "Cane Leg Armor",
 			"reference": "LTIA10",
-			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433); treat as resistant.",
+			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433), treat as resistant",
 			"tech_level": "0",
 			"tags": [
 				"Cane",
@@ -1116,7 +1116,7 @@
 			"id": "enBusL9f1xeI5VP0Z",
 			"description": "Cane Neck Armor",
 			"reference": "LTIA15",
-			"local_notes": "Don: 3 secs; Holdout: -5; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433); treat as resistant.",
+			"local_notes": "Don: 3 secs; Holdout: -5; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433), treat as resistant",
 			"tech_level": "0",
 			"tags": [
 				"Cane",
@@ -1146,7 +1146,7 @@
 			"id": "ei2PivGavZyeZbtMD",
 			"description": "Cane Pot Helm",
 			"reference": "LTIA13",
-			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433); treat as resistant.",
+			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433), treat as resistant",
 			"tech_level": "0",
 			"tags": [
 				"Cane",
@@ -1177,7 +1177,7 @@
 			"id": "e200eWmzf_iU8dDv9",
 			"description": "Cane Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1",
+			"local_notes": "Don: 6 secs; Holdout: -5; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433), treat as resistant",
 			"tech_level": "0",
 			"tags": [
 				"Cane",
@@ -1208,7 +1208,7 @@
 			"id": "eK_Ju4UXUveLhfdPM",
 			"description": "Cane Torso Armor",
 			"reference": "LTIA4",
-			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433); treat as resistant.",
+			"local_notes": "Don: 30 secs; Holdout: -4; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433), treat as resistant",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor",
@@ -1542,7 +1542,7 @@
 			"id": "e0XgEoxlybGM1sxmW",
 			"description": "Cloth, Padded Pot Helm, Padded",
 			"reference": "LTIA13",
-			"local_notes": "Don: 3 secs; Holdout: -1",
+			"local_notes": "Don: 3 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Cloth",
@@ -1608,7 +1608,7 @@
 			"id": "eAGTRRqWt8WZIVwP9",
 			"description": "Gauntlets, Hardened Leather",
 			"reference": "LTIA15",
-			"local_notes": "Don: 10 secs; Holdout: -4; Gives Ham-Fisted 2 (p. B138).",
+			"local_notes": "Don: 10 secs; Holdout: -4; Gives Ham-Fisted 2 (p. B138)",
 			"tech_level": "1",
 			"tags": [
 				"Hands",
@@ -1638,7 +1638,7 @@
 			"id": "eur06_PfX8L-FrAdE",
 			"description": "Gauntlets, Heavy Mail",
 			"reference": "LTIA15",
-			"local_notes": "Don: 10 secs; Holdout: -4; Flexible and susceptible to blunt trauma (p. B379); Gives Ham-Fisted 2 (p. B138).",
+			"local_notes": "Don: 10 secs; Holdout: -4; Flexible and susceptible to blunt trauma (p. B379); Gives Ham-Fisted 2 (p. B138)",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -1678,7 +1678,7 @@
 			"id": "e6hR_7K5Y4ELg8ouw",
 			"description": "Gauntlets, Light Plate",
 			"reference": "LTIA15",
-			"local_notes": "Don: 10 secs; Holdout: -4; Gives Ham-Fisted 2 (p. B138).",
+			"local_notes": "Don: 10 secs; Holdout: -4; Gives Ham-Fisted 2 (p. B138)",
 			"tech_level": "4",
 			"tags": [
 				"Hands",
@@ -1709,7 +1709,7 @@
 			"id": "e1Jc9oibz_7Se4NSl",
 			"description": "Gauntlets, Light Segmented",
 			"reference": "LTIA15",
-			"local_notes": "Don: 10 secs; Holdout: -4; Gives Ham-Fisted 2 (p. B138).",
+			"local_notes": "Don: 10 secs; Holdout: -4; Gives Ham-Fisted 2 (p. B138)",
 			"tech_level": "3",
 			"tags": [
 				"Hands",
@@ -1740,7 +1740,7 @@
 			"id": "eXb29dBeGn2jiLwyd",
 			"description": "Gauntlets, Medium Plate",
 			"reference": "LTIA15",
-			"local_notes": "Don: 10 secs; Holdout: -6; Gives Ham-Fisted 2 (p. B138).",
+			"local_notes": "Don: 10 secs; Holdout: -6; Gives Ham-Fisted 2 (p. B138)",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -1772,7 +1772,7 @@
 			"id": "elLRNlQeA1ZIzjwDY",
 			"description": "Gauntlets, Medium Segmented",
 			"reference": "LTIA15",
-			"local_notes": "Don: 10 secs; Holdout: -5; Gives Ham-Fisted 2 (p. B138).",
+			"local_notes": "Don: 10 secs; Holdout: -5; Gives Ham-Fisted 2 (p. B138)",
 			"tech_level": "3",
 			"tags": [
 				"Hands",
@@ -1803,7 +1803,7 @@
 			"id": "eUyhaqVa7eSPWoDtB",
 			"description": "Gauntlets, Padded Cloth",
 			"reference": "LTIA15",
-			"local_notes": "Don: 10 secs; Holdout: -2; Flexible and susceptible to blunt trauma (p. B379); Gives Ham-Fisted 1 (p. B138).",
+			"local_notes": "Don: 10 secs; Holdout: -2; Flexible and susceptible to blunt trauma (p. B379); Gives Ham-Fisted 1 (p. B138)",
 			"tech_level": "1",
 			"tags": [
 				"Cloth",
@@ -1834,7 +1834,7 @@
 			"id": "eYtckk0_SxXIvwCEl",
 			"description": "Gauntlets, Fine Mail",
 			"reference": "LTIA15",
-			"local_notes": "Don: 10 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); Gives Ham-Fisted 2 (p. B138).",
+			"local_notes": "Don: 10 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); Gives Ham-Fisted 2 (p. B138)",
 			"tech_level": "2",
 			"tags": [
 				"Fine Mail",
@@ -1873,7 +1873,7 @@
 			"id": "e55lxLmwMaK_c-XHw",
 			"description": "Gauntlets, Light Mail",
 			"reference": "LTIA15",
-			"local_notes": "Don: 10 secs; Holdout: -2; Flexible and susceptible to blunt trauma (p. B379); Gives Ham-Fisted 2 (p. B138).",
+			"local_notes": "Don: 10 secs; Holdout: -2; Flexible and susceptible to blunt trauma (p. B379); Gives Ham-Fisted 2 (p. B138)",
 			"tech_level": "2",
 			"tags": [
 				"Hands",
@@ -1912,7 +1912,7 @@
 			"id": "eixxfx23rzXgQ7VXP",
 			"description": "Gauntlets, Light Scale",
 			"reference": "LTIA15",
-			"local_notes": "Don: 10 secs; Holdout: -4; Gives Ham-Fisted 2 (p. B138).",
+			"local_notes": "Don: 10 secs; Holdout: -4; Gives Ham-Fisted 2 (p. B138)",
 			"tech_level": "1",
 			"tags": [
 				"Hands",
@@ -1951,7 +1951,7 @@
 			"id": "e_1tXA6dcIPkbkkIa",
 			"description": "Gloves, Cloth",
 			"reference": "LTIA15",
-			"local_notes": "Don: 10 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379); Protects vs. cold, heat and contact poisons; Gives Bad Grip 1(p.B123); Gives Ham-Fisted 1 (p. B138).",
+			"local_notes": "Don: 10 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379); Protects vs. cold, heat and contact poisons; Gives Bad Grip 1(p.B123); Gives Ham-Fisted 1 (p. B138)",
 			"tech_level": "1",
 			"tags": [
 				"Cloth",
@@ -1989,7 +1989,7 @@
 			"id": "en60StSySCEyH7YVO",
 			"description": "Gloves, Light Leather",
 			"reference": "LTIA15",
-			"local_notes": "Don: 10 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379); Protects vs. cold, heat and contact poisons; Gives Bad Grip 1(p.B123); Gives Ham-Fisted 1 (p. B138).",
+			"local_notes": "Don: 10 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379); Protects vs. cold, heat and contact poisons; Gives Bad Grip 1(p.B123); Gives Ham-Fisted 1 (p. B138)",
 			"tech_level": "1",
 			"tags": [
 				"Hands",
@@ -3282,7 +3282,7 @@
 			"description": "Jack of Plates Chest Armor",
 			"reference": "LTIA6",
 			"reference_highlight": "Jack of Plates",
-			"local_notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
+			"local_notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-2",
 			"tech_level": "2",
 			"tags": [
 				"Body Armor",
@@ -3400,7 +3400,7 @@
 			"description": "Jack of Plates Torso Armor",
 			"reference": "LTIA5",
 			"reference_highlight": "Jack of Plates",
-			"local_notes": "Don: 30 secs; Holdout: -3; Reaction Pen.-2; -1 DR vs. crushing.",
+			"local_notes": "Don: 30 secs; Holdout: -3; Reaction Pen.-2",
 			"tech_level": "2",
 			"tags": [
 				"Body Armor",
@@ -3950,7 +3950,7 @@
 			"description": "Layered Cloth, Light Pot Helm, Padded",
 			"reference": "LTIA13",
 			"reference_highlight": "Layered Cloth, Light",
-			"local_notes": "Don: 4 secs; Holdout: -1; Reaction Pen.-1",
+			"local_notes": "Don: 4 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
 			"tags": [
 				"Head (Skull + Face + Neck)",
@@ -4900,7 +4900,7 @@
 			"description": "Layered Leather, Light Pot Helm, Padded",
 			"reference": "LTIA13",
 			"reference_highlight": "Layered Leather, Light",
-			"local_notes": "Don: 4 secs; Holdout: -2; Reaction Pen.-1",
+			"local_notes": "Don: 4 secs; Holdout: -2; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "1",
 			"tags": [
 				"Head (Skull + Face + Neck)",
@@ -7682,7 +7682,7 @@
 			"description": "Mail, Heavy Arm Armor",
 			"reference": "LTIA8",
 			"reference_highlight": "Mail, Heavy",
-			"local_notes": "Don: 8 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379);",
+			"local_notes": "Don: 8 secs; Holdout: -3; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "2",
 			"legality_class": "3",
 			"tags": [
@@ -8057,7 +8057,7 @@
 			"description": "Mail, Jousting Abdomen Armor",
 			"reference": "LTIA6",
 			"reference_highlight": "Mail, Jousting",
-			"local_notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-2; Gives -1 DX, except for Lance skill.",
+			"local_notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-2; Gives -1 DX, except for Lance skill",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -8092,7 +8092,7 @@
 			"description": "Mail, Jousting Chest Armor",
 			"reference": "LTIA6",
 			"reference_highlight": "Mail, Jousting",
-			"local_notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-2; Gives -1 DX, except for Lance skill.",
+			"local_notes": "Don: 23 secs; Holdout: -3; Reaction Pen.-2; Gives -1 DX, except for Lance skill",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -8126,7 +8126,7 @@
 			"description": "Mail, Jousting Coif",
 			"reference": "LTIA14",
 			"reference_highlight": "Mail, Jousting",
-			"local_notes": "Don: 9 secs; Holdout: -4; Reaction Pen.-2; Gives -1 DX, except for Lance skill.",
+			"local_notes": "Don: 9 secs; Holdout: -4; Reaction Pen.-2; Gives -1 DX, except for Lance skill",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -8169,7 +8169,7 @@
 			"description": "Mail, Jousting Coif, Padded",
 			"reference": "LTIA14",
 			"reference_highlight": "Mail, Jousting",
-			"local_notes": "Don: 9 secs; Holdout: -4; Reaction Pen.-2; Gives -1 DX, except for Lance skill.",
+			"local_notes": "Don: 9 secs; Holdout: -4; Reaction Pen.-2; Gives -1 DX, except for Lance skill",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -8212,7 +8212,7 @@
 			"description": "Mail, Jousting Groin Armor",
 			"reference": "LTIA7",
 			"reference_highlight": "Mail, Jousting",
-			"local_notes": "Don: 3 secs; Holdout: -3; Reaction Pen.-1; Gives -1 DX, except for Lance skill.",
+			"local_notes": "Don: 3 secs; Holdout: -3; Reaction Pen.-1; Gives -1 DX, except for Lance skill",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -8245,7 +8245,7 @@
 			"description": "Mail, Jousting Torso Armor",
 			"reference": "LTIA5",
 			"reference_highlight": "Mail, Jousting",
-			"local_notes": "Don: 30 secs; Holdout: -3; Reaction Pen.-2; Gives -1 DX, except for Lance skill.",
+			"local_notes": "Don: 30 secs; Holdout: -3; Reaction Pen.-2; Gives -1 DX, except for Lance skill",
 			"tech_level": "3",
 			"legality_class": "3",
 			"tags": [
@@ -8325,7 +8325,7 @@
 			"description": "Mail, Light Arm Armor",
 			"reference": "LTIA7",
 			"reference_highlight": "Mail, Light",
-			"local_notes": "Don: 8 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379); -2 DR vs. crushing.",
+			"local_notes": "Don: 8 secs; Holdout: -1; Reaction Pen.-1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "2",
 			"tags": [
 				"Arms",
@@ -8691,7 +8691,7 @@
 			"id": "eJZyW8py6OBUqMrwN",
 			"description": "Mittens",
 			"reference": "LTIA15",
-			"local_notes": "Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); Protects vs. cold, heat and contact poisons; Gives Bad Grip 1(p.B123); Gives Ham-Fisted 2 (p. B138).",
+			"local_notes": "Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); Protects vs. cold, heat and contact poisons; Gives Bad Grip 1(p.B123); Gives Ham-Fisted 2 (p. B138)",
 			"tech_level": "0",
 			"tags": [
 				"Hands",
@@ -8729,7 +8729,7 @@
 			"id": "eAVm_WBOK8kNRrPbc",
 			"description": "Mittens, Padded Cloth",
 			"reference": "LTIA15",
-			"local_notes": "Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); Protects vs. cold, heat and contact poisons; Gives Bad Grip 1(p.B123); Gives Ham-Fisted 2 (p. B138).",
+			"local_notes": "Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); Protects vs. cold, heat and contact poisons; Gives Bad Grip 1(p.B123); Gives Ham-Fisted 2 (p. B138)",
 			"tech_level": "1",
 			"tags": [
 				"Cloth",
@@ -8835,7 +8835,7 @@
 			"description": "Paper, Proofed Chest Armor",
 			"reference": "LTIA6",
 			"reference_highlight": "Paper, Proofed",
-			"local_notes": "Don: 15 secs; Holdout: -6; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433); treat as resistant.",
+			"local_notes": "Don: 15 secs; Holdout: -6; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433), treat as resistant",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -8867,7 +8867,7 @@
 			"description": "Paper, Proofed Pot Helm",
 			"reference": "LTIA13",
 			"reference_highlight": "Paper, Proofed",
-			"local_notes": "Don: 4 secs; Holdout: -7; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433); treat as resistant.",
+			"local_notes": "Don: 4 secs; Holdout: -7; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433), treat as resistant",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -8899,7 +8899,7 @@
 			"description": "Paper, Proofed Pot Helm, Padded",
 			"reference": "LTIA13",
 			"reference_highlight": "Paper, Proofed",
-			"local_notes": "Don: 4 secs; Holdout: -7; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433); treat as resistant.",
+			"local_notes": "Don: 4 secs; Holdout: -7; Reaction Pen.-1; Combustible. See Making Things Burn (p. B433), treat as resistant",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -8931,7 +8931,7 @@
 			"description": "Paper, Proofed Torso Armor",
 			"reference": "LTIA5",
 			"reference_highlight": "Paper, Proofed",
-			"local_notes": "Don: 20 secs; Holdout: -6; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433); treat as resistant.",
+			"local_notes": "Don: 20 secs; Holdout: -6; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433), treat as resistant",
 			"tech_level": "4",
 			"legality_class": "3",
 			"tags": [
@@ -12403,7 +12403,7 @@
 			"description": "Straw Chest Armor",
 			"reference": "LTIA5",
 			"reference_highlight": "Straw",
-			"local_notes": "Don: 23 secs; Holdout: -9; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433); treat as resistant.",
+			"local_notes": "Don: 23 secs; Holdout: -9; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433), treat as resistant",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor",
@@ -12435,7 +12435,7 @@
 			"description": "Straw Torso Armor",
 			"reference": "LTIA5",
 			"reference_highlight": "Straw",
-			"local_notes": "Don: 30 secs; Holdout: -9; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433); treat as resistant.",
+			"local_notes": "Don: 30 secs; Holdout: -9; Reaction Pen.-2; Combustible. See Making Things Burn (p. B433), treat as resistant",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor",
@@ -12469,7 +12469,7 @@
 			"description": "Wood Abdomen Armor",
 			"reference": "LTIA6",
 			"reference_highlight": "Wood",
-			"local_notes": "Don: 23 secs; Holdout: -8; Reaction Pen.-2; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
+			"local_notes": "Don: 23 secs; Holdout: -8; Reaction Pen.-2; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47)",
 			"tech_level": "0",
 			"tags": [
 				"Abdomen Only Armor",
@@ -12502,7 +12502,7 @@
 			"description": "Wood Arm Armor",
 			"reference": "LTIA7",
 			"reference_highlight": "Wood",
-			"local_notes": "Don: 15 secs; Holdout: -8; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
+			"local_notes": "Don: 15 secs; Holdout: -8; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47)",
 			"tech_level": "0",
 			"tags": [
 				"Arms",
@@ -12533,7 +12533,7 @@
 			"description": "Wood Bascinet",
 			"reference": "LTIA14",
 			"reference_highlight": "Wood",
-			"local_notes": "Don: 8 secs; Holdout: -9; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
+			"local_notes": "Don: 8 secs; Holdout: -9; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47)",
 			"tech_level": "0",
 			"tags": [
 				"Bascinet (Skull + Back Face)",
@@ -12573,7 +12573,7 @@
 			"description": "Wood Bascinet, Padded",
 			"reference": "LTIA14",
 			"reference_highlight": "Wood",
-			"local_notes": "Don: 8 secs; Holdout: -9; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
+			"local_notes": "Don: 8 secs; Holdout: -9; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47)",
 			"tech_level": "0",
 			"tags": [
 				"Bascinet (Skull + Back Face)",
@@ -12613,7 +12613,7 @@
 			"description": "Wood Chest Armor",
 			"reference": "LTIA5",
 			"reference_highlight": "Wood",
-			"local_notes": "Don: 23 secs; Holdout: -8; Reaction Pen.-2; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
+			"local_notes": "Don: 23 secs; Holdout: -8; Reaction Pen.-2; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47)",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor",
@@ -12645,7 +12645,7 @@
 			"description": "Wood Full Helm",
 			"reference": "LTIA14",
 			"reference_highlight": "Wood",
-			"local_notes": "Don: 9 secs; Holdout: -9; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
+			"local_notes": "Don: 9 secs; Holdout: -9; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47)",
 			"tech_level": "0",
 			"tags": [
 				"Full Helms (Skull + Face)",
@@ -12678,7 +12678,7 @@
 			"description": "Wood Full Helm, Padded",
 			"reference": "LTIA14",
 			"reference_highlight": "Wood",
-			"local_notes": "Don: 9 secs; Holdout: -9; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
+			"local_notes": "Don: 9 secs; Holdout: -9; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47)",
 			"tech_level": "0",
 			"tags": [
 				"Full Helms (Skull + Face)",
@@ -12711,7 +12711,7 @@
 			"description": "Wood Groin Armor",
 			"reference": "LTIA7",
 			"reference_highlight": "Wood",
-			"local_notes": "Don: 3 secs; Holdout: -8; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
+			"local_notes": "Don: 3 secs; Holdout: -8; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47)",
 			"tech_level": "0",
 			"tags": [
 				"Groin Only",
@@ -12742,7 +12742,7 @@
 			"description": "Wood Leg Armor",
 			"reference": "LTIA10",
 			"reference_highlight": "Wood",
-			"local_notes": "Don: 30 secs; Holdout: -9; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
+			"local_notes": "Don: 30 secs; Holdout: -9; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47)",
 			"tech_level": "0",
 			"tags": [
 				"Legs",
@@ -12773,7 +12773,7 @@
 			"description": "Wood Neck Armor",
 			"reference": "LTIA15",
 			"reference_highlight": "Wood",
-			"local_notes": "Don: 3 secs; Holdout: -9; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
+			"local_notes": "Don: 3 secs; Holdout: -9; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47)",
 			"tech_level": "0",
 			"tags": [
 				"Head (Skull + Face + Neck)",
@@ -12804,7 +12804,7 @@
 			"description": "Wood Pot Helm",
 			"reference": "LTIA13",
 			"reference_highlight": "Wood",
-			"local_notes": "Don: 6 secs; Holdout: -9; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
+			"local_notes": "Don: 6 secs; Holdout: -9; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47)",
 			"tech_level": "0",
 			"tags": [
 				"Head (Skull + Face + Neck)",
@@ -12836,7 +12836,7 @@
 			"description": "Wood Pot Helm, Padded",
 			"reference": "LTIA13",
 			"reference_highlight": "Wood",
-			"local_notes": "Don: 6 secs; Holdout: -9; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
+			"local_notes": "Don: 6 secs; Holdout: -9; Reaction Pen.-1; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47)",
 			"tech_level": "0",
 			"tags": [
 				"Head (Skull + Face + Neck)",
@@ -12868,7 +12868,7 @@
 			"description": "Wood Torso Armor",
 			"reference": "LTIA5",
 			"reference_highlight": "Wood",
-			"local_notes": "Don: 30 secs; Holdout: -8; Reaction Pen.-2; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47).",
+			"local_notes": "Don: 30 secs; Holdout: -8; Reaction Pen.-2; Semi-ablative. Loses 1 DR per 10 points of basic damage it resists (see p. B47)",
 			"tech_level": "0",
 			"tags": [
 				"Body Armor",

--- a/Library/Low Tech/Low Tech Instant Armor.eqp
+++ b/Library/Low Tech/Low Tech Instant Armor.eqp
@@ -69,7 +69,7 @@
 		},
 		{
 			"id": "e8lwgtkMSuZ5kldYB",
-			"description": "Boots, Leather ",
+			"description": "Boots, Leather",
 			"reference": "LTIA16",
 			"local_notes": "Don: 6 secs; Holdout: -4; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "1",
@@ -107,7 +107,7 @@
 		},
 		{
 			"id": "edcVYnWCsEfIfsJWy",
-			"description": "Boots, Light Leather ",
+			"description": "Boots, Light Leather",
 			"reference": "LTIA16",
 			"local_notes": "Don: 6 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "1",
@@ -8762,7 +8762,7 @@
 		},
 		{
 			"id": "e2Oo1VPjY4Qqt622p",
-			"description": "Moccasins ",
+			"description": "Moccasins",
 			"reference": "LTIA16",
 			"local_notes": "Don: 6 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
@@ -8801,7 +8801,7 @@
 		},
 		{
 			"id": "eGJEpXOubDzKed8ZB",
-			"description": "Mukluks ",
+			"description": "Mukluks",
 			"reference": "LTIA16",
 			"local_notes": "Don: 6 secs; Holdout: -5; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
@@ -10230,7 +10230,7 @@
 		},
 		{
 			"id": "ecX489d3HkDaxCgzV",
-			"description": "Sabatons, Light Plate ",
+			"description": "Sabatons, Light Plate",
 			"reference": "LTIA16",
 			"local_notes": "Don: 10 secs; Holdout: -4",
 			"tech_level": "4",
@@ -10261,7 +10261,7 @@
 		},
 		{
 			"id": "euszDR29gjpuJCuGx",
-			"description": "Sabatons, Light Segmented ",
+			"description": "Sabatons, Light Segmented",
 			"reference": "LTIA16",
 			"local_notes": "Don: 10 secs; Holdout: -4",
 			"tech_level": "3",
@@ -10292,7 +10292,7 @@
 		},
 		{
 			"id": "efZ1g8nFsdzNr9dsR",
-			"description": "Sabatons, Medium Plate ",
+			"description": "Sabatons, Medium Plate",
 			"reference": "LTIA16",
 			"local_notes": "Don: 10 secs; Holdout: -6",
 			"tech_level": "4",
@@ -10324,7 +10324,7 @@
 		},
 		{
 			"id": "eQSlhhXKSGEOEYR6K",
-			"description": "Sabatons, Medium Segmented ",
+			"description": "Sabatons, Medium Segmented",
 			"reference": "LTIA16",
 			"local_notes": "Don: 10 secs; Holdout: -5",
 			"tech_level": "3",
@@ -10356,7 +10356,7 @@
 		},
 		{
 			"id": "eHeqzBzX8BvvEYC4T",
-			"description": "Sandals ",
+			"description": "Sandals",
 			"reference": "LTIA16",
 			"local_notes": "Don: 10 secs; Holdout: -2; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
@@ -10387,7 +10387,7 @@
 		},
 		{
 			"id": "eluvVD7j_wcbJxlCb",
-			"description": "Sandals, Hobnailed ",
+			"description": "Sandals, Hobnailed",
 			"reference": "LTIA16",
 			"local_notes": "Don: 10 secs; Holdout: -2; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "1",
@@ -12121,7 +12121,7 @@
 		},
 		{
 			"id": "eDBbcETSyRQ1HZJFH",
-			"description": "Shoes ",
+			"description": "Shoes",
 			"reference": "LTIA16",
 			"local_notes": "Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "1",
@@ -12159,7 +12159,7 @@
 		},
 		{
 			"id": "eEVj7rSYpu5Jt4-yF",
-			"description": "Shoes, Hobnailed ",
+			"description": "Shoes, Hobnailed",
 			"reference": "LTIA16",
 			"local_notes": "Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "1",
@@ -12207,7 +12207,7 @@
 		},
 		{
 			"id": "eJhyyjnFo7KmWVJTd",
-			"description": "Shoes, Medium Leather ",
+			"description": "Shoes, Medium Leather",
 			"reference": "LTIA16",
 			"local_notes": "Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "1",
@@ -12246,7 +12246,7 @@
 		},
 		{
 			"id": "e5oPk4D93B4R-kmaI",
-			"description": "Sollerets, Fine Mail ",
+			"description": "Sollerets, Fine Mail",
 			"reference": "LTIA16",
 			"local_notes": " Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "2",
@@ -12286,7 +12286,7 @@
 		},
 		{
 			"id": "eP-s_FvhbTPwA79h5",
-			"description": "Sollerets, Heavy Mail ",
+			"description": "Sollerets, Heavy Mail",
 			"reference": "LTIA16",
 			"local_notes": "Don: 6 secs; Holdout: -4; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "2",
@@ -12326,7 +12326,7 @@
 		},
 		{
 			"id": "evSioPxb1AeVS_V4J",
-			"description": "Sollerets, Light Mail ",
+			"description": "Sollerets, Light Mail",
 			"reference": "LTIA16",
 			"local_notes": "Don: 6 secs; Holdout: -2; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "2",
@@ -12365,7 +12365,7 @@
 		},
 		{
 			"id": "ea8f_-UbJnObc_qCO",
-			"description": "Sollerets, Light Scale ",
+			"description": "Sollerets, Light Scale",
 			"reference": "LTIA16",
 			"local_notes": "Don: 10 secs; Holdout: -4",
 			"tech_level": "1",

--- a/Library/Low Tech/Low Tech Instant Armor.eqp
+++ b/Library/Low Tech/Low Tech Instant Armor.eqp
@@ -7,7 +7,7 @@
 			"reference": "LTIA5",
 			"local_notes": "Don: 15 secs; Holdout: 0; Required for suit of plate. Light mail protects armpits and inside elbows.",
 			"tech_level": "4",
-			"legality_class": "5",
+			"legality_class": "4",
 			"tags": [
 				"Arming Garments",
 				"Body Armor",
@@ -111,7 +111,6 @@
 			"reference": "LTIA16",
 			"local_notes": "Don: 6 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "1",
-			"legality_class": "5",
 			"tags": [
 				"Feet",
 				"Leather",
@@ -1954,7 +1953,6 @@
 			"reference": "LTIA15",
 			"local_notes": "Don: 10 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379); Protects vs. cold, heat and contact poisons; Gives Bad Grip 1(p.B123); Gives Ham-Fisted 1 (p. B138).",
 			"tech_level": "1",
-			"legality_class": "5",
 			"tags": [
 				"Cloth",
 				"Hands",
@@ -1993,7 +1991,6 @@
 			"reference": "LTIA15",
 			"local_notes": "Don: 10 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379); Protects vs. cold, heat and contact poisons; Gives Bad Grip 1(p.B123); Gives Ham-Fisted 1 (p. B138).",
 			"tech_level": "1",
-			"legality_class": "5",
 			"tags": [
 				"Hands",
 				"Leather",
@@ -5840,7 +5837,7 @@
 			"reference_highlight": "Leather, Light",
 			"local_notes": "Don: 23 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
-			"legality_class": "5",
+			"legality_class": "4",
 			"tags": [
 				"Abdomen Only Armor",
 				"Body Armor",
@@ -5885,7 +5882,7 @@
 			"reference_highlight": "Leather, Light",
 			"local_notes": "Don: 15 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
-			"legality_class": "5",
+			"legality_class": "4",
 			"tags": [
 				"Arms",
 				"Leather",
@@ -5926,7 +5923,7 @@
 			"reference_highlight": "Leather, Light",
 			"local_notes": "Don: 8 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
-			"legality_class": "5",
+			"legality_class": "4",
 			"tags": [
 				"Bascinet (Skull + Back Face)",
 				"Head (Skull + Face + Neck)",
@@ -5984,7 +5981,7 @@
 			"reference_highlight": "Leather, Light",
 			"local_notes": "Don: 8 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
-			"legality_class": "5",
+			"legality_class": "4",
 			"tags": [
 				"Bascinet (Skull + Back Face)",
 				"Head (Skull + Face + Neck)",
@@ -6042,7 +6039,7 @@
 			"reference_highlight": "Leather, Light",
 			"local_notes": "Don: 23 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
-			"legality_class": "5",
+			"legality_class": "4",
 			"tags": [
 				"Body Armor",
 				"Chest Only Armor",
@@ -6084,7 +6081,7 @@
 			"reference_highlight": "Leather, Light",
 			"local_notes": "Don: 3 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
-			"legality_class": "5",
+			"legality_class": "4",
 			"tags": [
 				"Groin Only",
 				"Leather",
@@ -6125,7 +6122,7 @@
 			"reference_highlight": "Leather, Light",
 			"local_notes": "Don: 30 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
-			"legality_class": "5",
+			"legality_class": "4",
 			"tags": [
 				"Leather",
 				"Legs",
@@ -6166,7 +6163,7 @@
 			"reference_highlight": "Leather, Light",
 			"local_notes": "Don: 3 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
-			"legality_class": "5",
+			"legality_class": "4",
 			"tags": [
 				"Head (Skull + Face + Neck)",
 				"Leather",
@@ -6207,7 +6204,7 @@
 			"reference_highlight": "Leather, Light",
 			"local_notes": "Don: 6 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
-			"legality_class": "5",
+			"legality_class": "4",
 			"tags": [
 				"Head (Skull + Face + Neck)",
 				"Leather",
@@ -6249,7 +6246,7 @@
 			"reference_highlight": "Leather, Light",
 			"local_notes": "Don: 6 secs; Holdout: -1; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
-			"legality_class": "5",
+			"legality_class": "4",
 			"tags": [
 				"Head (Skull + Face + Neck)",
 				"Leather",
@@ -6291,7 +6288,7 @@
 			"reference_highlight": "Leather, Light",
 			"local_notes": "Don: 30 secs; Holdout: 0; Flexible and susceptible to blunt trauma (p. B379)",
 			"tech_level": "0",
-			"legality_class": "5",
+			"legality_class": "4",
 			"tags": [
 				"Body Armor",
 				"Leather",
@@ -8696,7 +8693,6 @@
 			"reference": "LTIA15",
 			"local_notes": "Don: 6 secs; Holdout: -3; Flexible and susceptible to blunt trauma (p. B379); Protects vs. cold, heat and contact poisons; Gives Bad Grip 1(p.B123); Gives Ham-Fisted 2 (p. B138).",
 			"tech_level": "0",
-			"legality_class": "5",
 			"tags": [
 				"Hands",
 				"Limbs",


### PR DESCRIPTION
This includes the following changes submitted by Teragen on Discord:
* Equipment is categorised using equipment containers. They are split by either type or by coverage, and then type and coverage subdivide by the various types or hit locations.
* Split DR is encoded into the "DR bonus" feature, instead of being purely based on notes.
* Some missing equipment from Instant Armor (like the Arming Doublet) have been added too.

I have made the following changes to that submission:
* Deleted stray source library references that came from the submitted file being created inside the user library.
* For any items that had their IDs changed, I changed them back.
* Because listing items in two different ways means duplicating them, I added source library references to the duplicate items referring to the originals. GCS currently doesn't seem to sync the items together if they both exist in the same library - which unfortunately means that altering the source item doesn't let it be automatically synced to the duplicate one - but since the source library information points to the original, once it's added to any other file, it can correctly pull changes from the original.