### PR TITLE
Martial Arts: Add Born Biter trait

### DIFF
--- a/Library/Dungeon Fantasy/Dungeon Fantasy Adventure 1/Rivals/Lizard King - Barbarian.gcs
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy Adventure 1/Rivals/Lizard King - Barbarian.gcs
@@ -805,14 +805,34 @@
 			"container_type": "ancestry",
 			"children": [
 				{
-					"id": "tjRUpGPqeboLqCsQ0",
+					"id": "tqnSPbYDHEU7JGk4j",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Martial Arts/Martial Arts Traits.adq",
+						"id": "t1EQWxaQ-jHONu6CT"
+					},
 					"name": "Born Biter",
-					"reference": "DF3:15",
-					"tags": [
-						"Physical"
+					"reference": "MA115, DF3:15, DFRC2:53, FFK9, FUR15",
+					"local_notes": "Can hold on and worry targets after a bite (if not already permitted)",
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "for attackers to hit your face, nose or jaw",
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to SM for determining what you can bite",
+							"amount": 1,
+							"per_level": true
+						}
 					],
+					"can_level": true,
+					"levels": 3,
 					"calc": {
-						"points": 0
+						"points": 0,
+						"current_level": 3
 					}
 				},
 				{
@@ -3549,7 +3569,7 @@
 		}
 	],
 	"created_date": "2022-11-18T19:41:21-05:00",
-	"modified_date": "2022-11-18T23:12:20-05:00",
+	"modified_date": "2026-05-29T19:43:45+01:00",
 	"calc": {
 		"swing": "3d+1",
 		"thrust": "2d-1",

--- a/Library/Dungeon Fantasy/Races/Dragon-Blooded.gct
+++ b/Library/Dungeon Fantasy/Races/Dragon-Blooded.gct
@@ -10,14 +10,34 @@
 			"container_type": "ancestry",
 			"children": [
 				{
-					"id": "tlAWjZrksT5Jzv0kP",
+					"id": "tV2X5seSurK2SOogw",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Martial Arts/Martial Arts Traits.adq",
+						"id": "t1EQWxaQ-jHONu6CT"
+					},
 					"name": "Born Biter",
-					"reference": "DF3:15",
-					"tags": [
-						"Physical"
+					"reference": "MA115, DF3:15, DFRC2:53, FFK9, FUR15",
+					"local_notes": "Can hold on and worry targets after a bite (if not already permitted)",
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "for attackers to hit your face, nose or jaw",
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to SM for determining what you can bite",
+							"amount": 1,
+							"per_level": true
+						}
 					],
+					"can_level": true,
+					"levels": 3,
 					"calc": {
-						"points": 0
+						"points": 0,
+						"current_level": 3
 					}
 				},
 				{

--- a/Library/Dungeon Fantasy/Races/Lizard Man.gct
+++ b/Library/Dungeon Fantasy/Races/Lizard Man.gct
@@ -10,14 +10,34 @@
 			"container_type": "ancestry",
 			"children": [
 				{
-					"id": "tuUugiQLwIL8_y43p",
+					"id": "tELYuGtebdh41CKkM",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Martial Arts/Martial Arts Traits.adq",
+						"id": "t1EQWxaQ-jHONu6CT"
+					},
 					"name": "Born Biter",
-					"reference": "DF3:15",
-					"tags": [
-						"Physical"
+					"reference": "MA115, DF3:15, DFRC2:53, FFK9, FUR15",
+					"local_notes": "Can hold on and worry targets after a bite (if not already permitted)",
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "for attackers to hit your face, nose or jaw",
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to SM for determining what you can bite",
+							"amount": 1,
+							"per_level": true
+						}
 					],
+					"can_level": true,
+					"levels": 3,
 					"calc": {
-						"points": 0
+						"points": 0,
+						"current_level": 3
 					}
 				},
 				{

--- a/Library/Fantasy Folk/Kobolds/Racial Templates/Kobold (Dungeon Fantasy).gct
+++ b/Library/Fantasy Folk/Kobolds/Racial Templates/Kobold (Dungeon Fantasy).gct
@@ -498,16 +498,34 @@
 					}
 				},
 				{
-					"id": "tTv6W4z_xaBxIqmv4",
+					"id": "tbqew5QIdsXg2Z_cy",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Martial Arts/Martial Arts Traits.adq",
+						"id": "t1EQWxaQ-jHONu6CT"
+					},
 					"name": "Born Biter",
