### PR TITLE
Fix born war leader

### DIFF
--- a/Library/Banestorm/Banestorm Traits.adq
+++ b/Library/Banestorm/Banestorm Traits.adq
@@ -136,8 +136,13 @@
 		},
 		{
 			"id": "tLYHL9pEv58Bzks0z",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Power Ups/Power Ups Traits.adq",
+				"id": "tgnQFo-hK7YwexD2S"
+			},
 			"name": "Talent (Born War-Leader)",
-			"reference": "BS184,DF1:14,PU3:12",
+			"reference": "PU3:12, BS184, DF1:14, MH1:25",
 			"tags": [
 				"Advantage",
 				"Mental",
@@ -145,15 +150,37 @@
 			],
 			"modifiers": [
 				{
-					"id": "mWoTPwBs7nzH3ZuRE",
-					"name": "Reaction Bonus",
-					"local_notes": "Military officers, tribal war-leaders, soldiers, and other professional warriors"
-				},
-				{
-					"id": "m2Slosn9ARL0-Z-bV",
-					"name": "Alternate Benefit",
-					"local_notes": "Bonus to initiative rolls if leader",
-					"disabled": true
+					"id": "MnYoC6SXIkwZcKT7r",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "m1l07XifEU2xPseoG",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "mn9StSpQDp5O682RP",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to initiative rolls if leader",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 5,
@@ -163,31 +190,7 @@
 					"selection_type": "skills_with_name",
 					"name": {
 						"compare": "is",
-						"qualifier": "Intelligence Analysis"
-					},
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "skill_bonus",
-					"selection_type": "skills_with_name",
-					"name": {
-						"compare": "is",
 						"qualifier": "Leadership"
-					},
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "skill_bonus",
-					"selection_type": "skills_with_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "Savoir-Faire"
-					},
-					"specialization": {
-						"compare": "is",
-						"qualifier": "Military"
 					},
 					"amount": 1,
 					"per_level": true
@@ -206,8 +209,32 @@
 					"type": "skill_bonus",
 					"selection_type": "skills_with_name",
 					"name": {
-						"compare": "is",
+						"compare": "starts_with",
 						"qualifier": "Tactics"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Intelligence Analysis"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Savoir-Faire"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Military"
 					},
 					"amount": 1,
 					"per_level": true

--- a/Library/Banestorm/Classes/Battle Wizard.gct
+++ b/Library/Banestorm/Classes/Battle Wizard.gct
@@ -600,11 +600,52 @@
 								},
 								{
 									"id": "tP7fwtyQgecLdiZDB",
-									"name": "Talent (Born War Leader)",
-									"reference": "DF1:14,PU3:12",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tgnQFo-hK7YwexD2S"
+									},
+									"name": "Talent (Born War-Leader)",
+									"reference": "PU3:12, BS184, DF1:14, MH1:25",
 									"tags": [
 										"Advantage",
-										"Physical"
+										"Mental",
+										"Talent"
+									],
+									"modifiers": [
+										{
+											"id": "MErWgBOhzz0vQxjo0",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "m2BPrkfd6g9R6GeRI",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "mU6Fn37Sbgtx0Ksus",
+													"name": "Alternative Benefit",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Bonus to initiative rolls if leader",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
+										}
 									],
 									"points_per_level": 5,
 									"features": [
@@ -613,7 +654,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "leadership"
+												"qualifier": "Leadership"
 											},
 											"amount": 1,
 											"per_level": true
@@ -623,7 +664,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "strategy"
+												"qualifier": "Strategy"
 											},
 											"amount": 1,
 											"per_level": true
@@ -633,7 +674,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "starts_with",
-												"qualifier": "tactics"
+												"qualifier": "Tactics"
 											},
 											"amount": 1,
 											"per_level": true
@@ -643,7 +684,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "intelligence analysis"
+												"qualifier": "Intelligence Analysis"
 											},
 											"amount": 1,
 											"per_level": true
@@ -653,11 +694,11 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "savoir-faire"
+												"qualifier": "Savoir-Faire"
 											},
 											"specialization": {
 												"compare": "is",
-												"qualifier": "military"
+												"qualifier": "Military"
 											},
 											"amount": 1,
 											"per_level": true

--- a/Library/Banestorm/Classes/Knight-Errant.gct
+++ b/Library/Banestorm/Classes/Knight-Errant.gct
@@ -539,11 +539,52 @@
 								},
 								{
 									"id": "t3hhIFOtCZHIE3Kct",
-									"name": "Talent (Born War Leader)",
-									"reference": "DF1:14,PU3:12",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tgnQFo-hK7YwexD2S"
+									},
+									"name": "Talent (Born War-Leader)",
+									"reference": "PU3:12, BS184, DF1:14, MH1:25",
 									"tags": [
 										"Advantage",
-										"Physical"
+										"Mental",
+										"Talent"
+									],
+									"modifiers": [
+										{
+											"id": "MqafoWWbiUj59mJpQ",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "muHdA7kS3J41LZq8v",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "mYtTPLBd4F0mqBtr4",
+													"name": "Alternative Benefit",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Bonus to initiative rolls if leader",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
+										}
 									],
 									"points_per_level": 5,
 									"features": [
@@ -552,7 +593,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "leadership"
+												"qualifier": "Leadership"
 											},
 											"amount": 1,
 											"per_level": true
@@ -562,7 +603,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "strategy"
+												"qualifier": "Strategy"
 											},
 											"amount": 1,
 											"per_level": true
@@ -572,7 +613,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "starts_with",
-												"qualifier": "tactics"
+												"qualifier": "Tactics"
 											},
 											"amount": 1,
 											"per_level": true
@@ -582,7 +623,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "intelligence analysis"
+												"qualifier": "Intelligence Analysis"
 											},
 											"amount": 1,
 											"per_level": true
@@ -592,11 +633,11 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "savoir-faire"
+												"qualifier": "Savoir-Faire"
 											},
 											"specialization": {
 												"compare": "is",
-												"qualifier": "military"
+												"qualifier": "Military"
 											},
 											"amount": 1,
 											"per_level": true

--- a/Library/Banestorm/Classes/Mercenary.gct
+++ b/Library/Banestorm/Classes/Mercenary.gct
@@ -320,11 +320,52 @@
 								},
 								{
 									"id": "trjW1zGO_VEKKNXmt",
-									"name": "Talent (Born War Leader)",
-									"reference": "DF1:14,PU3:12",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tgnQFo-hK7YwexD2S"
+									},
+									"name": "Talent (Born War-Leader)",
+									"reference": "PU3:12, BS184, DF1:14, MH1:25",
 									"tags": [
 										"Advantage",
-										"Physical"
+										"Mental",
+										"Talent"
+									],
+									"modifiers": [
+										{
+											"id": "M6s5-YRlQz9tOiqPf",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "md_gIhnXgr-PGPtbN",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "mSl05aYUqmCoLWqVV",
+													"name": "Alternative Benefit",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Bonus to initiative rolls if leader",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
+										}
 									],
 									"points_per_level": 5,
 									"features": [
@@ -333,7 +374,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "leadership"
+												"qualifier": "Leadership"
 											},
 											"amount": 1,
 											"per_level": true
@@ -343,7 +384,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "strategy"
+												"qualifier": "Strategy"
 											},
 											"amount": 1,
 											"per_level": true
@@ -353,7 +394,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "starts_with",
-												"qualifier": "tactics"
+												"qualifier": "Tactics"
 											},
 											"amount": 1,
 											"per_level": true
@@ -363,7 +404,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "intelligence analysis"
+												"qualifier": "Intelligence Analysis"
 											},
 											"amount": 1,
 											"per_level": true
@@ -373,11 +414,11 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "savoir-faire"
+												"qualifier": "Savoir-Faire"
 											},
 											"specialization": {
 												"compare": "is",
-												"qualifier": "military"
+												"qualifier": "Military"
 											},
 											"amount": 1,
 											"per_level": true

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 1/Classes/Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 1/Classes/Holy Warrior.gct
@@ -205,12 +205,53 @@
 					"name": "Class Advantages",
 					"children": [
 						{
-							"id": "t8QcY_PKaGoIw20fN",
-							"name": "Talent (Born War Leader)",
-							"reference": "DF1:14",
+							"id": "tKr13GP9COyzmHSas",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "tgnQFo-hK7YwexD2S"
+							},
+							"name": "Talent (Born War-Leader)",
+							"reference": "PU3:12, BS184, DF1:14, MH1:25",
 							"tags": [
 								"Advantage",
-								"Physical"
+								"Mental",
+								"Talent"
+							],
+							"modifiers": [
+								{
+									"id": "MtXN9N5MQExflgGhW",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "m8609dFdkLQBYMgwv",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "mGPWPaGZEBwXqQXry",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Bonus to initiative rolls if leader",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
+								}
 							],
 							"points_per_level": 5,
 							"features": [
@@ -219,7 +260,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "leadership"
+										"qualifier": "Leadership"
 									},
 									"amount": 1,
 									"per_level": true
@@ -229,7 +270,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "strategy"
+										"qualifier": "Strategy"
 									},
 									"amount": 1,
 									"per_level": true
@@ -239,7 +280,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "starts_with",
-										"qualifier": "tactics"
+										"qualifier": "Tactics"
 									},
 									"amount": 1,
 									"per_level": true
@@ -249,7 +290,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "intelligence analysis"
+										"qualifier": "Intelligence Analysis"
 									},
 									"amount": 1,
 									"per_level": true
@@ -259,7 +300,11 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "savoir-faire"
+										"qualifier": "Savoir-Faire"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "Military"
 									},
 									"amount": 1,
 									"per_level": true
@@ -1795,12 +1840,53 @@
 									}
 								},
 								{
-									"id": "td-Y2cwzWYkRRuHbM",
-									"name": "Talent (Born War Leader)",
-									"reference": "DF1:14",
+									"id": "tx8djEGSNG-1YVXff",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tgnQFo-hK7YwexD2S"
+									},
+									"name": "Talent (Born War-Leader)",
+									"reference": "PU3:12, BS184, DF1:14, MH1:25",
 									"tags": [
 										"Advantage",
-										"Physical"
+										"Mental",
+										"Talent"
+									],
+									"modifiers": [
+										{
+											"id": "MgnS0EBh5DG2pqWae",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "m6KbqGfaThAFCHOXc",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "mlvlDyRpx_PKvHNSQ",
+													"name": "Alternative Benefit",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Bonus to initiative rolls if leader",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
+										}
 									],
 									"points_per_level": 5,
 									"features": [
@@ -1809,7 +1895,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "leadership"
+												"qualifier": "Leadership"
 											},
 											"amount": 1,
 											"per_level": true
@@ -1819,7 +1905,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "strategy"
+												"qualifier": "Strategy"
 											},
 											"amount": 1,
 											"per_level": true
@@ -1829,7 +1915,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "starts_with",
-												"qualifier": "tactics"
+												"qualifier": "Tactics"
 											},
 											"amount": 1,
 											"per_level": true
@@ -1839,7 +1925,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "intelligence analysis"
+												"qualifier": "Intelligence Analysis"
 											},
 											"amount": 1,
 											"per_level": true
@@ -1849,7 +1935,11 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "savoir-faire"
+												"qualifier": "Savoir-Faire"
+											},
+											"specialization": {
+												"compare": "is",
+												"qualifier": "Military"
 											},
 											"amount": 1,
 											"per_level": true

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 1/Classes/Knight.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 1/Classes/Knight.gct
@@ -745,12 +745,53 @@
 							}
 						},
 						{
-							"id": "txvwNNo-cjYv98Q2f",
-							"name": "Talent (Born War Leader)",
-							"reference": "DF1:14",
+							"id": "txKboZ-dAzh9SxJwU",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "tgnQFo-hK7YwexD2S"
+							},
+							"name": "Talent (Born War-Leader)",
+							"reference": "PU3:12, BS184, DF1:14, MH1:25",
 							"tags": [
 								"Advantage",
-								"Physical"
+								"Mental",
+								"Talent"
+							],
+							"modifiers": [
+								{
+									"id": "MVcY0Bhf71cT0v4vw",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "m2ozbq8Wy7nNMQLM3",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "m-1kSgHSpiafYo-o_",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Bonus to initiative rolls if leader",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
+								}
 							],
 							"points_per_level": 5,
 							"features": [
@@ -759,7 +800,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "leadership"
+										"qualifier": "Leadership"
 									},
 									"amount": 1,
 									"per_level": true
@@ -769,7 +810,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "strategy"
+										"qualifier": "Strategy"
 									},
 									"amount": 1,
 									"per_level": true
@@ -779,7 +820,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "starts_with",
-										"qualifier": "tactics"
+										"qualifier": "Tactics"
 									},
 									"amount": 1,
 									"per_level": true
@@ -789,7 +830,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "intelligence analysis"
+										"qualifier": "Intelligence Analysis"
 									},
 									"amount": 1,
 									"per_level": true
@@ -799,7 +840,11 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "savoir-faire"
+										"qualifier": "Savoir-Faire"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "Military"
 									},
 									"amount": 1,
 									"per_level": true

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 1/Dungeon Fantasy 1 Traits.adq
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 1/Dungeon Fantasy 1 Traits.adq
@@ -233,11 +233,52 @@
 		},
 		{
 			"id": "tEyqlequcAVv3VyhX",
-			"name": "Talent (Born War Leader)",
-			"reference": "DF1:14,PU3:12",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Power Ups/Power Ups Traits.adq",
+				"id": "tgnQFo-hK7YwexD2S"
+			},
+			"name": "Talent (Born War-Leader)",
+			"reference": "PU3:12, BS184, DF1:14, MH1:25",
 			"tags": [
 				"Advantage",
-				"Physical"
+				"Mental",
+				"Talent"
+			],
+			"modifiers": [
+				{
+					"id": "MhAs7Mq-ftszpiXmL",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "m1asAmoqoAuMUFcFl",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "momncVD4SKXlKOBaX",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to initiative rolls if leader",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
+				}
 			],
 			"points_per_level": 5,
 			"features": [
@@ -246,7 +287,7 @@
 					"selection_type": "skills_with_name",
 					"name": {
 						"compare": "is",
-						"qualifier": "leadership"
+						"qualifier": "Leadership"
 					},
 					"amount": 1,
 					"per_level": true
@@ -256,7 +297,7 @@
 					"selection_type": "skills_with_name",
 					"name": {
 						"compare": "is",
-						"qualifier": "strategy"
+						"qualifier": "Strategy"
 					},
 					"amount": 1,
 					"per_level": true
@@ -266,7 +307,7 @@
 					"selection_type": "skills_with_name",
 					"name": {
 						"compare": "starts_with",
-						"qualifier": "tactics"
+						"qualifier": "Tactics"
 					},
 					"amount": 1,
 					"per_level": true
@@ -276,7 +317,7 @@
 					"selection_type": "skills_with_name",
 					"name": {
 						"compare": "is",
-						"qualifier": "intelligence analysis"
+						"qualifier": "Intelligence Analysis"
 					},
 					"amount": 1,
 					"per_level": true
@@ -286,11 +327,11 @@
 					"selection_type": "skills_with_name",
 					"name": {
 						"compare": "is",
-						"qualifier": "savoir-faire"
+						"qualifier": "Savoir-Faire"
 					},
 					"specialization": {
 						"compare": "is",
-						"qualifier": "military"
+						"qualifier": "Military"
 					},
 					"amount": 1,
 					"per_level": true

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 15/Archer.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 15/Archer.gct
@@ -511,12 +511,53 @@
 									}
 								},
 								{
-									"id": "tttEoXCki2NO7jmt9",
-									"name": "Talent (Born War Leader)",
-									"reference": "DF1:14",
+									"id": "tl7dYYa1VVGlswbJ7",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tgnQFo-hK7YwexD2S"
+									},
+									"name": "Talent (Born War-Leader)",
+									"reference": "PU3:12, BS184, DF1:14, MH1:25",
 									"tags": [
 										"Advantage",
-										"Physical"
+										"Mental",
+										"Talent"
+									],
+									"modifiers": [
+										{
+											"id": "MExlT77DSZ1Et9Q7w",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "mKnNFByyTgN_qQawu",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "mcPLuknwY72JGsZsW",
+													"name": "Alternative Benefit",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Bonus to initiative rolls if leader",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
+										}
 									],
 									"points_per_level": 5,
 									"features": [
@@ -525,7 +566,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "leadership"
+												"qualifier": "Leadership"
 											},
 											"amount": 1,
 											"per_level": true
