### PR TITLE
Fix the display of the >150% modifier to Enemy

### DIFF
--- a/Library/1shotadventures/Characters/Black Mine of Teihiihan/Hettie-Britton.gcs
+++ b/Library/1shotadventures/Characters/Black Mine of Teihiihan/Hettie-Britton.gcs
@@ -757,7 +757,7 @@
 					"id": "m6MiIMgJ_BeUGevOz",
 					"name": "Powerful Individual",
 					"reference": "B135",
-					"local_notes": "\u003e150% of your starting points",
+					"local_notes": "\\\u003e150% of your starting points",
 					"cost_adj": "-20",
 					"disabled": true
 				},

--- a/Library/1shotadventures/Characters/Harry Potter and the Warlocks Tower/Aphidos_Wilkes.gcs
+++ b/Library/1shotadventures/Characters/Harry Potter and the Warlocks Tower/Aphidos_Wilkes.gcs
@@ -859,7 +859,7 @@
 					"id": "mTgiZGpFi380MoEFY",
 					"name": "Powerful Individual",
 					"reference": "B135",
-					"local_notes": "\u003e150% of your starting points",
+					"local_notes": "\\\u003e150% of your starting points",
 					"cost_adj": "-20",
 					"disabled": true
 				},

--- a/Library/1shotadventures/Characters/Harry Potter and the Warlocks Tower/Fiona_Abbot.gcs
+++ b/Library/1shotadventures/Characters/Harry Potter and the Warlocks Tower/Fiona_Abbot.gcs
@@ -707,7 +707,7 @@
 					"id": "m0WZJ62WmNjETNaSQ",
 					"name": "Powerful Individual",
 					"reference": "B135",
-					"local_notes": "\u003e150% of your starting points",
+					"local_notes": "\\\u003e150% of your starting points",
 					"cost_adj": "-20",
 					"disabled": true
 				},

--- a/Library/1shotadventures/Characters/Never Forget to Die/Allura Lavender.gcs
+++ b/Library/1shotadventures/Characters/Never Forget to Die/Allura Lavender.gcs
@@ -1333,7 +1333,7 @@
 					"id": "mVxCs33twoTsbz73Y",
 					"name": "Powerful Individual",
 					"reference": "B135",
-					"local_notes": "\u003e150% of your starting points",
+					"local_notes": "\\\u003e150% of your starting points",
 					"cost_adj": "-20",
 					"disabled": true
 				},

--- a/Library/1shotadventures/Characters/The Phantom Jungle/Willy Van der Woodson.gcs
+++ b/Library/1shotadventures/Characters/The Phantom Jungle/Willy Van der Woodson.gcs
@@ -772,7 +772,7 @@
 					"id": "mEpLiVWI5XGsX8xbi",
 					"name": "Powerful Individual",
 					"reference": "B135",
-					"local_notes": "\u003e150% of your starting points",
+					"local_notes": "\\\u003e150% of your starting points",
 					"cost_adj": "-20",
 					"disabled": true
 				},

--- a/Library/1shotadventures/Characters/Who Tracks the Steps of Glory/Andrew_Seong.gcs
+++ b/Library/1shotadventures/Characters/Who Tracks the Steps of Glory/Andrew_Seong.gcs
@@ -1171,7 +1171,7 @@
 					"id": "mmw6iMZx91Y39adGc",
 					"name": "Powerful Individual",
 					"reference": "B135",
-					"local_notes": "\u003e150% of your starting points",
+					"local_notes": "\\\u003e150% of your starting points",
 					"cost_adj": "-20",
 					"disabled": true
 				},

--- a/Library/1shotadventures/Characters/Who Tracks the Steps of Glory/Bexley_Gracen.gcs
+++ b/Library/1shotadventures/Characters/Who Tracks the Steps of Glory/Bexley_Gracen.gcs
@@ -685,7 +685,7 @@
 					"id": "m3-yzp6y7uA9wqwXw",
 					"name": "Powerful Individual",
 					"reference": "B135",
-					"local_notes": "\u003e150% of your starting points",
+					"local_notes": "\\\u003e150% of your starting points",
 					"cost_adj": "-20",
 					"disabled": true
 				},

--- a/Library/Action/Action Traits.adq
+++ b/Library/Action/Action Traits.adq
@@ -7399,7 +7399,7 @@
 							"id": "mJtRfj1SR5hFsdp_E",
 							"name": "Powerful Individual",
 							"reference": "B135",
-							"local_notes": "\u003e150% of your starting points",
+							"local_notes": "\\\u003e150% of your starting points",
 							"cost_adj": "-20",
 							"disabled": true
 						},

--- a/Library/After the End/Templates/Nomad.gct
+++ b/Library/After the End/Templates/Nomad.gct
@@ -3497,7 +3497,7 @@
 											"id": "mDwcDmf-YvNR874jG",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},

--- a/Library/Aliens/Sparrials/NPCs/Leerlaounoora.gcs
+++ b/Library/Aliens/Sparrials/NPCs/Leerlaounoora.gcs
@@ -1016,7 +1016,7 @@
 							"id": "m1CbxOr6PUsovYlnJ",
 							"name": "Powerful Individual",
 							"reference": "B135",
-							"local_notes": "\u003e150% of your starting points",
+							"local_notes": "\\\u003e150% of your starting points",
 							"cost_adj": "-20",
 							"disabled": true
 						},

--- a/Library/Aliens/Sparrials/Templates/Hotshot Pilot.gct
+++ b/Library/Aliens/Sparrials/Templates/Hotshot Pilot.gct
@@ -1733,7 +1733,7 @@
 							"id": "ms2ynyBniOqu5lZQA",
 							"name": "Powerful Individual",
 							"reference": "B135",
-							"local_notes": "\u003e150% of your starting points",
+							"local_notes": "\\\u003e150% of your starting points",
 							"cost_adj": "-20",
 							"disabled": true
 						},
