### PR TITLE
Ultra Tech: Fix shotgun magazines

### DIFF
--- a/Library/Ultra Tech/Ultra Tech Equipment.eqp
+++ b/Library/Ultra Tech/Ultra Tech Equipment.eqp
@@ -6969,7 +6969,7 @@
 		},
 		{
 			"id": "EW4bTaE6_Zn87yF99",
-			"description": "Civilian Shotgun, 18.5mmPC, 50-round magazine",
+			"description": "Civilian Shotgun, 18.5mmPC, 5-round magazine",
 			"reference": "UT138,LOSC8",
 			"local_notes": "Requires 18.5mmPC ammunition",
 			"tech_level": "9",
@@ -51683,6 +51683,29 @@
 				"extended_value": 330,
 				"weight": "4 lb",
 				"extended_weight": "4 lb"
+			}
+		},
+		{
+			"id": "EiaFnxO2_c--vdZEw",
+			"description": "Shotgun Pistol, 18.5mmPC, 5-round magazine",
+			"reference": "UT138,LOSC8",
+			"local_notes": "Requires 18.5mmPC ammunition",
+			"tech_level": "9",
+			"legality_class": "3",
+			"tags": [
+				"Ammunition",
+				"Magazine",
+				"Missile Weapon"
+			],
+			"base_value": "17.3",
+			"base_weight": "0.24",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"value": 17.3,
+				"extended_value": 17.3,
+				"weight": "0.24 lb",
+				"extended_weight": "0.24 lb"
 			}
 		},
 		{


### PR DESCRIPTION
The Civilian Shotgun declared it to be a 50-shot magazine, which would be impressive if true, but it's not so it's just 5-shot.

The Shotgun Pistol uses a magazine with the same capacity, but shouldn't be used for both since the Loadouts: Starship Crew rules specifically state that the weight of magazines is the remainder after subtracting ammo weight.