### PR TITLE
Ptolemy's Elder Scrolls: Fix talents' source library references

### DIFF
--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Archer.gct
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Archer.gct
@@ -1454,11 +1454,11 @@
 								"path": "Power Ups/Power Ups Traits.adq",
 								"id": "tgnQFo-hK7YwexD2S"
 							},
-							"name": "Talent (Born War Leader)",
-							"reference": "DF1:14,PU3:12",
+							"name": "Talent (Born War-Leader)",
+							"reference": "PU3:12, BS184, DF1:14, MH1:25",
 							"tags": [
 								"Advantage",
-								"Physical",
+								"Mental",
 								"Talent"
 							],
 							"modifiers": [
@@ -1503,7 +1503,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "leadership"
+										"qualifier": "Leadership"
 									},
 									"amount": 1,
 									"per_level": true
@@ -1513,7 +1513,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "strategy"
+										"qualifier": "Strategy"
 									},
 									"amount": 1,
 									"per_level": true
@@ -1523,7 +1523,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "starts_with",
-										"qualifier": "tactics"
+										"qualifier": "Tactics"
 									},
 									"amount": 1,
 									"per_level": true
@@ -1533,7 +1533,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "intelligence analysis"
+										"qualifier": "Intelligence Analysis"
 									},
 									"amount": 1,
 									"per_level": true
@@ -1543,11 +1543,11 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "savoir-faire"
+										"qualifier": "Savoir-Faire"
 									},
 									"specialization": {
 										"compare": "is",
-										"qualifier": "military"
+										"qualifier": "Military"
 									},
 									"amount": 1,
 									"per_level": true
@@ -1563,7 +1563,7 @@
 						{
 							"id": "tSU_eLnyBXgH39MSx",
 							"source": {
-								"library": "/Github_library",
+								"library": "richardwilkes/gcs_master_library",
 								"path": "Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Traits.adq",
 								"id": "tXQApnx6f8L3Zo5vf"
 							},

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Battlemage.gct
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Battlemage.gct
@@ -1647,11 +1647,11 @@
 								"path": "Power Ups/Power Ups Traits.adq",
 								"id": "tgnQFo-hK7YwexD2S"
 							},
-							"name": "Talent (Born War Leader)",
-							"reference": "DF1:14,PU3:12",
+							"name": "Talent (Born War-Leader)",
+							"reference": "PU3:12, BS184, DF1:14, MH1:25",
 							"tags": [
 								"Advantage",
-								"Physical",
+								"Mental",
 								"Talent"
 							],
 							"modifiers": [
@@ -1696,7 +1696,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "leadership"
+										"qualifier": "Leadership"
 									},
 									"amount": 1,
 									"per_level": true
@@ -1706,7 +1706,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "strategy"
+										"qualifier": "Strategy"
 									},
 									"amount": 1,
 									"per_level": true
@@ -1716,7 +1716,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "starts_with",
-										"qualifier": "tactics"
+										"qualifier": "Tactics"
 									},
 									"amount": 1,
 									"per_level": true
@@ -1726,7 +1726,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "intelligence analysis"
+										"qualifier": "Intelligence Analysis"
 									},
 									"amount": 1,
 									"per_level": true
@@ -1736,11 +1736,11 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "savoir-faire"
+										"qualifier": "Savoir-Faire"
 									},
 									"specialization": {
 										"compare": "is",
-										"qualifier": "military"
+										"qualifier": "Military"
 									},
 									"amount": 1,
 									"per_level": true
@@ -1756,7 +1756,7 @@
 						{
 							"id": "t4fdlngNbE8n09VzP",
 							"source": {
-								"library": "/Github_library",
+								"library": "richardwilkes/gcs_master_library",
 								"path": "Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Traits.adq",
 								"id": "tXQApnx6f8L3Zo5vf"
 							},

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Crusader.gct
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Crusader.gct
@@ -2157,11 +2157,11 @@
 								"path": "Power Ups/Power Ups Traits.adq",
 								"id": "tgnQFo-hK7YwexD2S"
 							},
