### PR TITLE
Basic Set: Add Trait and Equipment modifiers to add reach based on the wielder's SM

### DIFF
--- a/Library/Basic Set/Basic Set Enhancement Modifiers.adm
+++ b/Library/Basic Set/Basic Set Enhancement Modifiers.adm
@@ -2,6 +2,209 @@
 	"version": 5,
 	"rows": [
 		{
+			"id": "Mqb9tJcYmw5RpDY0d",
+			"name": "Size Modifier and Reach modifiers",
+			"reference": "BX402",
+			"reference_highlight": "Size Modifier and Reach",
+			"local_notes": "Add these to the traits that grant you melee attacks if you're larger than SM+0.\n\n\u003e [!NOTE]\n\u003e The SM+1 Reach Bonus should not be added to traits that give you attacks with reach greater than C (kicks from Natural Attacks and Claws are fine)",
+			"children": [
+				{
+					"id": "mw_Qgg67cQLZjxM9z",
+					"name": "SM+1 Reach Bonus",
+					"reference": "BX402",
+					"features": [
+						{
+							"type": "weapon_max_reach_bonus",
+							"selection_type": "this_weapon",
+							"name": {
+								"compare": "is"
+							},
+							"specialization": {
+								"compare": "is_not",
+								"qualifier": "Kick"
+							},
+							"level": {
+								"compare": "at_least"
+							},
+							"amount": 1
+						}
+					],
+					"levels": 1
+				},
+				{
+					"id": "m_qH7fH1YkiYqRMIB",
+					"name": "SM+2 Reach Bonus",
+					"reference": "BX402",
+					"features": [
+						{
+							"type": "weapon_max_reach_bonus",
+							"selection_type": "this_weapon",
+							"name": {
+								"compare": "is"
+							},
+							"level": {
+								"compare": "at_least"
+							},
+							"amount": 1
+						}
+					],
+					"levels": 1
+				},
+				{
+					"id": "mS-APF5jd7TmzdOQb",
+					"name": "SM+3 Reach Bonus",
+					"reference": "BX402",
+					"features": [
+						{
+							"type": "weapon_max_reach_bonus",
+							"selection_type": "this_weapon",
+							"name": {
+								"compare": "is"
+							},
+							"level": {
+								"compare": "at_least"
+							},
+							"amount": 2
+						}
+					],
+					"levels": 1
+				},
+				{
+					"id": "mSx0si4gvxw_JdLre",
+					"name": "SM+4 Reach Bonus",
+					"reference": "BX402",
+					"features": [
+						{
+							"type": "weapon_max_reach_bonus",
+							"selection_type": "this_weapon",
+							"name": {
+								"compare": "is"
+							},
+							"level": {
+								"compare": "at_least"
+							},
+							"amount": 3
+						}
+					],
+					"levels": 1
+				},
+				{
+					"id": "moQAPmvXQaOsLVm3F",
+					"name": "SM+5 Reach Bonus",
+					"reference": "BX402",
+					"features": [
+						{
+							"type": "weapon_max_reach_bonus",
+							"selection_type": "this_weapon",
+							"name": {
+								"compare": "is"
+							},
+							"level": {
+								"compare": "at_least"
+							},
+							"amount": 5
+						}
+					],
+					"levels": 1
+				},
+				{
+					"id": "mQ3nItBV7EMbW9CFp",
+					"name": "SM+6 Reach Bonus",
+					"reference": "BX402",
+					"features": [
+						{
+							"type": "weapon_max_reach_bonus",
+							"selection_type": "this_weapon",
+							"name": {
+								"compare": "is"
+							},
+							"level": {
+								"compare": "at_least"
+							},
+							"amount": 7
+						}
+					],
+					"levels": 1
+				},
+				{
+					"id": "moN7q6uEULFoUtV-5",
+					"name": "SM+7 Reach Bonus",
+					"reference": "BX402",
+					"features": [
+						{
+							"type": "weapon_max_reach_bonus",
+							"selection_type": "this_weapon",
+							"name": {
+								"compare": "is"
+							},
+							"level": {
+								"compare": "at_least"
+							},
+							"amount": 10
+						}
+					],
+					"levels": 1
+				},
+				{
+					"id": "m-BLLo_LpGHFd1eeD",
+					"name": "SM+8 Reach Bonus",
+					"reference": "BX402",
+					"features": [
+						{
+							"type": "weapon_max_reach_bonus",
+							"selection_type": "this_weapon",
+							"name": {
+								"compare": "is"
+							},
+							"level": {
+								"compare": "at_least"
+							},
+							"amount": 15
+						}
+					],
+					"levels": 1
+				},
+				{
+					"id": "mkHRLNbWcMWCdunzs",
+					"name": "SM+9 Reach Bonus",
+					"reference": "BX402",
+					"features": [
+						{
+							"type": "weapon_max_reach_bonus",
+							"selection_type": "this_weapon",
+							"name": {
+								"compare": "is"
+							},
+							"level": {
+								"compare": "at_least"
+							},
+							"amount": 20
+						}
+					],
+					"levels": 1
+				},
+				{
+					"id": "mLZy5fMHYI68v_9rq",
+					"name": "SM+10 Reach Bonus",
+					"reference": "BX402",
+					"features": [
+						{
+							"type": "weapon_max_reach_bonus",
+							"selection_type": "this_weapon",
+							"name": {
+								"compare": "is"
+							},
+							"level": {
+								"compare": "at_least"
+							},
+							"amount": 30
+						}
+					],
+					"levels": 1
+				}
+			]
+		},
+		{
 			"id": "m5qUBbGg9xeI4r3J2",
 			"name": "2x Increased 1/2 D Range",
 			"reference": "B106",

--- a/Library/Basic Set/Basic Set Equipment Modifiers.eqm
+++ b/Library/Basic Set/Basic Set Equipment Modifiers.eqm
@@ -7,6 +7,234 @@
 			"local_notes": "Both Cost Factor and Multiplicative Modifiers for equipment are provided here. Kromm recommends using Cost Factor which was introduced in Low-Tech, rather than the multiplicative cost modifiers. But some GMs may wish to use multiplicative."
 		},
 		{
+			"id": "Fsspko63isUvbAyh5",
+			"name": "Size Modifier and Reach modifiers",
+			"reference": "BX402",
+			"reference_highlight": "Size Modifier and Reach",
+			"local_notes": "Add these to melee weapons if you are larger than SM+0.",
+			"children": [
+				{
+					"id": "fGvvL7yDy9wS4e3d-",
+					"name": "SM+1 wielder reach bonus",
+					"reference": "BX402",
+					"reference_highlight": "Size Modifier and Reach",
+					"local_notes": "\u003cscript\u003e\nvar errs = [];\nif (self.attachedTo \u0026\u0026 self.attachedTo.findWeapons(true)) {\n  for (const weapon of self.attachedTo.findWeapons(true)) {\n    if (weapon.reach != \"C,1\") { // we don't get pre-modifier reach, and C becomes C,1\n      errs.push(`Melee Attack ${weapon.usage} has reach other than C`)\n    }\n  }\n}\nif (errs.length) {\n  `\n\u003e [!CAUTION]\n\u003e * ${errs.join(\"\\n\u003e * \")}\n\n  `\n} else {\n  \"\"\n}\n\u003c/script\u003e",
+					"features": [
+						{
+							"type": "weapon_max_reach_bonus",
+							"selection_type": "this_weapon",
+							"name": {
+								"compare": "is"
+							},
+							"level": {
+								"compare": "at_least"
+							},
+							"amount": 1
+						}
+					],
+					"calc": {}
+				},
+				{
+					"id": "fxiqBvIt7CmUD8xIl",
+					"name": "SM+1 wielder reach bonus",
+					"reference": "BX402",
+					"reference_highlight": "Size Modifier and Reach",
+					"local_notes": "@One Usage@\u003cscript\u003e\nvar errs = [];\nif (self.attachedTo \u0026\u0026 self.attachedTo.findWeapons(true, \"\", \"@One Usage@\")) {\n  const weapons = self.attachedTo.findWeapons(true, \"\", \"@One Usage@\");\n  if (weapons.length) {\n    const weapon = weapons[0];\n    if (weapon.reach != \"C,1\") { // we don't get pre-modifier reach, and C becomes C,1\n      errs.push(`Melee Attack ${weapon.usage} has reach other than C`)\n    }\n  } else {\n    errs.push(\"Melee Attack has no usage named @One Usage@\");\n  }\n}\nif (errs.length) {\n  `\n\u003e [!CAUTION]\n\u003e * ${errs.join(\"\\n\u003e * \")}\n\n  `\n} else {\n  \"\"\n}\n\u003c/script\u003e",
+					"features": [
+						{
+							"type": "weapon_max_reach_bonus",
+							"selection_type": "this_weapon",
+							"name": {
+								"compare": "is"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "@One Usage@"
+							},
+							"level": {
+								"compare": "at_least"
+							},
+							"amount": 1
+						}
+					],
+					"calc": {
+						"resolved_notes": "@One Usage@"
+					}
+				},
+				{
+					"id": "fyVpXBUT1V5vFGONG",
+					"name": "SM+2 wielder reach bonus",
+					"reference": "BX402",
+					"reference_highlight": "Size Modifier and Reach",
+					"features": [
+						{
+							"type": "weapon_max_reach_bonus",
+							"selection_type": "this_weapon",
+							"name": {
+								"compare": "is"
+							},
+							"level": {
+								"compare": "at_least"
+							},
+							"amount": 1
+						}
+					]
+				},
+				{
+					"id": "fsVOxK31JusPtJmAN",
+					"name": "SM+3 wielder reach bonus",
+					"reference": "BX402",
+					"reference_highlight": "Size Modifier and Reach",
+					"features": [
+						{
+							"type": "weapon_max_reach_bonus",
+							"selection_type": "this_weapon",
+							"name": {
+								"compare": "is"
+							},
+							"level": {
+								"compare": "at_least"
+							},
+							"amount": 2
+						}
+					]
+				},
+				{
+					"id": "fIqZUDx4K6D5AUZq4",
+					"name": "SM+4 wielder reach bonus",
+					"reference": "BX402",
+					"reference_highlight": "Size Modifier and Reach",
+					"features": [
+						{
+							"type": "weapon_max_reach_bonus",
+							"selection_type": "this_weapon",
+							"name": {
+								"compare": "is"
+							},
+							"level": {
+								"compare": "at_least"
+							},
+							"amount": 3
+						}
+					]
+				},
+				{
+					"id": "fOUgsTJ2M12nPfoh9",
+					"name": "SM+5 wielder reach bonus",
+					"reference": "BX402",
+					"reference_highlight": "Size Modifier and Reach",
+					"features": [
+						{
+							"type": "weapon_max_reach_bonus",
+							"selection_type": "this_weapon",
+							"name": {
+								"compare": "is"
+							},
+							"level": {
+								"compare": "at_least"
+							},
+							"amount": 5
+						}
+					]
+				},
+				{
+					"id": "fDTYmTj2nwoCTdSCn",
+					"name": "SM+6 wielder reach bonus",
+					"reference": "BX402",
+					"reference_highlight": "Size Modifier and Reach",
+					"features": [
+						{
+							"type": "weapon_max_reach_bonus",
+							"selection_type": "this_weapon",
+							"name": {
+								"compare": "is"
+							},
+							"level": {
+								"compare": "at_least"
+							},
+							"amount": 7
+						}
+					]
+				},
+				{
+					"id": "fPoa8ouSaM2gNtI0D",
+					"name": "SM+7 wielder reach bonus",
+					"reference": "BX402",
+					"reference_highlight": "Size Modifier and Reach",
+					"features": [
+						{
+							"type": "weapon_max_reach_bonus",
+							"selection_type": "this_weapon",
+							"name": {
+								"compare": "is"
+							},
+							"level": {
+								"compare": "at_least"
+							},
+							"amount": 10
+						}
+					]
+				},
+				{
+					"id": "fIdr-MimLHFbPhNDU",
+					"name": "SM+8 wielder reach bonus",
+					"reference": "BX402",
+					"reference_highlight": "Size Modifier and Reach",
+					"features": [
+						{
+							"type": "weapon_max_reach_bonus",
+							"selection_type": "this_weapon",
+							"name": {
+								"compare": "is"
+							},
+							"level": {
+								"compare": "at_least"
+							},
+							"amount": 15
+						}
+					]
+				},
+				{
+					"id": "fu-7nGJQ4dBh-ioUi",
+					"name": "SM+9 wielder reach bonus",
+					"reference": "BX402",
+					"reference_highlight": "Size Modifier and Reach",
+					"features": [
+						{
+							"type": "weapon_max_reach_bonus",
+							"selection_type": "this_weapon",
+							"name": {
+								"compare": "is"
+							},
+							"level": {
+								"compare": "at_least"
+							},
+							"amount": 20
+						}
+					]
+				},
+				{
+					"id": "fJmOzTwUeI9alwwIe",
+					"name": "SM+10 wielder reach bonus",
+					"reference": "BX402",
+					"reference_highlight": "Size Modifier and Reach",
+					"features": [
+						{
+							"type": "weapon_max_reach_bonus",
+							"selection_type": "this_weapon",
+							"name": {
+								"compare": "is"
+							},
+							"level": {
+								"compare": "at_least"
+							},
+							"amount": 30
+						}
+					]
+				}
+			]
+		},
+		{
 			"id": "Fr5mKoVKQtFFDYYTf",
 			"name": "Shields",
 			"children": [


### PR DESCRIPTION
These trait and equipment modifiers for SM+1 to SM+10 that increase maximum reach, as described in _Size Modifier and Reach_ (see B402).

With thanks to Ptolemy for the original trait modifiers.

I used their trait modifiers to create equivalent equipment modifiers, and added some scripted notes to warn if they're being used incorrectly.