### PR TITLE
Ultra Tech: Add modifier for ETC Guns

### DIFF
--- a/Library/Ultra Tech/Ultra Tech Equipment Modifiers.eqm
+++ b/Library/Ultra Tech/Ultra Tech Equipment Modifiers.eqm
@@ -335,6 +335,108 @@
 					]
 				},
 				{
+					"id": "FccEpU8mUr_ROiURI",
+					"name": "Conventional and ETC Guns",
+					"reference": "135",
+					"children": [
+						{
+							"id": "FFLzzA32XuKT0m1x2",
+							"name": "Electrothermal-Chemical",
+							"reference": "UT139",
+							"children": [
+								{
+									"id": "fG70l3-GoUxPWtibz",
+									"name": "Electrothermal-Chemical",
+									"reference": "UT139",
+									"cost_type": "to_base_cost",
+									"tech_level": "9",
+									"cost": "+1 CF",
+									"features": [
+										{
+											"type": "weapon_bonus",
+											"percent": true,
+											"selection_type": "this_weapon",
+											"name": {
+												"compare": "is"
+											},
+											"level": {
+												"compare": "at_least"
+											},
+											"amount": 50
+										},
+										{
+											"type": "weapon_half_damage_range_bonus",
+											"percent": true,
+											"selection_type": "this_weapon",
+											"name": {
+												"compare": "is"
+											},
+											"level": {
+												"compare": "at_least"
+											},
+											"amount": 50
+										},
+										{
+											"type": "weapon_max_range_bonus",
+											"percent": true,
+											"selection_type": "this_weapon",
+											"name": {
+												"compare": "is"
+											},
+											"level": {
+												"compare": "at_least"
+											},
+											"amount": 50
+										}
+									]
+								},
+								{
+									"id": "FT9mtX83M9tFmCklf",
+									"name": "For Pistols",
+									"children": [
+										{
+											"id": "f1g3tDq3s4vKAhvPG",
+											"name": "Using unloaded cell stats",
+											"reference": "UT139",
+											"tech_level": "9",
+											"cost": "+0",
+											"weight": "-0.005 lb"
+										}
+									]
+								},
+								{
+									"id": "FG_MCjTyqczDjvSRy",
+									"name": "For SMGs, PDWs, shotguns, rifles",
+									"children": [
+										{
+											"id": "fsAX9jz4iVHBtVkWL",
+											"name": "Using unloaded cell stats",
+											"reference": "UT139",
+											"tech_level": "9",
+											"cost": "+0",
+											"weight": "-0.05 lb"
+										}
+									]
+								},
+								{
+									"id": "FNEK2fmBTty5KHbdh",
+									"name": "For heavy weapons",
+									"children": [
+										{
+											"id": "f_nu1TfBRubNKdHCR",
+											"name": "Using unloaded cell stats",
+											"reference": "UT139",
+											"tech_level": "9",
+											"cost": "+0",
+											"weight": "-0.5 lb"
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
 					"id": "FXmaHZ51MYexCZVwP",
 					"name": "Integrating and Modifying Equipment",
 					"reference": "UT15",
@@ -1256,6 +1358,107 @@
 							"tech_level": "9",
 							"cost": "x0.05",
 							"weight": "+0 lb"
+						}
+					]
+				},
+				{
+					"id": "FV9akOruc5qdkAYyH",
+					"name": "Conventional and ETC Guns",
+					"reference": "UT135",
+					"children": [
+						{
+							"id": "FzZCNX8Tl2RHRkiA1",
+							"name": "Electrothermal-Chemical",
+							"reference": "UT139",
+							"children": [
+								{
+									"id": "fS5rRZ_9jbui4nKml",
+									"name": "Electrothermal-Chemical",
+									"reference": "UT139",
+									"tech_level": "9",
+									"cost": "x2",
+									"features": [
+										{
+											"type": "weapon_bonus",
+											"percent": true,
+											"selection_type": "this_weapon",
+											"name": {
+												"compare": "is"
+											},
+											"level": {
+												"compare": "at_least"
+											},
+											"amount": 50
+										},
+										{
+											"type": "weapon_half_damage_range_bonus",
+											"percent": true,
+											"selection_type": "this_weapon",
+											"name": {
+												"compare": "is"
+											},
+											"level": {
+												"compare": "at_least"
+											},
+											"amount": 50
+										},
+										{
+											"type": "weapon_max_range_bonus",
+											"percent": true,
+											"selection_type": "this_weapon",
+											"name": {
+												"compare": "is"
+											},
+											"level": {
+												"compare": "at_least"
+											},
+											"amount": 50
+										}
+									]
+								},
+								{
+									"id": "F0pUZttnpBec3myy3",
+									"name": "For Pistols",
+									"children": [
+										{
+											"id": "f5cignvioZ6XK99BF",
+											"name": "Using unloaded cell stats",
+											"reference": "UT139",
+											"tech_level": "9",
+											"cost": "+0",
+											"weight": "-0.005 lb"
+										}
+									]
+								},
+								{
+									"id": "FpsbPhUehSAgJ_YyK",
+									"name": "For SMGs, PDWs, shotguns, rifles",
+									"children": [
+										{
+											"id": "f_8952Musw8Ex6_a2",
+											"name": "Using unloaded cell stats",
+											"reference": "UT139",
+											"tech_level": "9",
+											"cost": "+0",
+											"weight": "-0.05 lb"
+										}
+									]
+								},
+								{
+									"id": "FQm7Ma1h8lKms2QZV",
+									"name": "For heavy weapons",
+									"children": [
+										{
+											"id": "fiWKWTGfOe8O2y7VB",
+											"name": "Using unloaded cell stats",
+											"reference": "UT139",
+											"tech_level": "9",
+											"cost": "+0",
+											"weight": "-0.5 lb"
+										}
+									]
+								}
+							]
 						}
 					]
 				},


### PR DESCRIPTION
Following existing conventions there is a multiplicative cost version and a CF version.

Modifiers are provided for unloading the energy cell from the guns listed by category.