-					"reference": "FFK9",
-					"local_notes": "Can hold on and worry targets after a bite.  +3 for opponents to target your protruding snout.",
-					"tags": [
-						"Feature",
-						"Physical"
+					"reference": "MA115, DF3:15, DFRC2:53, FFK9, FUR15",
+					"local_notes": "Can hold on and worry targets after a bite (if not already permitted)",
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "for attackers to hit your face, nose or jaw",
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to SM for determining what you can bite",
+							"amount": 1,
+							"per_level": true
+						}
 					],
+					"can_level": true,
+					"levels": 3,
 					"calc": {
-						"points": 0
+						"points": 0,
+						"current_level": 3
 					}
 				},
 				{

--- a/Library/Home Brew/Enraged Eggplant/Monsters/Aberrant Cacodemon.gcs
+++ b/Library/Home Brew/Enraged Eggplant/Monsters/Aberrant Cacodemon.gcs
@@ -1218,9 +1218,29 @@
 					}
 				},
 				{
-					"id": "tiUu0X93SlLWE5GCB",
+					"id": "t8vB7AAFt3Z2JUoPl",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Martial Arts/Martial Arts Traits.adq",
+						"id": "t1EQWxaQ-jHONu6CT"
+					},
 					"name": "Born Biter",
-					"reference": "MA115",
+					"reference": "MA115, DF3:15, DFRC2:53, FFK9, FUR15",
+					"local_notes": "Can hold on and worry targets after a bite (if not already permitted)",
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "for attackers to hit your face, nose or jaw",
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to SM for determining what you can bite",
+							"amount": 1,
+							"per_level": true
+						}
+					],
 					"can_level": true,
 					"levels": 3,
 					"calc": {
@@ -3247,7 +3267,7 @@
 		}
 	],
 	"created_date": "2023-01-25T08:35:22+08:00",
-	"modified_date": "2023-12-26T14:15:17+08:00",
+	"modified_date": "2026-05-29T19:55:27+01:00",
 	"calc": {
 		"swing": "2d+2",
 		"thrust": "2d",

--- a/Library/Home Brew/Enraged Eggplant/Monsters/Barracuda.gcs
+++ b/Library/Home Brew/Enraged Eggplant/Monsters/Barracuda.gcs
@@ -601,8 +601,29 @@
 			"container_type": "ancestry",
 			"children": [
 				{
-					"id": "tnzfHPAqCTEy5EUwM",
+					"id": "tZUc-h0klSD-Yl6_U",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Martial Arts/Martial Arts Traits.adq",
+						"id": "t1EQWxaQ-jHONu6CT"
+					},
 					"name": "Born Biter",
+					"reference": "MA115, DF3:15, DFRC2:53, FFK9, FUR15",
+					"local_notes": "Can hold on and worry targets after a bite (if not already permitted)",
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "for attackers to hit your face, nose or jaw",
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to SM for determining what you can bite",
+							"amount": 1,
+							"per_level": true
+						}
+					],
 					"can_level": true,
 					"levels": 2,
 					"calc": {
@@ -1559,7 +1580,7 @@
 		}
 	],
 	"created_date": "2023-12-25T15:18:50+08:00",
-	"modified_date": "2023-12-28T13:38:48+08:00",
+	"modified_date": "2026-05-29T19:55:15+01:00",
 	"calc": {
 		"swing": "1d-3",
 		"thrust": "1d-4",

--- a/Library/Home Brew/Enraged Eggplant/Monsters/Cacodemon.gcs
+++ b/Library/Home Brew/Enraged Eggplant/Monsters/Cacodemon.gcs
@@ -1223,9 +1223,29 @@
 					}
 				},
 				{
-					"id": "tNwTx2ulRzsqS5-Bf",
+					"id": "tfDiH2Z7nXXF3UD-h",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Martial Arts/Martial Arts Traits.adq",
+						"id": "t1EQWxaQ-jHONu6CT"
+					},
 					"name": "Born Biter",
-					"reference": "MA115",
+					"reference": "MA115, DF3:15, DFRC2:53, FFK9, FUR15",
+					"local_notes": "Can hold on and worry targets after a bite (if not already permitted)",
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "for attackers to hit your face, nose or jaw",
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to SM for determining what you can bite",
+							"amount": 1,
+							"per_level": true
+						}
+					],
 					"can_level": true,
 					"levels": 3,
 					"calc": {
@@ -3357,7 +3377,7 @@
 		}
 	],
 	"created_date": "2023-01-25T08:35:22+08:00",