@@ -535,7 +576,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "strategy"
+												"qualifier": "Strategy"
 											},
 											"amount": 1,
 											"per_level": true
@@ -545,7 +586,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "starts_with",
-												"qualifier": "tactics"
+												"qualifier": "Tactics"
 											},
 											"amount": 1,
 											"per_level": true
@@ -555,7 +596,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "intelligence analysis"
+												"qualifier": "Intelligence Analysis"
 											},
 											"amount": 1,
 											"per_level": true
@@ -565,7 +606,11 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "savoir-faire"
+												"qualifier": "Savoir-Faire"
+											},
+											"specialization": {
+												"compare": "is",
+												"qualifier": "Military"
 											},
 											"amount": 1,
 											"per_level": true

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 15/Brute.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 15/Brute.gct
@@ -516,12 +516,53 @@
 									}
 								},
 								{
-									"id": "tO5Iy1W_DOc1ghDcT",
-									"name": "Talent (Born War Leader)",
-									"reference": "DF1:14",
+									"id": "tT07TcEIiGiRiyfk3",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tgnQFo-hK7YwexD2S"
+									},
+									"name": "Talent (Born War-Leader)",
+									"reference": "PU3:12, BS184, DF1:14, MH1:25",
 									"tags": [
 										"Advantage",
-										"Physical"
+										"Mental",
+										"Talent"
+									],
+									"modifiers": [
+										{
+											"id": "MyEIhw8qs-74-gYcl",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "mcI_cEsEjgFZdPE2W",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "myrMaDoh3xbar92Ge",
+													"name": "Alternative Benefit",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Bonus to initiative rolls if leader",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
+										}
 									],
 									"points_per_level": 5,
 									"features": [
@@ -530,7 +571,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "leadership"
+												"qualifier": "Leadership"
 											},
 											"amount": 1,
 											"per_level": true
@@ -540,7 +581,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "strategy"
+												"qualifier": "Strategy"
 											},
 											"amount": 1,
 											"per_level": true
@@ -550,7 +591,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "starts_with",
-												"qualifier": "tactics"
+												"qualifier": "Tactics"
 											},
 											"amount": 1,
 											"per_level": true
@@ -560,7 +601,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "intelligence analysis"
+												"qualifier": "Intelligence Analysis"
 											},
 											"amount": 1,
 											"per_level": true
@@ -570,7 +611,11 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "savoir-faire"
+												"qualifier": "Savoir-Faire"
+											},
+											"specialization": {
+												"compare": "is",
+												"qualifier": "Military"
 											},
 											"amount": 1,
 											"per_level": true

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 15/Squire.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 15/Squire.gct
@@ -793,12 +793,53 @@
 					"name": "Class Advantage",
 					"children": [
 						{
-							"id": "t01TK-RnM4jmNRSXk",
-							"name": "Talent (Born War Leader)",
-							"reference": "DF1:14",
+							"id": "tsByc6vqyF8vz2w1x",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "tgnQFo-hK7YwexD2S"
+							},
+							"name": "Talent (Born War-Leader)",
+							"reference": "PU3:12, BS184, DF1:14, MH1:25",
 							"tags": [
 								"Advantage",
-								"Physical"
+								"Mental",
+								"Talent"
+							],
+							"modifiers": [
+								{
+									"id": "Mt5sbqrdzpDG36Jai",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "mzECCWtiIoV3XZOo5",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "mn-4NQ6nAWbKvKUgb",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Bonus to initiative rolls if leader",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
+								}
 							],
 							"points_per_level": 5,
 							"features": [
@@ -807,7 +848,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "leadership"
+										"qualifier": "Leadership"
 									},
 									"amount": 1,
 									"per_level": true
@@ -817,7 +858,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "strategy"
+										"qualifier": "Strategy"
 									},
 									"amount": 1,
 									"per_level": true
@@ -827,7 +868,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "starts_with",
-										"qualifier": "tactics"
+										"qualifier": "Tactics"
 									},
 									"amount": 1,
 									"per_level": true
@@ -837,7 +878,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "intelligence analysis"
+										"qualifier": "Intelligence Analysis"
 									},
 									"amount": 1,
 									"per_level": true
@@ -847,7 +888,11 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "savoir-faire"
+										"qualifier": "Savoir-Faire"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "Military"
 									},
 									"amount": 1,
 									"per_level": true
@@ -1126,12 +1171,53 @@
 									}
 								},
 								{
-									"id": "t04hugbSI-ILWVNTJ",
-									"name": "Talent (Born War Leader)",
-									"reference": "DF1:14",
+									"id": "tAdk1LdIJQf03kuYa",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tgnQFo-hK7YwexD2S"
+									},
+									"name": "Talent (Born War-Leader)",
+									"reference": "PU3:12, BS184, DF1:14, MH1:25",
 									"tags": [
 										"Advantage",
-										"Physical"
+										"Mental",
+										"Talent"
+									],
+									"modifiers": [
+										{
+											"id": "MnOAfjSxVimDmhlnY",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "mZoJ1fsNqRvihJOhb",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "mDIgjQaltzIiFyRV7",
+													"name": "Alternative Benefit",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Bonus to initiative rolls if leader",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
+										}
 									],
 									"points_per_level": 5,
 									"features": [
@@ -1140,7 +1226,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "leadership"
+												"qualifier": "Leadership"
 											},
 											"amount": 1,
 											"per_level": true
@@ -1150,7 +1236,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "strategy"
+												"qualifier": "Strategy"
 											},
 											"amount": 1,
 											"per_level": true
@@ -1160,7 +1246,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "starts_with",
-												"qualifier": "tactics"
+												"qualifier": "Tactics"
 											},
 											"amount": 1,
 											"per_level": true
@@ -1170,7 +1256,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "intelligence analysis"
+												"qualifier": "Intelligence Analysis"
 											},
 											"amount": 1,
 											"per_level": true
@@ -1180,7 +1266,11 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "savoir-faire"
+												"qualifier": "Savoir-Faire"
+											},
+											"specialization": {
+												"compare": "is",
+												"qualifier": "Military"
 											},
 											"amount": 1,
 											"per_level": true

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 3/Unholy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 3/Unholy Warrior.gct
@@ -2437,12 +2437,53 @@
 									}
 								},
 								{
-									"id": "t_7xL9LbiCSwbhc9M",
-									"name": "Talent (Born War Leader)",
-									"reference": "DF1:14",
+									"id": "tle3AvzJoR8pLn9wR",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tgnQFo-hK7YwexD2S"
+									},
+									"name": "Talent (Born War-Leader)",
+									"reference": "PU3:12, BS184, DF1:14, MH1:25",
 									"tags": [
 										"Advantage",
-										"Physical"
+										"Mental",
+										"Talent"
+									],
+									"modifiers": [
+										{
+											"id": "MvqgXb5g03OBg0lhN",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "m37qOCkGRZ2AJzYlL",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "mkt9ykAo-BN_YSWgX",
+													"name": "Alternative Benefit",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Bonus to initiative rolls if leader",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
+										}
 									],
 									"points_per_level": 5,
 									"features": [
@@ -2451,7 +2492,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "leadership"
+												"qualifier": "Leadership"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2461,7 +2502,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "strategy"
+												"qualifier": "Strategy"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2471,7 +2512,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "starts_with",
-												"qualifier": "tactics"
+												"qualifier": "Tactics"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2481,7 +2522,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "intelligence analysis"
+												"qualifier": "Intelligence Analysis"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2491,7 +2532,11 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "savoir-faire"
+												"qualifier": "Savoir-Faire"
+											},
+											"specialization": {
+												"compare": "is",
+												"qualifier": "Military"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2581,12 +2626,53 @@
 							}
 						},
 						{
-							"id": "th2P5UaA5ULZeugBL",
-							"name": "Talent (Born War Leader)",
-							"reference": "DF1:14",
+							"id": "tpvQg9NFAbwW4Daq0",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "tgnQFo-hK7YwexD2S"
+							},
+							"name": "Talent (Born War-Leader)",
+							"reference": "PU3:12, BS184, DF1:14, MH1:25",
 							"tags": [
 								"Advantage",
-								"Physical"
+								"Mental",
+								"Talent"
+							],
+							"modifiers": [
+								{
+									"id": "Mis5sZGE_0aLoGyNN",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "mkXmPLX0In_TLq5rU",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "mv3uaODk4knsQTils",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Bonus to initiative rolls if leader",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
+								}
 							],
 							"points_per_level": 5,
 							"features": [
@@ -2595,7 +2681,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "leadership"
+										"qualifier": "Leadership"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2605,7 +2691,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "strategy"
+										"qualifier": "Strategy"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2615,7 +2701,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "starts_with",
-										"qualifier": "tactics"
+										"qualifier": "Tactics"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2625,7 +2711,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "intelligence analysis"
+										"qualifier": "Intelligence Analysis"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2635,7 +2721,11 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "savoir-faire"
+										"qualifier": "Savoir-Faire"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "Military"
 									},
 									"amount": 1,
 									"per_level": true

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Cleric Variants/War Cleric.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Cleric Variants/War Cleric.gct
@@ -929,12 +929,53 @@
 									}
 								},
 								{
-									"id": "tLn3iP179oBkFmsnt",
-									"name": "Talent (Born War Leader)",
-									"reference": "DF1:14,PU3:12",
+									"id": "tI31lntDKOY8odw8b",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tgnQFo-hK7YwexD2S"
+									},
+									"name": "Talent (Born War-Leader)",
+									"reference": "PU3:12, BS184, DF1:14, MH1:25",
 									"tags": [
 										"Advantage",
-										"Physical"
+										"Mental",
+										"Talent"
+									],
+									"modifiers": [
+										{
+											"id": "M79Kv2Cks_o_LAxQx",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "mZ8yy5LHuhQfYt8Hd",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "mQlZwo0flruQuS0Xx",
+													"name": "Alternative Benefit",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Bonus to initiative rolls if leader",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
+										}
 									],
 									"points_per_level": 5,
 									"features": [
@@ -943,7 +984,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "leadership"
+												"qualifier": "Leadership"
 											},
 											"amount": 1,
 											"per_level": true
@@ -953,7 +994,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "strategy"
+												"qualifier": "Strategy"
 											},
 											"amount": 1,
 											"per_level": true
@@ -963,7 +1004,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "starts_with",
-												"qualifier": "tactics"
+												"qualifier": "Tactics"
 											},
 											"amount": 1,
 											"per_level": true
@@ -973,7 +1014,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "intelligence analysis"
+												"qualifier": "Intelligence Analysis"
 											},
 											"amount": 1,
 											"per_level": true
