### PR TITLE
Home brew: Add ETK from UT designer's notes

### DIFF
--- a/Library/Home Brew/Ultra-Tech Designer's Notes/README.md
+++ b/Library/Home Brew/Ultra-Tech Designer's Notes/README.md
@@ -1,0 +1,9 @@
+# Ultra-Tech Designer's Notes
+
+See <https://www.sjgames.com/pyramid/sample.html?id=6292> for associated text.
+
+## Electrothermal-Kinetic Slugthrowers
+
+Apply the appropriate Electrothermal-Kinetic modifier for the weapon depending on whether it is one-handed or two-handed and if you use the RAW cost multiplier or the later recommendation to use Cost Factors.
+
+If tracking ammunition as items apply the relevant `Using unloaded cell stats` modifier to subtract the weight of the integrated energy cell, add a B cell for Pistols, C cell for long-arms and a D cell for larger weapons, set the uses for the cell to 10x the number of shots, add an appropriate ammunition item inside the magazine, apply the Electrothermal-Kinetic modifier to it and increase the count to the modified number of shots.

--- a/Library/Home Brew/Ultra-Tech Designer's Notes/Ultra-Tech Designer's Notes Equipment Modifiers.eqm
+++ b/Library/Home Brew/Ultra-Tech Designer's Notes/Ultra-Tech Designer's Notes Equipment Modifiers.eqm
@@ -1,0 +1,331 @@
+{
+	"version": 5,
+	"rows": [
+		{
+			"id": "FPtf905BvB_G-ILPr",
+			"name": "Electrothermal-Kinetic Slugthrowers",
+			"reference": "https://www.sjgames.com/pyramid/sample.html?id=6292",
+			"children": [
+				{
+					"id": "FeEKcclAYBN7hKPu7",
+					"name": "For one-handed weapons",
+					"children": [
+						{
+							"id": "fdG6VgVJdQyi_CsUp",
+							"name": "Electrothermal-Kinetic",
+							"reference": "https://www.sjgames.com/pyramid/sample.html?id=6292",
+							"cost_type": "to_base_cost",
+							"tech_level": "10",
+							"cost": "+1 CF",
+							"features": [
+								{
+									"type": "weapon_bonus",
+									"percent": true,
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 100
+								},
+								{
+									"type": "weapon_half_damage_range_bonus",
+									"percent": true,
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 100
+								},
+								{
+									"type": "weapon_max_range_bonus",
+									"percent": true,
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 100
+								},
+								{
+									"type": "weapon_non_chamber_shots_bonus",
+									"percent": true,
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 50
+								}
+							]
+						},
+						{
+							"id": "fnlYggVsS8c7w0-am",
+							"name": "Electrothermal-Kinetic",
+							"reference": "https://www.sjgames.com/pyramid/sample.html?id=6292",
+							"tech_level": "10",
+							"cost": "x2",
+							"features": [
+								{
+									"type": "weapon_bonus",
+									"percent": true,
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 100
+								},
+								{
+									"type": "weapon_half_damage_range_bonus",
+									"percent": true,
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 100
+								},
+								{
+									"type": "weapon_max_range_bonus",
+									"percent": true,
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 100
+								},
+								{
+									"type": "weapon_non_chamber_shots_bonus",
+									"percent": true,
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 50
+								}
+							]
+						}
+					]
+				},
+				{
+					"id": "FjpBWDW3lObo4X9Hr",
+					"name": "For two-handed weapons",
+					"children": [
+						{
+							"id": "fM_CiBAEl3GIRYvHL",
+							"name": "Electrothermal-Kinetic",
+							"reference": "https://www.sjgames.com/pyramid/sample.html?id=6292",
+							"cost_type": "to_base_cost",
+							"tech_level": "10",
+							"cost": "+1 CF",
+							"weight": "+0 lb",
+							"features": [
+								{
+									"type": "weapon_bonus",
+									"percent": true,
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 100
+								},
+								{
+									"type": "weapon_half_damage_range_bonus",
+									"percent": true,
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 100
+								},
+								{
+									"type": "weapon_max_range_bonus",
+									"percent": true,
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 100
+								},
+								{
+									"type": "weapon_non_chamber_shots_bonus",
+									"percent": true,
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 50
+								},
+								{
+									"type": "weapon_acc_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							]
+						},
+						{
+							"id": "fVVWo531Q7TDrp67T",
+							"name": "Electrothermal-Kinetic",
+							"reference": "https://www.sjgames.com/pyramid/sample.html?id=6292",
+							"tech_level": "10",
+							"cost": "x2",
+							"weight": "+0 lb",
+							"features": [
+								{
+									"type": "weapon_bonus",
+									"percent": true,
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 100
+								},
+								{
+									"type": "weapon_half_damage_range_bonus",
+									"percent": true,
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 100
+								},
+								{
+									"type": "weapon_max_range_bonus",
+									"percent": true,
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 100
+								},
+								{
+									"type": "weapon_non_chamber_shots_bonus",
+									"percent": true,
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 50
+								},
+								{
+									"type": "weapon_acc_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							]
+						}
+					]
+				},
+				{
+					"id": "Fl_ZhdDnpu2y-cMbc",
+					"name": "For pistols",
+					"children": [
+						{
+							"id": "fte1AtmrHBs0Bqgz-",
+							"name": "Using unloaded cell stats",
+							"reference": "https://www.sjgames.com/pyramid/sample.html?id=6292",
+							"tech_level": "10",
+							"weight": "-0.05 lb"
+						}
+					]
+				},
+				{
+					"id": "FcFHalr7CUxABWZ1D",
+					"name": "For SMGs, PDWs, shotguns, rifles",
+					"children": [
+						{
+							"id": "fw6JaDC9bNy4_dBc1",
+							"name": "Using unloaded cell stats",
+							"reference": "https://www.sjgames.com/pyramid/sample.html?id=6292",
+							"tech_level": "10",
+							"weight": "-0.5 lb"
+						}
+					]
+				},
+				{
+					"id": "FKuCMrs0L-Xflzk6W",
+					"name": "For larger weapons",
+					"children": [
+						{
+							"id": "fnjOdmtIGGjaYqW_k",
+							"name": "Using unloaded cell stats",
+							"reference": "https://www.sjgames.com/pyramid/sample.html?id=6292",
+							"tech_level": "10",
+							"weight": "-5 lb"
+						}
+					]
+				},
+				{
+					"id": "Fu9nwSOJvitksxMQs",
+					"name": "For ammunition",
+					"children": [
+						{
+							"id": "feQLmn4TJPxluoTL8",
+							"name": "Electrothermal-Kinetic",
+							"reference": "https://www.sjgames.com/pyramid/sample.html?id=6292",
+							"weight_type": "to_base_weight",
+							"tech_level": "10",
+							"weight": "x2/3"
+						}
+					]
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
Since page references are to PDFs instead of URLs the README.md includes the link to the article.

The Electrothermal-Kinetic modifier is represented as one each for one or two-handed so two-handed gets the +1 Acc, and there's a variant for multiplicative cost vs CF.

ETK gives 50% more shots per reload, but existing magazine items should be used since the only difference is the capacity to fill them with.