### PR TITLE
Settings: add Serpentoid Body Type from Template Toolkit: Races

### DIFF
--- a/Library/Settings/Body Types/Serpentoid.body
+++ b/Library/Settings/Body Types/Serpentoid.body
@@ -1,0 +1,81 @@
+{
+	"version": 5,
+	"name": "Serpentoid",
+	"roll": "3d",
+	"locations": [
+		{
+			"id": "eye",
+			"choice_name": "Eyes",
+			"table_name": "Eyes",
+			"hit_penalty": -9,
+			"description": "An attack that misses by 1 hits the torso instead. Only\nimpaling (imp), piercing (pi-, pi, pi+, pi++), and\ntight-beam burning (burn) attacks can target the eye – and\nonly from the front or sides. Injury over HP÷10 blinds the\neye. Otherwise, treat as skull, but without the extra DR!",
+			"calc": {
+				"roll_range": "-"
+			}
+		},
+		{
+			"id": "skull",
+			"choice_name": "Skull",
+			"table_name": "Skull",
+			"slots": 2,
+			"hit_penalty": -7,
+			"dr_bonus": 2,
+			"description": "An attack that misses by 1 hits the torso instead. Wounding\nmodifier is x4. Knockdown rolls are at -10. Critical hits\nuse the Critical Head Blow Table (B556). Exception: These\nspecial effects do not apply to toxic (tox) damage.",
+			"calc": {
+				"roll_range": "3-4"
+			}
+		},
+		{
+			"id": "face",
+			"choice_name": "Face",
+			"table_name": "Face",
+			"slots": 1,
+			"hit_penalty": -5,
+			"description": "An attack that misses by 1 hits the torso instead. Jaw,\ncheeks, nose, ears, etc. If the target has an open-faced\nhelmet, ignore its DR. Knockdown rolls are at -5. Critical\nhits use the Critical Head Blow Table (B556). Corrosion\n(cor) damage gets a x1½ wounding modifier, and if it\ninflicts a major wound, it also blinds one eye (both eyes on\ndamage over full HP). Random attacks from behind hit the\nskull instead.",
+			"calc": {
+				"roll_range": "5"
+			}
+		},
+		{
+			"id": "neck",
+			"choice_name": "Neck",
+			"table_name": "Neck",
+			"slots": 3,
+			"hit_penalty": -5,
+			"description": "An attack that misses by 1 hits the torso instead. Neck and\nthroat. Increase the wounding multiplier of crushing (cr)\nand corrosion (cor) attacks to x1½, and that of cutting\n(cut) damage to x2. At the GM’s option, anyone killed by a\ncutting (cut) blow to the neck is decapitated!",
+			"calc": {
+				"roll_range": "6-8"
+			}
+		},
+		{
+			"id": "torso",
+			"choice_name": "Torso",
+			"table_name": "Torso",
+			"slots": 8,
+			"calc": {
+				"roll_range": "9-16"
+			}
+		},
+		{
+			"id": "tail",
+			"choice_name": "Tail",
+			"table_name": "Tail",
+			"slots": 2,
+			"hit_penalty": -3,
+                        "description": "If a tail counts as an Extra Arm or a Striker, or is a fish\ntail, treat it as a limb (arm, leg) for crippling purposes;\notherwise, treat it as an extremity (hand, foot). A crippled\ntail affects balance. For a ground creature, this gives -1\nDX. For a swimmer or flyer, this gives -2 DX and halves\nMove. If the creature has no tail, or a very short one (like\na rabbit), treat as torso.",
+			"calc": {
+				"roll_range": "17-18"
+			}
+		},
+		{
+			"id": "vitals",
+			"choice_name": "Vitals",
+			"table_name": "Vitals",
+			"hit_penalty": -3,
+			"description": "An attack that misses by 1 hits the torso instead. Heart,\nlungs, kidneys, etc. Increase the wounding modifier for an\nimpaling (imp) or any piercing (pi-, pi, pi+, pi++) attack\nto x3. Increase the wounding modifier for a tight-beam\nburning (burn) attack to x2. Other attacks cannot target the\nvitals.",
+			"calc": {
+				"roll_range": "-"
+			}
+		}
+	]
+}


### PR DESCRIPTION
The Oracular Naga from Furries is Serpentoid, so it made sense to use the Body Type from Template Toolkit 2: Races