@@ -1885,7 +1885,7 @@
 							"id": "mIVJLVJt5wFBiWNEu",
 							"name": "Powerful Individual",
 							"reference": "B135",
-							"local_notes": "\u003e150% of your starting points",
+							"local_notes": "\\\u003e150% of your starting points",
 							"cost_adj": "-20",
 							"disabled": true
 						},

--- a/Library/Banestorm/Classes/Assassin.gct
+++ b/Library/Banestorm/Classes/Assassin.gct
@@ -51,7 +51,7 @@
 											"id": "mJAbORRsGVuViJbUe",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},

--- a/Library/Banestorm/Classes/Bard-Wizard.gct
+++ b/Library/Banestorm/Classes/Bard-Wizard.gct
@@ -1386,7 +1386,7 @@
 											"id": "mUEIh4PxDxdDqagHf",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},

--- a/Library/Banestorm/Classes/Bard.gct
+++ b/Library/Banestorm/Classes/Bard.gct
@@ -1386,7 +1386,7 @@
 											"id": "m4VMYe4FjAHMGOiko",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},

--- a/Library/Banestorm/Classes/Battle Wizard.gct
+++ b/Library/Banestorm/Classes/Battle Wizard.gct
@@ -1147,7 +1147,7 @@
 											"id": "mc-N4c1v_8Dae1rWK",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},

--- a/Library/Banestorm/Classes/Bounty Hunter.gct
+++ b/Library/Banestorm/Classes/Bounty Hunter.gct
@@ -1029,7 +1029,7 @@
 											"id": "mlmHiFryuR2CL8msw",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},

--- a/Library/Banestorm/Classes/Charlatan.gct
+++ b/Library/Banestorm/Classes/Charlatan.gct
@@ -174,7 +174,7 @@
 											"id": "mtJ-fRLM-1Nhe2Lt2",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},

--- a/Library/Banestorm/Classes/Courtier.gct
+++ b/Library/Banestorm/Classes/Courtier.gct
@@ -2525,7 +2525,7 @@
 											"id": "mRTe8LvUzHaaxIuyp",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},

--- a/Library/Banestorm/Classes/Entertainer.gct
+++ b/Library/Banestorm/Classes/Entertainer.gct
@@ -1220,7 +1220,7 @@
 											"id": "mM2sO6T5LTwcU2GC0",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},

--- a/Library/Banestorm/Classes/Freelance Wizard.gct
+++ b/Library/Banestorm/Classes/Freelance Wizard.gct
@@ -925,7 +925,7 @@
 											"id": "mTclj3UDnBM7NdEdO",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},

--- a/Library/Banestorm/Classes/Mercenary.gct
+++ b/Library/Banestorm/Classes/Mercenary.gct
@@ -1149,7 +1149,7 @@
 											"id": "m1mIdIzarzGVKC0Cd",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},

--- a/Library/Banestorm/Classes/Merchant.gct
+++ b/Library/Banestorm/Classes/Merchant.gct
@@ -1419,7 +1419,7 @@
 											"id": "mF2EuO8Ug4r4uHN46",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},

--- a/Library/Banestorm/Classes/Peasant Hero.gct
+++ b/Library/Banestorm/Classes/Peasant Hero.gct
@@ -1087,7 +1087,7 @@
 											"id": "mGkukTgdeJxeuA2Dk",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},

--- a/Library/Banestorm/Classes/Swashbuckler.gct
+++ b/Library/Banestorm/Classes/Swashbuckler.gct
@@ -1070,7 +1070,7 @@
 											"id": "mXW4KUd7eB03a3iCh",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},

--- a/Library/Banestorm/Classes/Underground Engineer.gct
+++ b/Library/Banestorm/Classes/Underground Engineer.gct
@@ -1243,7 +1243,7 @@
 											"id": "mAs4MTBybNYzDuNVc",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},
@@ -1460,7 +1460,7 @@
 											"id": "mavtxw4DG7pO43T_H",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},

--- a/Library/Banestorm/Classes/Urban Rogue.gct
+++ b/Library/Banestorm/Classes/Urban Rogue.gct
@@ -1133,7 +1133,7 @@
 											"id": "mXDTTgPdGfuBTFo8B",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},

--- a/Library/Banestorm/Classes/Watchman.gct
+++ b/Library/Banestorm/Classes/Watchman.gct
@@ -972,7 +972,7 @@
 											"id": "mFt3r1A5XnW2wzLpW",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},

--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -7297,7 +7297,7 @@
 							"id": "mnmgUy__PpxcSuWvG",
 							"name": "Powerful Individual",
 							"reference": "B135",
-							"local_notes": "\u003e150% of your starting points",
+							"local_notes": "\\\u003e150% of your starting points",
 							"cost_adj": "-20",
 							"disabled": true
 						},

--- a/Library/Basic Set/Characters/Janos Telkozep.gcs
+++ b/Library/Basic Set/Characters/Janos Telkozep.gcs
@@ -3241,7 +3241,7 @@
 					"id": "mzv9ghwt7LNLGR4mu",
 					"name": "Powerful Individual",
 					"reference": "B135",
-					"local_notes": "\u003e150% of your starting points",
+					"local_notes": "\\\u003e150% of your starting points",
 					"cost_adj": "-20",
 					"disabled": true
 				},

--- a/Library/Basic Set/Characters/Sora.gcs
+++ b/Library/Basic Set/Characters/Sora.gcs
@@ -1410,7 +1410,7 @@
 					"id": "m3JZPqwNGuu1T1k6P",
 					"name": "Powerful Individual",
 					"reference": "B135",
-					"local_notes": "\u003e150% of your starting points",
+					"local_notes": "\\\u003e150% of your starting points",
 					"cost_adj": "-20",
 					"disabled": true
 				},

