### PR TITLE
Basic Set Traits: Add Can't Wear Armour and Directional to Spines

### DIFF
--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -15566,6 +15566,23 @@
 				"Exotic",
 				"Physical"
 			],
+			"modifiers": [
+				{
+					"id": "mbXKveUVc-KASyLGV",
+					"name": "Can't wear armor",
+					"reference": "B47, FUR13",
+					"cost_adj": "-40%",
+					"disabled": true
+				},
+				{
+					"id": "mAbPrMnT3UE2qjrF0",
+					"name": "Directional",
+					"reference": "B47, FUR13",
+					"local_notes": "@Direction: Back, Right, Left, Top or Underside@",
+					"cost_adj": "-40%",
+					"disabled": true
+				}
+			],
 			"base_points": 3,
 			"weapons": [
 				{
@@ -23145,6 +23162,23 @@
 				"Exotic",
 				"Perk",
 				"Physical"
+			],
+			"modifiers": [
+				{
+					"id": "mCBqArG2HNSjuMlKv",
+					"name": "Can't wear armor",
+					"reference": "B47, FUR13",
+					"cost_adj": "-40%",
+					"disabled": true
+				},
+				{
+					"id": "mBq1Qz41Ys_kPfqWO",
+					"name": "Directional",
+					"reference": "B47, FUR13",
+					"local_notes": "@Direction: Back, Right, Left, Top or Underside@",
+					"cost_adj": "-40%",
+					"disabled": true
+				}
 			],
 			"base_points": 1,
 			"weapons": [


### PR DESCRIPTION
GURPS Furries page 13 states that those modifiers can also be used for Spines.