### PR TITLE
Basic Set Traits: Add DX-based Kicking technique

### DIFF
--- a/Library/Basic Set/Basic Set Skills.skl
+++ b/Library/Basic Set/Basic Set Skills.skl
@@ -11189,6 +11189,24 @@
 			"points": 2
 		},
 		{
+			"id": "q6mA8uvi7Ixh57qv6",
+			"name": "Kicking",
+			"reference": "B231,MA75",
+			"tags": [
+				"Combat",
+				"Melee Combat",
+				"Technique",
+				"Weapon"
+			],
+			"difficulty": "h",
+			"default": {
+				"type": "dx",
+				"modifier": -2
+			},
+			"limit": 0,
+			"points": 2
+		},
+		{
 			"id": "qXTByqKnuWLOC3_10",
 			"name": "Kicking",
 			"reference": "B231,MA75",


### PR DESCRIPTION
Brawling and Karate-based kicking techniques were present, but it was apparent from Furries that creatures can be trained in the Kicking technique without having a natural Brawling skill.