@@ -983,11 +1024,11 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "savoir-faire"
+												"qualifier": "Savoir-Faire"
 											},
 											"specialization": {
 												"compare": "is",
-												"qualifier": "military"
+												"qualifier": "Military"
 											},
 											"amount": 1,
 											"per_level": true

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Agriculture Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Agriculture Holy Warrior.gct
@@ -2311,12 +2311,53 @@
 									}
 								},
 								{
-									"id": "tKXklx5Ca36CVJXcF",
-									"name": "Talent (Born War Leader)",
-									"reference": "DF1:14",
+									"id": "tmEZUiut73B8CbZ0A",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tgnQFo-hK7YwexD2S"
+									},
+									"name": "Talent (Born War-Leader)",
+									"reference": "PU3:12, BS184, DF1:14, MH1:25",
 									"tags": [
 										"Advantage",
-										"Physical"
+										"Mental",
+										"Talent"
+									],
+									"modifiers": [
+										{
+											"id": "MqLoyLjS-7XbOawZM",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "m3lHhjpOFYvdcPYbj",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "m2uB2dPS7r8L5eMVC",
+													"name": "Alternative Benefit",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Bonus to initiative rolls if leader",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
+										}
 									],
 									"points_per_level": 5,
 									"features": [
@@ -2325,7 +2366,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "leadership"
+												"qualifier": "Leadership"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2335,7 +2376,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "strategy"
+												"qualifier": "Strategy"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2345,7 +2386,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "starts_with",
-												"qualifier": "tactics"
+												"qualifier": "Tactics"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2355,7 +2396,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "intelligence analysis"
+												"qualifier": "Intelligence Analysis"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2365,7 +2406,11 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "savoir-faire"
+												"qualifier": "Savoir-Faire"
+											},
+											"specialization": {
+												"compare": "is",
+												"qualifier": "Military"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2479,12 +2524,53 @@
 							}
 						},
 						{
-							"id": "tSrXUFlc5o9RYegRe",
-							"name": "Talent (Born War Leader)",
-							"reference": "DF1:14",
+							"id": "tRuFZwNzJN-Pm8ohG",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "tgnQFo-hK7YwexD2S"
+							},
+							"name": "Talent (Born War-Leader)",
+							"reference": "PU3:12, BS184, DF1:14, MH1:25",
 							"tags": [
 								"Advantage",
-								"Physical"
+								"Mental",
+								"Talent"
+							],
+							"modifiers": [
+								{
+									"id": "MFsHBGHJSGJELu0b4",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "mSocNs1HM9X4h0Iw0",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "mi_rifxMdgP-ITEEH",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Bonus to initiative rolls if leader",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
+								}
 							],
 							"points_per_level": 5,
 							"features": [
@@ -2493,7 +2579,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "leadership"
+										"qualifier": "Leadership"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2503,7 +2589,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "strategy"
+										"qualifier": "Strategy"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2513,7 +2599,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "starts_with",
-										"qualifier": "tactics"
+										"qualifier": "Tactics"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2523,7 +2609,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "intelligence analysis"
+										"qualifier": "Intelligence Analysis"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2533,7 +2619,11 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "savoir-faire"
+										"qualifier": "Savoir-Faire"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "Military"
 									},
 									"amount": 1,
 									"per_level": true

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Artificer Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Artificer Holy Warrior.gct
@@ -2270,12 +2270,53 @@
 									}
 								},
 								{
-									"id": "tbJl0wguoF2PrJRY6",
-									"name": "Talent (Born War Leader)",
-									"reference": "DF1:14",
+									"id": "tSWYu7s3196OMsxT4",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tgnQFo-hK7YwexD2S"
+									},
+									"name": "Talent (Born War-Leader)",
+									"reference": "PU3:12, BS184, DF1:14, MH1:25",
 									"tags": [
 										"Advantage",
-										"Physical"
+										"Mental",
+										"Talent"
+									],
+									"modifiers": [
+										{
+											"id": "MmCdBmg33nkITQWq7",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "m4iNfjAmIb6Pd1OJa",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "mgV5j04V-SxFOFQ_t",
+													"name": "Alternative Benefit",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Bonus to initiative rolls if leader",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
+										}
 									],
 									"points_per_level": 5,
 									"features": [
@@ -2284,7 +2325,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "leadership"
+												"qualifier": "Leadership"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2294,7 +2335,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "strategy"
+												"qualifier": "Strategy"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2304,7 +2345,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "starts_with",
-												"qualifier": "tactics"
+												"qualifier": "Tactics"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2314,7 +2355,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "intelligence analysis"
+												"qualifier": "Intelligence Analysis"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2324,7 +2365,11 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "savoir-faire"
+												"qualifier": "Savoir-Faire"
+											},
+											"specialization": {
+												"compare": "is",
+												"qualifier": "Military"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2402,12 +2447,53 @@
 							}
 						},
 						{
-							"id": "tZYGMra4uvrGS1tBN",
-							"name": "Talent (Born War Leader)",
-							"reference": "DF1:14",
+							"id": "tvq2Ohcb8K7k9w_ar",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "tgnQFo-hK7YwexD2S"
+							},
+							"name": "Talent (Born War-Leader)",
+							"reference": "PU3:12, BS184, DF1:14, MH1:25",
 							"tags": [
 								"Advantage",
-								"Physical"
+								"Mental",
+								"Talent"
+							],
+							"modifiers": [
+								{
+									"id": "Mwekbo7kmbMN79Xwe",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "m3M-Zxrz1kADZmsUT",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "mlxYm8DfYBt7n0E2D",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Bonus to initiative rolls if leader",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
+								}
 							],
 							"points_per_level": 5,
 							"features": [
@@ -2416,7 +2502,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "leadership"
+										"qualifier": "Leadership"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2426,7 +2512,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "strategy"
+										"qualifier": "Strategy"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2436,7 +2522,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "starts_with",
-										"qualifier": "tactics"
+										"qualifier": "Tactics"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2446,7 +2532,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "intelligence analysis"
+										"qualifier": "Intelligence Analysis"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2456,7 +2542,11 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "savoir-faire"
+										"qualifier": "Savoir-Faire"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "Military"
 									},
 									"amount": 1,
 									"per_level": true

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Death Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Death Holy Warrior.gct
@@ -2149,12 +2149,53 @@
 									}
 								},
 								{
-									"id": "tOx1qV3807S83sQky",
-									"name": "Talent (Born War Leader)",
-									"reference": "DF1:14",
+									"id": "tF7aMnx5osPqKAWhr",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tgnQFo-hK7YwexD2S"
+									},
+									"name": "Talent (Born War-Leader)",
+									"reference": "PU3:12, BS184, DF1:14, MH1:25",
 									"tags": [
 										"Advantage",
-										"Physical"
+										"Mental",
+										"Talent"
+									],
+									"modifiers": [
+										{
+											"id": "MLwYpdSbfNV8Yn6Tl",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "mD-Zla5X8GPeVIlT8",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "mwg-FCOJvVAW0_-5O",
+													"name": "Alternative Benefit",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Bonus to initiative rolls if leader",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
+										}
 									],
 									"points_per_level": 5,
 									"features": [
@@ -2163,7 +2204,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "leadership"
+												"qualifier": "Leadership"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2173,7 +2214,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "strategy"
+												"qualifier": "Strategy"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2183,7 +2224,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "starts_with",
-												"qualifier": "tactics"
+												"qualifier": "Tactics"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2193,7 +2234,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "intelligence analysis"
+												"qualifier": "Intelligence Analysis"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2203,7 +2244,11 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "savoir-faire"
+												"qualifier": "Savoir-Faire"
+											},
+											"specialization": {
+												"compare": "is",
+												"qualifier": "Military"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2253,22 +2298,8 @@
 							"name": "Choose one Higher Purpose",
 							"children": [
 								{
-									"id": "tJaghqm3RiqVOIB-t",
-									"name": "Higher Purpose (Preserve the boundaries of life and death)",
-									"reference": "B59",
-									"tags": [
-										"Advantage",
-										"Exotic",
-										"Mental"
-									],
-									"base_points": 5,
-									"calc": {
-										"points": 5
-									}
-								},
-								{
-									"id": "ty0KFKGU5Ohz3_u2x",
-									"name": "Higher Purpose (Locate and destroy unauthorized undead)",
+									"id": "tNqUyo1tl-SC-DUXT",
+									"name": "Higher Purpose (Bring the entire universe down to the underworld)",
 									"reference": "B59",
 									"tags": [
 										"Advantage",
@@ -2295,8 +2326,22 @@
 									}
 								},
 								{
-									"id": "tNqUyo1tl-SC-DUXT",
-									"name": "Higher Purpose (Bring the entire universe down to the underworld)",
+									"id": "ty0KFKGU5Ohz3_u2x",
+									"name": "Higher Purpose (Locate and destroy unauthorized undead)",
+									"reference": "B59",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Mental"
+									],
+									"base_points": 5,
+									"calc": {
+										"points": 5
+									}
+								},
+								{
+									"id": "tJaghqm3RiqVOIB-t",
+									"name": "Higher Purpose (Preserve the boundaries of life and death)",
 									"reference": "B59",
 									"tags": [
 										"Advantage",
@@ -2311,6 +2356,42 @@
 							],
 							"calc": {
 								"points": 20
+							}
+						},
+						{
+							"id": "TyGT3Vy5oDEFs_HRR",
+							"name": "Choose One:",
+							"children": [
+								{
+									"id": "tjHCLCswjCvpAZh9a",
+									"name": "Schtick",
+									"local_notes": "Always Look Good In Black",
+									"tags": [
+										"Physical"
+									],
+									"base_points": 1,
+									"calc": {
+										"points": 1
+									}
+								},
+								{
+									"id": "tk9r5A0fAcBjPtlox",
+									"name": "Schtick",
+									"reference": "B101,HT250,MA51",
+									"local_notes": "Foes slain personally can't rise as undead",
+									"tags": [
+										"Mental",
+										"Perk",
+										"Physical"
+									],
+									"base_points": 1,
+									"calc": {
+										"points": 1
+									}
+								}
+							],
+							"calc": {
+								"points": 2
 							}
 						},
 						{
@@ -2330,12 +2411,53 @@
 							}
 						},
 						{
-							"id": "tj65wi7jgIeMkZidw",
-							"name": "Talent (Born War Leader)",
-							"reference": "DF1:14",
+							"id": "t8x61Ckow9hFNcgIn",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "tgnQFo-hK7YwexD2S"
+							},
+							"name": "Talent (Born War-Leader)",
+							"reference": "PU3:12, BS184, DF1:14, MH1:25",
 							"tags": [
 								"Advantage",
-								"Physical"
+								"Mental",
+								"Talent"
+							],
+							"modifiers": [
+								{
+									"id": "Msg-njA9tCgkg1-Q0",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "m7ayiTu_WXBpa8bE2",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "mRtHGLj91lNy3FdVt",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Bonus to initiative rolls if leader",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
+								}
 							],
 							"points_per_level": 5,
 							"features": [
@@ -2344,7 +2466,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "leadership"
+										"qualifier": "Leadership"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2354,7 +2476,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "strategy"
+										"qualifier": "Strategy"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2364,7 +2486,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "starts_with",
-										"qualifier": "tactics"
+										"qualifier": "Tactics"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2374,7 +2496,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "intelligence analysis"
+										"qualifier": "Intelligence Analysis"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2384,7 +2506,11 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "savoir-faire"
+										"qualifier": "Savoir-Faire"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "Military"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2395,42 +2521,6 @@
 							"calc": {
 								"points": 5,
 								"current_level": 1
-							}
-						},
-						{
-							"id": "TyGT3Vy5oDEFs_HRR",
-							"name": "Choose One:",
-							"children": [
-								{
-									"id": "tk9r5A0fAcBjPtlox",
-									"name": "Schtick",
-									"reference": "B101,HT250,MA51",
-									"local_notes": "Foes slain personally can't rise as undead",
-									"tags": [
-										"Mental",
-										"Perk",
-										"Physical"
-									],
-									"base_points": 1,
-									"calc": {
-										"points": 1
-									}
-								},
-								{
-									"id": "tjHCLCswjCvpAZh9a",
-									"name": "Schtick",
-									"local_notes": "Always Look Good In Black",
-									"tags": [
-										"Physical"
-									],
-									"base_points": 1,
-									"calc": {
-										"points": 1
-									}
-								}
-							],
-							"calc": {
-								"points": 2
 							}
 						}
 					],

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Earth Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Earth Holy Warrior.gct
@@ -2684,12 +2684,53 @@
 									}
 								},
 								{
-									"id": "tlQ3W86M1DiqVxmv2",
-									"name": "Talent (Born War Leader)",
-									"reference": "DF1:14",
+									"id": "tj5fAErgJxJz7H93s",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tgnQFo-hK7YwexD2S"
+									},
+									"name": "Talent (Born War-Leader)",
+									"reference": "PU3:12, BS184, DF1:14, MH1:25",
 									"tags": [
 										"Advantage",
-										"Physical"
+										"Mental",
+										"Talent"
+									],
+									"modifiers": [
+										{
+											"id": "MJ9bWtgdP1CSqTs4K",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "mOoaxdE0pxT_SRU5r",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "mkFIHgql5WabDOhq2",
+													"name": "Alternative Benefit",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Bonus to initiative rolls if leader",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
+										}
 									],
 									"points_per_level": 5,
 									"features": [
@@ -2698,7 +2739,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "leadership"
+												"qualifier": "Leadership"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2708,7 +2749,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "strategy"
+												"qualifier": "Strategy"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2718,7 +2759,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "starts_with",
-												"qualifier": "tactics"
+												"qualifier": "Tactics"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2728,7 +2769,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "intelligence analysis"
+												"qualifier": "Intelligence Analysis"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2738,7 +2779,11 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "savoir-faire"
+												"qualifier": "Savoir-Faire"
+											},
+											"specialization": {
+												"compare": "is",
+												"qualifier": "Military"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2815,12 +2860,53 @@
 							}
 						},
 						{
-							"id": "tFyw8pO0s8AqsUbcR",
-							"name": "Talent (Born War Leader)",
-							"reference": "DF1:14",
+							"id": "tlLFHPf-enNJwFmw5",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "tgnQFo-hK7YwexD2S"
+							},
+							"name": "Talent (Born War-Leader)",
+							"reference": "PU3:12, BS184, DF1:14, MH1:25",
 							"tags": [
 								"Advantage",
-								"Physical"
+								"Mental",
+								"Talent"
+							],
+							"modifiers": [
+								{
+									"id": "M2IxR16-NKDKkI-fn",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "mY_E-w6E_TWLNgHQF",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "m7VADPdHmiDVw4-Ub",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Bonus to initiative rolls if leader",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
+								}
 							],
 							"points_per_level": 5,
 							"features": [
@@ -2829,7 +2915,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "leadership"
+										"qualifier": "Leadership"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2839,7 +2925,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "strategy"
+										"qualifier": "Strategy"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2849,7 +2935,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "starts_with",
-										"qualifier": "tactics"
+										"qualifier": "Tactics"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2859,7 +2945,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "intelligence analysis"
+										"qualifier": "Intelligence Analysis"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2869,7 +2955,11 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "savoir-faire"
+										"qualifier": "Savoir-Faire"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "Military"
 									},
 									"amount": 1,
 									"per_level": true

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Fire Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Fire Holy Warrior.gct
@@ -2817,12 +2817,53 @@
 									}
 								},
 								{
-									"id": "tW4Y_m53dphHI67uN",
-									"name": "Talent (Born War Leader)",
-									"reference": "DF1:14",
+									"id": "tI8KxAViLKJGC-InH",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tgnQFo-hK7YwexD2S"
+									},
+									"name": "Talent (Born War-Leader)",
+									"reference": "PU3:12, BS184, DF1:14, MH1:25",
 									"tags": [
 										"Advantage",
-										"Physical"
+										"Mental",
+										"Talent"
+									],
+									"modifiers": [
+										{
+											"id": "MitoMzybfY0bEjI6b",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "mCm-XYcfMvCFwOzs_",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "mre76ByH_zFsHcbd7",
+													"name": "Alternative Benefit",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Bonus to initiative rolls if leader",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
+										}
 									],
 									"points_per_level": 5,
 									"features": [
@@ -2831,7 +2872,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "leadership"
+												"qualifier": "Leadership"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2841,7 +2882,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "strategy"
+												"qualifier": "Strategy"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2851,7 +2892,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "starts_with",
-												"qualifier": "tactics"
+												"qualifier": "Tactics"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2861,7 +2902,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "intelligence analysis"
+												"qualifier": "Intelligence Analysis"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2871,7 +2912,11 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "savoir-faire"
+												"qualifier": "Savoir-Faire"
+											},
+											"specialization": {
+												"compare": "is",
+												"qualifier": "Military"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2985,12 +3030,53 @@
 							}
 						},
 						{
-							"id": "tQvZQb78RmM-CoeRx",
-							"name": "Talent (Born War Leader)",
-							"reference": "DF1:14",
+							"id": "t5PV5ZXiprMogiQdQ",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "tgnQFo-hK7YwexD2S"
+							},
+							"name": "Talent (Born War-Leader)",
+							"reference": "PU3:12, BS184, DF1:14, MH1:25",
 							"tags": [
 								"Advantage",
-								"Physical"
+								"Mental",
+								"Talent"
+							],
+							"modifiers": [
+								{
+									"id": "Mq1AdcW-i35UTUPjH",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "mLF_d9J9L2bESRBNV",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "mahZniAlTsSrxcuta",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Bonus to initiative rolls if leader",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
+								}
 							],
 							"points_per_level": 5,
 							"features": [
@@ -2999,7 +3085,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "leadership"
+										"qualifier": "Leadership"
 									},
 									"amount": 1,
 									"per_level": true
@@ -3009,7 +3095,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "strategy"
+										"qualifier": "Strategy"
 									},
 									"amount": 1,
 									"per_level": true
@@ -3019,7 +3105,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "starts_with",
-										"qualifier": "tactics"
+										"qualifier": "Tactics"
 									},
 									"amount": 1,
 									"per_level": true
@@ -3029,7 +3115,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "intelligence analysis"
+										"qualifier": "Intelligence Analysis"
 									},
 									"amount": 1,
 									"per_level": true