-							"name": "Talent (Born War Leader)",
-							"reference": "DF1:14,PU3:12",
+							"name": "Talent (Born War-Leader)",
+							"reference": "PU3:12, BS184, DF1:14, MH1:25",
 							"tags": [
 								"Advantage",
-								"Physical",
+								"Mental",
 								"Talent"
 							],
 							"modifiers": [
@@ -2206,7 +2206,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "leadership"
+										"qualifier": "Leadership"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2216,7 +2216,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "strategy"
+										"qualifier": "Strategy"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2226,7 +2226,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "starts_with",
-										"qualifier": "tactics"
+										"qualifier": "Tactics"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2236,7 +2236,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "intelligence analysis"
+										"qualifier": "Intelligence Analysis"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2246,11 +2246,11 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "savoir-faire"
+										"qualifier": "Savoir-Faire"
 									},
 									"specialization": {
 										"compare": "is",
-										"qualifier": "military"
+										"qualifier": "Military"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2266,7 +2266,7 @@
 						{
 							"id": "t4T_QBqApPK0gVB6j",
 							"source": {
-								"library": "/Github_library",
+								"library": "richardwilkes/gcs_master_library",
 								"path": "Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Traits.adq",
 								"id": "tXQApnx6f8L3Zo5vf"
 							},

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Knight.gct
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Knight.gct
@@ -218,11 +218,11 @@
 						"path": "Power Ups/Power Ups Traits.adq",
 						"id": "tgnQFo-hK7YwexD2S"
 					},
-					"name": "Talent (Born War Leader)",
-					"reference": "DF1:14,PU3:12",
+					"name": "Talent (Born War-Leader)",
+					"reference": "PU3:12, BS184, DF1:14, MH1:25",
 					"tags": [
 						"Advantage",
-						"Physical",
+						"Mental",
 						"Talent"
 					],
 					"modifiers": [
@@ -267,7 +267,7 @@
 							"selection_type": "skills_with_name",
 							"name": {
 								"compare": "is",
-								"qualifier": "leadership"
+								"qualifier": "Leadership"
 							},
 							"amount": 1,
 							"per_level": true
@@ -277,7 +277,7 @@
 							"selection_type": "skills_with_name",
 							"name": {
 								"compare": "is",
-								"qualifier": "strategy"
+								"qualifier": "Strategy"
 							},
 							"amount": 1,
 							"per_level": true
@@ -287,7 +287,7 @@
 							"selection_type": "skills_with_name",
 							"name": {
 								"compare": "starts_with",
-								"qualifier": "tactics"
+								"qualifier": "Tactics"
 							},
 							"amount": 1,
 							"per_level": true
@@ -297,7 +297,7 @@
 							"selection_type": "skills_with_name",
 							"name": {
 								"compare": "is",
-								"qualifier": "intelligence analysis"
+								"qualifier": "Intelligence Analysis"
 							},
 							"amount": 1,
 							"per_level": true
@@ -307,11 +307,11 @@
 							"selection_type": "skills_with_name",
 							"name": {
 								"compare": "is",
-								"qualifier": "savoir-faire"
+								"qualifier": "Savoir-Faire"
 							},
 							"specialization": {
 								"compare": "is",
-								"qualifier": "military"
+								"qualifier": "Military"
 							},
 							"amount": 1,
 							"per_level": true
@@ -2022,8 +2022,13 @@
 						},
 						{
 							"id": "t6rdKq7SIbI9dmqW1",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t8HajX_K4BDKPuUop"
+							},
 							"name": "Striking ST",
-							"reference": "B88",
+							"reference": "B88,P78",
 							"tags": [
 								"Advantage",
 								"Exotic",
@@ -2056,6 +2061,34 @@
 									"reference": "P79",
 									"local_notes": "@Attack@",
 									"cost_adj": "-60%",
+									"use_level_from_trait": true,
+									"features": [
+										{
+											"type": "weapon_effective_st_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"usage": {
+												"compare": "is",
+												"qualifier": "@Attack@"
+											},
+											"amount": 1,
+											"leveled": true
+										},
+										{
+											"type": "attribute_bonus",
+											"limitation": "striking_only",
+											"attribute": "st",
+											"amount": -1,
+											"per_level": true
+										}
+									],
+									"disabled": true
+								},
+								{
+									"id": "mrPwWAeOL2pkn2wwK",
+									"name": "Know Your Own Strength Pricing Variant",
+									"reference": "PY83:18",
+									"cost_adj": "-4",
+									"affects": "levels_only",
 									"disabled": true
 								}
 							],
@@ -2083,11 +2116,11 @@
 								"path": "Power Ups/Power Ups Traits.adq",
 								"id": "tgnQFo-hK7YwexD2S"
 							},
-							"name": "Talent (Born War Leader)",
-							"reference": "DF1:14,PU3:12",
+							"name": "Talent (Born War-Leader)",
+							"reference": "PU3:12, BS184, DF1:14, MH1:25",
 							"tags": [
 								"Advantage",
-								"Physical",
+								"Mental",
 								"Talent"
 							],
 							"modifiers": [
@@ -2132,7 +2165,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "leadership"
+										"qualifier": "Leadership"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2142,7 +2175,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "strategy"
+										"qualifier": "Strategy"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2152,7 +2185,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "starts_with",
-										"qualifier": "tactics"
+										"qualifier": "Tactics"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2162,7 +2195,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "intelligence analysis"
+										"qualifier": "Intelligence Analysis"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2172,11 +2205,11 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "savoir-faire"
+										"qualifier": "Savoir-Faire"
 									},
 									"specialization": {
 										"compare": "is",
-										"qualifier": "military"
+										"qualifier": "Military"
 									},
 									"amount": 1,
 									"per_level": true
