### PR TITLE
Fix ultra tech robot size

### DIFF
--- a/Library/Ultra Tech/Races/Android.gct
+++ b/Library/Ultra Tech/Races/Android.gct
@@ -895,37 +895,72 @@
 							],
 							"children": [
 								{
-									"id": "tQ6A9b6oIwKF82uNz",
-									"name": "No ST bonus",
+									"id": "tYUmR_UhK2VH6ZxXF",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "thI3hK3riuknUwkHF"
+									},
+									"name": "Decreased Strength",
+									"reference": "B14",
 									"tags": [
+										"Attribute",
+										"Disadvantage",
 										"Physical"
 									],
-									"prereqs": {
-										"type": "prereq_list",
-										"all": true,
-										"prereqs": [
-											{
-												"type": "trait_prereq",
-												"has": false,
-												"name": {
-													"compare": "is",
-													"qualifier": "Increased Strength"
-												}
-											}
-										]
-									},
+									"points_per_level": -10,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "st",
+											"amount": -1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 3,
 									"calc": {
-										"points": 0
+										"points": -30,
+										"current_level": 3
+									}
+								},
+								{
+									"id": "tJT9QFdFkCvx4Jwbx",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t9JmDbmYS-RXMN3vt"
+									},
+									"name": "Decreased Size Modifier",
+									"reference": "B19",
+									"tags": [
+										"Attribute",
+										"Disadvantage",
+										"Physical"
+									],
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "sm",
+											"amount": -1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": 0,
+										"current_level": 1
 									}
 								}
 							],
 							"calc": {
-								"points": 0
+								"points": -30
 							}
 						}
 					],
 					"calc": {
-						"points": 2
+						"points": -28
 					}
 				},
 				{
@@ -1822,7 +1857,7 @@
 				}
 			],
 			"calc": {
-				"points": 181
+				"points": 151
 			}
 		}
 	]

--- a/Library/Ultra Tech/Races/Petbot.gct
+++ b/Library/Ultra Tech/Races/Petbot.gct
@@ -1102,16 +1102,23 @@
 					"name": "Secondary Characteristic Modifiers",
 					"children": [
 						{
-							"id": "tgLLV6PQbajOQ6xRY",
-							"name": "Decreased Size",
-							"reference": "B17",
+							"id": "tGrKsix8H8imMBrhI",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t9JmDbmYS-RXMN3vt"
+							},
+							"name": "Decreased Size Modifier",
+							"reference": "B19",
 							"tags": [
+								"Attribute",
+								"Disadvantage",
 								"Physical"
 							],
 							"features": [
 								{
 									"type": "attribute_bonus",
-									"attribute": "st",
+									"attribute": "sm",
 									"amount": -1,
 									"per_level": true
 								}

--- a/Library/Ultra Tech/Races/Scout Robot.gct
+++ b/Library/Ultra Tech/Races/Scout Robot.gct
@@ -2159,16 +2159,23 @@
 					"name": "Secondary Characteristic Modifiers",
 					"children": [
 						{
-							"id": "tsQP8ne9ZUoKZVMXl",
-							"name": "Decreased Size",
-							"reference": "B17",
+							"id": "tTH29vzzDPgZ4sFyd",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t9JmDbmYS-RXMN3vt"
+							},
+							"name": "Decreased Size Modifier",
+							"reference": "B19",
 							"tags": [
+								"Attribute",
+								"Disadvantage",
 								"Physical"
 							],
 							"features": [
 								{
 									"type": "attribute_bonus",
-									"attribute": "st",
+									"attribute": "sm",
 									"amount": -1,
 									"per_level": true
 								}


### PR DESCRIPTION
I noticed that the Scout Robot's Decreased Size trait actually reduces its Strength attribute, so I went through all the Ultra Tech Races to make sure their size modifier was correct.

This includes:
* Made the Child Body lens for Android reduces its SM (minor editorialising because Ultra-Tech doesn't mention its Size Modifer directly, but Basic Set mentions the size modifier for a child of that equivalent age)
* Fixed the Petbot reducing ST instead of SM.
* Fixed the Scout Robot reducing ST instead of SM.