### PR TITLE
Template Toolkit Races: Allow Potential Form to set its point value with levels

### DIFF
--- a/Library/Template Toolkit/Template Toolkit 2 - Races/Template Toolkit 2 - Races Traits.adq
+++ b/Library/Template Toolkit/Template Toolkit 2 - Races/Template Toolkit 2 - Races Traits.adq
@@ -535,8 +535,11 @@
 				"Physical",
 				"Supernatural"
 			],
+			"points_per_level": 1,
+			"can_level": true,
 			"calc": {
-				"points": 0
+				"points": 0,
+				"current_level": 0
 			}
 		},
 		{


### PR DESCRIPTION
This is handy for a Potential Form that's worth more points - it has a point value equal to half the points of the new form, like Heir.