### PR TITLE
Basic Set Traits: Add melee attacks to Innate Attack

### DIFF
--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -11771,10 +11771,322 @@
 					"reference": "PSI20",
 					"cost_adj": "100%",
 					"disabled": true
+				},
+				{
+					"id": "MngsTyqWXTqAFoDaK",
+					"name": "Melee Attack modifiers",
+					"local_notes": "unhide the melee weapon usage and hide the ranged weapon usage",
+					"children": [
+						{
+							"id": "mxzvJTqwZTfACTZV6",
+							"name": "Melee Attack, Reach C",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-30%",
+							"disabled": true
+						},
+						{
+							"id": "m_P6-lGqPssdZYCn2",
+							"name": "Melee Attack, Reach 1",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-25%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mLB-FT5Ii7cpKkm1g",
+							"name": "Melee Attack, Reach 2",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-25%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mDYO1g_02km67ctT3",
+							"name": "Melee Attack, Reach C,1",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-20%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "m623U258Dv3pF4IH6",
+							"name": "Melee Attack, Reach 1,2",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-20%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mkqp54qVpYIfJx5Xx",
+							"name": "Melee Attack, Reach 2,3",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-20%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 3
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "msoQirAeJVs9YB80f",
+							"name": "Melee Attack, Reach 1-4",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-15%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 4
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mk71-9fFqmXhUvsYH",
+							"name": "Cannot Parry",
+							"reference": "B112",
+							"reference_highlight": "If your attack cannot parry",
+							"cost_adj": "-5%",
+							"features": [
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "can_parry",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 5,
 			"weapons": [
+				{
+					"id": "w8O51nk4nC69_wmwb",
+					"sv": 1,
+					"damage": {
+						"type": "burn",
+						"base_leveled": "1d"
+					},
+					"reach": "C",
+					"parry": "0",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Brawling"
+						},
+						{
+							"type": "dx"
+						}
+					],
+					"hide": true,
+					"calc": {
+						"damage": "1d per level  burn"
+					}
+				},
 				{
 					"id": "WOqqNtlHQ3HDlLdUs",
 					"sv": 1,
@@ -12053,10 +12365,322 @@
 					"reference": "B104",
 					"cost_adj": "10%",
 					"disabled": true
+				},
+				{
+					"id": "MPCOWLAYGlOVyqX4B",
+					"name": "Melee Attack modifiers",
+					"local_notes": "unhide the melee weapon usage and hide the ranged weapon usage",
+					"children": [
+						{
+							"id": "mDmQocywdTY2fN5DN",
+							"name": "Melee Attack, Reach C",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-30%",
+							"disabled": true
+						},
+						{
+							"id": "m8zAlqmz9bl3CzyAa",
+							"name": "Melee Attack, Reach 1",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-25%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mG18HFs-iZL_JDnjO",
+							"name": "Melee Attack, Reach 2",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-25%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mhIX7v9DMTfJXN1Se",
+							"name": "Melee Attack, Reach C,1",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-20%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "m2fiDFJsqDSQ2qT6x",
+							"name": "Melee Attack, Reach 1,2",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-20%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mAv2o8Gyd8X_T8uXC",
+							"name": "Melee Attack, Reach 2,3",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-20%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 3
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "md3YkL5kH6r-nM3Hn",
+							"name": "Melee Attack, Reach 1-4",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-15%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 4
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mA4RzDjSLL7yKXxhR",
+							"name": "Cannot Parry",
+							"reference": "B112",
+							"reference_highlight": "If your attack cannot parry",
+							"cost_adj": "-5%",
+							"features": [
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "can_parry",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 10,
 			"weapons": [
+				{
+					"id": "wv0RFMjGoRxAx38MG",
+					"sv": 1,
+					"damage": {
+						"type": "cor",
+						"base_leveled": "1d"
+					},
+					"reach": "C",
+					"parry": "0",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Brawling"
+						},
+						{
+							"type": "dx"
+						}
+					],
+					"hide": true,
+					"calc": {
+						"damage": "1d per level  cor"
+					}
+				},
 				{
 					"id": "W_2es21CldrtOcK1d",
 					"sv": 1,
@@ -12242,10 +12866,322 @@
 					"reference": "B104",
 					"cost_adj": "10%",
 					"disabled": true
+				},
+				{
+					"id": "McvqdzPh1eHEkNp_1",
+					"name": "Melee Attack modifiers",
+					"local_notes": "unhide the melee weapon usage and hide the ranged weapon usage",
+					"children": [
+						{
+							"id": "mzTCG61zirdRQGe23",
+							"name": "Melee Attack, Reach C",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-30%",
+							"disabled": true
+						},
+						{
+							"id": "mh2hxLFcqwUYnap1W",
+							"name": "Melee Attack, Reach 1",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-25%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mwTi4FiAvxNtE-FGF",
+							"name": "Melee Attack, Reach 2",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-25%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mz98gOcS-iRg3EteC",
+							"name": "Melee Attack, Reach C,1",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-20%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mjepoUNlzuKSmTV9e",
+							"name": "Melee Attack, Reach 1,2",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-20%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mu681jtTkkxta2XvE",
+							"name": "Melee Attack, Reach 2,3",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-20%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 3
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mCNdweAERgF73QqZi",
+							"name": "Melee Attack, Reach 1-4",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-15%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 4
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mKDPd9V12YWXIZk9R",
+							"name": "Cannot Parry",
+							"reference": "B112",
+							"reference_highlight": "If your attack cannot parry",
+							"cost_adj": "-5%",
+							"features": [
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "can_parry",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 5,
 			"weapons": [
+				{
+					"id": "wWOvvvwoJ1l1SB-aA",
+					"sv": 1,
+					"damage": {
+						"type": "cr",
+						"base_leveled": "1d"
+					},
+					"reach": "C",
+					"parry": "0",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Brawling"
+						},
+						{
+							"type": "dx"
+						}
+					],
+					"hide": true,
+					"calc": {
+						"damage": "1d per level  cr"
+					}
+				},
 				{
 					"id": "WNH41X_GiXmpOs0Sn",
 					"sv": 1,
@@ -12432,10 +13368,322 @@
 					"reference": "B104",
 					"cost_adj": "10%",
 					"disabled": true
+				},
+				{
+					"id": "MofcrqyjCRaoLTTWS",
+					"name": "Melee Attack modifiers",
+					"local_notes": "unhide the melee weapon usage and hide the ranged weapon usage",
+					"children": [
+						{
+							"id": "mBNAIYZ7wD1SsikEO",
+							"name": "Melee Attack, Reach C",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-30%",
+							"disabled": true
+						},
+						{
+							"id": "mY9XQwjpQMalVj5RU",
+							"name": "Melee Attack, Reach 1",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-25%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mryvITzEXhMhP_rd0",
+							"name": "Melee Attack, Reach 2",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-25%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mgpIX7X_xgWm-ZYex",
+							"name": "Melee Attack, Reach C,1",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-20%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "miNsxY53exY5rPcuN",
+							"name": "Melee Attack, Reach 1,2",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-20%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mFp59NsRaKcgm_V3H",
+							"name": "Melee Attack, Reach 2,3",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-20%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 3
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mHDBvbieVWFydgRQ3",
+							"name": "Melee Attack, Reach 1-4",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-15%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 4
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mFVe0Th6yI-vv3D7s",
+							"name": "Cannot Parry",
+							"reference": "B112",
+							"reference_highlight": "If your attack cannot parry",
+							"cost_adj": "-5%",
+							"features": [
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "can_parry",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 7,
 			"weapons": [
+				{
+					"id": "wVFUB8gy0FzWfLBvK",
+					"sv": 1,
+					"damage": {
+						"type": "cut",
+						"base_leveled": "1d"
+					},
+					"reach": "C",
+					"parry": "0",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Brawling"
+						},
+						{
+							"type": "dx"
+						}
+					],
+					"hide": true,
+					"calc": {
+						"damage": "1d per level  cut"
+					}
+				},
 				{
 					"id": "WzMZIve5naC08zogi",
 					"sv": 1,
@@ -12746,10 +13994,322 @@
 					"reference": "B104",
 					"cost_adj": "10%",
 					"disabled": true
+				},
+				{
+					"id": "MvF7O2Bb8z93_vP7O",
+					"name": "Melee Attack modifiers",
+					"local_notes": "unhide the melee weapon usage and hide the ranged weapon usage",
+					"children": [
+						{
+							"id": "mbIVEatg7J__1pzDL",
+							"name": "Melee Attack, Reach C",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-30%",
+							"disabled": true
+						},
+						{
+							"id": "ml8f2fiDeq4k--aoL",
+							"name": "Melee Attack, Reach 1",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-25%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "ml4kgEH5oQbPbHPZa",
+							"name": "Melee Attack, Reach 2",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-25%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mpvk2OCOOvybdRq5K",
+							"name": "Melee Attack, Reach C,1",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-20%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mfnzUwFzJWFOrB8IJ",
+							"name": "Melee Attack, Reach 1,2",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-20%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mazXA3l4g_CNM6Hvq",
+							"name": "Melee Attack, Reach 2,3",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-20%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 3
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mSBnQ3ue2ypaP0Uzq",
+							"name": "Melee Attack, Reach 1-4",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-15%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 4
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mIZ6PYI-G9Rr7zpcP",
+							"name": "Cannot Parry",
+							"reference": "B112",
+							"reference_highlight": "If your attack cannot parry",
+							"cost_adj": "-5%",
+							"features": [
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "can_parry",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 10,
 			"weapons": [
+				{
+					"id": "wysglpY-1KITKELAf",
+					"sv": 1,
+					"damage": {
+						"type": "fat",
+						"base_leveled": "1d"
+					},
+					"reach": "C",
+					"parry": "0",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Brawling"
+						},
+						{
+							"type": "dx"
+						}
+					],
+					"hide": true,
+					"calc": {
+						"damage": "1d per level  fat"
+					}
+				},
 				{
 					"id": "WF0ekK8hvBOJFnvUb",
 					"sv": 1,
@@ -12935,10 +14495,322 @@
 					"reference": "PU4:18",
 					"cost_adj": "35%",
 					"disabled": true
+				},
+				{
+					"id": "MgEvipsQA7KZClGXm",
+					"name": "Melee Attack modifiers",
+					"local_notes": "unhide the melee weapon usage and hide the ranged weapon usage",
+					"children": [
+						{
+							"id": "m47nWv7v6Dr8O7m9o",
+							"name": "Melee Attack, Reach C",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-30%",
+							"disabled": true
+						},
+						{
+							"id": "mrCfh-IN3lmXimEHj",
+							"name": "Melee Attack, Reach 1",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-25%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mga_lYWN5MUEMuKVW",
+							"name": "Melee Attack, Reach 2",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-25%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mgj5HUpW91s1R87Rb",
+							"name": "Melee Attack, Reach C,1",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-20%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mpNpXVDtOcSoDyv95",
+							"name": "Melee Attack, Reach 1,2",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-20%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "m52dw77Bow22djlZJ",
+							"name": "Melee Attack, Reach 2,3",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-20%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 3
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mn5z28sXGhJ75_nDy",
+							"name": "Melee Attack, Reach 1-4",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-15%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 4
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mHV4ZH7iT2lFLgSnL",
+							"name": "Cannot Parry",
+							"reference": "B112",
+							"reference_highlight": "If your attack cannot parry",
+							"cost_adj": "-5%",
+							"features": [
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "can_parry",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 8,
 			"weapons": [
+				{
+					"id": "wwZEKvt1M_EEZj1wM",
+					"sv": 1,
+					"damage": {
+						"type": "pi++",
+						"base_leveled": "1d"
+					},
+					"reach": "C",
+					"parry": "0",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Brawling"
+						},
+						{
+							"type": "dx"
+						}
+					],
+					"hide": true,
+					"calc": {
+						"damage": "1d per level  pi++"
+					}
+				},
 				{
 					"id": "WxqIj0_oaf96bbIjR",
 					"sv": 1,
@@ -13124,10 +14996,322 @@
 					"reference": "B104",
 					"cost_adj": "10%",
 					"disabled": true
+				},
+				{
+					"id": "MmSUoyaqhU38FUUaY",
+					"name": "Melee Attack modifiers",
+					"local_notes": "unhide the melee weapon usage and hide the ranged weapon usage",
+					"children": [
+						{
+							"id": "mnr0S88ol4ZZQhDxD",
+							"name": "Melee Attack, Reach C",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-30%",
+							"disabled": true
+						},
+						{
+							"id": "mKWjoN9nHo-m3H3mN",
+							"name": "Melee Attack, Reach 1",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-25%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mi8KucpWFcQ2cSgSo",
+							"name": "Melee Attack, Reach 2",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-25%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mGBjBSQ_b_AhN_ajU",
+							"name": "Melee Attack, Reach C,1",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-20%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mmKOk6LP-kNUzY7wk",
+							"name": "Melee Attack, Reach 1,2",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-20%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "myRduu9fp65MtKP0q",
+							"name": "Melee Attack, Reach 2,3",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-20%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 3
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mJaU71nu3hlY-02LV",
+							"name": "Melee Attack, Reach 1-4",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-15%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 4
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mEjqI-_O55_oOIQf-",
+							"name": "Cannot Parry",
+							"reference": "B112",
+							"reference_highlight": "If your attack cannot parry",
+							"cost_adj": "-5%",
+							"features": [
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "can_parry",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 8,
 			"weapons": [
+				{
+					"id": "wwoQb1wT3SKxBo8sY",
+					"sv": 1,
+					"damage": {
+						"type": "imp",
+						"base_leveled": "1d"
+					},
+					"reach": "C",
+					"parry": "0",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Brawling"
+						},
+						{
+							"type": "dx"
+						}
+					],
+					"hide": true,
+					"calc": {
+						"damage": "1d per level  imp"
+					}
+				},
 				{
 					"id": "W0diudF9UEWv3pkbX",
 					"sv": 1,
@@ -13328,10 +15512,322 @@
 					"reference": "PU4:18",
 					"cost_adj": "65%",
 					"disabled": true
+				},
+				{
+					"id": "MI4_WfHZ_OFc2hqJI",
+					"name": "Melee Attack modifiers",
+					"local_notes": "unhide the melee weapon usage and hide the ranged weapon usage",
+					"children": [
+						{
+							"id": "mxKkeoOZfBAd2Ocw2",
+							"name": "Melee Attack, Reach C",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-30%",
+							"disabled": true
+						},
+						{
+							"id": "mYv-BuWj79hLCaG1w",
+							"name": "Melee Attack, Reach 1",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-25%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mhSMLGzbUHPy1S0I2",
+							"name": "Melee Attack, Reach 2",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-25%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "m43duRyIZ41QPUBif",
+							"name": "Melee Attack, Reach C,1",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-20%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mQJDvR1EvZHuVn_02",
+							"name": "Melee Attack, Reach 1,2",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-20%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mSbeL6six4X84pD2e",
+							"name": "Melee Attack, Reach 2,3",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-20%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 3
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mQ-QaCJsErxXwdCnJ",
+							"name": "Melee Attack, Reach 1-4",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-15%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 4
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mAdOOcRTK9O8C4P2T",
+							"name": "Cannot Parry",
+							"reference": "B112",
+							"reference_highlight": "If your attack cannot parry",
+							"cost_adj": "-5%",
+							"features": [
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "can_parry",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 6,
 			"weapons": [
+				{
+					"id": "wDyKqjDRsoAOLbdZX",
+					"sv": 1,
+					"damage": {
+						"type": "pi+",
+						"base_leveled": "1d"
+					},
+					"reach": "C",
+					"parry": "0",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Brawling"
+						},
+						{
+							"type": "dx"
+						}
+					],
+					"hide": true,
+					"calc": {
+						"damage": "1d per level  pi+"
+					}
+				},
 				{
 					"id": "WAwftiP3wHW3h9kq3",
 					"sv": 1,
@@ -13532,10 +16028,322 @@
 					"reference": "PU4:18",
 					"cost_adj": "40%",
 					"disabled": true
+				},
+				{
+					"id": "Myh7uOUN74mbrDB8Q",
+					"name": "Melee Attack modifiers",
+					"local_notes": "unhide the melee weapon usage and hide the ranged weapon usage",
+					"children": [
+						{
+							"id": "mp-Ug7HeYR7LBkkuv",
+							"name": "Melee Attack, Reach C",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-30%",
+							"disabled": true
+						},
+						{
+							"id": "md_63b79-B6tSxKbi",
+							"name": "Melee Attack, Reach 1",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-25%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mv9WvN01zcwI70Gic",
+							"name": "Melee Attack, Reach 2",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-25%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mB7tYkuUhqKmwr56h",
+							"name": "Melee Attack, Reach C,1",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-20%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mZ8QIKQ-QTKzKf4bT",
+							"name": "Melee Attack, Reach 1,2",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-20%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mm56LdtoEYIy20aa6",
+							"name": "Melee Attack, Reach 2,3",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-20%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 3
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "m7VLJBCXjyL0KfbKE",
+							"name": "Melee Attack, Reach 1-4",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-15%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 4
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "m5P-cItZqGCgAYAy2",
+							"name": "Cannot Parry",
+							"reference": "B112",
+							"reference_highlight": "If your attack cannot parry",
+							"cost_adj": "-5%",
+							"features": [
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "can_parry",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 5,
 			"weapons": [
+				{
+					"id": "wQXOf5G_Jij4c576W",
+					"sv": 1,
+					"damage": {
+						"type": "pi",
+						"base_leveled": "1d"
+					},
+					"reach": "C",
+					"parry": "0",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Brawling"
+						},
+						{
+							"type": "dx"
+						}
+					],
+					"hide": true,
+					"calc": {
+						"damage": "1d per level  pi"
+					}
+				},
 				{
 					"id": "Wrkfa2KffJqL3RWx7",
 					"sv": 1,
@@ -13722,10 +16530,322 @@
 					"reference": "PU4:18",
 					"cost_adj": "40%",
 					"disabled": true
+				},
+				{
+					"id": "MceAwZwnuP1ZOmQCT",
+					"name": "Melee Attack modifiers",
+					"local_notes": "unhide the melee weapon usage and hide the ranged weapon usage",
+					"children": [
+						{
+							"id": "mkI--pGs4n2OniKCQ",
+							"name": "Melee Attack, Reach C",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-30%",
+							"disabled": true
+						},
+						{
+							"id": "m0CGb1-BsQzLy7pIl",
+							"name": "Melee Attack, Reach 1",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-25%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "m-rC0FiuQyupxBFxi",
+							"name": "Melee Attack, Reach 2",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-25%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "m011YMwW0eE_IeMEz",
+							"name": "Melee Attack, Reach C,1",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-20%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mU2mNg4UJwjbSZZXR",
+							"name": "Melee Attack, Reach 1,2",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-20%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mCKpavQU0TV-QrzDc",
+							"name": "Melee Attack, Reach 2,3",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-20%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 3
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mqiAvLJl-NoankzN5",
+							"name": "Melee Attack, Reach 1-4",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-15%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 4
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mJTdV9gDWbA-GvmBG",
+							"name": "Cannot Parry",
+							"reference": "B112",
+							"reference_highlight": "If your attack cannot parry",
+							"cost_adj": "-5%",
+							"features": [
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "can_parry",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 3,
 			"weapons": [
+				{
+					"id": "wbeCF2sysG5j9zyUe",
+					"sv": 1,
+					"damage": {
+						"type": "pi-",
+						"base_leveled": "1d"
+					},
+					"reach": "C",
+					"parry": "0",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Brawling"
+						},
+						{
+							"type": "dx"
+						}
+					],
+					"hide": true,
+					"calc": {
+						"damage": "1d per level  pi-"
+					}
+				},
 				{
 					"id": "WyKO8VQKM-6ayWMXz",
 					"sv": 1,
@@ -14011,10 +17131,322 @@
 					"reference": "B104",
 					"cost_adj": "10%",
 					"disabled": true
+				},
+				{
+					"id": "Mn7sD8pRMUQLuquZl",
+					"name": "Melee Attack modifiers",
+					"local_notes": "unhide the melee weapon usage and hide the ranged weapon usage",
+					"children": [
+						{
+							"id": "m9mVsgoBA2tPSB9IG",
+							"name": "Melee Attack, Reach C",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-30%",
+							"disabled": true
+						},
+						{
+							"id": "mnfsCKD3sJpSkg8TB",
+							"name": "Melee Attack, Reach 1",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-25%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mc9OZNTjRkb4XYcGg",
+							"name": "Melee Attack, Reach 2",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-25%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mraqO5fvAgTaZzyZC",
+							"name": "Melee Attack, Reach C,1",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-20%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mbm4aq9VJBRnTSAkm",
+							"name": "Melee Attack, Reach 1,2",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-20%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mQ0-aNO7pbekqbk4v",
+							"name": "Melee Attack, Reach 2,3",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-20%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 3
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mVIOHN73eyPit-WBk",
+							"name": "Melee Attack, Reach 1-4",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-15%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 4
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mz8EZPpuVY-UT8_pm",
+							"name": "Cannot Parry",
+							"reference": "B112",
+							"reference_highlight": "If your attack cannot parry",
+							"cost_adj": "-5%",
+							"features": [
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "can_parry",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 4,
 			"weapons": [
+				{
+					"id": "w581P3ugnKJAgucU_",
+					"sv": 1,
+					"damage": {
+						"type": "tox",
+						"base_leveled": "1d"
+					},
+					"reach": "C",
+					"parry": "0",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Brawling"
+						},
+						{
+							"type": "dx"
+						}
+					],
+					"hide": true,
+					"calc": {
+						"damage": "1d per level  tox"
+					}
+				},
 				{
 					"id": "WGg47FdXg4ENOxO8Q",
 					"sv": 1,

--- a/Library/Pyramid Magazine/Pyramid 103/Mad as Bones/Mad as Bones Traits.adq
+++ b/Library/Pyramid Magazine/Pyramid 103/Mad as Bones/Mad as Bones Traits.adq
@@ -554,10 +554,322 @@
 					],
 					"cost_adj": "+300%",
 					"disabled": true
+				},
+				{
+					"id": "MWUervvNJzC4EhX1x",
+					"name": "Melee Attack modifiers",
+					"local_notes": "unhide the melee weapon usage and hide the ranged weapon usage",
+					"children": [
+						{
+							"id": "mTfhcTwy0asivq8GV",
+							"name": "Melee Attack, Reach C",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-30%",
+							"disabled": true
+						},
+						{
+							"id": "m0RoG3nQ4KRys58xj",
+							"name": "Melee Attack, Reach 1",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-25%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mEMUSKZAc-Ad3pj2d",
+							"name": "Melee Attack, Reach 2",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-25%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "m45fYB3-8auA0taci",
+							"name": "Melee Attack, Reach C,1",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-20%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mMLnEZr9-BDANesHF",
+							"name": "Melee Attack, Reach 1,2",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-20%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mybDBjBDncvB9TazW",
+							"name": "Melee Attack, Reach 2,3",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-20%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 3
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 2
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mVWDbfXOmagaj-B58",
+							"name": "Melee Attack, Reach 1-4",
+							"reference": "B112",
+							"reference_highlight": "Melee Attack",
+							"cost_adj": "-15%",
+							"features": [
+								{
+									"type": "weapon_max_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 4
+								},
+								{
+									"type": "weapon_min_reach_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								},
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "close_combat",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						},
+						{
+							"id": "mKFvN1XVre75b9ONY",
+							"name": "Cannot Parry",
+							"reference": "B112",
+							"reference_highlight": "If your attack cannot parry",
+							"cost_adj": "-5%",
+							"features": [
+								{
+									"type": "weapon_switch",
+									"selection_type": "this_weapon",
+									"switch_type": "can_parry",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						}
+					]
 				}
 			],
 			"points_per_level": 10,
 			"weapons": [
+				{
+					"id": "wN6O2FvtL0Ur8dHOs",
+					"sv": 1,
+					"damage": {
+						"type": "stability",
+						"base_leveled": "1d"
+					},
+					"reach": "C",
+					"parry": "0",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": "Brawling"
+						},
+						{
+							"type": "dx"
+						}
+					],
+					"hide": true,
+					"calc": {
+						"damage": "1d per level  stability"
+					}
+				},
 				{
 					"id": "WzLiD1Le4xXwURARs",
 					"sv": 1,


### PR DESCRIPTION
This is implemented as adding a hidden melee attack in the Innate Attack
traits, and trait modifiers that change its reach and whether it can
parry.
