### PR TITLE
Basic Set Traits: add Long Neck

### DIFF
--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -8067,6 +8067,14 @@
 					"reference": "B54",
 					"cost_adj": "-20%",
 					"disabled": true
+				},
+				{
+					"id": "mbkgez8eJHL1z2Z2N",
+					"name": "Long",
+					"reference": "FUR12",
+					"reference_highlight": "the Long modifier",
+					"cost_adj": "+20%",
+					"disabled": true
 				}
 			],
 			"points_per_level": 15,
@@ -8075,6 +8083,28 @@
 			"calc": {
 				"points": 15,
 				"current_level": 1
+			}
+		},
+		{
+			"id": "tP6Q3MxnyLyReGgMk",
+			"name": "Modified Head",
+			"reference": "B54, FUR12",
+			"tags": [
+				"Advantage",
+				"Physical"
+			],
+			"modifiers": [
+				{
+					"id": "m7gGqs9AZ-lcMiMNF",
+					"name": "Long",
+					"reference": "FUR12",
+					"reference_highlight": "Long Neck",
+					"cost_adj": "+3",
+					"disabled": true
+				}
+			],
+			"calc": {
+				"points": 0
 			}
 		},
 		{


### PR DESCRIPTION
Technically, Long Neck comes from Furries, not Basic Set, but adding a modifier to the Basic Set trait helps keep all the modifiers in one place.