### PR TITLE
Fix Urban Jungle Gym

### DIFF
--- a/Library/Action/Action Traits.adq
+++ b/Library/Action/Action Traits.adq
@@ -2082,7 +2082,7 @@
 								}
 							},
 							{
-								"type": "trait_prereq",
+								"type": "skill_prereq",
 								"has": true,
 								"name": {
 									"compare": "is",

--- a/Library/Action/Classes/Furious Fists/Traceur.gct
+++ b/Library/Action/Classes/Furious Fists/Traceur.gct
@@ -2257,6 +2257,11 @@
 						},
 						{
 							"id": "tsio8iUPqboIyGi2x",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Action/Action Traits.adq",
+								"id": "t4sOWG4Gcp4ifp7nM"
+							},
 							"name": "Urban Jungle Gym",
 							"reference": "ACT3:15",
 							"local_notes": "When not in combat, \"urban\" obstacles require no skill rolls and have no effect on Move.",
@@ -2292,7 +2297,7 @@
 										}
 									},
 									{
-										"type": "trait_prereq",
+										"type": "skill_prereq",
 										"has": true,
 										"name": {
 											"compare": "is",

--- a/Library/Action/Classes/Furious Fists/Weapon Master.gct
+++ b/Library/Action/Classes/Furious Fists/Weapon Master.gct
@@ -2543,6 +2543,11 @@
 						},
 						{
 							"id": "t_L0hkxp4blIsozpC",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Action/Action Traits.adq",
+								"id": "t4sOWG4Gcp4ifp7nM"
+							},
 							"name": "Urban Jungle Gym",
 							"reference": "ACT3:15",
 							"local_notes": "When not in combat, \"urban\" obstacles require no skill rolls and have no effect on Move.",
@@ -2578,7 +2583,7 @@
 										}
 									},
 									{
-										"type": "trait_prereq",
+										"type": "skill_prereq",
 										"has": true,
 										"name": {
 											"compare": "is",


### PR DESCRIPTION
As reported on Discord by Jeffrywith1e, the Urban Jungle Gym trait was erroneously requiring a trait named Jumping at level 16, rather than the skill Jumping at level 16.

This fixes it in the Action Traits library, and both the templates that use it.