### PR TITLE
Scripting Guide: Fix the link to Trait Modifiers

### DIFF
--- a/Library/Markdown/User Guide/Scripting Guide.md
+++ b/Library/Markdown/User Guide/Scripting Guide.md
@@ -25,7 +25,7 @@ When your Javascript code is called, the following globals will be available for
   - [Skills](Scripting/Skill)
   - [Spells](Scripting/Spell)
   - [Traits](Scripting/Trait)
-  - [Trait Modifiers](Scripting/Trait%20Modifiers)
+  - [Trait Modifiers](Scripting/Trait%20Modifier)
   - [Weapon](Scripting/Weapon)
 - [Top-Level Functions](Scripting/Top-Level%20Functions)
   - formatNum


### PR DESCRIPTION
The Trait Modifiers file is called "Trait Modifier", but the link previously went to "Trait Modifiers".