@@ -3039,7 +3125,11 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "savoir-faire"
+										"qualifier": "Savoir-Faire"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "Military"
 									},
 									"amount": 1,
 									"per_level": true

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Healing Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Healing Holy Warrior.gct
@@ -2195,12 +2195,53 @@
 									}
 								},
 								{
-									"id": "tGRcg0ltncUeoAGXp",
-									"name": "Talent (Born War Leader)",
-									"reference": "DF1:14",
+									"id": "tQIt4wdyYWw00-_DV",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tgnQFo-hK7YwexD2S"
+									},
+									"name": "Talent (Born War-Leader)",
+									"reference": "PU3:12, BS184, DF1:14, MH1:25",
 									"tags": [
 										"Advantage",
-										"Physical"
+										"Mental",
+										"Talent"
+									],
+									"modifiers": [
+										{
+											"id": "MLomVw3dshYxG3_jg",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "mTx72L8CIrSnoQqrI",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "mTk3xpYpS2eBj2MEm",
+													"name": "Alternative Benefit",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Bonus to initiative rolls if leader",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
+										}
 									],
 									"points_per_level": 5,
 									"features": [
@@ -2209,7 +2250,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "leadership"
+												"qualifier": "Leadership"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2219,7 +2260,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "strategy"
+												"qualifier": "Strategy"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2229,7 +2270,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "starts_with",
-												"qualifier": "tactics"
+												"qualifier": "Tactics"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2239,7 +2280,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "intelligence analysis"
+												"qualifier": "Intelligence Analysis"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2249,7 +2290,11 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "savoir-faire"
+												"qualifier": "Savoir-Faire"
+											},
+											"specialization": {
+												"compare": "is",
+												"qualifier": "Military"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2340,12 +2385,53 @@
 							}
 						},
 						{
-							"id": "tKWr9y6Z_42bsvcc0",
-							"name": "Talent (Born War Leader)",
-							"reference": "DF1:14",
+							"id": "tVHx2FeuOCvGOAv9j",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "tgnQFo-hK7YwexD2S"
+							},
+							"name": "Talent (Born War-Leader)",
+							"reference": "PU3:12, BS184, DF1:14, MH1:25",
 							"tags": [
 								"Advantage",
-								"Physical"
+								"Mental",
+								"Talent"
+							],
+							"modifiers": [
+								{
+									"id": "MVIQpLFnPbGjcrAUm",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "mnI2fRT9mOnmMYImu",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "mw1i49ZZBcke49GS2",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Bonus to initiative rolls if leader",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
+								}
 							],
 							"points_per_level": 5,
 							"features": [
@@ -2354,7 +2440,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "leadership"
+										"qualifier": "Leadership"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2364,7 +2450,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "strategy"
+										"qualifier": "Strategy"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2374,7 +2460,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "starts_with",
-										"qualifier": "tactics"
+										"qualifier": "Tactics"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2384,7 +2470,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "intelligence analysis"
+										"qualifier": "Intelligence Analysis"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2394,7 +2480,11 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "savoir-faire"
+										"qualifier": "Savoir-Faire"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "Military"
 									},
 									"amount": 1,
 									"per_level": true

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Hunter Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Hunter Holy Warrior.gct
@@ -2471,12 +2471,53 @@
 									}
 								},
 								{
-									"id": "ti_0FBDGap_q2Ve14",
-									"name": "Talent (Born War Leader)",
-									"reference": "DF1:14",
+									"id": "t03MvFFK82hxpqJcQ",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tgnQFo-hK7YwexD2S"
+									},
+									"name": "Talent (Born War-Leader)",
+									"reference": "PU3:12, BS184, DF1:14, MH1:25",
 									"tags": [
 										"Advantage",
-										"Physical"
+										"Mental",
+										"Talent"
+									],
+									"modifiers": [
+										{
+											"id": "MuDm8Wj7NADEljTAo",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "mu4fCfEZcgZdnaTRG",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "m5AHN4wMH9wkuWHiK",
+													"name": "Alternative Benefit",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Bonus to initiative rolls if leader",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
+										}
 									],
 									"points_per_level": 5,
 									"features": [
@@ -2485,7 +2526,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "leadership"
+												"qualifier": "Leadership"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2495,7 +2536,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "strategy"
+												"qualifier": "Strategy"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2505,7 +2546,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "starts_with",
-												"qualifier": "tactics"
+												"qualifier": "Tactics"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2515,7 +2556,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "intelligence analysis"
+												"qualifier": "Intelligence Analysis"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2525,7 +2566,11 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "savoir-faire"
+												"qualifier": "Savoir-Faire"
+											},
+											"specialization": {
+												"compare": "is",
+												"qualifier": "Military"
 											},
 											"amount": 1,
 											"per_level": true

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Love and Fertility Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Love and Fertility Holy Warrior.gct
@@ -2271,12 +2271,53 @@
 									}
 								},
 								{
-									"id": "t5d6pn8VmBOa8xqIT",
-									"name": "Talent (Born War Leader)",
-									"reference": "DF1:14",
+									"id": "tVY0n2mNf9c8dveE5",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tgnQFo-hK7YwexD2S"
+									},
+									"name": "Talent (Born War-Leader)",
+									"reference": "PU3:12, BS184, DF1:14, MH1:25",
 									"tags": [
 										"Advantage",
-										"Physical"
+										"Mental",
+										"Talent"
+									],
+									"modifiers": [
+										{
+											"id": "MxFrb2OzDoc4-p2PW",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "mtnxkVGnEDi-nv7wN",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "m2q70SvU9I9SuEJh5",
+													"name": "Alternative Benefit",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Bonus to initiative rolls if leader",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
+										}
 									],
 									"points_per_level": 5,
 									"features": [
@@ -2285,7 +2326,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "leadership"
+												"qualifier": "Leadership"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2295,7 +2336,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "strategy"
+												"qualifier": "Strategy"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2305,7 +2346,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "starts_with",
-												"qualifier": "tactics"
+												"qualifier": "Tactics"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2315,7 +2356,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "intelligence analysis"
+												"qualifier": "Intelligence Analysis"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2325,7 +2366,11 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "savoir-faire"
+												"qualifier": "Savoir-Faire"
+											},
+											"specialization": {
+												"compare": "is",
+												"qualifier": "Military"
 											},
 											"amount": 1,
 											"per_level": true

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Messenger Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Messenger Holy Warrior.gct
@@ -2160,12 +2160,53 @@
 							}
 						},
 						{
-							"id": "tpsdO3EqtYa30AWEA",
-							"name": "Talent (Born War Leader)",
-							"reference": "DF1:14",
+							"id": "tSOQjpLaWdaUIXbZM",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "tgnQFo-hK7YwexD2S"
+							},
+							"name": "Talent (Born War-Leader)",
+							"reference": "PU3:12, BS184, DF1:14, MH1:25",
 							"tags": [
 								"Advantage",
-								"Physical"
+								"Mental",
+								"Talent"
+							],
+							"modifiers": [
+								{
+									"id": "MWPhS9rUMZTxNQAOw",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "ml3BMTrj918Ty5NfD",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "mA1V_bZ0w2PTvTzQz",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Bonus to initiative rolls if leader",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
+								}
 							],
 							"points_per_level": 5,
 							"features": [
@@ -2174,7 +2215,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "leadership"
+										"qualifier": "Leadership"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2184,7 +2225,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "strategy"
+										"qualifier": "Strategy"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2194,7 +2235,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "starts_with",
-										"qualifier": "tactics"
+										"qualifier": "Tactics"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2204,7 +2245,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "intelligence analysis"
+										"qualifier": "Intelligence Analysis"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2214,7 +2255,11 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "savoir-faire"
+										"qualifier": "Savoir-Faire"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "Military"
 									},
 									"amount": 1,
 									"per_level": true

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Night Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Night Holy Warrior.gct
@@ -2139,12 +2139,53 @@
 									}
 								},
 								{
-									"id": "tDVDYzD5PW7FCYdUE",
-									"name": "Talent (Born War Leader)",
-									"reference": "DF1:14",
+									"id": "tfogFop9jIRQZHGEA",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tgnQFo-hK7YwexD2S"
+									},
+									"name": "Talent (Born War-Leader)",
+									"reference": "PU3:12, BS184, DF1:14, MH1:25",
 									"tags": [
 										"Advantage",
-										"Physical"
+										"Mental",
+										"Talent"
+									],
+									"modifiers": [
+										{
+											"id": "Maf1V5zmJEVsUoPy0",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "mKmeqSH1tffr_3QSH",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "muiSya2SeAFcw-bnh",
+													"name": "Alternative Benefit",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Bonus to initiative rolls if leader",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
+										}
 									],
 									"points_per_level": 5,
 									"features": [
@@ -2153,7 +2194,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "leadership"
+												"qualifier": "Leadership"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2163,7 +2204,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "strategy"
+												"qualifier": "Strategy"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2173,7 +2214,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "starts_with",
-												"qualifier": "tactics"
+												"qualifier": "Tactics"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2183,7 +2224,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "intelligence analysis"
+												"qualifier": "Intelligence Analysis"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2193,7 +2234,11 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "savoir-faire"
+												"qualifier": "Savoir-Faire"
+											},
+											"specialization": {
+												"compare": "is",
+												"qualifier": "Military"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2292,12 +2337,53 @@
 							}
 						},
 						{
-							"id": "tezr5cUxU-66wkakA",
-							"name": "Talent (Born War Leader)",
-							"reference": "DF1:14",
+							"id": "tlvCFHdKDaT_q7T-l",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "tgnQFo-hK7YwexD2S"
+							},
+							"name": "Talent (Born War-Leader)",
+							"reference": "PU3:12, BS184, DF1:14, MH1:25",
 							"tags": [
 								"Advantage",
-								"Physical"
+								"Mental",
+								"Talent"
+							],
+							"modifiers": [
+								{
+									"id": "MRfZUqkwJUregi5xt",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "mZGEknTLGurLYZGtT",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "m8VyZR2xj6EZAjXR5",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Bonus to initiative rolls if leader",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
+								}
 							],
 							"points_per_level": 5,
 							"features": [
@@ -2306,7 +2392,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "leadership"
+										"qualifier": "Leadership"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2316,7 +2402,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "strategy"
+										"qualifier": "Strategy"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2326,7 +2412,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "starts_with",
-										"qualifier": "tactics"
+										"qualifier": "Tactics"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2336,7 +2422,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "intelligence analysis"
+										"qualifier": "Intelligence Analysis"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2346,7 +2432,11 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "savoir-faire"
+										"qualifier": "Savoir-Faire"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "Military"
 									},
 									"amount": 1,
 									"per_level": true

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Rogue Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Rogue Holy Warrior.gct
@@ -2181,12 +2181,53 @@
 							}
 						},
 						{
-							"id": "tCH-kjPQIefowBGVS",
-							"name": "Talent (Born War Leader)",
-							"reference": "DF1:14",
+							"id": "t3vkmImo_O_7GPWTv",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "tgnQFo-hK7YwexD2S"
+							},
+							"name": "Talent (Born War-Leader)",
+							"reference": "PU3:12, BS184, DF1:14, MH1:25",
 							"tags": [
 								"Advantage",
-								"Physical"
+								"Mental",
+								"Talent"
+							],
+							"modifiers": [
+								{
+									"id": "MlaFt0X3HzHFmi1i_",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "mvxGTkoDe5ZDLXoet",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "mQn6febC2R_45WW2E",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Bonus to initiative rolls if leader",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
+								}
 							],
 							"points_per_level": 5,
 							"features": [
@@ -2195,7 +2236,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "leadership"
+										"qualifier": "Leadership"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2205,7 +2246,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "strategy"
+										"qualifier": "Strategy"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2215,7 +2256,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "starts_with",
-										"qualifier": "tactics"
+										"qualifier": "Tactics"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2225,7 +2266,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "intelligence analysis"
+										"qualifier": "Intelligence Analysis"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2235,7 +2276,11 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "savoir-faire"
+										"qualifier": "Savoir-Faire"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "Military"
 									},
 									"amount": 1,
 									"per_level": true

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Sea Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Sea Holy Warrior.gct
@@ -2660,12 +2660,53 @@
 									}
 								},
 								{
-									"id": "to8Q5daem9qR7igRI",
-									"name": "Talent (Born War Leader)",
-									"reference": "DF1:14",
+									"id": "tkTFOyOdVM1pt4-fC",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tgnQFo-hK7YwexD2S"
+									},
+									"name": "Talent (Born War-Leader)",
+									"reference": "PU3:12, BS184, DF1:14, MH1:25",
 									"tags": [
 										"Advantage",
-										"Physical"
+										"Mental",
+										"Talent"
+									],
+									"modifiers": [
+										{
+											"id": "M3QAd5vRNUBaMoOEi",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "mxnZRU116-3nuvQ2-",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "mXnl92KhvLxnMbDOp",
+													"name": "Alternative Benefit",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Bonus to initiative rolls if leader",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
+										}
 									],
 									"points_per_level": 5,
 									"features": [
@@ -2674,7 +2715,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "leadership"
+												"qualifier": "Leadership"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2684,7 +2725,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "strategy"
+												"qualifier": "Strategy"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2694,7 +2735,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "starts_with",
-												"qualifier": "tactics"
+												"qualifier": "Tactics"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2704,7 +2745,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "intelligence analysis"
+												"qualifier": "Intelligence Analysis"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2714,7 +2755,11 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "savoir-faire"
+												"qualifier": "Savoir-Faire"
+											},
+											"specialization": {
+												"compare": "is",
+												"qualifier": "Military"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2952,12 +2997,53 @@
 							}
 						},
 						{
-							"id": "tyR7UaLBrgoobHErq",
-							"name": "Talent (Born War Leader)",
-							"reference": "DF1:14",
+							"id": "tATFy50PLBsvy3nQK",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "tgnQFo-hK7YwexD2S"
+							},
+							"name": "Talent (Born War-Leader)",
+							"reference": "PU3:12, BS184, DF1:14, MH1:25",
 							"tags": [
 								"Advantage",
-								"Physical"
+								"Mental",
+								"Talent"
+							],
+							"modifiers": [
+								{
+									"id": "Mn_VtmWM6xXtuSCZY",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "m_Psx5jyo9aeOuPh4",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "mLLO5jX6zmPTu9Ccy",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Bonus to initiative rolls if leader",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
+								}
 							],
 							"points_per_level": 5,
 							"features": [
@@ -2966,7 +3052,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "leadership"
+										"qualifier": "Leadership"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2976,7 +3062,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "strategy"
+										"qualifier": "Strategy"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2986,7 +3072,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "starts_with",
-										"qualifier": "tactics"
+										"qualifier": "Tactics"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2996,7 +3082,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "intelligence analysis"
+										"qualifier": "Intelligence Analysis"
 									},
 									"amount": 1,
 									"per_level": true
