### PR TITLE
Magic: Fix incorrect Prerequisite Count for Shield and its dependents

### DIFF
--- a/Library/Magic/Ritual Magic Spells.spl
+++ b/Library/Magic/Ritual Magic Spells.spl
@@ -821,7 +821,7 @@
 			"casting_time": "1 sec",
 			"duration": "1 min",
 			"base_skill": "Ritual Magic",
-			"prereq_count": 3
+			"prereq_count": 1
 		},
 		{
 			"id": "rLqs-2pfC4r8OMyq5",
@@ -1368,7 +1368,7 @@
 			"casting_time": "1 sec",
 			"duration": "1 min",
 			"base_skill": "Ritual Magic",
-			"prereq_count": 3
+			"prereq_count": 1
 		},
 		{
 			"id": "r3x_cSFq19ioxYi_J",
@@ -11067,7 +11067,7 @@
 			"casting_time": "1 sec",
 			"duration": "1 min",
 			"base_skill": "Ritual Magic",
-			"prereq_count": 3
+			"prereq_count": 1
 		},
 		{
 			"id": "rViHIO5yeP20FEC7k",
@@ -11221,7 +11221,7 @@
 			"casting_time": "5 min",
 			"duration": "10 hrs",
 			"base_skill": "Ritual Magic",
-			"prereq_count": 3
+			"prereq_count": 1
 		},
 		{
 			"id": "rxLgknHzCWFzGUmmg",
@@ -14107,7 +14107,7 @@
 			"casting_time": "1 sec",
 			"duration": "1 min",
 			"base_skill": "Ritual Magic",
-			"prereq_count": 4
+			"prereq_count": 2
 		},
 		{
 			"id": "rM8H__9qMAaFB8Op3",
@@ -14384,7 +14384,7 @@
 			"casting_time": "1 sec",
 			"duration": "1 min",
 			"base_skill": "Ritual Magic",
-			"prereq_count": 3
+			"prereq_count": 2
 		},
 		{
 			"id": "rAguoP0XTkak3pov0",
@@ -15449,7 +15449,7 @@
 			"casting_time": "10 sec",
 			"duration": "1 hr",
 			"base_skill": "Ritual Magic",
-			"prereq_count": 3
+			"prereq_count": 1
 		},
 		{
 			"id": "rvMnVnzrj0tqn_13t",
@@ -15821,8 +15821,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
-			"prereq_count": 2
+			"base_skill": "Ritual Magic"
 		},
 		{
 			"id": "r-HPKWDsy_rGI1Y7j",
@@ -18988,7 +18987,7 @@
 			"casting_time": "2 sec",
 			"duration": "10 min",
 			"base_skill": "Ritual Magic",
-			"prereq_count": 3
+			"prereq_count": 1
 		},
 		{
 			"id": "rqpVi3Z2OUagOMY4W",


### PR DESCRIPTION
p. 200 states "The Spell Table does not consider non-spell prerequisites" but the spell table appears to take into account non-spell prerequisites for the spell Shield and its dependents.

I submitted an errata report to SJG about this and expect that it may be fixed in a future printing.

Affected spells [Spell Name (Current P# -> Correct P#)]:
- Shield (2 -> 0)
- Armor (3 -> 1)
- Bladeturning (3 -> 1)
- Missile Shield (3 -> 1)
- Mystic Mist (3 -> 1)
- Shade (3 -> 1)
- Umbrella (3 -> 1)
- Reverse Missiles (3 -> 2)
- Resist Water (4 -> 2)

Resolves #300 