--- a/Library/Discworld Roleplaying Game/Occupational Templates/Low-Powered Characters/Noble.gct
+++ b/Library/Discworld Roleplaying Game/Occupational Templates/Low-Powered Characters/Noble.gct
@@ -1212,7 +1212,7 @@
 										{
 											"id": "mxnwd-VN1iNzReTZC",
 											"name": "Powerful Individual",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},

--- a/Library/Fantasy Folk/Winged Folk/Profession Templates/Trader.gct
+++ b/Library/Fantasy Folk/Winged Folk/Profession Templates/Trader.gct
@@ -3814,7 +3814,7 @@
 									"id": "mnF0HiJxlu526sCml",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Fantasy/Classes/Bandit.gct
+++ b/Library/Fantasy/Classes/Bandit.gct
@@ -953,7 +953,7 @@
 											"id": "mjgO_er7m2Z5526pF",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},

--- a/Library/Fantasy/Classes/Slayer.gct
+++ b/Library/Fantasy/Classes/Slayer.gct
@@ -141,7 +141,7 @@
 											"id": "mN3AjMubDsSFM88YC",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},

--- a/Library/Fantasy/Races/Imp.gct
+++ b/Library/Fantasy/Races/Imp.gct
@@ -1006,7 +1006,7 @@
 									"id": "m4l2Jer110w9131vL",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},
@@ -1151,7 +1151,7 @@
 									"id": "mQPZJdPAgghd5DwVq",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20"
 								},
 								{

--- a/Library/Home Brew/Characters/Caravan to Ein Arris Pregens/Agal.gcs
+++ b/Library/Home Brew/Characters/Caravan to Ein Arris Pregens/Agal.gcs
@@ -656,7 +656,7 @@
 					"id": "m0VM9CiimZiH5jtFM",
 					"name": "Powerful Individual",
 					"reference": "B135",
-					"local_notes": "\u003e150% of your starting points",
+					"local_notes": "\\\u003e150% of your starting points",
 					"cost_adj": "-20",
 					"disabled": true
 				},

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Acrobat.gct
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Acrobat.gct
@@ -2502,7 +2502,7 @@
 									"id": "mY1HRugkg1GSqpzsr",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Agent.gct
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Agent.gct
@@ -2828,7 +2828,7 @@
 									"id": "mL72dNHBvd8uNtR4p",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Archer.gct
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Archer.gct
@@ -2264,7 +2264,7 @@
 									"id": "ma461jDkcP0kFY_-a",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Assassin.gct
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Assassin.gct
@@ -2206,7 +2206,7 @@
 									"id": "mpjYZWo0lntbs6KYE",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Barbarian.gct
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Barbarian.gct
@@ -3794,7 +3794,7 @@
 									"id": "mrUhRnaEc3IdedRyd",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Bard.gct
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Bard.gct
@@ -3212,7 +3212,7 @@
 									"id": "mQx7pRnI3KpafyOeL",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Battlemage.gct
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Battlemage.gct
@@ -2478,7 +2478,7 @@
 									"id": "mDxp2ZZAa88c1EWF0",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Crusader.gct
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Crusader.gct
@@ -2816,7 +2816,7 @@
 									"id": "mAIaMhxumUuORjXrC",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Healer.gct
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Healer.gct
@@ -2947,7 +2947,7 @@
 									"id": "maAJvf2pZULSPOj7e",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Knight.gct
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Knight.gct
@@ -2888,7 +2888,7 @@
 									"id": "mKmRqi3L1G57FUUxt",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Mage.gct
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Mage.gct
@@ -1803,7 +1803,7 @@
 									"id": "mr5lsDROFQ58TTzOI",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Monk.gct
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Monk.gct
@@ -2511,7 +2511,7 @@
 									"id": "mBLAIsVnxmCTU2HeA",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Nightblade.gct
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Nightblade.gct
@@ -2207,7 +2207,7 @@
 									"id": "mKOyCAQSFjBGntTSN",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Pilgrim.gct
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Pilgrim.gct
@@ -2327,7 +2327,7 @@
 									"id": "mQqx8cQbvRSdQgVex",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Rogue.gct
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Rogue.gct
@@ -3238,7 +3238,7 @@
 									"id": "mt8WljnPYTpb1Ho01",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Scout.gct
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Scout.gct
@@ -2421,7 +2421,7 @@
 									"id": "mq77VYAgMf4Xh-FMe",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Sorcerer.gct
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Sorcerer.gct
@@ -1927,7 +1927,7 @@
 									"id": "mOI1To5YcUkctB5Qu",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Spellsword.gct
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Spellsword.gct
@@ -2360,7 +2360,7 @@
 									"id": "mVkj256QaaY7YRRIr",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Thief.gct
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Thief.gct
@@ -2784,7 +2784,7 @@
 									"id": "msPZdKEiNzjgJuFJg",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Warrior.gct
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Warrior.gct
@@ -2557,7 +2557,7 @@
 									"id": "mheyf79cITr1Erstq",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Witchhunter.gct
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Witchhunter.gct
@@ -2420,7 +2420,7 @@
 									"id": "mJe91yNMSQ_fTeC4t",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Horror/Classes/Attorney.gct
+++ b/Library/Horror/Classes/Attorney.gct
@@ -1535,7 +1535,7 @@
 											"id": "mRWXk9VofDXoIab9u",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},

--- a/Library/Horror/Classes/Criminal.gct
+++ b/Library/Horror/Classes/Criminal.gct
@@ -1237,7 +1237,7 @@
 													"id": "mR7gdNUDGSm8EnEiE",
 													"name": "Powerful Individual",
 													"reference": "B135",
-													"local_notes": "\u003e150% of your starting points",
+													"local_notes": "\\\u003e150% of your starting points",
 													"cost_adj": "-20",
 													"disabled": true
 												},

