### PR TITLE
Basic Set Traits: Fix Striking ST's One Attack Only modifier's price

### DIFF
--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -24797,31 +24797,39 @@
 			],
 			"modifiers": [
 				{
-					"id": "mCVSG-r2Udy4p-_4W",
+					"id": "mrwY7GUU_azOnL6Um",
 					"name": "No Fine Manipulators",
 					"cost_adj": "-40%",
 					"disabled": true
 				},
 				{
-					"id": "mbnsSDwIOp_Nc5rNz",
+					"id": "moJHQeAfOHdqbF-EM",
 					"name": "Size",
 					"cost_adj": "-10%",
 					"levels": 1,
 					"disabled": true
 				},
 				{
-					"id": "mabAG6vQcxlGwNP2H",
+					"id": "mWYxXWWmWe2yEUKR5",
 					"name": "Super Effort",
 					"reference": "SU24",
 					"cost_adj": "400%",
 					"disabled": true
 				},
 				{
-					"id": "m59X2IFkrAEJ-T7-M",
+					"id": "mKJgqHbq-ShcnSx8w",
 					"name": "One Attack Only",
 					"reference": "P79",
 					"local_notes": "@Attack@",
 					"cost_adj": "-60%",
+					"disabled": true
+				},
+				{
+					"id": "mLKT6nC2M9dezueCh",
+					"name": "One Attack Only effects",
+					"reference": "P79",
+					"local_notes": "\u003cscript\u003eself.attachedTo ? \"\" : \"enable me if One Attack Only is used\"\u003c/script\u003e",
+					"cost_adj": "+0",
 					"use_level_from_trait": true,
 					"features": [
 						{
@@ -24842,10 +24850,13 @@
 							"per_level": true
 						}
 					],
-					"disabled": true
+					"disabled": true,
+					"calc": {
+						"resolved_notes": "enable me if One Attack Only is used"
+					}
 				},
 				{
-					"id": "mLaPvDbwggNMFH8xj",
+					"id": "m-UVJk8SZQN5VL4ns",
 					"name": "Know Your Own Strength Pricing Variant",
 					"reference": "PY83:18",
 					"cost_adj": "-4",


### PR DESCRIPTION
Previously, it was applying -60% to the price _per level_ of the advantage, whereas it should be -60% irrespective of trait level.