### PR TITLE
Fix quick sheathe

### DIFF
--- a/Library/Gun Fu/Gun Fu Traits.adq
+++ b/Library/Gun Fu/Gun Fu Traits.adq
@@ -618,12 +618,22 @@
 		},
 		{
 			"id": "tbqz7rtAcmvf4pjDS",
-			"name": "Quick-Sheathe (Long Arm)",
-			"reference": "GF21",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Power Ups/Power Ups Traits.adq",
+				"id": "tWjd3khLNVuiesibK"
+			},
+			"name": "Quick-Sheathe (@Fast-Draw Specialty@)",
+			"reference": "PU2:7,HT249,MA51,GF21,TS40",
+			"local_notes": "Lets you use Fast-Draw to save one second when sheathing",
 			"tags": [
 				"Perk",
-				"Physical"
+				"Physical",
+				"Tactical Shooting"
 			],
+			"replacements": {
+				"Fast-Draw Specialty": "Long Arm"
+			},
 			"base_points": 1,
 			"calc": {
 				"points": 1
@@ -631,12 +641,22 @@
 		},
 		{
 			"id": "tgKPWS-AZ58iGlWmx",
-			"name": "Quick-Sheathe (Pistol)",
-			"reference": "GF21",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Power Ups/Power Ups Traits.adq",
+				"id": "tWjd3khLNVuiesibK"
+			},
+			"name": "Quick-Sheathe (@Fast-Draw Specialty@)",
+			"reference": "PU2:7,HT249,MA51,GF21,TS40",
+			"local_notes": "Lets you use Fast-Draw to save one second when sheathing",
 			"tags": [
 				"Perk",
-				"Physical"
+				"Physical",
+				"Tactical Shooting"
 			],