--- a/Library/Horror/Classes/Explorer.gct
+++ b/Library/Horror/Classes/Explorer.gct
@@ -1180,7 +1180,7 @@
 											"id": "mNXTL-lrxrj_-2CSx",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20"
 										},
 										{

--- a/Library/Horror/Classes/Mystic Charlatan.gct
+++ b/Library/Horror/Classes/Mystic Charlatan.gct
@@ -2137,7 +2137,7 @@
 											"id": "mQDqG3lz8eSfhcGNv",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},

--- a/Library/Horror/Classes/Slayer.gct
+++ b/Library/Horror/Classes/Slayer.gct
@@ -866,7 +866,7 @@
 											"id": "mNNvUmn7aAdcol2cO",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},

--- a/Library/Lands Out of Time/Classes/Tribal Chief.gct
+++ b/Library/Lands Out of Time/Classes/Tribal Chief.gct
@@ -953,7 +953,7 @@
 											"id": "mJy1dJGNLA7VQl2S5",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},

--- a/Library/Monster Hunters/Classes/Champions/Crusader.gct
+++ b/Library/Monster Hunters/Classes/Champions/Crusader.gct
@@ -2840,7 +2840,7 @@
 											"id": "mJfVc6e-bRuiihGUv",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},

--- a/Library/Monster Hunters/Classes/Champions/Experiment.gct
+++ b/Library/Monster Hunters/Classes/Champions/Experiment.gct
@@ -2731,7 +2731,7 @@
 											"id": "m52X44ZBoVLyLsTVW",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},

--- a/Library/Monster Hunters/Classes/Champions/Inhuman.gct
+++ b/Library/Monster Hunters/Classes/Champions/Inhuman.gct
@@ -1945,7 +1945,7 @@
 											"id": "m5glTjXvYqKQjDIKz",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},

--- a/Library/Monster Hunters/Classes/Champions/Psi.gct
+++ b/Library/Monster Hunters/Classes/Champions/Psi.gct
@@ -2436,7 +2436,7 @@
 											"id": "m-wT7pa-VHSvCe2Ep",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},

--- a/Library/Monster Hunters/Classes/Motivational Lenses/Accidental Hero.gct
+++ b/Library/Monster Hunters/Classes/Motivational Lenses/Accidental Hero.gct
@@ -444,7 +444,7 @@
 											"id": "mem_3FdJ962gmFSm9",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},

--- a/Library/Monster Hunters/Classes/Motivational Lenses/Avenger Atoner.gct
+++ b/Library/Monster Hunters/Classes/Motivational Lenses/Avenger Atoner.gct
@@ -171,7 +171,7 @@
 											"id": "mn__BLrpDq1Tmuxon",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},

--- a/Library/Monster Hunters/Classes/Motivational Lenses/Chosen One.gct
+++ b/Library/Monster Hunters/Classes/Motivational Lenses/Chosen One.gct
@@ -401,7 +401,7 @@
 											"id": "msckvhHLWypkmGiQq",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},

--- a/Library/Monster Hunters/Classes/Motivational Lenses/Criminal.gct
+++ b/Library/Monster Hunters/Classes/Motivational Lenses/Criminal.gct
@@ -365,7 +365,7 @@
 											"id": "mkKqKbAn8JC0GlsbO",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},
@@ -545,7 +545,7 @@
 									"id": "mqvVi6XioyX5c_5Ou",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Monster Hunters/Classes/Sidekicks/Gifted.gct
+++ b/Library/Monster Hunters/Classes/Sidekicks/Gifted.gct
@@ -1706,7 +1706,7 @@
 									"id": "mAvs-YR5A3TY3iQrU",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Monster Hunters/Monster Hunters Traits.adq
+++ b/Library/Monster Hunters/Monster Hunters Traits.adq
@@ -780,7 +780,7 @@
 					"id": "mq9hNCx5n2v-X9Olg",
 					"name": "Powerful Individual",
 					"reference": "B135",
-					"local_notes": "\u003e150% of your starting points",
+					"local_notes": "\\\u003e150% of your starting points",
 					"cost_adj": "-20",
 					"disabled": true
 				},

--- a/Library/Psionics/Classes/Celebrity.gct
+++ b/Library/Psionics/Classes/Celebrity.gct
@@ -4158,7 +4158,7 @@
 															"id": "mO3eOvNsaRrnVNPaN",
 															"name": "Powerful Individual",
 															"reference": "B135",
-															"local_notes": "\u003e150% of your starting points",
+															"local_notes": "\\\u003e150% of your starting points",
 															"cost_adj": "-20",
 															"disabled": true
 														},
@@ -5703,7 +5703,7 @@
 											"id": "mBmH2G9zIkdVb737m",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},

--- a/Library/Psionics/Classes/Child.gct
+++ b/Library/Psionics/Classes/Child.gct
@@ -2729,7 +2729,7 @@
 															"id": "mYr5YU6U8GEuv6Tri",
 															"name": "Powerful Individual",
 															"reference": "B135",
-															"local_notes": "\u003e150% of your starting points",
+															"local_notes": "\\\u003e150% of your starting points",
 															"cost_adj": "-20",
 															"disabled": true
 														},
@@ -4268,7 +4268,7 @@
 											"id": "mS8dL3mmiYjaMLg3D",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},
@@ -4415,7 +4415,7 @@
 											"id": "mUSr-tR2HyCzrEUvB",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},

--- a/Library/Psionics/Classes/Criminal.gct
+++ b/Library/Psionics/Classes/Criminal.gct
@@ -3495,7 +3495,7 @@
 											"id": "mVGtwWZUGWAnS75Xc",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},
@@ -3951,7 +3951,7 @@
 															"id": "mmcc0TWLoK7bXzmJx",
 															"name": "Powerful Individual",
 															"reference": "B135",
-															"local_notes": "\u003e150% of your starting points",
+															"local_notes": "\\\u003e150% of your starting points",
 															"cost_adj": "-20",
 															"disabled": true
 														},

