### PR TITLE
High Tech Equipment: Fix Winchester Model 70's stats

### DIFF
--- a/Library/High Tech/High Tech Equipment.eqp
+++ b/Library/High Tech/High Tech Equipment.eqp
@@ -87398,8 +87398,8 @@
 						"base": "7d+1"
 					},
 					"strength": "10†",
-					"accuracy": "51",
-					"range": "100/4,500",
+					"accuracy": "5",
+					"range": "1,100/4,500",
 					"rate_of_fire": "1",
 					"shots": "5(3i)",
 					"bulk": "-5",


### PR DESCRIPTION
As reported on the discord by amendoca, its Accuracy and 1/2D range were incorrect.