-	"modified_date": "2023-12-26T14:15:49+08:00",
+	"modified_date": "2026-05-29T19:55:09+01:00",
 	"calc": {
 		"swing": "2d+2",
 		"thrust": "2d",

--- a/Library/Home Brew/Enraged Eggplant/Monsters/Carcass Eater.gcs
+++ b/Library/Home Brew/Enraged Eggplant/Monsters/Carcass Eater.gcs
@@ -1283,10 +1283,29 @@
 					}
 				},
 				{
-					"id": "t3S8vsNpolZ-gPlWQ",
-					"name": "Born Biter ",
-					"reference_highlight": "MA115",
-					"local_notes": "+1 to +3 to effective SM only to determine how they bite. Apply the same bonus to rolls to hit their jaw or nose. A SM 0 reptile man with +3 SM for biting would bite as if he had SM +3, but enemies would target his jaw at only -3, his nose at -4. Those with any level of this feature suffer a nose hit on a roll of 1-2 on 1d when struck in the face.",
+					"id": "twtPDcr_mANBTN_yz",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Martial Arts/Martial Arts Traits.adq",
+						"id": "t1EQWxaQ-jHONu6CT"
+					},
+					"name": "Born Biter",
+					"reference": "MA115, DF3:15, DFRC2:53, FFK9, FUR15",
+					"local_notes": "Can hold on and worry targets after a bite (if not already permitted)",
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "for attackers to hit your face, nose or jaw",
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to SM for determining what you can bite",
+							"amount": 1,
+							"per_level": true
+						}
+					],
 					"can_level": true,
 					"levels": 3,
 					"calc": {
@@ -1640,7 +1659,7 @@
 		}
 	],
 	"created_date": "2023-10-27T23:49:21+03:00",
-	"modified_date": "2024-03-12T16:17:06+08:00",
+	"modified_date": "2026-05-29T19:55:01+01:00",
 	"calc": {
 		"swing": "1d-1",
 		"thrust": "1d-3",

--- a/Library/Home Brew/Enraged Eggplant/Monsters/Couatl.gcs
+++ b/Library/Home Brew/Enraged Eggplant/Monsters/Couatl.gcs
@@ -622,9 +622,29 @@
 					}
 				},
 				{
-					"id": "tpjOgu9o8dIv9n3by",
+					"id": "tci7sVD6UMQV79mmT",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Martial Arts/Martial Arts Traits.adq",
+						"id": "t1EQWxaQ-jHONu6CT"
+					},
 					"name": "Born Biter",
-					"reference": "MA115",
+					"reference": "MA115, DF3:15, DFRC2:53, FFK9, FUR15",
+					"local_notes": "Can hold on and worry targets after a bite (if not already permitted)",
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "for attackers to hit your face, nose or jaw",
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to SM for determining what you can bite",
+							"amount": 1,
+							"per_level": true
+						}
+					],
 					"can_level": true,
 					"levels": 2,
 					"calc": {
@@ -5281,7 +5301,7 @@
 		}
 	],
 	"created_date": "2023-01-16T15:24:06+08:00",
-	"modified_date": "2023-12-26T14:16:59+08:00",
+	"modified_date": "2026-05-29T19:54:51+01:00",
 	"calc": {
 		"swing": "3d-1",
 		"thrust": "2d+1",

--- a/Library/Home Brew/Enraged Eggplant/Monsters/Fiery Cacodemon.gcs
+++ b/Library/Home Brew/Enraged Eggplant/Monsters/Fiery Cacodemon.gcs
@@ -1271,9 +1271,29 @@
 					}
 				},
 				{
-					"id": "tKtNeCKfxXGGB9NiG",
+					"id": "tSscFtMJSSwhwRFkN",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Martial Arts/Martial Arts Traits.adq",
+						"id": "t1EQWxaQ-jHONu6CT"
+					},
 					"name": "Born Biter",
-					"reference": "MA115",
+					"reference": "MA115, DF3:15, DFRC2:53, FFK9, FUR15",
+					"local_notes": "Can hold on and worry targets after a bite (if not already permitted)",
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "for attackers to hit your face, nose or jaw",
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to SM for determining what you can bite",
+							"amount": 1,
+							"per_level": true
+						}
+					],
 					"can_level": true,
 					"levels": 3,
 					"calc": {
@@ -3367,7 +3387,7 @@
 		}
 	],
 	"created_date": "2023-01-25T08:35:22+08:00",