--- a/Library/Psionics/Classes/Experiment.gct
+++ b/Library/Psionics/Classes/Experiment.gct
@@ -2393,7 +2393,7 @@
 											"id": "myGSUDXECyYb09_Ut",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20"
 										},
 										{
@@ -2538,7 +2538,7 @@
 											"id": "mmONjTkb5_gmqDtsH",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20"
 										},
 										{
@@ -2683,7 +2683,7 @@
 											"id": "mPHc4v-lo2xNBYaHb",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20"
 										},
 										{
@@ -2992,7 +2992,7 @@
 															"id": "mesO8m-FiM2R8OgIP",
 															"name": "Powerful Individual",
 															"reference": "B135",
-															"local_notes": "\u003e150% of your starting points",
+															"local_notes": "\\\u003e150% of your starting points",
 															"cost_adj": "-20",
 															"disabled": true
 														},

--- a/Library/Psionics/Classes/Investigator.gct
+++ b/Library/Psionics/Classes/Investigator.gct
@@ -3705,7 +3705,7 @@
 															"id": "m4gi3xnU3jV9NhkDO",
 															"name": "Powerful Individual",
 															"reference": "B135",
-															"local_notes": "\u003e150% of your starting points",
+															"local_notes": "\\\u003e150% of your starting points",
 															"cost_adj": "-20",
 															"disabled": true
 														},

--- a/Library/Psionics/Classes/Manipulator.gct
+++ b/Library/Psionics/Classes/Manipulator.gct
@@ -3339,7 +3339,7 @@
 															"id": "mXz78O3pob9kmrPzK",
 															"name": "Powerful Individual",
 															"reference": "B135",
-															"local_notes": "\u003e150% of your starting points",
+															"local_notes": "\\\u003e150% of your starting points",
 															"cost_adj": "-20",
 															"disabled": true
 														},

--- a/Library/Psionics/Classes/Mythbuster.gct
+++ b/Library/Psionics/Classes/Mythbuster.gct
@@ -2876,7 +2876,7 @@
 															"id": "mc5KN8prII43tB4vi",
 															"name": "Powerful Individual",
 															"reference": "B135",
-															"local_notes": "\u003e150% of your starting points",
+															"local_notes": "\\\u003e150% of your starting points",
 															"cost_adj": "-20",
 															"disabled": true
 														},
@@ -4302,7 +4302,7 @@
 											"id": "mGjOGQaepMd08JiGH",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},

--- a/Library/Psionics/Classes/Parapsychologist.gct
+++ b/Library/Psionics/Classes/Parapsychologist.gct
@@ -3352,7 +3352,7 @@
 															"id": "mnzhFpk0LHgm-gXqP",
 															"name": "Powerful Individual",
 															"reference": "B135",
-															"local_notes": "\u003e150% of your starting points",
+															"local_notes": "\\\u003e150% of your starting points",
 															"cost_adj": "-20",
 															"disabled": true
 														},

--- a/Library/Psionics/Classes/Secret Agent.gct
+++ b/Library/Psionics/Classes/Secret Agent.gct
@@ -3852,7 +3852,7 @@
 															"id": "mMo0OrJt5wzI-S_hm",
 															"name": "Powerful Individual",
 															"reference": "B135",
-															"local_notes": "\u003e150% of your starting points",
+															"local_notes": "\\\u003e150% of your starting points",
 															"cost_adj": "-20",
 															"disabled": true
 														},
@@ -5324,7 +5324,7 @@
 											"id": "mQ33XFXTFHk07pcjj",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},

--- a/Library/Psionics/Classes/Soldier.gct
+++ b/Library/Psionics/Classes/Soldier.gct
@@ -2239,7 +2239,7 @@
 															"id": "mKsZuxmlImfOtQoE7",
 															"name": "Powerful Individual",
 															"reference": "B135",
-															"local_notes": "\u003e150% of your starting points",
+															"local_notes": "\\\u003e150% of your starting points",
 															"cost_adj": "-20",
 															"disabled": true
 														},

--- a/Library/Psionics/Classes/Soothsayer.gct
+++ b/Library/Psionics/Classes/Soothsayer.gct
@@ -3293,7 +3293,7 @@
 															"id": "mTcjp_r4dFiokMYrz",
 															"name": "Powerful Individual",
 															"reference": "B135",
-															"local_notes": "\u003e150% of your starting points",
+															"local_notes": "\\\u003e150% of your starting points",
 															"cost_adj": "-20",
 															"disabled": true
 														},

--- a/Library/Psionics/Classes/Unexpected Psi.gct
+++ b/Library/Psionics/Classes/Unexpected Psi.gct
@@ -369,7 +369,7 @@
 															"id": "m1bwDDrllkWrjBCI_",
 															"name": "Powerful Individual",
 															"reference": "B135",
-															"local_notes": "\u003e150% of your starting points",
+															"local_notes": "\\\u003e150% of your starting points",
 															"cost_adj": "-20",
 															"disabled": true
 														},

--- a/Library/Pyramid Magazine/Pyramid 115/Medical Professional.gct
+++ b/Library/Pyramid Magazine/Pyramid 115/Medical Professional.gct
@@ -1006,7 +1006,7 @@
 											"id": "mjQ439DPdNGBnanSw",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},

--- a/Library/Pyramid Magazine/Pyramid 115/Researcher.gct
+++ b/Library/Pyramid Magazine/Pyramid 115/Researcher.gct
@@ -605,7 +605,7 @@
 											"id": "mJCJ1R_F4AjtxpA1C",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},

--- a/Library/Reign of Steel Will to Live/Classes/Humans/Black Zoner.gct
+++ b/Library/Reign of Steel Will to Live/Classes/Humans/Black Zoner.gct
@@ -140,7 +140,7 @@
 							"id": "ml1aANMtBbHj3Q_iS",
 							"name": "Powerful Individual",
 							"reference": "B135",
-							"local_notes": "\u003e150% of your starting points",
+							"local_notes": "\\\u003e150% of your starting points",
 							"cost_adj": "-20",
 							"disabled": true
 						},

