### PR TITLE
Pyramid 65: Automated Natural Weapons customization, mostly, and added Sample Abilities.

### DIFF
--- a/Library/Pyramid Magazine/Pyramid 65/Pyramid 65 Traits.adq
+++ b/Library/Pyramid Magazine/Pyramid 65/Pyramid 65 Traits.adq
@@ -6768,21 +6768,21 @@
 					],
 					"modifiers": [
 						{
-							"id": "mGQr_ssihpiE1IgZ9",
+							"id": "mG9ORvJgauGwk2Ze4",
 							"name": "Destructive Parry",
 							"reference": "PY65:24",
 							"cost_adj": "40%",
 							"disabled": true
 						},
 						{
-							"id": "md7yBFhroa-sefT_R",
+							"id": "m8PD4VCJ1qWq6ZF6V",
 							"name": "Disarming",
 							"reference": "PY65:24",
 							"cost_adj": "20%",
 							"disabled": true
 						},
 						{
-							"id": "mp3ybOqiNvjTA_gxL",
+							"id": "m4IeSAsV30toCsCBu",
 							"name": "Extra Damage Type",
 							"reference": "PY65:24",
 							"local_notes": "***Apply manually!***",
@@ -6790,7 +6790,7 @@
 							"disabled": true
 						},
 						{
-							"id": "mXmydZ_rt0wzzyCuf",
+							"id": "mX4BH2vGzuvHaNMjp",
 							"name": "Extra Reach",
 							"reference": "PY65:24",
 							"reference_highlight": "Changing reach from C to 1 is free.",
@@ -6823,7 +6823,7 @@
 							"disabled": true
 						},
 						{
-							"id": "mJQxWeJHs3aExjQ2i",
+							"id": "m5srRVOAzz26MQshj",
 							"name": "Extra Reach",
 							"reference": "PY65:24",
 							"local_notes": "At max reach only",
@@ -6881,7 +6881,7 @@
 							"disabled": true
 						},
 						{
-							"id": "m5ZIgSdcU1j37bX2L",
+							"id": "m9qqM0NZA5g_xbDTj",
 							"name": "Extra Reach",
 							"reference": "PY65:24",
 							"local_notes": "Any reach",
@@ -6904,7 +6904,7 @@
 							"disabled": true
 						},
 						{
-							"id": "m6vxrYwZXgqiiUxmf",
+							"id": "mEju3uivoV6siLfxn",
 							"name": "Extra Reach",
 							"reference": "PY65:24",
 							"local_notes": "Requires Ready",
@@ -6940,7 +6940,7 @@
 							"disabled": true
 						},
 						{
-							"id": "mB7IrWe8xKBKsCXrT",
+							"id": "mSyJbJN7OHYe6Vq8z",
 							"name": "Flexible",
 							"reference": "PY65:24",
 							"local_notes": "Whip-like",
@@ -6948,7 +6948,7 @@
 							"disabled": true
 						},
 						{
-							"id": "m7bbUoQuvwGehNhBU",
+							"id": "mc9pRlAFYtfThBaiP",
 							"name": "Flexible",
 							"reference": "PY65:24",
 							"local_notes": "Flail-like",
@@ -6956,7 +6956,7 @@
 							"disabled": true
 						},
 						{
-							"id": "mrCOmUX8s3np-D2-w",
+							"id": "mW7wS3mu3GurbUi7X",
 							"name": "Good Defense +1",
 							"reference": "PY65:24",
 							"cost_adj": "30%",
@@ -6976,7 +6976,7 @@
 							"disabled": true
 						},
 						{
-							"id": "mKzpCpfOf1m1dbbVY",
+							"id": "m23qpFxlckE1voRJU",
 							"name": "Good Defense +2",
 							"reference": "PY65:24",
 							"cost_adj": "60%",
@@ -6996,7 +6996,7 @@
 							"disabled": true
 						},
 						{
-							"id": "mEEaCfHbt3LKGqxrf",
+							"id": "mim0OZ8SoRh-_7cxx",
 							"name": "Heavy",
 							"reference": "PY65:24",
 							"cost_adj": "10%",
@@ -7004,14 +7004,14 @@
 							"disabled": true
 						},
 						{
-							"id": "mQe_3P79cMYWa2XtT",
+							"id": "mNgIBsSslb5RHfDqo",
 							"name": "Hidden",
 							"reference": "PY65:24",
 							"cost_adj": "20%",
 							"disabled": true
 						},
 						{
-							"id": "mVBBPYb3aJxqkxe7e",
+							"id": "m6JwoyzNCQhoQn8N2",
 							"name": "Increased Damage",
 							"reference": "PY65:24",
 							"cost_adj": "30%",
@@ -7033,7 +7033,7 @@
 							"disabled": true
 						},
 						{
-							"id": "mwd7Dsc9W2-NVYzA8",
+							"id": "mlcQ22VLh4pUuP4Mv",
 							"name": "Increased Damage",
 							"reference": "PY65:24",
 							"local_notes": "per die",
@@ -7057,7 +7057,7 @@
 							"disabled": true
 						},
 						{
-							"id": "m7_CYKW0ZhZWLiqGf",
+							"id": "mV0MBo9gfH-3Dw8RO",
 							"name": "Intangible",
 							"reference": "PY65:24",
 							"local_notes": "Diffuse",
@@ -7068,21 +7068,21 @@
 							"disabled": true
 						},
 						{
-							"id": "m8ZYZ-NARHI2zVEIv",
+							"id": "mWTdb5fKd9HPGwf0_",
 							"name": "Projected",
 							"reference": "PY65:25",
 							"cost_adj": "50%",
 							"disabled": true
 						},
 						{
-							"id": "m_3cKEiYIUmv96wMa",
+							"id": "mQoaCsicA6Us445AF",
 							"name": "Ranged",
 							"reference": "PY65:25",
 							"cost_adj": "100%",
 							"disabled": true
 						},
 						{
-							"id": "mrL1mpvyi-j7FOmud",
+							"id": "mKmYUw-X3JTYO0SPz",
 							"name": "Resilient",
 							"reference": "PY65:25",
 							"local_notes": "Fine",
@@ -7093,7 +7093,7 @@
 							"disabled": true
 						},
 						{
-							"id": "mfb8EqVrvNAZVN3Ao",
+							"id": "ms5mADca5_hQi84Pj",
 							"name": "Resilient",
 							"reference": "PY65:25",
 							"local_notes": "Very Fine",
@@ -7104,7 +7104,7 @@
 							"disabled": true
 						},
 						{
-							"id": "m3C9mXfDV3yQk5pPa",
+							"id": "mfFf0y5JPVBMFXKXV",
 							"name": "Resilient",
 							"reference": "PY65:25",
 							"local_notes": "Unbreakable",
@@ -7115,7 +7115,7 @@
 							"disabled": true
 						},
 						{
-							"id": "mfGY7LDJc4XoLtkek",
+							"id": "m2NPSgQcwrmayG4fs",
 							"name": "Swing-Capable",
 							"reference": "PY65:25",
 							"local_notes": "Swing only",
@@ -7123,7 +7123,7 @@
 							"disabled": true
 						},
 						{
-							"id": "mlb4BL3wgCEXKLKJt",
+							"id": "m3loRm_lQ83Uyn3s2",
 							"name": "Swing-Capable",
 							"reference": "PY65:25",
 							"local_notes": "Swing \u0026 Thrust",
@@ -7131,7 +7131,7 @@
 							"disabled": true
 						},
 						{
-							"id": "mWwujK7naQYXIt1aT",
+							"id": "m6Lh-jqUYR64puKV5",
 							"name": "Swing-Capable",
 							"reference": "PY65:25",
 							"local_notes": "per Extra Damage Type",
@@ -7140,7 +7140,7 @@
 							"disabled": true
 						},
 						{
-							"id": "mAc_gSASEQ2WpZZmV",
+							"id": "mcGlYcF8udsHQgzti",
 							"name": "Cannot Parry",
 							"reference": "PY65:25",
 							"cost_adj": "-40%",
@@ -7161,7 +7161,7 @@
 							"disabled": true
 						},
 						{
-							"id": "mbjUo_D_dKOTJMXHJ",
+							"id": "mlpmZOjDxwpRUxg8v",
 							"name": "Fragile",
 							"reference": "PY65:25",
 							"local_notes": "Cheap",
@@ -7172,7 +7172,7 @@
 							"disabled": true
 						},
 						{
-							"id": "mgFU80tKjhEGgq_2T",
+							"id": "mKoMmYybIA5Q_4SOV",
 							"name": "Light",
 							"reference": "PY65:25",
 							"cost_adj": "-5%",
@@ -7180,7 +7180,7 @@
 							"disabled": true
 						},
 						{
-							"id": "msstqhCuKCFJnG6Z-",
+							"id": "m2vSJYgkxulXly0p1",
 							"name": "Poor Defense",
 							"reference": "PY65:25",
 							"cost_adj": "-20%",
@@ -7200,29 +7200,7 @@
 							"disabled": true
 						},
 						{
-							"id": "mrUVfxmBjeVjpVwgM",
-							"name": "Reduced Damage",
-							"reference": "PY65:25",
-							"cost_adj": "-30%",
-							"features": [
-								{
-									"type": "weapon_bonus",
-									"selection_type": "weapons_with_required_skill",
-									"name": {
-										"compare": "is",
-										"qualifier": "Punch"
-									},
-									"level": {
-										"compare": "at_least"
-									},
-									"amount": -1
-								}
-							],
-							"levels": 1,
-							"disabled": true
-						},
-						{
-							"id": "msihi-GVLgyg0q8Lw",
+							"id": "m_eU1ELcQ1hP3itoa",
 							"name": "Reduced Damage -1",
 							"reference": "PY65:25",
 							"cost_adj": "-30%",
@@ -7244,7 +7222,7 @@
 							"disabled": true
 						},
 						{
-							"id": "mSoKQIrmPLQ_lI6Hs",
+							"id": "mQ5bb-VKjMTNSn2n9",
 							"name": "Reduced Damage -2",
 							"reference": "PY65:25",
 							"cost_adj": "-60%",
@@ -7266,14 +7244,14 @@
 							"disabled": true
 						},
 						{
-							"id": "m95Qk3TxZT1E2vAiu",
+							"id": "mQNaWfRTkVTioNTQy",
 							"name": "Single",
 							"reference": "PY65:25",
 							"cost_adj": "-20%",
 							"disabled": true
 						},
 						{
-							"id": "mLh07XFGppKzXWzGj",
+							"id": "m1pANFYi5nkJ8x2MY",
 							"name": "Two-Handed",
 							"reference": "PY65:25",
 							"cost_adj": "-20%",
@@ -7307,7 +7285,7 @@
 							"disabled": true
 						},
 						{
-							"id": "mI1QlKFJlma00D6qn",
+							"id": "mtuR2qwIIVjckUp-G",
 							"name": "Unbalanced",
 							"reference": "PY65:25",
 							"cost_adj": "-30%",
@@ -7332,7 +7310,7 @@
 					"base_points": 10,
 					"weapons": [
 						{
-							"id": "w2gQFan7HnESt7FJI",
+							"id": "wG7bXXOznmkTbHHCC",
 							"sv": 1,
 							"damage": {
 								"type": "fat",
@@ -7356,7 +7334,7 @@
 							}
 						},
 						{
-							"id": "wf34hrSY9PZjI7VCJ",
+							"id": "wLO2xiWKAEoXqiJYd",
 							"sv": 1,
 							"damage": {
 								"type": "fat",
@@ -7381,7 +7359,7 @@
 							}
 						},
 						{
-							"id": "WBhlQMYVGZvqQeaaL",
+							"id": "WfeGgnsE2EpIyxuBm",
 							"sv": 1,
 							"damage": {
 								"type": "fat",
@@ -7415,7 +7393,7 @@
 							}
 						},
 						{
-							"id": "Wt83Cf84HCeYCXjHD",
+							"id": "WPXmJEXZ133GJ9PXh",
 							"sv": 1,
 							"damage": {
 								"type": "fat",


### PR DESCRIPTION
Previously, Natural Weapons from PY65:24-26 had no pre-made weapon profiles or features; all stats and modifiers had to be applied manually by the user.

Here, all chosen modifiers are applied automatically to the pre-made attached weapon, with the following exceptions in two categories:

**Type 1**, which are typically described only in the trait/item description, and _not_ described on the weapon profile, or reflected in stats:
- Destructive Parry[^1]
- Disarming[^2]
- Hidden[^3]
- Single[^4]

**Type 2**, which are impossible to implement at present:
- Extra damage type[^5]
- Projected[^6]
- Ranged[^7]
- Swing-capable (All types)[^8]

As a workaround: extra weapon profiles (hidden by default, that have to be manually un-hidden by the user) are provided to facilitate Ranged and Swing-Capable. To facilitate Projected, the Ranged attacks default to `Brawling` with Specialization `<delete this if you took Projected>`+0

To allow easy choosing of the primary damage types, the old singular Natural Weapons trait was split into 11. Cutting variant (with sample modifiers, all automatic) seen below.

<img width="720" height="118" alt="image" src="https://github.com/user-attachments/assets/efbb8660-e96f-49ed-9993-40203364bc3b" />

I also added the remaining Sample Abilities from the article:
- Dragon's Breath, Freezing Strike, Hammer Hands, Lightning Whip, Minotaur's Horns, Psychic Dagger, Telekinetic Push, Ultra-Sharp Claws

...and added weapon profiles to the existing ones:
- Bone Stakes, Chi Blast, Decaying Touch

[^1]: Always damages opponent's weapon on contact.
[^2]: +2 to disarming attempts.
[^3]: Can be drawn or retracted as a free action.
[^4]: Comes in one copy, instead of one per limb.
[^5]: Adds a secondary usage with any chosen damage type.
Sadly, weapons can't be added, unhidden, nor their damage types changed by Features.
[^6]: Allows Ranged uses at Brawling instead of Innate Attack.
Sadly, skill defaults can't cleanly be changed by Features.
[^7]: Adds a Ranged usage.
Sadly, a weapon can't be added nor unhidden by Features.
[^8]: Changed damage from `thr` to `sw`.
Sadly, neither a weapon's hidden status nor damage source can be changed by Features.