-	"modified_date": "2023-12-26T14:18:14+08:00",
+	"modified_date": "2026-05-29T19:53:56+01:00",
 	"calc": {
 		"swing": "2d",
 		"thrust": "1d+2",

--- a/Library/Home Brew/Enraged Eggplant/Monsters/Hyena.gcs
+++ b/Library/Home Brew/Enraged Eggplant/Monsters/Hyena.gcs
@@ -743,8 +743,29 @@
 					}
 				},
 				{
-					"id": "tIV2ZEzVJOZB6n2U6",
+					"id": "ta3-L4J5qN2o_Cx-0",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Martial Arts/Martial Arts Traits.adq",
+						"id": "t1EQWxaQ-jHONu6CT"
+					},
 					"name": "Born Biter",
+					"reference": "MA115, DF3:15, DFRC2:53, FFK9, FUR15",
+					"local_notes": "Can hold on and worry targets after a bite (if not already permitted)",
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "for attackers to hit your face, nose or jaw",
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to SM for determining what you can bite",
+							"amount": 1,
+							"per_level": true
+						}
+					],
 					"can_level": true,
 					"levels": 2,
 					"calc": {
@@ -2016,7 +2037,7 @@
 		}
 	],
 	"created_date": "2024-01-27T17:59:18+08:00",
-	"modified_date": "2024-01-27T18:05:11+08:00",
+	"modified_date": "2026-05-29T19:53:49+01:00",
 	"calc": {
 		"swing": "1d-1",
 		"thrust": "1d-2",

--- a/Library/Home Brew/Enraged Eggplant/Monsters/Ixitxachitl, Average.gcs
+++ b/Library/Home Brew/Enraged Eggplant/Monsters/Ixitxachitl, Average.gcs
@@ -615,8 +615,29 @@
 					}
 				},
 				{
-					"id": "txxkM835U9TgSagZv",
+					"id": "tSoHrD7xqst2Yoj_d",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Martial Arts/Martial Arts Traits.adq",
+						"id": "t1EQWxaQ-jHONu6CT"
+					},
 					"name": "Born Biter",
+					"reference": "MA115, DF3:15, DFRC2:53, FFK9, FUR15",
+					"local_notes": "Can hold on and worry targets after a bite (if not already permitted)",
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "for attackers to hit your face, nose or jaw",
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to SM for determining what you can bite",
+							"amount": 1,
+							"per_level": true
+						}
+					],
 					"can_level": true,
 					"levels": 2,
 					"calc": {
@@ -1570,7 +1591,7 @@
 		}
 	],
 	"created_date": "2024-02-06T15:45:16+08:00",
-	"modified_date": "2024-02-06T16:15:31+08:00",
+	"modified_date": "2026-05-29T19:53:43+01:00",
 	"calc": {
 		"swing": "1d-1",
 		"thrust": "1d-3",

--- a/Library/Home Brew/Enraged Eggplant/Monsters/Kamaitachi.gcs
+++ b/Library/Home Brew/Enraged Eggplant/Monsters/Kamaitachi.gcs
@@ -704,13 +704,28 @@
 					}
 				},
 				{
-					"id": "t72_2d0kNPCGmlyqb",
+					"id": "tNYzHOzv9umSfNBZL",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Martial Arts/Martial Arts Traits.adq",
+						"id": "t1EQWxaQ-jHONu6CT"
+					},
 					"name": "Born Biter",
-					"reference": "MA115",
-					"tags": [
-						"Exotic",
-						"Feature",
-						"Physical"
+					"reference": "MA115, DF3:15, DFRC2:53, FFK9, FUR15",
+					"local_notes": "Can hold on and worry targets after a bite (if not already permitted)",
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "for attackers to hit your face, nose or jaw",
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to SM for determining what you can bite",
+							"amount": 1,
+							"per_level": true
+						}
 					],
 					"can_level": true,
 					"levels": 1,
@@ -3403,7 +3418,7 @@
 		}
 	],
 	"created_date": "2023-01-19T12:25:18+08:00",