@@ -3006,7 +3092,11 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "savoir-faire"
+										"qualifier": "Savoir-Faire"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "Military"
 									},
 									"amount": 1,
 									"per_level": true

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Storm Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Storm Holy Warrior.gct
@@ -2530,12 +2530,53 @@
 									}
 								},
 								{
-									"id": "tikO-RaFTH65a5a_F",
-									"name": "Talent (Born War Leader)",
-									"reference": "DF1:14",
+									"id": "tJVioSkybshj9cexF",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tgnQFo-hK7YwexD2S"
+									},
+									"name": "Talent (Born War-Leader)",
+									"reference": "PU3:12, BS184, DF1:14, MH1:25",
 									"tags": [
 										"Advantage",
-										"Physical"
+										"Mental",
+										"Talent"
+									],
+									"modifiers": [
+										{
+											"id": "MadQKDRNqdcXOE1qi",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "m1UBzqbpD7uvSJ8g_",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "mztXTBRKsmUaeAgCD",
+													"name": "Alternative Benefit",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Bonus to initiative rolls if leader",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
+										}
 									],
 									"points_per_level": 5,
 									"features": [
@@ -2544,7 +2585,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "leadership"
+												"qualifier": "Leadership"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2554,7 +2595,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "strategy"
+												"qualifier": "Strategy"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2564,7 +2605,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "starts_with",
-												"qualifier": "tactics"
+												"qualifier": "Tactics"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2574,7 +2615,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "intelligence analysis"
+												"qualifier": "Intelligence Analysis"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2584,7 +2625,11 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "savoir-faire"
+												"qualifier": "Savoir-Faire"
+											},
+											"specialization": {
+												"compare": "is",
+												"qualifier": "Military"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2698,12 +2743,53 @@
 							}
 						},
 						{
-							"id": "tMBj0dk6L7Qb-f8Gu",
-							"name": "Talent (Born War Leader)",
-							"reference": "DF1:14",
+							"id": "tM8HglYhh6zUENlez",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "tgnQFo-hK7YwexD2S"
+							},
+							"name": "Talent (Born War-Leader)",
+							"reference": "PU3:12, BS184, DF1:14, MH1:25",
 							"tags": [
 								"Advantage",
-								"Physical"
+								"Mental",
+								"Talent"
+							],
+							"modifiers": [
+								{
+									"id": "MhJgACnkRRYM_TZbk",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "m1X8KcEJlXlE8LtQY",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "mNBn05aTrHGLteo7o",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Bonus to initiative rolls if leader",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
+								}
 							],
 							"points_per_level": 5,
 							"features": [
@@ -2712,7 +2798,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "leadership"
+										"qualifier": "Leadership"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2722,7 +2808,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "strategy"
+										"qualifier": "Strategy"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2732,7 +2818,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "starts_with",
-										"qualifier": "tactics"
+										"qualifier": "Tactics"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2742,7 +2828,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "intelligence analysis"
+										"qualifier": "Intelligence Analysis"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2752,7 +2838,11 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "savoir-faire"
+										"qualifier": "Savoir-Faire"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "Military"
 									},
 									"amount": 1,
 									"per_level": true

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Sun Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Sun Holy Warrior.gct
@@ -2493,12 +2493,53 @@
 									}
 								},
 								{
-									"id": "t1T8jKNT30NUBBc78",
-									"name": "Talent (Born War Leader)",
-									"reference": "DF1:14",
+									"id": "tRVIG5o037jKw5Sjk",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tgnQFo-hK7YwexD2S"
+									},
+									"name": "Talent (Born War-Leader)",
+									"reference": "PU3:12, BS184, DF1:14, MH1:25",
 									"tags": [
 										"Advantage",
-										"Physical"
+										"Mental",
+										"Talent"
+									],
+									"modifiers": [
+										{
+											"id": "MzY30pOba21mnFUcK",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "mBmUu631PpkbLTffA",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "mNLOW3b4AVT51TVOH",
+													"name": "Alternative Benefit",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Bonus to initiative rolls if leader",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
+										}
 									],
 									"points_per_level": 5,
 									"features": [
@@ -2507,7 +2548,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "leadership"
+												"qualifier": "Leadership"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2517,7 +2558,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "strategy"
+												"qualifier": "Strategy"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2527,7 +2568,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "starts_with",
-												"qualifier": "tactics"
+												"qualifier": "Tactics"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2537,7 +2578,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "intelligence analysis"
+												"qualifier": "Intelligence Analysis"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2547,7 +2588,11 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "savoir-faire"
+												"qualifier": "Savoir-Faire"
+											},
+											"specialization": {
+												"compare": "is",
+												"qualifier": "Military"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2661,12 +2706,53 @@
 							}
 						},
 						{
-							"id": "tqIgMSVo9Km2py1rk",
-							"name": "Talent (Born War Leader)",
-							"reference": "DF1:14",
+							"id": "tn1o4C7hTXJSCO8A7",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "tgnQFo-hK7YwexD2S"
+							},
+							"name": "Talent (Born War-Leader)",
+							"reference": "PU3:12, BS184, DF1:14, MH1:25",
 							"tags": [
 								"Advantage",
-								"Physical"
+								"Mental",
+								"Talent"
+							],
+							"modifiers": [
+								{
+									"id": "M8iSmsRx9gSjhGZoN",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "mAM5AOsdxM-RUFTSB",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "mBwfphob25azGy6kY",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Bonus to initiative rolls if leader",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
+								}
 							],
 							"points_per_level": 5,
 							"features": [
@@ -2675,7 +2761,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "leadership"
+										"qualifier": "Leadership"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2685,7 +2771,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "strategy"
+										"qualifier": "Strategy"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2695,7 +2781,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "starts_with",
-										"qualifier": "tactics"
+										"qualifier": "Tactics"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2705,7 +2791,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "intelligence analysis"
+										"qualifier": "Intelligence Analysis"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2715,7 +2801,11 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "savoir-faire"
+										"qualifier": "Savoir-Faire"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "Military"
 									},
 									"amount": 1,
 									"per_level": true

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Urban Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Urban Holy Warrior.gct
@@ -2195,12 +2195,53 @@
 									}
 								},
 								{
-									"id": "tZJzOCA9W9mkzZEFI",
-									"name": "Talent (Born War Leader)",
-									"reference": "DF1:14",
+									"id": "tMJP9RALsCU0YX7EZ",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tgnQFo-hK7YwexD2S"
+									},
+									"name": "Talent (Born War-Leader)",
+									"reference": "PU3:12, BS184, DF1:14, MH1:25",
 									"tags": [
 										"Advantage",
-										"Physical"
+										"Mental",
+										"Talent"
+									],
+									"modifiers": [
+										{
+											"id": "MPacuQcRhWqq0NoQK",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "mfhuDMGxP2lxXbz10",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "mbOcoOXYHd7NAhiaJ",
+													"name": "Alternative Benefit",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Bonus to initiative rolls if leader",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
+										}
 									],
 									"points_per_level": 5,
 									"features": [
@@ -2209,7 +2250,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "leadership"
+												"qualifier": "Leadership"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2219,7 +2260,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "strategy"
+												"qualifier": "Strategy"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2229,7 +2270,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "starts_with",
-												"qualifier": "tactics"
+												"qualifier": "Tactics"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2239,7 +2280,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "intelligence analysis"
+												"qualifier": "Intelligence Analysis"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2249,7 +2290,11 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "savoir-faire"
+												"qualifier": "Savoir-Faire"
+											},
+											"specialization": {
+												"compare": "is",
+												"qualifier": "Military"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2326,12 +2371,53 @@
 							}
 						},
 						{
-							"id": "tB5Fc1mbifJZ8iS1C",
-							"name": "Talent (Born War Leader)",
-							"reference": "DF1:14",
+							"id": "tdatMarmsVJJ753-n",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "tgnQFo-hK7YwexD2S"
+							},
+							"name": "Talent (Born War-Leader)",
+							"reference": "PU3:12, BS184, DF1:14, MH1:25",
 							"tags": [
 								"Advantage",
-								"Physical"
+								"Mental",
+								"Talent"
+							],
+							"modifiers": [
+								{
+									"id": "MOaqvwATFPtGJ9yFo",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "msWyahCilSiXTyuoQ",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "mGv3n2JRYUOmHWySh",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Bonus to initiative rolls if leader",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
+								}
 							],
 							"points_per_level": 5,
 							"features": [
@@ -2340,7 +2426,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "leadership"
+										"qualifier": "Leadership"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2350,7 +2436,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "strategy"
+										"qualifier": "Strategy"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2360,7 +2446,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "starts_with",
-										"qualifier": "tactics"
+										"qualifier": "Tactics"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2370,7 +2456,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "intelligence analysis"
+										"qualifier": "Intelligence Analysis"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2380,7 +2466,11 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "savoir-faire"
+										"qualifier": "Savoir-Faire"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "Military"
 									},
 									"amount": 1,
 									"per_level": true

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/War Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/War Holy Warrior.gct
@@ -2070,12 +2070,53 @@
 									}
 								},
 								{
-									"id": "tyXHwdXiDg2FjGFU9",
-									"name": "Talent (Born War Leader)",
-									"reference": "DF1:14",
+									"id": "tsg2gREAT7x31sW2S",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tgnQFo-hK7YwexD2S"
+									},
+									"name": "Talent (Born War-Leader)",
+									"reference": "PU3:12, BS184, DF1:14, MH1:25",
 									"tags": [
 										"Advantage",
-										"Physical"
+										"Mental",
+										"Talent"
+									],
+									"modifiers": [
+										{
+											"id": "M_qUwlt4ff73tFxdv",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "mVKPOPvORpLsSgoan",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "mNdQHfHpKwRSA7ieG",
+													"name": "Alternative Benefit",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Bonus to initiative rolls if leader",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
+										}
 									],
 									"points_per_level": 5,
 									"features": [
@@ -2084,7 +2125,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "leadership"
+												"qualifier": "Leadership"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2094,7 +2135,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "strategy"
+												"qualifier": "Strategy"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2104,7 +2145,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "starts_with",
-												"qualifier": "tactics"
+												"qualifier": "Tactics"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2114,7 +2155,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "intelligence analysis"
+												"qualifier": "Intelligence Analysis"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2124,7 +2165,11 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "savoir-faire"
+												"qualifier": "Savoir-Faire"
+											},
+											"specialization": {
+												"compare": "is",
+												"qualifier": "Military"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2238,12 +2283,53 @@
 							}
 						},
 						{
-							"id": "tKkfMfCiX0t3Cn1W2",
-							"name": "Talent (Born War Leader)",
-							"reference": "DF1:14",
+							"id": "tyU3e_1igjvz1arb4",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "tgnQFo-hK7YwexD2S"
+							},
+							"name": "Talent (Born War-Leader)",
+							"reference": "PU3:12, BS184, DF1:14, MH1:25",
 							"tags": [
 								"Advantage",
-								"Physical"
+								"Mental",
+								"Talent"
+							],
+							"modifiers": [
+								{
+									"id": "MS3o9frbSYI0kGVVC",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "mAyiMhsyrs6M24Cjx",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "mW_YxE3-OtYTEe5-a",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Bonus to initiative rolls if leader",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
+								}
 							],
 							"points_per_level": 5,
 							"features": [
@@ -2252,7 +2338,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "leadership"
+										"qualifier": "Leadership"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2262,7 +2348,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "strategy"
+										"qualifier": "Strategy"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2272,7 +2358,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "starts_with",
-										"qualifier": "tactics"
+										"qualifier": "Tactics"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2282,7 +2368,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "intelligence analysis"
+										"qualifier": "Intelligence Analysis"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2292,7 +2378,11 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "savoir-faire"
+										"qualifier": "Savoir-Faire"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "Military"
 									},
 									"amount": 1,
 									"per_level": true

--- a/Library/Dungeon Fantasy/Dungeon Fantasy Adventure 1/Rivals/Holy Warrior.gcs
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy Adventure 1/Rivals/Holy Warrior.gcs
@@ -1018,12 +1018,53 @@
 					}
 				},
 				{
-					"id": "tfNMF6K-paNMUnw5K",
-					"name": "Talent (Born War Leader)",
-					"reference": "DF1:14",
+					"id": "tpKIlFaD-uKcIQOh4",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Power Ups/Power Ups Traits.adq",
+						"id": "tgnQFo-hK7YwexD2S"
+					},
+					"name": "Talent (Born War-Leader)",
+					"reference": "PU3:12, BS184, DF1:14, MH1:25",
 					"tags": [
 						"Advantage",
-						"Physical"
+						"Mental",
+						"Talent"
+					],
+					"modifiers": [
+						{
+							"id": "M8TmQL3iu37pGwoCP",
+							"name": "Benefits",
+							"children": [
+								{
+									"id": "mr0upg7nAGx4fWvU0",
+									"name": "Reaction Bonus",
+									"use_level_from_trait": true,
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+											"amount": 1,
+											"per_level": true
+										}
+									]
+								},
+								{
+									"id": "mjsGZjqNexNHB0KX6",
+									"name": "Alternative Benefit",
+									"use_level_from_trait": true,
+									"features": [
+										{
+											"type": "conditional_modifier",
+											"situation": "Bonus to initiative rolls if leader",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"disabled": true
+								}
+							]
+						}
 					],
 					"points_per_level": 5,
 					"features": [
@@ -1032,7 +1073,7 @@
 							"selection_type": "skills_with_name",
 							"name": {
 								"compare": "is",
-								"qualifier": "leadership"
+								"qualifier": "Leadership"
 							},
 							"amount": 1,
 							"per_level": true
@@ -1042,7 +1083,7 @@
 							"selection_type": "skills_with_name",
 							"name": {
 								"compare": "is",
-								"qualifier": "strategy"
+								"qualifier": "Strategy"
 							},
 							"amount": 1,
 							"per_level": true
@@ -1052,7 +1093,7 @@
 							"selection_type": "skills_with_name",
 							"name": {
 								"compare": "starts_with",
-								"qualifier": "tactics"
+								"qualifier": "Tactics"
 							},
 							"amount": 1,
 							"per_level": true
@@ -1062,7 +1103,7 @@
 							"selection_type": "skills_with_name",
 							"name": {
 								"compare": "is",
-								"qualifier": "intelligence analysis"
+								"qualifier": "Intelligence Analysis"
 							},
 							"amount": 1,
 							"per_level": true
@@ -1072,7 +1113,11 @@
 							"selection_type": "skills_with_name",
 							"name": {
 								"compare": "is",
-								"qualifier": "savoir-faire"
+								"qualifier": "Savoir-Faire"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Military"
 							},
 							"amount": 1,
 							"per_level": true
@@ -2970,7 +3015,7 @@
 		}
 	],
 	"created_date": "2022-11-17T22:04:18-05:00",
-	"modified_date": "2025-08-30T20:56:27+01:00",
+	"modified_date": "2026-04-21T18:55:55+01:00",
 	"calc": {
 		"swing": "2d",
 		"thrust": "1d",

--- a/Library/Dungeon Fantasy/Dungeon Fantasy Adventure 1/Rivals/Noble Knight.gcs
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy Adventure 1/Rivals/Noble Knight.gcs
@@ -597,12 +597,53 @@
 			"reference": "DF1:8",
 			"children": [
 				{
-					"id": "tolIdkPgd7QZ4xzDK",
-					"name": "Talent (Born War Leader)",
-					"reference": "DF1:14",
+					"id": "tF-Fcm6U7zdMRw581",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Power Ups/Power Ups Traits.adq",
+						"id": "tgnQFo-hK7YwexD2S"
+					},
+					"name": "Talent (Born War-Leader)",
+					"reference": "PU3:12, BS184, DF1:14, MH1:25",
 					"tags": [
 						"Advantage",
-						"Physical"
+						"Mental",
+						"Talent"
+					],
+					"modifiers": [
+						{
+							"id": "MisvHv1yXar2ugdMs",
+							"name": "Benefits",
+							"children": [
+								{
+									"id": "mxzJGpNl_yBIBwkR1",
+									"name": "Reaction Bonus",
+									"use_level_from_trait": true,
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+											"amount": 1,
+											"per_level": true
+										}
+									]
+								},
+								{
+									"id": "mC4IGt0u9FJFH7t-O",
+									"name": "Alternative Benefit",
+									"use_level_from_trait": true,
+									"features": [
+										{
+											"type": "conditional_modifier",
+											"situation": "Bonus to initiative rolls if leader",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"disabled": true
+								}
+							]
+						}
 					],
 					"points_per_level": 5,
 					"features": [
@@ -611,7 +652,7 @@
 							"selection_type": "skills_with_name",
 							"name": {
 								"compare": "is",
-								"qualifier": "leadership"
+								"qualifier": "Leadership"
 							},
 							"amount": 1,
 							"per_level": true
@@ -621,7 +662,7 @@
 							"selection_type": "skills_with_name",
 							"name": {
 								"compare": "is",
-								"qualifier": "strategy"
+								"qualifier": "Strategy"
 							},
 							"amount": 1,
 							"per_level": true
@@ -631,7 +672,7 @@
 							"selection_type": "skills_with_name",
 							"name": {
 								"compare": "starts_with",
-								"qualifier": "tactics"
+								"qualifier": "Tactics"
 							},
 							"amount": 1,
 							"per_level": true
@@ -641,7 +682,7 @@
 							"selection_type": "skills_with_name",
 							"name": {
 								"compare": "is",
-								"qualifier": "intelligence analysis"
+								"qualifier": "Intelligence Analysis"
 							},
 							"amount": 1,
 							"per_level": true
@@ -651,7 +692,11 @@
 							"selection_type": "skills_with_name",
 							"name": {
 								"compare": "is",
-								"qualifier": "savoir-faire"
+								"qualifier": "Savoir-Faire"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Military"
 							},
 							"amount": 1,
 							"per_level": true
@@ -2949,7 +2994,7 @@
 		}
 	],
 	"created_date": "2022-11-24T23:24:39-05:00",
-	"modified_date": "2022-11-26T01:02:42-05:00",
+	"modified_date": "2026-04-21T18:55:41+01:00",
 	"calc": {
 		"swing": "2d+1",
 		"thrust": "1d+1",

--- a/Library/Dungeon Fantasy/Dungeon Fantasy Denizens/Barbarians/Savage Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy Denizens/Barbarians/Savage Warrior.gct
@@ -1503,12 +1503,53 @@
 									}
 								},
 								{
-									"id": "t0oL0U2qygKiB6Kzh",
-									"name": "Talent (Born War Leader)",
-									"reference": "DF1:14",
+									"id": "tqghCP2HAZ11L_eor",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tgnQFo-hK7YwexD2S"
+									},
+									"name": "Talent (Born War-Leader)",
+									"reference": "PU3:12, BS184, DF1:14, MH1:25",
 									"tags": [
 										"Advantage",
-										"Physical"
+										"Mental",
+										"Talent"
+									],
+									"modifiers": [
+										{
+											"id": "Mv4FxI5UhjeuVDY25",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "m4PnMZqdC0cEr1umj",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "mjTBs7PFHuLalRY4p",
+													"name": "Alternative Benefit",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Bonus to initiative rolls if leader",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
+										}
 									],
 									"points_per_level": 5,
 									"features": [
@@ -1517,7 +1558,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "leadership"
+												"qualifier": "Leadership"
 											},
 											"amount": 1,
 											"per_level": true