+			"replacements": {
+				"Fast-Draw Specialty": "Pistol"
+			},
 			"base_points": 1,
 			"calc": {
 				"points": 1

--- a/Library/High Tech/High Tech Traits.adq
+++ b/Library/High Tech/High Tech Traits.adq
@@ -72,13 +72,18 @@
 		},
 		{
 			"id": "tWli0m9-YsdkmcUvd",
-			"name": "Quick-Sheathe (@Weapon Skill@)",
-			"reference": "HT249,MA51",
-			"local_notes": "Let you use Fast-Draw to save one second when sheating",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Power Ups/Power Ups Traits.adq",
+				"id": "tWjd3khLNVuiesibK"
+			},
+			"name": "Quick-Sheathe (@Fast-Draw Specialty@)",
+			"reference": "PU2:7,HT249,MA51,GF21,TS40",
+			"local_notes": "Lets you use Fast-Draw to save one second when sheathing",
 			"tags": [
-				"Cinematic",
-				"Mental",
-				"Perk"
+				"Perk",
+				"Physical",
+				"Tactical Shooting"
 			],
 			"base_points": 1,
 			"calc": {

--- a/Library/Martial Arts/Martial Arts Traits.adq
+++ b/Library/Martial Arts/Martial Arts Traits.adq
@@ -429,6 +429,26 @@
 			}
 		},
 		{
+			"id": "tyAfqDxIDa-dU8X2s",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Power Ups/Power Ups Traits.adq",
+				"id": "tWjd3khLNVuiesibK"
+			},
+			"name": "Quick-Sheathe (@Fast-Draw Specialty@)",
+			"reference": "PU2:7,HT249,MA51,GF21,TS40",
+			"local_notes": "Lets you use Fast-Draw to save one second when sheathing",
+			"tags": [
+				"Perk",
+				"Physical",
+				"Tactical Shooting"
+			],
+			"base_points": 1,
+			"calc": {
+				"points": 1
+			}
+		},
+		{
 			"id": "tjInaW-wKYILbF0-T",
 			"name": "Rapid Retraction (@Kick or Punch@)",
 			"reference": "MA51",

--- a/Library/Power Ups/Power Ups Traits.adq
+++ b/Library/Power Ups/Power Ups Traits.adq
@@ -13618,11 +13618,13 @@
 		},
 		{
 			"id": "tWjd3khLNVuiesibK",
-			"name": "Quick-Sheathe (@Weapon@)",
-			"reference": "PU2:7",
+			"name": "Quick-Sheathe (@Fast-Draw Specialty@)",
+			"reference": "PU2:7,HT249,MA51,GF21,TS40",
+			"local_notes": "Lets you use Fast-Draw to save one second when sheathing",
 			"tags": [
 				"Perk",
-				"Physical"
+				"Physical",
+				"Tactical Shooting"
 			],
 			"base_points": 1,
 			"calc": {

--- a/Library/Pyramid Magazine/Pyramid 112/More Skill Sets for Specialists/Knife Fighter.gct
+++ b/Library/Pyramid Magazine/Pyramid 112/More Skill Sets for Specialists/Knife Fighter.gct
@@ -9,12 +9,22 @@
 			"children": [
 				{
 					"id": "tEpTu06rENkkAuWDv",
-					"name": "Quick-Sheathe (Knife)",
-					"reference": "PU2:7",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Power Ups/Power Ups Traits.adq",
+						"id": "tWjd3khLNVuiesibK"
+					},
+					"name": "Quick-Sheathe (@Fast-Draw Specialty@)",
+					"reference": "PU2:7,HT249,MA51,GF21,TS40",
+					"local_notes": "Lets you use Fast-Draw to save one second when sheathing",
 					"tags": [
 						"Perk",
-						"Physical"
+						"Physical",
+						"Tactical Shooting"
 					],
+					"replacements": {
+						"Fast-Draw Specialty": "Knife"
+					},
 					"base_points": 1,
 					"calc": {
 						"points": 1

--- a/Library/Pyramid Magazine/Pyramid 36/Musketeer.gct
+++ b/Library/Pyramid Magazine/Pyramid 36/Musketeer.gct
@@ -759,11 +759,18 @@
 								},
 								{
 									"id": "tVAjeaK7aPMrml3RZ",
-									"name": "Quick-Sheathe (@Weapon@)",
-									"reference": "PU2:7",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups Traits.adq",
+										"id": "tWjd3khLNVuiesibK"
+									},
+									"name": "Quick-Sheathe (@Fast-Draw Specialty@)",
+									"reference": "PU2:7,HT249,MA51,GF21,TS40",
+									"local_notes": "Lets you use Fast-Draw to save one second when sheathing",
 									"tags": [
 										"Perk",
-										"Physical"
+										"Physical",
+										"Tactical Shooting"
 									],
 									"base_points": 1,
 									"calc": {

--- a/Library/Tactical Shooting/Tactical Shooting Traits.adq
+++ b/Library/Tactical Shooting/Tactical Shooting Traits.adq
@@ -256,13 +256,22 @@
 		},
 		{
 			"id": "twjI7_JGeWubQheZk",
-			"name": "Quick-Sheathe (Long Arm)",
-			"reference": "TS40",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Power Ups/Power Ups Traits.adq",
+				"id": "tWjd3khLNVuiesibK"
+			},
+			"name": "Quick-Sheathe (@Fast-Draw Specialty@)",
+			"reference": "PU2:7,HT249,MA51,GF21,TS40",
+			"local_notes": "Lets you use Fast-Draw to save one second when sheathing",
 			"tags": [
 				"Perk",
 				"Physical",
 				"Tactical Shooting"
 			],
+			"replacements": {
+				"Fast-Draw Specialty": "Long Arm"
+			},
 			"base_points": 1,
 			"calc": {
 				"points": 1
@@ -270,13 +279,22 @@
 		},
 		{
 			"id": "t7l0PnpKSG63P0fTa",
-			"name": "Quick-Sheathe (Pistol)",
-			"reference": "TS40",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Power Ups/Power Ups Traits.adq",
+				"id": "tWjd3khLNVuiesibK"
+			},
+			"name": "Quick-Sheathe (@Fast-Draw Specialty@)",
+			"reference": "PU2:7,HT249,MA51,GF21,TS40",
+			"local_notes": "Lets you use Fast-Draw to save one second when sheathing",
 			"tags": [
 				"Perk",
 				"Physical",
 				"Tactical Shooting"
 			],
+			"replacements": {
+				"Fast-Draw Specialty": "Pistol"
+			},
 			"base_points": 1,
 			"calc": {
 				"points": 1


### PR DESCRIPTION
In the GCS discord server, Geognome reported that Quick-Sheathe's notes have typos in.
I have corrected the typos, and also merged all Quick-Sheathe traits across the master library together, and made sure they all refer back to Power Ups Traits as the source trait.

This also includes adding Quick-Sheathe to Martial Arts traits, as it's listed in that book too.