### PR TITLE
Power Ups: allow Obvious quirk to specialize by sense

### DIFF
--- a/Library/Power Ups/Power Ups Traits.adq
+++ b/Library/Power Ups/Power Ups Traits.adq
@@ -14264,7 +14264,7 @@
 		},
 		{
 			"id": "tRGj9yvtkuBdIQIIZ",
-			"name": "Obvious",
+			"name": "Obvious (@sense@)",
 			"reference": "PU6:12",
 			"tags": [
 				"Exotic",
@@ -14272,6 +14272,13 @@
 				"Quirk"
 			],
 			"base_points": -1,
+			"features": [
+				{
+					"type": "conditional_modifier",
+					"situation": "to detect you by @sense@",
+					"amount": 1
+				}
+			],
 			"calc": {
 				"points": -1
 			}


### PR DESCRIPTION
The description of Obvious in Power-ups states that Obvious is a weaker, generalised form of Noisy to any sense, and Furries gives anthropomorphic skunks Obvious (Musk).