-	"modified_date": "2023-12-26T14:20:48+08:00",
+	"modified_date": "2026-05-29T19:53:37+01:00",
 	"calc": {
 		"swing": "1d",
 		"thrust": "1d-1",

--- a/Library/Home Brew/Enraged Eggplant/Monsters/Kobold Sorcerer.gcs
+++ b/Library/Home Brew/Enraged Eggplant/Monsters/Kobold Sorcerer.gcs
@@ -774,8 +774,29 @@
 			"container_type": "ancestry",
 			"children": [
 				{
-					"id": "tgaYRFiqqBPjz2Z1e",
+					"id": "tIQ-v8rbPrwDludxG",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Martial Arts/Martial Arts Traits.adq",
+						"id": "t1EQWxaQ-jHONu6CT"
+					},
 					"name": "Born Biter",
+					"reference": "MA115, DF3:15, DFRC2:53, FFK9, FUR15",
+					"local_notes": "Can hold on and worry targets after a bite (if not already permitted)",
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "for attackers to hit your face, nose or jaw",
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to SM for determining what you can bite",
+							"amount": 1,
+							"per_level": true
+						}
+					],
 					"can_level": true,
 					"levels": 3,
 					"calc": {
@@ -2134,7 +2155,7 @@
 		}
 	],
 	"created_date": "2023-12-26T14:40:00+08:00",
-	"modified_date": "2023-12-26T14:50:28+08:00",
+	"modified_date": "2026-05-29T19:53:32+01:00",
 	"calc": {
 		"swing": "1d-3",
 		"thrust": "1d-4",

--- a/Library/Home Brew/Enraged Eggplant/Monsters/Kobold Warrior.gcs
+++ b/Library/Home Brew/Enraged Eggplant/Monsters/Kobold Warrior.gcs
@@ -774,8 +774,29 @@
 			"container_type": "ancestry",
 			"children": [
 				{
-					"id": "tf2HpUgGqKHsThdQj",
+					"id": "tXJgC8PXfoak__tPx",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Martial Arts/Martial Arts Traits.adq",
+						"id": "t1EQWxaQ-jHONu6CT"
+					},
 					"name": "Born Biter",
+					"reference": "MA115, DF3:15, DFRC2:53, FFK9, FUR15",
+					"local_notes": "Can hold on and worry targets after a bite (if not already permitted)",
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "for attackers to hit your face, nose or jaw",
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to SM for determining what you can bite",
+							"amount": 1,
+							"per_level": true
+						}
+					],
 					"can_level": true,
 					"levels": 3,
 					"calc": {
@@ -1724,7 +1745,7 @@
 		}
 	],
 	"created_date": "2023-12-26T14:40:00+08:00",
-	"modified_date": "2023-12-26T14:45:54+08:00",
+	"modified_date": "2026-05-29T19:53:25+01:00",
 	"calc": {
 		"swing": "1d-3",
 		"thrust": "1d-4",

--- a/Library/Home Brew/Enraged Eggplant/Monsters/Malwrath.gcs
+++ b/Library/Home Brew/Enraged Eggplant/Monsters/Malwrath.gcs
@@ -1223,9 +1223,29 @@
 					}
 				},
 				{
-					"id": "t_wmeEQfRl9vp3lya",
+					"id": "thtgz-ujk-wHa64zC",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Martial Arts/Martial Arts Traits.adq",
+						"id": "t1EQWxaQ-jHONu6CT"
+					},
 					"name": "Born Biter",
-					"reference": "MA115",
+					"reference": "MA115, DF3:15, DFRC2:53, FFK9, FUR15",
+					"local_notes": "Can hold on and worry targets after a bite (if not already permitted)",
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "for attackers to hit your face, nose or jaw",
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to SM for determining what you can bite",
+							"amount": 1,
+							"per_level": true
+						}
+					],
 					"can_level": true,
 					"levels": 3,
 					"calc": {
@@ -3357,7 +3377,7 @@
 		}
 	],
 	"created_date": "2023-01-25T08:35:22+08:00",
-	"modified_date": "2023-12-26T14:20:58+08:00",
+	"modified_date": "2026-05-29T19:53:19+01:00",
 	"calc": {
 		"swing": "2d",
 		"thrust": "1d+2",

--- a/Library/Home Brew/Enraged Eggplant/Monsters/Riding Dog.gcs
+++ b/Library/Home Brew/Enraged Eggplant/Monsters/Riding Dog.gcs
@@ -744,8 +744,29 @@
 					}
 				},
 				{
-					"id": "t0AMoVaORcUILDtrz",
+					"id": "t2ssMHHTFlzbbuV-L",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Martial Arts/Martial Arts Traits.adq",
+						"id": "t1EQWxaQ-jHONu6CT"
+					},
 					"name": "Born Biter",