--- a/Library/Reign of Steel Will to Live/Classes/Humans/Botlicker.gct
+++ b/Library/Reign of Steel Will to Live/Classes/Humans/Botlicker.gct
@@ -304,7 +304,7 @@
 							"id": "msrPPvkwkpt7as3J-",
 							"name": "Powerful Individual",
 							"reference": "B135",
-							"local_notes": "\u003e150% of your starting points",
+							"local_notes": "\\\u003e150% of your starting points",
 							"cost_adj": "-20",
 							"disabled": true
 						},

--- a/Library/Reign of Steel Will to Live/Classes/Humans/Deejay.gct
+++ b/Library/Reign of Steel Will to Live/Classes/Humans/Deejay.gct
@@ -262,7 +262,7 @@
 							"id": "mVPrtXHYpdBTZ61Id",
 							"name": "Powerful Individual",
 							"reference": "B135",
-							"local_notes": "\u003e150% of your starting points",
+							"local_notes": "\\\u003e150% of your starting points",
 							"cost_adj": "-20",
 							"disabled": true
 						},

--- a/Library/Reign of Steel Will to Live/Classes/Humans/Experimental Cyborg.gct
+++ b/Library/Reign of Steel Will to Live/Classes/Humans/Experimental Cyborg.gct
@@ -114,7 +114,7 @@
 							"id": "mswAo4nbcvKGTD1ma",
 							"name": "Powerful Individual",
 							"reference": "B135",
-							"local_notes": "\u003e150% of your starting points",
+							"local_notes": "\\\u003e150% of your starting points",
 							"cost_adj": "-20",
 							"disabled": true
 						},

--- a/Library/Reign of Steel Will to Live/Classes/Humans/FBI Agent.gct
+++ b/Library/Reign of Steel Will to Live/Classes/Humans/FBI Agent.gct
@@ -829,7 +829,7 @@
 							"id": "mWrgpn-O7ixQt0d6-",
 							"name": "Powerful Individual",
 							"reference": "B135",
-							"local_notes": "\u003e150% of your starting points",
+							"local_notes": "\\\u003e150% of your starting points",
 							"cost_adj": "-20",
 							"disabled": true
 						},

--- a/Library/Reign of Steel Will to Live/Classes/Humans/Guerilla Fighter.gct
+++ b/Library/Reign of Steel Will to Live/Classes/Humans/Guerilla Fighter.gct
@@ -471,7 +471,7 @@
 									"id": "muKUdH3LOimAi36ZX",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Reign of Steel Will to Live/Classes/Humans/Marauder.gct
+++ b/Library/Reign of Steel Will to Live/Classes/Humans/Marauder.gct
@@ -507,7 +507,7 @@
 									"id": "meEiSuBqP0shTjFb9",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Reign of Steel Will to Live/Classes/Humans/Mechrider.gct
+++ b/Library/Reign of Steel Will to Live/Classes/Humans/Mechrider.gct
@@ -443,7 +443,7 @@
 									"id": "mW4ZVip-F3ejRNXQs",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Reign of Steel Will to Live/Classes/Humans/Underground Member.gct
+++ b/Library/Reign of Steel Will to Live/Classes/Humans/Underground Member.gct
@@ -115,7 +115,7 @@
 							"id": "mM5V0vdFlHqJJ7dmm",
 							"name": "Powerful Individual",
 							"reference": "B135",
-							"local_notes": "\u003e150% of your starting points",
+							"local_notes": "\\\u003e150% of your starting points",
 							"cost_adj": "-20",
 							"disabled": true
 						},

--- a/Library/Star Wars/Templates/Species/Charon.gct
+++ b/Library/Star Wars/Templates/Species/Charon.gct
@@ -1351,7 +1351,7 @@
 											"id": "mahQneATB1bdQMG9p",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},

--- a/Library/Steampunk/Templates/Adventurer-Journalist.gct
+++ b/Library/Steampunk/Templates/Adventurer-Journalist.gct
@@ -1468,7 +1468,7 @@
 											"id": "m7i2V_JqNyKAu-vEe",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},

--- a/Library/Steampunk/Templates/Radical.gct
+++ b/Library/Steampunk/Templates/Radical.gct
@@ -2661,7 +2661,7 @@
 											"id": "mCjc20SfqnHzGXdSZ",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},
@@ -2809,7 +2809,7 @@
 											"id": "mOuEo5X5lo849j5W5",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},
@@ -2957,7 +2957,7 @@
 											"id": "mJHvn3QD1hypHSmpE",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},

--- a/Library/Steampunk/Templates/Reporter.gct
+++ b/Library/Steampunk/Templates/Reporter.gct
@@ -1354,7 +1354,7 @@
 											"id": "mnhCVaUXheCqcYSbP",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},

--- a/Library/Supers/Templates/Dreadnought.gct
+++ b/Library/Supers/Templates/Dreadnought.gct
@@ -1895,7 +1895,7 @@
 							"id": "mjedfJaGPpuTOVhVy",
 							"name": "Powerful Individual",
 							"reference": "B135",
-							"local_notes": "\u003e150% of your starting points",
+							"local_notes": "\\\u003e150% of your starting points",
 							"cost_adj": "-20",
 							"disabled": true
 						},

--- a/Library/Tales of the Solar Patrol/Classes/Pirate.gct
+++ b/Library/Tales of the Solar Patrol/Classes/Pirate.gct
@@ -1378,7 +1378,7 @@
 							"id": "mPPxkLFPbe3ofhy17",
 							"name": "Powerful Individual",
 							"reference": "B135",
-							"local_notes": "\u003e150% of your starting points",
+							"local_notes": "\\\u003e150% of your starting points",
 							"cost_adj": "-20",
 							"disabled": true
 						},

