### PR TITLE
Basic Set Traits: Add Hypersensory modifier to Danger Sense

### DIFF
--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -5286,6 +5286,15 @@
 				"Advantage",
 				"Mental"
 			],
+			"modifiers": [
+				{
+					"id": "mJ5GG1A-ydx8LO5y-",
+					"name": "Hypersensory",
+					"reference": "FUR12",
+					"cost_adj": "-50%",
+					"disabled": true
+				}
+			],
 			"base_points": 15,
 			"calc": {
 				"points": 15


### PR DESCRIPTION
This trait is declared for Danger Sense in Furries.

There is also a more general form of Hypersensory in Powers: Enhanced Senses that might be used instead, but Furries' description is not identical and the GURPS Furries book doesn't require Enhanced Senses.