@@ -1527,7 +1568,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "strategy"
+												"qualifier": "Strategy"
 											},
 											"amount": 1,
 											"per_level": true
@@ -1537,7 +1578,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "starts_with",
-												"qualifier": "tactics"
+												"qualifier": "Tactics"
 											},
 											"amount": 1,
 											"per_level": true
@@ -1547,7 +1588,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "intelligence analysis"
+												"qualifier": "Intelligence Analysis"
 											},
 											"amount": 1,
 											"per_level": true
@@ -1557,7 +1598,11 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "savoir-faire"
+												"qualifier": "Savoir-Faire"
+											},
+											"specialization": {
+												"compare": "is",
+												"qualifier": "Military"
 											},
 											"amount": 1,
 											"per_level": true
@@ -1845,12 +1890,53 @@
 							}
 						},
 						{
-							"id": "trp4Yb3H7_3bMD_np",
-							"name": "Talent (Born War Leader)",
-							"reference": "DF1:14",
+							"id": "tLVGXRXTsz6wuI2qZ",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "tgnQFo-hK7YwexD2S"
+							},
+							"name": "Talent (Born War-Leader)",
+							"reference": "PU3:12, BS184, DF1:14, MH1:25",
 							"tags": [
 								"Advantage",
-								"Physical"
+								"Mental",
+								"Talent"
+							],
+							"modifiers": [
+								{
+									"id": "Mas4fxnxbykv79yg8",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "mkroDEbch3Ow7UQif",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "mdl3zgDBAqcBQ2fLX",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Bonus to initiative rolls if leader",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
+								}
 							],
 							"points_per_level": 5,
 							"features": [
@@ -1859,7 +1945,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "leadership"
+										"qualifier": "Leadership"
 									},
 									"amount": 1,
 									"per_level": true
@@ -1869,7 +1955,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "strategy"
+										"qualifier": "Strategy"
 									},
 									"amount": 1,
 									"per_level": true
@@ -1879,7 +1965,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "starts_with",
-										"qualifier": "tactics"
+										"qualifier": "Tactics"
 									},
 									"amount": 1,
 									"per_level": true
@@ -1889,7 +1975,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "intelligence analysis"
+										"qualifier": "Intelligence Analysis"
 									},
 									"amount": 1,
 									"per_level": true
@@ -1899,7 +1985,11 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "savoir-faire"
+										"qualifier": "Savoir-Faire"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "Military"
 									},
 									"amount": 1,
 									"per_level": true

--- a/Library/Dungeon Fantasy/Dungeon Fantasy Denizens/Swashbucklers/Aristocrat Henchman.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy Denizens/Swashbucklers/Aristocrat Henchman.gct
@@ -1323,12 +1323,53 @@
 									}
 								},
 								{
-									"id": "t2xY3JARjHzq3VGsm",
-									"name": "Talent (Born War Leader)",
-									"reference": "DF1:14,PU3:12",
+									"id": "tAszrIGn8FY9JCCLg",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tgnQFo-hK7YwexD2S"
+									},
+									"name": "Talent (Born War-Leader)",
+									"reference": "PU3:12, BS184, DF1:14, MH1:25",
 									"tags": [
 										"Advantage",
-										"Physical"
+										"Mental",
+										"Talent"
+									],
+									"modifiers": [
+										{
+											"id": "MmGHNy3foCHgoQt56",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "mcTFx7i8JuoafFsHa",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "mb2iPw7FtrdJ5uFiY",
+													"name": "Alternative Benefit",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Bonus to initiative rolls if leader",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
+										}
 									],
 									"points_per_level": 5,
 									"features": [
@@ -1337,7 +1378,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "leadership"
+												"qualifier": "Leadership"
 											},
 											"amount": 1,
 											"per_level": true
@@ -1347,7 +1388,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "strategy"
+												"qualifier": "Strategy"
 											},
 											"amount": 1,
 											"per_level": true
@@ -1357,7 +1398,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "starts_with",
-												"qualifier": "tactics"
+												"qualifier": "Tactics"
 											},
 											"amount": 1,
 											"per_level": true
@@ -1367,7 +1408,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "intelligence analysis"
+												"qualifier": "Intelligence Analysis"
 											},
 											"amount": 1,
 											"per_level": true
@@ -1377,11 +1418,11 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "savoir-faire"
+												"qualifier": "Savoir-Faire"
 											},
 											"specialization": {
 												"compare": "is",
-												"qualifier": "military"
+												"qualifier": "Military"
 											},
 											"amount": 1,
 											"per_level": true

--- a/Library/Dungeon Fantasy/Dungeon Fantasy Denizens/Swashbucklers/Aristocrat.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy Denizens/Swashbucklers/Aristocrat.gct
@@ -1665,12 +1665,53 @@
 							}
 						},
 						{
-							"id": "tEgfD_J9cKd45o-hS",
-							"name": "Talent (Born War Leader)",
-							"reference": "DF1:14,PU3:12",
+							"id": "tmZjRcVPPNQ_n8IRW",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "tgnQFo-hK7YwexD2S"
+							},
+							"name": "Talent (Born War-Leader)",
+							"reference": "PU3:12, BS184, DF1:14, MH1:25",
 							"tags": [
 								"Advantage",
-								"Physical"
+								"Mental",
+								"Talent"
+							],
+							"modifiers": [
+								{
+									"id": "MJinDsmH2yOSCkLAk",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "mgMLG9uQe2i2-WZK1",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "m8TeHB0cYeDgpNzeR",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Bonus to initiative rolls if leader",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
+								}
 							],
 							"points_per_level": 5,
 							"features": [
@@ -1679,7 +1720,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "leadership"
+										"qualifier": "Leadership"
 									},
 									"amount": 1,
 									"per_level": true
@@ -1689,7 +1730,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "strategy"
+										"qualifier": "Strategy"
 									},
 									"amount": 1,
 									"per_level": true
@@ -1699,7 +1740,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "starts_with",
-										"qualifier": "tactics"
+										"qualifier": "Tactics"
 									},
 									"amount": 1,
 									"per_level": true
@@ -1709,7 +1750,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "intelligence analysis"
+										"qualifier": "Intelligence Analysis"
 									},
 									"amount": 1,
 									"per_level": true
@@ -1719,11 +1760,11 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "savoir-faire"
+										"qualifier": "Savoir-Faire"
 									},
 									"specialization": {
 										"compare": "is",
-										"qualifier": "military"
+										"qualifier": "Military"
 									},
 									"amount": 1,
 									"per_level": true

--- a/Library/Home Brew/Enraged Eggplant/Occupational Templates/Fighter.gct
+++ b/Library/Home Brew/Enraged Eggplant/Occupational Templates/Fighter.gct
@@ -1313,13 +1313,53 @@
 							}
 						},
 						{
-							"id": "tGUhGNSGwIls9ol8x",
-							"name": "Talent (Born War Leader)",
-							"reference": "DF1:14,PU3:12",
+							"id": "tRwBr9GLCJO1YRV3s",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "tgnQFo-hK7YwexD2S"
+							},
+							"name": "Talent (Born War-Leader)",
+							"reference": "PU3:12, BS184, DF1:14, MH1:25",
 							"tags": [
 								"Advantage",
-								"Physical",
+								"Mental",
 								"Talent"
+							],
+							"modifiers": [
+								{
+									"id": "M07Wed7tqUiLIIXe0",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "mMyvmHjzTlbYW5F1m",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "m-kB3L-5iIYZHI6F1",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Bonus to initiative rolls if leader",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
+								}
 							],
 							"points_per_level": 5,
 							"features": [
@@ -1328,7 +1368,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "leadership"
+										"qualifier": "Leadership"
 									},
 									"amount": 1,
 									"per_level": true
@@ -1338,7 +1378,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "strategy"
+										"qualifier": "Strategy"
 									},
 									"amount": 1,
 									"per_level": true
@@ -1348,7 +1388,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "starts_with",
-										"qualifier": "tactics"
+										"qualifier": "Tactics"
 									},
 									"amount": 1,
 									"per_level": true
@@ -1358,7 +1398,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "intelligence analysis"
+										"qualifier": "Intelligence Analysis"
 									},
 									"amount": 1,
 									"per_level": true
@@ -1368,24 +1408,12 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "savoir-faire"
+										"qualifier": "Savoir-Faire"
 									},
 									"specialization": {
 										"compare": "is",
-										"qualifier": "military"
+										"qualifier": "Military"
 									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "reaction_bonus",
-									"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "conditional_modifier",
-									"situation": "Bonus to initiative rolls if leader",
 									"amount": 1,
 									"per_level": true
 								}

--- a/Library/Home Brew/Enraged Eggplant/Occupational Templates/Paladin.gct
+++ b/Library/Home Brew/Enraged Eggplant/Occupational Templates/Paladin.gct
@@ -1534,13 +1534,53 @@
 							}
 						},
 						{
-							"id": "tpn_ULumYNVzMLhGz",
-							"name": "Talent (Born War Leader)",
-							"reference": "DF1:14,PU3:12",
+							"id": "txvPdjKLw6D5tdMTy",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "tgnQFo-hK7YwexD2S"
+							},
+							"name": "Talent (Born War-Leader)",
+							"reference": "PU3:12, BS184, DF1:14, MH1:25",
 							"tags": [
 								"Advantage",
-								"Physical",
+								"Mental",
 								"Talent"
+							],
+							"modifiers": [
+								{
+									"id": "MHQ8kBfheBIz6v7O0",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "mvrQyRXFXddvOLVOE",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "mYJ2xGRCaHJTN6As1",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Bonus to initiative rolls if leader",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
+								}
 							],
 							"points_per_level": 5,
 							"features": [
@@ -1549,7 +1589,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "leadership"
+										"qualifier": "Leadership"
 									},
 									"amount": 1,
 									"per_level": true
@@ -1559,7 +1599,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "strategy"
+										"qualifier": "Strategy"
 									},
 									"amount": 1,
 									"per_level": true
@@ -1569,7 +1609,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "starts_with",
-										"qualifier": "tactics"
+										"qualifier": "Tactics"
 									},
 									"amount": 1,
 									"per_level": true
@@ -1579,7 +1619,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "intelligence analysis"
+										"qualifier": "Intelligence Analysis"
 									},
 									"amount": 1,
 									"per_level": true
@@ -1589,24 +1629,12 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "savoir-faire"
+										"qualifier": "Savoir-Faire"
 									},
 									"specialization": {
 										"compare": "is",
-										"qualifier": "military"
+										"qualifier": "Military"
 									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "reaction_bonus",
-									"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "conditional_modifier",
-									"situation": "Bonus to initiative rolls if leader",
 									"amount": 1,
 									"per_level": true
 								}