--- a/Library/Tales of the Solar Patrol/Races and Animals/Jupiter/Callisto/Callistan warrior.gct
+++ b/Library/Tales of the Solar Patrol/Races and Animals/Jupiter/Callisto/Callistan warrior.gct
@@ -648,7 +648,7 @@
 									"id": "mV9cXPJB3iBfri50Z",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Tales of the Solar Patrol/Races and Animals/Venus/Krik leader.gct
+++ b/Library/Tales of the Solar Patrol/Races and Animals/Venus/Krik leader.gct
@@ -690,7 +690,7 @@
 							"id": "mZfiabk524CgOmHjB",
 							"name": "Powerful Individual",
 							"reference": "B135",
-							"local_notes": "\u003e150% of your starting points",
+							"local_notes": "\\\u003e150% of your starting points",
 							"cost_adj": "-20",
 							"disabled": true
 						},

--- a/Library/Tales of the Solar Patrol/Races and Animals/Venus/Krik warrior.gct
+++ b/Library/Tales of the Solar Patrol/Races and Animals/Venus/Krik warrior.gct
@@ -733,7 +733,7 @@
 							"id": "m6qF4ejMr-f4ZxJtn",
 							"name": "Powerful Individual",
 							"reference": "B135",
-							"local_notes": "\u003e150% of your starting points",
+							"local_notes": "\\\u003e150% of your starting points",
 							"cost_adj": "-20",
 							"disabled": true
 						},

--- a/Library/Tales of the Solar Patrol/Races and Animals/Venus/Salishal racial template.gct
+++ b/Library/Tales of the Solar Patrol/Races and Animals/Venus/Salishal racial template.gct
@@ -699,7 +699,7 @@
 							"id": "mQj9fP8rpqaWKkK3H",
 							"name": "Powerful Individual",
 							"reference": "B135",
-							"local_notes": "\u003e150% of your starting points",
+							"local_notes": "\\\u003e150% of your starting points",
 							"cost_adj": "-20",
 							"disabled": true
 						},

--- a/Library/Technomancer/Template - Alchemist.gct
+++ b/Library/Technomancer/Template - Alchemist.gct
@@ -1135,7 +1135,7 @@
 											"id": "mivYKKxY-6_1UHSyG",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},

--- a/Library/Technomancer/Template - Hellhound.gct
+++ b/Library/Technomancer/Template - Hellhound.gct
@@ -812,7 +812,7 @@
 											"id": "mL5B8RGmK00iXIyul",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},

--- a/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Commander.gct
+++ b/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Commander.gct
@@ -4110,7 +4110,7 @@
 													"id": "m-RFsgb4m_hK-PbC9",
 													"name": "Powerful Individual",
 													"reference": "B135",
-													"local_notes": "\u003e150% of your starting points",
+													"local_notes": "\\\u003e150% of your starting points",
 													"cost_adj": "-20",
 													"disabled": true
 												},

--- a/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Engineer.gct
+++ b/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Engineer.gct
@@ -2925,7 +2925,7 @@
 													"id": "mHlSHiEs5NnRS4w2D",
 													"name": "Powerful Individual",
 													"reference": "B135",
-													"local_notes": "\u003e150% of your starting points",
+													"local_notes": "\\\u003e150% of your starting points",
 													"cost_adj": "-20",
 													"disabled": true
 												},

--- a/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Helmsman.gct
+++ b/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Helmsman.gct
@@ -2955,7 +2955,7 @@
 													"id": "mMHtl3uZgXwWqxJ_q",
 													"name": "Powerful Individual",
 													"reference": "B135",
-													"local_notes": "\u003e150% of your starting points",
+													"local_notes": "\\\u003e150% of your starting points",
 													"cost_adj": "-20",
 													"disabled": true
 												},

--- a/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Loadmaster.gct
+++ b/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Loadmaster.gct
@@ -2905,7 +2905,7 @@
 													"id": "m0489tmXoxkFLLK24",
 													"name": "Powerful Individual",
 													"reference": "B135",
-													"local_notes": "\u003e150% of your starting points",
+													"local_notes": "\\\u003e150% of your starting points",
 													"cost_adj": "-20",
 													"disabled": true
 												},

--- a/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Medical Officer.gct
+++ b/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Medical Officer.gct
@@ -2804,7 +2804,7 @@
 													"id": "mMA3IA0ZLVXv3F3qB",
 													"name": "Powerful Individual",
 													"reference": "B135",
-													"local_notes": "\u003e150% of your starting points",
+													"local_notes": "\\\u003e150% of your starting points",
 													"cost_adj": "-20",
 													"disabled": true
 												},

--- a/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Operations Officer.gct
+++ b/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Operations Officer.gct
@@ -368,7 +368,7 @@
 													"id": "mjtJjZY5jQTCc5NlM",
 													"name": "Powerful Individual",
 													"reference": "B135",
-													"local_notes": "\u003e150% of your starting points",
+													"local_notes": "\\\u003e150% of your starting points",
 													"cost_adj": "-20",
 													"disabled": true
 												},

--- a/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Science Officer.gct
+++ b/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Science Officer.gct
@@ -2887,7 +2887,7 @@
 													"id": "mbJ_zGgH0NqmqSKbV",
 													"name": "Powerful Individual",
 													"reference": "B135",
-													"local_notes": "\u003e150% of your starting points",
+													"local_notes": "\\\u003e150% of your starting points",
 													"cost_adj": "-20",
 													"disabled": true
 												},

--- a/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Security Officer.gct
+++ b/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Security Officer.gct
@@ -2824,7 +2824,7 @@
 													"id": "me04sEBez3HhbooP5",
 													"name": "Powerful Individual",
 													"reference": "B135",
-													"local_notes": "\u003e150% of your starting points",
+													"local_notes": "\\\u003e150% of your starting points",
 													"cost_adj": "-20",
 													"disabled": true
 												},

--- a/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Steward.gct
+++ b/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Steward.gct
@@ -3900,7 +3900,7 @@
 													"id": "mH2jPI6wlcL3LrYrQ",
 													"name": "Powerful Individual",
 													"reference": "B135",