+					"reference": "MA115, DF3:15, DFRC2:53, FFK9, FUR15",
+					"local_notes": "Can hold on and worry targets after a bite (if not already permitted)",
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "for attackers to hit your face, nose or jaw",
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to SM for determining what you can bite",
+							"amount": 1,
+							"per_level": true
+						}
+					],
 					"can_level": true,
 					"levels": 2,
 					"calc": {
@@ -1679,7 +1700,7 @@
 		}
 	],
 	"created_date": "2024-01-27T17:59:18+08:00",
-	"modified_date": "2024-01-27T18:10:47+08:00",
+	"modified_date": "2026-05-29T19:53:12+01:00",
 	"calc": {
 		"swing": "1d-2",
 		"thrust": "1d-4",

--- a/Library/Home Brew/Enraged Eggplant/Monsters/Spectral Cacodemon.gcs
+++ b/Library/Home Brew/Enraged Eggplant/Monsters/Spectral Cacodemon.gcs
@@ -1223,9 +1223,29 @@
 					}
 				},
 				{
-					"id": "tM6r_BhSDXsvB68v9",
+					"id": "tb75IETgirAGdpJXW",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Martial Arts/Martial Arts Traits.adq",
+						"id": "t1EQWxaQ-jHONu6CT"
+					},
 					"name": "Born Biter",
-					"reference": "MA115",
+					"reference": "MA115, DF3:15, DFRC2:53, FFK9, FUR15",
+					"local_notes": "Can hold on and worry targets after a bite (if not already permitted)",
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "for attackers to hit your face, nose or jaw",
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to SM for determining what you can bite",
+							"amount": 1,
+							"per_level": true
+						}
+					],
 					"can_level": true,
 					"levels": 3,
 					"calc": {
@@ -3474,7 +3494,7 @@
 		}
 	],
 	"created_date": "2023-01-25T08:35:22+08:00",
-	"modified_date": "2023-12-26T14:22:50+08:00",
+	"modified_date": "2026-05-29T19:53:07+01:00",
 	"calc": {
 		"swing": "2d+2",
 		"thrust": "2d",

--- a/Library/Home Brew/Enraged Eggplant/Monsters/Vampiric Ixitxachitl.gcs
+++ b/Library/Home Brew/Enraged Eggplant/Monsters/Vampiric Ixitxachitl.gcs
@@ -768,8 +768,29 @@
 					}
 				},
 				{
-					"id": "tFM6SyPmLKLmjYkJJ",
+					"id": "tUgfM4nc0JAxj-yZR",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Martial Arts/Martial Arts Traits.adq",
+						"id": "t1EQWxaQ-jHONu6CT"
+					},
 					"name": "Born Biter",
+					"reference": "MA115, DF3:15, DFRC2:53, FFK9, FUR15",
+					"local_notes": "Can hold on and worry targets after a bite (if not already permitted)",
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "for attackers to hit your face, nose or jaw",
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to SM for determining what you can bite",
+							"amount": 1,
+							"per_level": true
+						}
+					],
 					"can_level": true,
 					"levels": 2,
 					"calc": {
@@ -1826,7 +1847,7 @@
 		}
 	],
 	"created_date": "2024-02-06T15:45:16+08:00",
-	"modified_date": "2024-02-06T16:18:01+08:00",
+	"modified_date": "2026-05-29T19:53:00+01:00",
 	"calc": {
 		"swing": "1d-1",
 		"thrust": "1d-3",

--- a/Library/Home Brew/Enraged Eggplant/Monsters/Wolf Skeleton.gcs
+++ b/Library/Home Brew/Enraged Eggplant/Monsters/Wolf Skeleton.gcs
@@ -1033,8 +1033,29 @@
 					}
 				},
 				{
-					"id": "tLTGzqs-5oG1njj_5",
+					"id": "tCmdto4gbzsRQ1MLw",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Martial Arts/Martial Arts Traits.adq",
+						"id": "t1EQWxaQ-jHONu6CT"
+					},
 					"name": "Born Biter",
+					"reference": "MA115, DF3:15, DFRC2:53, FFK9, FUR15",
+					"local_notes": "Can hold on and worry targets after a bite (if not already permitted)",
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "for attackers to hit your face, nose or jaw",
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to SM for determining what you can bite",
+							"amount": 1,
+							"per_level": true
+						}
+					],
 					"can_level": true,
 					"levels": 2,
 					"calc": {
@@ -3084,7 +3105,7 @@
 		}
 	],
 	"created_date": "2022-08-03T16:55:00+08:00",
