### PR TITLE
Basic Set Traits: add Cosmetic modifier to Growth and Shrinking

### DIFF
--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -9449,6 +9449,13 @@
 			],
 			"modifiers": [
 				{
+					"id": "m4zEYits3fYb_MDAD",
+					"name": "Cosmetic",
+					"reference": "FUR31, B84",
+					"cost_adj": "-50%",
+					"disabled": true
+				},
+				{
 					"id": "mEZen9ehSDR9ciY3a",
 					"name": "Maximum Size Only",
 					"reference": "B58",
@@ -23274,6 +23281,13 @@
 					"reference": "B85",
 					"local_notes": "Up to Heavy Encumbrance",
 					"cost_adj": "100%",
+					"disabled": true
+				},
+				{
+					"id": "mF_M8jBFdWx1HCBOG",
+					"name": "Cosmetic",
+					"reference": "FUR31, B84",
+					"cost_adj": "-50%",
 					"disabled": true
 				},
 				{


### PR DESCRIPTION
Furries allows Cosmetic to be added to Growth and Shrinking. Being cosmetically larger is good for intimidation, being cosmetically smaller is good for hiding.