--- a/Library/Home Brew/Historical Folks Skill Sets/Skill Sets/Commander.gct
+++ b/Library/Home Brew/Historical Folks Skill Sets/Skill Sets/Commander.gct
@@ -14,13 +14,53 @@
 			},
 			"children": [
 				{
-					"id": "t7SMoJn84UeN_Ztkq",
-					"name": "Talent (Born War Leader)",
-					"reference": "DF1:14,PU3:12",
+					"id": "taCo_WjcA66zfNwo7",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Power Ups/Power Ups Traits.adq",
+						"id": "tgnQFo-hK7YwexD2S"
+					},
+					"name": "Talent (Born War-Leader)",
+					"reference": "PU3:12, BS184, DF1:14, MH1:25",
 					"tags": [
 						"Advantage",
-						"Physical",
+						"Mental",
 						"Talent"
+					],
+					"modifiers": [
+						{
+							"id": "MTFajJIIox6O3To42",
+							"name": "Benefits",
+							"children": [
+								{
+									"id": "m3qCXGWEORmYKuR82",
+									"name": "Reaction Bonus",
+									"use_level_from_trait": true,
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+											"amount": 1,
+											"per_level": true
+										}
+									]
+								},
+								{
+									"id": "mFspNrM87-ZsXmUdX",
+									"name": "Alternative Benefit",
+									"use_level_from_trait": true,
+									"features": [
+										{
+											"type": "conditional_modifier",
+											"situation": "Bonus to initiative rolls if leader",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"disabled": true
+								}
+							]
+						}
 					],
 					"points_per_level": 5,
 					"features": [
@@ -29,7 +69,7 @@
 							"selection_type": "skills_with_name",
 							"name": {
 								"compare": "is",
-								"qualifier": "leadership"
+								"qualifier": "Leadership"
 							},
 							"amount": 1,
 							"per_level": true
@@ -39,7 +79,7 @@
 							"selection_type": "skills_with_name",
 							"name": {
 								"compare": "is",
-								"qualifier": "strategy"
+								"qualifier": "Strategy"
 							},
 							"amount": 1,
 							"per_level": true
@@ -49,7 +89,7 @@
 							"selection_type": "skills_with_name",
 							"name": {
 								"compare": "starts_with",
-								"qualifier": "tactics"
+								"qualifier": "Tactics"
 							},
 							"amount": 1,
 							"per_level": true
@@ -59,7 +99,7 @@
 							"selection_type": "skills_with_name",
 							"name": {
 								"compare": "is",
-								"qualifier": "intelligence analysis"
+								"qualifier": "Intelligence Analysis"
 							},
 							"amount": 1,
 							"per_level": true
@@ -69,24 +109,12 @@
 							"selection_type": "skills_with_name",
 							"name": {
 								"compare": "is",
-								"qualifier": "savoir-faire"
+								"qualifier": "Savoir-Faire"
 							},
 							"specialization": {
 								"compare": "is",
-								"qualifier": "military"
+								"qualifier": "Military"
 							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "reaction_bonus",
-							"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "conditional_modifier",
-							"situation": "Bonus to initiative rolls if leader",
 							"amount": 1,
 							"per_level": true
 						}

--- a/Library/Home Brew/Historical Folks Skill Sets/Skill Sets/Page.gct
+++ b/Library/Home Brew/Historical Folks Skill Sets/Skill Sets/Page.gct
@@ -169,13 +169,53 @@
 					}
 				},
 				{
-					"id": "tiolvLoJG4-9ZLzvq",
-					"name": "Talent (Born War Leader)",
-					"reference": "DF1:14,PU3:12",
+					"id": "tyPzBJSolicPYWWii",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Power Ups/Power Ups Traits.adq",
+						"id": "tgnQFo-hK7YwexD2S"
+					},
+					"name": "Talent (Born War-Leader)",
+					"reference": "PU3:12, BS184, DF1:14, MH1:25",
 					"tags": [
 						"Advantage",
-						"Physical",
+						"Mental",
 						"Talent"
+					],
+					"modifiers": [
+						{
+							"id": "MRtP_XXagz1mEB5r6",
+							"name": "Benefits",
+							"children": [
+								{
+									"id": "mcsdaVAI-mGQNMb8h",
+									"name": "Reaction Bonus",
+									"use_level_from_trait": true,
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+											"amount": 1,
+											"per_level": true
+										}
+									]
+								},
+								{
+									"id": "m47WUM7tMXmvmNltK",
+									"name": "Alternative Benefit",
+									"use_level_from_trait": true,
+									"features": [
+										{
+											"type": "conditional_modifier",
+											"situation": "Bonus to initiative rolls if leader",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"disabled": true
+								}
+							]
+						}
 					],
 					"points_per_level": 5,
 					"features": [
@@ -184,7 +224,7 @@
 							"selection_type": "skills_with_name",
 							"name": {
 								"compare": "is",
-								"qualifier": "leadership"
+								"qualifier": "Leadership"
 							},
 							"amount": 1,
 							"per_level": true
@@ -194,7 +234,7 @@
 							"selection_type": "skills_with_name",
 							"name": {
 								"compare": "is",
-								"qualifier": "strategy"
+								"qualifier": "Strategy"
 							},
 							"amount": 1,
 							"per_level": true
@@ -204,7 +244,7 @@
 							"selection_type": "skills_with_name",
 							"name": {
 								"compare": "starts_with",
-								"qualifier": "tactics"
+								"qualifier": "Tactics"
 							},
 							"amount": 1,
 							"per_level": true
@@ -214,7 +254,7 @@
 							"selection_type": "skills_with_name",
 							"name": {
 								"compare": "is",
-								"qualifier": "intelligence analysis"
+								"qualifier": "Intelligence Analysis"
 							},
 							"amount": 1,
 							"per_level": true
@@ -224,24 +264,12 @@
 							"selection_type": "skills_with_name",
 							"name": {
 								"compare": "is",
-								"qualifier": "savoir-faire"
+								"qualifier": "Savoir-Faire"
 							},
 							"specialization": {
 								"compare": "is",
-								"qualifier": "military"
+								"qualifier": "Military"
 							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "reaction_bonus",
-							"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "conditional_modifier",
-							"situation": "Bonus to initiative rolls if leader",
 							"amount": 1,
 							"per_level": true
 						}

--- a/Library/Home Brew/Historical Folks Skill Sets/Skill Sets/Soldier.gct
+++ b/Library/Home Brew/Historical Folks Skill Sets/Skill Sets/Soldier.gct
@@ -198,13 +198,53 @@
 					}
 				},
 				{
-					"id": "tGPLNcq2mGJbYpp8V",
-					"name": "Talent (Born War Leader)",
-					"reference": "DF1:14,PU3:12",
+					"id": "tKRaFkiMTFcM2WI9X",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Power Ups/Power Ups Traits.adq",
+						"id": "tgnQFo-hK7YwexD2S"
+					},
+					"name": "Talent (Born War-Leader)",
+					"reference": "PU3:12, BS184, DF1:14, MH1:25",
 					"tags": [
 						"Advantage",
-						"Physical",
+						"Mental",
 						"Talent"
+					],
+					"modifiers": [
+						{
+							"id": "MupXpnathS6uUt7ij",
+							"name": "Benefits",
+							"children": [
+								{
+									"id": "mO7NY81ZSbJcnZ-Np",
+									"name": "Reaction Bonus",
+									"use_level_from_trait": true,
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+											"amount": 1,
+											"per_level": true
+										}
+									]
+								},
+								{
+									"id": "mcjvTpd0TZP521YPh",
+									"name": "Alternative Benefit",
+									"use_level_from_trait": true,
+									"features": [
+										{
+											"type": "conditional_modifier",
+											"situation": "Bonus to initiative rolls if leader",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"disabled": true
+								}
+							]
+						}
 					],
 					"points_per_level": 5,
 					"features": [
@@ -213,7 +253,7 @@
 							"selection_type": "skills_with_name",
 							"name": {
 								"compare": "is",
-								"qualifier": "leadership"
+								"qualifier": "Leadership"
 							},
 							"amount": 1,
 							"per_level": true
@@ -223,7 +263,7 @@
 							"selection_type": "skills_with_name",
 							"name": {
 								"compare": "is",
-								"qualifier": "strategy"
+								"qualifier": "Strategy"
 							},
 							"amount": 1,
 							"per_level": true
@@ -233,7 +273,7 @@
 							"selection_type": "skills_with_name",
 							"name": {
 								"compare": "starts_with",
-								"qualifier": "tactics"
+								"qualifier": "Tactics"
 							},
 							"amount": 1,
 							"per_level": true
@@ -243,7 +283,7 @@
 							"selection_type": "skills_with_name",
 							"name": {
 								"compare": "is",
-								"qualifier": "intelligence analysis"
+								"qualifier": "Intelligence Analysis"
 							},
 							"amount": 1,
 							"per_level": true
@@ -253,24 +293,12 @@
 							"selection_type": "skills_with_name",
 							"name": {
 								"compare": "is",
-								"qualifier": "savoir-faire"
+								"qualifier": "Savoir-Faire"
 							},
 							"specialization": {
 								"compare": "is",
-								"qualifier": "military"
+								"qualifier": "Military"
 							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "reaction_bonus",
-							"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "conditional_modifier",
-							"situation": "Bonus to initiative rolls if leader",
 							"amount": 1,
 							"per_level": true
 						}

--- a/Library/Home Brew/Historical Folks Skill Sets/Skill Sets/Squire.gct
+++ b/Library/Home Brew/Historical Folks Skill Sets/Skill Sets/Squire.gct
@@ -170,13 +170,53 @@
 					}
 				},
 				{
-					"id": "t0cphiYg-PBEDJgdV",
-					"name": "Talent (Born War Leader)",
-					"reference": "DF1:14,PU3:12",
+					"id": "tqAE9RKYMCKissvtn",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Power Ups/Power Ups Traits.adq",
+						"id": "tgnQFo-hK7YwexD2S"
+					},
+					"name": "Talent (Born War-Leader)",
+					"reference": "PU3:12, BS184, DF1:14, MH1:25",
 					"tags": [
 						"Advantage",
-						"Physical",
+						"Mental",
 						"Talent"
+					],
+					"modifiers": [
+						{
+							"id": "MWWmHM_HdgjIiVR88",
+							"name": "Benefits",
+							"children": [
+								{
+									"id": "mhtIRJfjMlGKN5RGe",
+									"name": "Reaction Bonus",
+									"use_level_from_trait": true,
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+											"amount": 1,
+											"per_level": true
+										}
+									]
+								},
+								{
+									"id": "m_XWOSj6rxF9RQ14s",
+									"name": "Alternative Benefit",
+									"use_level_from_trait": true,
+									"features": [
+										{
+											"type": "conditional_modifier",
+											"situation": "Bonus to initiative rolls if leader",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"disabled": true
+								}
+							]
+						}
 					],
 					"points_per_level": 5,
 					"features": [
@@ -185,7 +225,7 @@
 							"selection_type": "skills_with_name",
 							"name": {
 								"compare": "is",
-								"qualifier": "leadership"
+								"qualifier": "Leadership"
 							},
 							"amount": 1,
 							"per_level": true
@@ -195,7 +235,7 @@
 							"selection_type": "skills_with_name",
 							"name": {
 								"compare": "is",
-								"qualifier": "strategy"
+								"qualifier": "Strategy"
 							},
 							"amount": 1,
 							"per_level": true
@@ -205,7 +245,7 @@
 							"selection_type": "skills_with_name",
 							"name": {
 								"compare": "starts_with",
-								"qualifier": "tactics"
+								"qualifier": "Tactics"
 							},
 							"amount": 1,
 							"per_level": true
@@ -215,7 +255,7 @@
 							"selection_type": "skills_with_name",
 							"name": {
 								"compare": "is",
-								"qualifier": "intelligence analysis"
+								"qualifier": "Intelligence Analysis"
 							},
 							"amount": 1,
 							"per_level": true
@@ -225,24 +265,12 @@
 							"selection_type": "skills_with_name",
 							"name": {
 								"compare": "is",
-								"qualifier": "savoir-faire"
+								"qualifier": "Savoir-Faire"
 							},
 							"specialization": {
 								"compare": "is",
-								"qualifier": "military"
+								"qualifier": "Military"
 							},
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "reaction_bonus",
-							"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "conditional_modifier",
-							"situation": "Bonus to initiative rolls if leader",
 							"amount": 1,
 							"per_level": true
 						}

--- a/Library/Monster Hunters/Classes/Champions/Commando.gct
+++ b/Library/Monster Hunters/Classes/Champions/Commando.gct
@@ -696,14 +696,110 @@
 								},
 								{
 									"id": "tAexvRbw3lEOGoHUS",
-									"name": "Born War-Leader",
-									"reference": "MH1:25",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tgnQFo-hK7YwexD2S"
+									},
+									"name": "Talent (Born War-Leader)",
+									"reference": "PU3:12, BS184, DF1:14, MH1:25",
 									"tags": [
 										"Advantage",
-										"Physical",
+										"Mental",
 										"Talent"
 									],
+									"modifiers": [
+										{
+											"id": "MeuGzeWVDL3jyaYTe",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "mh6nuFbTVjImqaDWt",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "moXydFng6jgPuIUo6",
+													"name": "Alternative Benefit",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Bonus to initiative rolls if leader",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
+										}
+									],
 									"points_per_level": 5,
+									"features": [
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "Leadership"
+											},
+											"amount": 1,
+											"per_level": true
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "Strategy"
+											},
+											"amount": 1,
+											"per_level": true
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "starts_with",
+												"qualifier": "Tactics"
+											},
+											"amount": 1,
+											"per_level": true
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "Intelligence Analysis"
+											},
+											"amount": 1,
+											"per_level": true
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "Savoir-Faire"
+											},
+											"specialization": {
+												"compare": "is",
+												"qualifier": "Military"
+											},
+											"amount": 1,
+											"per_level": true
+										}
+									],
 									"can_level": true,
 									"levels": 4,
 									"calc": {

--- a/Library/Monster Hunters/Classes/Champions/Warrior.gct
+++ b/Library/Monster Hunters/Classes/Champions/Warrior.gct
@@ -863,12 +863,56 @@
 								},
 								{
 									"id": "tBo0Gv139McoqR3di",
-									"name": "Born War Leader",
-									"reference": "DF1:14,PU3:12",
-									"local_notes": "1-4 levels",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tgnQFo-hK7YwexD2S"
+									},
+									"name": "Talent (Born War-Leader)",
+									"reference": "PU3:12, BS184, DF1:14, MH1:25",
 									"tags": [
 										"Advantage",
-										"Physical"
+										"Mental",
+										"Talent"
+									],
+									"modifiers": [
+										{
+											"id": "m5kYq5NTpxAoHkYxV",
+											"name": "1-4 levels"
+										},
+										{
+											"id": "Md1EaDM9PEpcTnaMs",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "m7GwhUvSGQK5ygpPy",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "mED_0EneXWtEhuAVS",
+													"name": "Alternative Benefit",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Bonus to initiative rolls if leader",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
+										}
 									],
 									"points_per_level": 5,
 									"features": [

--- a/Library/Monster Hunters/Monster Hunters Traits.adq
+++ b/Library/Monster Hunters/Monster Hunters Traits.adq
@@ -519,14 +519,110 @@
 		},
 		{
 			"id": "t50wLkUoWU-X01NbA",
-			"name": "Born War-Leader",
-			"reference": "MH1:25",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Power Ups/Power Ups Traits.adq",
+				"id": "tgnQFo-hK7YwexD2S"
+			},
+			"name": "Talent (Born War-Leader)",
+			"reference": "PU3:12, BS184, DF1:14, MH1:25",
 			"tags": [
 				"Advantage",
 				"Mental",
 				"Talent"
 			],
+			"modifiers": [
+				{
+					"id": "MShAr-l2Xey_kfFWF",
+					"name": "Benefits",
+					"children": [
+						{
+							"id": "mVtI6NZxHVm--gs_G",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
+						},
+						{
+							"id": "m1ciMDMQqpYRmDY--",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to initiative rolls if leader",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
+						}
+					]
+				}
+			],
 			"points_per_level": 5,
+			"features": [
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Leadership"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Strategy"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "starts_with",
+						"qualifier": "Tactics"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Intelligence Analysis"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Savoir-Faire"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Military"
+					},
+					"amount": 1,
+					"per_level": true
+				}
+			],
 			"can_level": true,
 			"levels": 1,
 			"calc": {

--- a/Library/Power Ups/Power Ups Traits.adq
+++ b/Library/Power Ups/Power Ups Traits.adq
@@ -10439,7 +10439,7 @@
 			"reference": "DF1:14,PU3:12",
 			"tags": [
 				"Advantage",
-				"Physical",
+				"Mental",
 				"Talent"
 			],
 			"modifiers": [

--- a/Library/Power Ups/Power Ups Traits.adq
+++ b/Library/Power Ups/Power Ups Traits.adq
@@ -10436,7 +10436,7 @@
 		{
 			"id": "tgnQFo-hK7YwexD2S",
 			"name": "Talent (Born War-Leader)",
-			"reference": "DF1:14,PU3:12",
+			"reference": "PU3:12, BS184, DF1:14, MH1:25",
 			"tags": [
 				"Advantage",
 				"Mental",

--- a/Library/Power Ups/Power Ups Traits.adq
+++ b/Library/Power Ups/Power Ups Traits.adq
@@ -10494,7 +10494,7 @@
 					"selection_type": "skills_with_name",
 					"name": {
 						"compare": "is",
-						"qualifier": "Srategy"
+						"qualifier": "Strategy"
 					},
 					"amount": 1,
 					"per_level": true

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Leader.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Leader.gct
@@ -79,12 +79,53 @@
 							}
 						},
 						{
-							"id": "t6BrnDFonMGvpfja5",
-							"name": "Born War Leader",
-							"reference": "DFA47",
+							"id": "ttkPxKhpJBVsPiBS8",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "tgnQFo-hK7YwexD2S"
+							},
+							"name": "Talent (Born War-Leader)",
+							"reference": "PU3:12, BS184, DF1:14, MH1:25",
 							"tags": [
 								"Advantage",
-								"Physical"
+								"Mental",
+								"Talent"
+							],
+							"modifiers": [
+								{
+									"id": "M-mbXOT6NFvl3fQC5",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "msXHpQImlZ2EEn-td",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "mOUa6sHLKJKM_Z3oV",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Bonus to initiative rolls if leader",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
+								}
 							],
 							"points_per_level": 5,
 							"features": [
@@ -93,7 +134,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "leadership"
+										"qualifier": "Leadership"
 									},
 									"amount": 1,
 									"per_level": true
@@ -103,7 +144,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "strategy"
+										"qualifier": "Strategy"
 									},
 									"amount": 1,
 									"per_level": true
@@ -113,7 +154,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "starts_with",
-										"qualifier": "tactics"
+										"qualifier": "Tactics"
 									},
 									"amount": 1,
 									"per_level": true
@@ -123,21 +164,21 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "Connoisseur"
+										"qualifier": "Intelligence Analysis"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Savoir-Faire"
 									},
 									"specialization": {
 										"compare": "is",
-										"qualifier": "Weapons"
-									},
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"name": {
-										"compare": "is",
-										"qualifier": "savoir-faire"
+										"qualifier": "Military"
 									},
 									"amount": 1,
 									"per_level": true