-	"modified_date": "2024-03-12T18:04:05+08:00",
+	"modified_date": "2026-05-29T19:52:45+01:00",
 	"calc": {
 		"swing": "1d",
 		"thrust": "1d-2",

--- a/Library/Home Brew/Enraged Eggplant/Monsters/Wolf Zombie.gcs
+++ b/Library/Home Brew/Enraged Eggplant/Monsters/Wolf Zombie.gcs
@@ -1042,8 +1042,29 @@
 					}
 				},
 				{
-					"id": "tZxpS5AqvWNIWBZCK",
+					"id": "tvOkUjekioaERuL-A",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Martial Arts/Martial Arts Traits.adq",
+						"id": "t1EQWxaQ-jHONu6CT"
+					},
 					"name": "Born Biter",
+					"reference": "MA115, DF3:15, DFRC2:53, FFK9, FUR15",
+					"local_notes": "Can hold on and worry targets after a bite (if not already permitted)",
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "for attackers to hit your face, nose or jaw",
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to SM for determining what you can bite",
+							"amount": 1,
+							"per_level": true
+						}
+					],
 					"can_level": true,
 					"levels": 2,
 					"calc": {
@@ -3097,7 +3118,7 @@
 		}
 	],
 	"created_date": "2022-08-03T16:55:00+08:00",
-	"modified_date": "2024-02-10T16:36:01+08:00",
+	"modified_date": "2026-05-29T19:52:38+01:00",
 	"calc": {
 		"swing": "1d+1",
 		"thrust": "1d-1",

--- a/Library/Home Brew/Enraged Eggplant/Monsters/Wolf.gcs
+++ b/Library/Home Brew/Enraged Eggplant/Monsters/Wolf.gcs
@@ -760,10 +760,28 @@
 					}
 				},
 				{
-					"id": "thZAC4Y53mJu0eigZ",
+					"id": "t9u8zJcPQeZEi1D7_",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Martial Arts/Martial Arts Traits.adq",
+						"id": "t1EQWxaQ-jHONu6CT"
+					},
 					"name": "Born Biter",
-					"tags": [
-						"Physical"
+					"reference": "MA115, DF3:15, DFRC2:53, FFK9, FUR15",
+					"local_notes": "Can hold on and worry targets after a bite (if not already permitted)",
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "for attackers to hit your face, nose or jaw",
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to SM for determining what you can bite",
+							"amount": 1,
+							"per_level": true
+						}
 					],
 					"can_level": true,
 					"levels": 2,
@@ -2216,7 +2234,7 @@
 		}
 	],
 	"created_date": "2022-07-28T13:38:00+08:00",
-	"modified_date": "2023-12-29T12:34:02+08:00",
+	"modified_date": "2026-05-29T19:52:51+01:00",
 	"calc": {
 		"swing": "1d",
 		"thrust": "1d-1",

--- a/Library/Home Brew/Enraged Eggplant/Monsters/Wretched.gcs
+++ b/Library/Home Brew/Enraged Eggplant/Monsters/Wretched.gcs
@@ -1223,9 +1223,29 @@
 					}
 				},
 				{
-					"id": "tUDPAXuelzQop1tlY",
+					"id": "tBCaQ0YWhQFo9l-my",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Martial Arts/Martial Arts Traits.adq",
+						"id": "t1EQWxaQ-jHONu6CT"
+					},
 					"name": "Born Biter",
-					"reference": "MA115",
+					"reference": "MA115, DF3:15, DFRC2:53, FFK9, FUR15",
+					"local_notes": "Can hold on and worry targets after a bite (if not already permitted)",
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "for attackers to hit your face, nose or jaw",
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to SM for determining what you can bite",
+							"amount": 1,
+							"per_level": true
+						}
+					],
 					"can_level": true,
 					"levels": 3,
 					"calc": {
@@ -3357,7 +3377,7 @@
 		}
 	],
 	"created_date": "2023-01-25T08:35:22+08:00",
-	"modified_date": "2023-12-26T14:24:47+08:00",
+	"modified_date": "2026-05-29T19:52:31+01:00",
 	"calc": {
 		"swing": "3d-1",
 		"thrust": "2d+2",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Daedra/Daedroth.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Daedra/Daedroth.gcs
@@ -1858,12 +1858,34 @@
 			}
 		},
 		{
-			"id": "tomKat4ZK3gmyHp_Q",
+			"id": "tLQCDilNI6hfL4CaY",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Martial Arts/Martial Arts Traits.adq",
+				"id": "t1EQWxaQ-jHONu6CT"
+			},
 			"name": "Born Biter",
