### PR TITLE
Remove erroneous Basic Set Limitation named 'Electrical'

### DIFF
--- a/Library/Basic Set/Basic Set Limitation Modifiers.adm
+++ b/Library/Basic Set/Basic Set Limitation Modifiers.adm
@@ -109,12 +109,6 @@
 			"cost_adj": "-50%"
 		},
 		{
-			"id": "mQMxcYI5lTneo5CNm",
-			"name": "Electrical",
-			"reference": "B134",
-			"cost_adj": "-20%"
-		},
-		{
 			"id": "mk76f3SlpNhhWuzRi",
 			"name": "Emanation",
 			"reference": "B112,P102",


### PR DESCRIPTION
As raised by https://github.com/richardwilkes/gcs_master_library/issues/513

Places that might have used it should be using Temporary Disadvantage (@Temporary Disadvantage@), with a level equal to the trait's point cost.

i.e. Electrical -> Temporary Disadvantage (Electrical) 20.