-													"local_notes": "\u003e150% of your starting points",
+													"local_notes": "\\\u003e150% of your starting points",
 													"cost_adj": "-20",
 													"disabled": true
 												},

--- a/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Tactical Officer.gct
+++ b/Library/Template Toolkit/Template Toolkit 3 - Starship Crew/Tactical Officer.gct
@@ -2594,7 +2594,7 @@
 													"id": "msNKLD7y1c1fmdCkY",
 													"name": "Powerful Individual",
 													"reference": "B135",
-													"local_notes": "\u003e150% of your starting points",
+													"local_notes": "\\\u003e150% of your starting points",
 													"cost_adj": "-20",
 													"disabled": true
 												},

--- a/Library/Thaumatology/Thaumatology Magical Styles/Magical Style - The Onyx Path.gct
+++ b/Library/Thaumatology/Thaumatology Magical Styles/Magical Style - The Onyx Path.gct
@@ -1268,7 +1268,7 @@
 									"id": "mDbO_MO4hnc_SB9Sq",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Traveller/Templates/Academician.gct
+++ b/Library/Traveller/Templates/Academician.gct
@@ -1265,7 +1265,7 @@
 									"id": "mXR3N73B_kVehyg4X",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Traveller/Templates/Athlete.gct
+++ b/Library/Traveller/Templates/Athlete.gct
@@ -1893,7 +1893,7 @@
 									"id": "mCz1kM0XzQVxctjGa",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Traveller/Templates/Attorney.gct
+++ b/Library/Traveller/Templates/Attorney.gct
@@ -2068,7 +2068,7 @@
 									"id": "mSr6HQf7IiGHB8Jhi",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Traveller/Templates/Capitalist.gct
+++ b/Library/Traveller/Templates/Capitalist.gct
@@ -2156,7 +2156,7 @@
 									"id": "mcV9iH_hl3HVU_v_0",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Traveller/Templates/Dilettante.gct
+++ b/Library/Traveller/Templates/Dilettante.gct
@@ -2367,7 +2367,7 @@
 									"id": "mIiu1eTywQzZioLXI",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Traveller/Templates/Diplomat.gct
+++ b/Library/Traveller/Templates/Diplomat.gct
@@ -2313,7 +2313,7 @@
 									"id": "mse-Bw2y4tonJGnJ2",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Traveller/Templates/Marine.gct
+++ b/Library/Traveller/Templates/Marine.gct
@@ -997,7 +997,7 @@
 									"id": "mireMnkFLn3ltFyYT",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Traveller/Templates/Policeman.gct
+++ b/Library/Traveller/Templates/Policeman.gct
@@ -1204,7 +1204,7 @@
 									"id": "m-EEKD-QECO51jHeK",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Traveller/Templates/Politician.gct
+++ b/Library/Traveller/Templates/Politician.gct
@@ -2021,7 +2021,7 @@
 									"id": "mrhCvxoQpxjmGWFVm",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Traveller/Templates/Rogue.gct
+++ b/Library/Traveller/Templates/Rogue.gct
@@ -2496,7 +2496,7 @@
 									"id": "mHBAniUmXayKYiRqf",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Traveller/Templates/Scientist.gct
+++ b/Library/Traveller/Templates/Scientist.gct
@@ -1365,7 +1365,7 @@
 									"id": "mzOKEoUrxiP3Ytyx-",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Traveller/Templates/Soldier.gct
+++ b/Library/Traveller/Templates/Soldier.gct
@@ -948,7 +948,7 @@
 									"id": "m0Us0IfPP-HQORhmH",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Traveller/Templates/Spy.gct
+++ b/Library/Traveller/Templates/Spy.gct
@@ -1601,7 +1601,7 @@
 									"id": "mMpm5H89PMicIYKdu",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Traveller/Templates/Starship Bridge Officer.gct
+++ b/Library/Traveller/Templates/Starship Bridge Officer.gct
@@ -1321,7 +1321,7 @@
 									"id": "mu6OfFtKO50rc1pGv",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Traveller/Templates/Starship Commander.gct
+++ b/Library/Traveller/Templates/Starship Commander.gct
@@ -1389,7 +1389,7 @@
 									"id": "mTGZ7G299oA0oEpXm",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Traveller/Templates/Starship Deckhand.gct
+++ b/Library/Traveller/Templates/Starship Deckhand.gct
@@ -1296,7 +1296,7 @@
 									"id": "m9bs7i1hEQE5e69qn",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Traveller/Templates/Starship Engineer.gct
+++ b/Library/Traveller/Templates/Starship Engineer.gct
@@ -1555,7 +1555,7 @@
 									"id": "mClvex1OUyC7HiPk1",
 									"name": "Powerful Individual",
 									"reference": "B135",
-									"local_notes": "\u003e150% of your starting points",
+									"local_notes": "\\\u003e150% of your starting points",
 									"cost_adj": "-20",
 									"disabled": true
 								},

--- a/Library/Vorkosigan Saga/Dendarii Mercenary.gct
+++ b/Library/Vorkosigan Saga/Dendarii Mercenary.gct
@@ -1132,7 +1132,7 @@
 											"id": "myAQ2qSMsNRP_ILo6",
 											"name": "Powerful Individual",
 											"reference": "B135",
-											"local_notes": "\u003e150% of your starting points",
+											"local_notes": "\\\u003e150% of your starting points",
 											"cost_adj": "-20",
 											"disabled": true
 										},


### PR DESCRIPTION
Enemy has a modifier called "Powerful Individual" with notes that say ">150% of your starting points".

Because trait modifier notes' sections are now parsed as markdown, the leading ">" gets misinterpreted as starting a quotation block.

These changes are broad but purely mechanical, and were achieved by running the command-line
`find Library/ -exec sed -i 's@"\\u003e150%@"\\\\\\u003e150%@g' {} \;`.