-			"reference": "DF3:15",
-			"local_notes": "You have an elongated jaw optimized for trapping prey. You can opt to hold on after you bite; thus, the bite doubles as a grapple. On later turns, you can worry, which counts as an attack but always hits – simply roll biting damage! If your victim’s SM is three or more greater than yours, you can only do this to an extremity (hand, foot, etc.), and the grapple is considered one-handed. If his SM is only one or two larger, you can target anything, and the grapple is treated as two handed. The same is true if his SM is equal to or smaller than  yours, but you can also attempt to pin him while standing! The catch is that foes get +3 to target your protruding snout, allowing them to attack your face (not skull) at only -2.",
+			"reference": "MA115, DF3:15, DFRC2:53, FFK9, FUR15",
+			"local_notes": "Can hold on and worry targets after a bite (if not already permitted)",
+			"features": [
+				{
+					"type": "conditional_modifier",
+					"situation": "for attackers to hit your face, nose or jaw",
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "conditional_modifier",
+					"situation": "to SM for determining what you can bite",
+					"amount": 1,
+					"per_level": true
+				}
+			],
+			"can_level": true,
+			"levels": 3,
 			"calc": {
-				"points": 0
+				"points": 0,
+				"current_level": 3
 			}
 		},
 		{
@@ -2675,7 +2697,7 @@
 		}
 	],
 	"created_date": "2023-11-26T21:44:08-05:00",
-	"modified_date": "2026-04-07T19:16:14-04:00",
+	"modified_date": "2026-05-29T19:49:38+01:00",
 	"calc": {
 		"swing": "3d+2",
 		"thrust": "2d-1",

--- a/Library/Martial Arts/Martial Arts Traits.adq
+++ b/Library/Martial Arts/Martial Arts Traits.adq
@@ -1543,6 +1543,32 @@
 			"calc": {
 				"points": 1
 			}
+		},
+		{
+			"id": "t1EQWxaQ-jHONu6CT",
+			"name": "Born Biter",
+			"reference": "MA115, DF3:15, DFRC2:53, FFK9, FUR15",
+			"local_notes": "Can hold on and worry targets after a bite (if not already permitted)",
+			"features": [
+				{
+					"type": "conditional_modifier",
+					"situation": "for attackers to hit your face, nose or jaw",
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "conditional_modifier",
+					"situation": "to SM for determining what you can bite",
+					"amount": 1,
+					"per_level": true
+				}
+			],
+			"can_level": true,
+			"levels": 1,
+			"calc": {
+				"points": 0,
+				"current_level": 1
+			}
 		}
 	]
 }

--- a/Library/Pyramid Magazine/Pyramid 115/Homo Sapiens Vulpes.gct
+++ b/Library/Pyramid Magazine/Pyramid 115/Homo Sapiens Vulpes.gct
@@ -135,12 +135,28 @@
 					}
 				},
 				{
-					"id": "t4ag6EyoWX7YJksbJ",
+					"id": "tM7KSPKFw8bRVyqBJ",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Martial Arts/Martial Arts Traits.adq",
+						"id": "t1EQWxaQ-jHONu6CT"
+					},
 					"name": "Born Biter",
-					"reference": "DF3:15",
-					"local_notes": "Face is considered SM plus Level in terms of biting and being targeted ",
-					"tags": [
-						"Physical"
+					"reference": "MA115, DF3:15, DFRC2:53, FFK9, FUR15",
+					"local_notes": "Can hold on and worry targets after a bite (if not already permitted)",
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "for attackers to hit your face, nose or jaw",
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to SM for determining what you can bite",
+							"amount": 1,
+							"per_level": true
+						}
 					],
 					"can_level": true,
 					"levels": 1,


### PR DESCRIPTION
Born Biter is a trait that's popular for reptilians or other bitey humanoids.

This has page references for all the places I've seen that define what Born Biter does.

There are broadly two definitions of Born Biter:
1. From Dungeon Fantasy, a +3 to SM for biting purposes, +3 to hit the face, and allows you to grapple as part of a bite and then worry on subsequent turns.
2. From Martial Arts, a levelled trait that raises the effective SM for biting purposes but gives a bonus to hit your nose or jaw. Being able to grapple and worry are things anyone can do, but more effective when you're bigger.

I've split the difference with a levelled trait including a note that grants the ability to grapple and worry where not already permitted.