### PR TITLE
High Tech: Add Unloaded modifiers to Enfield SA80

### DIFF
--- a/Library/High Tech/High Tech Equipment.eqp
+++ b/Library/High Tech/High Tech Equipment.eqp
@@ -25367,6 +25367,15 @@
 					}
 				}
 			],
+			"modifiers": [
+				{
+					"id": "fV-q-yqztnWvwvWAi",
+					"name": "Using unloaded stats",
+					"cost": "-34",
+					"weight": "-1 lb",
+					"disabled": true
+				}
+			],
 			"quantity": 1,
 			"calc": {
 				"value": 1300,
@@ -25474,6 +25483,15 @@
 					"calc": {
 						"damage": "5d pi"
 					}
+				}
+			],
+			"modifiers": [
+				{
+					"id": "f184Ki_1rIZ9BLfam",
+					"name": "Using unloaded stats",
+					"cost": "-34",
+					"weight": "-1 lb",
+					"disabled": true
 				}
 			],
 			"quantity": 1,
@@ -25585,6 +25603,15 @@
 					}
 				}
 			],
+			"modifiers": [
+				{
+					"id": "fpc-bDBAeXwjAcCgQ",
+					"name": "Using unloaded stats",
+					"cost": "-34",
+					"weight": "-1 lb",
+					"disabled": true
+				}
+			],
 			"quantity": 1,
 			"calc": {
 				"value": 1500,
@@ -25694,12 +25721,44 @@
 					}
 				}
 			],
+			"modifiers": [
+				{
+					"id": "fOhndW4IDaHj0YTzS",
+					"name": "Using unloaded stats",
+					"cost": "-34",
+					"weight": "-1 lb",
+					"disabled": true
+				}
+			],
 			"quantity": 1,
 			"calc": {
 				"value": 1500,
 				"extended_value": 1500,
 				"weight": "14.5 lb",
 				"extended_weight": "14.5 lb"
+			}
+		},
+		{
+			"id": "EuNvJnpVGU1VqzfvB",
+			"description": "Enfield L8*, 5.56x45mm 30-round magazine",
+			"reference": "HT119",
+			"local_notes": "Requires 5.56x45mm ammunition",
+			"tech_level": "7",
+			"legality_class": "3",
+			"tags": [
+				"Ammunition",
+				"Magazines",
+				"Rifle"
+			],
+			"base_value": "34",
+			"base_weight": "0.2 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"value": 34,
+				"extended_value": 34,
+				"weight": "0.2 lb",
+				"extended_weight": "0.2 lb"
 			}
 		},
 		{


### PR DESCRIPTION
This adds the unloaded modifier for the L85A1, L85A2 and LMG variants.

They should use M4 30-shot magazines.