### PR TITLE
Add generic perks and quirks

### DIFF
--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -98,7 +98,8 @@
 		{
 			"id": "trPM4mpwMJnj-tqdg",
 			"name": "@Mental Quirk@",
-			"reference": "B162",
+			"reference": "B162, PU6:17",
+			"reference_highlight": "Mental Quirks",
 			"tags": [
 				"Mental",
 				"Quirk"
@@ -111,9 +112,38 @@
 		{
 			"id": "tHv97hIejdmH2l3xH",
 			"name": "@Physical Quirk@",
-			"reference": "B164",
+			"reference": "B165, PU6:22",
+			"reference_highlight": "Physical Quirks",
 			"tags": [
 				"Physical",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "tL2-Lhu39oX2g5Wan",
+			"name": "@Social Quirk@",
+			"reference": "B162, PU6:32",
+			"reference_highlight": "Quirks",
+			"tags": [
+				"Social",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "tBdGajq0OpXSg-Rz7",
+			"name": "@Supernatural Quirk@",
+			"reference": "B162, PU6:33",
+			"reference_highlight": "Quirks",
+			"tags": [
+				"Supernatural",
 				"Quirk"
 			],
 			"base_points": -1,

--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -40,6 +40,62 @@
 			}
 		},
 		{
+			"id": "tgfF0MZG_QvCG2sCz",
+			"name": "@Mental Perk@",
+			"reference": "B100, PU2:12",
+			"reference_highlight": "Perks",
+			"tags": [
+				"Mental",
+				"Perk"
+			],
+			"base_points": 1,
+			"calc": {
+				"points": 1
+			}
+		},
+		{
+			"id": "tl6hXl2u897stCQ0T",
+			"name": "@Physical Perk@",
+			"reference": "B100, PU2:13",
+			"reference_highlight": "Perks",
+			"tags": [
+				"Physical",
+				"Perk"
+			],
+			"base_points": 1,
+			"calc": {
+				"points": 1
+			}
+		},
+		{
+			"id": "tQ70c3nkNTkQLRqCL",
+			"name": "@Social Perk@",
+			"reference": "B100, PU2:17",
+			"reference_highlight": "Perks",
+			"tags": [
+				"Social",
+				"Perk"
+			],
+			"base_points": 1,
+			"calc": {
+				"points": 1
+			}
+		},
+		{
+			"id": "tOPXlb-UVg1jhrhNv",
+			"name": "@Supernatural Perk@",
+			"reference": "B100, PU2:19",
+			"reference_highlight": "Perks",
+			"tags": [
+				"Supernatural",
+				"Perk"
+			],
+			"base_points": 1,
+			"calc": {
+				"points": 1
+			}
+		},
+		{
 			"id": "trPM4mpwMJnj-tqdg",
 			"name": "@Mental Quirk@",
 			"reference": "B162",


### PR DESCRIPTION
As requested in #533.

Perks and quirks are less strictly-defined than other traits and can be whatever the GM and Players agree is worth 1 point.