--- a/Library/Pyramid Magazine/Pyramid 118/Shield-Bearer.gct
+++ b/Library/Pyramid Magazine/Pyramid 118/Shield-Bearer.gct
@@ -1140,13 +1140,57 @@
 							}
 						},
 						{
-							"id": "t83qat0juGKGdB0fs",
-							"name": "Talent (Born War Leader)",
-							"reference": "DF1:14",
-							"local_notes": "Level 1 to 4",
+							"id": "tLHPhdk722AZZgOIV",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "tgnQFo-hK7YwexD2S"
+							},
+							"name": "Talent (Born War-Leader)",
+							"reference": "PU3:12, BS184, DF1:14, MH1:25",
 							"tags": [
 								"Advantage",
-								"Physical"
+								"Mental",
+								"Talent"
+							],
+							"modifiers": [
+								{
+									"id": "mFnBiNOokvaGHLyf6",
+									"name": "Level 1 to 4"
+								},
+								{
+									"id": "McjC1024n2sIZblDR",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "mywA3HhZLhw20sW1B",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "m5wR8c2vhMmTKtw9V",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Bonus to initiative rolls if leader",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
+								}
 							],
 							"points_per_level": 5,
 							"features": [
@@ -1155,7 +1199,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "leadership"
+										"qualifier": "Leadership"
 									},
 									"amount": 1,
 									"per_level": true
@@ -1165,7 +1209,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "strategy"
+										"qualifier": "Strategy"
 									},
 									"amount": 1,
 									"per_level": true
@@ -1175,7 +1219,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "starts_with",
-										"qualifier": "tactics"
+										"qualifier": "Tactics"
 									},
 									"amount": 1,
 									"per_level": true
@@ -1185,7 +1229,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "intelligence analysis"
+										"qualifier": "Intelligence Analysis"
 									},
 									"amount": 1,
 									"per_level": true
@@ -1195,17 +1239,21 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "savoir-faire"
+										"qualifier": "Savoir-Faire"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "Military"
 									},
 									"amount": 1,
 									"per_level": true
 								}
 							],
 							"can_level": true,
-							"levels": 1,
+							"levels": 4,
 							"calc": {
-								"points": 5,
-								"current_level": 1
+								"points": 20,
+								"current_level": 4
 							}
 						},
 						{
@@ -1224,12 +1272,12 @@
 						}
 					],
 					"calc": {
-						"points": 332
+						"points": 347
 					}
 				}
 			],
 			"calc": {
-				"points": 387
+				"points": 402
 			}
 		},
 		{

--- a/Library/Pyramid Magazine/Pyramid 36/Warrior-Saint.gct
+++ b/Library/Pyramid Magazine/Pyramid 36/Warrior-Saint.gct
@@ -206,12 +206,53 @@
 							}
 						},
 						{
-							"id": "tWVjD0vZZ1MPPWbf_",
-							"name": "Talent (Born War Leader)",
-							"reference": "DF1:14",
+							"id": "tPzYQoTNWO16B8S3G",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "tgnQFo-hK7YwexD2S"
+							},
+							"name": "Talent (Born War-Leader)",
+							"reference": "PU3:12, BS184, DF1:14, MH1:25",
 							"tags": [
 								"Advantage",
-								"Physical"
+								"Mental",
+								"Talent"
+							],
+							"modifiers": [
+								{
+									"id": "MIyAXIcoK6H5VrksK",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "mimdTRDCeskQqH_uZ",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "mKK534tFIbxbHjrSt",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Bonus to initiative rolls if leader",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
+								}
 							],
 							"points_per_level": 5,
 							"features": [
@@ -220,7 +261,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "leadership"
+										"qualifier": "Leadership"
 									},
 									"amount": 1,
 									"per_level": true
@@ -230,7 +271,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "strategy"
+										"qualifier": "Strategy"
 									},
 									"amount": 1,
 									"per_level": true
@@ -240,7 +281,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "starts_with",
-										"qualifier": "tactics"
+										"qualifier": "Tactics"
 									},
 									"amount": 1,
 									"per_level": true
@@ -250,7 +291,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "intelligence analysis"
+										"qualifier": "Intelligence Analysis"
 									},
 									"amount": 1,
 									"per_level": true
@@ -260,7 +301,11 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "savoir-faire"
+										"qualifier": "Savoir-Faire"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "Military"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2188,12 +2233,53 @@
 									}
 								},
 								{
-									"id": "t4AImOyTnJ2LE1IWK",
-									"name": "Talent (Born War Leader)",
-									"reference": "DF1:14",
+									"id": "tX4hQu_jLeZq53nld",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tgnQFo-hK7YwexD2S"
+									},
+									"name": "Talent (Born War-Leader)",
+									"reference": "PU3:12, BS184, DF1:14, MH1:25",
 									"tags": [
 										"Advantage",
-										"Physical"
+										"Mental",
+										"Talent"
+									],
+									"modifiers": [
+										{
+											"id": "MXVmgJIS4jik9Bdrs",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "mzO1ZeLV4ALflt8dC",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "mhoyJX0LeNgv6GA6U",
+													"name": "Alternative Benefit",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Bonus to initiative rolls if leader",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
+										}
 									],
 									"points_per_level": 5,
 									"features": [
@@ -2202,7 +2288,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "leadership"
+												"qualifier": "Leadership"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2212,7 +2298,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "strategy"
+												"qualifier": "Strategy"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2222,7 +2308,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "starts_with",
-												"qualifier": "tactics"
+												"qualifier": "Tactics"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2232,7 +2318,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "intelligence analysis"
+												"qualifier": "Intelligence Analysis"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2242,7 +2328,11 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "savoir-faire"
+												"qualifier": "Savoir-Faire"
+											},
+											"specialization": {
+												"compare": "is",
+												"qualifier": "Military"
 											},
 											"amount": 1,
 											"per_level": true

--- a/Library/Pyramid Magazine/Pyramid 78/Chaos Holy Warrior.gct
+++ b/Library/Pyramid Magazine/Pyramid 78/Chaos Holy Warrior.gct
@@ -2594,12 +2594,53 @@
 									}
 								},
 								{
-									"id": "tdUdK5xZu4A9hg0J3",
-									"name": "Talent (Born War Leader)",
-									"reference": "DF1:14",
+									"id": "tlHUmV4ElNPD_DHS7",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tgnQFo-hK7YwexD2S"
+									},
+									"name": "Talent (Born War-Leader)",
+									"reference": "PU3:12, BS184, DF1:14, MH1:25",
 									"tags": [
 										"Advantage",
-										"Physical"
+										"Mental",
+										"Talent"
+									],
+									"modifiers": [
+										{
+											"id": "M1N6mHmxIH1WSjtk8",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "maKgk-xo5Ts0MdK92",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "m5XSl3lGga538v8Cq",
+													"name": "Alternative Benefit",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Bonus to initiative rolls if leader",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
+										}
 									],
 									"points_per_level": 5,
 									"features": [
@@ -2608,7 +2649,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "leadership"
+												"qualifier": "Leadership"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2618,7 +2659,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "strategy"
+												"qualifier": "Strategy"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2628,7 +2669,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "starts_with",
-												"qualifier": "tactics"
+												"qualifier": "Tactics"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2638,7 +2679,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "intelligence analysis"
+												"qualifier": "Intelligence Analysis"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2648,7 +2689,11 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "savoir-faire"
+												"qualifier": "Savoir-Faire"
+											},
+											"specialization": {
+												"compare": "is",
+												"qualifier": "Military"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2812,12 +2857,53 @@
 							}
 						},
 						{
-							"id": "tP2SBRU4alQYaMAm3",
-							"name": "Talent (Born War Leader)",
-							"reference": "DF1:14",
+							"id": "tXOsAIc37JN6gicsQ",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "tgnQFo-hK7YwexD2S"
+							},
+							"name": "Talent (Born War-Leader)",
+							"reference": "PU3:12, BS184, DF1:14, MH1:25",
 							"tags": [
 								"Advantage",
-								"Physical"
+								"Mental",
+								"Talent"
+							],
+							"modifiers": [
+								{
+									"id": "MhuBSectqrmptk-4T",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "mrikXyzxFQ69GVQWJ",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "migrur7H0luIh8HYr",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Bonus to initiative rolls if leader",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
+								}
 							],
 							"points_per_level": 5,
 							"features": [
@@ -2826,7 +2912,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "leadership"
+										"qualifier": "Leadership"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2836,7 +2922,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "strategy"
+										"qualifier": "Strategy"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2846,7 +2932,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "starts_with",
-										"qualifier": "tactics"
+										"qualifier": "Tactics"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2856,7 +2942,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "intelligence analysis"
+										"qualifier": "Intelligence Analysis"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2866,7 +2952,11 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "savoir-faire"
+										"qualifier": "Savoir-Faire"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "Military"
 									},
 									"amount": 1,
 									"per_level": true

--- a/Library/Pyramid Magazine/Pyramid 78/Order Holy Warrior.gct
+++ b/Library/Pyramid Magazine/Pyramid 78/Order Holy Warrior.gct
@@ -2838,12 +2838,53 @@
 									}
 								},
 								{
-									"id": "tyLLD-aXdXWrwZSKP",
-									"name": "Talent (Born War Leader)",
-									"reference": "DF1:14",
+									"id": "tfrmGeUzyamFa60c5",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tgnQFo-hK7YwexD2S"
+									},
+									"name": "Talent (Born War-Leader)",
+									"reference": "PU3:12, BS184, DF1:14, MH1:25",
 									"tags": [
 										"Advantage",
-										"Physical"
+										"Mental",
+										"Talent"
+									],
+									"modifiers": [
+										{
+											"id": "M4gKOFQs7gStHlWk3",
+											"name": "Benefits",
+											"children": [
+												{
+													"id": "mquyEhJV98nZQw_lT",
+													"name": "Reaction Bonus",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "reaction_bonus",
+															"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+															"amount": 1,
+															"per_level": true
+														}
+													]
+												},
+												{
+													"id": "mIf1FyCiVpFIpjiDn",
+													"name": "Alternative Benefit",
+													"use_level_from_trait": true,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Bonus to initiative rolls if leader",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"disabled": true
+												}
+											]
+										}
 									],
 									"points_per_level": 5,
 									"features": [
@@ -2852,7 +2893,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "leadership"
+												"qualifier": "Leadership"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2862,7 +2903,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "strategy"
+												"qualifier": "Strategy"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2872,7 +2913,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "starts_with",
-												"qualifier": "tactics"
+												"qualifier": "Tactics"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2882,7 +2923,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "intelligence analysis"
+												"qualifier": "Intelligence Analysis"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2892,7 +2933,11 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "savoir-faire"
+												"qualifier": "Savoir-Faire"
+											},
+											"specialization": {
+												"compare": "is",
+												"qualifier": "Military"
 											},
 											"amount": 1,
 											"per_level": true
@@ -2982,12 +3027,53 @@
 							}
 						},
 						{
-							"id": "t8M1TdOTpFeEpCytM",
-							"name": "Talent (Born War Leader)",
-							"reference": "DF1:14",
+							"id": "txih2LNyxhyMCrZGK",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups Traits.adq",
+								"id": "tgnQFo-hK7YwexD2S"
+							},
+							"name": "Talent (Born War-Leader)",
+							"reference": "PU3:12, BS184, DF1:14, MH1:25",
 							"tags": [
 								"Advantage",
-								"Physical"
+								"Mental",
+								"Talent"
+							],
+							"modifiers": [
+								{
+									"id": "McpP2JDTGVpEORL3m",
+									"name": "Benefits",
+									"children": [
+										{
+											"id": "mpC0wDML7XVw7EquJ",
+											"name": "Reaction Bonus",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "reaction_bonus",
+													"situation": "From military officers, tribal war-leaders, soldiers, and other professional warriors.",
+													"amount": 1,
+													"per_level": true
+												}
+											]
+										},
+										{
+											"id": "me2xlSOsJOblgILul",
+											"name": "Alternative Benefit",
+											"use_level_from_trait": true,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Bonus to initiative rolls if leader",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"disabled": true
+										}
+									]
+								}
 							],
 							"points_per_level": 5,
 							"features": [
@@ -2996,7 +3082,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "leadership"
+										"qualifier": "Leadership"
 									},
 									"amount": 1,
 									"per_level": true
@@ -3006,7 +3092,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "strategy"
+										"qualifier": "Strategy"
 									},
 									"amount": 1,
 									"per_level": true
@@ -3016,7 +3102,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "starts_with",
-										"qualifier": "tactics"
+										"qualifier": "Tactics"
 									},
 									"amount": 1,
 									"per_level": true
@@ -3026,7 +3112,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "intelligence analysis"
+										"qualifier": "Intelligence Analysis"
 									},
 									"amount": 1,
 									"per_level": true
@@ -3036,7 +3122,11 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "savoir-faire"
+										"qualifier": "Savoir-Faire"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "Military"
 									},
 									"amount": 1,
 									"per_level": true

--- a/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Tactical Officer.gct
+++ b/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Tactical Officer.gct
@@ -165,10 +165,10 @@
 								"id": "tgnQFo-hK7YwexD2S"
 							},
 							"name": "Talent (Born War-Leader)",
-							"reference": "DF1:14,PU3:12",
+							"reference": "DF1:14, MH1:25, PU3:12",
 							"tags": [
 								"Advantage",
-								"Physical",
+								"Mental",
 								"Talent"
 							],
 							"modifiers": [
@@ -223,7 +223,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "Srategy"
+										"qualifier": "Strategy"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2028,10 +2028,10 @@
 										"id": "tgnQFo-hK7YwexD2S"
 									},
 									"name": "Talent (Born War-Leader)",
-									"reference": "DF1:14,PU3:12",
+									"reference": "DF1:14, MH1:25, PU3:12",
 									"tags": [
 										"Advantage",
-										"Physical",
+										"Mental",
 										"Talent"
 									],
 									"modifiers": [
@@ -2086,7 +2086,7 @@
 											"selection_type": "skills_with_name",
 											"name": {
 												"compare": "is",
-												"qualifier": "Srategy"
+												"qualifier": "Strategy"
 											},
 											"amount": 1,
 											"per_level": true
@@ -3335,10 +3335,10 @@
 								"id": "tgnQFo-hK7YwexD2S"
 							},
 							"name": "Talent (Born War-Leader)",
-							"reference": "DF1:14,PU3:12",
+							"reference": "DF1:14, MH1:25, PU3:12",
 							"tags": [
 								"Advantage",
-								"Physical",
+								"Mental",
 								"Talent"
 							],
 							"modifiers": [
@@ -3393,7 +3393,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "Srategy"
+										"qualifier": "Strategy"
 									},
 									"amount": 1,
 									"per_level": true
@@ -3525,10 +3525,10 @@
 								"id": "tgnQFo-hK7YwexD2S"
 							},
 							"name": "Talent (Born War-Leader)",
-							"reference": "DF1:14,PU3:12",
+							"reference": "DF1:14, MH1:25, PU3:12",
 							"tags": [
 								"Advantage",
-								"Physical",
+								"Mental",
 								"Talent"
 							],
 							"modifiers": [
@@ -3583,7 +3583,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "Srategy"
+										"qualifier": "Strategy"
 									},
 									"amount": 1,
 									"per_level": true


### PR DESCRIPTION
As reported by Ptolemy on discord, Born War-Leader in Power-Ups Traits has a typo in its bonus to Strategy.

This does the following:
* Fixes the typo in Born War-Leader.
* Changes the trait type from Physical to Mental (talents are mental traits)
* Adds missing page references from Monster Hunters and Banestorm.
* Replaces the Born War-Leader trait in Banestorm Traits, Dungeon Fantasy 1 Traits, and Monster Hunters Traits (which has source library data pointing it to Power-Ups Traits, so if Power-Ups traits changes then sheets and templates that use these trait libraries can be updated as well).
* Update all character sheets and templates that use Born War-Leader to use the one from Power-Ups Traits (except for Dungeon Fantasy Roleplaying Game and Discworld Roleplaying game, because they have different skill bonuses; and Ptolemy's Elder Scrolls, as there are changes in-flight for that).