@@ -2192,7 +2225,7 @@
 						{
 							"id": "t9U1G10n0ea47m3Ti",
 							"source": {
-								"library": "/Github_library",
+								"library": "richardwilkes/gcs_master_library",
 								"path": "Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Traits.adq",
 								"id": "tXQApnx6f8L3Zo5vf"
 							},

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Spellsword.gct
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Spellsword.gct
@@ -1583,11 +1583,11 @@
 								"path": "Power Ups/Power Ups Traits.adq",
 								"id": "tgnQFo-hK7YwexD2S"
 							},
-							"name": "Talent (Born War Leader)",
-							"reference": "DF1:14,PU3:12",
+							"name": "Talent (Born War-Leader)",
+							"reference": "PU3:12, BS184, DF1:14, MH1:25",
 							"tags": [
 								"Advantage",
-								"Physical",
+								"Mental",
 								"Talent"
 							],
 							"modifiers": [
@@ -1632,7 +1632,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "leadership"
+										"qualifier": "Leadership"
 									},
 									"amount": 1,
 									"per_level": true
@@ -1642,7 +1642,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "strategy"
+										"qualifier": "Strategy"
 									},
 									"amount": 1,
 									"per_level": true
@@ -1652,7 +1652,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "starts_with",
-										"qualifier": "tactics"
+										"qualifier": "Tactics"
 									},
 									"amount": 1,
 									"per_level": true
@@ -1662,7 +1662,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "intelligence analysis"
+										"qualifier": "Intelligence Analysis"
 									},
 									"amount": 1,
 									"per_level": true
@@ -1672,11 +1672,11 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "savoir-faire"
+										"qualifier": "Savoir-Faire"
 									},
 									"specialization": {
 										"compare": "is",
-										"qualifier": "military"
+										"qualifier": "Military"
 									},
 									"amount": 1,
 									"per_level": true
@@ -1692,7 +1692,7 @@
 						{
 							"id": "tmlV58oMvoCBTe09U",
 							"source": {
-								"library": "/Github_library",
+								"library": "richardwilkes/gcs_master_library",
 								"path": "Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Traits.adq",
 								"id": "tXQApnx6f8L3Zo5vf"
 							},

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Warrior.gct
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Warrior.gct
@@ -1789,11 +1789,11 @@
 								"path": "Power Ups/Power Ups Traits.adq",
 								"id": "tgnQFo-hK7YwexD2S"
 							},
-							"name": "Talent (Born War Leader)",
-							"reference": "DF1:14,PU3:12",
+							"name": "Talent (Born War-Leader)",
+							"reference": "PU3:12, BS184, DF1:14, MH1:25",
 							"tags": [
 								"Advantage",
-								"Physical",
+								"Mental",
 								"Talent"
 							],
 							"modifiers": [
@@ -1838,7 +1838,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "leadership"
+										"qualifier": "Leadership"
 									},
 									"amount": 1,
 									"per_level": true
@@ -1848,7 +1848,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "strategy"
+										"qualifier": "Strategy"
 									},
 									"amount": 1,
 									"per_level": true
@@ -1858,7 +1858,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "starts_with",
-										"qualifier": "tactics"
+										"qualifier": "Tactics"
 									},
 									"amount": 1,
 									"per_level": true
@@ -1868,7 +1868,7 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "intelligence analysis"
+										"qualifier": "Intelligence Analysis"
 									},
 									"amount": 1,
 									"per_level": true
@@ -1878,11 +1878,11 @@
 									"selection_type": "skills_with_name",
 									"name": {
 										"compare": "is",
-										"qualifier": "savoir-faire"
+										"qualifier": "Savoir-Faire"
 									},
 									"specialization": {
 										"compare": "is",
-										"qualifier": "military"
+										"qualifier": "Military"
 									},
 									"amount": 1,
 									"per_level": true
@@ -1898,7 +1898,7 @@
 						{
 							"id": "t-gDQo-70tS2FLswV",
 							"source": {
-								"library": "/Github_library",
+								"library": "richardwilkes/gcs_master_library",
 								"path": "Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Traits.adq",
 								"id": "tXQApnx6f8L3Zo5vf"
 							},

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Races/Nord.gct
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Races/Nord.gct
@@ -750,7 +750,7 @@
 						{
 							"id": "t8LR2fWsdF0Amd6Yp",
 							"source": {
-								"library": "/Github_library",
+								"library": "richardwilkes/gcs_master_library",
 								"path": "Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Traits.adq",
 								"id": "taLnXfZRpSMmJ_slb"
 							},


### PR DESCRIPTION
This includes:
* Fix source library references for Legion Training and Nord Battlecraft traits
* Sync with most recent Born War Leader
* Add source library reference for Striking ST to the Knight