### PR TITLE
Power Ups: Add Easily Suppressed Disadvantage and its examples

### DIFF
--- a/Library/Power Ups/Power Ups Traits.adq
+++ b/Library/Power Ups/Power Ups Traits.adq
@@ -95,6 +95,20 @@
 			}
 		},
 		{
+			"id": "tG9VigVLJ8-NkRqiB",
+			"name": "Vainglorious",
+			"reference": "PU6:10",
+			"local_notes": "Easily Suppressed Selfish",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
 			"id": "tFZvG08mNU_rUW6bU",
 			"name": "Unwelcome Accessory (@Subject@)",
 			"reference": "PU6:13",
@@ -134,6 +148,34 @@
 			}
 		},
 		{
+			"id": "tv8O07bHnNiuZN1WQ",
+			"name": "Unselfish",
+			"reference": "PU6:10",
+			"local_notes": "Easily Suppressed Selfless",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "tUzFIgF2xvhWwI2RQ",
+			"name": "Unquestioning",
+			"reference": "PU6:10",
+			"local_notes": "Easily Suppressed Incurious",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
 			"id": "tJh4coqWXK3V5DxTS",
 			"name": "Unique Technique (@Technique@)",
 			"reference": "PU2:21",
@@ -143,6 +185,20 @@
 			"base_points": 1,
 			"calc": {
 				"points": 1
+			}
+		},
+		{
+			"id": "tCmBH1LcYvNvFr0QL",
+			"name": "Unfriendly",
+			"reference": "PU6:10",
+			"local_notes": "Easily Suppressed Loner",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
 			}
 		},
 		{
@@ -12694,6 +12750,20 @@
 			}
 		},
 		{
+			"id": "tgvrrXbU3Wb2ls-vV",
+			"name": "Status-conscious",
+			"reference": "PU6:10",
+			"local_notes": "Easily Suppressed Selfish",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
 			"id": "tvmIjpuMT6T4g2eLv",
 			"name": "Standard Operating Procedure (On Alert)",
 			"reference": "PU2:15",
@@ -12863,6 +12933,20 @@
 			}
 		},
 		{
+			"id": "tl1oNJZ5qLMVAtndQ",
+			"name": "Solitary",
+			"reference": "PU6:10",
+			"local_notes": "Easily Suppressed Loner",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
 			"id": "tDppcf0Vx1LijoxoE",
 			"name": "Soft Spot (@Group@)",
 			"reference": "PU6:27",
@@ -12870,6 +12954,48 @@
 				"Mental",
 				"Quirk",
 				"Social"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "troh9N27bvzHuMVT4",
+			"name": "Social",
+			"reference": "PU6:10",
+			"local_notes": "Easily Suppressed Compulsive Carousing",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "tDGtG2PcbaHTf42zN",
+			"name": "Snooty",
+			"reference": "PU6:10",
+			"local_notes": "Easily Suppressed Selfish",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "t-EWvZZ9VXE4jD0A8",
+			"name": "Snobby",
+			"reference": "PU6:10",
+			"local_notes": "Easily Suppressed Selfish",
+			"tags": [
+				"Mental",
+				"Quirk"
 			],
 			"base_points": -1,
 			"calc": {
@@ -12982,6 +13108,20 @@
 			}
 		},
 		{
+			"id": "ti5CWs7T05j_lYfat",
+			"name": "Sincere",
+			"reference": "PU6:10",
+			"local_notes": "Easily Suppressed Truthfulness",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
 			"id": "tVBMtlZOmSoYxws-m",
 			"name": "Show-Off (@Skill@)",
 			"reference": "PU6:32",
@@ -13023,6 +13163,20 @@
 			"base_points": 1,
 			"calc": {
 				"points": 1
+			}
+		},
+		{
+			"id": "tsoQC4_EOPbn0A9sT",
+			"name": "Shopaholic",
+			"reference": "PU6:10",
+			"local_notes": "Easily Suppressed Compulsive Spending",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
 			}
 		},
 		{
@@ -13646,6 +13800,20 @@
 			}
 		},
 		{
+			"id": "tMgsGveU283JEVL5N",
+			"name": "Prying",
+			"reference": "PU6:10",
+			"local_notes": "Easily Suppressed Curious",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
 			"id": "t0n6DnWxc91I-DHtf",
 			"name": "Proud",
 			"reference": "PU6:20",
@@ -13685,6 +13853,20 @@
 			"base_points": 1,
 			"calc": {
 				"points": 1
+			}
+		},
+		{
+			"id": "tjxegbtS3yZ2u4MZB",
+			"name": "Prefers being alone",
+			"reference": "PU6:10",
+			"local_notes": "Easily Suppressed Loner",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
 			}
 		},
 		{
@@ -13790,6 +13972,20 @@
 			"reference": "PU6:24",
 			"tags": [
 				"Physical",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "tEAJ0FxwG0kEz4aSK",
+			"name": "Pompous",
+			"reference": "PU6:10",
+			"local_notes": "Easily Suppressed Selfish",
+			"tags": [
+				"Mental",
 				"Quirk"
 			],
 			"base_points": -1,
@@ -14054,6 +14250,20 @@
 			}
 		},
 		{
+			"id": "tuhTXRAaKaBeOPnx9",
+			"name": "Party Animal",
+			"reference": "PU6:10",
+			"local_notes": "Easily Suppressed Compulsive Carousing",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
 			"id": "tBqVpfTuEOBrDvL-5",
 			"name": "Parthenogenesis",
 			"reference": "PU2:11",
@@ -14304,6 +14514,20 @@
 			}
 		},
 		{
+			"id": "twHS7EG11UDN1eq8o",
+			"name": "Oath-taker",
+			"reference": "PU6:10",
+			"local_notes": "Easily Suppressed Compulsive Vowing",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
 			"id": "tDO_EymGiSVoKvAm8",
 			"name": "Nosy",
 			"reference": "PU6:20",
@@ -14521,6 +14745,20 @@
 			}
 		},
 		{
+			"id": "tliMO3QSHWrfsDSLm",
+			"name": "Munificent",
+			"reference": "PU6:10",
+			"local_notes": "Easily Suppressed Compulsive Generosity",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
 			"id": "tFSrjMRH7InkXbJzw",
 			"name": "Missing Toes",
 			"reference": "PU6:23",
@@ -14649,6 +14887,20 @@
 			"base_points": 1,
 			"calc": {
 				"points": 1
+			}
+		},
+		{
+			"id": "tHyVQ_nrfiesVoy1C",
+			"name": "Magnanimous",
+			"reference": "PU6:10",
+			"local_notes": "Easily Suppressed Compulsive Generosity",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
 			}
 		},
 		{
@@ -14788,6 +15040,62 @@
 			}
 		},
 		{
+			"id": "teL_qXkEuLqM3S_6m",
+			"name": "Likes to eat",
+			"reference": "PU6:10",
+			"local_notes": "Easily Suppressed Gluttony",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "t3GX7aCjWZyApG9YT",
+			"name": "Likes games of chance",
+			"reference": "PU6:10",
+			"local_notes": "Easily Suppressed Compulsive Gambling",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "tSEhYC9DwvMBdtmr0",
+			"name": "Likes fire",
+			"reference": "PU6:10",
+			"local_notes": "Easily Suppressed Pyromania",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "tRa2MPZefSwgvSJZz",
+			"name": "Likes bets",
+			"reference": "PU6:10",
+			"local_notes": "Easily Suppressed Compulsive Gambling",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
 			"id": "tgMTR7wr2w0uqF4A3",
 			"name": "Like (@Subject@)",
 			"reference": "PU6:26",
@@ -14857,6 +15165,20 @@
 			"id": "tm73ZXqKCQOQqOyk1",
 			"name": "Layabout",
 			"reference": "PU6:19",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "tOd70K-b3NIeupJ8X",
+			"name": "Keeps to self",
+			"reference": "PU6:10",
+			"local_notes": "Easily Suppressed Loner",
 			"tags": [
 				"Mental",
 				"Quirk"
@@ -15012,6 +15334,34 @@
 				"Mental",
 				"Quirk",
 				"Social"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "tD812KJOVfeuTRw8_",
+			"name": "Inquisitive",
+			"reference": "PU6:10",
+			"local_notes": "Easily Suppressed Curious",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "toqlxb94M22qbQWyx",
+			"name": "Ingenuous",
+			"reference": "PU6:10",
+			"local_notes": "Easily Suppressed Truthfulness",
+			"tags": [
+				"Mental",
+				"Quirk"
 			],
 			"base_points": -1,
 			"calc": {
@@ -16285,6 +16635,20 @@
 			}
 		},
 		{
+			"id": "tVWmBhfD8h2LKFCN6",
+			"name": "Haughty",
+			"reference": "PU6:10",
+			"local_notes": "Easily Suppressed Selfish",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
 			"id": "tGHsMElCLWWNd9CPD",
 			"name": "Hated by @Group@",
 			"reference": "PU6:33",
@@ -16352,6 +16716,20 @@
 			}
 		},
 		{
+			"id": "tDmb3vjP5M6d2MP7L",
+			"name": "Gourmand",
+			"reference": "PU6:10",
+			"local_notes": "Easily Suppressed Gluttony",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
 			"id": "tLdoK4ipfLF46kB0x",
 			"name": "Good with @Social Group@",
 			"reference": "PU2:13",
@@ -16381,6 +16759,20 @@
 			"id": "tKnTO9tRIpKGTxa_9",
 			"name": "Glimpses of Clarity",
 			"reference": "PU6:19",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "tqh81OVeaZuCqtdwM",
+			"name": "Generous",
+			"reference": "PU6:10",
+			"local_notes": "Easily Suppressed Compulsive Generosity",
 			"tags": [
 				"Mental",
 				"Quirk"
@@ -16475,6 +16867,20 @@
 			}
 		},
 		{
+			"id": "tThmif-7mtQuQkNNP",
+			"name": "Forthright",
+			"reference": "PU6:10",
+			"local_notes": "Easily Suppressed Truthfulness",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
 			"id": "tLZSsYV2CH-grZOsM",
 			"name": "Former Alcoholic",
 			"reference": "PU6:29",
@@ -16563,6 +16969,20 @@
 			}
 		},
 		{
+			"id": "tb5oXhAxaTvhqhoXd",
+			"name": "Fond of food and drink",
+			"reference": "PU6:10",
+			"local_notes": "Easily Suppressed Gluttony",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
 			"id": "tq_W9nszVQayK7eXK",
 			"name": "Follow-Through (@Weapon Skill@)",
 			"reference": "PU2:15",
@@ -16624,6 +17044,20 @@
 			"id": "tZ5M_NYxebUIx89tu",
 			"name": "Flirtatious",
 			"reference": "PU6:28",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "tbiTF-XAi8j_V0dAF",
+			"name": "Firebug",
+			"reference": "PU6:10",
+			"local_notes": "Easily Suppressed Pyromania",
 			"tags": [
 				"Mental",
 				"Quirk"
@@ -17034,6 +17468,34 @@
 			}
 		},
 		{
+			"id": "tPKuv8eKumvehZoGF",
+			"name": "Enjoys Gambling",
+			"reference": "PU6:10",
+			"local_notes": "Easily Suppressed Compulsive Gambling",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "tvJgtOACKCwBGh_J5",
+			"name": "Enjoys Carousing",
+			"reference": "PU6:10",
+			"local_notes": "Easily Suppressed Compulsive Carousing",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
 			"id": "tEqFcQzQ_zAylyMla",
 			"name": "Emeritus Professor",
 			"reference": "PU2:18",
@@ -17320,6 +17782,20 @@
 			"base_points": 1,
 			"calc": {
 				"points": 1
+			}
+		},
+		{
+			"id": "tl5glOyuhoGK4hlE6",
+			"name": "Displays wealth ostentatiously",
+			"reference": "PU6:10",
+			"local_notes": "Easily Suppressed Compulsive Spending",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
 			}
 		},
 		{
@@ -17736,12 +18212,12 @@
 			}
 		},
 		{
-			"id": "ttLKldJusYLybAXmd",
+			"id": "tHLd_4QinELGXjXPK",
 			"name": "Controllable Disadvantage (@Disadvantage@)",
-			"reference": "PU2:13",
+			"reference": "PU2:12",
 			"tags": [
-				"Perk",
-				"Physical"
+				"Mental",
+				"Perk"
 			],
 			"base_points": 1,
 			"calc": {
@@ -17749,12 +18225,12 @@
 			}
 		},
 		{
-			"id": "tHLd_4QinELGXjXPK",
+			"id": "ttLKldJusYLybAXmd",
 			"name": "Controllable Disadvantage (@Disadvantage@)",
-			"reference": "PU2:12",
+			"reference": "PU2:13",
 			"tags": [
-				"Mental",
-				"Perk"
+				"Perk",
+				"Physical"
 			],
 			"base_points": 1,
 			"calc": {
@@ -17769,6 +18245,34 @@
 				"Mental",
 				"Quirk",
 				"Social"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "tpPOLdPQTjdhou6aI",
+			"name": "Confident",
+			"reference": "PU6:10",
+			"local_notes": "Easily Suppressed Overconfidence",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "tN_EcdnuNvITPIVng",
+			"name": "Conceited",
+			"reference": "PU6:10",
+			"local_notes": "Easily Suppressed Selfish",
+			"tags": [
+				"Mental",
+				"Quirk"
 			],
 			"base_points": -1,
 			"calc": {
@@ -18321,6 +18825,20 @@
 			}
 		},
 		{
+			"id": "t20xYPaRbZdlL_Vrw",
+			"name": "Bold",
+			"reference": "PU6:10",
+			"local_notes": "Easily Suppressed Overconfidence",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
 			"id": "tW0DvFNmLfo0iB624",
 			"name": "Biting Mastery",
 			"reference": "PU2:5",
@@ -18331,6 +18849,20 @@
 			"base_points": 1,
 			"calc": {
 				"points": 1
+			}
+		},
+		{
+			"id": "tpE58dhG3lC5o4uzP",
+			"name": "Big Spender",
+			"reference": "PU6:10",
+			"local_notes": "Easily Suppressed Compulsive Spending",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
 			}
 		},
 		{
@@ -18375,6 +18907,20 @@
 			}
 		},
 		{
+			"id": "tP0jiR24Ws4jDi4J4",
+			"name": "Bad dreams",
+			"reference": "PU6:10",
+			"local_notes": "Easily Suppressed Nightmares",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
 			"id": "t1pWNapLR3rois5_K",
 			"name": "Background Knowledge (@Background@)",
 			"reference": "PU2:16",
@@ -18399,6 +18945,20 @@
 			"base_points": 1,
 			"calc": {
 				"points": 1
+			}
+		},
+		{
+			"id": "tP6md_boJN6vEwMyL",
+			"name": "Audacious",
+			"reference": "PU6:10",
+			"local_notes": "Easily Suppressed Overconfidence",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
 			}
 		},
 		{
@@ -19595,6 +20155,34 @@
 			}
 		},
 		{
+			"id": "tw7LpqTTHyVar4jEk",
+			"name": "Altruistic",
+			"reference": "PU6:10",
+			"local_notes": "Easily Suppressed Selfless",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "tKfaEA_-LQO4xUXiV",
+			"name": "Aloof",
+			"reference": "PU6:10",
+			"local_notes": "Easily Suppressed Loner",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
 			"id": "tlhjdZkzrmVVIiSrR",
 			"name": "Allergy (@Subject@)",
 			"reference": "PU6:22",
@@ -19832,6 +20420,21 @@
 				"Mental",
 				"Quirk",
 				"Social"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "tWmERST-UCYqjx1ST",
+			"name": "@Easily Suppressed Disadvantage@",
+			"reference": "PU6:10",
+			"reference_highlight": "Easily Suppressed Disadvantage",
+			"local_notes": "Easily Suppressed @Disadvantage@",
+			"tags": [
+				"Mental",
+				"Quirk"
 			],
 			"base_points": -1,
 			"calc": {


### PR DESCRIPTION
Making a disadvantage easily-suppressed is a common way of turning one into a quirk.

This adds a generic easily-suppressed disadvantage with substitutions, and all the listed examples of Easily Suppressed Disadvantages.