### PR TITLE
Ultra Tech: Add 3mm ice ammunition

### DIFF
--- a/Library/Ultra Tech/Ultra Tech Equipment.eqp
+++ b/Library/Ultra Tech/Ultra Tech Equipment.eqp
@@ -948,6 +948,26 @@
 			}
 		},
 		{
+			"id": "eMw7nejkAh1Z0SpX4",
+			"description": "3mm ice",
+			"reference": "UT140",
+			"tech_level": "10",
+			"legality_class": "2",
+			"tags": [
+				"Ammunition",
+				"Weaponry"
+			],
+			"base_value": "0",
+			"base_weight": "0.025 lb",
+			"quantity": 1,
+			"calc": {
+				"value": 0,
+				"extended_value": 0,
+				"weight": "0.025 lb",
+				"extended_weight": "0.025 lb"
+			}
+		},
+		{
 			"id": "ePbxmOJP6071GlL-W",
 			"description": "3mmN",
 			"reference": "UT140",


### PR DESCRIPTION
This item is required to enable tracking Ice gun ammunition as equipment but statistics were not included in Ultra Tech, presumably because you don't need to buy or carry spare ammo.

Absent official figures, the text describes it as a cup of water, which would weigh 0.5 lb, and provides 20 shots so each weighs 0.025 lb.